### PR TITLE
Reconnect tunnel after migration from AppDelegate

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -84,9 +84,6 @@ final class TunnelManager: StorePaymentObserver {
     /// Last processed device check identifier.
     private var lastDeviceCheckIdentifier: UUID?
 
-    /// Flag indicating tunnel reconnected after settings migration.
-    private var reconnectedTunnelAfterMigration = false
-
     // MARK: - Initialization
 
     init(
@@ -696,14 +693,6 @@ final class TunnelManager: StorePaymentObserver {
             // Start polling tunnel status to keep the relay information up to date
             // while the tunnel process is trying to connect.
             startPollingTunnelStatus(interval: establishingTunnelStatusPollInterval)
-
-            if newTunnelStatus.packetTunnelStatus.lastErrors.contains(.readConfiguration),
-               !reconnectedTunnelAfterMigration
-            {
-                reconnectTunnel(selectNewRelay: true)
-
-                reconnectedTunnelAfterMigration = true
-            }
 
         case .connected, .waitingForConnectivity:
             // Start polling tunnel status to keep connectivity status up to date.


### PR DESCRIPTION
We used to reconnect the tunnel from `TunnelManager` in response to connection status event. However this assumption doesn't quite work, because exactly the same tunnel status is being returned on subsequent poll attempts and so we usually discard/ignore those and thus never reconnect the tuunnel.

However since we know when we do migration, we can restart the tunnel right after, somewhere from `AppDelegate`. This PR adds additional `SettingsMigrationResult` type that informs us in regards of how migration went and so if it succeeded then we restart the tunnel. In other cases, hopefully tunnel manager should discard the tunnel during initialization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4231)
<!-- Reviewable:end -->
