### PR TITLE
Rename settings error variants

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -59,11 +59,11 @@ pub enum Error {
     #[error(display = "Failed to read the settings")]
     Read(#[error(source)] io::Error),
 
-    #[error(display = "Malformed settings")]
-    Parse(#[error(source)] serde_json::Error),
+    #[error(display = "Failed to deserialize settings")]
+    Deserialize(#[error(source)] serde_json::Error),
 
-    #[error(display = "Unable to read any version of the settings")]
-    NoMatchingVersion,
+    #[error(display = "Unexpected settings format")]
+    InvalidSettingsContent,
 
     #[error(display = "Unable to serialize settings to JSON")]
     Serialize(#[error(source)] serde_json::Error),
@@ -132,10 +132,10 @@ pub(crate) async fn migrate_all(
     let settings_bytes = fs::read(&path).await.map_err(Error::Read)?;
 
     let mut settings: serde_json::Value =
-        serde_json::from_reader(&settings_bytes[..]).map_err(Error::Parse)?;
+        serde_json::from_reader(&settings_bytes[..]).map_err(Error::Deserialize)?;
 
     if !settings.is_object() {
-        return Err(Error::NoMatchingVersion);
+        return Err(Error::InvalidSettingsContent);
     }
 
     let old_settings = settings.clone();

--- a/mullvad-daemon/src/migrations/v2.rs
+++ b/mullvad-daemon/src/migrations/v2.rs
@@ -27,7 +27,7 @@ pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     {
         settings
             .as_object_mut()
-            .ok_or(Error::NoMatchingVersion)?
+            .ok_or(Error::InvalidSettingsContent)?
             .remove("show_beta_releases");
     }
 
@@ -55,7 +55,7 @@ pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
         settings["tunnel_options"]["wireguard"]["rotation_interval"] = serde_json::json!(new_ivl);
         settings["tunnel_options"]["wireguard"]
             .as_object_mut()
-            .ok_or(Error::NoMatchingVersion)?
+            .ok_or(Error::InvalidSettingsContent)?
             .remove("automatic_rotation");
     }
 

--- a/mullvad-daemon/src/migrations/v3.rs
+++ b/mullvad-daemon/src/migrations/v3.rs
@@ -61,7 +61,7 @@ pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
                 DnsState::Default
             };
             let addresses = if let Some(addrs) = options.get("addresses") {
-                serde_json::from_value(addrs.clone()).map_err(Error::Parse)?
+                serde_json::from_value(addrs.clone()).map_err(|_| Error::InvalidSettingsContent)?
             } else {
                 vec![]
             };


### PR DESCRIPTION
`NoMatchingVersion` was used for any invalid settings format as long as it could be deserialized to JSON. So it has been renamed to `InvalidSettingsContent`.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4356)
<!-- Reviewable:end -->
