### PR TITLE
Make test_load_balancing much less likely to fail

### DIFF
--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -2088,7 +2088,7 @@ mod test {
             let mut actual_ports = HashSet::new();
             let mut actual_ips = HashSet::new();
 
-            for retry_attempt in 0..10 {
+            for retry_attempt in 0..30 {
                 let (relay, ..) = relay_selector.get_relay(retry_attempt).unwrap();
                 match relay {
                     SelectedRelay::Normal(relay) => {


### PR DESCRIPTION
The correct fix would be to mock the PRNG. Let's just make it extremely unlikely to fail for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4409)
<!-- Reviewable:end -->
