### PR TITLE
Remove Rust dependencies from Android that were unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,7 +3238,6 @@ dependencies = [
  "err-derive",
  "futures",
  "ipnetwork",
- "jnix",
  "lazy_static",
  "libc",
  "log",

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 cfg-if = "1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
-clap = { version = "3.0", features = ["cargo"] }
 err-derive = "0.3.1"
 fern = { version = "0.6", features = ["colored"] }
 futures = "0.3"
@@ -18,7 +17,6 @@ ipnetwork = "0.16"
 lazy_static = "1.0"
 libc = "0.2"
 log = "0.4"
-log-panics = "2.0.0"
 parking_lot = "0.11"
 rand = "0.8.5"
 regex = "1.0"
@@ -28,7 +26,6 @@ tokio = { version = "1.8", features =  ["fs", "io-util", "rt-multi-thread", "syn
 tokio-stream = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 
-mullvad-paths = { path = "../mullvad-paths" }
 mullvad-relay-selector = { path = "../mullvad-relay-selector" }
 mullvad-types = { path = "../mullvad-types" }
 mullvad-api = { path = "../mullvad-api" }
@@ -39,7 +36,10 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 talpid-time = { path = "../talpid-time" }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
+clap = { version = "3.0", features = ["cargo"] }
+log-panics = "2.0.0"
 mullvad-management-interface = { path = "../mullvad-management-interface" }
+mullvad-paths = { path = "../mullvad-paths" }
 
 [target.'cfg(target_os="android")'.dependencies]
 android_logger = "0.8"

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 
 [dependencies]
 err-derive = "0.3.1"
+
+[target.'cfg(not(target_os="android"))'.dependencies]
 log = "0.4"
 
 [target.'cfg(windows)'.dependencies]

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-clap = { version = "3.0", features = ["cargo"] }
 dirs-next = "2.0"
-env_logger = "0.8.2"
 err-derive = "0.3.1"
 lazy_static = "1.0"
 log = "0.4"
@@ -24,10 +22,12 @@ mullvad-version = { path = "../mullvad-version" }
 talpid-types = { path = "../talpid-types" }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 
+[target.'cfg(not(target_os="android"))'.dependencies]
+clap = { version = "3.0", features = ["cargo"] }
+env_logger = "0.8.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 duct = "0.13"
-
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/mullvad-version/Cargo.toml
+++ b/mullvad-version/Cargo.toml
@@ -13,5 +13,5 @@ what version string a build should have. This crate is responsible for computing
 and other formats.
 """
 
-[dependencies]
+[target.'cfg(not(target_os="android"))'.dependencies]
 regex = "1.6.0"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 bitflags = "1.2"
 async-trait = "0.1"
-atty = "0.2"
 cfg-if = "1.0"
 duct = "0.13"
 err-derive = "0.3.1"
@@ -24,37 +23,36 @@ log = "0.4"
 os_pipe = "0.9"
 parking_lot = "0.11"
 regex = "1.1.0"
-shell-escape = "0.1"
 talpid-routing = { path = "../talpid-routing" }
 talpid-types = { path = "../talpid-types" }
 talpid-time = { path = "../talpid-time" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-wireguard = { path = "../talpid-wireguard" }
-uuid = { version = "0.8", features = ["v4"] }
 zeroize = "1"
 chrono = "0.4.21"
 tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
 rand = "0.8.5"
-shadowsocks-service = { version = "1.14.3", default-features = false, features = ["local", "stream-cipher"] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
+atty = "0.2"
 byteorder = "1"
 internet-checksum = "0.2"
+shadowsocks-service = { version = "1.14.3", default-features = false, features = ["local", "stream-cipher"] }
+shell-escape = "0.1"
 socket2 = { version = "0.4.2", features = ["all"] }
+prost = "0.11"
 parity-tokio-ipc = "0.9"
 talpid-openvpn = { path = "../talpid-openvpn" }
 triggered = "0.1.1"
 tonic = "0.8"
-prost = "0.11"
+uuid = { version = "0.8", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
 
-
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.5", features = ["derive"] }
-
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inotify = "0.10"

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -13,13 +13,10 @@ err-derive = "0.3.1"
 futures = "0.3.15"
 ipnetwork = "0.16"
 log = "0.4"
-talpid-types = { path = "../talpid-types" }
 tokio = { version = "1.8", features = ["process", "rt-multi-thread"] }
 
-
-[target.'cfg(target_os = "android")'.dependencies]
-jnix = { version = "0.5", features = ["derive"] }
-
+[target.'cfg(not(target_os="android"))'.dependencies]
+talpid-types = { path = "../talpid-types" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -16,7 +16,7 @@ talpid-types = { path = "../talpid-types" }
 futures = "0.3.15"
 tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 duct = "0.13"
 nix = "0.23"
 


### PR DESCRIPTION
I ran `cargo udeps` towards the `aarch64-linux-android` target and found these to be unused.

I'll prepare a separate PR for running `cargo udeps --target aarch64-linux-android` in CI to catch future unused dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4271)
<!-- Reviewable:end -->
