### PR TITLE
Add extra captive portal domain to custom resolver allow-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.
 
+#### MacOS
+- Improved reliability of the connectivity check workaround by adding an extra captive portal check
+  domain
+
 
 ## [2023.1-beta1] - 2023-01-26
 ### Added

--- a/docs/allow-macos-network-check.md
+++ b/docs/allow-macos-network-check.md
@@ -6,20 +6,26 @@ daemon relies on the routing table to obtain a default route to route traffic to
 and since macOS's network reachability seemingly does too, the daemon won't be able to connect to a
 relay and thus stay in the blocked state for a prolonged time. The default route is only published
 when macOS finishes or times out its captive portal check. The captive portal check involves
-looking up `captive.apple.com` and issuing an HTTP request to the resolved address, and by default,
-if the app is blocking traffic, none of these network operations can take place, so the timeout is
-always incurred, which forces the app into the offline error state for a prolonged time.
+looking up specific captive portal domains and issuing an HTTP request to the resolved address, and
+by default, if the app is blocking traffic, none of these network operations can take place, so the
+timeout is always incurred, which forces the app into the offline error state for a prolonged time.
 
 To not have to wait for macOS to time out its captive portal check, the app should allow the
 captive portal check even when it's in a blocking state, whilst still blocking all arbitrary DNS
 traffic. However, only a DNS response is required to appease the connectivity check - and it doesn't
 even need to be valid. As such, during blocked states the app can run a custom resolver that only
-responds to queries for `captive.apple.com` to allow macOS to do its connectivity check. Since no
+responds to queries for captive portal domains to allow macOS to do its connectivity check. Since no
 lookups have to be made, no traffic needs to be leaked.
 
 # Overcoming these issues in the daemon.
 
 To allow the connectivity check to pass when blocking traffic, the daemon runs a custom resolver
 that listens only on localhost on an arbitrary port. Traffic to it is only redirected during blocked
-states. The resolver only replies to queries for `captive.apple.com`. The resolver won't actually
+states. The resolver only replies to queries for captive portal domains. The resolver won't actually
 send any packets besides replying to DNS query that originates from localhost.
+
+### List of currently known captive portal domains
+
+- `captive.apple.com`
+- `netcts.cdn-apple.com`
+

--- a/talpid-core/src/resolver.rs
+++ b/talpid-core/src/resolver.rs
@@ -30,7 +30,16 @@ use trust_dns_server::{
 };
 
 const ALLOWED_RECORD_TYPES: &[RecordType] = &[RecordType::A, RecordType::AAAA, RecordType::CNAME];
-const CAPTIVE_PORTAL_DOMAIN: &str = "captive.apple.com";
+const CAPTIVE_PORTAL_DOMAINS: &[&str] = &["captive.apple.com", "netcts.cdn-apple.com"];
+
+lazy_static::lazy_static! {
+    static ref ALLOWED_DOMAINS: Vec<LowerName> =
+        CAPTIVE_PORTAL_DOMAINS
+            .iter()
+            .map(|domain| LowerName::from(Name::from_str(domain).unwrap()))
+            .collect();
+}
+
 const TTL_SECONDS: u32 = 3;
 /// An IP address to be used in the DNS response to the captive domain query. The address itself
 /// belongs to the documentation range so should never be reachable.
@@ -166,9 +175,7 @@ impl FilteringResolver {
     /// Determines whether a DNS query is allowable. Currently, this implies that the query is
     /// either a `A`, `AAAA` or a `CNAME` query for `captive.apple.com`.
     fn allow_query(&self, query: &LowerQuery) -> bool {
-        let captive_apple_com: LowerName =
-            LowerName::from(Name::from_str(CAPTIVE_PORTAL_DOMAIN).unwrap());
-        ALLOWED_RECORD_TYPES.contains(&query.query_type()) && query.name() == &captive_apple_com
+        ALLOWED_RECORD_TYPES.contains(&query.query_type()) && ALLOWED_DOMAINS.contains(query.name())
     }
 }
 
@@ -296,13 +303,13 @@ mod test {
         let handle = rt.block_on(start_resolver());
         let test_resolver = get_test_resolver(handle.listening_port());
 
-        let captive_portal_domain = LowerName::from(Name::from_str(CAPTIVE_PORTAL_DOMAIN).unwrap());
-        let resolver_result = rt.block_on(async move {
-            test_resolver
-                .lookup(captive_portal_domain, RecordType::A)
-                .await
-        });
-        resolver_result.expect("Failed to resolve test domain");
+        rt.block_on(async move {
+            for domain in &*ALLOWED_DOMAINS {
+                test_resolver.lookup(domain, RecordType::A).await?;
+            }
+            Ok::<(), trust_dns_server::resolver::error::ResolveError>(())
+        })
+        .expect("Resolution of domains failed");
     }
 
     #[test]


### PR DESCRIPTION
Since it seems like there's another captive portal domain used for macOS's connectivity check, the custom resolver has been changed to match against both domains.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4329)
<!-- Reviewable:end -->
