### PR TITLE
Upgrade post-quantum gRPC endpoint and add kyber1024 into the mix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Line wrap the file at 100 chars.                                              Th
 
 
 ## [Unreleased]
+### Added
+- Add Kyber1024 KEM algorithm into the Post-Quantum secure key exchange algorithm. This means the
+  Quantum-resistant-tunnels feature now mixes both Classic McEliece and Kyber for added protection.
+
+### Changed
+- Update the Post-Quantum secure key exchange gRPC client to use the stabilized
+  `PskExchangeV1` endpoint
+
 ### Fixed
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b79004a05337e54e8ffc0ec7470e40fa26eca6fe182968ec2b803247f2283c"
 dependencies = [
  "rand_core 0.6.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -3304,6 +3305,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cesu8"
@@ -457,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array 0.14.4",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -712,7 +712,7 @@ dependencies = [
  "crypto-bigint",
  "der",
  "generic-array 0.14.4",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -2302,6 +2302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
+name = "pqc_kyber"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b79004a05337e54e8ffc0ec7470e40fa26eca6fe182968ec2b803247f2283c"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,7 +2480,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2491,7 +2500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2505,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.3",
 ]
@@ -2952,7 +2961,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3287,6 +3296,7 @@ version = "0.0.0"
 dependencies = [
  "classic-mceliece-rust",
  "log",
+ "pqc_kyber",
  "prost",
  "rand 0.8.5",
  "talpid-types",
@@ -4223,7 +4233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -60,7 +60,7 @@ fn create_wireguard_mtu_subcommand() -> clap::App<'static> {
 
 fn create_wireguard_quantum_resistant_tunnel_subcommand() -> clap::App<'static> {
     clap::App::new("quantum-resistant-tunnel")
-        .about("EXPERIMENTAL: Enables quantum-resistant PSK exchange in the tunnel")
+        .about("Controls the quantum-resistant PSK exchange in the tunnel")
         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
         .subcommand(clap::App::new("get"))
         .subcommand(clap::App::new("set").arg(clap::Arg::new("policy").required(true)))

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -16,6 +16,7 @@ prost = "0.11"
 tower = "0.4"
 tokio = "1"
 classic-mceliece-rust = { version = "2.0.0", features = ["mceliece460896f"] }
+pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -15,8 +15,9 @@ tonic = "0.8"
 prost = "0.11"
 tower = "0.4"
 tokio = "1"
-classic-mceliece-rust = { version = "2.0.0", features = ["mceliece460896f"] }
-pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024"] }
+classic-mceliece-rust = { version = "2.0.0", features = ["mceliece460896f", "zeroize"] }
+pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024", "zeroize"] }
+zeroize = "1.5.7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/talpid-tunnel-config-client/examples/tuncfg-server.rs
+++ b/talpid-tunnel-config-client/examples/tuncfg-server.rs
@@ -53,6 +53,12 @@ impl PostQuantumSecure for PostQuantumSecureImpl {
                         classic_mceliece_rust::encapsulate_boxed(&public_key, &mut rng);
                     (ciphertext.as_array().to_vec(), *shared_secret.as_array())
                 }
+                "Kyber1024" => {
+                    let public_key = kem_pubkey.key_data.as_slice();
+                    let (ciphertext, shared_secret) =
+                        pqc_kyber::encapsulate(public_key, &mut rng).unwrap();
+                    (ciphertext.to_vec(), shared_secret)
+                }
                 name => panic!("Unsupported KEM algorithm: {name}"),
             };
 

