### PR TITLE
New build script tweaks for new linux build server

### DIFF
--- a/ci/buildserver-build-android.sh
+++ b/ci/buildserver-build-android.sh
@@ -18,14 +18,14 @@ ANDROID_CREDENTIALS_DIR="$SCRIPT_DIR/credentials-android"
 BRANCHES_TO_BUILD=("origin/main")
 TAG_PATTERN_TO_BUILD="^android/"
 
-upload() {
+function upload {
     for f in MullvadVPN-*.{apk,aab}; do
         sha256sum "$f" > "$f.sha256"
         mv "$f" "$f.sha256" "$UPLOAD_DIR/"
     done
 }
 
-build_ref() {
+function build_ref {
     ref=$1
     tag=${2:-""}
 

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -32,7 +32,7 @@ case "$(uname -s)" in
 esac
 
 # Uploads whatever matches the first argument to the Linux build server
-upload_sftp() {
+function upload_sftp {
     echo "Uploading Mullvad VPN installers to app-build-linux:upload/"
     sftp app-build-linux <<EOF
 cd upload
@@ -41,7 +41,7 @@ bye
 EOF
 }
 
-upload() {
+function upload {
     version=$1
 
     files=( * )
@@ -66,7 +66,7 @@ upload() {
 
 # Run the arguments in an environment suitable for building the app. This
 # means in a container on Linux, and straight up in the local shell elsewhere.
-run_in_build_env() {
+function run_in_build_env {
     if [[ "$(uname -s)" == "Linux" ]]; then
         ./building/container-run.sh linux "$@"
     else
@@ -78,7 +78,7 @@ run_in_build_env() {
 # To cross compile pass in `target` as an environment variable
 # to this function. Must also pass `artifact_dir` to show where to move the built artifacts.
 # Pass all the build arguments as arguments to this function
-build() {
+function build {
     local target=${target:-""}
     local build_args=("${@}")
 
@@ -92,7 +92,7 @@ build() {
 
 # Checks out the passed git reference passed to the working directory.
 # Returns an error code if the commit/tag at `ref` is not properly signed.
-checkout_ref() {
+function checkout_ref {
     ref=$1
     if [[ $ref == "refs/tags/"* ]] && ! git verify-tag "$ref"; then
         echo "!!!"
@@ -114,7 +114,7 @@ checkout_ref() {
     git clean -df
 }
 
-build_ref() {
+function build_ref {
     ref=$1
     tag=${2:-""}
 

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -17,7 +17,7 @@ shopt -s nullglob
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$SCRIPT_DIR/mullvadvpn-app"
 LAST_BUILT_DIR="$SCRIPT_DIR/last-built"
-UPLOAD_DIR="/home/upload/upload"
+UPLOAD_DIR="$SCRIPT_DIR/upload"
 
 BRANCHES_TO_BUILD=("origin/main")
 
@@ -189,7 +189,10 @@ build_ref() {
     yes | rm -r "$artifact_dir"
 
     touch "$LAST_BUILT_DIR/$current_hash"
-    echo "Successfully finished build at $(date)"
+
+    echo ""
+    echo "Successfully finished building $version at $(date)"
+    echo ""
 }
 
 cd "$BUILD_DIR"

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -5,8 +5,11 @@ shopt -s nullglob
 
 CODE_SIGNING_KEY_FINGERPRINT="A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF"
 UPLOAD_SERVER="releases.mullvad.net"
-UPLOAD_DIR="/home/upload/upload"
-cd $UPLOAD_DIR
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+UPLOAD_DIR="$SCRIPT_DIR/upload"
+
+cd "$UPLOAD_DIR"
 
 while true; do
     sleep 10


### PR DESCRIPTION
Some final touches to be able to run the Linux builds on the new Linux build server (`app-build-linux2`).

Also fixed some bash to look like our own coding guidelines.

The change here is essentially to use `./upload` as the upload dir, instead of `/home/upload/upload`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4413)
<!-- Reviewable:end -->
