### PR TITLE
Convert rustfmt CI run to use stable rustfmt

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,23 +7,21 @@ on:
       - rustfmt.toml
       - '**/*.rs'
   workflow_dispatch:
-env:
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2023-01-13
 jobs:
   check-formatting:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install nightly Rust
         uses: actions-rs/toolchain@v1.0.6
         with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+          toolchain: stable
           components: rustfmt
           default: true
 
       - name: Check formatting
         run: |-
           rustfmt --version
-          cargo fmt -- --check --unstable-features
+          cargo fmt -- --check

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,10 +1,14 @@
+edition = "2021"
+
 # Activation of features, almost objectively better ;)
 use_try_shorthand = true
 use_field_init_shorthand = true
-condense_wildcard_suffixes = true
-normalize_comments = true
-wrap_comments = true
-imports_granularity = "Crate"
 
-# Heavily subjective style choices
+# Nightly only. Will not run in CI, but please format with these locally
+wrap_comments = true
+normalize_comments = true
 comment_width = 100
+
+condense_wildcard_suffixes = true
+
+imports_granularity = "Crate"


### PR DESCRIPTION
Requesting review from all Rust coders since it affects formatting / potentially the dev setup.

I still recommend you run the formatting locally with the nightly toolchain. That way we get the benefit of merging imports etc that we can't get on stable. But to avoid nightly breakages we run CI on stable. That means the CI will accept some formatting that `cargo +nightly fmt` can change. Does this feel OK? The downside is that someone will very likely merge such a change at some point (or maybe rather frequently) and then your local `cargo +nightly fmt` will change code you did not touch. The two alternatives I see include:
* Close this PR, continue using nightly on CI (this breaks from time to time)
* Use stable locally for formatting also and ignore the potential benefits that the nightly options might give us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4299)
<!-- Reviewable:end -->
