### PR TITLE
Decouple system tunnels from tunnel manager

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		06D9845428F99133003AABE9 /* libMullvadLogging.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 581943D628F800C900B0CB5E /* libMullvadLogging.a */; };
 		06D9845A28F9918C003AABE9 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 06D9845928F9918C003AABE9 /* Logging */; };
 		06D9846328F9A049003AABE9 /* libMullvadLogging.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 581943D628F800C900B0CB5E /* libMullvadLogging.a */; };
+		5803B4B02940A47300C23744 /* TunnelConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5803B4AF2940A47300C23744 /* TunnelConfiguration.swift */; };
+		5803B4B22940A48700C23744 /* TunnelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5803B4B12940A48700C23744 /* TunnelStore.swift */; };
 		5806767C27048E9B00C858CB /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CE5E7B224146470008646E /* PacketTunnelProvider.swift */; };
 		5807483B27DB8A980020ECBF /* WireGuardKitTypes in Frameworks */ = {isa = PBXBuildFile; productRef = 5807483A27DB8A980020ECBF /* WireGuardKitTypes */; };
 		5807E2C02432038B00F5FF30 /* String+Split.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5807E2BF2432038B00F5FF30 /* String+Split.swift */; };
@@ -571,6 +573,8 @@
 		06FAE67B28F83CA50033DD93 /* REST.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = REST.swift; sourceTree = "<group>"; };
 		06FAE67C28F83CA50033DD93 /* URLSessionTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTransport.swift; sourceTree = "<group>"; };
 		06FAE67D28F83CA50033DD93 /* RESTTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RESTTransport.swift; sourceTree = "<group>"; };
+		5803B4AF2940A47300C23744 /* TunnelConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelConfiguration.swift; sourceTree = "<group>"; };
+		5803B4B12940A48700C23744 /* TunnelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelStore.swift; sourceTree = "<group>"; };
 		58059DDB28465E8F002B1049 /* TransformOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformOperation.swift; sourceTree = "<group>"; };
 		58059DDD28468158002B1049 /* OutputOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputOperation.swift; sourceTree = "<group>"; };
 		58059DDF2846823E002B1049 /* ResultOperation+Output.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResultOperation+Output.swift"; sourceTree = "<group>"; };
@@ -1092,6 +1096,8 @@
 				58F2E143276A13F300A79513 /* StartTunnelOperation.swift */,
 				58F2E145276A2C9900A79513 /* StopTunnelOperation.swift */,
 				58E0A98727C8F46300FE6BDD /* Tunnel.swift */,
+				5803B4B12940A48700C23744 /* TunnelStore.swift */,
+				5803B4AF2940A47300C23744 /* TunnelConfiguration.swift */,
 				5875960926F371FC00BF6711 /* Tunnel+Messaging.swift */,
 				58968FAD28743E2000B799DC /* TunnelInteractor.swift */,
 				5835B7CB233B76CB0096D79F /* TunnelManager.swift */,
@@ -2159,6 +2165,7 @@
 				5846227126E229F20035F7C2 /* StoreSubscription.swift in Sources */,
 				58421030282D8A3C00F24E46 /* UpdateAccountDataOperation.swift in Sources */,
 				58FF2C03281BDE02009EF542 /* SettingsManager.swift in Sources */,
+				5803B4B02940A47300C23744 /* TunnelConfiguration.swift in Sources */,
 				587EB672271451E300123C75 /* PreferencesViewModel.swift in Sources */,
 				586A950C290125EE007BAF2B /* AlertPresenter.swift in Sources */,
 				584D26C6270C8741004EA533 /* SettingsDNSTextCell.swift in Sources */,
@@ -2298,6 +2305,7 @@
 				58ACF64B26553C3F00ACE4B7 /* SettingsSwitchCell.swift in Sources */,
 				587EB67027143B6500123C75 /* DataSourceSnapshot.swift in Sources */,
 				580F8B8328197881002E0998 /* TunnelSettingsV2.swift in Sources */,
+				5803B4B22940A48700C23744 /* TunnelStore.swift in Sources */,
 				586A950F29012BEE007BAF2B /* AddressCacheTracker.swift in Sources */,
 				587B753D2666468F00DEF7E9 /* NotificationController.swift in Sources */,
 			);

--- a/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
+++ b/ios/MullvadVPN.xcodeproj/xcshareddata/xcschemes/MullvadVPN.xcscheme
@@ -88,7 +88,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "1"
+      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -196,7 +196,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // MARK: - Notifications
 
     @objc private func didBecomeActive(_ notification: Notification) {
-        tunnelManager.refreshTunnelStatus()
         tunnelManager.startPeriodicPrivateKeyRotation()
         relayCacheTracker.startPeriodicUpdates()
         addressCacheTracker.startPeriodicUpdates()

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -31,6 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         return operationQueue
     }()
 
