### PR TITLE
Backport automatic tracking of login overlay

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		58421030282D8A3C00F24E46 /* UpdateAccountDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5842102F282D8A3C00F24E46 /* UpdateAccountDataOperation.swift */; };
 		58421032282E42B000F24E46 /* UpdateDeviceDataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58421031282E42B000F24E46 /* UpdateDeviceDataOperation.swift */; };
 		58421034282E4B1500F24E46 /* TunnelSettingsV2+REST.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58421033282E4B1500F24E46 /* TunnelSettingsV2+REST.swift */; };
+		584555F42991176200DD0657 /* UIPresentationController+Private.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584555F32991176200DD0657 /* UIPresentationController+Private.swift */; };
 		584592612639B4A200EF967F /* TermsOfServiceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584592602639B4A200EF967F /* TermsOfServiceContentView.swift */; };
 		5846227126E229F20035F7C2 /* StoreSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846227026E229F20035F7C2 /* StoreSubscription.swift */; };
 		5846227326E22A160035F7C2 /* StorePaymentObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846227226E22A160035F7C2 /* StorePaymentObserver.swift */; };
@@ -698,6 +699,7 @@
 		5842102F282D8A3C00F24E46 /* UpdateAccountDataOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAccountDataOperation.swift; sourceTree = "<group>"; };
 		58421031282E42B000F24E46 /* UpdateDeviceDataOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateDeviceDataOperation.swift; sourceTree = "<group>"; };
 		58421033282E4B1500F24E46 /* TunnelSettingsV2+REST.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TunnelSettingsV2+REST.swift"; sourceTree = "<group>"; };
+		584555F32991176200DD0657 /* UIPresentationController+Private.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPresentationController+Private.swift"; sourceTree = "<group>"; };
 		584592602639B4A200EF967F /* TermsOfServiceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceContentView.swift; sourceTree = "<group>"; };
 		5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsRequestOperation.swift; sourceTree = "<group>"; };
 		5846227026E229F20035F7C2 /* StoreSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSubscription.swift; sourceTree = "<group>"; };
@@ -1496,6 +1498,7 @@
 				58E11187292FA11F009FCA84 /* SettingsMigrationUIHandler.swift */,
 				58A8EE592976BFBB009C0F8D /* SKError+Localized.swift */,
 				58ACA9EC2979569500B5825C /* ModalRootAdaptivePresentationDelegate.swift */,
+				584555F32991176200DD0657 /* UIPresentationController+Private.swift */,
 			);
 			path = MullvadVPN;
 			sourceTree = "<group>";
@@ -2373,6 +2376,7 @@
 				58DF28A52417CB4B00E836B0 /* StorePaymentManager.swift in Sources */,
 				583DA21425FA4B5C00318683 /* LocationDataSource.swift in Sources */,
 				587EB6742714520600123C75 /* PreferencesDataSourceDelegate.swift in Sources */,
+				584555F42991176200DD0657 /* UIPresentationController+Private.swift in Sources */,
 				582BB1AF229566420055B6EF /* SettingsCell.swift in Sources */,
 				58F3C0A4249CB069003E76BE /* HeaderBarView.swift in Sources */,
 				587A01FC23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift in Sources */,

--- a/ios/MullvadVPN/ModalRootAdaptivePresentationDelegate.swift
+++ b/ios/MullvadVPN/ModalRootAdaptivePresentationDelegate.swift
@@ -54,9 +54,16 @@ final class ModalRootAdaptivePresentationDelegate: NSObject,
         self.modalRootContainer = modalRootContainer
 
         super.init()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(dismissalTransitionDidEnd(_:)),
+            name: UIPresentationController.dismissalTransitionDidEndNotification,
+            object: modalRootContainer
+        )
     }
 
-    func finishPresentation() {
+    private func finishPresentation() {
         parentRootContainer.removeSettingsButtonFromPresentationContainer()
     }
 
@@ -64,11 +71,7 @@ final class ModalRootAdaptivePresentationDelegate: NSObject,
         for controller: UIPresentationController,
         traitCollection: UITraitCollection
     ) -> UIModalPresentationStyle {
-        if controller.presentedViewController is RootContainerViewController {
-            return traitCollection.horizontalSizeClass == .regular ? .formSheet : .fullScreen
-        } else {
-            return .none
-        }
+        return traitCollection.horizontalSizeClass == .regular ? .formSheet : .fullScreen
     }
 
     func presentationController(
@@ -107,6 +110,18 @@ final class ModalRootAdaptivePresentationDelegate: NSObject,
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         finishPresentation()
+    }
+
+    @objc private func dismissalTransitionDidEnd(_ notification: Notification) {
+        guard let isCompleted = notification
+            .userInfo?[
+                UIPresentationController
+                    .dismissalTransitionDidEndCompletedUserInfoKey
+            ] as? NSNumber else { return }
+
+        if isCompleted.boolValue {
+            finishPresentation()
+        }
     }
 }
 

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -362,10 +362,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, UISplitViewControllerDe
             return
         }
 
-        modalRootContainer.dismiss(animated: animated) {
-            self.modalRootAdaptivePresentationDelegate.finishPresentation()
-            completion()
-        }
+        modalRootContainer.dismiss(animated: animated, completion: completion)
     }
 
     private var isModalRootPresented: Bool {

--- a/ios/MullvadVPN/UIPresentationController+Private.swift
+++ b/ios/MullvadVPN/UIPresentationController+Private.swift
@@ -1,0 +1,35 @@
+//
+//  UIPresentationController+Private.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 31/01/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+extension UIPresentationController {
+    static let presentationTransitionWillBegin = Notification.Name(
+        "UIPresentationControllerPresentationTransitionWillBeginNotification"
+    )
+
+    static let presentationTransitionDidEndNotification = Notification.Name(
+        "UIPresentationControllerPresentationTransitionDidEndNotification"
+    )
+
+    static let dismissalTransitionWillBeginNotification = Notification.Name(
+        "UIPresentationControllerDismissalTransitionWillBeginNotification"
+    )
+
+    static let dismissalTransitionDidEndNotification = Notification.Name(
+        "UIPresentationControllerDismissalTransitionDidEndNotification"
+    )
+
+    /// Included in `presentationTransitionDidEndNotification` notifications.
+    static let presentationTransitionDidEndCompletedUserInfoKey =
+        "UIPresentationControllerPresentationTransitionDidEndCompletedKey"
+
+    /// Included in `dismissalTransitionDidEndNotification` notifications.
+    static let dismissalTransitionDidEndCompletedUserInfoKey =
+        "UIPresentationControllerDismissalTransitionDidEndCompletedKey"
+}


### PR DESCRIPTION
This PR backports automatic tracking of presentation controller dismissal of login overlay. Hopefully that should fix any outstanding issues related to settings button disappearance.

This PR relies on private notifications issued by `UIPresentationController` which is unfortunate but they have been around since a long time ago and I think it's fair to assume they will continue working in the foreseeable future. Eventually we will switch to our custom form-sheet presentation controller but for now that should do it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4336)
<!-- Reviewable:end -->
