### PR TITLE
Deny clippy `unused_async` lint

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -37,4 +37,4 @@ jobs:
         run: |-
           export RUSTFLAGS="--deny warnings"
           source env.sh
-          time cargo clippy --locked --verbose
+          time cargo clippy --locked -- -W clippy::unused_async

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -274,7 +274,7 @@ impl RequestServiceHandle {
     }
 
     /// Forcibly update the connection mode.
-    pub async fn next_api_endpoint(&self) -> Result<()> {
+    pub fn next_api_endpoint(&self) -> Result<()> {
         self.tx
             .unbounded_send(RequestCommand::NextApiConfig)
             .map_err(|_| Error::SendError)

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -148,7 +148,7 @@ pub(crate) async fn migrate_all(
     account_history::migrate_location(cache_dir, settings_dir).await;
     account_history::migrate_formats(settings_dir, &mut settings).await?;
 
-    let migration_data = v5::migrate(&mut settings).await?;
+    let migration_data = v5::migrate(&mut settings)?;
 
     if settings == old_settings {
         // Nothing changed

--- a/mullvad-daemon/src/migrations/v5.rs
+++ b/mullvad-daemon/src/migrations/v5.rs
@@ -48,7 +48,7 @@ pub enum SelectedObfuscation {
 
 // ======================================================
 
-pub(crate) struct MigrationData {
+pub struct MigrationData {
     pub token: AccountToken,
     pub wg_data: Option<serde_json::Value>,
 }
@@ -68,7 +68,7 @@ pub(crate) struct MigrationData {
 /// Additionally, the WireGuard protocol constraint, if set to be using TCP, is migrated into
 /// having an active Udp2Tcp obfuscator. The protocol constraint is then removed from WireGuard
 /// settings since all WireGuard traffic is UDP.
-pub(crate) async fn migrate(settings: &mut serde_json::Value) -> Result<Option<MigrationData>> {
+pub fn migrate(settings: &mut serde_json::Value) -> Result<Option<MigrationData>> {
     if !version_matches(settings) {
         return Ok(None);
     }
@@ -329,7 +329,7 @@ mod test {
         let mut old_settings = serde_json::from_str(V5_SETTINGS).unwrap();
 
         assert!(version_matches(&mut old_settings));
-        migrate(&mut old_settings).await.unwrap();
+        migrate(&mut old_settings).unwrap();
         let new_settings: serde_json::Value = serde_json::from_str(V6_SETTINGS).unwrap();
 
         assert_eq!(&old_settings, &new_settings);

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -105,7 +105,7 @@ async fn main() {
         Some(("remove-device", _)) => remove_device().await,
         Some(("is-older-version", sub_matches)) => {
             let old_version = sub_matches.value_of("OLDVERSION").unwrap();
-            match is_older_version(old_version).await {
+            match is_older_version(old_version) {
                 // Returning exit status
                 Ok(status) => process::exit(status as i32),
                 Err(error) => Err(error),
@@ -120,7 +120,7 @@ async fn main() {
     }
 }
 
-async fn is_older_version(old_version: &str) -> Result<ExitStatus, Error> {
+fn is_older_version(old_version: &str) -> Result<ExitStatus, Error> {
     let parsed_version =
         ParsedAppVersion::from_str(old_version).map_err(|_| Error::ParseVersionStringError)?;
 

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -460,6 +460,7 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
         Ok(monitor)
     }
 
+    #[cfg_attr(not(windows), allow(clippy::unused_async))]
     async fn prepare_process(
         cmd: C,
         #[cfg(windows)] wintun: Arc<Box<dyn WintunContext>>,

--- a/talpid-routing/src/linux.rs
+++ b/talpid-routing/src/linux.rs
@@ -357,7 +357,7 @@ impl RouteManagerImpl {
                     self.process_command(command).await?;
                 },
                 (route_change, _socket) = self.messages.select_next_some().fuse() => {
-                    if let Err(error) = self.process_netlink_message(route_change).await {
+                    if let Err(error) = self.process_netlink_message(route_change) {
                         log::error!("{}", error.display_chain_with_msg("Failed to process netlink message"));
                     }
                 }
@@ -401,7 +401,7 @@ impl RouteManagerImpl {
         Ok(())
     }
 
-    async fn process_netlink_message(&mut self, msg: NetlinkMessage<RtnlMessage>) -> Result<()> {
+    fn process_netlink_message(&mut self, msg: NetlinkMessage<RtnlMessage>) -> Result<()> {
         match msg.payload {
             NetlinkPayload::InnerMessage(RtnlMessage::NewLink(new_link)) => {
                 if let Some((idx, name)) = Self::map_interface(new_link) {


### PR DESCRIPTION
We had a bunch of `async fn`s that did not really do anything asynchronous. This lint is for some reason at the pedantic level, but I think it's a good lint. So I propose we bring it in and make it a hard error.

I wish there was a way to deny specific lints in `clippy.toml`, but that seems not possible. This documentation only talks about doing it on the command line: https://doc.rust-lang.org/stable/clippy/configuration.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4343)
<!-- Reviewable:end -->
