### PR TITLE
Create container-shell.sh script to easier get container shell

### DIFF
--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Gives you a shell or runs a given command in the Android or Linux build container,
+# as designated by the *-container-image.txt files. Uses podman unless overridden using the
+# environment variable `CONTAINER_RUNNER`. Note that this script uses named
+# docker volumes that can be overridden using enviornment variables (see the
+# beginning of the script).
+#
+# Usage: $ container-run.sh <linux/android> [command ...]
+#
+# Not supplying any command gives you a shell in the container.
+
+set -eu
+
+REPO_MOUNT_TARGET="/build"
+CARGO_TARGET_VOLUME_NAME=${CARGO_TARGET_VOLUME_NAME:-"cargo-target"}
+CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
+GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
+ANDROID_CREDENTIALS_DIR=${ANDROID_CREDENTIALS_DIR:-""}
+CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+cd "$SCRIPT_DIR"
+
+source "$REPO_DIR/scripts/utils/log"
+
+case ${1-:""} in
+    linux)
+        container_image_name=$(cat "$SCRIPT_DIR/linux-container-image.txt")
+        shift 1
+    ;;
+    android)
+        container_image_name=$(cat "$SCRIPT_DIR/android-container-image.txt")
+        optional_gradle_cache_volume=(-v "$GRADLE_CACHE_VOLUME_NAME:/root/.gradle:Z")
+
+        if [ -n "$ANDROID_CREDENTIALS_DIR" ]; then
+            optional_android_credentials_volume=(-v "$ANDROID_CREDENTIALS_DIR:$REPO_MOUNT_TARGET/android/credentials:Z")
+        fi
+
+        shift 1
+    ;;
+    *)
+        log_error "Invalid platform. Specify 'linux' or 'android' as first argument"
+        exit 1
+esac
+
+set -x
+exec "$CONTAINER_RUNNER" run --rm -it \
+    -v "$REPO_DIR:$REPO_MOUNT_TARGET:Z" \
+    -v "$CARGO_TARGET_VOLUME_NAME:/root/.cargo/target:Z" \
+    -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
+    "${optional_gradle_cache_volume[@]}" \
+    "${optional_android_credentials_volume[@]}" \
+    "$container_image_name" "$@"

--- a/building/containerized-build.sh
+++ b/building/containerized-build.sh
@@ -1,19 +1,9 @@
 #!/usr/bin/env bash
 
-# Builds the Android or Linux app in the current build container, as designated
-# by the *-container-image.txt files. Uses podman unless overridden using the
-# environment variable `CONTAINER_RUNNER`. Note that this script uses named
-# docker volumes that can be overridden using enviornment variables (see the
-# beginning of the script).
+# Builds the Android or Linux app in the current build container.
+# See the `container-run.sh` script for possible configuration.
 
 set -eu
-
-REPO_MOUNT_TARGET="/build"
-CARGO_TARGET_VOLUME_NAME=${CARGO_TARGET_VOLUME_NAME:-"cargo-target"}
-CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
-GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
-ANDROID_CREDENTIALS_DIR=${ANDROID_CREDENTIALS_DIR:-""}
-CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -21,21 +11,14 @@ cd "$SCRIPT_DIR"
 
 source "$REPO_DIR/scripts/utils/log"
 
-case ${1-:""} in
+platform=${1-:""}
+case $platform in
     linux)
-        container_image_name=$(cat "$SCRIPT_DIR/linux-container-image.txt")
-        build_command=("$REPO_MOUNT_TARGET/build.sh")
+        build_command=("./build.sh")
         shift 1
     ;;
     android)
-        container_image_name=$(cat "$SCRIPT_DIR/android-container-image.txt")
-        build_command=("$REPO_MOUNT_TARGET/build-apk.sh" "--no-docker")
-        optional_gradle_cache_volume=(-v "$GRADLE_CACHE_VOLUME_NAME:/root/.gradle:Z")
-
-        if [ -n "$ANDROID_CREDENTIALS_DIR" ]; then
-            optional_android_credentials_volume=(-v "$ANDROID_CREDENTIALS_DIR:$REPO_MOUNT_TARGET/android/credentials:Z")
-        fi
-
+        build_command=("./build-apk.sh" "--no-docker")
         shift 1
     ;;
     *)
@@ -44,11 +27,4 @@ case ${1-:""} in
 esac
 
 set -x
-exec "$CONTAINER_RUNNER" run --rm -it \
-    -v "$REPO_DIR:$REPO_MOUNT_TARGET:Z" \
-    -v "$CARGO_TARGET_VOLUME_NAME:/root/.cargo/target:Z" \
-    -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
-    "${optional_gradle_cache_volume[@]}" \
-    "${optional_android_credentials_volume[@]}" \
-    "$container_image_name" \
-    "${build_command[@]}" "$@"
+exec "$SCRIPT_DIR/container-run.sh" "$platform" "${build_command[@]}" "$@"


### PR DESCRIPTION
I found it cumbersome to get a shell in or run arbitrary commands in our build containers. This can be very useful to do other stuff than just building the app. For example linting and other stuff without needing those tools on your host. I split `containerized-build.sh` up into two scripts basically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4345)
<!-- Reviewable:end -->
