### PR TITLE
Restart wg-go when reconnecting

### DIFF
--- a/ios/Configurations/Version.xcconfig
+++ b/ios/Configurations/Version.xcconfig
@@ -7,4 +7,4 @@ MARKETING_VERSION = 2023.1
 // Build number
 // Normally we reset the build number to 1 after bumping MARKETING_VERSION.
 // Otherwise increment it for each subsequent TestFlight submission.
-CURRENT_PROJECT_VERSION = 5
+CURRENT_PROJECT_VERSION = 6

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -3624,7 +3624,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = 309bb8d58a3ed25ff11c4630b88bbe883e53e835;
+				revision = e0f6ff554a791524700c7baa61fd828a89e9f809;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "309bb8d58a3ed25ff11c4630b88bbe883e53e835"
+        "revision" : "e0f6ff554a791524700c7baa61fd828a89e9f809"
       }
     }
   ],


### PR DESCRIPTION
It seems like the tunnel device might get recreated during the lifetime of the network extension process. wireguard-go doesn't account for this, so it's restarted whenever the extension connects to a new tunnel. This will also rebind  UDP sockets. This is achieved in a somewhat blunt way, but seems to work well enough to run a TestFlight.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4394)
<!-- Reviewable:end -->
