### PR TITLE
Check the authorization status of the launch daemon on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Line wrap the file at 100 chars.                                              Th
 - Improved reliability of the connectivity check workaround by adding an extra captive portal check
   domain
 - Show "Mullvad VPN" in the Login Items UI instead of "Amagicom AB".
+- Detect whether users need to approve the launch daemon in the Login Items UI.
 
 
 ## [2023.1-beta1] - 2023-01-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1668,7 @@ dependencies = [
  "mullvad-types",
  "mullvad-version",
  "nix 0.23.1",
+ "objc",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "regex",
@@ -1992,6 +2002,15 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -10,6 +10,8 @@ exec 2>&1 > $LOG_DIR/postinstall.log
 echo "Running postinstall at $(date)"
 
 INSTALL_DIR=$2
+# NOTE: This path must be kept in sync with the path defined
+# in mullvad-daemon/src/macos_launch_daemon.rs
 DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"
 
 DAEMON_PLIST=$(cat <<-EOM

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -147,6 +147,9 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
+msgid "Go to System Settings"
+msgstr ""
+
 #. This is a button which closes a dialog.
 msgid "Got it!"
 msgstr ""
@@ -617,6 +620,10 @@ msgstr ""
 
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
+msgstr ""
+
+msgctxt "launch-view"
+msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr ""
 
 #. This is a warning message shown when the app is blocking the users

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -1,6 +1,8 @@
+import { exec } from 'child_process';
 import { app, BrowserWindow, dialog, Menu, nativeImage, screen, Tray } from 'electron';
 import path from 'path';
 import { sprintf } from 'sprintf-js';
+import { promisify } from 'util';
 
 import { closeToExpiry, hasExpired } from '../shared/account-expiry';
 import { connectEnabled, disconnectEnabled, reconnectEnabled } from '../shared/connect-helper';
@@ -19,6 +21,8 @@ import { WebContentsConsoleInput } from './logging';
 import { isMacOs11OrNewer } from './platform-version';
 import TrayIconController, { TrayIconType } from './tray-icon-controller';
 import WindowController, { WindowControllerDelegate } from './window-controller';
+
+const execAsync = promisify(exec);
 
 export interface UserInterfaceDelegate {
   cancelPendingNotifications(): void;
@@ -68,6 +72,16 @@ export default class UserInterface implements WindowControllerDelegate {
       });
       this.browsingFiles = false;
       return response;
+    });
+
+    IpcMainEventChannel.app.handleShowLaunchDaemonSettings(async () => {
+      try {
+        await execAsync(
+          'open -W x-apple.systempreferences:com.apple.LoginItems-Settings.extension',
+        );
+      } catch (error) {
+        log.error(`Failed to open launch daemon settings: ${error}`);
+      }
     });
   }
 

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -125,6 +125,10 @@ export default class AppRenderer {
       this.setIsPerformingPostUpgrade(isPerformingPostUpgrade);
     });
 
+    IpcRendererEventChannel.daemon.listenDaemonAllowed((daemonAllowed) => {
+      this.reduxActions.userInterface.setDaemonAllowed(daemonAllowed);
+    });
+
     IpcRendererEventChannel.account.listen((newAccountData?: IAccountData) => {
       this.setAccountExpiry(newAccountData?.expiry);
     });
