### PR TITLE
Fix window not closing properly after pinning window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix close to expiry notification not showing unless app is opened once within the last three days
   in the desktop app.
+- Fix desktop app not quitting properly after switching from unpinned to pinned window.
 
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -169,6 +169,8 @@ export default class UserInterface implements WindowControllerDelegate {
       // work since the old webContents is destroyed after the IPC wrapper has been updated with the
       // new one.
       this.windowController.webContents?.removeListener('destroyed', unsetIpcWebContents);
+      // Remove window close handler that calls `preventDefault` when closed.
+      this.windowController.window?.removeListener('close', this.windowCloseHandler);
 
       const window = this.createWindow();
       changeIpcWebContents(window.webContents);
@@ -510,11 +512,13 @@ export default class UserInterface implements WindowControllerDelegate {
       return;
     }
 
-    this.windowController.window?.on('close', (closeEvent: Event) => {
-      closeEvent.preventDefault();
-      this.windowController.hide();
-    });
+    this.windowController.window?.on('close', this.windowCloseHandler);
   }
+
+  private windowCloseHandler = (closeEvent: Event) => {
+    closeEvent.preventDefault();
+    this.windowController.hide();
+  };
 
   private installTrayClickHandlers() {
     switch (process.platform) {


### PR DESCRIPTION
This PR fixes a bug where the unpinned window wasn't closed and destroyed when switching to a pinned window. This resulted in the app quit procedure not finishing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4379)
<!-- Reviewable:end -->
