### PR TITLE
Prevent red cell icons after visiting the split tunneling view on Linux

### DIFF
--- a/gui/src/renderer/components/cell/Label.tsx
+++ b/gui/src/renderer/components/cell/Label.tsx
@@ -33,7 +33,7 @@ const StyledTintedIcon = styled(ImageView).attrs((props: IImageViewProps) => ({
   ':hover': {
     backgroundColor: props.tintColor,
   },
-  [`${CellButton}:not(:disabled):hover &`]: {
+  [`${CellButton}:not(:disabled):hover &&`]: {
     backgroundColor: props.tintHoverColor,
   },
 }));


### PR DESCRIPTION
This PR makes the icon in `Label.tsx` set the hover style only to the same instance, not to all instances of the component. This error caused cell icons to be red after visiting the split tunneling view on Linux.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4260)
<!-- Reviewable:end -->
