### PR TITLE
Tune down logger

### DIFF
--- a/ios/MullvadLogging/Logging.swift
+++ b/ios/MullvadLogging/Logging.swift
@@ -25,6 +25,7 @@ public struct LoggerBuilder {
     private var outputs: [LoggerOutput] = []
 
     public var metadata: Logger.Metadata = [:]
+    public var logLevel: Logger.Level = .debug
 
     public init() {}
 
@@ -75,6 +76,7 @@ public struct LoggerBuilder {
             } else {
                 var multiplex = MultiplexLogHandler(logHandlers)
                 multiplex.metadata = metadata
+                multiplex.logLevel = logLevel
                 return multiplex
             }
         }

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -288,7 +288,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
                 return
             }
 
-            self.providerLogger.debug("Received app message: \(message)")
+            self.providerLogger.trace("Received app message: \(message)")
 
             switch message {
             case let .reconnectTunnel(appSelectorResult):
@@ -572,7 +572,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
         } catch {
             providerLogger.error(
                 error: error,
-                message: "Failed to read device states"
+                message: "Failed to read device state."
             )
             return
         }
@@ -581,7 +581,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
             return
         }
 
-        providerLogger.debug("Start device check")
+        providerLogger.debug("Start device check.")
 
         let accountOperation = createGetAccountDataOperation(
             accountNumber: storedAccountData.number

--- a/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
@@ -520,14 +520,12 @@ final class TunnelMonitor: PingerDelegate {
             }
 
             try pinger.openSocket(bindTo: interfaceName)
+
+            state.connectionState = .connecting
+            startConnectivityCheckTimer()
         } catch {
             logger.error(error: error, message: "Failed to open socket.")
-            return
         }
-
-        state.connectionState = .connecting
-
-        startConnectivityCheckTimer()
     }
 
     private func stopMonitoring(resetRetryAttempt: Bool) {

--- a/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
@@ -228,7 +228,7 @@ final class TunnelMonitor: PingerDelegate {
     private var state = State()
     private var probeAddress: IPv4Address?
 
-    private var logger = Logger(label: "TunnelMonitor")
+    private let logger = Logger(label: "TunnelMonitor")
 
     private weak var _delegate: TunnelMonitorDelegate?
     weak var delegate: TunnelMonitorDelegate? {
@@ -305,7 +305,7 @@ final class TunnelMonitor: PingerDelegate {
             logger.debug("Start with address: \(probeAddress).")
         } else {
             stopNoQueue(forRestart: true)
-            logger.debug("Restart with address: \(probeAddress)")
+            logger.debug("Restart with address: \(probeAddress).")
         }
 
         self.probeAddress = probeAddress
@@ -348,7 +348,7 @@ final class TunnelMonitor: PingerDelegate {
             newStats.bytesSent < state.netStats.bytesSent
 
         guard !isStatsReset else {
-            logger.debug("Stats was being reset.")
+            logger.trace("Stats was being reset.")
             state.netStats = newStats
             return
         }
@@ -364,7 +364,7 @@ final class TunnelMonitor: PingerDelegate {
         let evaluation = state.evaluateConnection(now: now, pingTimeout: timeout)
 
         if evaluation != .ok {
-            logger.debug("Evaluation: \(evaluation)")
+            logger.trace("Evaluation: \(evaluation)")
         }
 
         switch evaluation {
@@ -394,7 +394,7 @@ final class TunnelMonitor: PingerDelegate {
 
         guard rxDelta > 0 || txDelta > 0 else { return }
 
-        logger.debug(
+        logger.trace(
             """
             rx: \(newStats.bytesReceived) (+\(rxDelta)) \
             tx: \(newStats.bytesSent) (+\(txDelta))
@@ -430,7 +430,7 @@ final class TunnelMonitor: PingerDelegate {
             let sendResult = try pinger.send(to: receiver)
             state.updatePingStats(sendResult: sendResult, now: now)
 
-            logger.debug("Send ping icmp_seq=\(sendResult.sequenceNumber).")
+            logger.trace("Send ping icmp_seq=\(sendResult.sequenceNumber).")
         } catch {
             logger.error(error: error, message: "Failed to send ping.")
         }
@@ -485,23 +485,25 @@ final class TunnelMonitor: PingerDelegate {
         guard let probeAddress = probeAddress else { return }
 
         if sender.rawValue != probeAddress.rawValue {
-            logger.debug("Got reply from unknown sender: \(sender), expected: \(probeAddress).")
+            logger.trace("Got reply from unknown sender: \(sender), expected: \(probeAddress).")
         }
 
         let now = Date()
         let sequenceNumber = icmpHeader.sequenceNumber
         guard let pingTimestamp = state.setPingReplyReceived(sequenceNumber, now: now) else {
-            logger.debug("Got unknown ping sequence: \(sequenceNumber).")
+            logger.trace("Got unknown ping sequence: \(sequenceNumber).")
             return
         }
 
-        let time = now.timeIntervalSince(pingTimestamp) * 1000
-        let message = String(
-            format: "Received reply icmp_seq=%d, time=%.2f ms.",
-            sequenceNumber,
-            time
-        )
-        logger.debug(.init(stringLiteral: message))
+        logger.trace({
+            let time = now.timeIntervalSince(pingTimestamp) * 1000
+            let message = String(
+                format: "Received reply icmp_seq=%d, time=%.2f ms.",
+                sequenceNumber,
+                time
+            )
+            return Logger.Message(stringLiteral: message)
+        }())
 
         if case .connecting = state.connectionState {
             state.connectionState = .connected
@@ -564,7 +566,7 @@ final class TunnelMonitor: PingerDelegate {
     }
 
     private func onWakeNoQueue() {
-        logger.debug("Wake up.")
+        logger.trace("Wake up.")
 
         switch state.connectionState {
         case .connecting, .connected:
@@ -576,7 +578,7 @@ final class TunnelMonitor: PingerDelegate {
     }
 
     private func onSleepNoQueue() {
-        logger.debug("Prepare to sleep.")
+        logger.trace("Prepare to sleep.")
 
         switch state.connectionState {
         case .connecting, .connected:


### PR DESCRIPTION
- Remove logging from `Pinger` since we usually log all errors that it throws in `TunnelMonitor` anyway.
- Change log level from `debug` to `trace` for all connection diagnostic messages.
- Expose log level in the log builder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4362)
<!-- Reviewable:end -->
