### PR TITLE
Stricter cargo audit (deny warnings)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -37,9 +37,8 @@ jobs:
         #
         # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
         # so it should be safe to ignore it. Stop ignoring the warning once
-        # atty has been replaced in clap and env_logger:
+        # atty has been replaced in clap (when we upgrade to clap 4):
         # https://github.com/clap-rs/clap/pull/4249
-        # https://github.com/rust-cli/env_logger/pull/246
         run: |
           cargo audit --deny warnings \
             --ignore RUSTSEC-2020-0071 \

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -34,9 +34,13 @@ jobs:
       - name: Audit
         # RUSTSEC-2020-0071: Ignore the time segfault CVE since there are no known
         # good workarounds, and we want logs etc to be in local time.
+        #
         # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
         # so it should be safe to ignore it. Stop ignoring the warning once
         # atty has been replaced in clap and env_logger:
         # https://github.com/clap-rs/clap/pull/4249
         # https://github.com/rust-cli/env_logger/pull/246
-        run: cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0145
+        run: |
+          cargo audit --deny warnings \
+            --ignore RUSTSEC-2020-0071 \
+            --ignore RUSTSEC-2021-0145

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -752,8 +752,18 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "atty",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -781,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1035,6 +1045,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6d6206008e25125b1f97fbe5d309eb7b85141cf9199d52dbd3729a1584dd16"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ioctl-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1307,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37209be0ad225457e63814401415e748e2453a5297f9b637338f5fb8afa4ec00"
 dependencies = [
  "ipnet",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1379,9 +1420,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libdbus-sys"
@@ -1397,6 +1438,12 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1580,7 +1627,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "env_logger 0.8.4",
+ "env_logger 0.10.0",
  "err-derive",
  "futures",
  "itertools",
@@ -1714,7 +1761,7 @@ dependencies = [
  "clap",
  "dirs-next",
  "duct",
- "env_logger 0.8.4",
+ "env_logger 0.10.0",
  "err-derive",
  "lazy_static",
  "log",
@@ -1757,7 +1804,7 @@ name = "mullvad-setup"
 version = "0.0.0"
 dependencies = [
  "clap",
- "env_logger 0.8.4",
+ "env_logger 0.10.0",
  "err-derive",
  "lazy_static",
  "mullvad-api",
@@ -1953,7 +2000,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -2652,6 +2699,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,7 +3262,7 @@ dependencies = [
 name = "talpid-openvpn-plugin"
 version = "0.0.0"
 dependencies = [
- "env_logger 0.8.4",
+ "env_logger 0.10.0",
  "err-derive",
  "log",
  "mullvad-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,16 +748,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -2469,8 +2459,6 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.8.4",
- "log",
  "rand 0.8.5",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-tools"

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.13"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "3.0", features = ["cargo"] }
 err-derive = "0.3.1"
-env_logger = "0.8.2"
+env_logger = "0.10.0"
 futures = "0.3"
 natord = "1.0.9"
 serde = "1.0"

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -24,7 +24,7 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
 clap = { version = "3.0", features = ["cargo"] }
-env_logger = "0.8.2"
+env_logger = "0.10.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 duct = "0.13"

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "3.0", features = ["cargo"] }
-env_logger = "0.8.2"
+env_logger = "0.10.0"
 err-derive = "0.3.1"
 lazy_static = "1.1.0"
 

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -112,6 +112,6 @@ tonic-build = { version = "0.8", default-features = false, features = ["transpor
 
 [dev-dependencies]
 tempfile = "3.0"
-quickcheck = "1.0"
+quickcheck = { version = "1.0", default-features = false }
 quickcheck_macros = "1.0"
 tokio = { version = "1", features = [ "test-util" ] }

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 err-derive = "0.3.1"
 log = "0.4"
-env_logger = "0.8.2"
+env_logger = "0.10.0"
 parity-tokio-ipc = "0.9"
 tokio = { version = "1.8", features =  ["rt"] }
 


### PR DESCRIPTION
We do explicitly ignore `RUSTSEC-2021-0145`. But that CVE is only an info level warning, so just `cargo audit` did not trigger an error on it anyway. `--deny warnings` was needed for that. This PR makes our audit check stricter by denying all warnings.

This means that minor stuff such as unmaintained dependencies will trigger an error. That can be annoying. But I figure we can then explicitly add that CVE to this list when it happens. I think that's better than silently ignoring warnings. This way we will get flagged when something is unmaintained etc and we can act on it.

This PR fixes a warnings we had: Upgrade `bumpalo` to avoid [RUSTSEC-2022-0078](https://rustsec.org/advisories/RUSTSEC-2022-0078)

I also upgrade `env_logger`. Since we were mentioning that as a blocker for not ignoring `RUSTSEC-2021-0145` but `env_logger` has already fixed the issue, I figured we better upgrade. We are still pulling in `atty` against our will in a few places, but now they are at least fewer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4322)
<!-- Reviewable:end -->
