### PR TITLE
Allow quantum-resistant tunnels (PQ) to work together with multihop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Line wrap the file at 100 chars.                                              Th
   "off", but this might change in the future.
 - Update OpenVPN to 2.6.0 from 2.5.3.
 - Update OpenSSL to 1.1.1t from 1.1.1j.
+- Post-Quantum secure tunnels and multihop can now be used at the same time.
 
 #### Windows
 - Remove automatic fallback to wireguard-go. This is done as a first step before fully

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,10 +197,11 @@ metadata that might be useful.
 To establish a quantum-resistant tunnel, a pre-shared key (PSK) is derived using a quantum-safe
 key encapsulation mechanism (KEM) with the relay. This is achieved by initiating a regular
 WireGuard tunnel to the relay and deriving the PSK within the tunnel.
-The PSK is saved on the relay and the client, along with a new client generated ephemeral WireGuard
-key. Subsequently, a new tunnel is created using the new WireGuard key and the PSK, ensuring that
-the tunnel is quantum-resistant.
-See [this](../talpid-tunnel-config-client/proto/tunnel_config.proto) for more details on the protocol.
+The PSK is stored in memory on the relay and the client, along with a new client generated ephemeral
+WireGuard key. Subsequently, a new tunnel is created using the new WireGuard key and the PSK,
+ensuring that the tunnel is quantum-resistant.
+See the [protocol definition file](../talpid-tunnel-config-client/proto/tunnel_config.proto) for
+more details on the protocol.
 
 #### Quantum-resistant tunnels & Multihop
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,6 +190,30 @@ metadata that might be useful.
 
 ### Firewall integration
 
