### PR TITLE
Settings coordinator

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -223,10 +223,12 @@
 		58B993B12608A34500BA7811 /* LoginContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B993B02608A34500BA7811 /* LoginContentView.swift */; };
 		58B9EB152489139B00095626 /* RESTError+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B9EB142489139B00095626 /* RESTError+Display.swift */; };
 		58BA693123EADA6A009DC256 /* SimulatorTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */; };
+		58BBB38B29708E8600C8DB7C /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BBB38A29708E8600C8DB7C /* Navigator.swift */; };
 		58BFA5C622A7C97F00A6173D /* RelayCacheTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5C522A7C97F00A6173D /* RelayCacheTracker.swift */; };
 		58BFA5CC22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
 		58C3A4B222456F1B00340BDB /* AccountInputGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3A4B122456F1A00340BDB /* AccountInputGroupView.swift */; };
 		58C3F4F92964B08300D72515 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3F4F82964B08300D72515 /* MapViewController.swift */; };
+		58C3F4FB296C3AD500D72515 /* SettingsNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3F4FA296C3AD500D72515 /* SettingsNavigationCoordinator.swift */; };
 		58CC40EF24A601900019D96E /* ObserverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CC40EE24A601900019D96E /* ObserverList.swift */; };
 		58CCA010224249A1004F3011 /* TunnelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA00F224249A1004F3011 /* TunnelViewController.swift */; };
 		58CCA01222424D11004F3011 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA01122424D11004F3011 /* SettingsViewController.swift */; };
@@ -829,10 +831,12 @@
 		58B9EB122488ED2100095626 /* AlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresenter.swift; sourceTree = "<group>"; };
 		58B9EB142489139B00095626 /* RESTError+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RESTError+Display.swift"; sourceTree = "<group>"; };
 		58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorTunnelProvider.swift; sourceTree = "<group>"; };
+		58BBB38A29708E8600C8DB7C /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		58BFA5C522A7C97F00A6173D /* RelayCacheTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCacheTracker.swift; sourceTree = "<group>"; };
 		58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationConfiguration.swift; sourceTree = "<group>"; };
 		58C3A4B122456F1A00340BDB /* AccountInputGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInputGroupView.swift; sourceTree = "<group>"; };
 		58C3F4F82964B08300D72515 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
+		58C3F4FA296C3AD500D72515 /* SettingsNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationCoordinator.swift; sourceTree = "<group>"; };
 		58CC40EE24A601900019D96E /* ObserverList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverList.swift; sourceTree = "<group>"; };
 		58CCA00F224249A1004F3011 /* TunnelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelViewController.swift; sourceTree = "<group>"; };
 		58CCA01122424D11004F3011 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
@@ -1471,6 +1475,8 @@
 				584D26C5270C8741004EA533 /* SettingsDNSTextCell.swift */,
 				580F8B88281A79A7002E0998 /* SettingsManager */,
 				58E6771E24ADFE7800AA26E7 /* SettingsNavigationController.swift */,
+				58C3F4FA296C3AD500D72515 /* SettingsNavigationCoordinator.swift */,
+				58BBB38A29708E8600C8DB7C /* Navigator.swift */,
 				5867770F290975E8006F721F /* SettingsInteractorFactory.swift */,
 				584D26C1270C8542004EA533 /* SettingsStaticTextFooterView.swift */,
 				58ACF64A26553C3F00ACE4B7 /* SettingsSwitchCell.swift */,
@@ -2294,6 +2300,7 @@
 				5867771429097BCD006F721F /* PaymentState.swift in Sources */,
 				587D96742886D87C00CD8F1C /* DeviceManagementContentView.swift in Sources */,
 				589A454C28DDF5E100565204 /* Swizzle.swift in Sources */,
