### PR TITLE
Drop account number authorization

### DIFF
--- a/ios/MullvadREST/RESTAuthorization.swift
+++ b/ios/MullvadREST/RESTAuthorization.swift
@@ -17,10 +17,7 @@ protocol RESTAuthorizationProvider {
 }
 
 extension REST {
-    enum Authorization {
-        case accountNumber(String)
-        case accessToken(String)
-    }
+    typealias Authorization = String
 
     struct AccessTokenProvider: RESTAuthorizationProvider {
         private let accessTokenManager: AccessTokenManager
@@ -43,7 +40,7 @@ extension REST {
                 retryStrategy: retryStrategy
             ) { operationCompletion in
                 completion(operationCompletion.map { tokenData in
-                    return .accessToken(tokenData.accessToken)
+                    return tokenData.accessToken
                 })
             }
         }

--- a/ios/MullvadREST/RESTRequestFactory.swift
+++ b/ios/MullvadREST/RESTRequestFactory.swift
@@ -113,16 +113,10 @@ extension REST {
         }
 
         mutating func setAuthorization(_ authorization: REST.Authorization) {
-            let value: String
-            switch authorization {
-            case let .accountNumber(accountNumber):
-                value = "Token \(accountNumber)"
-
-            case let .accessToken(accessToken):
-                value = "Bearer \(accessToken)"
-            }
-
-            restRequest.urlRequest.addValue(value, forHTTPHeaderField: HTTPHeader.authorization)
+            restRequest.urlRequest.addValue(
+                "Bearer \(authorization)",
+                forHTTPHeaderField: HTTPHeader.authorization
+            )
         }
 
         func getRequest() -> REST.Request {


### PR DESCRIPTION
This PR migrates the last call using account number authorization (`/app/v1/create-apple-payment`) to access token based authorization. `REST.Authorization.accountNumber` is dropped too and `REST.Authorization` is simplified to be an alias to `String`, which is basically account token.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4334)
<!-- Reviewable:end -->