+    private(set) var tunnelStore: TunnelStore!
     private(set) var tunnelManager: TunnelManager!
     private(set) var addressCache: REST.AddressCache!
 
@@ -80,8 +81,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             store: addressCache
         )
 
+        tunnelStore = TunnelStore(application: application)
+
         tunnelManager = TunnelManager(
             application: application,
+            tunnelStore: tunnelStore,
             relayCacheTracker: relayCacheTracker,
             accountsProxy: accountsProxy,
             devicesProxy: devicesProxy
@@ -94,7 +98,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             accountsProxy: accountsProxy
         )
 
-        transportMonitor = TransportMonitor(tunnelManager: tunnelManager)
+        transportMonitor = TransportMonitor(tunnelManager: tunnelManager, tunnelStore: tunnelStore)
 
         #if targetEnvironment(simulator)
         // Configure mock tunnel provider on simulator
@@ -108,6 +112,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         setupPaymentHandler()
         setupNotificationHandler()
         addApplicationNotifications(application: application)
+
+        let loadTunnelsOperation = AsyncBlockOperation(dispatchQueue: .main) { operation in
+            self.tunnelStore.loadPersistentTunnels { error in
+                if let error = error {
+                    self.logger.error(
+                        error: error,
+                        message: "Failed to load persistent tunnels."
+                    )
+                }
+                operation.finish()
+            }
+        }
 
         let migrateSettingsOperation = AsyncBlockOperation(dispatchQueue: .main) { operation in
             SettingsManager.migrateStore(with: self.proxyFactory) { error in
@@ -128,6 +144,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
             }
         }
+        migrateSettingsOperation.addDependency(loadTunnelsOperation)
 
         let loadTunnelConfigurationOperation =
             AsyncBlockOperation(dispatchQueue: .main) { operation in
@@ -148,7 +165,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         loadTunnelConfigurationOperation.addDependency(migrateSettingsOperation)
 
         operationQueue.addOperations(
-            [migrateSettingsOperation, loadTunnelConfigurationOperation],
+            [loadTunnelsOperation, migrateSettingsOperation, loadTunnelConfigurationOperation],
             waitUntilFinished: false
         )
 

--- a/ios/MullvadVPN/SimulatorTunnelProvider.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider.swift
@@ -85,7 +85,7 @@ class SimulatorTunnelProviderDelegate {
     }
 }
 
