### PR TITLE
Ignore potentially spurious errors when removing app files

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -855,6 +855,7 @@
 	# If $INSTDIR is gone or can be removed, proceed anyway
 	#
 	IfFileExists $INSTDIR\*.* 0 customUnInstallCheck_Done
+	ClearErrors
 	RMDir /r $INSTDIR
 	IfErrors 0 customUnInstallCheck_Done
 
@@ -1086,6 +1087,7 @@
 
 	# Remove application files
 	log::Log "Deleting $INSTDIR"
+	ClearErrors
 	RMDir /r $INSTDIR
 	IfErrors 0 customRemoveFiles_final_cleanup
 
@@ -1138,6 +1140,8 @@
 	${EndIf}
 
 	${UnloadPlugins}
+
+	ClearErrors
 
 	Pop $R0
 	Pop $1


### PR DESCRIPTION
`RMDir` doesn't appear to reset the error flag if it succeeds. The error flag may be set for many reasons prior to it being called, but only reasons that we can safely ignore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4202)
<!-- Reviewable:end -->
