### PR TITLE
Run `cargo clippy --fix` with the new Rust 1.67 preferred format

### DIFF
--- a/android/translations-converter/src/android/plurals.rs
+++ b/android/translations-converter/src/android/plurals.rs
@@ -104,7 +104,7 @@ impl Display for PluralResources {
         writeln!(formatter, "<resources>")?;
 
         for entry in &self.entries {
-            write!(formatter, "{}", entry)?;
+            write!(formatter, "{entry}")?;
         }
 
         writeln!(formatter, "</resources>")
@@ -116,7 +116,7 @@ impl Display for PluralResource {
         writeln!(formatter, r#"    <plurals name="{}">"#, self.name)?;
 
         for item in &self.items {
-            writeln!(formatter, "        {}", item)?;
+            writeln!(formatter, "        {item}")?;
         }
 
         writeln!(formatter, "    </plurals>")
@@ -143,6 +143,6 @@ impl Display for PluralQuantity {
             PluralQuantity::Other => "other",
         };
 
-        write!(formatter, "{}", quantity)
+        write!(formatter, "{quantity}")
     }
 }

--- a/android/translations-converter/src/android/strings.rs
+++ b/android/translations-converter/src/android/strings.rs
@@ -91,7 +91,7 @@ impl Display for StringResources {
         writeln!(formatter, "<resources>")?;
 
         for string in &self.entries {
-            writeln!(formatter, "    {}", string)?;
+            writeln!(formatter, "    {string}")?;
         }
 
         writeln!(formatter, "</resources>")

--- a/android/translations-converter/src/gettext/mod.rs
+++ b/android/translations-converter/src/gettext/mod.rs
@@ -38,12 +38,12 @@ pub fn append_to_template(
         writeln!(writer, r#"msgid "{}""#, entry.id)?;
 
         match entry.value {
-            MsgValue::Invariant(value) => writeln!(writer, r#"msgstr "{}""#, value)?,
+            MsgValue::Invariant(value) => writeln!(writer, r#"msgstr "{value}""#)?,
             MsgValue::Plural { plural_id, values } => {
-                writeln!(writer, r#"msgid_plural "{}""#, plural_id)?;
+                writeln!(writer, r#"msgid_plural "{plural_id}""#)?;
 
                 for (index, value) in values.into_iter().enumerate() {
-                    writeln!(writer, r#"msgstr[{}] "{}""#, index, value)?;
+                    writeln!(writer, r#"msgstr[{index}] "{value}""#)?;
                 }
             }
         }

--- a/android/translations-converter/src/gettext/parser.rs
+++ b/android/translations-converter/src/gettext/parser.rs
@@ -487,7 +487,7 @@ impl Parser {
 /// by extracting the index (1), and then extracting the message string by skipping the separator
 /// (`] "`).
 fn extract_plural_variant(index_and_string: &str) -> Result<(usize, MsgString), Error> {
-    let recreate_line = || format!("msgstr[{}\"", index_and_string);
+    let recreate_line = || format!("msgstr[{index_and_string}\"");
 
     let parts: Vec<_> = index_and_string.splitn(2, "] \"").collect();
 
@@ -530,26 +530,26 @@ fn collect_variants(
 #[derive(Clone, Debug, Display, Error, Eq, PartialEq)]
 pub enum Error {
     /// An unexpected line was read while parsing.
-    #[display(fmt = "Unexpected line parsing gettext messages: {}", _0)]
+    #[display(fmt = "Unexpected line parsing gettext messages: {_0}")]
     UnexpectedLine(#[error(not(source))] String),
 
     /// Input uses an unrecognized plural forumal.
-    #[display(fmt = "Input uses an unrecognized formula for the plural form: {}", _0)]
+    #[display(fmt = "Input uses an unrecognized formula for the plural form: {_0}")]
     UnrecognizedPluralFormula(#[error(not(source))] String),
 
     /// Input ended with an incomplete entry.
-    #[display(fmt = "Input ended with an incomplete gettext entry with ID: {}", _0)]
+    #[display(fmt = "Input ended with an incomplete gettext entry with ID: {_0}")]
     IncompleteEntry(#[error(not(source))] MsgString),
 
     /// Plural entry definition is missing a plural variant.
-    #[display(fmt = "Plural entry is missing a plural variant: {}", _0)]
+    #[display(fmt = "Plural entry is missing a plural variant: {_0}")]
     IncompletePluralEntry(#[error(not(source))] MsgString),
 
     /// Plural variant is invalid.
-    #[display(fmt = "Plural variant line is invalid: {}", _0)]
+    #[display(fmt = "Plural variant line is invalid: {_0}")]
     InvalidPluralVariant(#[error(not(source))] String),
 
     /// Plural variant index was not parsable.
-    #[display(fmt = "Plural variant line contains an invalid index: {}", _0)]
+    #[display(fmt = "Plural variant line contains an invalid index: {_0}")]
     InvalidPluralIndex(#[error(not(source))] String),
 }

--- a/android/translations-converter/src/gettext/plural_form.rs
+++ b/android/translations-converter/src/gettext/plural_form.rs
@@ -46,5 +46,5 @@ impl FromStr for PluralForm {
 ///
 /// The formula could be an invalid formula, or support for it hasn't been added yet.
 #[derive(Clone, Debug, Display, Error)]
-#[display(fmt = "Unsupported plural formula: {}", _0)]
+#[display(fmt = "Unsupported plural formula: {_0}")]
 pub struct UnsupportedPluralFormulaError(#[error(not(source))] String);

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
             &template_path,
             missing_translations
                 .into_iter()
-                .inspect(|(missing_translation, id)| println!("  {}: {}", id, missing_translation))
+                .inspect(|(missing_translation, id)| println!("  {id}: {missing_translation}"))
                 .map(|(id, _)| gettext::MsgEntry {
                     id: gettext::MsgString::from_unescaped(&id),
                     value: gettext::MsgString::empty().into(),

--- a/mullvad-api/src/access.rs
+++ b/mullvad-api/src/access.rs
@@ -102,7 +102,7 @@ impl AccessTokenProxy {
 
         let rest_request = self
             .factory
-            .post_json(&format!("{}/token", AUTH_URL_PREFIX), &request)?;
+            .post_json(&format!("{AUTH_URL_PREFIX}/token"), &request)?;
         let response = service.request(rest_request).await?;
         let response = rest::parse_rest_response(response, &[StatusCode::OK]).await?;
         rest::deserialize_body(response).await

--- a/mullvad-api/src/device.rs
+++ b/mullvad-api/src/device.rs
@@ -58,7 +58,7 @@ impl DevicesProxy {
             let response = rest::send_json_request(
                 &factory,
                 service,
-                &format!("{}/devices", ACCOUNTS_URL_PREFIX),
+                &format!("{ACCOUNTS_URL_PREFIX}/devices"),
                 Method::POST,
                 &submission,
                 Some((access_proxy, account)),
@@ -108,7 +108,7 @@ impl DevicesProxy {
             let response = rest::send_request(
                 &factory,
                 service,
-                &format!("{}/devices/{}", ACCOUNTS_URL_PREFIX, id),
+                &format!("{ACCOUNTS_URL_PREFIX}/devices/{id}"),
                 Method::GET,
                 Some((access_proxy, account)),
                 &[StatusCode::OK],
@@ -129,7 +129,7 @@ impl DevicesProxy {
             let response = rest::send_request(
                 &factory,
                 service,
-                &format!("{}/devices", ACCOUNTS_URL_PREFIX),
+                &format!("{ACCOUNTS_URL_PREFIX}/devices"),
                 Method::GET,
                 Some((access_proxy, account)),
                 &[StatusCode::OK],
@@ -151,7 +151,7 @@ impl DevicesProxy {
             let response = rest::send_request(
                 &factory,
                 service,
-                &format!("{}/devices/{}", ACCOUNTS_URL_PREFIX, id),
+                &format!("{ACCOUNTS_URL_PREFIX}/devices/{id}"),
                 Method::DELETE,
                 Some((access_proxy, account)),
                 &[StatusCode::NO_CONTENT],
@@ -184,7 +184,7 @@ impl DevicesProxy {
             let response = rest::send_json_request(
                 &factory,
                 service,
-                &format!("{}/devices/{}/pubkey", ACCOUNTS_URL_PREFIX, id),
+                &format!("{ACCOUNTS_URL_PREFIX}/devices/{id}/pubkey"),
                 Method::PUT,
                 &req_body,
                 Some((access_proxy, account)),

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -130,7 +130,7 @@ impl ApiEndpoint {
             match env::var(key) {
                 Ok(v) => Some(v),
                 Err(env::VarError::NotPresent) => None,
-                Err(env::VarError::NotUnicode(_)) => panic!("{} does not contain valid UTF-8", key),
+                Err(env::VarError::NotUnicode(_)) => panic!("{key} does not contain valid UTF-8"),
             }
         }
 
@@ -394,7 +394,7 @@ impl AccountsProxy {
             let response = rest::send_request(
                 &factory,
                 service,
-                &format!("{}/accounts/me", ACCOUNTS_URL_PREFIX),
+                &format!("{ACCOUNTS_URL_PREFIX}/accounts/me"),
                 Method::GET,
                 Some((access_proxy, account)),
                 &[StatusCode::OK],
@@ -416,7 +416,7 @@ impl AccountsProxy {
         let response = rest::send_request(
             &self.handle.factory,
             service,
-            &format!("{}/accounts", ACCOUNTS_URL_PREFIX),
+            &format!("{ACCOUNTS_URL_PREFIX}/accounts"),
             Method::POST,
             None,
             &[StatusCode::CREATED],
@@ -447,7 +447,7 @@ impl AccountsProxy {
             let response = rest::send_json_request(
                 &factory,
                 service,
-                &format!("{}/submit-voucher", APP_URL_PREFIX),
+                &format!("{APP_URL_PREFIX}/submit-voucher"),
                 Method::POST,
                 &submission,
                 Some((access_proxy, account_token)),
@@ -475,7 +475,7 @@ impl AccountsProxy {
             let response = rest::send_request(
                 &factory,
                 service,
-                &format!("{}/www-auth-token", APP_URL_PREFIX),
+                &format!("{APP_URL_PREFIX}/www-auth-token"),
                 Method::POST,
                 Some((access_proxy, account)),
                 &[StatusCode::OK],
@@ -523,7 +523,7 @@ impl ProblemReportProxy {
         let request = rest::send_json_request(
             &self.handle.factory,
             service,
-            &format!("{}/problem-report", APP_URL_PREFIX),
+            &format!("{APP_URL_PREFIX}/problem-report"),
             Method::POST,
             &report,
             None,
@@ -573,7 +573,7 @@ impl AppVersionProxy {
     ) -> impl Future<Output = Result<AppVersionResponse, rest::Error>> {
         let service = self.handle.service.clone();
 
-        let path = format!("{}/releases/{}/{}", APP_URL_PREFIX, platform, app_version);
+        let path = format!("{APP_URL_PREFIX}/releases/{platform}/{app_version}");
         let request = self.handle.factory.request(&path, Method::GET);
 
         async move {
@@ -603,7 +603,7 @@ impl ApiProxy {
         let response = rest::send_request(
             &self.handle.factory,
             service,
-            &format!("{}/api-addrs", APP_URL_PREFIX),
+            &format!("{APP_URL_PREFIX}/api-addrs"),
             Method::GET,
             None,
             &[StatusCode::OK],

--- a/mullvad-api/src/proxy.rs
+++ b/mullvad-api/src/proxy.rs
@@ -69,8 +69,7 @@ impl ApiConnectionMode {
                 log::error!(
                     "{}",
                     error.display_chain_with_msg(&format!(
-                        "Failed to deserialize \"{}\"",
-                        CURRENT_CONFIG_FILENAME
+                        "Failed to deserialize \"{CURRENT_CONFIG_FILENAME}\""
                     ))
                 );
                 io::Error::new(io::ErrorKind::Other, "deserialization failed")

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -328,7 +328,7 @@ impl RestRequest {
     pub fn set_auth(&mut self, auth: Option<String>) -> Result<()> {
         let header = match auth {
             Some(auth) => Some(
-                HeaderValue::from_str(&format!("Bearer {}", auth))
+                HeaderValue::from_str(&format!("Bearer {auth}"))
                     .map_err(Error::InvalidHeaderError)?,
             ),
             None => None,

--- a/mullvad-api/src/tls_stream.rs
+++ b/mullvad-api/src/tls_stream.rs
@@ -43,7 +43,7 @@ where
             Err(_) => {
                 return Err(io::Error::new(
                     ErrorKind::InvalidInput,
-                    format!("invalid hostname \"{}\"", domain),
+                    format!("invalid hostname \"{domain}\""),
                 ));
             }
         };

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -123,7 +123,7 @@ impl Account {
         rpc.login_account(token.clone())
             .await
             .map_err(map_device_error)?;
-        println!("Mullvad account \"{}\" set", token);
+        println!("Mullvad account \"{token}\" set");
         Ok(())
     }
 
@@ -161,7 +161,7 @@ impl Account {
                         inner_device.created.with_timezone(&chrono::Local)
                     );
                     for port in inner_device.ports {
-                        println!("Device port    : {}", port);
+                        println!("Device port    : {port}");
                     }
                 }
                 let expiry = rpc
@@ -175,10 +175,10 @@ impl Account {
                 );
             }
             State::LoggedOut => {
-                println!("{}", NOT_LOGGED_IN_MESSAGE);
+                println!("{NOT_LOGGED_IN_MESSAGE}");
             }
             State::Revoked => {
-                println!("{}", REVOKED_MESSAGE);
+                println!("{REVOKED_MESSAGE}");
             }
         }
 
@@ -212,7 +212,7 @@ impl Account {
                     device.created.with_timezone(&chrono::Local)
                 );
                 for port in device.ports {
-                    println!("Port      : {}", port);
+                    println!("Port      : {port}");
                 }
             } else {
                 println!("{}", device.pretty_name());

--- a/mullvad-cli/src/cmds/beta_program.rs
+++ b/mullvad-cli/src/cmds/beta_program.rs
@@ -34,7 +34,7 @@ impl Command for BetaProgram {
                 } else {
                     "off"
                 };
-                println!("Beta program: {}", enabled_str);
+                println!("Beta program: {enabled_str}");
                 Ok(())
             }
             Some(("set", matches)) => {
@@ -50,7 +50,7 @@ impl Command for BetaProgram {
                 let mut rpc = new_rpc_client().await?;
                 rpc.set_show_beta_releases(enable).await?;
 
-                println!("Beta program: {}", enable_str);
+                println!("Beta program: {enable_str}");
                 Ok(())
             }
             _ => {

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -229,7 +229,7 @@ impl Bridge {
                 }
             },
             BridgeSettings::Normal(constraints) => {
-                println!("Bridge constraints: {}", constraints)
+                println!("Bridge constraints: {constraints}")
             }
         };
         Ok(())

--- a/mullvad-cli/src/cmds/dns.rs
+++ b/mullvad-cli/src/cmds/dns.rs
@@ -172,7 +172,7 @@ impl Dns {
             DnsState::Custom => {
                 println!("Custom DNS: yes\nServers:");
                 for server in &options.custom_options.addresses {
-                    println!("{}", server);
+                    println!("{server}");
                 }
             }
         }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -350,7 +350,7 @@ impl Relay {
 
     fn validate_wireguard_key(key_str: &str) -> [u8; 32] {
         let key_bytes = base64::decode(key_str.trim()).unwrap_or_else(|e| {
-            eprintln!("Failed to decode wireguard key: {}", e);
+            eprintln!("Failed to decode wireguard key: {e}");
             std::process::exit(1);
         });
 

--- a/mullvad-cli/src/cmds/reset.rs
+++ b/mullvad-cli/src/cmds/reset.rs
@@ -31,7 +31,7 @@ impl Reset {
         loop {
             let mut buf = String::new();
             if let Err(e) = stdin().read_line(&mut buf) {
-                eprintln!("Couldn't read from STDIN: {}", e);
+                eprintln!("Couldn't read from STDIN: {e}");
                 return false;
             }
             match buf.trim() {

--- a/mullvad-cli/src/cmds/split_tunnel/linux.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/linux.rs
@@ -71,7 +71,7 @@ impl SplitTunnel {
                 println!("Excluded PIDs:");
 
                 while let Some(pid) = pids_stream.message().await? {
-                    println!("    {}", pid);
+                    println!("    {pid}");
                 }
 
                 Ok(())

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -44,7 +44,7 @@ impl Command for Status {
         let state = rpc.get_tunnel_state(()).await?.into_inner();
 
         if debug {
-            println!("Tunnel state: {:#?}", state);
+            println!("Tunnel state: {state:#?}");
         } else {
             let state = TunnelState::try_from(state).expect("invalid tunnel state");
             format::print_state(&state, verbose);
@@ -64,7 +64,7 @@ impl Command for Status {
                             TunnelState::try_from(new_state).expect("invalid tunnel state");
 
                         if debug {
-                            println!("New tunnel state: {:#?}", new_state);
+                            println!("New tunnel state: {new_state:#?}");
                         } else {
                             format::print_state(&new_state, verbose);
                         }
@@ -80,27 +80,27 @@ impl Command for Status {
                     }
                     EventType::Settings(settings) => {
                         if debug {
-                            println!("New settings: {:#?}", settings);
+                            println!("New settings: {settings:#?}");
                         }
                     }
                     EventType::RelayList(relay_list) => {
                         if debug {
-                            println!("New relay list: {:#?}", relay_list);
+                            println!("New relay list: {relay_list:#?}");
                         }
                     }
                     EventType::VersionInfo(app_version_info) => {
                         if debug {
-                            println!("New app version info: {:#?}", app_version_info);
+                            println!("New app version info: {app_version_info:#?}");
                         }
                     }
                     EventType::Device(device) => {
                         if debug {
-                            println!("Device event: {:#?}", device);
+                            println!("Device event: {device:#?}");
                         }
                     }
                     EventType::RemoveDevice(device) => {
                         if debug {
-                            println!("Remove device event: {:#?}", device);
+                            println!("Remove device event: {device:#?}");
                         }
                     }
                 }
@@ -124,10 +124,10 @@ async fn print_location(rpc: &mut ManagementServiceClient) -> Result<()> {
         }
     };
     if let Some(ipv4) = location.ipv4 {
-        println!("IPv4: {}", ipv4);
+        println!("IPv4: {ipv4}");
     }
     if let Some(ipv6) = location.ipv6 {
-        println!("IPv6: {}", ipv6);
+        println!("IPv6: {ipv6}");
     }
 
     println!(

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -319,7 +319,7 @@ impl Tunnel {
         match tunnel_options.wireguard.unwrap().rotation_interval {
             Some(interval) => {
                 let hours = duration_hours(&Duration::try_from(interval).unwrap());
-                println!("Rotation interval: {} hour(s)", hours);
+                println!("Rotation interval: {hours} hour(s)");
             }
             None => println!(
                 "Rotation interval: default ({} hours)",
@@ -337,7 +337,7 @@ impl Tunnel {
                 .expect("Failed to convert rotation interval to prost_types::Duration"),
         )
         .await?;
-        println!("Set key rotation interval: {} hour(s)", rotate_interval);
+        println!("Set key rotation interval: {rotate_interval} hour(s)");
         Ok(())
     }
 

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -58,14 +58,14 @@ fn format_relay_connection(
                 city: Some(city),
                 ..
             }) => {
-                format!("{exit} in {}, {}", city, country)
+                format!("{exit} in {city}, {country}")
             }
             Some(GeoIpLocation {
                 country,
                 city: None,
                 ..
             }) => {
-                format!("{exit} in {}", country)
+                format!("{exit} in {country}")
             }
             None => exit,
         }
@@ -163,7 +163,7 @@ fn print_error_state(error_state: &ErrorState) {
     match error_state.cause() {
         #[cfg(target_os = "linux")]
         cause @ talpid_types::tunnel::ErrorStateCause::SetFirewallPolicyError(_) => {
-            println!("Blocked: {}", cause);
+            println!("Blocked: {cause}");
             println!("Your kernel might be terribly out of date or missing nftables");
         }
         talpid_types::tunnel::ErrorStateCause::AuthFailed(Some(auth_failed)) => {
@@ -172,7 +172,7 @@ fn print_error_state(error_state: &ErrorState) {
                 get_auth_failed_message(AuthFailed::from(auth_failed.as_str()))
             );
         }
-        cause => println!("Blocked: {}", cause),
+        cause => println!("Blocked: {cause}"),
     }
 }
 

--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -63,7 +63,7 @@ async fn send_location_request_internal(
 }
 
 fn log_network_error(err: Error, version: &'static str) {
-    let err_message = &format!("Unable to fetch {} GeoIP location", version);
+    let err_message = &format!("Unable to fetch {version} GeoIP location");
     match err {
         Error::HyperError(hyper_err) if hyper_err.is_connect() => {
             if let Some(cause) = hyper_err.into_cause() {

--- a/mullvad-daemon/src/logging.rs
+++ b/mullvad-daemon/src/logging.rs
@@ -155,7 +155,7 @@ impl Formatter {
         message: &fmt::Arguments<'_>,
         record: &log::Record<'_>,
     ) {
-        let message = escape_newlines(format!("{}", message));
+        let message = escape_newlines(format!("{message}"));
 
         out.finish(format_args!(
             "{}[{}][{}] {}",

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -24,7 +24,7 @@ const EARLY_BOOT_LOG_FILENAME: &str = "early-boot-fw.log";
 fn main() {
     let config = cli::get_config();
     let log_dir = init_daemon_logging(config).unwrap_or_else(|error| {
-        eprintln!("{}", error);
+        eprintln!("{error}");
         std::process::exit(1)
     });
 
@@ -122,7 +122,7 @@ async fn run_platform(config: &cli::Config, log_dir: Option<PathBuf>) -> Result<
     if config.initialize_firewall_and_exit {
         return crate::early_boot_firewall::initialize_firewall()
             .await
-            .map_err(|err| format!("{}", err));
+            .map_err(|err| format!("{err}"));
     }
     run_standalone(log_dir).await
 }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -983,7 +983,7 @@ fn map_rest_error(error: &RestError) -> Status {
         }
         RestError::TimeoutError(_elapsed) => Status::deadline_exceeded("API request timed out"),
         RestError::HyperError(_) => Status::unavailable("Cannot reach the API"),
-        error => Status::unknown(format!("REST error: {}", error)),
+        error => Status::unknown(format!("REST error: {error}")),
     }
 }
 

--- a/mullvad-exclude/src/main.rs
+++ b/mullvad-exclude/src/main.rs
@@ -54,17 +54,17 @@ fn main() {
         Err(Error::InvalidArguments) => {
             let mut args = env::args();
             let program = args.next().unwrap_or_else(|| PROGRAM_NAME.to_string());
-            eprintln!("Usage: {} COMMAND [ARGS]", program);
+            eprintln!("Usage: {program} COMMAND [ARGS]");
             std::process::exit(1);
         }
         Err(e) => {
-            let mut s = format!("{}", e);
+            let mut s = format!("{e}");
             let mut source = e.source();
             while let Some(error) = source {
-                write!(&mut s, "\nCaused by: {}", error).expect("formatting failed");
+                write!(&mut s, "\nCaused by: {error}").expect("formatting failed");
                 source = error.source();
             }
-            eprintln!("{}", s);
+            eprintln!("{s}");
 
             std::process::exit(1);
         }

--- a/mullvad-management-interface/build.rs
+++ b/mullvad-management-interface/build.rs
@@ -1,5 +1,5 @@
 fn main() {
     const PROTO_FILE: &str = "proto/management_interface.proto";
     tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={}", PROTO_FILE);
+    println!("cargo:rerun-if-changed={PROTO_FILE}");
 }

--- a/mullvad-types/src/endpoint.rs
+++ b/mullvad-types/src/endpoint.rs
@@ -34,7 +34,7 @@ impl MullvadEndpoint {
         match self {
             Self::Wireguard(endpoint) => endpoint,
             other => {
-                panic!("Expected WireGuard enum variant but got {:?}", other);
+                panic!("Expected WireGuard enum variant but got {other:?}");
             }
         }
     }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -151,7 +151,7 @@ impl fmt::Display for RelaySettings {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             RelaySettings::CustomTunnelEndpoint(endpoint) => {
-                write!(f, "custom endpoint {}", endpoint)
+                write!(f, "custom endpoint {endpoint}")
             }
             RelaySettings::Normal(constraints) => constraints.fmt(f),
         }
@@ -258,7 +258,7 @@ impl fmt::Display for RelayConstraints {
         match self.ownership {
             Constraint::Any => Ok(()),
             Constraint::Only(ref constraint) => {
-                write!(f, " and {}", constraint)
+                write!(f, " and {constraint}")
             }
         }
     }
@@ -414,9 +414,9 @@ impl fmt::Display for Providers {
         write!(f, "provider(s) ")?;
         for (i, provider) in self.providers.iter().enumerate() {
             if i == 0 {
-                write!(f, "{}", provider)?;
+                write!(f, "{provider}")?;
             } else {
-                write!(f, ", {}", provider)?;
+                write!(f, ", {provider}")?;
             }
         }
         Ok(())
@@ -426,10 +426,10 @@ impl fmt::Display for Providers {
 impl fmt::Display for LocationConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            LocationConstraint::Country(country) => write!(f, "country {}", country),
-            LocationConstraint::City(country, city) => write!(f, "city {}, {}", city, country),
+            LocationConstraint::Country(country) => write!(f, "country {country}"),
+            LocationConstraint::City(country, city) => write!(f, "city {city}, {country}"),
             LocationConstraint::Hostname(country, city, hostname) => {
-                write!(f, "city {}, {}, hostname {}", city, country, hostname)
+                write!(f, "city {city}, {country}, hostname {hostname}")
             }
         }
     }
@@ -454,7 +454,7 @@ impl fmt::Display for OpenVpnConstraints {
             Constraint::Only(port) => {
                 match port.port {
                     Constraint::Any => write!(f, "any port")?,
-                    Constraint::Only(port) => write!(f, "port {}", port)?,
+                    Constraint::Only(port) => write!(f, "port {port}")?,
                 }
                 write!(f, "/{}", port.protocol)
             }
@@ -476,17 +476,17 @@ impl fmt::Display for WireguardConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.port {
             Constraint::Any => write!(f, "any port")?,
-            Constraint::Only(port) => write!(f, "port {}", port)?,
+            Constraint::Only(port) => write!(f, "port {port}")?,
         }
         write!(f, " over ")?;
         match self.ip_version {
             Constraint::Any => write!(f, "IPv4 or IPv6")?,
-            Constraint::Only(protocol) => write!(f, "{}", protocol)?,
+            Constraint::Only(protocol) => write!(f, "{protocol}")?,
         }
         if self.use_multihop {
             match &self.entry_location {
                 Constraint::Any => write!(f, " (via any location)"),
-                Constraint::Only(location) => write!(f, " (via {})", location),
+                Constraint::Only(location) => write!(f, " (via {location})"),
             }
         } else {
             Ok(())
@@ -533,7 +533,7 @@ impl fmt::Display for Udp2TcpObfuscationSettings {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.port {
             Constraint::Any => write!(f, "any port"),
-            Constraint::Only(port) => write!(f, "port {}", port),
+            Constraint::Only(port) => write!(f, "port {port}"),
         }
     }
 }
@@ -571,7 +571,7 @@ impl fmt::Display for BridgeConstraints {
         match self.ownership {
             Constraint::Any => Ok(()),
             Constraint::Only(ref constraint) => {
-                write!(f, " and {}", constraint)
+                write!(f, " and {constraint}")
             }
         }
     }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -44,8 +44,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V5 as u32 => Ok(SettingsVersion::V5),
             v if v == SettingsVersion::V6 as u32 => Ok(SettingsVersion::V6),
             v => Err(serde::de::Error::custom(format!(
-                "{} is not a valid SettingsVersion",
-                v
+                "{v} is not a valid SettingsVersion"
             ))),
         }
     }

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -144,15 +144,15 @@ impl PartialOrd for ParsedAppVersion {
 impl ToString for ParsedAppVersion {
     fn to_string(&self) -> String {
         match self {
-            Self::Stable(year, version) => format!("{}.{}", year, version),
+            Self::Stable(year, version) => format!("{year}.{version}"),
             Self::Beta(year, version, beta_version) => {
-                format!("{}.{}-beta{}", year, version, beta_version)
+                format!("{year}.{version}-beta{beta_version}")
             }
             Self::Dev(year, version, beta_version, hash) => {
                 if let Some(beta_version) = beta_version {
-                    format!("{}.{}-beta{}-dev-{}", year, version, beta_version, hash)
+                    format!("{year}.{version}-beta{beta_version}-dev-{hash}")
                 } else {
-                    format!("{}.{}-dev-{}", year, version, hash)
+                    format!("{year}.{version}-dev-{hash}")
                 }
             }
         }

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -65,5 +65,5 @@ fn main() {
 fn generate_grpc_code() {
     const PROTO_FILE: &str = "../talpid-openvpn-plugin/proto/openvpn_plugin.proto";
     tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={}", PROTO_FILE);
+    println!("cargo:rerun-if-changed={PROTO_FILE}");
 }

--- a/talpid-core/src/dns/linux/resolvconf.rs
+++ b/talpid-core/src/dns/linux/resolvconf.rs
@@ -76,7 +76,7 @@ impl Resolvconf {
     }
 
     pub fn set_dns(&mut self, interface: &str, servers: &[IpAddr]) -> Result<()> {
-        let record_name = format!("{}.mullvad", interface);
+        let record_name = format!("{interface}.mullvad");
         let mut record_contents = String::new();
 
         for address in servers {

--- a/talpid-openvpn-plugin/build.rs
+++ b/talpid-openvpn-plugin/build.rs
@@ -6,7 +6,7 @@ fn make_lang_id(p: u16, s: u16) -> u16 {
 fn main() {
     const PROTO_FILE: &str = "proto/openvpn_plugin.proto";
     tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={}", PROTO_FILE);
+    println!("cargo:rerun-if-changed={PROTO_FILE}");
 
     #[cfg(windows)]
     {

--- a/talpid-openvpn/build.rs
+++ b/talpid-openvpn/build.rs
@@ -5,5 +5,5 @@ fn main() {
 fn generate_grpc_code() {
     const PROTO_FILE: &str = "../talpid-openvpn-plugin/proto/openvpn_plugin.proto";
     tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={}", PROTO_FILE);
+    println!("cargo:rerun-if-changed={PROTO_FILE}");
 }

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -651,7 +651,7 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
         log::debug!("Writing credentials to {}", temp_file.as_ref().display());
         let mut file = fs::File::create(&temp_file)?;
         Self::set_user_pass_file_permissions(&file)?;
-        write!(file, "{}\n{}\n", username, password)?;
+        write!(file, "{username}\n{password}\n")?;
         Ok(temp_file)
     }
 
@@ -1076,9 +1076,9 @@ mod event_server {
     {
         let uuid = uuid::Uuid::new_v4().to_string();
         let ipc_path = if cfg!(windows) {
-            format!("//./pipe/talpid-openvpn-{}", uuid)
+            format!("//./pipe/talpid-openvpn-{uuid}")
         } else {
-            format!("/tmp/talpid-openvpn-{}", uuid)
+            format!("/tmp/talpid-openvpn-{uuid}")
         };
 
         let endpoint = IpcEndpoint::new(ipc_path.clone());

--- a/talpid-platform-metadata/src/linux.rs
+++ b/talpid-platform-metadata/src/linux.rs
@@ -14,7 +14,7 @@ pub fn version() -> String {
         })
     });
 
-    format!("Linux {}", version)
+    format!("Linux {version}")
 }
 
 pub fn short_version() -> String {
@@ -22,7 +22,7 @@ pub fn short_version() -> String {
         parse_lsb_release().unwrap_or_else(|| String::from("[Failed to detect version]"))
     });
 
-    format!("Linux {}", version)
+    format!("Linux {version}")
 }
 
 fn read_os_release_file_short() -> Option<String> {
@@ -33,7 +33,7 @@ fn read_os_release_file_short() -> Option<String> {
     if let Some(os_name) = os_name {
         if os_name != "NixOS" {
             if let Some(os_version_id) = os_version_id {
-                return Some(format!("{} {}", os_name, os_version_id));
+                return Some(format!("{os_name} {os_version_id}"));
             }
         }
     }

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -170,11 +170,11 @@ impl Node {
 impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ip) = &self.ip {
-            write!(f, "{}", ip)?;
+            write!(f, "{ip}")?;
         }
         if let Some(device) = &self.device {
             let extra_space = if self.ip.is_some() { " " } else { "" };
-            write!(f, "{}dev {}", extra_space, device)?;
+            write!(f, "{extra_space}dev {device}")?;
         }
         Ok(())
     }

--- a/talpid-tunnel-config-client/build.rs
+++ b/talpid-tunnel-config-client/build.rs
@@ -1,5 +1,5 @@
 fn main() {
     const PROTO_FILE: &str = "proto/tunnel_config.proto";
     tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={}", PROTO_FILE);
+    println!("cargo:rerun-if-changed={PROTO_FILE}");
 }

--- a/talpid-tunnel-config-client/examples/psk-exchange.rs
+++ b/talpid-tunnel-config-client/examples/psk-exchange.rs
@@ -21,6 +21,6 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("private key: {:?}", private_key);
-    println!("psk: {:?}", psk);
+    println!("private key: {private_key:?}");
+    println!("psk: {psk:?}");
 }

--- a/talpid-tunnel-config-client/examples/tuncfg-server.rs
+++ b/talpid-tunnel-config-client/examples/tuncfg-server.rs
@@ -57,14 +57,14 @@ impl PostQuantumSecure for PostQuantumSecureImpl {
             };
 
             ciphertexts.push(ciphertext);
-            println!("\tshared secret: {:?}", shared_secret);
+            println!("\tshared secret: {shared_secret:?}");
             for (psk_byte, shared_secret_byte) in psk_data.iter_mut().zip(shared_secret.iter()) {
                 *psk_byte ^= shared_secret_byte;
             }
         }
 
         let psk = PresharedKey::from(psk_data);
-        println!("psk: {:?}", psk);
+        println!("psk: {psk:?}");
         println!("==============================================");
         Ok(Response::new(PskResponseExperimentalV1 { ciphertexts }))
     }

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -22,7 +22,7 @@ impl std::fmt::Display for Error {
         use Error::*;
         match self {
             GrpcConnectError(_) => "Failed to connect to config service".fmt(f),
-            GrpcError(status) => write!(f, "RPC failed: {}", status),
+            GrpcError(status) => write!(f, "RPC failed: {status}"),
             InvalidCiphertextLength { actual, expected } => write!(
                 f,
                 "Expected a ciphertext of length {expected}, got {actual} bytes"

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -21,20 +21,20 @@ pub trait ErrorExt {
 
 impl<E: Error> ErrorExt for E {
     fn display_chain(&self) -> String {
-        let mut s = format!("Error: {}", self);
+        let mut s = format!("Error: {self}");
         let mut source = self.source();
         while let Some(error) = source {
-            write!(&mut s, "\nCaused by: {}", error).expect("formatting failed");
+            write!(&mut s, "\nCaused by: {error}").expect("formatting failed");
             source = error.source();
         }
         s
     }
 
     fn display_chain_with_msg(&self, msg: &str) -> String {
-        let mut s = format!("Error: {}\nCaused by: {}", msg, self);
+        let mut s = format!("Error: {msg}\nCaused by: {self}");
         let mut source = self.source();
         while let Some(error) = source {
-            write!(&mut s, "\nCaused by: {}", error).expect("formatting failed");
+            write!(&mut s, "\nCaused by: {error}").expect("formatting failed");
             source = error.source();
         }
         s

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -121,7 +121,7 @@ impl fmt::Display for TunnelType {
             TunnelType::OpenVpn => "OpenVPN",
             TunnelType::Wireguard => "WireGuard",
         };
-        write!(f, "{}", tunnel)
+        write!(f, "{tunnel}")
     }
 }
 
@@ -159,10 +159,10 @@ impl fmt::Display for TunnelEndpoint {
             }
             TunnelType::Wireguard => {
                 if let Some(ref entry_endpoint) = self.entry_endpoint {
-                    write!(f, " via {}", entry_endpoint)?;
+                    write!(f, " via {entry_endpoint}")?;
                 }
                 if let Some(ref obfuscation) = self.obfuscation {
-                    write!(f, " via {}", obfuscation)?;
+                    write!(f, " via {obfuscation}")?;
                 }
             }
         }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -16,7 +16,7 @@ impl fmt::Display for ProxyType {
             ProxyType::Shadowsocks => "Shadowsocks",
             ProxyType::Custom => "custom bridge",
         };
-        write!(f, "{}", bridge)
+        write!(f, "{bridge}")
     }
 }
 

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -181,7 +181,7 @@ impl fmt::Display for ErrorStateCause {
                     FirewallPolicyError::Locked(Some(value)) => {
                         write!(f, "{}: {} (pid {})", err, value.name, value.pid)
                     }
-                    _ => write!(f, "{}", err),
+                    _ => write!(f, "{err}"),
                 };
             }
             SetDnsError => "Failed to set system DNS server",
@@ -199,7 +199,7 @@ impl fmt::Display for ErrorStateCause {
             }
             StartTunnelError => "Failed to start connection to remote server",
             TunnelParameterError(ref err) => {
-                return write!(f, "Failure to generate tunnel parameters: {}", err);
+                return write!(f, "Failure to generate tunnel parameters: {err}");
             }
             IsOffline => "This device is offline, no tunnels can be established",
             #[cfg(target_os = "android")]
@@ -208,6 +208,6 @@ impl fmt::Display for ErrorStateCause {
             SplitTunnelError => "The split tunneling module reported an error",
         };
 
-        write!(f, "{}", description)
+        write!(f, "{description}")
     }
 }

--- a/talpid-wireguard/build.rs
+++ b/talpid-wireguard/build.rs
@@ -16,10 +16,10 @@ fn main() {
         "windows" => "",
         #[cfg(windows)]
         "windows" => "dylib",
-        _ => panic!("Unsupported platform: {}", target_os),
+        _ => panic!("Unsupported platform: {target_os}"),
     };
 
-    println!("cargo:rustc-link-lib{}=wg", link_type);
+    println!("cargo:rustc-link-lib{link_type}=wg");
 }
 
 fn declare_libs_dir(base: &str) {

--- a/talpid-wireguard/src/connectivity_check.rs
+++ b/talpid-wireguard/src/connectivity_check.rs
@@ -650,7 +650,9 @@ mod test {
         let (_tx, rx) = mpsc::channel();
         let pinger = MockPinger::default();
         let now = Instant::now();
-        let start = now - (BYTES_RX_TIMEOUT + PING_TIMEOUT + Duration::from_secs(10));
+        let start = now
+            .checked_sub((BYTES_RX_TIMEOUT + PING_TIMEOUT + Duration::from_secs(10)))
+            .unwrap();
         let mut monitor = mock_monitor(start, Box::new(pinger), tunnel, rx);
 
         // Mock the state - connectivity has been established
@@ -668,7 +670,7 @@ mod test {
         let (_tx, rx) = mpsc::channel();
         let pinger = MockPinger::default();
         let now = Instant::now();
-        let start = now - Duration::from_secs(1);
+        let start = now.checked_sub(Duration::from_secs(1)).unwrap();
         let mut monitor = mock_monitor(start, Box::new(pinger), tunnel, rx);
 
         assert!(!monitor.check_connectivity(now).unwrap())
@@ -682,7 +684,7 @@ mod test {
         let (_tx, rx) = mpsc::channel();
         let pinger = MockPinger::default();
         let now = Instant::now();
-        let start = now - Duration::from_secs(1);
+        let start = now.checked_sub(Duration::from_secs(1)).unwrap();
         let mut monitor = mock_monitor(start, Box::new(pinger), tunnel, rx);
 
         // Mock the state - connectivity has been established
@@ -701,7 +703,7 @@ mod test {
         let (stop_tx, stop_rx) = mpsc::channel();
         std::thread::spawn(move || {
             let now = Instant::now();
-            let start = now - Duration::from_secs(1);
+            let start = now.checked_sub(Duration::from_secs(1)).unwrap();
             let mut monitor = mock_monitor(start, Box::new(pinger), tunnel, stop_rx);
 
             let start_result = monitor.establish_connectivity(0);
@@ -755,7 +757,7 @@ mod test {
         let (_stop_tx, stop_rx) = mpsc::channel();
         std::thread::spawn(move || {
             let now = Instant::now();
-            let start = now - Duration::from_secs(1);
+            let start = now.checked_sub(Duration::from_secs(1)).unwrap();
             let mut monitor = mock_monitor(start, Box::new(pinger), tunnel, stop_rx);
             let start_result = monitor.establish_connectivity(0);
             result_tx.send(start_result).unwrap();
@@ -794,7 +796,7 @@ mod test {
         let (_stop_tx, stop_rx) = mpsc::channel();
         std::thread::spawn(move || {
             let now = Instant::now();
-            let start = now - Duration::from_secs(1);
+            let start = now.checked_sub(Duration::from_secs(1)).unwrap();
             let mut monitor = mock_monitor(start, Box::new(pinger), tunnel, stop_rx);
 
             const ESTABLISH_TIMEOUT_MULTIPLIER: u32 = 2;

--- a/talpid-wireguard/src/connectivity_check.rs
+++ b/talpid-wireguard/src/connectivity_check.rs
@@ -651,7 +651,7 @@ mod test {
         let pinger = MockPinger::default();
         let now = Instant::now();
         let start = now
-            .checked_sub((BYTES_RX_TIMEOUT + PING_TIMEOUT + Duration::from_secs(10)))
+            .checked_sub(BYTES_RX_TIMEOUT + PING_TIMEOUT + Duration::from_secs(10))
             .unwrap();
         let mut monitor = mock_monitor(start, Box::new(pinger), tunnel, rx);
 

--- a/talpid-wireguard/src/wireguard_kernel/parsers.rs
+++ b/talpid-wireguard/src/wireguard_kernel/parsers.rs
@@ -20,7 +20,7 @@ pub fn parse_ip_addr(bytes: &[u8]) -> Result<IpAddr, DecodeError> {
         Ok(IpAddr::from(ipv6_bytes))
     } else {
         log::error!("Expected either 4 or 16 bytes, got {} bytes", bytes.len());
-        Err(format!("Invalid bytes for IP address: {:?}", bytes).into())
+        Err(format!("Invalid bytes for IP address: {bytes:?}").into())
     }
 }
 
@@ -31,7 +31,7 @@ pub fn parse_wg_key(buffer: &[u8]) -> Result<[u8; 32], DecodeError> {
             key.clone_from_slice(buffer);
             Ok(key)
         }
-        anything_else => Err(format!("Unexpected length of key: {}", anything_else).into()),
+        anything_else => Err(format!("Unexpected length of key: {anything_else}").into()),
     }
 }
 
@@ -61,7 +61,7 @@ pub fn parse_inet_sockaddr(buffer: &[u8]) -> Result<InetAddr, DecodeError> {
             Ok(InetAddr::V6(*sockaddr))
         },
         unexpected_addr_family => {
-            Err(format!("Unexpected address family: {}", unexpected_addr_family).into())
+            Err(format!("Unexpected address family: {unexpected_addr_family}").into())
         }
     }
 }
@@ -80,7 +80,7 @@ pub fn parse_timespec(buffer: &[u8]) -> Result<TimeSpec, DecodeError> {
 
 pub fn parse_cstring(buffer: &[u8]) -> Result<CString, DecodeError> {
     Ok(CStr::from_bytes_with_nul(buffer)
-        .map_err(|err| format!("{}", err))?
+        .map_err(|err| format!("{err}"))?
         .into())
 }
 

--- a/tunnel-obfuscation/src/main.rs
+++ b/tunnel-obfuscation/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     println!("endpoint() returns {:?}", obfuscator.endpoint());
 
     if let Err(err) = obfuscator.run().await {
-        println!("obfuscator.run() failed: {:?}", err);
+        println!("obfuscator.run() failed: {err:?}");
     }
 }
 


### PR DESCRIPTION
Since Rust 1.67 clippy now has some new lints. And since want to follow the default recommendations as much as possible, we adapt to this. I personally think the changes are sane and makes some stuff more readable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4317)
<!-- Reviewable:end -->
