### PR TITLE
Disable multi-window support and shortcuts on iPad

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -31,8 +31,8 @@ Line wrap the file at 100 chars.                                              Th
   backend.
 - Add ability to manage registered devices if too many devices detected during log-in.
 - Add intents: start VPN, stop VPN, reconnect VPN (acts as start VPN when the tunnel is down,
-  otherwise picks new relay).
-- Add menu item to control shortcuts.
+  otherwise picks new relay). iPhone only.
+- Add menu item to control shortcuts. iPhone only.
 - Add continuous monitoring of tunnel connection. Verify ping replies to detect whether traffic is 
   really flowing.
 - Check if device is revoked or account has expired when the tunnel fails to connect on each second

--- a/ios/MullvadVPN/Info.plist
+++ b/ios/MullvadVPN/Info.plist
@@ -28,13 +28,13 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>INIntentsRestrictedWhileLocked</key>
+	<key>INIntentsRestrictedWhileLocked~iphone</key>
 	<array>
 		<string>StartVPNIntent</string>
 		<string>StopVPNIntent</string>
 		<string>ReconnectVPNIntent</string>
 	</array>
-	<key>INIntentsSupported</key>
+	<key>INIntentsSupported~iphone</key>
 	<array>
 		<string>StartVPNIntent</string>
 		<string>StopVPNIntent</string>
@@ -44,7 +44,7 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSUserActivityTypes</key>
+	<key>NSUserActivityTypes~iphone</key>
 	<array>
 		<string>StartVPNIntent</string>
 		<string>StopVPNIntent</string>
@@ -54,6 +54,11 @@
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<true/>
+	</dict>
+	<key>UIApplicationSceneManifest~ipad</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
 	</dict>
 	<key>UIBackgroundModes</key>
 	<array>

--- a/ios/MullvadVPN/SettingsDataSource.swift
+++ b/ios/MullvadVPN/SettingsDataSource.swift
@@ -98,7 +98,11 @@ final class SettingsDataSource: NSObject, UITableViewDataSource, UITableViewDele
 
         if interactor.deviceState.isLoggedIn {
             newSnapshot.appendSections([.main])
-            newSnapshot.appendItems([.account, .preferences, .shortcuts], in: .main)
+            newSnapshot.appendItems([.account, .preferences], in: .main)
+
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                newSnapshot.appendItems([.shortcuts], in: .main)
+            }
         }
 
         newSnapshot.appendSections([.version, .problemReport])


### PR DESCRIPTION
Alternative PR to https://github.com/mullvad/mullvadvpn-app/pull/4185. This one simply enables intents on iPhone only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4187)
<!-- Reviewable:end -->
