### PR TITLE
Relax permissions for settings.json

### DIFF
--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -992,8 +992,7 @@ fn map_settings_error(error: settings::Error) -> Status {
     match error {
         settings::Error::DeleteError(..)
         | settings::Error::WriteError(..)
-        | settings::Error::ReadError(..)
-        | settings::Error::SetPermissions(..) => {
+        | settings::Error::ReadError(..) => {
             Status::new(Code::FailedPrecondition, error.to_string())
         }
         settings::Error::SerializeError(..) | settings::Error::ParseError(..) => {

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -157,12 +157,7 @@ pub(crate) async fn migrate_all(
 
     let buffer = serde_json::to_string_pretty(&settings).map_err(Error::Serialize)?;
 
-    let mut options = fs::OpenOptions::new();
-    #[cfg(unix)]
-    {
-        options.mode(0o600);
-    }
-    let mut file = options
+    let mut file = fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)


### PR DESCRIPTION
Previously, only root has read access to settings.json, as it contained the account number. Since that's no longer the case, making it readable by any user is fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4342)
<!-- Reviewable:end -->
