### PR TITLE
Add scheduler for first "close to expiry"-notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Line wrap the file at 100 chars.                                              Th
   deprecating it on Windows.
 
 ### Fixed
+- Fix close to expiry notification not showing unless app is opened once within the last three days
+  in the desktop app.
+
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.
 


### PR DESCRIPTION
This PR adds a scheduler for showing the first "close to expiry"-notification. Previously the app had to be opened after the three day limit was passed to show the notifications.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4354)
<!-- Reviewable:end -->
