### PR TITLE
Switch to self-hosted runner for Android tests

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -133,7 +133,7 @@ jobs:
 
   instrumented-tests:
     name: Instrumented tests
-    runs-on: macos-latest
+    runs-on: [self-hosted, android-emulator]
     timeout-minutes: 30
     needs: [build]
     strategy:
@@ -147,42 +147,6 @@ jobs:
           name: apks
           path: android/app/build/outputs/apk
 
-      - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: emulator-api-33
-
-      - name: Create avd and generate snapshot
-        uses: reactivecircus/android-emulator-runner@v2
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        with:
-          force-avd-creation: false
-          api-level: 33
-          target: google_apis
-          arch: x86_64
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-            -camera-back none
-          disable-animations: true
-          profile: pixel
-          script: echo "Generated AVD snapshot for caching."
-        env:
-          API_LEVEL: 33
-
       - name: Run Android instrumented tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          force-avd-creation: false
-          api-level: 33
-          target: google_apis
-          arch: x86_64
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect
-            -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          profile: pixel
-          script: ./android/scripts/run-instrumented-tests.sh app
-        env:
-          API_LEVEL: 33
+        shell: bash -ieo pipefail {0}
+        run: ./android/scripts/run-instrumented-tests.sh app

--- a/android/scripts/run-instrumented-tests.sh
+++ b/android/scripts/run-instrumented-tests.sh
@@ -69,6 +69,9 @@ LOG_FILE_PATH="/tmp/$LOG_FILE_NAME"
 echo "Starting instrumented tests of type: $TEST_TYPE"
 echo ""
 
+echo "### Clean up previous logs ###"
+rm "$LOG_FILE_PATH"
+
 echo "### Ensure that packages are not previously installed ###"
 adb uninstall net.mullvad.mullvadvpn || echo "App package not installed"
 adb uninstall "$TEST_PACKAGE" || echo "Test package not installed"


### PR DESCRIPTION
This PR switches to a self-hosted test runner for instrumented Android tests.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4307)
<!-- Reviewable:end -->
