### PR TITLE
Drop Debian 10 support (Upgrade build container to Debian 11)

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -14,9 +14,11 @@
 #
 # And add -e TARGETS="aarch64-unknown-linux-gnu" to build for ARM64
 
-# Debian 10 is the oldest supported distro. It has the oldest glibc that we support
-# This checksum points to a 10.13-slim image.
-FROM debian@sha256:557ee531b81ce380d012d83b7bb56211572e5d6088d3e21a3caef7d7ed7f718b
+# When building the app, we must link towards the oldest glibc version we want to support.
+# This is currently glibc 2.31 which is the version in Debian 11.
+# When updating this base image, to find the checksum, run: podman inspect <image> | jq '.[]["Digest"]'
+# This checksum points to a 11.6-slim image.
+FROM debian@sha256:77f46c1cf862290e750e913defffb2828c889d291a93bdd10a7a0597720948fc
 
 LABEL org.opencontainers.image.source=https://github.com/mullvad/mullvadvpn-app
 LABEL org.opencontainers.image.description="Mullvad VPN app Linux build container"


### PR DESCRIPTION
[Debian 10 reached end of life on 2022-09-10](https://wiki.debian.org/DebianReleases) (It's LTS-supported for another year or so, but that is not maintained by the Debian security team). We are technically held back by the old kernel and the old compilers on Debian 10. So it would be a good quality of life for developers to be able to upgrade. It will also allow simplifying the firewall rules which will affect all Linux users in a tiny but positive way (way less verbose output of `nft list ruleset`).

This means we stop supporting glibc <2.31. Both Debian 11 and Ubuntu 20.04 use 2.31. Before this PR we supported glibc 2.28 and newer.

I have tried building a container image from this new dockerfile. And I have built the Linux app in it, and it seems to work. I tried both x86 and arm64. Building the GUI tests seem to fail and I will debug that.

If any Debian 10 user lands on this PR I want you to know that you can still continue using version `2023.2` and `2023.3` for quite a while longer. And vanilla WireGuard and OpenVPN will always be available to you also. So this change does not block you from using the Mullvad VPN service!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4425)
<!-- Reviewable:end -->
