### PR TITLE
Add background observer for IPC operations

### DIFF
--- a/ios/MullvadVPN/TunnelManager/SendTunnelProviderMessageOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SendTunnelProviderMessageOperation.swift
@@ -6,11 +6,11 @@
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.
 //
 
-import Foundation
 import MullvadTypes
 import NetworkExtension
 import Operations
 import TunnelProviderMessaging
+import UIKit
 
 /// Delay for sending tunnel provider messages to the tunnel when in connecting state.
 /// Used to workaround a bug when talking to the tunnel too early during startup may cause it
@@ -23,6 +23,7 @@ private let defaultTimeout: TimeInterval = 5
 final class SendTunnelProviderMessageOperation<Output>: ResultOperation<Output> {
     typealias DecoderHandler = (Data?) throws -> Output
 
+    private let application: UIApplication
     private let tunnel: Tunnel
     private let message: TunnelProviderMessage
     private let timeout: TimeInterval
@@ -37,12 +38,14 @@ final class SendTunnelProviderMessageOperation<Output>: ResultOperation<Output> 
 
     init(
         dispatchQueue: DispatchQueue,
+        application: UIApplication,
         tunnel: Tunnel,
         message: TunnelProviderMessage,
         timeout: TimeInterval? = nil,
         decoderHandler: @escaping DecoderHandler,
         completionHandler: CompletionHandler?
     ) {
+        self.application = application
         self.tunnel = tunnel
         self.message = message
         self.timeout = timeout ?? defaultTimeout
@@ -53,6 +56,14 @@ final class SendTunnelProviderMessageOperation<Output>: ResultOperation<Output> 
             dispatchQueue: dispatchQueue,
             completionQueue: dispatchQueue,
             completionHandler: completionHandler
+        )
+
+        addObserver(
+            BackgroundObserver(
+                application: application,
+                name: "Send tunnel provider message: \(message)",
+                cancelUponExpiration: true
+            )
         )
     }
 
@@ -184,6 +195,11 @@ final class SendTunnelProviderMessageOperation<Output>: ResultOperation<Output> 
             return
         }
 
+        guard application.backgroundTimeRemaining > timeout else {
+            finish(result: .failure(SendTunnelProviderMessageError.notEnoughBackgroundTime))
+            return
+        }
+
         // Send IPC message.
         do {
             try tunnel.sendProviderMessage(messageData) { [weak self] responseData in
@@ -204,6 +220,7 @@ final class SendTunnelProviderMessageOperation<Output>: ResultOperation<Output> 
 extension SendTunnelProviderMessageOperation where Output: Codable {
     convenience init(
         dispatchQueue: DispatchQueue,
+        application: UIApplication,
         tunnel: Tunnel,
         message: TunnelProviderMessage,
         timeout: TimeInterval? = nil,
@@ -211,6 +228,7 @@ extension SendTunnelProviderMessageOperation where Output: Codable {
     ) {
         self.init(
             dispatchQueue: dispatchQueue,
+            application: application,
             tunnel: tunnel,
             message: message,
             timeout: timeout,
@@ -229,6 +247,7 @@ extension SendTunnelProviderMessageOperation where Output: Codable {
 extension SendTunnelProviderMessageOperation where Output == Void {
     convenience init(
         dispatchQueue: DispatchQueue,
+        application: UIApplication,
         tunnel: Tunnel,
         message: TunnelProviderMessage,
         timeout: TimeInterval? = nil,
@@ -236,6 +255,7 @@ extension SendTunnelProviderMessageOperation where Output == Void {
     ) {
         self.init(
             dispatchQueue: dispatchQueue,
+            application: application,
             tunnel: tunnel,
             message: message,
             timeout: timeout,
@@ -255,12 +275,17 @@ enum SendTunnelProviderMessageError: LocalizedError, WrappingError {
     /// System error.
     case system(Error)
 
+    /// Not enough background time to accommodate the operation.
+    case notEnoughBackgroundTime
+
     var errorDescription: String? {
         switch self {
         case let .tunnelDown(status):
             return "Tunnel is either down or about to go down (status: \(status))."
         case .timeout:
             return "Send timeout."
+        case .notEnoughBackgroundTime:
+            return "Not enough background time to accommodate the operation."
         case let .system(error):
             return "System error: \(error.localizedDescription)"
         }
@@ -270,7 +295,7 @@ enum SendTunnelProviderMessageError: LocalizedError, WrappingError {
         switch self {
         case let .system(error):
             return error
-        case .timeout, .tunnelDown:
+        case .timeout, .tunnelDown, .notEnoughBackgroundTime:
             return nil
         }
     }

--- a/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
+++ b/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
@@ -31,6 +31,7 @@ extension Tunnel {
     ) -> Cancellable {
         let operation = SendTunnelProviderMessageOperation(
             dispatchQueue: dispatchQueue,
+            application: .shared,
             tunnel: self,
             message: .reconnectTunnel(relaySelectorResult),
             completionHandler: completionHandler
@@ -47,6 +48,7 @@ extension Tunnel {
     ) -> Cancellable {
         let operation = SendTunnelProviderMessageOperation(
             dispatchQueue: dispatchQueue,
+            application: .shared,
             tunnel: self,
             message: .getTunnelStatus,
             completionHandler: completionHandler
@@ -64,6 +66,7 @@ extension Tunnel {
     ) -> Cancellable {
         let operation = SendTunnelProviderMessageOperation(
             dispatchQueue: dispatchQueue,
+            application: .shared,
             tunnel: self,
             message: .sendURLRequest(proxyRequest),
             timeout: proxyRequestTimeout,
@@ -76,6 +79,7 @@ extension Tunnel {
 
                 let cancelOperation = SendTunnelProviderMessageOperation(
                     dispatchQueue: dispatchQueue,
+                    application: .shared,
                     tunnel: self,
                     message: .cancelURLRequest(proxyRequest.id),
                     completionHandler: nil


### PR DESCRIPTION
This is a bit of shot in the dark but we spoke about the fact that sometimes the tunnel somehow deadlocks in connecting state and that opening the UI app somehow unclogs it. So I can only assume what's really going on, but it's possible that XPC between UI <-> PacketTunnel falls into coma if the other end is being suspended. This PR attempts to remedy this assumption by adding background observer condition that will automatically request background execution before starting operation and additional guard that will make sure that we don't attempt to start IPC interaction if we have less time than anticipated for it to complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4421)
<!-- Reviewable:end -->
