### PR TITLE
Allow passing in env vars to the container

### DIFF
--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -52,4 +52,4 @@ exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \
     "${optional_android_credentials_volume[@]}" \
-    "$container_image_name" "$@"
+    "$container_image_name" bash -c "$*"


### PR DESCRIPTION
Precursor to the PR where I adapt `buildserver-build.sh` to build with containers on Linux. This change is needed to allow passing env vars into the container. I submit this as a separate PR because it will become easier for me to test the larger change if this change can land in `main` first.

The intention is to use this as:
```
./building/container-run.sh linux TARGETS=aarch64-unknown-linux-gnu ./build.sh
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4405)
<!-- Reviewable:end -->
