### PR TITLE
Remove automatic fallback to wireguard-go on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Line wrap the file at 100 chars.                                              Th
 - Update the Post-Quantum secure key exchange gRPC client to use the stabilized
   `PskExchangeV1` endpoint
 
+#### Windows
+- Remove automatic fallback to wireguard-go. This is done as a first step before fully
+  deprecating it on Windows.
+
 ### Fixed
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.

--- a/talpid-wireguard/src/wireguard_nt.rs
+++ b/talpid-wireguard/src/wireguard_nt.rs
@@ -410,6 +410,27 @@ impl WgNtTunnel {
         config: &Config,
         log_path: Option<&Path>,
         resource_dir: &Path,
+        done_tx: futures::channel::mpsc::Sender<std::result::Result<(), BoxedError>>,
+    ) -> std::result::Result<Self, super::TunnelError> {
+        Self::start_tunnel_inner(config, log_path, resource_dir, done_tx).map_err(|error| {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to setup WireGuardNT tunnel")
+            );
+
+            match error {
+                Error::CreateTunnelDeviceError(_) => {
+                    super::TunnelError::RecoverableStartWireguardError
+                }
+                _ => super::TunnelError::FatalStartWireguardError,
+            }
+        })
+    }
+
+    fn start_tunnel_inner(
+        config: &Config,
+        log_path: Option<&Path>,
+        resource_dir: &Path,
         mut done_tx: futures::channel::mpsc::Sender<std::result::Result<(), BoxedError>>,
     ) -> Result<Self> {
         let dll = load_wg_nt_dll(resource_dir)?;
@@ -447,13 +468,12 @@ impl WgNtTunnel {
                 .await;
         });
 
-        let tunnel = WgNtTunnel {
+        Ok(WgNtTunnel {
             device,
             interface_name,
             setup_handle,
             _logger_handle: logger_handle,
-        };
-        Ok(tunnel)
+        })
     }
 
     fn stop_tunnel(&mut self) {


### PR DESCRIPTION
It's unclear how often this path is taken, so it makes sense to keep the option to use wireguard-go for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4337)
<!-- Reviewable:end -->