-class SimulatorTunnelProvider {
+final class SimulatorTunnelProvider {
     static let shared = SimulatorTunnelProvider()
 
     private let lock = NSLock()
@@ -223,7 +223,9 @@ class SimulatorVPNConnection: NSObject, VPNConnectionProtocol {
 
 // MARK: - NETunnelProviderSession stubs
 
-class SimulatorTunnelProviderSession: SimulatorVPNConnection, VPNTunnelProviderSessionProtocol {
+final class SimulatorTunnelProviderSession: SimulatorVPNConnection,
+    VPNTunnelProviderSessionProtocol
+{
     func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
         SimulatorTunnelProvider.shared.handleAppMessage(
             messageData,
@@ -267,7 +269,7 @@ private struct SimulatorTunnelInfo {
     init() {}
 }
 
-class SimulatorTunnelProviderManager: VPNTunnelProviderManagerProtocol, Equatable {
+final class SimulatorTunnelProviderManager: NSObject, VPNTunnelProviderManagerProtocol {
     static let tunnelsLock = NSRecursiveLock()
     fileprivate static var tunnels = [SimulatorTunnelInfo]()
 
@@ -370,12 +372,14 @@ class SimulatorTunnelProviderManager: VPNTunnelProviderManagerProtocol, Equatabl
         completionHandler(tunnelProviders, nil)
     }
 
-    required convenience init() {
-        self.init(tunnelInfo: SimulatorTunnelInfo())
+    override required init() {
+        tunnelInfo = SimulatorTunnelInfo()
+        super.init()
     }
 
     private init(tunnelInfo: SimulatorTunnelInfo) {
         self.tunnelInfo = tunnelInfo
+        super.init()
     }
 
     func loadFromPreferences(completionHandler: (Error?) -> Void) {

--- a/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProviderHost.swift
@@ -17,7 +17,7 @@ import RelayCache
 import RelaySelector
 import TunnelProviderMessaging
 
-class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
+final class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
     private var selectorResult: RelaySelectorResult?
     private let urlSession = REST.makeURLSession()
     private var proxiedRequests = [UUID: URLSessionDataTask]()

--- a/ios/MullvadVPN/TransportMonitor/PacketTunnelTransport.swift
+++ b/ios/MullvadVPN/TransportMonitor/PacketTunnelTransport.swift
@@ -11,15 +11,14 @@ import protocol MullvadREST.RESTTransport
 import MullvadTypes
 import TunnelProviderMessaging
 
-final class PacketTunnelTransport: RESTTransport {
+struct PacketTunnelTransport: RESTTransport {
     var name: String {
         return "packet-tunnel"
     }
 
-    let tunnelManager: TunnelManager
-
-    init(tunnelManager: TunnelManager) {
-        self.tunnelManager = tunnelManager
+    let tunnel: Tunnel
+    init(tunnel: Tunnel) {
+        self.tunnel = tunnel
     }
 
     func sendRequest(
@@ -28,7 +27,7 @@ final class PacketTunnelTransport: RESTTransport {
     ) throws -> Cancellable {
         let proxyRequest = try ProxyURLRequest(id: UUID(), urlRequest: request)
 
-        return try tunnelManager.sendRequest(proxyRequest) { result in
+        return tunnel.sendRequest(proxyRequest) { result in
             switch result {
             case .cancelled:
                 completion(nil, nil, URLError(.cancelled))

--- a/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
@@ -22,25 +22,11 @@ class LoadTunnelConfigurationOperation: ResultOperation<Void, Error> {
     }
 
     override func main() {
-        TunnelProviderManagerType.loadAllFromPreferences { tunnels, error in
-            self.dispatchQueue.async {
-                if let error = error {
-                    self.finish(completion: .failure(error))
-                } else {
-                    self.didLoadVPNConfigurations(tunnels: tunnels)
-                }
-            }
-        }
-    }
-
-    private func didLoadVPNConfigurations(tunnels: [TunnelProviderManagerType]?) {
         let settingsResult = readSettings()
         let deviceStateResult = readDeviceState()
 
-        let tunnel = tunnels?.first.map { tunnelProvider in
-            return Tunnel(tunnelProvider: tunnelProvider)
-        }
-
+        let persistentTunnels = interactor.getPersistentTunnels()
+        let tunnel = persistentTunnels.first
         let settings = settingsResult.flattenValue()
         let deviceState = deviceStateResult.flattenValue()
 

--- a/ios/MullvadVPN/TunnelManager/TunnelConfiguration.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelConfiguration.swift
@@ -1,0 +1,26 @@
+//
+//  TunnelConfiguration.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 07/12/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import NetworkExtension
+
+struct TunnelConfiguration {
+    var isEnabled: Bool
+    var localizedDescription: String
+    var protocolConfiguration: NETunnelProviderProtocol
+    var onDemandRules: [NEOnDemandRule]
+    var isOnDemandEnabled: Bool
+
+    func apply(to manager: TunnelProviderManagerType) {
+        manager.isEnabled = isEnabled
+        manager.localizedDescription = localizedDescription
+        manager.protocolConfiguration = protocolConfiguration
+        manager.onDemandRules = onDemandRules
+        manager.isOnDemandEnabled = isOnDemandEnabled
+    }
+}

--- a/ios/MullvadVPN/TunnelManager/TunnelInteractor.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelInteractor.swift
@@ -14,6 +14,9 @@ protocol TunnelInteractor {
     // MARK: - Tunnel manipulation
 
     var tunnel: Tunnel? { get }
+
+    func getPersistentTunnels() -> [Tunnel]
+    func createNewTunnel() -> Tunnel
     func setTunnel(_ tunnel: Tunnel?, shouldRefreshTunnelState: Bool)
 
     // MARK: - Tunnel status

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -50,6 +50,7 @@ final class TunnelManager: StorePaymentObserver {
     // MARK: - Internal variables
 
     private let application: UIApplication
+    fileprivate let tunnelStore: TunnelStore
     private let relayCacheTracker: RelayCacheTracker
     private let accountsProxy: REST.AccountsProxy
     private let devicesProxy: REST.DevicesProxy
@@ -87,11 +88,13 @@ final class TunnelManager: StorePaymentObserver {
 
     init(
         application: UIApplication,
+        tunnelStore: TunnelStore,
         relayCacheTracker: RelayCacheTracker,
         accountsProxy: REST.AccountsProxy,
         devicesProxy: REST.DevicesProxy
     ) {
         self.application = application
+        self.tunnelStore = tunnelStore
         self.relayCacheTracker = relayCacheTracker
         self.accountsProxy = accountsProxy
         self.devicesProxy = devicesProxy
@@ -536,20 +539,6 @@ final class TunnelManager: StorePaymentObserver {
             },
             completionHandler: completionHandler
         )
-    }
-
-    /// Send URL request via packet tunnel process bypassing VPN.
-    /// This function is primarily used by `PacketTunnelTransport` to go outside of VPN when the
-    /// tunnel is broken.
-    func sendRequest(
-        _ proxyRequest: ProxyURLRequest,
-        completionHandler: @escaping (OperationCompletion<ProxyURLResponse, Error>) -> Void
-    ) throws -> Cancellable {
-        if let tunnel = tunnel {
-            return tunnel.sendRequest(proxyRequest, completionHandler: completionHandler)
-        } else {
-            throw UnsetTunnelError()
-        }
     }
 
     // MARK: - Tunnel observeration
@@ -1018,6 +1007,14 @@ private struct TunnelInteractorProxy: TunnelInteractor {
 
     var tunnel: Tunnel? {
         return tunnelManager.tunnel
+    }
+
+    func getPersistentTunnels() -> [Tunnel] {
+        return tunnelManager.tunnelStore.getPersistentTunnels()
+    }
+
+    func createNewTunnel() -> Tunnel {
+        return tunnelManager.tunnelStore.createNewTunnel()
     }
 
     func setTunnel(_ tunnel: Tunnel?, shouldRefreshTunnelState: Bool) {

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -1,0 +1,119 @@
+//
+//  TunnelStore.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 07/12/2022.
+//  Copyright © 2022 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+import NetworkExtension
+import UIKit
+
+/// Wrapper around system VPN tunnels.
+final class TunnelStore: TunnelStatusObserver {
+    private let logger = Logger(label: "TunnelStore")
+    private let lock = NSLock()
+
+    /// Persistent tunnels registered with the system.
+    private var persistentTunnels: [Tunnel] = []
+
+    /// Newly created tunnels, stored as collection of weak boxes.
+    private var newTunnels: [WeakBox<Tunnel>] = []
+
+    init(application: UIApplication) {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive(_:)),
+            name: UIApplication.didBecomeActiveNotification,
+            object: application
+        )
+    }
+
+    func getPersistentTunnels() -> [Tunnel] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return persistentTunnels
+    }
+
+    func loadPersistentTunnels(completion: @escaping (Error?) -> Void) {
+        TunnelProviderManagerType.loadAllFromPreferences { managers, error in
+            self.lock.lock()
+            defer {
+                self.lock.unlock()
+
+                completion(error)
+            }
+
+            guard error == nil else { return }
+
+            self.persistentTunnels.forEach { tunnel in
+                tunnel.removeObserver(self)
+            }
+
+            self.persistentTunnels = managers?.map { manager in
+                let tunnel = Tunnel(tunnelProvider: manager)
+                tunnel.addObserver(self)
+
+                self.logger.debug(
+                    "Loaded persistent tunnel: \(tunnel.logFormat()) with status: \(tunnel.status)."
+                )
+
+                return tunnel
+            } ?? []
+        }
+    }
+
+    func createNewTunnel() -> Tunnel {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let tunnelProviderManager = TunnelProviderManagerType()
+        let tunnel = Tunnel(tunnelProvider: tunnelProviderManager)
+        tunnel.addObserver(self)
+
+        newTunnels = newTunnels.filter { $0.value != nil }
+        newTunnels.append(WeakBox(tunnel))
+
+        logger.debug("Create new tunnel: \(tunnel.logFormat()).")
+
+        return tunnel
+    }
+
+    func tunnel(_ tunnel: Tunnel, didReceiveStatus status: NEVPNStatus) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        handleTunnelStatus(tunnel: tunnel, status: status)
+    }
+
+    private func handleTunnelStatus(tunnel: Tunnel, status: NEVPNStatus) {
+        if status == .invalid, let index = persistentTunnels.firstIndex(of: tunnel) {
+            persistentTunnels.remove(at: index)
+            logger.debug("Persistent tunnel was removed: \(tunnel.logFormat()).")
+        }
+
+        if status != .invalid, let index = newTunnels.firstIndex(where: { $0.value == tunnel }) {
+            newTunnels.remove(at: index)
+            persistentTunnels.append(tunnel)
+            logger.debug("New tunnel became persistent: \(tunnel.logFormat()).")
+        }
+    }
+
+    @objc private func applicationDidBecomeActive(_ notification: Notification) {
+        refreshStatus()
+    }
+
+    private func refreshStatus() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let allTunnels = persistentTunnels + newTunnels.compactMap { $0.value }
+
+        for tunnel in allTunnels {
+            handleTunnelStatus(tunnel: tunnel, status: tunnel.status)
+        }
+    }
+}


### PR DESCRIPTION
1. Introduce `TunnelStore` to list and create VPN configurations (see `Tunnel` as well)
2. Introduce `TunnelConfiguration` as a way to apply configuration to the system VPN configuration.
3. Remove `TunnelManager.sendRequest()` since `Tunnel` already provides means for IPC.
4. Rework `PacketTunnelTransport` to accept `Tunnel`. Adapt `TransportMonitor`.
5. Listen to `UIApplication.didBecomeActiveNotification` in `TunnelManager` and automatically refresh the tunnel status.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4198)
<!-- Reviewable:end -->