+### Connection logic
+
+#### Quantum-resistant tunnels
+
+To establish a quantum-resistant tunnel, a pre-shared key (PSK) is derived using a quantum-safe
+key encapsulation mechanism (KEM) with the relay. This is achieved by initiating a regular
+WireGuard tunnel to the relay and deriving the PSK within the tunnel.
+The PSK is saved on the relay and the client, along with a new client generated ephemeral WireGuard
+key. Subsequently, a new tunnel is created using the new WireGuard key and the PSK, ensuring that
+the tunnel is quantum-resistant.
+See [this](../talpid-tunnel-config-client/proto/tunnel_config.proto) for more details on the protocol.
+
+#### Quantum-resistant tunnels & Multihop
+
+To create a multihop tunnel where both hops are quantum resistant the client must negotiate a unique
+PSK with both the entry and the exit relay separately. It must use the same ephemeral WireGuard key
+on both relays since the end result (just as with regular multihop tunnels) is two peers on a
+single WireGuard interface, which can only have a single key for the local peer.
+
+The PSKs are established by first creating a regular multihop tunnel to the exit via the entry relay
+and negotiate a PSK with the exit. Then establish a regular tunnel to just the entry and negotiate a
+PSK with it. Lastly the client can set up a multihop tunnel using the new ephemeral WireGuard key
+and the two PSKs via the entry to the exit.
+
 ### Detecting device offline
 
 The tunnel state machine has an offline monitor that tries to detect when a device will certainly

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -592,26 +592,6 @@ impl Relay {
         if let Some(entry) = matches.values_of("entry location") {
             wireguard_constraints.entry_location = parse_entry_location_constraint(entry);
             let use_multihop = wireguard_constraints.entry_location.is_some();
-            if use_multihop {
-                let quantum_resistant = rpc
-                    .get_settings(())
-                    .await?
-                    .into_inner()
-                    .tunnel_options
-                    .unwrap()
-                    .wireguard
-                    .unwrap()
-                    .quantum_resistant;
-                if quantum_resistant
-                    == Some(types::QuantumResistantState {
-                        state: i32::from(types::quantum_resistant_state::State::On),
-                    })
-                {
-                    return Err(Error::CommandFailed(
-                        "Quantum resistant tunnels do not work when multihop is enabled",
-                    ));
-                }
-            }
             wireguard_constraints.use_multihop = use_multihop;
         }
 

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -251,27 +251,6 @@ impl Tunnel {
             _ => unreachable!("invalid PQ state"),
         };
         let mut rpc = new_rpc_client().await?;
-        let settings = rpc.get_settings(()).await?;
-        if quantum_resistant == types::quantum_resistant_state::State::On {
-            let multihop_is_enabled = settings
-                .into_inner()
-                .relay_settings
-                .unwrap()
-                .endpoint
-                .and_then(|endpoint| {
-                    if let types::relay_settings::Endpoint::Normal(settings) = endpoint {
-                        Some(settings.wireguard_constraints.unwrap().use_multihop)
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(false);
-            if multihop_is_enabled {
-                return Err(Error::CommandFailed(
-                    "Quantum resistant tunnels do not work when multihop is enabled",
-                ));
-            }
-        }
         rpc.set_quantum_resistant_tunnel(types::QuantumResistantState {
             state: i32::from(quantum_resistant),
         })

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -103,6 +103,7 @@ features = [
     "Win32_NetworkManagement_Ndis",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_System_SystemInformation",
 ]
 
 [build-dependencies]

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -576,8 +576,12 @@ impl<'a> PolicyBatch<'a> {
                             self.add_allow_tunnel_rules(&tunnel.interface)?;
                         }
                         AllowedTunnelTraffic::None => (),
-                        AllowedTunnelTraffic::Only(endpoint) => {
+                        AllowedTunnelTraffic::One(endpoint) => {
                             self.add_allow_in_tunnel_endpoint_rules(&tunnel.interface, endpoint)?;
+                        }
+                        AllowedTunnelTraffic::Two(endpoint1, endpoint2) => {
+                            self.add_allow_in_tunnel_endpoint_rules(&tunnel.interface, endpoint1)?;
+                            self.add_allow_in_tunnel_endpoint_rules(&tunnel.interface, endpoint2)?;
                         }
                     }
                     if *allow_lan {

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -130,7 +130,7 @@ impl Firewall {
 
                 if let Some(tunnel) = tunnel {
                     rules.extend(
-                        self.get_allow_tunnel_rule(&tunnel.interface, allowed_tunnel_traffic)?
+                        self.get_allow_tunnel_rules(&tunnel.interface, allowed_tunnel_traffic)?
                             .into_iter(),
                     );
                 }
@@ -159,7 +159,7 @@ impl Firewall {
                 rules.append(&mut self.get_block_dns_rules()?);
 
                 rules.extend(
-                    self.get_allow_tunnel_rule(
+                    self.get_allow_tunnel_rules(
                         tunnel.interface.as_str(),
                         &AllowedTunnelTraffic::All,
                     )?
@@ -330,28 +330,55 @@ impl Firewall {
         Ok(vec![block_tcp_dns_rule, block_udp_dns_rule])
     }
 
-    fn get_allow_tunnel_rule(
+    fn base_rule(
         &self,
+        action: FilterRuleAction,
         tunnel_interface: &str,
-        allowed_traffic: &AllowedTunnelTraffic,
-    ) -> Result<Option<pfctl::FilterRule>> {
-        let mut rule_builder = self.create_rule_builder(FilterRuleAction::Pass);
-        let mut base_rule = rule_builder
+    ) -> pfctl::FilterRuleBuilder {
+        let mut rule_builder = self.create_rule_builder(action);
+        rule_builder
             .quick(true)
             .interface(tunnel_interface)
             .keep_state(pfctl::StatePolicy::Keep)
             .tcp_flags(Self::get_tcp_flags());
-        match allowed_traffic {
-            AllowedTunnelTraffic::Only(endpoint) => {
+        rule_builder
+    }
+
+    fn get_allow_tunnel_rules(
+        &self,
+        tunnel_interface: &str,
+        allowed_traffic: &AllowedTunnelTraffic,
+    ) -> Result<Vec<pfctl::FilterRule>> {
+        Ok(match allowed_traffic {
+            AllowedTunnelTraffic::One(endpoint) => {
+                let mut base_rule = &mut self.base_rule(FilterRuleAction::Pass, tunnel_interface);
                 let pfctl_proto = as_pfctl_proto(endpoint.protocol);
                 base_rule = base_rule.to(endpoint.address).proto(pfctl_proto);
+                vec![base_rule.build()?]
             }
-            AllowedTunnelTraffic::All => {}
+            AllowedTunnelTraffic::Two(endpoint1, endpoint2) => {
+                let mut rules = Vec::with_capacity(2);
+
+                let mut base_rule = &mut self.base_rule(FilterRuleAction::Pass, tunnel_interface);
+                let pfctl_proto = as_pfctl_proto(endpoint1.protocol);
+                base_rule = base_rule.to(endpoint1.address).proto(pfctl_proto);
+                rules.push(base_rule.build()?);
+
+                let mut base_rule = &mut self.base_rule(FilterRuleAction::Pass, tunnel_interface);
+                let pfctl_proto = as_pfctl_proto(endpoint2.protocol);
+                base_rule = base_rule.to(endpoint2.address).proto(pfctl_proto);
+                rules.push(base_rule.build()?);
+
+                rules
+            }
+            AllowedTunnelTraffic::All => {
+                let base_rule = &mut self.base_rule(FilterRuleAction::Pass, tunnel_interface);
+                vec![base_rule.build()?]
+            }
             AllowedTunnelTraffic::None => {
-                return Ok(None);
+                vec![]
             }
-        };
-        Ok(Some(base_rule.build()?))
+        })
     }
 
     fn get_allow_loopback_rules(&self) -> Result<Vec<pfctl::FilterRule>> {

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -143,18 +143,7 @@ impl TunnelMonitor {
         let config = talpid_wireguard::config::Config::from_parameters(params)?;
         let monitor = talpid_wireguard::WireguardMonitor::start(
             config,
-            if params.options.quantum_resistant {
-                Some(
-                    params
-                        .connection
-                        .exit_peer
-                        .as_ref()
-                        .map(|peer| peer.public_key.clone())
-                        .unwrap_or_else(|| params.connection.peer.public_key.clone()),
-                )
-            } else {
-                None
-            },
+            params.options.quantum_resistant,
             log.as_deref(),
             args,
         )?;

--- a/talpid-tunnel-config-client/examples/psk-exchange.rs
+++ b/talpid-tunnel-config-client/examples/psk-exchange.rs
@@ -2,7 +2,7 @@
 //! Useful to test this crate's implementation.
 
 use std::net::IpAddr;
-use talpid_types::net::wireguard::PublicKey;
+use talpid_types::net::wireguard::{PrivateKey, PublicKey};
 
 #[tokio::main]
 async fn main() {
@@ -16,10 +16,15 @@ async fn main() {
         .next()
         .expect("Give WireGuard public key as second argument");
     let pubkey = PublicKey::from_base64(pubkey_string.trim()).expect("Invalid public key");
+    let private_key = PrivateKey::new_from_random();
 
-    let (private_key, psk) = talpid_tunnel_config_client::push_pq_key(tuncfg_server_ip, pubkey)
-        .await
-        .unwrap();
+    let psk = talpid_tunnel_config_client::push_pq_key(
+        tuncfg_server_ip,
+        pubkey,
+        private_key.public_key(),
+    )
+    .await
+    .unwrap();
 
     println!("private key: {private_key:?}");
     println!("psk: {psk:?}");

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -284,15 +284,21 @@ impl fmt::Display for AllowedEndpoint {
 pub enum AllowedTunnelTraffic {
     None,
     All,
-    Only(Endpoint),
+    One(Endpoint),
+    Two(Endpoint, Endpoint),
 }
 
 impl fmt::Display for AllowedTunnelTraffic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match *self {
+        match self {
             AllowedTunnelTraffic::None => "None".fmt(f),
             AllowedTunnelTraffic::All => "All".fmt(f),
-            AllowedTunnelTraffic::Only(endpoint) => endpoint.fmt(f),
+            AllowedTunnelTraffic::One(endpoint) => endpoint.fmt(f),
+            AllowedTunnelTraffic::Two(endpoint1, endpoint2) => {
+                endpoint1.fmt(f)?;
+                f.write_str(", ")?;
+                endpoint2.fmt(f)
+            }
         }
     }
 }

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -6,7 +6,7 @@ use std::{
 use talpid_types::net::{obfuscation::ObfuscatorConfig, wireguard, GenericTunnelOptions};
 
 /// Config required to set up a single WireGuard tunnel
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Config {
     /// Contains tunnel endpoint specific config
     pub tunnel: wireguard::TunnelConfig,

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -218,12 +218,15 @@ bool FwContext::applyPolicyConnecting
 				));
 				break;
 			}
-			case WinFwAllowedTunnelTrafficType::Only:
+			case WinFwAllowedTunnelTrafficType::One:
 			{
-				const auto onlyEndpoint = std::make_optional(baseline::PermitVpnTunnel::Endpoint{
-					wfp::IpAddress(allowedTunnelTraffic.endpoint->ip),
-					allowedTunnelTraffic.endpoint->port,
-					allowedTunnelTraffic.endpoint->protocol
+				auto onlyEndpoint = std::make_optional<baseline::PermitVpnTunnel::Endpoints>({
+						baseline::PermitVpnTunnel::Endpoint{
+						wfp::IpAddress(allowedTunnelTraffic.entryEndpoint->ip),
+						allowedTunnelTraffic.entryEndpoint->port,
+						allowedTunnelTraffic.entryEndpoint->protocol
+						},
+						std::nullopt,
 				});
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
 					*tunnelInterfaceAlias,
@@ -233,6 +236,30 @@ bool FwContext::applyPolicyConnecting
 					*tunnelInterfaceAlias,
 					onlyEndpoint
 				));
+				break;
+			}
+			case WinFwAllowedTunnelTrafficType::Two:
+			{
+				auto endpoints = std::make_optional<baseline::PermitVpnTunnel::Endpoints>({
+						baseline::PermitVpnTunnel::Endpoint{
+						wfp::IpAddress(allowedTunnelTraffic.entryEndpoint->ip),
+						allowedTunnelTraffic.entryEndpoint->port,
+						allowedTunnelTraffic.entryEndpoint->protocol
+						},
+						std::make_optional<baseline::PermitVpnTunnel::Endpoint>({
+								wfp::IpAddress(allowedTunnelTraffic.exitEndpoint->ip),
+								allowedTunnelTraffic.exitEndpoint->port,
+								allowedTunnelTraffic.exitEndpoint->protocol
+								})
+				});
+				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
+							*tunnelInterfaceAlias,
+							endpoints
+							));
+				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
+							*tunnelInterfaceAlias,
+							endpoints
+							));
 				break;
 			}
 			// For the "None" case, do nothing.

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -222,9 +222,9 @@ bool FwContext::applyPolicyConnecting
 			{
 				auto onlyEndpoint = std::make_optional<baseline::PermitVpnTunnel::Endpoints>({
 						baseline::PermitVpnTunnel::Endpoint{
-						wfp::IpAddress(allowedTunnelTraffic.entryEndpoint->ip),
-						allowedTunnelTraffic.entryEndpoint->port,
-						allowedTunnelTraffic.entryEndpoint->protocol
+						wfp::IpAddress(allowedTunnelTraffic.endpoint1->ip),
+						allowedTunnelTraffic.endpoint1->port,
+						allowedTunnelTraffic.endpoint1->protocol
 						},
 						std::nullopt,
 				});
@@ -242,14 +242,14 @@ bool FwContext::applyPolicyConnecting
 			{
 				auto endpoints = std::make_optional<baseline::PermitVpnTunnel::Endpoints>({
 						baseline::PermitVpnTunnel::Endpoint{
-						wfp::IpAddress(allowedTunnelTraffic.entryEndpoint->ip),
-						allowedTunnelTraffic.entryEndpoint->port,
-						allowedTunnelTraffic.entryEndpoint->protocol
+						wfp::IpAddress(allowedTunnelTraffic.endpoint1->ip),
+						allowedTunnelTraffic.endpoint1->port,
+						allowedTunnelTraffic.endpoint1->protocol
 						},
 						std::make_optional<baseline::PermitVpnTunnel::Endpoint>({
-								wfp::IpAddress(allowedTunnelTraffic.exitEndpoint->ip),
-								allowedTunnelTraffic.exitEndpoint->port,
-								allowedTunnelTraffic.exitEndpoint->protocol
+								wfp::IpAddress(allowedTunnelTraffic.endpoint2->ip),
+								allowedTunnelTraffic.endpoint2->port,
+								allowedTunnelTraffic.endpoint2->protocol
 								})
 				});
 				ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -130,14 +130,14 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcpServer_Outbound_Response_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_Exit()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_1()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_2()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_2()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Router_Solicitation()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Inbound_Router_Advertisement()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Neighbor_Solicitation()));
@@ -667,7 +667,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1()
 {
 	static const GUID g =
 	{
@@ -681,7 +681,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1()
 {
 	static const GUID g =
 	{
@@ -695,7 +695,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2()
 {
 	static const GUID g =
 	{
@@ -709,7 +709,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2()
 {
 	static const GUID g =
 	{
@@ -723,7 +723,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_1()
 {
 	static const GUID g =
 	{
@@ -737,7 +737,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_1()
 {
 	static const GUID g =
 	{
@@ -751,7 +751,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_2()
 {
 	static const GUID g =
 	{
@@ -765,7 +765,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Exit()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_2()
 {
 
 	static const GUID g =

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -130,10 +130,14 @@ MullvadGuids::DetailedIdentityRegistry MullvadGuids::DetailedRegistry(IdentityQu
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitDhcpServer_Outbound_Response_Ipv4()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnRelay()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitEndpoint()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4()));
-	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit()));
+	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitVpnTunnelService_Ipv6_Exit()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Router_Solicitation()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Inbound_Router_Advertisement()));
 	registry.insert(std::make_pair(WfpObjectType::Filter, Filter_Baseline_PermitNdp_Outbound_Neighbor_Solicitation()));
@@ -663,7 +667,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitEndpoint()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry()
 {
 	static const GUID g =
 	{
@@ -677,7 +681,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry()
 {
 	static const GUID g =
 	{
@@ -691,7 +695,35 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit()
+{
+	static const GUID g =
+	{
+		0x7e09435c,
+		0xefd7,
+		0x482d,
+		{ 0xa1, 0xec, 0x6c, 0xc3, 0x80, 0xac, 0xf3, 0xf1 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit()
+{
+	static const GUID g =
+	{
+		0x276bc66f,
+		0xf9ef,
+		0x4428,
+		{ 0xb1, 0x5e, 0xd9, 0xe2, 0x6e, 0xf4, 0xf0, 0x06 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry()
 {
 	static const GUID g =
 	{
@@ -705,7 +737,7 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4()
 }
 
 //static
-const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6()
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry()
 {
 	static const GUID g =
 	{
@@ -713,6 +745,35 @@ const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6()
 		0x1845,
 		0x42e5,
 		{ 0xad, 0xf3, 0x33, 0xb2, 0x7a, 0xd, 0x5d, 0x38 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit()
+{
+	static const GUID g =
+	{
+		0x98c99ac3,
+		0xaa54,
+		0x45e7,
+		{ 0x91, 0xc4, 0x61, 0x1a, 0x1e, 0xe2, 0x64, 0x83 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Exit()
+{
+
+	static const GUID g =
+	{
+		0x01deb2b8,
+		0xb25d,
+		0x4e60,
+		{ 0x81, 0x52, 0xef, 0x3b, 0x40, 0xc0, 0x8e, 0xdc }
 	};
 
 	return g;

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -71,15 +71,15 @@ public:
 
 	static const GUID &Filter_Baseline_PermitEndpoint();
 
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry();
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry();
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit();
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2();
 
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry();
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry();
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit();
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_Exit();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_1();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_2();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_2();
 
 	static const GUID &Filter_Baseline_PermitNdp_Outbound_Router_Solicitation();
 	static const GUID &Filter_Baseline_PermitNdp_Inbound_Router_Advertisement();

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -71,11 +71,15 @@ public:
 
 	static const GUID &Filter_Baseline_PermitEndpoint();
 
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4();
-	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit();
+	static const GUID &Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit();
 
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4();
-	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit();
+	static const GUID &Filter_Baseline_PermitVpnTunnelService_Ipv6_Exit();
 
 	static const GUID &Filter_Baseline_PermitNdp_Outbound_Router_Solicitation();
 	static const GUID &Filter_Baseline_PermitNdp_Inbound_Router_Advertisement();

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
@@ -17,45 +17,64 @@ namespace rules::baseline
 
 PermitVpnTunnel::PermitVpnTunnel(
 	const std::wstring &tunnelInterfaceAlias,
-	const std::optional<Endpoint> &onlyEndpoint
+	const std::optional<Endpoints> &potentialEndpoints
 )
 	: m_tunnelInterfaceAlias(tunnelInterfaceAlias)
-	, m_tunnelOnlyEndpoint(onlyEndpoint)
+	, m_potentialEndpoints(potentialEndpoints)
 {
 }
 
-bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
+bool PermitVpnTunnel::AddEndpointFilter(const std::optional<Endpoint> &endpoint, const GUID &ipv4Guid, const GUID &ipv6Guid, IObjectInstaller &objectInstaller)
 {
 	wfp::FilterBuilder filterBuilder;
 
-	bool includeV4 = !m_tunnelOnlyEndpoint.has_value() || m_tunnelOnlyEndpoint->ip.type() == wfp::IpAddress::Ipv4;
-	bool includeV6 = !m_tunnelOnlyEndpoint.has_value() || m_tunnelOnlyEndpoint->ip.type() == wfp::IpAddress::Ipv6;
-
-	//
-	// #1 Permit outbound connections, IPv4.
-	//
-
 	filterBuilder
-		.key(MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4())
-		.name(L"Permit outbound connections on tunnel interface (IPv4)")
 		.description(L"This filter is part of a rule that permits communications inside the VPN tunnel")
 		.provider(MullvadGuids::Provider())
-		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
 		.sublayer(MullvadGuids::SublayerBaseline())
 		.weight(wfp::FilterBuilder::WeightClass::Medium)
 		.permit();
+    bool shouldAddV4Filter = !endpoint.has_value() || endpoint.value().ip.type() == wfp::IpAddress::Ipv4;
+    bool shouldAddV6Filter = !endpoint.has_value() || endpoint.value().ip.type() == wfp::IpAddress::Ipv6;
 
-	if (includeV4)
+	if (shouldAddV4Filter)
 	{
+		filterBuilder
+			.key(ipv4Guid)
+			.name(L"Permit outbound connections on tunnel interface (IPv4)")
+			.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
+	
 		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
-
+	
 		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
-
-		if (m_tunnelOnlyEndpoint.has_value())
+		if (endpoint.has_value())
 		{
-			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
-			conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
-			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
+			conditionBuilder.add_condition(ConditionIp::Remote(endpoint.value().ip));
+			conditionBuilder.add_condition(ConditionPort::Remote(endpoint.value().port));
+			conditionBuilder.add_condition(CreateProtocolCondition(endpoint.value().protocol));
+		}
+	
+		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
+		{
+			return false;
+		}
+	}
+	
+	if (shouldAddV6Filter)
+	{
+		filterBuilder
+			.key(ipv6Guid)
+			.name(L"Permit outbound connections on tunnel interface (IPv6)")
+			.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+	
+		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+	
+		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
+		if (endpoint.has_value())
+		{
+			conditionBuilder.add_condition(ConditionIp::Remote(endpoint.value().ip));
+			conditionBuilder.add_condition(ConditionPort::Remote(endpoint.value().port));
+			conditionBuilder.add_condition(CreateProtocolCondition(endpoint.value().protocol));
 		}
 
 		if (!objectInstaller.addFilter(filterBuilder, conditionBuilder))
@@ -63,32 +82,36 @@ bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
 			return false;
 		}
 	}
+	return true;
+}
 
-	//
-	// #2 Permit outbound connections, IPv6.
-	//
 
-	filterBuilder
-		.key(MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6())
-		.name(L"Permit outbound connections on tunnel interface (IPv6)")
-		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
-
-	if (includeV6)
+bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
+{
+	if (!m_potentialEndpoints.has_value())
 	{
-		wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
-
-		conditionBuilder.add_condition(ConditionInterface::Alias(m_tunnelInterfaceAlias));
-
-		if (m_tunnelOnlyEndpoint.has_value())
-		{
-			conditionBuilder.add_condition(ConditionIp::Remote(m_tunnelOnlyEndpoint->ip));
-			conditionBuilder.add_condition(ConditionPort::Remote(m_tunnelOnlyEndpoint->port));
-			conditionBuilder.add_condition(CreateProtocolCondition(m_tunnelOnlyEndpoint->protocol));
-		}
-
-		return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+		return AddEndpointFilter(
+			std::nullopt,
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry(),
+			objectInstaller
+		);
 	}
-
+	AddEndpointFilter(
+			std::make_optional<Endpoint>(m_potentialEndpoints.value().entryEndpoint),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry(),
+			objectInstaller
+		);
+	if (m_potentialEndpoints.value().exitEndpoint.has_value())
+	{
+		AddEndpointFilter(
+				m_potentialEndpoints.value().exitEndpoint.value(),
+				MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit(),
+				MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit(),
+				objectInstaller
+			);
+	}
 	return true;
 }
 

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.cpp
@@ -92,23 +92,23 @@ bool PermitVpnTunnel::apply(IObjectInstaller &objectInstaller)
 	{
 		return AddEndpointFilter(
 			std::nullopt,
-			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry(),
-			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1(),
 			objectInstaller
 		);
 	}
 	AddEndpointFilter(
 			std::make_optional<Endpoint>(m_potentialEndpoints.value().entryEndpoint),
-			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Entry(),
-			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Entry(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_1(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_1(),
 			objectInstaller
 		);
 	if (m_potentialEndpoints.value().exitEndpoint.has_value())
 	{
 		AddEndpointFilter(
 				m_potentialEndpoints.value().exitEndpoint.value(),
-				MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_Exit(),
-				MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_Exit(),
+				MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv4_2(),
+				MullvadGuids::Filter_Baseline_PermitVpnTunnel_Outbound_Ipv6_2(),
 				objectInstaller
 			);
 	}

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnel.h
@@ -19,17 +19,23 @@ public:
 		WinFwProtocol protocol;
 	};
 
+	struct Endpoints {
+		Endpoint entryEndpoint;
+		std::optional<Endpoint> exitEndpoint;
+	};
+
 	PermitVpnTunnel(
 		const std::wstring &tunnelInterfaceAlias,
-		const std::optional<Endpoint> &onlyEndpoint
+		const std::optional<Endpoints> &potentialEndpoints
 	);
 	
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
+	bool AddEndpointFilter(const std::optional<Endpoint> &endpoint, const GUID &ipv4Guid, const GUID &ipv6Guid, IObjectInstaller &objectInstaller);
 
 	const std::wstring m_tunnelInterfaceAlias;
-	const std::optional<Endpoint> m_tunnelOnlyEndpoint;
+	const std::optional<Endpoints> m_potentialEndpoints;
 };
 
 }

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.cpp
@@ -94,23 +94,23 @@ bool PermitVpnTunnelService::apply(IObjectInstaller &objectInstaller)
 	{
 		return AddEndpointFilter(
 			std::nullopt,
-			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry(),
-			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_1(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_1(),
 			objectInstaller
 		);
 	}
 	AddEndpointFilter(
 			std::make_optional<Endpoint>(m_potentialEndpoints.value().entryEndpoint),
-			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Entry(),
-			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Entry(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_1(),
+			MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_1(),
 			objectInstaller
 		);
 	if (m_potentialEndpoints.value().exitEndpoint.has_value())
 	{
 		AddEndpointFilter(
 				m_potentialEndpoints.value().exitEndpoint.value(),
-				MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_Exit(),
-				MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_Exit(),
+				MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv4_2(),
+				MullvadGuids::Filter_Baseline_PermitVpnTunnelService_Ipv6_2(),
 				objectInstaller
 			);
 	}

--- a/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitvpntunnelservice.h
@@ -16,15 +16,16 @@ public:
 
 	PermitVpnTunnelService(
 		const std::wstring &tunnelInterfaceAlias,
-		const std::optional<PermitVpnTunnel::Endpoint> &onlyEndpoint
+		const std::optional<PermitVpnTunnel::Endpoints> &potentialEndpoints
 	);
 
 	bool apply(IObjectInstaller &objectInstaller) override;
 
 private:
+	bool AddEndpointFilter(const std::optional<PermitVpnTunnel::Endpoint> &endpoint, const GUID &ipv4Guid, const GUID &ipv6Guid, IObjectInstaller &objectInstaller);
 
 	const std::wstring m_tunnelInterfaceAlias;
-	const std::optional<PermitVpnTunnel::Endpoint> m_tunnelOnlyEndpoint;
+	const std::optional<PermitVpnTunnel::Endpoints> m_potentialEndpoints;
 };
 
 }

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -59,13 +59,15 @@ enum WinFwAllowedTunnelTrafficType : uint8_t
 {
 	None,
 	All,
-	Only
+	One,
+	Two
 };
 
 typedef struct tag_WinFwAllowedTunnelTraffic
 {
 	WinFwAllowedTunnelTrafficType type;
-	WinFwEndpoint *endpoint;
+	WinFwEndpoint *entryEndpoint;
+	WinFwEndpoint *exitEndpoint;
 }
 WinFwAllowedTunnelTraffic;
 
@@ -181,9 +183,9 @@ WinFw_ApplyPolicyConnecting(
 // Parameters:
 //
 // tunnelInterfaceAlias:
-//   Friendly name of VPN tunnel interface
+//	 Friendly name of VPN tunnel interface
 // dnsServers:
-//   Array of string-encoded IP addresses of DNS servers to use
+//	 Array of string-encoded IP addresses of DNS servers to use
 //
 extern "C"
 WINFW_LINKAGE

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -66,8 +66,8 @@ enum WinFwAllowedTunnelTrafficType : uint8_t
 typedef struct tag_WinFwAllowedTunnelTraffic
 {
 	WinFwAllowedTunnelTrafficType type;
-	WinFwEndpoint *entryEndpoint;
-	WinFwEndpoint *exitEndpoint;
+	WinFwEndpoint *endpoint1;
+	WinFwEndpoint *endpoint2;
 }
 WinFwAllowedTunnelTraffic;
 


### PR DESCRIPTION
This PR makes it possible to use PQ while using wireguards multihop. It does this by modifying the firewall API and doing two PQ handshakes through the WG tunnel to establish the PQ PSKs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4353)
<!-- Reviewable:end -->
