### PR TITLE
Bump linux-container-image to mullvadvpn-app-build:20d7550f1

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -69,7 +69,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Checkout binaries submodule
-        run: git submodule update --init --depth=1 dist-assets/binaries
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init --depth=1 dist-assets/binaries
 
       # The container image already has rustup and Rust, but only the stable toolchain
       - name: Install Rust toolchain

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -41,7 +41,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Checkout binaries submodule
-        run: git submodule update --init --depth=1 dist-assets/binaries
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init --depth=1 dist-assets/binaries
 
       - name: Install nightly Rust toolchain
         run: rustup default $RUST_NIGHTLY_TOOLCHAIN

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/rust-unused-dependencies.yml
       - '**/*.rs'
       - '**/Cargo.toml'
+      - 'building/*-container-image.txt'
   workflow_dispatch:
 env:
   RUST_NIGHTLY_TOOLCHAIN: nightly-2023-01-13

--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:62371bb6c
+ghcr.io/mullvad/mullvadvpn-app-build:20d7550f1


### PR DESCRIPTION
Update the Linux build container image to include #4346 and Rust 1.67

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4349)
<!-- Reviewable:end -->
