### PR TITLE
Add Clippy and the Windows toolchain in the Linux build container

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -1,4 +1,4 @@
-# To build the image:
+# To build the image (executed from this Dockerfile directory):
 # podman build . -t mullvadvpn-app-build-android
 #
 # To build using the image:

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -38,13 +38,21 @@ RUN dpkg --add-architecture arm64 && apt-get update -y && apt-get install -y \
     libdbus-1-dev libdbus-1-dev:arm64 \
     rpm \
     protobuf-compiler \
+    # For cross-compiling/linting towards Windows
+    gcc-mingw-w64-x86-64 \
     && rm -rf /var/lib/apt/lists/*
 
 # === Rust ===
 
-# Install latest stable Rust toolchain for both x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu
+# Install latest stable Rust toolchain for both x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu,
+# plus x86_64-pc-windows-gnu for Windows cross-compilation/linting
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- --default-toolchain stable --profile minimal --target aarch64-unknown-linux-gnu -y
+    sh -s -- -y \
+    --default-toolchain stable \
+    --profile minimal \
+    --component clippy \
+    --target aarch64-unknown-linux-gnu \
+    --target x86_64-pc-windows-gnu
 
 ENV PATH=/root/.cargo/bin:$PATH
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc" \

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -1,5 +1,5 @@
-# To build the image:
-# podman build . -t mullvadvpn-app-build
+# To build the image (executed from the repository root):
+# podman build -f building/Dockerfile . -t mullvadvpn-app-build
 #
 # To run the image and build the app you need to mount the app's source directory into the
 # container. You also probably want to mount in a directory for CARGO_HOME, so each container


### PR DESCRIPTION
This makes the container ~560 MiB larger (1.86 -> 2.45 GiB), but as a reward we can easily run `cargo check --target x86_64-pc-windows-gnu` and `cargo clippy --target x86_64-pc-windows-gnu` on our Linux dev machines, something at least I find pretty cumbersome at the moment.

This can potentially also help with #4344, allowing us to have a single job and container running clippy for both Linux and Windows at least, potentially speeding up the CI?

I have not done any deep research, but it seems hard to do the same thing for macOS sadly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4346)
<!-- Reviewable:end -->
