### PR TITLE
Fix timeout duration not fitting into 32-bit signed integer

### DIFF
--- a/gui/src/main/account.ts
+++ b/gui/src/main/account.ts
@@ -225,8 +225,9 @@ export default class Account {
         const expiry = new Date(this.accountData.expiry).getTime();
         const now = new Date().getTime();
         const threeDays = 3 * 24 * 60 * 60 * 1000;
-        // Add 10 seconds to be on the safe side
-        const timeout = expiry - now - threeDays + 10_000;
+        // Add 10 seconds to be on the safe side. Never make it longer than a 24 days since
+        // the timeout needs to fit into a signed 32-bit integer.
+        const timeout = Math.min(expiry - now - threeDays + 10_000, 24 * 24 * 60 * 60 * 1000);
         this.firstExpiryNotificationScheduler.schedule(() => this.handleAccountExpiry(), timeout);
       }
     }


### PR DESCRIPTION
The new timeout for showing account expiry notifications immediately when there is three days left had a too large duration. The duration needs to fit into a signed 32-bit integer which means that the maximum is around 24 days. I've changed the duration to max out at 24 days.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4378)
<!-- Reviewable:end -->
