### PR TITLE
Make buildserver-build.sh use containers to build on Linux

### DIFF
--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -52,4 +52,4 @@ exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \
     "${optional_android_credentials_volume[@]}" \
-    "$container_image_name" "$@"
+    "$container_image_name" bash -c "$*"

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -124,6 +124,7 @@ build_ref() {
     git submodule update
     git clean -df
 
+    # When we build in containers, the updating of toolchains is done by updating containers.
     if [[ "$(uname -s)" != "Linux" ]]; then
         echo "Updating Rust toolchain..."
         rustup update


### PR DESCRIPTION
Updating `buildserver-build.sh` to use our official container for building on Linux.

This PR supersedes #4405 as I just rolled it up here instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4406)
<!-- Reviewable:end -->