+				58C3F4FB296C3AD500D72515 /* SettingsNavigationCoordinator.swift in Sources */,
 				5857F24724C882D700CF6F47 /* SelectLocationNavigationController.swift in Sources */,
 				5846227126E229F20035F7C2 /* StoreSubscription.swift in Sources */,
 				58421030282D8A3C00F24E46 /* UpdateAccountDataOperation.swift in Sources */,
@@ -2424,6 +2431,7 @@
 				587D9676288989DB00CD8F1C /* NSLayoutConstraint+Helpers.swift in Sources */,
 				58293FAE2510CA58005D0BB5 /* ProblemReportViewController.swift in Sources */,
 				58B9EB152489139B00095626 /* RESTError+Display.swift in Sources */,
+				58BBB38B29708E8600C8DB7C /* Navigator.swift in Sources */,
 				587B753F2668E5A700DEF7E9 /* NotificationContainerView.swift in Sources */,
 				58421034282E4B1500F24E46 /* TunnelSettingsV2+REST.swift in Sources */,
 				58ACA9ED2979569500B5825C /* ModalRootAdaptivePresentationDelegate.swift in Sources */,

--- a/ios/MullvadVPN/Navigator.swift
+++ b/ios/MullvadVPN/Navigator.swift
@@ -1,0 +1,63 @@
+//
+//  Navigator.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 12/01/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+class Navigator: NSObject, UINavigationControllerDelegate {
+    private var animationDidFinish: (() -> Void)?
+
+    let navigationController: UINavigationController
+    var willShow: ((UIViewController) -> Void)?
+
+    var children: [UIViewController] {
+        return navigationController.viewControllers
+    }
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+        super.init()
+
+        navigationController.delegate = self
+    }
+
+    func replace(_ children: [UIViewController], animated: Bool, completion: (() -> Void)? = nil) {
+        animationDidFinish = completion
+        navigationController.setViewControllers(children, animated: animated)
+    }
+
+    func push(_ child: UIViewController, animated: Bool, completion: (() -> Void)? = nil) {
+        animationDidFinish = completion
+        navigationController.pushViewController(child, animated: animated)
+    }
+
+    func popToRoot(animated: Bool, completion: (() -> Void)? = nil) {
+        animationDidFinish = completion
+        navigationController.popToRootViewController(animated: animated)
+    }
+
+    // MARK: - UINavigationControllerDelegate
+
+    func navigationController(
+        _ navigationController: UINavigationController,
+        willShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        willShow?(viewController)
+    }
+
+    func navigationController(
+        _ navigationController: UINavigationController,
+        didShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        let completionHandler = animationDidFinish
+        animationDidFinish = nil
+
+        completionHandler?()
+    }
+}

--- a/ios/MullvadVPN/SettingsNavigationController.swift
+++ b/ios/MullvadVPN/SettingsNavigationController.swift
@@ -8,39 +8,7 @@
 
 import UIKit
 
