### PR TITLE
Fix potential division by zero

### DIFF
--- a/ios/MullvadVPN/MapViewController.swift
+++ b/ios/MullvadVPN/MapViewController.swift
@@ -179,6 +179,13 @@ final class MapViewController: UIViewController, MKMapViewDelegate {
 
         self.center = center
 
+        logger.debug(
+            """
+            Set map region to: (\(region.center.latitude), \(region.center.longitude), \
+            \(region.span.latitudeDelta), \(region.span.longitudeDelta))
+            """
+        )
+
         // Map view does not call delegate methods when attempting to set the same region.
         mapView.setRegion(region, animated: animated)
 
@@ -247,6 +254,7 @@ final class MapViewController: UIViewController, MKMapViewDelegate {
     ) -> MKCoordinateRegion {
         // Map view center lies within layout margins frame.
         let mapViewLayoutFrame = mapView.layoutMarginsGuide.layoutFrame
+        guard mapViewLayoutFrame.width > 0 else { return region }
 
         // MKMapView.convert(_:toRectTo:) returns CGRect scaled to the zoom level derived from
         // currently set region.


### PR DESCRIPTION
This PR guards against potential division by zero when computing map region. Which in turn produces invalid `MKCoordinateRegion` and causes `MKMapView` to throw NSException

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4285)
<!-- Reviewable:end -->
