### PR TITLE
Return non-zero status if sending a problem report fails

### DIFF
--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -127,14 +127,10 @@ fn send_problem_report(
     report_path: &Path,
 ) -> Result<(), Error> {
     let cache_dir = mullvad_paths::get_cache_dir().map_err(Error::ObtainCacheDirectory)?;
-    match mullvad_problem_report::send_problem_report(
-        user_email,
-        user_message,
-        report_path,
-        &cache_dir,
-    ) {
-        Ok(()) => println!("Problem report sent"),
-        Err(e) => eprintln!("{}", e.display_chain()),
-    }
-    Ok(())
+    mullvad_problem_report::send_problem_report(user_email, user_message, report_path, &cache_dir)
+        .map(|()| println!("Problem report sent"))
+        .map_err(|error| {
+            eprintln!("{}", error.display_chain());
+            error
+        })
 }


### PR DESCRIPTION
Previously, the GUI would always report that the problem report was successfully sent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4212)
<!-- Reviewable:end -->
