### PR TITLE
Update onSend function when the report message changes

### DIFF
--- a/gui/src/renderer/components/ProblemReport.tsx
+++ b/gui/src/renderer/components/ProblemReport.tsx
@@ -451,7 +451,7 @@ const ProblemReportContextProvider = ({ children }: { children: ReactNode }) => 
         // No-op
       }
     }
-  }, [email, sendState]);
+  }, [email, sendReport, sendState]);
 
   /**
    * Save the form whenever email or message gets updated


### PR DESCRIPTION
Previously, the problem report tool didn't always receive the correct message from the UI as `onSend` was using a cached/outdated message. This PR fixes this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4279)
<!-- Reviewable:end -->
