### PR TITLE
Display remaining account time in years if equal to or more than two years, otherwise display days

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -41,6 +41,8 @@ with the option to buy more time.
 - Use exponential backoff with jitter for delay interval when retrying REST API requests.
 - REST API requests will bypass VPN when tunnel is not functional.
 - Swap vertical position of country and city labels on connection view.
+- Display remaining account time in years if equal to or more than two years,
+  otherwise display days.
 
 ### Fixed
 - Improve random port distribution. Should be less biased towards port 53.

--- a/ios/MullvadVPN/CustomDateComponentsFormatting.swift
+++ b/ios/MullvadVPN/CustomDateComponentsFormatting.swift
@@ -15,10 +15,11 @@ extension CustomDateComponentsFormatting {
     ///
     /// The behaviour of that method differs from `DateComponentsFormatter`:
     ///
-    /// 1. Intervals between 23h 30m - 23h 59m are rounded to 1 day to fix the iOS SDK bug which
+    /// 1. Intervals of two years or more are formatted in years quantity.
+    /// 2. Intervals between 23h 30m - 23h 59m are rounded to 1 day to fix the iOS SDK bug which
     ///    results in the wrong output ("0 months").
-    /// 2. Intervals between 26 and 90 days are formatted in days quantity.
     /// 3. Produce "Less than a minute" message for intervals below 1 minute.
+    /// 4. Intervals matching none of the above are formatted in days quantity.
     ///
     static func localizedString(
         from start: Date,
@@ -33,26 +34,28 @@ extension CustomDateComponentsFormatting {
         formatter.maximumUnitCount = 1
 
         let dateComponents = calendar
-            .dateComponents([.day, .hour, .minute, .second], from: start, to: end)
+            .dateComponents([.year, .day, .hour, .minute, .second], from: start, to: end)
 
+        let years = dateComponents.year ?? 0
         let days = dateComponents.day ?? 0
         let hours = dateComponents.hour ?? 0
         let minutes = dateComponents.minute ?? 0
         let seconds = dateComponents.second ?? 0
 
-        if days == 0, hours == 0, minutes == 0, seconds < 60 {
+        if years >= 2 {
+            formatter.allowedUnits = [.year]
+            return formatter.string(from: dateComponents)
+        } else if days == 0, hours == 23, minutes >= 30 {
+            return formatter.string(from: DateComponents(calendar: calendar, day: 1))
+        } else if days == 0, hours == 0, minutes == 0, seconds < 60 {
             return NSLocalizedString(
                 "LESS_THAN_ONE_MINUTE",
                 tableName: "CustomDateComponentsFormatting",
                 value: "Less than a minute",
                 comment: "Phrase used for less than 1 minute duration."
             )
-        } else if days == 0, hours == 23, minutes >= 30 {
-            return formatter.string(from: DateComponents(calendar: calendar, day: 1))
-        } else if days >= 1, days <= 90 {
-            formatter.allowedUnits = [.day]
-            return formatter.string(from: dateComponents)
         } else {
+            formatter.allowedUnits = [.day]
             return formatter.string(from: start, to: end)
         }
     }

--- a/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
+++ b/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
@@ -9,6 +9,40 @@
 import XCTest
 
 class CustomDateComponentsFormattingTests: XCTestCase {
+    func testEqualToTwoYearsFormatting() throws {
+        var dateComponents = DateComponents()
+        dateComponents.year = 2
+
+        let (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
+
+        let result = CustomDateComponentsFormatting.localizedString(
+            from: startDate,
+            to: endDate,
+            calendar: calendar,
+            unitsStyle: .full
+        )
+
+        XCTAssertEqual(result, "2 years")
+    }
+
+    func testLessThanTwoYearsFormatting() throws {
+        var dateComponents = DateComponents()
+        dateComponents.year = 2
+
+        var (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
+        endDate = endDate.addingTimeInterval(-1)
+
+        let result = CustomDateComponentsFormatting.localizedString(
+            from: startDate,
+            to: endDate,
+            calendar: calendar,
+            unitsStyle: .full
+        )
+
+        let expectedDays = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+        XCTAssertEqual(result, "\(expectedDays) days")
+    }
+
     func testCloseToOneDayFormatting() throws {
         var dateComponents = DateComponents()
         dateComponents.hour = 23
@@ -44,7 +78,7 @@ class CustomDateComponentsFormattingTests: XCTestCase {
 
     private func makeDateRange(addingComponents dateComponents: DateComponents) -> (Date, Date) {
         let startDate = Date()
-        let endDate = Calendar.current.date(byAdding: dateComponents, to: startDate)!
+        let endDate = calendar.date(byAdding: dateComponents, to: startDate)!
 
         return (startDate, endDate)
     }


### PR DESCRIPTION
The account row on the settings screen should display remaining time in years if equal to or more than two years, otherwise days. This brings the iOS app to parity with the intended behavior for all platforms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4424)
<!-- Reviewable:end -->
