### PR TITLE
Remove reference to dist-assets/api-ip-address.txt as it does not exist

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -77,7 +77,6 @@ jobs:
           path: |
             ./android/app/build/extraJni
             ./build/relays.json
-            ./dist-assets/api-ip-address.txt
           key: android-native-libs-${{ runner.os }}-x86_64-${{ steps.native-lib-cache-hash.outputs.native_lib_hash}}
 
       - name: Build native libraries


### PR DESCRIPTION
This got me confused for a while. But I think this was the correct thing to do. We don't have any `dist-assets/api-ip-address.txt` anywhere any longer. That was removed a long time ago. However, the references to `$cache/api-ip-address.txt` are still valid, since we still cache the **single** last known API IP with that filename, it's just that we stopped shipping the app with a **list of** API IPs under that filename.

If the above is correct, this was the only mention of the now obsolete file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4305)
<!-- Reviewable:end -->
