### PR TITLE
Upload all build artifacts at the same time

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 UPLOAD_DIR="/home/upload/upload"
+BUILD_ARTIFACT_EXTENSIONS="deb|rpm|exe|pkg|apk|aab"
 
 set -eu
 shopt -s nullglob
@@ -9,39 +10,45 @@ cd $UPLOAD_DIR
 
 while true; do
   sleep 10
-  for f_checksum in MullvadVPN-*.{deb,rpm,exe,pkg,apk,aab}.sha256; do
+
+  for checksums_path in *.sha256; do
     sleep 1
-    f="${f_checksum/.sha256/}"
-    if ! sha256sum --quiet -c "$f_checksum"; then
-      echo "Failed to verify checksum for $f"
+
+    # Strip everything from the last "+" in the file name to only keep the version and tag (if
+    # present).
+    version="${checksums_path%+*}"
+    if ! sha256sum --quiet -c "$checksums_path"; then
+      echo "Failed to verify checksums for $version"
       continue
     fi
 
-    version=$(echo "$f" | sed -Ee 's/MullvadVPN-(.*)(\.exe|\.pkg|_amd64\.deb|_x86_64\.rpm|_arm64\.deb|_aarch64\.rpm|\.apk|\.aab)/\1/g')
     if [[ $version == *"-dev-"* ]]; then
-        upload_path="builds"
+      upload_path="builds"
     else
-        upload_path="releases"
+      upload_path="releases"
     fi
 
-    rsync -av --rsh='ssh -p 1122' "$f" "build@releases.mullvad.net:$upload_path/$version/" || continue
+    files=$(awk '{print $2}' < "$checksums_path")
+    for file in $files; do
+      file_upload_dir="$upload_path/$version"
+      if [[ ! $file =~ \.($BUILD_ARTIFACT_EXTENSIONS|asc)$ ]]; then
+        file_upload_dir="$file_upload_dir/additional-files"
+      fi
 
-    rm -f "$f.asc"
-    gpg -u A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF --pinentry-mode loopback --sign --armor --detach-sign "$f"
-    rsync -av --rsh='ssh -p 1122' "$f.asc" "build@releases.mullvad.net:$upload_path/$version/" || continue
-    yes | rm "$f" "$f_checksum" "$f.asc"
-  done
+      rsync -av --rsh='ssh -p 1122' "$file" "build@releases.mullvad.net:$file_upload_dir/" || continue
 
-  # Upload PDB files (Windows debugging info)
-  for f_checksum in pdb-*.sha256; do
-    sleep 1
-    f="${f_checksum/.sha256/}"
-    if ! sha256sum --quiet -c "$f_checksum"; then
-      echo "Failed to verify checksum for $f"
-      continue
-    fi
+      if [[ $file =~ \.($BUILD_ARTIFACT_EXTENSIONS)$ ]]; then
+        rm -f "$file.asc"
+        gpg -u A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF --pinentry-mode loopback --sign --armor --detach-sign "$file"
+        rsync -av --rsh='ssh -p 1122' "$file.asc" "build@releases.mullvad.net:$file_upload_dir/" || continue
+        rm -f "$file.asc"
+      fi
 
-    rsync -av --rsh='ssh -p 1122' "$f" "build@releases.mullvad.net:builds/pdb/" || continue
-    yes | rm "$f" "$f_checksum"
+      # shellcheck disable=SC2216
+      yes | rm "$file"
+    done
+
+    # shellcheck disable=SC2216
+    yes | rm "$checksums_path"
   done
 done


### PR DESCRIPTION
This PR makes a few improvements to `buildserver-build.sh` and `buildserver-upload.sh`:
* Uploads/transfers all artifacts to the upload directory at the same time.
* Uses a single `sha256` file for all artifacts.
* Adds the version name to the `.pdb` file.
* Uploads the `.pdb` files to a subdirectory in the version directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4314)
<!-- Reviewable:end -->
