### PR TITLE
Serialize reconnect

### DIFF
--- a/ios/PacketTunnel/TunnelMonitor/TunnelMonitorDelegate.swift
+++ b/ios/PacketTunnel/TunnelMonitor/TunnelMonitorDelegate.swift
@@ -13,10 +13,7 @@ protocol TunnelMonitorDelegate: AnyObject {
     func tunnelMonitorDidDetermineConnectionEstablished(_ tunnelMonitor: TunnelMonitor)
 
     /// Invoked when tunnel monitor determined that connection attempt has failed.
-    func tunnelMonitorDelegate(
-        _ tunnelMonitor: TunnelMonitor,
-        shouldHandleConnectionRecoveryWithCompletion completionHandler: @escaping () -> Void
-    )
+    func tunnelMonitorDelegateShouldHandleConnectionRecovery(_ tunnelMonitor: TunnelMonitor)
 
     /// Invoked when network reachability status changes.
     func tunnelMonitor(


### PR DESCRIPTION
1. Serialize calls to reconnect the tunnel and cancel the previous one to avoid congestion.
2. Rework tunnel monitor to use locks instead of internal queue which simplified things quite a bit.
3. Rework recovery phase. Added new `.recovering` state and paused path monitor when recovering to prevent tunnel monitor from starting when reconnecting the tunnel.
4. Ignore all requests to reconnect after receiving the first call to `stopTunnel()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4408)
<!-- Reviewable:end -->
