### PR TITLE
Fix select location transition glitch

### DIFF
--- a/gui/src/renderer/components/SearchBar.tsx
+++ b/gui/src/renderer/components/SearchBar.tsx
@@ -89,7 +89,7 @@ export default function SearchBar(props: ISearchBarProps) {
 
   useEffect(() => {
     if (!props.disableAutoFocus) {
-      inputRef.current?.focus();
+      inputRef.current?.focus({ preventScroll: true });
     }
   }, []);
 

--- a/gui/src/renderer/components/select-location/RelayListContext.tsx
+++ b/gui/src/renderer/components/select-location/RelayListContext.tsx
@@ -179,7 +179,7 @@ function useRelayList(
 // Return all RelayLocations that should be expanded
 function useExpandedLocations(filteredLocations: Array<IRelayLocationRedux>) {
   const { locationType, searchTerm } = useSelectLocationContext();
-  const { spacePreAllocationViewRef, scrollViewRef } = useScrollPositionContext();
+  const { spacePreAllocationViewRef, scrollIntoView } = useScrollPositionContext();
   const relaySettings = useNormalRelaySettings();
   const bridgeSettings = useNormalBridgeSettings();
 
@@ -217,7 +217,7 @@ function useExpandedLocations(filteredLocations: Array<IRelayLocationRedux>) {
       if (invokedByUser) {
         locationRect.height += expandedContentHeight;
         spacePreAllocationViewRef.current?.allocate(expandedContentHeight);
-        scrollViewRef.current?.scrollIntoView(locationRect);
+        scrollIntoView(locationRect);
       }
     },
     [],

--- a/gui/src/renderer/components/select-location/ScrollPositionContext.tsx
+++ b/gui/src/renderer/components/select-location/ScrollPositionContext.tsx
@@ -17,6 +17,7 @@ interface ScrollPositionContext {
   spacePreAllocationViewRef: React.RefObject<SpacePreAllocationView>;
   saveScrollPosition: () => void;
   resetScrollPositions: () => void;
+  scrollIntoView: (rect: DOMRect) => void;
 }
 
 type ScrollPosition = [number, number];
@@ -58,6 +59,10 @@ export function ScrollPositionContextProvider(props: ScrollPositionContextProps)
     }
   }, [locationType]);
 
+  const scrollIntoView = useCallback((rect: DOMRect) => {
+    scrollViewRef.current?.scrollIntoView(rect);
+  }, []);
+
   const value = useMemo(
     () => ({
       scrollPositions,
@@ -66,6 +71,7 @@ export function ScrollPositionContextProvider(props: ScrollPositionContextProps)
       spacePreAllocationViewRef,
       saveScrollPosition,
       resetScrollPositions,
+      scrollIntoView,
     }),
     [saveScrollPosition, resetScrollPositions],
   );


### PR DESCRIPTION
This PR fixes the scroll glitch when automatically focusing the search bar in the select location view during the view transition.

I've also moved the `scrollViewRef.current?.scrollIntoView` call to `scrollPositionContext` to keep all scroll related logic in that context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4175)
<!-- Reviewable:end -->
