### PR TITLE
Move shell-completions to build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 /dist-assets/talpid_openvpn_plugin.dll
 /dist-assets/openvpn
 /dist-assets/openvpn.exe
-/dist-assets/shell-completions/
 /dist-assets/aarch64-apple-darwin/
 /dist-assets/x86_64-apple-darwin/
 /windows/version.h

--- a/build.sh
+++ b/build.sh
@@ -316,11 +316,11 @@ fi
 log_header "Preparing for packaging Mullvad VPN $PRODUCT_VERSION"
 
 if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "Linux" ]]; then
-    mkdir -p "dist-assets/shell-completions"
+    mkdir -p "build/shell-completions"
     for sh in bash zsh fish; do
         log_info "Generating shell completion script for $sh..."
         cargo run --bin mullvad "${CARGO_ARGS[@]}" -- shell-completions "$sh" \
-            "dist-assets/shell-completions/"
+            "build/shell-completions/"
     done
 fi
 

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -26,7 +26,7 @@ const config = {
   compression: noCompression ? 'store' : 'normal',
   extraResources: [
     { from: distAssets('ca.crt'), to: '.' },
-    { from: root('build/relays.json'), to: '.' },
+    { from: buildAssets('relays.json'), to: '.' },
     { from: root('CHANGELOG.md'), to: '.' },
   ],
 
@@ -99,8 +99,8 @@ const config = {
       },
       { from: distAssets(path.join('binaries', '${env.TARGET_TRIPLE}', 'openvpn')), to: '.' },
       { from: distAssets('uninstall_macos.sh'), to: './uninstall.sh' },
-      { from: distAssets('shell-completions/_mullvad'), to: '.' },
-      { from: distAssets('shell-completions/mullvad.fish'), to: '.' },
+      { from: buildAssets('shell-completions/_mullvad'), to: '.' },
+      { from: buildAssets('shell-completions/mullvad.fish'), to: '.' },
     ],
   },
 
@@ -142,7 +142,7 @@ const config = {
         to: '.',
       },
       { from: distAssets('binaries/x86_64-pc-windows-msvc/openvpn.exe'), to: '.' },
-      { from: root('build/lib/x86_64-pc-windows-msvc/libwg.dll'), to: '.' },
+      { from: buildAssets('lib/x86_64-pc-windows-msvc/libwg.dll'), to: '.' },
       { from: distAssets('binaries/x86_64-pc-windows-msvc/wintun/wintun.dll'), to: '.' },
       { from: distAssets('binaries/x86_64-pc-windows-msvc/split-tunnel/mullvad-split-tunnel.sys'), to: '.' },
       {
@@ -190,10 +190,10 @@ const config = {
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-daemon')) + '=/usr/bin/',
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-exclude')) + '=/usr/bin/',
       distAssets('linux/problem-report-link') + '=/usr/bin/mullvad-problem-report',
-      distAssets('shell-completions/mullvad.bash') +
+      buildAssets('shell-completions/mullvad.bash') +
         '=/usr/share/bash-completion/completions/mullvad',
-      distAssets('shell-completions/_mullvad') + '=/usr/local/share/zsh/site-functions/_mullvad',
-      distAssets('shell-completions/mullvad.fish') +
+      buildAssets('shell-completions/_mullvad') + '=/usr/local/share/zsh/site-functions/_mullvad',
+      buildAssets('shell-completions/mullvad.fish') +
         '=/usr/share/fish/vendor_completions.d/mullvad.fish',
     ],
     afterInstall: distAssets('linux/after-install.sh'),
@@ -215,10 +215,10 @@ const config = {
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-daemon')) + '=/usr/bin/',
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-exclude')) + '=/usr/bin/',
       distAssets('linux/problem-report-link') + '=/usr/bin/mullvad-problem-report',
-      distAssets('shell-completions/mullvad.bash') +
+      buildAssets('shell-completions/mullvad.bash') +
         '=/usr/share/bash-completion/completions/mullvad',
-      distAssets('shell-completions/_mullvad') + '=/usr/share/zsh/site-functions/_mullvad',
-      distAssets('shell-completions/mullvad.fish') +
+      buildAssets('shell-completions/_mullvad') + '=/usr/share/zsh/site-functions/_mullvad',
+      buildAssets('shell-completions/mullvad.fish') +
         '=/usr/share/fish/vendor_completions.d/mullvad.fish',
     ],
     afterInstall: distAssets('linux/after-install.sh'),
@@ -369,6 +369,10 @@ function packLinux() {
       },
     },
   });
+}
+
+function buildAssets(relativePath) {
+  return path.join(path.resolve(__dirname, '../../build'), relativePath);
 }
 
 function distAssets(relativePath) {


### PR DESCRIPTION
Follow up to #4303. Store less build time generated data in `dist-assets/` and instead use `build/` for that.

I have tested this on Linux and macOS and the shell completions still seem to install fine with artifacts from this branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4304)
<!-- Reviewable:end -->
