### PR TITLE
Suppress CVE-2021-37533

### DIFF
--- a/android/config/dependency-check-suppression.xml
+++ b/android/config/dependency-check-suppression.xml
@@ -21,4 +21,19 @@
         <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-javalite@.*$</packageUrl>
         <cve>CVE-2022-3171</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This CVE affects the Apache Commons Net's FTP client that this app doesn't use.
+        https://www.openwall.com/lists/oss-security/2022/12/03/1
+
+        File names:
+        - commons-beanutils-1.9.4.jar
+        - commons-collections-3.2.2.jar
+        - commons-digester-2.1.jar
+        - commons-logging-1.2.jar
+        - commons-validator-1.7.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/commons\-.*/commons\-.*@.*$</packageUrl>
+        <cve>CVE-2021-37533</cve>
+    </suppress>
 </suppressions>

--- a/android/e2e/e2e-suppression.xml
+++ b/android/e2e/e2e-suppression.xml
@@ -28,4 +28,19 @@
         <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-javalite@.*$</packageUrl>
         <cve>CVE-2022-3171</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        This CVE affects the Apache Commons Net's FTP client that this app doesn't use.
+        https://www.openwall.com/lists/oss-security/2022/12/03/1
+
+        File names:
+        - commons-beanutils-1.9.4.jar
+        - commons-collections-3.2.2.jar
+        - commons-digester-2.1.jar
+        - commons-logging-1.2.jar
+        - commons-validator-1.7.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/commons\-.*/commons\-.*@.*$</packageUrl>
+        <cve>CVE-2021-37533</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
This CVE affects the Apache Commons Net's FTP client that this app doesn't use. https://www.openwall.com/lists/oss-security/2022/12/03/1

File names:
- commons-beanutils-1.9.4.jar
- commons-collections-3.2.2.jar
- commons-digester-2.1.jar
- commons-logging-1.2.jar
- commons-validator-1.7.jar

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4201)
<!-- Reviewable:end -->
