### PR TITLE
Add associated bundle id to launch daemon plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.
 
-#### MacOS
+#### macOS
 - Improved reliability of the connectivity check workaround by adding an extra captive portal check
   domain
+- Show "Mullvad VPN" in the Login Items UI instead of "Amagicom AB".
 
 
 ## [2023.1-beta1] - 2023-01-26

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -41,6 +41,9 @@ DAEMON_PLIST=$(cat <<-EOM
                         <integer>1024</integer>
                 </dict>
 
+                <key>AssociatedBundleIdentifiers</key>
+                <string>net.mullvad.vpn</string>
+
                 <key>StandardErrorPath</key>
                 <string>$LOG_DIR/stderr.log</string>
         </dict>


### PR DESCRIPTION
If this isn't set, the name in the Login Items UI is set to the organization of the signing certificate, ie Amagicom AB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4325)
<!-- Reviewable:end -->
