### PR TITLE
Extract adaptive presentation delegate

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		58A8EE5A2976BFBB009C0F8D /* SKError+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A8EE592976BFBB009C0F8D /* SKError+Localized.swift */; };
 		58A8EE5E2976DB00009C0F8D /* StorePaymentManagerError+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A8EE5D2976DB00009C0F8D /* StorePaymentManagerError+Display.swift */; };
 		58A99ED3240014A0006599E9 /* TermsOfServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A99ED2240014A0006599E9 /* TermsOfServiceViewController.swift */; };
+		58ACA9ED2979569500B5825C /* ModalRootAdaptivePresentationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACA9EC2979569500B5825C /* ModalRootAdaptivePresentationDelegate.swift */; };
 		58ACF6492655365700ACE4B7 /* PreferencesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACF6482655365700ACE4B7 /* PreferencesViewController.swift */; };
 		58ACF64B26553C3F00ACE4B7 /* SettingsSwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACF64A26553C3F00ACE4B7 /* SettingsSwitchCell.swift */; };
 		58ACF64D26567A5000ACE4B7 /* CustomSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ACF64C26567A4F00ACE4B7 /* CustomSwitch.swift */; };
@@ -803,6 +804,7 @@
 		58A8EE5D2976DB00009C0F8D /* StorePaymentManagerError+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorePaymentManagerError+Display.swift"; sourceTree = "<group>"; };
 		58A94AE326CFD945001CB97C /* TunnelStatusNotificationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelStatusNotificationProvider.swift; sourceTree = "<group>"; };
 		58A99ED2240014A0006599E9 /* TermsOfServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewController.swift; sourceTree = "<group>"; };
+		58ACA9EC2979569500B5825C /* ModalRootAdaptivePresentationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalRootAdaptivePresentationDelegate.swift; sourceTree = "<group>"; };
 		58ACF6482655365700ACE4B7 /* PreferencesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesViewController.swift; sourceTree = "<group>"; };
 		58ACF64A26553C3F00ACE4B7 /* SettingsSwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchCell.swift; sourceTree = "<group>"; };
 		58ACF64C26567A4F00ACE4B7 /* CustomSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSwitch.swift; sourceTree = "<group>"; };
@@ -1490,6 +1492,7 @@
 				58F7CA872692E34000FC59FD /* WireguardKeysContentView.swift */,
 				58E11187292FA11F009FCA84 /* SettingsMigrationUIHandler.swift */,
 				58A8EE592976BFBB009C0F8D /* SKError+Localized.swift */,
+				58ACA9EC2979569500B5825C /* ModalRootAdaptivePresentationDelegate.swift */,
 			);
 			path = MullvadVPN;
 			sourceTree = "<group>";
@@ -2413,6 +2416,7 @@
 				58B9EB152489139B00095626 /* RESTError+Display.swift in Sources */,
 				587B753F2668E5A700DEF7E9 /* NotificationContainerView.swift in Sources */,
 				58421034282E4B1500F24E46 /* TunnelSettingsV2+REST.swift in Sources */,
+				58ACA9ED2979569500B5825C /* ModalRootAdaptivePresentationDelegate.swift in Sources */,
 				58F2E144276A13F300A79513 /* StartTunnelOperation.swift in Sources */,
 				5868BD33261DCD2600E6027F /* CustomSplitViewController.swift in Sources */,
 				58CCA01E2242787B004F3011 /* AccountTextField.swift in Sources */,

