### PR TITLE
Upgrade `udp-over-tcp` nodelay and enable `TCP_NODELAY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add notification dot to tray icon and system notification throttling.
 - Add troubleshooting information to some in-app notifications.
 - Add setting for quantum resistant tunnels to the desktop GUI.
+- Enable `TCP_NODELAY` for the socket used by WireGuard over TCP. Improves latency and performance.
 
 ### Changed
 - Update the Post-Quantum secure key exchange gRPC client to use the stabilized

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,8 +3934,8 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "udp-over-tcp"
-version = "0.2.0"
-source = "git+https://github.com/mullvad/udp-over-tcp?rev=4d52f93cd9962562cb52d66e36771d5f5c70e25a#4d52f93cd9962562cb52d66e36771d5f5c70e25a"
+version = "0.3.0"
+source = "git+https://github.com/mullvad/udp-over-tcp?rev=87936ac29b68b902565955f138ab02294bcc8593#87936ac29b68b902565955f138ab02294bcc8593"
 dependencies = [
  "err-context",
  "futures",

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -12,4 +12,4 @@ async-trait = "0.1"
 err-derive = "0.3.0"
 futures = "0.3.5"
 tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "net", "io-util"] }
-udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "4d52f93cd9962562cb52d66e36771d5f5c70e25a" }
+udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "87936ac29b68b902565955f138ab02294bcc8593" }

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -49,6 +49,8 @@ impl Udp2Tcp {
             TcpOptions {
                 #[cfg(target_os = "linux")]
                 fwmark: settings.fwmark,
+                // Disables the Nagle algorithm on the TCP socket. Improves performance
+                nodelay: true,
                 ..TcpOptions::default()
             },
         )


### PR DESCRIPTION
Upgrades to a version of `udp-over-tcp` with https://github.com/mullvad/udp-over-tcp/pull/39. Allows us to enable `TCP_NODELAY` and get better performance for WireGuard over TCP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4395)
<!-- Reviewable:end -->
