### PR TITLE
Upgrade tokio to avoid RUSTSEC-2023-0005

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,9 +3510,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a54aca0c15d014013256222ba0ebed095673f89345dd79119d912eb561b7a8"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",


### PR DESCRIPTION
Upgrading tokio due to a CVE https://rustsec.org/advisories/RUSTSEC-2023-0005.

Found by CI: https://github.com/mullvad/mullvadvpn-app/actions/runs/4101000289/jobs/7072358220

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4335)
<!-- Reviewable:end -->
