### PR TITLE
Use a shorter and smarter include path list for the "Daemon+CLI" job

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -2,33 +2,27 @@
 name: Daemon+CLI - Build and test
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - .github/workflows/android*.yml
-      - .github/workflows/frontend.yml
-      - .github/workflows/ios.yml
-      - .github/workflows/rustfmt.yml
-      - .github/workflows/translations.yml
-      - android/**
-      - audits/**
-      - ci/buildserver-*
-      - ci/ci-*
-      - dist-assets/**
-      - docs/**
-      - graphics/**
-      - gui/**
-      - ios/**
-      - mullvad-jni/**
-      - scripts/**
-      - .*ignore
-      - .editorconfig
-      - .gitattributes
-      - Dockerfile
-      - build.sh
-      - build-apk.sh
-      - integration-tests.sh
-      - prepare-release.sh
-      - rustfmt.toml
+    paths:
+      - '**'
+      - '!**/**.md'
+      - '!.github/workflows/**'
+      - '.github/workflows/daemon.yml'
+      - '!android/**'
+      - '!audits/**'
+      - '!build-apk.sh'
+      - '!build.sh'
+      - '!clippy.toml'
+      - '!deny.toml'
+      - '!docs/**'
+      - '!graphics/**'
+      - '!gui/**'
+      - '!ios/**'
+      - '!scripts/**'
+      - '!.*ignore'
+      - '!prepare-release.sh'
+      - '!rustfmt.toml'
+      - '!.yamllint'
+
   workflow_dispatch:
     inputs:
       override_container_image:


### PR DESCRIPTION
Follow up to #4273 basically. The `Daemon+CLI` build job was triggered on a bunch of unrelated stuff. This change should make it more exact and at the same time clean up some old stuff that no longer exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4302)
<!-- Reviewable:end -->
