### PR TITLE
Replace serde-xml-rs with quick-xml in translations-converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,18 +2769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-xml-rs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0bf1ba0696ccf0872866277143ff1fd14d22eec235d2b23702f95e6660f7dfa"
-dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml-rs",
 ]
 
 [[package]]
@@ -3705,9 +3703,9 @@ dependencies = [
  "derive_more",
  "htmlize",
  "lazy_static",
+ "quick-xml",
  "regex",
  "serde",
- "serde-xml-rs",
 ]
 
 [[package]]
@@ -4238,12 +4236,6 @@ dependencies = [
  "rand_core 0.6.4",
  "zeroize",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zeroize"

--- a/android/translations-converter/Cargo.toml
+++ b/android/translations-converter/Cargo.toml
@@ -12,4 +12,4 @@ htmlize = "0.5"
 lazy_static = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
-serde-xml-rs = "0.4"
+quick-xml = { version = "0.27.1", features = ["serialize"] }

--- a/android/translations-converter/src/android/plurals.rs
+++ b/android/translations-converter/src/android/plurals.rs
@@ -18,6 +18,7 @@ pub struct PluralResources {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PluralResource {
     /// The plural resource ID.
+    #[serde(rename = "@name")]
     pub name: String,
 
     /// The items of the plural resource, one for each quantity variant.
@@ -31,6 +32,7 @@ pub struct PluralResource {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PluralVariant {
     /// The quantity for this variant to be used.
+    #[serde(rename = "@quantity")]
     pub quantity: PluralQuantity,
 
     /// The string value

--- a/android/translations-converter/src/android/string_value.rs
+++ b/android/translations-converter/src/android/string_value.rs
@@ -197,7 +197,7 @@ mod tests {
             parameters %2$s %d %1$d</root>"#;
 
         let deserialized: Wrapper =
-            serde_xml_rs::from_str(serialized_input).expect("Mal-formed serialized input");
+            quick_xml::de::from_str(serialized_input).expect("Mal-formed serialized input");
 
         let expected = StringValue(
             r#"A multi-line string value with \"quotes\" and parameters %2$s %d %1$d"#.to_owned(),

--- a/android/translations-converter/src/android/strings.rs
+++ b/android/translations-converter/src/android/strings.rs
@@ -18,9 +18,11 @@ pub struct StringResources {
 #[derive(Clone, Debug, Eq, Deserialize, PartialEq, Serialize)]
 pub struct StringResource {
     /// The string resource ID.
+    #[serde(rename = "@name")]
     pub name: String,
 
     /// If the string should be translated or not.
+    #[serde(rename = "@translatable")]
     #[serde(default = "default_translatable")]
     pub translatable: bool,
 
@@ -143,7 +145,7 @@ mod tests {
         ]);
 
         let deserialized: StringResources =
-            serde_xml_rs::from_str(xml_input).expect("malformed XML in test input");
+            quick_xml::de::from_str(xml_input).expect("malformed XML in test input");
 
         assert_eq!(deserialized, expected);
     }
@@ -182,7 +184,7 @@ mod tests {
         ]);
 
         let deserialized: StringResources =
-            serde_xml_rs::from_str(xml_input).expect("malformed XML in test input");
+            quick_xml::de::from_str(xml_input).expect("malformed XML in test input");
 
         assert_eq!(deserialized, expected);
     }

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -39,6 +39,7 @@ use crate::normalize::Normalize;
 use std::{
     collections::HashMap,
     fs::{self, File},
+    io::BufReader,
     path::Path,
 };
 
@@ -48,7 +49,8 @@ fn main() {
     let strings_file = File::open(resources_dir.join("values/strings.xml"))
         .expect("Failed to open string resources file");
     let string_resources: android::StringResources =
-        serde_xml_rs::from_reader(strings_file).expect("Failed to read string resources file");
+        quick_xml::de::from_reader(BufReader::new(strings_file))
+            .expect("Failed to read string resources file");
 
     let known_strings: HashMap<_, _> = string_resources
         .into_iter()
@@ -58,7 +60,8 @@ fn main() {
     let plurals_file = File::open(resources_dir.join("values/plurals.xml"))
         .expect("Failed to open plurals resources file");
     let plural_resources: android::PluralResources =
-        serde_xml_rs::from_reader(plurals_file).expect("Failed to read plural resources file");
+        quick_xml::de::from_reader(BufReader::new(plurals_file))
+            .expect("Failed to read plural resources file");
 
     let known_plurals: HashMap<_, _> = plural_resources
         .iter()


### PR DESCRIPTION
We currently get a warning in `cargo audit` due to [RUSTSEC-2022-0048](https://rustsec.org/advisories/RUSTSEC-2022-0048). It does not look like `serde-xml-rs` is [interested in migrating away from `xml-rs`](https://github.com/RReverser/serde-xml-rs/issues/180) and they mention `quick-xml` as a more up to date replacement. So I migrated to `quick-xml` instead.

Some serde annotation changes were needed to make it pick up fields, which are parsed a bit differently in `quick-xml`. Their documentation on mapping XML to Rust types is here: https://docs.rs/quick-xml/0.27.1/quick_xml/de/index.html#mapping-xml-to-rust-types

The only testing I have done here is making sure `cargo test` passes and that `cargo run` does not change anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4321)
<!-- Reviewable:end -->
