### PR TITLE
Fix Send Anyway button in problem report

### DIFF
--- a/gui/src/renderer/components/ProblemReport.tsx
+++ b/gui/src/renderer/components/ProblemReport.tsx
@@ -451,7 +451,7 @@ const ProblemReportContextProvider = ({ children }: { children: ReactNode }) => 
         // No-op
       }
     }
-  }, [email]);
+  }, [email, sendState]);
 
   /**
    * Save the form whenever email or message gets updated


### PR DESCRIPTION
This PR adds a missing dependency to the `onSend` function in the problem report view. The missing dependency caused the problem report to not send after confirming to send it without an email address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4263)
<!-- Reviewable:end -->
