### PR TITLE
Allow problem reports to be sent in blocking states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix regression where WireGuard relays were connected to over OpenVPN after a couple of failed
   attempts, when the tunnel type was set to `any`.
 - Fix missing connect timeout when connecting to a WireGuard relay over TCP.
+- Fix inability to send problem report in the error state on macOS and Linux. Previously, it would
+  fail but appear to succeed.
 
 #### macOS
 - Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "mullvad-api",
  "mullvad-paths",
  "mullvad-version",
+ "nix 0.23.1",
  "regex",
  "talpid-platform-metadata",
  "talpid-types",

--- a/dist-assets/linux/after-install.sh
+++ b/dist-assets/linux/after-install.sh
@@ -2,6 +2,7 @@
 set -eu
 
 chmod u+s "/usr/bin/mullvad-exclude"
+chmod u+s "/usr/bin/mullvad-problem-report"
 
 systemctl enable "/usr/lib/systemd/system/mullvad-daemon.service"
 systemctl start mullvad-daemon.service

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -71,6 +71,8 @@ mkdir -p /usr/local/bin
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad" /usr/local/bin/mullvad
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-problem-report" /usr/local/bin/mullvad-problem-report
 
+chmod u+s "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-problem-report"
+
 mkdir -p "$ZSH_COMPLETIONS_DIR"
 ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/_mullvad" "$ZSH_COMPLETIONS_DIR/_mullvad"
 

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -28,6 +28,9 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 [target.'cfg(target_os = "android")'.dependencies]
 duct = "0.13"
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+nix = "0.23"
+
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"


### PR DESCRIPTION
Use the setuid bit to ensure that `mullvad-problem-report` can send problem reports. The effective uid is set to the uid of the current user. It is then temporarily restored to 0 just before the report is sent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4221)
<!-- Reviewable:end -->
