### PR TITLE
Rename all mentions of the "master" branch to "main"

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -23,9 +23,9 @@ on:
         description: Override container image
         type: string
         required: false
-  # Build if master is updated to ensure up-to-date caches are available
+  # Build if main is updated to ensure up-to-date caches are available
   push:
-    branches: [master]
+    branches: [main]
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -29,8 +29,8 @@ jobs:
         run: |-
           commits=${{ github.event.pull_request.commits }}
           if [[ -n "$commits" ]]; then
-              # Prepare enough depth for diffs with master, currently hard-coded but should probably be
+              # Prepare enough depth for diffs with main, currently hard-coded but should probably be
               # whatever branch is merged into
-              git fetch --depth="$(( commits + 1 ))" origin ${{ github.head_ref }} master
+              git fetch --depth="$(( commits + 1 ))" origin ${{ github.head_ref }} main
           fi
-          ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/master
+          ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/main

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ in other DEs, but we don't regularly test those.
 
 ## Features
 
-Here is a table containing the features of the app across platforms. This reflects the current
-state of latest master, not necessarily any existing release.
+Here is a table containing the features of the app across platforms. This is intended to reflect
+the current state of the latest code in git, not necessarily any existing release.
 
 |                               | Windows | Linux | macOS | Android | iOS |
 |-------------------------------|:-------:|:-----:|:-----:|:-------:|:---:|
@@ -84,7 +84,7 @@ cd mullvadvpn-app
 git submodule update --init
 ```
 
-We sign every commit on the master branch as well as our release tags. If you would like to verify
+We sign every commit on the `main` branch as well as our release tags. If you would like to verify
 your checkout, you can find our developer keys on [Mullvad's Open Source page].
 
 ### Binaries submodule

--- a/ci/buildserver-build-android.sh
+++ b/ci/buildserver-build-android.sh
@@ -15,7 +15,7 @@ LAST_BUILT_DIR="$SCRIPT_DIR/last-built"
 UPLOAD_DIR="$SCRIPT_DIR/upload"
 ANDROID_CREDENTIALS_DIR="$SCRIPT_DIR/credentials-android"
 
-BRANCHES_TO_BUILD=("origin/master")
+BRANCHES_TO_BUILD=("origin/main")
 TAG_PATTERN_TO_BUILD=("^android/")
 
 upload() {

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -19,7 +19,7 @@ BUILD_DIR="$SCRIPT_DIR/mullvadvpn-app"
 LAST_BUILT_DIR="$SCRIPT_DIR/last-built"
 UPLOAD_DIR="/home/upload/upload"
 
-BRANCHES_TO_BUILD=("origin/master")
+BRANCHES_TO_BUILD=("origin/main")
 
 case "$(uname -s)" in
   Darwin*|MINGW*|MSYS_NT*)

--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -12,7 +12,7 @@ import_gpg_keys="false"
 # The policy of enforcing lockfiles to be signed was not in place before this commit and
 # as such some of the commits before are not signed
 # The whitelisted commit can be set in order to allow github actions to only check changes
-# since origin/master
+# since origin/main
 whitelisted_commit="618130520"
 
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
The plan is to change all our git repos to call their default branch `main`. To make this switch in this main app repository we need to adapt some scripts, CI jobs and documentation.

Once this PR has been approved I plan on doing things in this order:

1. Get all build servers ready with the updated build scripts and stop the current build scripts.
2. Rename the default branch on Github (this will automatically change all open PRs to be based off of `main`)
3. Merge this PR
4. Restart build server build scripts so they start using `main`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4387)
<!-- Reviewable:end -->
