### PR TITLE
Fix navigation transition raceconditions for e2e tests

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -27,7 +27,7 @@
         "styled-components": "^5.1.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.26.1",
+        "@playwright/test": "^1.27.1",
         "@types/chai": "^4.3.3",
         "@types/chai-as-promised": "^7.1.5",
         "@types/chai-spies": "^1.0.3",
@@ -70,7 +70,7 @@
         "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^5.0.1",
         "pkg": "^5.8.0",
-        "playwright": "^1.26.1",
+        "playwright": "^1.27.1",
         "prettier": "^2.2.1",
         "sinon": "^14.0.1",
         "ts-node": "^10.9.1",
@@ -1099,13 +1099,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-      "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.26.1"
+        "playwright-core": "1.27.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11387,13 +11387,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.1.tgz",
-      "integrity": "sha512-WQmEdCgYYe8jOEkhkW9QLcK0PB+w1RZztBLYIT10MEEsENYg251cU0IzebDINreQsUt+HCwwRhtdz4weH9ICcQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.27.1.tgz",
+      "integrity": "sha512-xXYZ7m36yTtC+oFgqH0eTgullGztKSRMb4yuwLPl8IYSmgBM88QiB+3IWb1mRIC9/NNwcgbG0RwtFlg+EAFQHQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.26.1"
+        "playwright-core": "1.27.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11403,9 +11403,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -15779,13 +15779,13 @@
       }
     },
     "@playwright/test": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-      "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.26.1"
+        "playwright-core": "1.27.1"
       }
     },
     "@protobufjs/aspromise": {
@@ -23965,18 +23965,18 @@
       }
     },
     "playwright": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.1.tgz",
-      "integrity": "sha512-WQmEdCgYYe8jOEkhkW9QLcK0PB+w1RZztBLYIT10MEEsENYg251cU0IzebDINreQsUt+HCwwRhtdz4weH9ICcQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.27.1.tgz",
+      "integrity": "sha512-xXYZ7m36yTtC+oFgqH0eTgullGztKSRMb4yuwLPl8IYSmgBM88QiB+3IWb1mRIC9/NNwcgbG0RwtFlg+EAFQHQ==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.26.1"
+        "playwright-core": "1.27.1"
       }
     },
     "playwright-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true
     },
     "plist": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -33,7 +33,7 @@
     "nseventmonitor": "^1.0.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.26.1",
+    "@playwright/test": "^1.27.1",
     "@types/chai": "^4.3.3",
     "@types/chai-as-promised": "^7.1.5",
     "@types/chai-spies": "^1.0.3",
@@ -76,7 +76,7 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^5.0.1",
     "pkg": "^5.8.0",
