### PR TITLE
Fix window height being too small

### DIFF
--- a/gui/src/main/window-controller.ts
+++ b/gui/src/main/window-controller.ts
@@ -318,10 +318,7 @@ export default class WindowController {
       case 'win32':
         // On Windows the app height ends up slightly lower than we set it to if running in unpinned
         // mode and the app becomes a tiny bit taller when pinned to task bar.
-        return unpinnedWindow ? contentHeight + 19 : contentHeight - 1;
-      case 'linux':
-        // On Linux the app ends up slightly lower than we set it to.
-        return contentHeight - 25;
+        return unpinnedWindow ? contentHeight + 25 : contentHeight;
       default:
         return contentHeight;
     }

--- a/gui/src/renderer/components/TunnelControl.tsx
+++ b/gui/src/renderer/components/TunnelControl.tsx
@@ -34,7 +34,7 @@ const Body = styled.div({
   display: 'flex',
   flexDirection: 'column',
   padding: `0 ${measurements.viewMargin}`,
-  minHeight: '170px',
+  minHeight: '185px',
 });
 
 const Wrapper = styled.div({


### PR DESCRIPTION
This PR fixes an issue where the app isn't high enough. It seems to be improssible to set an exact height so the change here makes it default to be too big which prevents UI glitches at least.

I've also changed the `TunnelControl` `min-height` to accomodate for the IPv6 out-IP to not make the content above jump when the connection panel is expanded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4266)
<!-- Reviewable:end -->
