### PR TITLE
WIP: Run clippy on all desktop platforms

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,7 +9,10 @@ on:
   workflow_dispatch:
 jobs:
   clippy_check:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -29,11 +32,13 @@ jobs:
           override: true
 
       - name: Install build dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install libdbus-1-dev
 
       - name: Clippy check
+        shell: bash
         run: |-
           export RUSTFLAGS="--deny warnings"
           source env.sh


### PR DESCRIPTION
We have *lots* of clippy warnings because we have only run clippy in CI on Linux up until now.

We might not want to go and fix all of this in a big chunk. But it would be great if Rust developers try this out and tackle a few lints here and there until we are down to zero clippy issues.

We still don't run clippy on Android. We should add that also.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4344)
<!-- Reviewable:end -->
