### PR TITLE
Fix position of connection panel when overflowing

### DIFF
--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -34,13 +34,13 @@ const Body = styled.div({
   display: 'flex',
   flexDirection: 'column',
   padding: `0 ${measurements.viewMargin}`,
-  marginTop: '176px',
-  flex: 1,
+  minHeight: '170px',
 });
 
 const Wrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
+  justifyContent: 'end',
   flex: 1,
 });
 


### PR DESCRIPTION
This PR fixes the overflowing of the connection panel that happens on Linux (and probably other platforms) when the window is too small.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4264)
<!-- Reviewable:end -->
