### PR TITLE
Replace atty with is-terminal as a direct dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,7 +3134,6 @@ name = "talpid-core"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "atty",
  "bitflags",
  "byteorder",
  "cfg-if",
@@ -3215,13 +3214,13 @@ name = "talpid-openvpn"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "atty",
  "bitflags",
  "byteorder",
  "cfg-if",
  "duct",
  "err-derive",
  "futures",
+ "is-terminal",
  "lazy_static",
  "log",
  "os_pipe",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -35,7 +35,6 @@ tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
 rand = "0.8.5"
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-atty = "0.2"
 byteorder = "1"
 internet-checksum = "0.2"
 shadowsocks-service = { version = "1.14.3", default-features = false, features = ["local", "stream-cipher"] }

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 [dependencies]
 bitflags = "1.2"
 async-trait = "0.1"
-atty = "0.2"
 cfg-if = "1.0"
 duct = "0.13"
 err-derive = "0.3.1"
 futures = "0.3.15"
+is-terminal = "0.4.2"
 lazy_static = "1.0"
 log = "0.4"
 os_pipe = "0.9"

--- a/talpid-openvpn/src/process/openvpn.rs
+++ b/talpid-openvpn/src/process/openvpn.rs
@@ -1,7 +1,6 @@
 use duct;
 
 use super::stoppable_process::StoppableProcess;
-use atty;
 use os_pipe::{pipe, PipeWriter};
 use parking_lot::Mutex;
 use shell_escape;
@@ -388,11 +387,13 @@ pub struct OpenVpnProcHandle {
 impl OpenVpnProcHandle {
     /// Constructor for a new openvpn proc handle
     pub fn new(mut cmd: duct::Expression) -> io::Result<Self> {
-        if !atty::is(atty::Stream::Stdout) {
+        use is_terminal::IsTerminal;
+
+        if !std::io::stdout().is_terminal() {
             cmd = cmd.stdout_null();
         }
 
-        if !atty::is(atty::Stream::Stderr) {
+        if !std::io::stderr().is_terminal() {
             cmd = cmd.stderr_null();
         }
 


### PR DESCRIPTION
Basically a follow up to #4322 and #4323. Getting rid of our direct dependencies on the unmaintained and unsound crate `atty`.

We still depend on `atty` via `clap` and `fern`. For `fern` the issue is tracked [here](https://github.com/daboross/fern/issues/113) and for `clap` "all" we have to do is to upgrade to clap 4.

I have no idea why `cargo udeps` did not catch `atty` being unused in `talpid-core` however :shrug:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4327)
<!-- Reviewable:end -->