--- a/talpid-tunnel-config-client/proto/tunnel_config.proto
+++ b/talpid-tunnel-config-client/proto/tunnel_config.proto
@@ -5,11 +5,6 @@ option go_package = "github.com/mullvad/wg-manager/server/tuncfg";
 package tunnel_config;
 
 service PostQuantumSecure {
-  // PskExchangeExperimentalV0 uses the common API defined by LibOQS.  See:
-  // https://github.com/open-quantum-safe/liboqs
-  // This endpoint is deprecated in favor for `PskExchangeExperimentalV1`. Please use that instead.
-  rpc PskExchangeExperimentalV0(PskRequestExperimentalV0) returns (PskResponseExperimentalV0) {}
-
   // Allows deriving a preshared key (PSK) using one or multiple PQ-secure key-encapsulation
   // mechanisms (KEM). The preshared key is added to WireGuard's preshared-key field in a new
   // ephemeral peer (PQ-peer). This makes the tunnel resistant towards attacks using
@@ -71,35 +66,20 @@ service PostQuantumSecure {
   // Mixing with XOR (A = B ^ C) is fine since nothing about A is revealed even if one of B or C
   // is known. Both B *and* C must be known to compute any bit in A. This means all involved
   // KEM algorithms must be broken before the PSK can be computed by an attacker.
-  rpc PskExchangeExperimentalV1(PskRequestExperimentalV1) returns (PskResponseExperimentalV1) {}
+  rpc PskExchangeV1(PskRequestV1) returns (PskResponseV1) {}
 }
 
-message PskRequestExperimentalV0 {
+message PskRequestV1 {
   bytes wg_pubkey = 1;
   bytes wg_psk_pubkey = 2;
-  KemPubkeyExperimentalV0 kem_pubkey = 3;
+  repeated KemPubkeyV1 kem_pubkeys = 3;
 }
 
-message KemPubkeyExperimentalV0 {
+message KemPubkeyV1 {
   string algorithm_name = 1;
   bytes key_data = 2;
 }
 
-message PskResponseExperimentalV0 {
-  bytes ciphertext = 1;
-}
-
-message PskRequestExperimentalV1 {
-  bytes wg_pubkey = 1;
-  bytes wg_psk_pubkey = 2;
-  repeated KemPubkeyExperimentalV1 kem_pubkeys = 3;
-}
-
-message KemPubkeyExperimentalV1 {
-  string algorithm_name = 1;
-  bytes key_data = 2;
-}
-
-message PskResponseExperimentalV1 {
+message PskResponseV1 {
   repeated bytes ciphertexts = 1;
 }

--- a/talpid-tunnel-config-client/src/classic_mceliece.rs
+++ b/talpid-tunnel-config-client/src/classic_mceliece.rs
@@ -1,4 +1,6 @@
-use classic_mceliece_rust::{keypair_boxed, SharedSecret};
+use classic_mceliece_rust::{
+    keypair_boxed, Ciphertext, PublicKey, SecretKey, SharedSecret, CRYPTO_CIPHERTEXTBYTES,
+};
 
 /// The `keypair_boxed` function needs just under 1 MiB of stack in debug
 /// builds. Even though it probably works to run it directly on the main
@@ -6,7 +8,9 @@ use classic_mceliece_rust::{keypair_boxed, SharedSecret};
 /// keys on a separate thread with a large enough stack.
 const STACK_SIZE: usize = 2 * 1024 * 1024;
 
-pub use classic_mceliece_rust::{Ciphertext, PublicKey, SecretKey, CRYPTO_CIPHERTEXTBYTES};
+/// Use the smallest CME variant with NIST security level 3. This variant has significantly smaller
+/// keys than the larger variants, and is considered safe.
+pub const ALGORITHM_NAME: &str = "Classic-McEliece-460896f-round3";
 
 pub async fn generate_keys() -> (PublicKey<'static>, SecretKey<'static>) {
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -22,6 +26,21 @@ pub async fn generate_keys() -> (PublicKey<'static>, SecretKey<'static>) {
     rx.await.unwrap()
 }
 
-pub fn decapsulate(secret: &SecretKey, ciphertext: &Ciphertext) -> SharedSecret<'static> {
-    classic_mceliece_rust::decapsulate_boxed(ciphertext, secret)
+pub fn decapsulate(
+    secret: &SecretKey,
+    ciphertext_slice: &[u8],
+) -> Result<SharedSecret<'static>, super::Error> {
+    let ciphertext_array =
+        <[u8; CRYPTO_CIPHERTEXTBYTES]>::try_from(ciphertext_slice).map_err(|_| {
+            super::Error::InvalidCiphertextLength {
+                algorithm: ALGORITHM_NAME,
+                actual: ciphertext_slice.len(),
+                expected: CRYPTO_CIPHERTEXTBYTES,
+            }
+        })?;
+    let ciphertext = Ciphertext::from(ciphertext_array);
+    Ok(classic_mceliece_rust::decapsulate_boxed(
+        &ciphertext,
+        secret,
+    ))
 }

--- a/talpid-tunnel-config-client/src/kyber.rs
+++ b/talpid-tunnel-config-client/src/kyber.rs
@@ -1,10 +1,28 @@
-use pqc_kyber::SecretKey;
+use pqc_kyber::{SecretKey, KYBER_CIPHERTEXTBYTES};
 
-pub use pqc_kyber::{keypair, KyberError, KYBER_CIPHERTEXTBYTES};
+pub use pqc_kyber::{keypair, KyberError};
 
+/// Use the strongest variant of Kyber. It is fast and the keys are small, so there is no practical
+/// benefit of going with anything lower.
+pub const ALGORITHM_NAME: &str = "Kyber1024";
+
+// Always inline in order to try to avoid potential copies of `shared_secret` to multiple places on the stack.
+#[inline(always)]
 pub fn decapsulate(
     secret_key: SecretKey,
-    ciphertext: [u8; KYBER_CIPHERTEXTBYTES],
-) -> Result<[u8; 32], KyberError> {
-    pqc_kyber::decapsulate(ciphertext.as_slice(), secret_key.as_slice())
+    ciphertext_slice: &[u8],
+) -> Result<[u8; 32], super::Error> {
+    // The `pqc_kyber` library takes a byte slice. But we convert it into an array
+    // in order to catch the length mismatch error and report it better than `pqc_kyber` would.
+    let ciphertext_array =
+        <[u8; KYBER_CIPHERTEXTBYTES]>::try_from(ciphertext_slice).map_err(|_| {
+            super::Error::InvalidCiphertextLength {
+                algorithm: ALGORITHM_NAME,
+                actual: ciphertext_slice.len(),
+                expected: KYBER_CIPHERTEXTBYTES,
+            }
+        })?;
+    let shared_secret = pqc_kyber::decapsulate(ciphertext_array.as_slice(), secret_key.as_slice())
+        .map_err(super::Error::FailedDecapsulateKyber)?;
+    Ok(shared_secret)
 }

--- a/talpid-tunnel-config-client/src/kyber.rs
+++ b/talpid-tunnel-config-client/src/kyber.rs
@@ -1,0 +1,7 @@
+use pqc_kyber::SecretKey;
+
+pub use pqc_kyber::{keypair, KYBER_CIPHERTEXTBYTES, KyberError};
+
+pub fn decapsulate(secret_key: SecretKey, ciphertext: [u8; KYBER_CIPHERTEXTBYTES]) -> Result<[u8; 32], KyberError> {
+    pqc_kyber::decapsulate(ciphertext.as_slice(), secret_key.as_slice())
+}

--- a/talpid-tunnel-config-client/src/kyber.rs
+++ b/talpid-tunnel-config-client/src/kyber.rs
@@ -1,7 +1,10 @@
 use pqc_kyber::SecretKey;
 
-pub use pqc_kyber::{keypair, KYBER_CIPHERTEXTBYTES, KyberError};
+pub use pqc_kyber::{keypair, KyberError, KYBER_CIPHERTEXTBYTES};
 
-pub fn decapsulate(secret_key: SecretKey, ciphertext: [u8; KYBER_CIPHERTEXTBYTES]) -> Result<[u8; 32], KyberError> {
+pub fn decapsulate(
+    secret_key: SecretKey,
+    ciphertext: [u8; KYBER_CIPHERTEXTBYTES],
+) -> Result<[u8; 32], KyberError> {
     pqc_kyber::decapsulate(ciphertext.as_slice(), secret_key.as_slice())
 }

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -54,7 +54,11 @@ pub const CONFIG_SERVICE_PORT: u16 = 1337;
 
 /// Use the smallest CME variant with NIST security level 3. This variant has significantly smaller
 /// keys than the larger variants, and is considered safe.
-const CLASSIC_MCELIECE_VARIANT: &str = "Classic-McEliece-460896f";
+const CLASSIC_MCELIECE_VARIANT: &str = "Classic-McEliece-460896f-round3";
+
+/// Use the strongest variant of Kyber. It is fast and the keys are small, so there is no practical
+/// benefit of going with anything lower.
+const KYBER_VARIANT: &str = "Kyber1024";
 
 /// Generates a new WireGuard key pair and negotiates a PSK with the relay in a PQ-safe
 /// manner. This creates a peer on the relay with the new WireGuard pubkey and PSK,
@@ -70,16 +74,16 @@ pub async fn push_pq_key(
 
     let mut client = new_client(service_address).await?;
     let response = client
-        .psk_exchange_experimental_v1(proto::PskRequestExperimentalV1 {
+        .psk_exchange_v1(proto::PskRequestV1 {
             wg_pubkey: wg_pubkey.as_bytes().to_vec(),
             wg_psk_pubkey: wg_psk_privkey.public_key().as_bytes().to_vec(),
             kem_pubkeys: vec![
-                proto::KemPubkeyExperimentalV1 {
+                proto::KemPubkeyV1 {
                     algorithm_name: CLASSIC_MCELIECE_VARIANT.to_owned(),
                     key_data: cme_kem_pubkey.as_array().to_vec(),
                 },
-                proto::KemPubkeyExperimentalV1 {
-                    algorithm_name: "Kyber1024".to_owned(),
+                proto::KemPubkeyV1 {
+                    algorithm_name: KYBER_VARIANT.to_owned(),
                     key_data: kyber_keypair.public.to_vec(),
                 },
             ],


### PR DESCRIPTION
This adds [`pqc_kyber`](https://crates.io/crates/pqc_kyber) as a dependency in order to be able to use the Kyber KEM algorithm alongside CME for the Post-quantum key exchange and PSK computation. The PR also upgrades to the stabilized gPRC endpoint `PskExchangeV1` and removes both experimental endpoints since they are no longer needed client side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4312)
<!-- Reviewable:end -->
