### PR TITLE
Make git always treat the container sigstore as binary files

### DIFF
--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -15,6 +15,7 @@ on:
             - building/mullvad-app-container-signing.asc
             - building/linux-container-image-tag.txt
             - building/android-container-image-tag.txt
+            - building/sigstore/
     workflow_dispatch:
 jobs:
     verify-signatures:

--- a/building/sigstore/.gitattributes
+++ b/building/sigstore/.gitattributes
@@ -1,0 +1,1 @@
+signature-* binary


### PR DESCRIPTION
Sometimes git treats the `signature-x` files as text files and tries to show their content/diffs in `git diff` and `git show`. This is terribly annoying and messes up the TTY. Adding this tells git to always treat them as binary files.

## Alternative solution

Move `.gitattributes` up one level to `building/` and have the contents be `sigstore/ binary`. I have not yet published any new containers after adding this file. I hope `podman`/`docker` wont trip up if this file exists in the sigstore, but I can't guarantee it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4195)
<!-- Reviewable:end -->