-    "playwright": "^1.26.1",
+    "playwright": "^1.27.1",
     "prettier": "^2.2.1",
     "sinon": "^14.0.1",
     "ts-node": "^10.9.1",

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -780,6 +780,9 @@ export default class AppRenderer {
 
         switch (this.loginState) {
           case 'none':
+            reduxAccount.loggedIn(accountToken, device);
+            this.resetNavigation();
+            break;
           case 'logging in':
             reduxAccount.loggedIn(accountToken, device);
 
@@ -792,10 +795,6 @@ export default class AppRenderer {
           case 'creating account':
             reduxAccount.accountCreated(accountToken, device, new Date().toISOString());
             break;
-        }
-
-        if (this.loginState !== 'logging in' && this.loginState !== 'creating account') {
-          this.resetNavigation();
         }
         break;
       }

--- a/gui/src/renderer/components/AppRouter.tsx
+++ b/gui/src/renderer/components/AppRouter.tsx
@@ -59,7 +59,7 @@ export default function AppRouter() {
   return (
     <Focus ref={focusRef}>
       <TransitionContainer onTransitionEnd={onNavigation} {...transition}>
-        <TransitionView viewId={currentLocation.key || ''}>
+        <TransitionView viewId={currentLocation.key || ''} routePath={history.location.pathname}>
           <Switch key={currentLocation.key} location={currentLocation}>
             <Route exact path={RoutePath.launch} component={Launch} />
             <Route exact path={RoutePath.login} component={LoginPage} />

--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -6,6 +6,7 @@ import { WillExit } from '../lib/will-exit';
 
 interface ITransitioningViewProps {
   viewId: string;
+  routePath: string;
   children?: React.ReactNode;
 }
 
@@ -47,25 +48,28 @@ export const StyledTransitionContainer = styled.div(
   }),
 );
 
-export const StyledTransitionContent = styled.div({}, (props: { transition?: IItemStyle }) => {
-  const x = `${props.transition?.x ?? 0}%`;
-  const y = `${props.transition?.y ?? 0}%`;
-  const duration = props.transition?.duration ?? 450;
+export const StyledTransitionContent = styled.div.attrs({ 'data-testid': 'transition-content' })(
+  {},
+  (props: { transition?: IItemStyle }) => {
+    const x = `${props.transition?.x ?? 0}%`;
+    const y = `${props.transition?.y ?? 0}%`;
+    const duration = props.transition?.duration ?? 450;
 
-  return {
-    display: 'flex',
-    flexDirection: 'column',
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0,
-    zIndex: props.transition?.inFront ? 1 : 0,
-    willChange: 'transform',
-    transform: `translate3d(${x}, ${y}, 0)`,
-    transition: `transform ${duration}ms ease-in-out`,
-  };
-});
+    return {
+      display: 'flex',
+      flexDirection: 'column',
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      zIndex: props.transition?.inFront ? 1 : 0,
+      willChange: 'transform',
+      transform: `translate3d(${x}, ${y}, 0)`,
+      transition: `transform ${duration}ms ease-in-out`,
+    };
+  },
+);
 
 export const StyledTransitionView = styled.div({
   display: 'flex',
@@ -77,7 +81,11 @@ export const StyledTransitionView = styled.div({
 
 export class TransitionView extends React.Component<ITransitioningViewProps> {
   public render() {
-    return <StyledTransitionView>{this.props.children}</StyledTransitionView>;
+    return (
+      <StyledTransitionView data-testid={this.props.routePath}>
+        {this.props.children}
+      </StyledTransitionView>
+    );
   }
 }
 

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -221,7 +221,7 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
     const city = this.props.city === undefined ? '' : relayLocations.gettext(this.props.city);
     return (
       <LocationRow>
-        <StyledMarquee data-test-id="city">{city}</StyledMarquee>
+        <StyledMarquee data-testid="city">{city}</StyledMarquee>
       </LocationRow>
     );
   }
@@ -231,7 +231,7 @@ export default class TunnelControl extends React.Component<ITunnelControlProps> 
       this.props.country === undefined ? '' : relayLocations.gettext(this.props.country);
     return (
       <LocationRow>
-        <StyledMarquee data-test-id="country">{country}</StyledMarquee>
+        <StyledMarquee data-testid="country">{country}</StyledMarquee>
       </LocationRow>
     );
   }

--- a/gui/test/e2e/installed/requires-input/login.spec.ts
+++ b/gui/test/e2e/installed/requires-input/login.spec.ts
@@ -26,7 +26,7 @@ test('App should go from login view to main view when daemon logs in', async () 
   expect(await util.currentRoute()).toEqual(RoutePath.login);
 
   // Waiting for the daemon to log in
-  expect(await util.nextRoute()).toEqual(RoutePath.main);
+  expect(await util.waitForNavigation()).toEqual(RoutePath.main);
 
   await assertDisconnected(page);
 });

--- a/gui/test/e2e/installed/state-dependent/location.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/location.spec.ts
@@ -1,13 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { Page } from 'playwright';
 
-import { TestUtils } from '../../utils';
 import { startInstalledApp } from '../installed-utils';
 
 // This test expects the daemon to be logged into an account that has time left.
 
 let page: Page;
-let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
@@ -18,10 +16,10 @@ test.afterAll(async () => {
 });
 
 test('App should have a country', async () => {
-  const countryLabel = util.getByTestId('country');
+  const countryLabel = page.getByTestId('country');
   await expect(countryLabel).not.toBeEmpty();
 
-  const cityLabel = util.getByTestId('city');
+  const cityLabel = page.getByTestId('city');
   const noCityLabel = await cityLabel.count() === 0;
   expect(noCityLabel).toBeTruthy();
 });

--- a/gui/test/e2e/installed/state-dependent/location.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/location.spec.ts
@@ -8,7 +8,7 @@ import { startInstalledApp } from '../installed-utils';
 let page: Page;
 
 test.beforeAll(async () => {
-  ({ page, util } = await startInstalledApp());
+  ({ page } = await startInstalledApp());
 });
 
 test.afterAll(async () => {

--- a/gui/test/e2e/mocked/mocked-utils.ts
+++ b/gui/test/e2e/mocked/mocked-utils.ts
@@ -55,13 +55,17 @@ type SendMockIpcResponseProps<T> = {
   response: T;
 };
 
-export type SendMockIpcResponse = ReturnType<typeof generateMockIpcHandle>;
+export type SendMockIpcResponse = ReturnType<typeof generateSendMockIpcResponse>;
 
 export const generateSendMockIpcResponse = (electronApp: ElectronApplication) => {
   return async <T>({ channel, response }: SendMockIpcResponseProps<T>) => {
     await electronApp.evaluate(
       ({ webContents }, { channel, response }) => {
-        webContents.getAllWebContents()[0].send(channel, response);
+        webContents
+          .getAllWebContents()
+          // Select window that isn't devtools
+          .find((webContents) => webContents.getURL().startsWith('file://'))!
+          .send(channel, response);
       },
       { channel, response },
     );

--- a/gui/test/e2e/mocked/settings.spec.ts
+++ b/gui/test/e2e/mocked/settings.spec.ts
@@ -9,7 +9,7 @@ let util: MockedTestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startMockedApp());
-  await page.click('button[aria-label="Settings"]');
+  await util.waitForNavigation(() => page.click('button[aria-label="Settings"]'));
 });
 
 test.afterAll(async () => {

--- a/gui/test/e2e/setup/main.ts
+++ b/gui/test/e2e/setup/main.ts
@@ -140,7 +140,6 @@ class ApplicationMain {
 
     this.registerIpcListeners();
 
-    // @ts-ignore
     const filePath = path.resolve(path.join(__dirname, '../../../src/renderer/index.html'));
     await window.loadFile(filePath);
 

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -7,7 +7,6 @@ export interface StartAppResponse {
 }
 
 export interface TestUtils {
-  getByTestId: (id: string) => Locator;
   currentRoute: () => Promise<void>;
   nextRoute: () => Promise<string>;
 }
@@ -27,7 +26,6 @@ export const startApp = async (options: LaunchOptions): Promise<StartAppResponse
   page.on('console', (msg) => console.log(msg.text()));
 
   const util: TestUtils = {
-    getByTestId: (id: string) => page.locator(`data-test-id=${id}`),
     currentRoute: currentRouteFactory(app),
     nextRoute: nextRouteFactory(app),
   };

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -42,7 +42,10 @@ export const launch = async (options: LaunchOptions): Promise<ElectronApplicatio
 
   await app.evaluate(({ webContents }) => {
     return new Promise((resolve) => {
-      webContents.getAllWebContents()[0].once('did-finish-load', resolve);
+      webContents.getAllWebContents()
+          // Select window that isn't devtools
+          .find((webContents) => webContents.getURL().startsWith('file://'))!
+          .once('did-finish-load', resolve);
     });
   });
 
@@ -52,7 +55,10 @@ export const launch = async (options: LaunchOptions): Promise<ElectronApplicatio
 const currentRouteFactory = (app: ElectronApplication) => {
   return async () => {
     return await app.evaluate(({ webContents }) => {
-      return webContents.getAllWebContents()[0].executeJavaScript('window.e2e.location');
+      return webContents.getAllWebContents()
+          // Select window that isn't devtools
+          .find((webContents) => webContents.getURL().startsWith('file://'))!
+          .executeJavaScript('window.e2e.location');
     });
   };
 }

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -58,7 +58,10 @@ const waitForNavigationFactory = (
   app: ElectronApplication,
   page: Page,
 ) => {
+  // Wait for navigation animation to finish. A function can be provided that initiates the
+  // navigation, e.g. clicks a button.
   return async (initiateNavigation?: () => Promise<void> | void) => {
+    // Wait for route to change after optionally initiating the navigation.
     const [route] = await Promise.all([
       waitForNextRoute(app),
       initiateNavigation?.(),
@@ -67,6 +70,7 @@ const waitForNavigationFactory = (
     // Wait for view corresponding to new route to appear
     await page.getByTestId(route).isVisible();
 
+    // Wait until there's only one transitionContents
     const transitionContents = page.getByTestId('transition-content');
     let  transitionContentsCount;
     do {
@@ -81,6 +85,7 @@ const waitForNavigationFactory = (
   };
 };
 
+// Returns the route when it changes
 const waitForNextRoute = async (app: ElectronApplication): Promise<string> => {
   return await app.evaluate(({ ipcMain }) => {
     return new Promise((resolve) => {


### PR DESCRIPTION
This PR fixes a few race conditions related to transitions when running e2e tests.
* `startApp` now waits for initial navigation to finish.
* Function `waitForNavigation` wait's for navigation and transition to finish.
* Make sure the tests interact with the correct `webContents` when the devtools window is open.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4251)
<!-- Reviewable:end -->
