### PR TITLE
Add helper to create serial operation queue

### DIFF
--- a/ios/MullvadREST/RESTAccessTokenManager.swift
+++ b/ios/MullvadREST/RESTAccessTokenManager.swift
@@ -14,15 +14,12 @@ import Operations
 extension REST {
     public final class AccessTokenManager {
         private let logger = Logger(label: "REST.AccessTokenManager")
-        private let operationQueue = AsyncOperationQueue()
+        private let operationQueue = AsyncOperationQueue.makeSerial()
         private let dispatchQueue = DispatchQueue(label: "REST.AccessTokenManager.dispatchQueue")
         private let proxy: AuthenticationProxy
         private var tokens = [String: AccessTokenData]()
 
         public init(authenticationProxy: AuthenticationProxy) {
-            operationQueue.name = "REST.AccessTokenManager.operationQueue"
-            operationQueue.maxConcurrentOperationCount = 1
-            operationQueue.underlyingQueue = dispatchQueue
             proxy = authenticationProxy
         }
 

--- a/ios/MullvadVPN/AddressCacheTracker.swift
+++ b/ios/MullvadVPN/AddressCacheTracker.swift
@@ -39,11 +39,7 @@ final class AddressCacheTracker {
     private var timer: DispatchSourceTimer?
 
     /// Operation queue.
-    private let operationQueue: AsyncOperationQueue = {
-        let operationQueue = AsyncOperationQueue()
-        operationQueue.maxConcurrentOperationCount = 1
-        return operationQueue
-    }()
+    private let operationQueue = AsyncOperationQueue.makeSerial()
 
     /// Lock used for synchronizing member access.
     private let nslock = NSLock()

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -25,11 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private var simulatorTunnelProviderHost: SimulatorTunnelProviderHost?
     #endif
 
-    private let operationQueue: AsyncOperationQueue = {
-        let operationQueue = AsyncOperationQueue()
-        operationQueue.maxConcurrentOperationCount = 1
-        return operationQueue
-    }()
+    private let operationQueue = AsyncOperationQueue.makeSerial()
 
     private(set) var tunnelStore: TunnelStore!
     private(set) var tunnelManager: TunnelManager!

--- a/ios/MullvadVPN/MapViewController.swift
+++ b/ios/MullvadVPN/MapViewController.swift
@@ -16,11 +16,7 @@ private let geoJSONSourceFileName = "countries.geo.json"
 
 final class MapViewController: UIViewController, MKMapViewDelegate {
     private let logger = Logger(label: "MapViewController")
-    private let animationQueue: AsyncOperationQueue = {
-        let animationQueue = AsyncOperationQueue()
-        animationQueue.maxConcurrentOperationCount = 1
-        return animationQueue
-    }()
+    private let animationQueue = AsyncOperationQueue.makeSerial()
 
     private let locationMarker = MKPointAnnotation()
     private var willChangeRegion = false

--- a/ios/MullvadVPN/Operations/AlertPresenter.swift
+++ b/ios/MullvadVPN/Operations/AlertPresenter.swift
@@ -13,12 +13,7 @@ public final class AlertPresenter {
     static let alertControllerDidDismissNotification = Notification
         .Name("UIAlertControllerDidDismiss")
 
-    private let operationQueue: OperationQueue = {
-        let operationQueue = AsyncOperationQueue()
-        operationQueue.name = "AlertPresenterQueue"
-        operationQueue.maxConcurrentOperationCount = 1
-        return operationQueue
-    }()
+    private let operationQueue = AsyncOperationQueue.makeSerial()
 
     private static let initClass: Void = {
         /// Swizzle `viewDidDisappear` on `UIAlertController` in order to be able to

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -32,11 +32,7 @@ final class RelayCacheTracker {
     private let nslock = NSLock()
 
     /// Internal operation queue.
-    private let operationQueue: OperationQueue = {
-        let operationQueue = AsyncOperationQueue()
-        operationQueue.maxConcurrentOperationCount = 1
-        return operationQueue
-    }()
+    private let operationQueue = AsyncOperationQueue.makeSerial()
 
     /// A timer source used for periodic updates.
     private var timerSource: DispatchSourceTimer?

--- a/ios/Operations/AsyncOperationQueue.swift
+++ b/ios/Operations/AsyncOperationQueue.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class AsyncOperationQueue: OperationQueue {
+public final class AsyncOperationQueue: OperationQueue {
     override public func addOperation(_ operation: Operation) {
         if let operation = operation as? AsyncOperation {
             let categories = operation.conditions
@@ -41,6 +41,12 @@ public class AsyncOperationQueue: OperationQueue {
                 operation.waitUntilFinished()
             }
         }
+    }
+
+    public static func makeSerial() -> AsyncOperationQueue {
+        let queue = AsyncOperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        return queue
     }
 }
 


### PR DESCRIPTION
This is a small PR that adds a convenience method to create serial operation queue `AsyncOperationQueue.makeSerial()`. We have quite a bunch of places where we rely on serial operation queues. I also dropped names of queues in most places as we don't really use them for anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4283)
<!-- Reviewable:end -->
