### PR TITLE
Fix tag being included in release build directory name

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -148,7 +148,9 @@ build_ref() {
       done
       popd
 
-      version="$version$version_suffix"
+      if [[ $version == *"-dev-"* ]]; then
+          version="$version$version_suffix"
+      fi
   fi
 
   (cd "$artifact_dir" && upload "$version") || return 0


### PR DESCRIPTION
This PR fixes an issue where `buildserver-build.sh` added the tag name to the name of release build directories.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4374)
<!-- Reviewable:end -->
