### PR TITLE
Add build configs for embedded frameworks

### DIFF
--- a/ios/BuildInstructions.md
+++ b/ios/BuildInstructions.md
@@ -183,10 +183,7 @@ xcrun altool --store-password-in-keychain-item <KEYCHAIN_ITEM_NAME> \
 Copy template files of Xcode build configuration:
 
 ```
-cp ./ios/Configurations/Base.xcconfig.template ./ios/Configurations/Base.xcconfig
-cp ./ios/Configurations/App.xcconfig.template ./ios/Configurations/App.xcconfig
-cp ./ios/Configurations/PacketTunnel.xcconfig.template ./ios/Configurations/PacketTunnel.xcconfig
-cp ./ios/Configurations/Screenshots.xcconfig.template ./ios/Configurations/Screenshots.xcconfig
+for file in ./ios/Configurations/*.template ; do cp $file ${file//.template/} ; done
 ```
 
 Template files provide our team ID and correct provisioning profiles and generally do not require 

--- a/ios/Configurations/.gitignore
+++ b/ios/Configurations/.gitignore
@@ -1,4 +1,1 @@
-Base.xcconfig
-App.xcconfig
-PacketTunnel.xcconfig
-Screenshots.xcconfig
+*.xcconfig

--- a/ios/Configurations/App.xcconfig.template
+++ b/ios/Configurations/App.xcconfig.template
@@ -3,4 +3,4 @@
 // Provisioning profiles
 // Comment out the lines below if using automatic code sign
 PROVISIONING_PROFILE_SPECIFIER[config=Debug][sdk=*][arch=*] = Mullvad VPN Development
-PROVISIONING_PROFILE_SPECIFIER[config=Release][sdk=*][arch=*] = Mullvad VPN Distribution
+PROVISIONING_PROFILE_SPECIFIER[config=Release][sdk=*][arch=*] = Mullvad VPN Release

--- a/ios/Configurations/Base.xcconfig.template
+++ b/ios/Configurations/Base.xcconfig.template
@@ -10,3 +10,7 @@ SECURITY_GROUP_IDENTIFIER = group.net.mullvad.MullvadVPN
 // Code signing style
 // Possible values: Manual or Automatic
 CODE_SIGN_STYLE = Manual
+
+// Code signing identity
+CODE_SIGN_IDENTITY[config=Debug] = Apple Development
+CODE_SIGN_IDENTITY[config=Release] = Apple Distribution

--- a/ios/Configurations/PacketTunnel.xcconfig.template
+++ b/ios/Configurations/PacketTunnel.xcconfig.template
@@ -3,4 +3,4 @@
 // Provisioning profiles
 // Comment out the lines below if using automatic code sign
 PROVISIONING_PROFILE_SPECIFIER[config=Debug][sdk=*][arch=*] = Packet Tunnel Development
-PROVISIONING_PROFILE_SPECIFIER[config=Release][sdk=*][arch=*] = Packet Tunnel Distribution
+PROVISIONING_PROFILE_SPECIFIER[config=Release][sdk=*][arch=*] = Packet Tunnel Release

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -2545,11 +2545,11 @@
 /* Begin XCBuildConfiguration section */
 		063F027B2902B63F001FA09F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5808273928487E3E006B77A4 /* Base.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2565,9 +2565,12 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.mullvad.RelayCache;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER).RelayCache";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2578,11 +2581,11 @@
 		};
 		063F027C2902B63F001FA09F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5808273928487E3E006B77A4 /* Base.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2598,9 +2601,12 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.mullvad.RelayCache;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER).RelayCache";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2631,9 +2637,12 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.mullvad.MullvadREST;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER).MullvadREST";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2664,9 +2673,12 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = net.mullvad.MullvadREST;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER).MullvadREST";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3116,7 +3128,6 @@
 		};
 		58E5126928DDF04200B0BCDE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5808273928487E3E006B77A4 /* Base.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";


### PR DESCRIPTION
1. Rename provisioning specifier to `Mullvad VPN Release` since this is what we use.
2. Set code signing identity (`CODE_SIGN_IDENTITY`) to generic Apple Development in debug builds and Apple Distribution in release builds. This should solve compilation issues for embedded frameworks; they don't need separate provisioning profiles.
3. Use `APPLICATION_IDENTIFIER` to form the bundle ID of embedded frameworks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4222)
<!-- Reviewable:end -->
