### PR TITLE
Don't panic when the default directories cannot be obtained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.
 
+#### Windows
+- Don't fail to show the mullvad-daemon help text if some of the default paths cannot be obtained.
+
 
 ## [2023.1-beta2] - 2023-02-06
 ### Fixed

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -68,9 +68,9 @@ lazy_static::lazy_static! {
 
 ",
         mullvad_paths::get_default_resource_dir().display(),
-        mullvad_paths::get_default_settings_dir().expect("Unable to get settings dir").display(),
-        mullvad_paths::get_default_cache_dir().expect("Unable to get cache dir").display(),
-        mullvad_paths::get_default_log_dir().expect("Unable to get log dir").display(),
+        mullvad_paths::get_default_settings_dir().map(|dir| dir.display().to_string()).unwrap_or_else(|_| "N/A".to_string()),
+        mullvad_paths::get_default_cache_dir().map(|dir| dir.display().to_string()).unwrap_or_else(|_| "N/A".to_string()),
+        mullvad_paths::get_default_log_dir().map(|dir| dir.display().to_string()).unwrap_or_else(|_| "N/A".to_string()),
         mullvad_paths::get_default_rpc_socket_path().display());
 }
 


### PR DESCRIPTION
Previously, `mullvad-daemon` would panic if, for example, the path to the settings directory could not be obtained. This was problematic in the install script, since we one user reported that it would fail to install the system service, even though that directory was irrelevant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4360)
<!-- Reviewable:end -->
