### PR TITLE
Bump Go version in workflow to 1.19.5

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.5
+          go-version: 1.19.5
 
       - name: Prepare iOS simulator
         # yamllint disable rule:line-length


### PR DESCRIPTION
After rebasing `wireguard-apple` on the latest upstream, it seems that GitHub can no longer run our tests. I'll try and fix this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4426)
<!-- Reviewable:end -->
