### PR TITLE
Fix deadlock in set_tunnel_addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Line wrap the file at 100 chars.                                              Th
   Previously, the installer would abort.
 - Revert to using netsh for DNS config, as some Windows builds did not deal with changes correctly.
   `TALPID_DNS_MODULE` can be used to override this.
+- Fix deadlock that could occur when the default route changed while initializing split tunneling.
 
 ### Changed
 - Update Electron from 19.0.13 to 21.1.1.

--- a/talpid-routing/src/windows/mod.rs
+++ b/talpid-routing/src/windows/mod.rs
@@ -117,7 +117,7 @@ impl RouteManagerHandle {
                 response_tx,
             ))
             .map_err(|_| Error::RouteManagerDown)?;
-        response_rx.await.map_err(|_| Error::ManagerChannelDown)?
+        Ok(response_rx.await.map_err(|_| Error::ManagerChannelDown)?)
     }
 
     /// Applies the given routes while the route manager is running.
@@ -143,7 +143,7 @@ pub enum RouteManagerCommand {
     AddRoutes(HashSet<RequiredRoute>, oneshot::Sender<Result<()>>),
     GetMtuForRoute(IpAddr, oneshot::Sender<Result<u16>>),
     ClearRoutes,
-    RegisterDefaultRouteChangeCallback(Callback, oneshot::Sender<Result<CallbackHandle>>),
+    RegisterDefaultRouteChangeCallback(Callback, oneshot::Sender<CallbackHandle>),
     Shutdown,
 }
 
@@ -180,7 +180,7 @@ impl RouteManager {
             {
                 return Err(Error::RouteManagerDown);
             }
-            result_rx.await.map_err(|_| Error::ManagerChannelDown)?
+            Ok(result_rx.await.map_err(|_| Error::ManagerChannelDown)?)
         } else {
             Err(Error::RouteManagerDown)
         }

--- a/talpid-routing/src/windows/route_manager.rs
+++ b/talpid-routing/src/windows/route_manager.rs
@@ -458,18 +458,15 @@ impl RouteManagerInternal {
         Ok(())
     }
 
-    pub fn register_default_route_changed_callback(
-        &self,
-        callback: Callback,
-    ) -> Result<CallbackHandle> {
+    pub fn register_default_route_changed_callback(&self, callback: Callback) -> CallbackHandle {
         let (nonce, callbacks) = &mut *self.callbacks.lock().unwrap();
         let old_nonce = *nonce;
         callbacks.insert(old_nonce, callback);
         *nonce = nonce.wrapping_add(1);
-        Ok(CallbackHandle {
+        CallbackHandle {
             nonce: old_nonce,
             callbacks: self.callbacks.clone(),
-        })
+        }
     }
 
     fn default_route_change<'a>(


### PR DESCRIPTION
Previously, it was possible for a deadlock to occur in `set_tunnel_addresses` if it was called *and failed* at the same time as a route change occurred (i.e., if `split_tunnel_default_route_change_handler` was called at the right time). This PR fixes this by making sure that all mutexes are always released in the correct order.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4287)
<!-- Reviewable:end -->
