### PR TITLE
Prevent firewall update with non-existent tunnel device in connecting state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix regression where WireGuard relays were connected to over OpenVPN after a couple of failed
   attempts, when the tunnel type was set to `any`.
 - Fix missing connect timeout when connecting to a WireGuard relay over TCP.
+- Fix failure to apply firewall rules that could occur when connecting timed out.
 
 #### macOS
 - Fix fish shell completions when installed via Homebrew on Apple Silicon Macs.

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -40,6 +40,8 @@ const MIN_TUNNEL_ALIVE_TIME: Duration = Duration::from_millis(1000);
 #[cfg(target_os = "windows")]
 const MAX_ADAPTER_FAIL_RETRIES: u32 = 4;
 
+const INITIAL_ALLOWED_TUNNEL_TRAFFIC: AllowedTunnelTraffic = AllowedTunnelTraffic::None;
+
 /// The tunnel has been started, but it is not established/functional.
 pub struct ConnectingState {
     tunnel_events: TunnelEventsReceiver,
@@ -208,7 +210,7 @@ impl ConnectingState {
             tunnel_events: event_rx.fuse(),
             tunnel_parameters: parameters,
             tunnel_metadata: None,
-            allowed_tunnel_traffic: AllowedTunnelTraffic::None,
+            allowed_tunnel_traffic: INITIAL_ALLOWED_TUNNEL_TRAFFIC,
             tunnel_close_event: tunnel_close_event_rx.fuse(),
             tunnel_close_tx,
             retry_attempt,
@@ -441,7 +443,15 @@ impl ConnectingState {
                 shared_values,
                 self.into_connected_state_bootstrap(metadata),
             )),
-            Some((TunnelEvent::Down, _)) => SameState(self.into()),
+            Some((TunnelEvent::Down, _)) => {
+                // It is important to reset this before the tunnel device is down,
+                // or else commands that reapply the firewall rules will fail since
+                // they refer to a non-existent device.
+                self.allowed_tunnel_traffic = INITIAL_ALLOWED_TUNNEL_TRAFFIC;
+                self.tunnel_metadata = None;
+
+                SameState(self.into())
+            }
             None => {
                 // The channel was closed
                 log::debug!("The tunnel disconnected unexpectedly");

--- a/talpid-tunnel/src/lib.rs
+++ b/talpid-tunnel/src/lib.rs
@@ -57,6 +57,6 @@ pub enum TunnelEvent {
     InterfaceUp(TunnelMetadata, AllowedTunnelTraffic),
     /// Sent when the tunnel comes up and is ready for traffic.
     Up(TunnelMetadata),
-    /// Sent when the tunnel goes down.
+    /// Sent when the tunnel goes down, but before destroying the tunnel device.
     Down,
 }

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -639,10 +639,11 @@ impl WireguardMonitor {
 
         let _ = self.pinger_stop_sender.send(());
 
-        self.stop_tunnel();
-
         self.runtime
             .block_on((self.event_callback)(TunnelEvent::Down));
+
+        self.stop_tunnel();
+
         wait_result
     }
 


### PR DESCRIPTION
Previously, setting the firewall rules would sometimes fail in the connecting state:

```
Error: Failed to apply firewall policy for connecting state
Caused by: Unable to translate network interface name "wg-mullvad" into index
Caused by: Failed to get index for interface wg-mullvad
Caused by: No such device (os error 19)
```

This was due to a race between the `AllowEndpoint` tunnel command and tunnel monitor shutdown. The command reapplies the current firewall rules, and if this occurs immediately after the tunnel device has been destroyed, the new rules may refer to a non-existent device.

This PR fixes this by sending `TunnelEvent::Down` to the tunnel state machine, where the tunnel metadata is cleared, and waiting for it to complete before actually destroying the tunnel device.

Closes #4243.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4282)
<!-- Reviewable:end -->
