### PR TITLE
Update to openvpn 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add "auto" setting for the quantum-resistant tunnel feature, and make it the default. If it was
   previously set to off, it will now be set to auto instead. That currently means the same thing as
   "off", but this might change in the future.
+- Update OpenVPN to 2.6.0 from 2.5.3.
+- Update OpenSSL to 1.1.1t from 1.1.1j.
 
 #### Windows
 - Remove automatic fallback to wireguard-go. This is done as a first step before fully

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,9 +2042,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openvpn-plugin"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d63bb4b48a4dc331d31e86aeac7e51b70e3d8d5a1626fe7642538cf4e126c3"
+checksum = "693396ea7e46ef8dfd60a644b87c976f99b59dedf27dc218d604ee2d6a2fdf90"
 dependencies = [
  "derive-try-from-primitive",
  "log",

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -223,7 +223,7 @@ const config = {
     ],
     afterInstall: distAssets('linux/after-install.sh'),
     afterRemove: distAssets('linux/after-remove.sh'),
-    depends: ['libXScrnSaver', 'libnotify', 'libnsl', 'dbus-libs'],
+    depends: ['libXScrnSaver', 'libnotify', 'dbus-libs'],
   },
 };
 

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.10.0"
 parity-tokio-ipc = "0.9"
 tokio = { version = "1.8", features =  ["rt"] }
 
-openvpn-plugin = { version = "0.4", features = ["serde", "log", "auth-failed-event"] }
+openvpn-plugin = { version = "0.4.2", features = ["serde", "log", "auth-failed-event"] }
 talpid-types = { path = "../talpid-types" }
 
 tonic = "0.8"

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -100,11 +100,6 @@ pub enum Error {
     #[error(display = "Failed to start OpenVPN")]
     StartProcessError,
 
-    /// The IP routing program was not found.
-    #[cfg(target_os = "linux")]
-    #[error(display = "The IP routing program `ip` was not found")]
-    IpRouteNotFound(#[error(source)] which::Error),
-
     /// The OpenVPN binary was not found.
     #[error(display = "No OpenVPN binary found at {}", _0)]
     OpenVpnNotFound(String),
@@ -690,8 +685,6 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
         if let Some(config) = Self::get_config_path(resource_dir) {
             cmd.config(config);
         }
-        #[cfg(target_os = "linux")]
-        cmd.iproute_bin(which::which("ip").map_err(Error::IpRouteNotFound)?);
         cmd.remote(params.config.endpoint)
             .user_pass(user_pass_file)
             .tunnel_options(&params.options)

--- a/talpid-openvpn/src/process/openvpn.rs
+++ b/talpid-openvpn/src/process/openvpn.rs
@@ -64,7 +64,6 @@ pub struct OpenVpnCommand {
     proxy_auth_path: Option<PathBuf>,
     ca: Option<PathBuf>,
     crl: Option<PathBuf>,
-    iproute_bin: Option<OsString>,
     plugin: Option<(PathBuf, Vec<String>)>,
     log: Option<PathBuf>,
     tunnel_options: net::openvpn::TunnelOptions,
@@ -88,7 +87,6 @@ impl OpenVpnCommand {
             proxy_auth_path: None,
             ca: None,
             crl: None,
-            iproute_bin: None,
             plugin: None,
             log: None,
             tunnel_options: net::openvpn::TunnelOptions::default(),
@@ -143,12 +141,6 @@ impl OpenVpnCommand {
     /// Sets the path to the CRL (Certificate revocation list) file.
     pub fn crl(&mut self, path: impl AsRef<Path>) -> &mut Self {
         self.crl = Some(path.as_ref().to_path_buf());
-        self
-    }
-
-    /// Sets the path to the ip route command.
-    pub fn iproute_bin(&mut self, iproute_bin: impl Into<OsString>) -> &mut Self {
-        self.iproute_bin = Some(iproute_bin.into());
         self
     }
 
@@ -213,11 +205,6 @@ impl OpenVpnCommand {
 
         args.extend(self.remote_arguments().iter().map(OsString::from));
         args.extend(self.authentication_arguments());
-
-        if let Some(ref iproute_bin) = self.iproute_bin {
-            args.push(OsString::from("--iproute"));
-            args.push(iproute_bin.clone());
-        }
 
         if let Some(ref ca) = self.ca {
             args.push(OsString::from("--ca"));


### PR DESCRIPTION
Notably, this adds potential support for DCO and (as a result) removes the dependency on `iproute2`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4381)
<!-- Reviewable:end -->
