### PR TITLE
Fix some scaling issues on Windows

### DIFF
--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -196,8 +196,9 @@ export default class WindowController {
 
   public updatePosition() {
     if (this.window) {
-      const { x, y } = this.windowPositioning.getPosition(this.window);
-      this.window.setPosition(x, y, false);
+      const position = this.windowPositioning.getPosition(this.window);
+      const size = WindowController.getContentSize(this.delegate.isUnpinnedWindow());
+      this.window.setBounds({ ...position, ...size }, false);
     }
 
     this.notifyUpdateWindowShape();


### PR DESCRIPTION
This PR hopefully improves the scaling issues on Windows when or after a DPI/scale change. The specific case I was able to reproduce was that the window became taller for each time it was opened when it was unpinned and after changing the Windows scale factor. Hopefully this fixes more issues.

My guess is that `setPosition` sets the bounds but somehow has incorrect values for height and width after a scale/DPI change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4177)
<!-- Reviewable:end -->
