### PR TITLE
Add word break hyphen

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -33,6 +33,7 @@ import AppRouter from './components/AppRouter';
 import { Changelog } from './components/Changelog';
 import ErrorBoundary from './components/ErrorBoundary';
 import KeyboardNavigation from './components/KeyboardNavigation';
+import Lang from './components/Lang';
 import MacOsScrollbarDetection from './components/MacOsScrollbarDetection';
 import { ModalContainer } from './components/Modal';
 import { AppContext } from './context';
@@ -264,17 +265,19 @@ export default class AppRenderer {
     return (
       <AppContext.Provider value={{ app: this }}>
         <Provider store={this.reduxStore}>
-          <Router history={this.history.asHistory}>
-            <ErrorBoundary>
-              <ModalContainer>
-                <KeyboardNavigation>
-                  <AppRouter />
-                  <Changelog />
-                </KeyboardNavigation>
-                {window.env.platform === 'darwin' && <MacOsScrollbarDetection />}
-              </ModalContainer>
-            </ErrorBoundary>
-          </Router>
+          <Lang>
+            <Router history={this.history.asHistory}>
+              <ErrorBoundary>
+                <ModalContainer>
+                  <KeyboardNavigation>
+                    <AppRouter />
+                    <Changelog />
+                  </KeyboardNavigation>
+                  {window.env.platform === 'darwin' && <MacOsScrollbarDetection />}
+                </ModalContainer>
+              </ErrorBoundary>
+            </Router>
+          </Lang>
         </Provider>
       </AppContext.Provider>
     );

--- a/gui/src/renderer/components/Lang.tsx
+++ b/gui/src/renderer/components/Lang.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+import { useSelector } from '../redux/store';
+
+const StyledLang = styled.div({
+  display: 'flex',
+  flex: '1',
+});
+
+export default function Lang(props: PropsWithChildren) {
+  const locale = useSelector((state) => state.userInterface.locale);
+  return <StyledLang lang={locale}>{props.children}</StyledLang>;
+}

--- a/gui/src/renderer/components/SettingsHeader.tsx
+++ b/gui/src/renderer/components/SettingsHeader.tsx
@@ -20,6 +20,7 @@ export const ContentWrapper = styled.div({
 
 export const HeaderTitle = styled.span(hugeText, {
   wordWrap: 'break-word',
+  hyphens: 'auto',
 });
 export const HeaderSubTitle = styled.span(tinyText, {
   color: colors.white60,


### PR DESCRIPTION
This PR adds hyphens to words that are broken apart in settings headers. This is done by adding the `lang` attribute to an element at the top of the tree and adding `hyphen: auto` to the title element.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4259)
<!-- Reviewable:end -->