--- a/ios/MullvadVPN/ModalRootAdaptivePresentationDelegate.swift
+++ b/ios/MullvadVPN/ModalRootAdaptivePresentationDelegate.swift
@@ -1,0 +1,127 @@
+//
+//  ModalRootAdaptivePresentationDelegate.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 19/01/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+/**
+
+ Adaptive presentation delegate for `SceneDelegate.modalRootContainer` used for presenting
+ the login flow on iPad.
+
+ The primary purpose of this class is to swap between fullscreen and formsheet presentation based
+ on horizontal size class and make settings (cog) accessible even when parent root is overlayed with
+ modal root.
+
+ Unlike iPhone where only one `RootContainerViewController` is used and behaves very much like
+ navigation controller, iPad uses two of such controllers defined as parent and (think child) modal
+ within this class.
+
+ ## iPhone view controller hierarchy
+
+ - UIWindow
+   - RootContainerViewController
+     - LoginViewController
+     - etc.
+
+ ## iPad view controller hierarchy
+
+ - UIWindow
+   - RootContainerViewController (parent)
+     - UISplitViewController
+       - TunnelViewController
+       - SelectLocationViewController
+     - RootContainerViewController (child [modal])
+       - LoginViewController
+       - etc.
+
+ */
+final class ModalRootAdaptivePresentationDelegate: NSObject,
+    UIAdaptivePresentationControllerDelegate
+{
+    let parentRootContainer: RootContainerViewController
+    let modalRootContainer: RootContainerViewController
+
+    init(
+        parentRootContainer: RootContainerViewController,
+        modalRootContainer: RootContainerViewController
+    ) {
+        self.parentRootContainer = parentRootContainer
+        self.modalRootContainer = modalRootContainer
+
+        super.init()
+    }
+
+    func finishPresentation() {
+        parentRootContainer.removeSettingsButtonFromPresentationContainer()
+    }
+
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        if controller.presentedViewController is RootContainerViewController {
+            return traitCollection.horizontalSizeClass == .regular ? .formSheet : .fullScreen
+        } else {
+            return .none
+        }
+    }
+
+    func presentationController(
+        _ presentationController: UIPresentationController,
+        willPresentWithAdaptiveStyle style: UIModalPresentationStyle,
+        transitionCoordinator: UIViewControllerTransitionCoordinator?
+    ) {
+        // The style is set to none when adaptive presentation is not changing.
+        let actualStyle: UIModalPresentationStyle = style == .none
+            ? presentationController.presentedViewController.modalPresentationStyle
+            : style
+
+        // Force hide header bar in .formSheet presentation and show it in .fullScreen presentation
+        modalRootContainer.setOverrideHeaderBarHidden(actualStyle == .formSheet, animated: false)
+
+        let transitionActions = {
+            if let containerView = self.modalRootContainer.modalPresentationContainerView {
+                self.parentRootContainer.addSettingsButtonToPresentationContainer(containerView)
+            }
+        }
+
+        if actualStyle == .formSheet {
+            // Add settings button into the modal container to make it accessible by users
+            if let transitionCoordinator = transitionCoordinator {
+                transitionCoordinator.animate { _ in
+                    transitionActions()
+                }
+            } else {
+                transitionActions()
+            }
+        } else {
+            // Move settings button back into header bar
+            finishPresentation()
+        }
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        finishPresentation()
+    }
+}
+
+private extension UIViewController {
+    /// Returns private `UITransitionView` used by UIKit that acts as a container view for modally
+    /// presented controllers. When implementing a presentation controller subclass, this view
+    /// is the one that is used to add additional decorations.
+    var modalPresentationContainerView: UIView? {
+        var currentView = view
+        let iterator = AnyIterator { () -> UIView? in
+            currentView = currentView?.superview
+            return currentView
+        }
+        return iterator.first { view -> Bool in
+            return view.description.starts(with: "<UITransitionView")
+        }
+    }
+}


### PR DESCRIPTION
Besides extracting adaptive presentation delegate for modal root, this PR also fixes issues in former implementation where `transitionCoordinator.containerView` used to return `UIWindow` when changing to split screen which made settings cog available in modal contexts above modal root.

New implementation makes a manual lookup of `UITransitionView` to ensure that the settings cog is added into the right container view.

In the future this better be replaced with `UISheetPresentationController` (iOS 15+) subclass but for now we'll keep adding the settings cog manually within the adaptivity call.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4300)
<!-- Reviewable:end -->