-enum SettingsNavigationRoute {
-    case root
-    case account
-    case preferences
-    case problemReport
-}
-
-enum SettingsDismissReason {
-    case none
-    case userLoggedOut
-}
-
-protocol SettingsNavigationControllerDelegate: AnyObject {
-    func settingsNavigationController(
-        _ controller: SettingsNavigationController,
-        willNavigateTo route: SettingsNavigationRoute
-    )
-
-    func settingsNavigationController(
-        _ controller: SettingsNavigationController,
-        didFinishWithReason reason: SettingsDismissReason
-    )
-}
-
-class SettingsNavigationController: UINavigationController, SettingsViewControllerDelegate,
-    AccountViewControllerDelegate, UIAdaptivePresentationControllerDelegate,
-    UINavigationControllerDelegate
-{
-    private let interactorFactory: SettingsInteractorFactory
-    private var currentRoutes: [SettingsNavigationRoute] = [.root]
-
-    weak var settingsDelegate: SettingsNavigationControllerDelegate?
-
+final class SettingsNavigationController: UINavigationController {
     override var childForStatusBarStyle: UIViewController? {
         return topViewController
     }
@@ -49,120 +17,13 @@ class SettingsNavigationController: UINavigationController, SettingsViewControll
         return topViewController
     }
 
-    init(interactorFactory: SettingsInteractorFactory) {
-        self.interactorFactory = interactorFactory
-
+    init() {
         super.init(navigationBarClass: CustomNavigationBar.self, toolbarClass: nil)
 
         navigationBar.prefersLargeTitles = true
-
-        // Navigation controller ignores `prefersLargeTitles` when using `setViewControllers()`.
-        pushViewController(makeViewController(for: .root), animated: false)
-
-        delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - UINavigationControllerDelegate
-
-    func navigationController(
-        _ navigationController: UINavigationController,
-        willShow viewController: UIViewController,
-        animated: Bool
-    ) {
-        let newRoutes = viewControllers.compactMap { route(for: $0) }
-
-        if currentRoutes != newRoutes, let nextRoute = newRoutes.last {
-            currentRoutes = newRoutes
-            settingsDelegate?.settingsNavigationController(self, willNavigateTo: nextRoute)
-        }
-    }
-
-    // MARK: - SettingsViewControllerDelegate
-
-    func settingsViewControllerDidFinish(_ controller: SettingsViewController) {
-        settingsDelegate?.settingsNavigationController(self, didFinishWithReason: .none)
-    }
-
-    // MARK: - AccountViewControllerDelegate
-
-    func accountViewControllerDidLogout(_ controller: AccountViewController) {
-        settingsDelegate?.settingsNavigationController(self, didFinishWithReason: .userLoggedOut)
-    }
-
-    // MARK: - Navigation
-
-    func navigate(to route: SettingsNavigationRoute, animated: Bool) {
-        guard route != .root else {
-            popToRootViewController(animated: animated)
-            return
-        }
-
-        settingsDelegate?.settingsNavigationController(self, willNavigateTo: route)
-
-        let nextViewController = makeViewController(for: route)
-
-        if let rootController = viewControllers.first, viewControllers.count > 1 {
-            let newChildren = [rootController, nextViewController]
-            let newRoutes = newChildren.compactMap { self.route(for: $0) }
-
-            currentRoutes = newRoutes
-            setViewControllers(newChildren, animated: animated)
-        } else {
-            currentRoutes.append(route)
-            pushViewController(nextViewController, animated: animated)
-        }
-    }
-
-    private func makeViewController(for route: SettingsNavigationRoute) -> UIViewController {
-        switch route {
-        case .root:
-            let controller = SettingsViewController(
-                interactor: interactorFactory.makeSettingsInteractor()
-            )
-            controller.delegate = self
-            return controller
-
-        case .account:
-            let controller = AccountViewController(
-                interactor: interactorFactory.makeAccountInteractor()
-            )
-            controller.delegate = self
-            return controller
-
-        case .preferences:
-            return PreferencesViewController(
-                interactor: interactorFactory.makePreferencesInteractor()
-            )
-
-        case .problemReport:
-            return ProblemReportViewController(
-                interactor: interactorFactory.makeProblemReportInteractor()
-            )
-        }
-    }
-
-    private func route(for viewController: UIViewController) -> SettingsNavigationRoute? {
-        switch viewController {
-        case is SettingsViewController:
-            return .root
-        case is AccountViewController:
-            return .account
-        case is PreferencesViewController:
-            return .preferences
-        case is ProblemReportViewController:
-            return .problemReport
-        default:
-            return nil
-        }
-    }
-
-    // MARK: - UIAdaptivePresentationControllerDelegate
-
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        settingsDelegate?.settingsNavigationController(self, didFinishWithReason: .none)
     }
 }

--- a/ios/MullvadVPN/SettingsNavigationCoordinator.swift
+++ b/ios/MullvadVPN/SettingsNavigationCoordinator.swift
@@ -1,0 +1,370 @@
+//
+//  SettingsNavigationCoordinator.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 09/01/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadLogging
+import Operations
+import SafariServices
+import UIKit
+
+enum SettingsNavigationRoute: Equatable {
+    case root
+    case account
+    case preferences
+    case problemReport
+    case faq
+
+    var isModalPresentation: Bool {
+        return self == .faq
+    }
+}
+
+enum SettingsDismissReason: Equatable {
+    case none
+    case userLoggedOut
+}
+
+protocol SettingsNavigationCoordinatorDelegate: AnyObject {
+    func settingsNavigationCoordinator(
+        _ coordinator: SettingsNavigationCoordinator,
+        willNavigateFrom source: SettingsNavigationRoute?,
+        to destination: SettingsNavigationRoute
+    )
+
+    func settingsNavigationCoordinator(
+        _ coordinator: SettingsNavigationCoordinator,
+        didFinishWithReason reason: SettingsDismissReason
+    )
+}
+
+final class SettingsNavigationCoordinator: NSObject, UIAdaptivePresentationControllerDelegate,
+    SettingsViewControllerDelegate, AccountViewControllerDelegate, SFSafariViewControllerDelegate
+{
+    private var navigator: Navigator?
+
+    private let interactorFactory: SettingsInteractorFactory
+    private var currentRoute: SettingsNavigationRoute?
+
+    private let transitionQueue = AsyncOperationQueue.makeSerial()
+    private let logger = Logger(label: "SettingsNavigationCoordinator")
+
+    weak var delegate: SettingsNavigationCoordinatorDelegate?
+
+    init(interactorFactory: SettingsInteractorFactory) {
+        self.interactorFactory = interactorFactory
+
+        super.init()
+    }
+
+    // MARK: - Presentation
+
+    var isPresented: Bool {
+        return navigator?.navigationController.isPresented ?? false
+    }
+
+    func present(
+        route: SettingsNavigationRoute?,
+        from parent: UIViewController,
+        animated: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        enqueueTransition { finish in
+            self.presentNoQueue(route: route, from: parent, animated: animated) {
+                completion?()
+                finish()
+            }
+        }
+    }
+
+    func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
+        enqueueTransition { finish in
+            self.dismissNoQueue(animated: animated) {
+                completion?()
+                finish()
+            }
+        }
+    }
+
+    // MARK: - Navigation
+
+    private func show(
+        route: SettingsNavigationRoute,
+        animated: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        enqueueTransition { finish in
+            self.showNoQueue(route: route, animated: animated) {
+                completion?()
+                finish()
+            }
+        }
+    }
+
+    private func showNoQueue(
+        route: SettingsNavigationRoute,
+        animated: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        guard let navigator = navigator else {
+            completion?()
+            return
+        }
+
+        showNoQueueInner(
+            navigator: navigator,
+            route: route,
+            animated: animated,
+            completion: completion
+        )
+    }
+
+    private func showNoQueueInner(
+        navigator: Navigator,
+        route: SettingsNavigationRoute,
+        animated: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        if route.isModalPresentation {
+            navigator.navigationController.present(
+                makeViewController(for: route),
+                animated: animated,
+                completion: completion
+            )
+        } else {
+            pushInline(
+                navigator: navigator,
+                route: route,
+                animated: animated,
+                completion: completion
+            )
+        }
+    }
+
+    private func presentNoQueue(
+        route: SettingsNavigationRoute?,
+        from parent: UIViewController,
+        animated: Bool,
+        completion: @escaping () -> Void
+    ) {
+        let isModalRoute = route?.isModalPresentation ?? false
+
+        if let navigator = navigator, let route = route {
+            showNoQueueInner(
+                navigator: navigator,
+                route: route,
+                animated: animated,
+                completion: completion
+            )
+        } else if navigator == nil, !isModalRoute {
+            let navigator = makeNavigator()
+            self.navigator = navigator
+
+            if let route = route {
+                pushInline(navigator: navigator, route: route, animated: false)
+            }
+
+            presentNavigator(navigator, from: parent, animated: animated, completion: completion)
+        } else {
+            completion()
+        }
+    }
+
+    private func dismissNoQueue(animated: Bool, completion: (() -> Void)? = nil) {
+        guard let navigator = navigator else {
+            completion?()
+            return
+        }
+
+        navigator.navigationController.dismiss(animated: animated) {
+            self.navigatorDidDismiss()
+            completion?()
+        }
+    }
+
+    private func pushInline(
+        navigator: Navigator,
+        route: SettingsNavigationRoute,
+        animated: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        switch route {
+        case .root:
+            navigator.popToRoot(animated: animated, completion: completion)
+
+        default:
+            let nextViewController = makeViewController(for: route)
+            let viewControllers = navigator.children
+
+            if let rootController = viewControllers.first, viewControllers.count > 1 {
+                navigator.replace(
+                    [rootController, nextViewController],
+                    animated: animated,
+                    completion: completion
+                )
+            } else {
+                navigator.push(nextViewController, animated: animated, completion: completion)
+            }
+        }
+    }
+
+    private func presentNavigator(
+        _ navigator: Navigator,
+        from parent: UIViewController,
+        animated: Bool,
+        completion: @escaping () -> Void
+    ) {
+        let navigationController = navigator.navigationController
+
+        guard !navigationController.isPresented else {
+            completion()
+            return
+        }
+
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            navigationController.preferredContentSize = CGSize(width: 480, height: 568)
+            navigationController.modalPresentationStyle = .formSheet
+        }
+
+        navigationController.presentationController?.delegate = self
+
+        parent.present(navigationController, animated: animated, completion: completion)
+    }
+
+    private func makeNavigator() -> Navigator {
+        let navigator = Navigator(navigationController: SettingsNavigationController())
+        navigator.push(makeViewController(for: .root), animated: false)
+        navigator.willShow = { [weak self] vc in
+            guard let self = self, let route = self.route(for: vc) else { return }
+
+            self.logger.debug(
+                "Navigate from \(self.currentRoute.map { "\($0)" } ?? "none") -> \(route)"
+            )
+
+            self.delegate?.settingsNavigationCoordinator(
+                self,
+                willNavigateFrom: self.currentRoute,
+                to: route
+            )
+
+            self.currentRoute = route
+        }
+        return navigator
+    }
+
+    private func navigatorDidDismiss() {
+        navigator = nil
+        currentRoute = nil
+    }
+
+    private func enqueueTransition(_ body: @escaping (_ finish: @escaping () -> Void) -> Void) {
+        let operation = AsyncBlockOperation(dispatchQueue: .main) { operation in
+            body {
+                operation.finish()
+            }
+        }
+        transitionQueue.addOperation(operation)
+    }
+
+    // MARK: - UIAdaptivePresentationControllerDelegate
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        navigatorDidDismiss()
+        delegate?.settingsNavigationCoordinator(self, didFinishWithReason: .none)
+    }
+
+    // MARK: - SettingsViewControllerDelegate
+
+    func settingsViewControllerDidFinish(_ controller: SettingsViewController) {
+        delegate?.settingsNavigationCoordinator(self, didFinishWithReason: .none)
+    }
+
+    func settingsViewController(
+        _ controller: SettingsViewController,
+        didRequestRoutePresentation route: SettingsNavigationRoute
+    ) {
+        show(route: route, animated: true)
+    }
+
+    // MARK: - AccountViewControllerDelegate
+
+    func accountViewControllerDidLogout(_ controller: AccountViewController) {
+        delegate?.settingsNavigationCoordinator(self, didFinishWithReason: .userLoggedOut)
+    }
+
+    // MARK: - Route mapping
+
+    private func makeViewController(for route: SettingsNavigationRoute) -> UIViewController {
+        switch route {
+        case .root:
+            let controller = SettingsViewController(
+                interactor: interactorFactory.makeSettingsInteractor()
+            )
+            controller.delegate = self
+            return controller
+
+        case .account:
+            let controller = AccountViewController(
+                interactor: interactorFactory.makeAccountInteractor()
+            )
+            controller.delegate = self
+            return controller
+
+        case .preferences:
+            return PreferencesViewController(
+                interactor: interactorFactory.makePreferencesInteractor()
+            )
+
+        case .problemReport:
+            return ProblemReportViewController(
+                interactor: interactorFactory.makeProblemReportInteractor()
+            )
+
+        case .faq:
+            let safariViewController = SFSafariViewController(
+                url: ApplicationConfiguration.faqAndGuidesURL
+            )
+            safariViewController.delegate = self
+
+            return safariViewController
+        }
+    }
+
+    private func route(for viewController: UIViewController) -> SettingsNavigationRoute? {
+        switch viewController {
+        case is SettingsViewController:
+            return .root
+        case is AccountViewController:
+            return .account
+        case is PreferencesViewController:
+            return .preferences
+        case is ProblemReportViewController:
+            return .problemReport
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - SFSafariViewControllerDelegate
+
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        enqueueTransition { finish in
+            controller.dismiss(animated: true, completion: finish)
+        }
+    }
+
+    func safariViewControllerWillOpenInBrowser(_ controller: SFSafariViewController) {
+        enqueueTransition { finish in
+            controller.dismiss(animated: false, completion: finish)
+        }
+    }
+}
+
+extension UIViewController {
+    var isPresented: Bool {
+        return presentingViewController != nil
+    }
+}

