### PR TITLE
Disable retry strategy for access tokens

### DIFF
--- a/ios/MullvadREST/RESTAPIProxy.swift
+++ b/ios/MullvadREST/RESTAPIProxy.swift
@@ -130,10 +130,7 @@ extension REST {
 
                     return requestBuilder.getRequest()
                 },
-                authorizationProvider: createAuthorizationProvider(
-                    accountNumber: accountNumber,
-                    retryStrategy: .default
-                )
+                authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber)
             )
 
             let responseHandler =

--- a/ios/MullvadREST/RESTAccessTokenManager.swift
+++ b/ios/MullvadREST/RESTAccessTokenManager.swift
@@ -25,7 +25,6 @@ extension REST {
 
         func getAccessToken(
             accountNumber: String,
-            retryStrategy: REST.RetryStrategy,
             completionHandler: @escaping (OperationCompletion<REST.AccessTokenData, REST.Error>)
                 -> Void
         ) -> Cancellable {
@@ -39,7 +38,7 @@ extension REST {
 
                 let task = self.proxy.getAccessToken(
                     accountNumber: accountNumber,
-                    retryStrategy: retryStrategy
+                    retryStrategy: .noRetry
                 ) { completion in
                     self.dispatchQueue.async {
                         switch completion {

--- a/ios/MullvadREST/RESTAccountsProxy.swift
+++ b/ios/MullvadREST/RESTAccountsProxy.swift
@@ -66,10 +66,7 @@ extension REST {
 
                     return requestBuilder.getRequest()
                 },
-                authorizationProvider: createAuthorizationProvider(
-                    accountNumber: accountNumber,
-                    retryStrategy: .default
-                )
+                authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber)
             )
 
             let responseHandler = REST.defaultResponseHandler(

--- a/ios/MullvadREST/RESTAuthorization.swift
+++ b/ios/MullvadREST/RESTAuthorization.swift
@@ -22,40 +22,28 @@ extension REST {
     struct AccessTokenProvider: RESTAuthorizationProvider {
         private let accessTokenManager: AccessTokenManager
         private let accountNumber: String
-        private let retryStrategy: REST.RetryStrategy
 
-        init(
-            accessTokenManager: AccessTokenManager,
-            accountNumber: String,
-            retryStrategy: REST.RetryStrategy
-        ) {
+        init(accessTokenManager: AccessTokenManager, accountNumber: String) {
             self.accessTokenManager = accessTokenManager
             self.accountNumber = accountNumber
-            self.retryStrategy = retryStrategy
         }
 
         func getAuthorization(completion: @escaping (Completion) -> Void) -> Cancellable {
-            return accessTokenManager.getAccessToken(
-                accountNumber: accountNumber,
-                retryStrategy: retryStrategy
-            ) { operationCompletion in
-                completion(operationCompletion.map { tokenData in
-                    return tokenData.accessToken
-                })
-            }
+            return accessTokenManager
+                .getAccessToken(accountNumber: accountNumber) { operationCompletion in
+                    completion(operationCompletion.map { tokenData in
+                        return tokenData.accessToken
+                    })
+                }
         }
     }
 }
 
 extension REST.Proxy where ConfigurationType == REST.AuthProxyConfiguration {
-    func createAuthorizationProvider(
-        accountNumber: String,
-        retryStrategy: REST.RetryStrategy
-    ) -> RESTAuthorizationProvider {
+    func createAuthorizationProvider(accountNumber: String) -> RESTAuthorizationProvider {
         return REST.AccessTokenProvider(
             accessTokenManager: configuration.accessTokenManager,
-            accountNumber: accountNumber,
-            retryStrategy: retryStrategy
+            accountNumber: accountNumber
         )
     }
 }

--- a/ios/MullvadREST/RESTDevicesProxy.swift
+++ b/ios/MullvadREST/RESTDevicesProxy.swift
@@ -53,10 +53,7 @@ extension REST {
 
                     return requestBuilder.getRequest()
                 },
-                authorizationProvider: createAuthorizationProvider(
-                    accountNumber: accountNumber,
-                    retryStrategy: .default
-                )
+                authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber)
             )
 
             let responseHandler =
@@ -104,10 +101,7 @@ extension REST {
 
                     return requestBuilder.getRequest()
                 },
-                authorizationProvider: createAuthorizationProvider(
-                    accountNumber: accountNumber,
-                    retryStrategy: .default
-                )
+                authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber)
             )
 
             let responseHandler = REST.defaultResponseHandler(
@@ -146,10 +140,7 @@ extension REST {
 
                     return requestBuilder.getRequest()
                 },
-                authorizationProvider: createAuthorizationProvider(
-                    accountNumber: accountNumber,
-                    retryStrategy: .default
-                )
+                authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber)
             )
 
             let responseHandler = REST.defaultResponseHandler(
@@ -196,10 +187,7 @@ extension REST {
 
                     return requestBuilder.getRequest()
                 },
-                authorizationProvider: createAuthorizationProvider(
-                    accountNumber: accountNumber,
-                    retryStrategy: .default
-                )
+                authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber)
             )
 
             let responseHandler =
@@ -268,10 +256,7 @@ extension REST {
 
                     return urlRequest
                 },
-                authorizationProvider: createAuthorizationProvider(
-                    accountNumber: accountNumber,
-                    retryStrategy: .default
-                )
+                authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber)
             )
 
             let responseHandler = REST.defaultResponseHandler(


### PR DESCRIPTION
Requests that require authorization already implement their own retry strategy. Hence access token requests should be a part of that strategy and not behave as each having their individual strategy.

Previously a request requiring authentication configured with 3 retry attempts would perform 9 calls (3 * 3) to obtain access token in the worst case. That's because each individual request to obtain access token was configured with default retry strategy (3 retry attempts). With this change exactly 3 attempts will be made in total.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4341)
<!-- Reviewable:end -->
