### PR TITLE
Override the API hostname using the InetSocketAddress

### DIFF
--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiTest.kt
@@ -15,7 +15,6 @@ import net.mullvad.mullvadvpn.lib.endpoint.CustomApiEndpointConfiguration
 import net.mullvad.mullvadvpn.test.common.interactor.AppInteractor
 import net.mullvad.mullvadvpn.test.common.rule.CaptureScreenshotOnFailedTestRule
 import net.mullvad.mullvadvpn.test.mockapi.constant.LOG_TAG
-import net.mullvad.mullvadvpn.test.mockapi.constant.MOCK_SERVER_LOCALHOST_ADDRESS
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -68,7 +67,7 @@ abstract class MockApiTest {
 
     private fun createEndpoint(port: Int): CustomApiEndpointConfiguration {
         val mockApiSocket = InetSocketAddress(
-            InetAddress.getByName(MOCK_SERVER_LOCALHOST_ADDRESS),
+            InetAddress.getLocalHost(),
             port
         )
         val api = ApiEndpoint(

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/constant/Constants.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/constant/Constants.kt
@@ -2,8 +2,6 @@ package net.mullvad.mullvadvpn.test.mockapi.constant
 
 const val LOG_TAG = "mullvad-mockapi"
 
-const val MOCK_SERVER_LOCALHOST_ADDRESS = "127.0.0.1"
-
 const val AUTH_TOKEN_URL_PATH = "/auth/v1/token"
 const val DEVICES_URL_PATH = "/accounts/v1/devices"
 const val ACCOUNT_URL_PATH = "/accounts/v1/accounts/me"


### PR DESCRIPTION
Previously, this could only be used to override the IP. This diff also takes the hostname from the `InetSocketAddress` when `api-override` is enabled.

It's not possible to specify both IP and hostname in `InetSocketAddress`, so the IP is always resolved from the hostname.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4392)
<!-- Reviewable:end -->