--- a/ios/MullvadVPN/SettingsViewController.swift
+++ b/ios/MullvadVPN/SettingsViewController.swift
@@ -7,16 +7,17 @@
 //
 
 import Foundation
-import SafariServices
 import UIKit
 
 protocol SettingsViewControllerDelegate: AnyObject {
     func settingsViewControllerDidFinish(_ controller: SettingsViewController)
+    func settingsViewController(
+        _ controller: SettingsViewController,
+        didRequestRoutePresentation route: SettingsNavigationRoute
+    )
 }
 
-class SettingsViewController: UITableViewController, SettingsDataSourceDelegate,
-    SFSafariViewControllerDelegate
-{
+class SettingsViewController: UITableViewController, SettingsDataSourceDelegate {
     weak var delegate: SettingsViewControllerDelegate?
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -71,29 +72,9 @@ class SettingsViewController: UITableViewController, SettingsDataSourceDelegate,
         _ dataSource: SettingsDataSource,
         didSelectItem item: SettingsDataSource.Item
     ) {
-        if let route = item.navigationRoute {
-            let settingsNavigationController = navigationController as? SettingsNavigationController
+        guard let route = item.navigationRoute else { return }
 
-            settingsNavigationController?.navigate(to: route, animated: true)
-        } else if case .faq = item {
-            let safariViewController = SFSafariViewController(
-                url: ApplicationConfiguration
-                    .faqAndGuidesURL
-            )
-            safariViewController.delegate = self
-
-            present(safariViewController, animated: true)
-        }
-    }
-
-    // MARK: - SFSafariViewControllerDelegate
-
-    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        controller.dismiss(animated: true)
-    }
-
-    func safariViewControllerWillOpenInBrowser(_ controller: SFSafariViewController) {
-        controller.dismiss(animated: false)
+        delegate?.settingsViewController(self, didRequestRoutePresentation: route)
     }
 }
 
@@ -109,7 +90,7 @@ extension SettingsDataSource.Item {
         case .problemReport:
             return .problemReport
         case .faq:
-            return nil
+            return .faq
         }
     }
 }


### PR DESCRIPTION
1. Drop `CustomNavigationViewController` and simply disable pop gesture in problem report VC.
2. Add `Navigator` class similar to what @sajacl proposed before for managing navigation controllers.
3. Add `AsyncOperationQueue.makeSerial()` to create serial operation queue to reduce boilerplate across the codebase.
4. Add `SettingsNavigationCoordinator` and move everything related to navigation from `SettingsNavigationController` into it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4275)
<!-- Reviewable:end -->
