### PR TITLE
Fix uninstall_macos.sh failing when brew is not found

### DIFF
--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -30,13 +30,8 @@ sudo rm -f /usr/local/share/zsh/site-functions/_mullvad
 
 echo "Removing fish shell completion symlink ..."
 
-BREW_PREFIX=$(brew --prefix)
-if [[ "$?" -eq 0 ]]; then
-    FISH_COMPLETIONS_PATH="${BREW_PREFIX}/share/fish/vendor_completions.d/mullvad.fish"
-    sudo rm -f "$FISH_COMPLETIONS_PATH"
-fi
-FISH_COMPLETIONS_PATH="/usr/local/share/fish/vendor_completions.d/mullvad.fish"
-sudo rm -f "$FISH_COMPLETIONS_PATH"
+sudo rm -f "/opt/homebrew/share/fish/vendor_completions.d/mullvad.fish"
+sudo rm -f "/usr/local/share/fish/vendor_completions.d/mullvad.fish"
 
 echo "Removing CLI symlinks from /usr/local/bin/ ..."
 sudo rm -f /usr/local/bin/mullvad /usr/local/bin/mullvad-problem-report


### PR DESCRIPTION
`postinstall` puts the completions in either `/opt/homebrew/share/fish/vendor_completions.d/` or `/usr/local/share/fish/vendor_completions.d/`, so let's just keep it simple and always delete both of those paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4230)
<!-- Reviewable:end -->