@@ -203,6 +207,10 @@ export default class AppRenderer {
     this.setAccountExpiry(initialState.accountData?.expiry);
     this.setSettings(initialState.settings);
     this.setIsPerformingPostUpgrade(initialState.isPerformingPostUpgrade);
+
+    if (initialState.daemonAllowed !== undefined) {
+      this.reduxActions.userInterface.setDaemonAllowed(initialState.daemonAllowed);
+    }
 
     if (initialState.deviceState) {
       const deviceState = initialState.deviceState;
@@ -470,6 +478,10 @@ export default class AppRenderer {
     void IpcRendererEventChannel.windowsSplitTunneling.removeApplication(application);
   }
 
+  public async showLaunchDaemonSettings() {
+    await IpcRendererEventChannel.app.showLaunchDaemonSettings();
+  }
+
   public async sendProblemReport(
     email: string,
     message: string,
@@ -617,6 +629,7 @@ export default class AppRenderer {
   private onDaemonConnected() {
     this.connectedToDaemon = true;
     this.reduxActions.userInterface.setConnectedToDaemon(true);
+    this.reduxActions.userInterface.setDaemonAllowed(true);
     this.resetNavigation();
   }
 

--- a/gui/src/renderer/components/ErrorView.tsx
+++ b/gui/src/renderer/components/ErrorView.tsx
@@ -1,10 +1,14 @@
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
 import { colors } from '../../config.json';
-import { measurements } from './common-styles';
+import { messages } from '../../shared/gettext';
+import { useAppContext } from '../context';
+import * as AppButton from './AppButton';
+import { measurements, tinyText } from './common-styles';
 import { HeaderBarSettingsButton } from './HeaderBar';
 import ImageView from './ImageView';
-import { Container, Header, Layout } from './Layout';
+import { Container, Footer, Header, Layout } from './Layout';
 
 const StyledContainer = styled(Container)({
   flex: 1,
@@ -12,6 +16,31 @@ const StyledContainer = styled(Container)({
   alignItems: 'center',
   justifyContent: 'center',
   marginTop: '-150px',
+});
+
+const StyledFooter = styled(Footer)({}, (props: { show: boolean }) => ({
+  backgroundColor: colors.blue,
+  padding: '12px',
+  position: 'absolute',
+  bottom: 0,
+  transform: `translateY(${props.show ? 0 : 100}%)`,
+  transition: 'transform 250ms ease-in-out',
+}));
+
+const StyledSystemSettingsContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  alignSelf: 'start',
+  backgroundColor: colors.darkBlue,
+  borderRadius: '8px',
+  margin: 0,
+  padding: '16px',
+});
+
+const StyledLaunchFooterPrompt = styled.span(tinyText, {
+  color: colors.white,
+  margin: '9px 0 20px 0',
 });
 
 const Logo = styled(ImageView)({
@@ -34,18 +63,50 @@ const Subtitle = styled.span({
 
 interface ErrorViewProps {
   settingsUnavailable?: boolean;
+  showSettingsFooter?: boolean;
   children: React.ReactNode | React.ReactNode[];
 }
 
-export default function ErrorView(props: ErrorViewProps) {
+export default class ErrorView extends React.Component<ErrorViewProps> {
+  public render() {
+    return (
+      <Layout>
+        <Header>{!this.props.settingsUnavailable && <HeaderBarSettingsButton />}</Header>
+        <StyledContainer>
+          <Logo height={106} width={106} source="logo-icon" />
+          <Title height={18} source="logo-text" />
+          <Subtitle role="alert">{this.props.children}</Subtitle>
+        </StyledContainer>
+        <SettingsFooter show={this.props.showSettingsFooter} />
+      </Layout>
+    );
+  }
+}
+
+interface ISettingsFooterProps {
+  show?: boolean;
+}
+
+function SettingsFooter(props: ISettingsFooterProps) {
+  const { showLaunchDaemonSettings } = useAppContext();
+
+  const openSettings = useCallback(async () => {
+    await showLaunchDaemonSettings();
+  }, []);
+
   return (
-    <Layout>
-      <Header>{!props.settingsUnavailable && <HeaderBarSettingsButton />}</Header>
-      <StyledContainer>
-        <Logo height={106} width={106} source="logo-icon" />
-        <Title height={18} source="logo-text" />
-        <Subtitle role="alert">{props.children}</Subtitle>
-      </StyledContainer>
-    </Layout>
+    <StyledFooter show={props.show ? props.show : false}>
+      <StyledSystemSettingsContainer>
+        <StyledLaunchFooterPrompt>
+          {messages.pgettext(
+            'launch-view',
+            'Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting.',
+          )}
+        </StyledLaunchFooterPrompt>
+        <AppButton.BlueButton onClick={openSettings}>
+          {messages.gettext('Go to System Settings')}
+        </AppButton.BlueButton>
+      </StyledSystemSettingsContainer>
+    </StyledFooter>
   );
 }

--- a/gui/src/renderer/components/ErrorView.tsx
+++ b/gui/src/renderer/components/ErrorView.tsx
@@ -1,46 +1,25 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { colors } from '../../config.json';
-import { messages } from '../../shared/gettext';
-import { useAppContext } from '../context';
-import * as AppButton from './AppButton';
-import { measurements, tinyText } from './common-styles';
+import { measurements } from './common-styles';
 import { HeaderBarSettingsButton } from './HeaderBar';
 import ImageView from './ImageView';
-import { Container, Footer, Header, Layout } from './Layout';
+import { Container, Header, Layout } from './Layout';
 
 const StyledContainer = styled(Container)({
   flex: 1,
   flexDirection: 'column',
   alignItems: 'center',
-  justifyContent: 'center',
-  marginTop: '-150px',
+  justifyContent: 'end',
 });
 
-const StyledFooter = styled(Footer)({}, (props: { show: boolean }) => ({
-  backgroundColor: colors.blue,
-  padding: '12px',
-  position: 'absolute',
-  bottom: 0,
-  transform: `translateY(${props.show ? 0 : 100}%)`,
-  transition: 'transform 250ms ease-in-out',
-}));
-
-const StyledSystemSettingsContainer = styled.div({
+const StyledContent = styled.div({
   display: 'flex',
-  flexDirection: 'column',
   flex: 1,
-  alignSelf: 'start',
-  backgroundColor: colors.darkBlue,
-  borderRadius: '8px',
-  margin: 0,
-  padding: '16px',
-});
-
-const StyledLaunchFooterPrompt = styled.span(tinyText, {
-  color: colors.white,
-  margin: '9px 0 20px 0',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'end',
 });
 
 const Logo = styled(ImageView)({
@@ -61,52 +40,31 @@ const Subtitle = styled.span({
   textAlign: 'center',
 });
 
+const StyledFooterContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'end',
+  minHeight: '241px',
+});
+
 interface ErrorViewProps {
   settingsUnavailable?: boolean;
-  showSettingsFooter?: boolean;
+  footer?: React.ReactNode | React.ReactNode[];
   children: React.ReactNode | React.ReactNode[];
 }
 
-export default class ErrorView extends React.Component<ErrorViewProps> {
-  public render() {
-    return (
-      <Layout>
-        <Header>{!this.props.settingsUnavailable && <HeaderBarSettingsButton />}</Header>
-        <StyledContainer>
+export default function ErrorView(props: ErrorViewProps) {
+  return (
+    <Layout>
+      <Header>{!props.settingsUnavailable && <HeaderBarSettingsButton />}</Header>
+      <StyledContainer>
+        <StyledContent>
           <Logo height={106} width={106} source="logo-icon" />
           <Title height={18} source="logo-text" />
-          <Subtitle role="alert">{this.props.children}</Subtitle>
-        </StyledContainer>
-        <SettingsFooter show={this.props.showSettingsFooter} />
-      </Layout>
-    );
-  }
-}
-
-interface ISettingsFooterProps {
-  show?: boolean;
-}
-
-function SettingsFooter(props: ISettingsFooterProps) {
-  const { showLaunchDaemonSettings } = useAppContext();
-
-  const openSettings = useCallback(async () => {
-    await showLaunchDaemonSettings();
-  }, []);
-
-  return (
-    <StyledFooter show={props.show ? props.show : false}>
-      <StyledSystemSettingsContainer>
-        <StyledLaunchFooterPrompt>
-          {messages.pgettext(
-            'launch-view',
-            'Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting.',
-          )}
-        </StyledLaunchFooterPrompt>
-        <AppButton.BlueButton onClick={openSettings}>
-          {messages.gettext('Go to System Settings')}
-        </AppButton.BlueButton>
-      </StyledSystemSettingsContainer>
-    </StyledFooter>
+          <Subtitle role="alert">{props.children}</Subtitle>
+        </StyledContent>
+        <StyledFooterContainer>{props.footer}</StyledFooterContainer>
+      </StyledContainer>
+    </Layout>
   );
 }

--- a/gui/src/renderer/components/Launch.tsx
+++ b/gui/src/renderer/components/Launch.tsx
@@ -1,9 +1,11 @@
 import { messages } from '../../shared/gettext';
+import { useSelector } from '../redux/store';
 import ErrorView from './ErrorView';
 
 export default function Launch() {
+  const daemonAllowed = useSelector((state) => state.userInterface.daemonAllowed);
   return (
-    <ErrorView>
+    <ErrorView showSettingsFooter={daemonAllowed === false}>
       {messages.pgettext('launch-view', 'Connecting to Mullvad system service...')}
     </ErrorView>
   );

--- a/gui/src/renderer/components/Launch.tsx
+++ b/gui/src/renderer/components/Launch.tsx
@@ -1,12 +1,72 @@
+import { useCallback } from 'react';
+import styled from 'styled-components';
+
+import { colors } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { useAppContext } from '../context';
 import { useSelector } from '../redux/store';
+import * as AppButton from './AppButton';
+import { measurements, tinyText } from './common-styles';
 import ErrorView from './ErrorView';
+import { Footer } from './Layout';
 
 export default function Launch() {
   const daemonAllowed = useSelector((state) => state.userInterface.daemonAllowed);
+  const footer = <SettingsFooter show={daemonAllowed === false} />;
+
   return (
-    <ErrorView showSettingsFooter={daemonAllowed === false}>
+    <ErrorView footer={footer}>
       {messages.pgettext('launch-view', 'Connecting to Mullvad system service...')}
     </ErrorView>
+  );
+}
+
+const StyledFooter = styled(Footer)({}, (props: { show: boolean }) => ({
+  backgroundColor: colors.blue,
+  padding: `0 14px ${measurements.viewMargin}`,
+  opacity: props.show ? 1 : 0,
+  transition: 'opacity 250ms ease-in-out',
+}));
+
+const StyledSystemSettingsContainer = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  backgroundColor: colors.darkBlue,
+  borderRadius: '8px',
+  margin: 0,
+  padding: '16px',
+});
+
+const StyledLaunchFooterPrompt = styled.span(tinyText, {
+  color: colors.white,
+  margin: `8px 0 ${measurements.buttonVerticalMargin} 0`,
+});
+
+interface ISettingsFooterProps {
+  show: boolean;
+}
+
+function SettingsFooter(props: ISettingsFooterProps) {
+  const { showLaunchDaemonSettings } = useAppContext();
+
+  const openSettings = useCallback(async () => {
+    await showLaunchDaemonSettings();
+  }, []);
+
+  return (
+    <StyledFooter show={props.show}>
+      <StyledSystemSettingsContainer>
+        <StyledLaunchFooterPrompt>
+          {messages.pgettext(
+            'launch-view',
+            'Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting.',
+          )}
+        </StyledLaunchFooterPrompt>
+        <AppButton.BlueButton onClick={openSettings}>
+          {messages.gettext('Go to System Settings')}
+        </AppButton.BlueButton>
+      </StyledSystemSettingsContainer>
+    </StyledFooter>
   );
 }

--- a/gui/src/renderer/redux/userinterface/actions.ts
+++ b/gui/src/renderer/redux/userinterface/actions.ts
@@ -30,6 +30,11 @@ export interface ISetConnectedToDaemon {
   connectedToDaemon: boolean;
 }
 
+export interface ISetDaemonAllowed {
+  type: 'SET_DAEMON_ALLOWED';
+  daemonAllowed: boolean;
+}
+
 export interface ISetChangelog {
   type: 'SET_CHANGELOG';
   changelog: IChangelog;
@@ -52,6 +57,7 @@ export type UserInterfaceAction =
   | ISetWindowFocusedAction
   | ISetMacOsScrollbarVisibility
   | ISetConnectedToDaemon
+  | ISetDaemonAllowed
   | ISetChangelog
   | ISetForceShowChanges
   | ISetIsPerformingPostUpgrade;
@@ -99,6 +105,13 @@ function setConnectedToDaemon(connectedToDaemon: boolean): ISetConnectedToDaemon
   };
 }
 
+function setDaemonAllowed(daemonAllowed: boolean): ISetDaemonAllowed {
+  return {
+    type: 'SET_DAEMON_ALLOWED',
+    daemonAllowed,
+  };
+}
+
 function setChangelog(changelog: IChangelog): ISetChangelog {
   return {
     type: 'SET_CHANGELOG',
@@ -127,6 +140,7 @@ export default {
   setWindowFocused,
   setMacOsScrollbarVisibility,
   setConnectedToDaemon,
+  setDaemonAllowed,
   setChangelog,
   setForceShowChanges,
   setIsPerformingPostUpgrade,

--- a/gui/src/renderer/redux/userinterface/reducers.ts
+++ b/gui/src/renderer/redux/userinterface/reducers.ts
@@ -9,6 +9,7 @@ export interface IUserInterfaceReduxState {
   windowFocused: boolean;
   macOsScrollbarVisibility?: MacOsScrollbarVisibility;
   connectedToDaemon: boolean;
+  daemonAllowed?: boolean;
   changelog: IChangelog;
   forceShowChanges: boolean;
   isPerformingPostUpgrade: boolean;
@@ -20,6 +21,7 @@ const initialState: IUserInterfaceReduxState = {
   windowFocused: false,
   macOsScrollbarVisibility: undefined,
   connectedToDaemon: false,
+  daemonAllowed: undefined,
   changelog: [],
   forceShowChanges: false,
   isPerformingPostUpgrade: false,
@@ -47,6 +49,9 @@ export default function (
 
     case 'SET_CONNECTED_TO_DAEMON':
       return { ...state, connectedToDaemon: action.connectedToDaemon };
+
+    case 'SET_DAEMON_ALLOWED':
+      return { ...state, daemonAllowed: action.daemonAllowed };
 
     case 'SET_CHANGELOG':
       return {

--- a/gui/src/shared/ipc-schema.ts
+++ b/gui/src/shared/ipc-schema.ts
@@ -57,6 +57,7 @@ export interface IAppStateSnapshot {
   tunnelState: TunnelState;
   settings: ISettings;
   isPerformingPostUpgrade: boolean;
+  daemonAllowed?: boolean;
   deviceState?: DeviceState;
   relayList?: IRelayListWithEndpointData;
   currentVersion: ICurrentAppVersionInfo;
@@ -124,6 +125,7 @@ export const ipcSchema = {
   },
   daemon: {
     isPerformingPostUpgrade: notifyRenderer<boolean>(),
+    daemonAllowed: notifyRenderer<boolean>(),
     connected: notifyRenderer<void>(),
     disconnected: notifyRenderer<void>(),
   },
@@ -141,6 +143,7 @@ export const ipcSchema = {
     quit: send<void>(),
     openUrl: invoke<string, void>(),
     showOpenDialog: invoke<Electron.OpenDialogOptions, Electron.OpenDialogReturnValue>(),
+    showLaunchDaemonSettings: invoke<void, void>(),
   },
   location: {
     get: invoke<void, ILocation>(),

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -51,6 +51,9 @@ simple-signal = "1.1"
 [target.'cfg(target_os="linux")'.dependencies]
 talpid-dbus = { path = "../talpid-dbus" }
 
+[target.'cfg(target_os="macos")'.dependencies]
+objc = "0.2.3"
+
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"
 duct = "0.13"

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -7,6 +7,8 @@ pub struct Config {
     pub log_stdout_timestamps: bool,
     pub run_as_service: bool,
     pub register_service: bool,
+    #[cfg(target_os = "macos")]
+    pub launch_daemon_status: bool,
     #[cfg(target_os = "linux")]
     pub initialize_firewall_and_exit: bool,
 }
@@ -35,6 +37,8 @@ pub fn create_config() -> Config {
         cfg!(target_os = "linux") && matches.is_present("initialize-early-boot-firewall");
     let run_as_service = cfg!(windows) && matches.is_present("run_as_service");
     let register_service = cfg!(windows) && matches.is_present("register_service");
+    #[cfg(target_os = "macos")]
+    let launch_daemon_status = matches.is_present("launch_daemon_status");
 
     Config {
         #[cfg(target_os = "linux")]
@@ -44,6 +48,8 @@ pub fn create_config() -> Config {
         log_stdout_timestamps,
         run_as_service,
         register_service,
+        #[cfg(target_os = "macos")]
+        launch_daemon_status,
     }
 }
 
@@ -110,6 +116,12 @@ fn create_app() -> App<'static> {
                 .long("initialize-early-boot-firewall")
                 .help("Initialize firewall to be used during early boot and exit"),
         )
+    }
+
+    if cfg!(target_os = "macos") {
+        app = app.arg(Arg::new("launch_daemon_status").long("launch-daemon-status").help(
+            "Checks the status of the launch daemon. The exit code represents the current status",
+        ))
     }
     app
 }

--- a/mullvad-daemon/src/macos_launch_daemon.rs
+++ b/mullvad-daemon/src/macos_launch_daemon.rs
@@ -1,0 +1,97 @@
+//! Provides functions to handle or query the status of the Mullvad launch
+//! daemon/system service on macOS.
+//!
+//! If the service exists but needs to be approved by the user, this status
+//! must be checked so that the user can be directed to approve the launch
+//! daemon in the system settings.
+
+use objc::{class, msg_send, sel, sel_impl};
+use std::ffi::CStr;
+
+type Id = *mut objc::runtime::Object;
+
+// Framework that contains `SMAppService`.
+#[link(name = "ServiceManagement", kind = "framework")]
+extern "C" {}
+
+/// Returned by `[NSProcessInfo operatingSystemVersion]`. Contains the current
+#[repr(C)]
+#[derive(Debug)]
+struct NSOperatingSystemVersion {
+    major_version: libc::c_ulong,
+    minor_version: libc::c_ulong,
+    patch_version: libc::c_ulong,
+}
+
+/// Authorization status of the Mullvad daemon.
+#[repr(i32)]
+pub enum LaunchDaemonStatus {
+    Ok = 0,
+    NotFound = 1,
+    NotAuthorized = 2,
+    Unknown = 3,
+}
+
+/// Return whether the daemon is running, not found, or is not authorized.
+/// NOTE: On macos < 13, this function always returns `LaunchDaemonStatus::Ok`.
+pub fn get_status() -> LaunchDaemonStatus {
+    // `SMAppService` does not exist if the major version is less than 13.
+    if get_os_version().major_version < 13 {
+        return LaunchDaemonStatus::Ok;
+    }
+    get_status_for_url(&daemon_plist_url())
+}
+
+fn get_status_for_url(url: &Object) -> LaunchDaemonStatus {
+    let status: libc::c_long =
+        unsafe { msg_send![class!(SMAppService), statusForLegacyURL: url.0] };
+
+    match status {
+        // SMAppServiceStatusNotRegistered | SMAppServiceStatusNotFound
+        0 | 3 => LaunchDaemonStatus::NotFound,
+        // SMAppServiceStatusEnabled
+        1 => LaunchDaemonStatus::Ok,
+        // SMAppServiceStatusRequiresApproval
+        2 => LaunchDaemonStatus::NotAuthorized,
+        // Unknown status
+        _ => LaunchDaemonStatus::Unknown,
+    }
+}
+
+fn get_os_version() -> NSOperatingSystemVersion {
+    // the object is lazily instantiated, so we don't release it
+    let proc_info: Id = unsafe { msg_send![class!(NSProcessInfo), processInfo] };
+    unsafe { msg_send![proc_info, operatingSystemVersion] }
+}
+
+/// Returns an `NSURL` instance for `DAEMON_PLIST_PATH`.
+fn daemon_plist_url() -> Object {
+    /// Path to the plist that defines the Mullvad launch daemon.
+    /// It must be kept in sync with the path defined in
+    /// `dist-assets/pkg-scripts/postinstall`.
+    const DAEMON_PLIST_PATH: &CStr = unsafe {
+        CStr::from_bytes_with_nul_unchecked(b"/Library/LaunchDaemons/net.mullvad.daemon.plist\0")
+    };
+
+    let nsstr_inst: Id = unsafe { msg_send![class!(NSString), alloc] };
+    let nsstr_inst: Id =
+        unsafe { msg_send![nsstr_inst, initWithUTF8String: DAEMON_PLIST_PATH.as_ptr()] };
+
+    let nsurl_inst: Id = unsafe { msg_send![class!(NSURL), alloc] };
+    let nsurl_inst: Id = unsafe { msg_send![nsurl_inst, initWithString: nsstr_inst] };
+
+    let _: libc::c_void = unsafe { msg_send![nsstr_inst, release] };
+
+    assert!(!nsurl_inst.is_null());
+
+    Object(nsurl_inst)
+}
+
+/// Calls `[self.0 release]` when the wrapped instance is dropped.
+struct Object(Id);
+
+impl Drop for Object {
+    fn drop(&mut self) {
+        let _: libc::c_void = unsafe { msg_send![self.0, release] };
+    }
+}

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -14,6 +14,8 @@ mod cli;
 #[cfg(target_os = "linux")]
 mod early_boot_firewall;
 mod exception_logging;
+#[cfg(target_os = "macos")]
+mod macos_launch_daemon;
 #[cfg(windows)]
 mod system_service;
 
@@ -50,6 +52,11 @@ fn init_daemon_logging(config: &cli::Config) -> Result<Option<PathBuf>, String> 
     #[cfg(target_os = "linux")]
     if config.initialize_firewall_and_exit {
         init_early_boot_logging(config);
+        return Ok(None);
+    }
+
+    #[cfg(target_os = "macos")]
+    if config.launch_daemon_status {
         return Ok(None);
     }
 
@@ -127,7 +134,15 @@ async fn run_platform(config: &cli::Config, log_dir: Option<PathBuf>) -> Result<
     run_standalone(log_dir).await
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(target_os = "macos")]
+async fn run_platform(config: &cli::Config, log_dir: Option<PathBuf>) -> Result<(), String> {
+    if config.launch_daemon_status {
+        std::process::exit(macos_launch_daemon::get_status() as i32);
+    }
+    run_standalone(log_dir).await
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 async fn run_platform(_config: &cli::Config, log_dir: Option<PathBuf>) -> Result<(), String> {
     run_standalone(log_dir).await
 }


### PR DESCRIPTION
This PR adds a flag to `mullvad-daemon`, `--query-service`, which returns the authorization status of the launch daemon. If it is disallowed (`SMAppServiceStatusRequiresApproval`), then the GUI displays a message and a button that opens the login items panel, where the user can allow it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4319)
<!-- Reviewable:end -->
