### PR TITLE
Move dist-assets/relays.json to build/relays.json

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           path: |
             ./android/app/build/extraJni
-            ./dist-assets/relays.json
+            ./build/relays.json
             ./dist-assets/api-ip-address.txt
           key: android-native-libs-${{ runner.os }}-x86_64-${{ steps.native-lib-cache-hash.outputs.native_lib_hash}}
 
@@ -94,7 +94,7 @@ jobs:
           NDK_TOOLCHAIN_STRIP_TOOL="$NDK_TOOLCHAIN_DIR/x86_64-linux-android-strip"
           ./wireguard/build-wireguard-go.sh --android --no-docker
           cargo build --target $TARGET --verbose --package mullvad-jni
-          cargo run --bin relay_list > dist-assets/relays.json
+          cargo run --bin relay_list > build/relays.json
           $NDK_TOOLCHAIN_STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
 
       - name: Build Android app

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 .idea/
 .DS_Store
 *.log
-/dist-assets/relays.json
 /dist-assets/mullvad
 /dist-assets/mullvad.exe
 /dist-assets/mullvad-daemon

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -153,7 +153,7 @@ configure<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension> {
 }
 
 tasks.register("copyExtraAssets", Copy::class) {
-    from("$repoRootPath/dist-assets")
+    from("$repoRootPath/build")
     include("relays.json")
     into(extraAssetsDirectory)
 }

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -122,7 +122,7 @@ for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
 done
 
 echo "Updating relays.json..."
-cargo run --bin relay_list $CARGO_ARGS > dist-assets/relays.json
+cargo run --bin relay_list $CARGO_ARGS > build/relays.json
 
 cd "$SCRIPT_DIR/android"
 $GRADLE_CMD --console plain "$GRADLE_TASK"

--- a/build.sh
+++ b/build.sh
@@ -325,7 +325,7 @@ if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "Linux" ]]; then
 fi
 
 log_info "Updating relays.json..."
-cargo run --bin relay_list "${CARGO_ARGS[@]}" > dist-assets/relays.json
+cargo run --bin relay_list "${CARGO_ARGS[@]}" > build/relays.json
 
 
 log_header "Installing JavaScript dependencies"

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -26,7 +26,7 @@ const config = {
   compression: noCompression ? 'store' : 'normal',
   extraResources: [
     { from: distAssets('ca.crt'), to: '.' },
-    { from: distAssets('relays.json'), to: '.' },
+    { from: root('build/relays.json'), to: '.' },
     { from: root('CHANGELOG.md'), to: '.' },
   ],
 


### PR DESCRIPTION
As discussed in chat: We want to stop using `dist-assets/` for assets and files generated at build time, and keep only git versioned distribution assets in there. This PR is the first step in that process. Moving the `relays.json` we bundle into the app into `build/` instead.

I wanted to keep the scope small, so I intentionally did not go ahead and moved other assets in the same PR. As far as I know this is the only asset *of this kind* we have in `dist-assets/` so it's a small and nicely contained PR.

If this goes through smoothly I aim to move the `shell-completions` after this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4303)
<!-- Reviewable:end -->
