### PR TITLE
Swap vertical position of country and city on connection view

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -30,7 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add revoked device view displayed when the app detects that device is no longer registered on
   backend.
 - Add ability to manage registered devices if too many devices detected during log-in.
-- Add continuous monitoring of tunnel connection. Verify ping replies to detect whether traffic is 
+- Add continuous monitoring of tunnel connection. Verify ping replies to detect whether traffic is
   really flowing.
 - Check if device is revoked or account has expired when the tunnel fails to connect on each second
   failed attempt.
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 with the option to buy more time.
 - Use exponential backoff with jitter for delay interval when retrying REST API requests.
 - REST API requests will bypass VPN when tunnel is not functional.
+- Swap vertical position of country and city labels on connection view.
 
 ### Fixed
 - Improve random port distribution. Should be less biased towards port 53.

--- a/ios/MullvadVPN/TunnelControlView.swift
+++ b/ios/MullvadVPN/TunnelControlView.swift
@@ -232,7 +232,7 @@ final class TunnelControlView: UIView {
     // MARK: - Private
 
     private func addSubviews() {
-        for subview in [secureLabel, cityLabel, countryLabel] {
+        for subview in [secureLabel, countryLabel, cityLabel] {
             locationContainerView.addSubview(subview)
         }
 
@@ -267,14 +267,14 @@ final class TunnelControlView: UIView {
             secureLabel.leadingAnchor.constraint(equalTo: locationContainerView.leadingAnchor),
             secureLabel.trailingAnchor.constraint(equalTo: locationContainerView.trailingAnchor),
 
-            cityLabel.topAnchor.constraint(equalTo: secureLabel.bottomAnchor, constant: 8),
-            cityLabel.leadingAnchor.constraint(equalTo: locationContainerView.leadingAnchor),
-            cityLabel.trailingAnchor.constraint(equalTo: locationContainerView.trailingAnchor),
-
-            countryLabel.topAnchor.constraint(equalTo: cityLabel.bottomAnchor, constant: 8),
+            countryLabel.topAnchor.constraint(equalTo: secureLabel.bottomAnchor, constant: 8),
             countryLabel.leadingAnchor.constraint(equalTo: locationContainerView.leadingAnchor),
             countryLabel.trailingAnchor.constraint(equalTo: locationContainerView.trailingAnchor),
-            countryLabel.bottomAnchor.constraint(equalTo: locationContainerView.bottomAnchor),
+
+            cityLabel.topAnchor.constraint(equalTo: countryLabel.bottomAnchor, constant: 8),
+            cityLabel.leadingAnchor.constraint(equalTo: locationContainerView.leadingAnchor),
+            cityLabel.trailingAnchor.constraint(equalTo: locationContainerView.trailingAnchor),
+            cityLabel.bottomAnchor.constraint(equalTo: locationContainerView.bottomAnchor),
 
             connectionPanel.topAnchor.constraint(
                 equalTo: locationContainerView.bottomAnchor,


### PR DESCRIPTION
Displays country above city on the connection screen, bringing it to parity with the select location screen where country is displayed as top item and city as sub item. Also prevents country from jumping up and down when reconnecting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4422)
<!-- Reviewable:end -->
