### PR TITLE
Remove ⌘Q (Cmd-Q) hotkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Remove all settings when the app is uninstalled silently.
 
+### Removed
+#### macOS
+- Remove ⌘Q shortcut.
+
 ### Fixed
 - When a country is selected, and the constraints only match relays that are not included on the
   country level, select those relays anyway.

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -411,9 +411,9 @@ export default class UserInterface implements WindowControllerDelegate {
   // On macOS, hotkeys are bound to the app menu and won't work if it's not set,
   // even though the app menu itself is not visible because the app does not appear in the dock.
   private setMacOsAppMenu() {
-    const mullvadVpnSubmenu: Electron.MenuItemConstructorOptions[] = [{ role: 'quit' }];
+    const mullvadVpnSubmenu: Electron.MenuItemConstructorOptions[] = [];
     if (process.env.NODE_ENV === 'development') {
-      mullvadVpnSubmenu.unshift({ role: 'reload' }, { role: 'forceReload' });
+      mullvadVpnSubmenu.unshift({ role: 'quit' }, { role: 'reload' }, { role: 'forceReload' });
     }
 
     const template: Electron.MenuItemConstructorOptions[] = [


### PR DESCRIPTION
This PR removes the ⌘Q shortcut from app builds. The shortcut was confusing since it didn't disconnect the tunnel as when quitting with the "Disconnect & quit" button. If we were to change it to also disconnecting, then users would risk accidentally disconnecting the tunnel by pressing the shortcut.

Closes https://github.com/mullvad/mullvadvpn-app/issues/4250.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4252)
<!-- Reviewable:end -->
