### PR TITLE
Bump NDK version to 25c

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -28,7 +28,7 @@ LABEL org.opencontainers.image.licenses=GPL-3.0
 # === Define toolchain versions and paths ===
 
 ENV SDK_VERSION=platforms;android-33 \
-    BUILD_TOOLS_VERSION=build-tools;30.0.2
+    BUILD_TOOLS_VERSION=build-tools;30.0.3
 
 # Command line tools and checksum from: https://developer.android.com/studio#command-tools
 ENV COMMAND_LINE_TOOLS_VERSION=9123335 \

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -37,7 +37,7 @@ ENV COMMAND_LINE_TOOLS_VERSION=9123335 \
 # NDK and checksum from: https://github.com/android/ndk/wiki/Unsupported-Downloads
 ENV NDK_VERSION=r25c \
     NDK_SHA1_CHECKSUM=53af80a1cce9144025b81c78c8cd556bff42bd0e \
-    MIN_SDK_VERSION=21
+    MIN_SDK_VERSION=26
 
 ENV ANDROID_SDK_ROOT=/opt/android
 # ANDROID_HOME is kept for backwards compatibility

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -35,8 +35,8 @@ ENV COMMAND_LINE_TOOLS_VERSION=9123335 \
     COMMAND_LINE_TOOLS_SHA256_CHECKSUM=0bebf59339eaa534f4217f8aa0972d14dc49e7207be225511073c661ae01da0a
 
 # NDK and checksum from: https://github.com/android/ndk/wiki/Unsupported-Downloads
-ENV NDK_VERSION=r20b \
-    NDK_SHA1_CHECKSUM=d903fdf077039ad9331fb6c3bee78aa46d45527b \
+ENV NDK_VERSION=r25c \
+    NDK_SHA1_CHECKSUM=53af80a1cce9144025b81c78c8cd556bff42bd0e \
     MIN_SDK_VERSION=21
 
 ENV ANDROID_SDK_ROOT=/opt/android
@@ -47,22 +47,22 @@ ENV NDK_TOOLCHAIN_DIR=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/
 ENV GRADLE_USER_HOME=/root/.gradle
 
 # Rust cross-compilation for: aarch64
-ENV AR_aarch64_linux_android=${NDK_TOOLCHAIN_DIR}/aarch64-linux-android-ar \
+ENV AR_aarch64_linux_android=${NDK_TOOLCHAIN_DIR}/llvm-ar \
     CC_aarch64_linux_android=${NDK_TOOLCHAIN_DIR}/aarch64-linux-android${MIN_SDK_VERSION}-clang \
     CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${NDK_TOOLCHAIN_DIR}/aarch64-linux-android${MIN_SDK_VERSION}-clang
 
 # Rust cross-compilation for: armv7
-ENV AR_armv7_linux_androideabi=${NDK_TOOLCHAIN_DIR}/arm-linux-androideabi-ar \
+ENV AR_armv7_linux_androideabi=${NDK_TOOLCHAIN_DIR}/llvm-ar \
     CC_armv7_linux_androideabi=${NDK_TOOLCHAIN_DIR}/armv7a-linux-androideabi${MIN_SDK_VERSION}-clang \
     CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=${NDK_TOOLCHAIN_DIR}/armv7a-linux-androideabi${MIN_SDK_VERSION}-clang
 
 # Rust cross-compilation for: i686
-ENV AR_i686_linux_android=${NDK_TOOLCHAIN_DIR}/i686-linux-android-ar \
+ENV AR_i686_linux_android=${NDK_TOOLCHAIN_DIR}/llvm-ar \
     CC_i686_linux_android=${NDK_TOOLCHAIN_DIR}/i686-linux-android${MIN_SDK_VERSION}-clang \
     CARGO_TARGET_I686_LINUX_ANDROID_LINKER=${NDK_TOOLCHAIN_DIR}/i686-linux-android${MIN_SDK_VERSION}-clang
 
 # Rust cross-compilation for: x86_64
-ENV AR_x86_64_linux_android=${NDK_TOOLCHAIN_DIR}/x86_64-linux-android-ar \
+ENV AR_x86_64_linux_android=${NDK_TOOLCHAIN_DIR}/llvm-ar \
     CC_x86_64_linux_android=${NDK_TOOLCHAIN_DIR}/x86_64-linux-android${MIN_SDK_VERSION}-clang \
     CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=${NDK_TOOLCHAIN_DIR}/x86_64-linux-android${MIN_SDK_VERSION}-clang
 
@@ -94,7 +94,7 @@ RUN curl -sfLo /tmp/cmdline-tools.zip https://dl.google.com/android/repository/c
 RUN yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager $SDK_VERSION $BUILD_TOOLS_VERSION "platform-tools"
 
 # Install Android NDK
-RUN curl -sfLo /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip && \
+RUN curl -sfLo /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip && \
     echo "$NDK_SHA1_CHECKSUM /tmp/ndk.zip" | sha1sum -c && \
     unzip -q /tmp/ndk.zip -d $ANDROID_SDK_ROOT && \
     rm /tmp/ndk.zip

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -86,22 +86,18 @@ popd
 for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
     case "$ARCHITECTURE" in
         "x86_64")
-            LLVM_TRIPLE="x86_64-linux-android"
             TARGET="x86_64-linux-android"
             ABI="x86_64"
             ;;
         "i686")
-            LLVM_TRIPLE="i686-linux-android"
             TARGET="i686-linux-android"
             ABI="x86"
             ;;
         "aarch64")
-            LLVM_TRIPLE="aarch64-linux-android"
             TARGET="aarch64-linux-android"
             ABI="arm64-v8a"
             ;;
         "armv7")
-            LLVM_TRIPLE="arm-linux-androideabi"
             TARGET="armv7-linux-androideabi"
             ABI="armeabi-v7a"
             ;;
@@ -110,7 +106,7 @@ for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
     echo "Building mullvad-daemon for $TARGET"
     cargo build $CARGO_ARGS --target "$TARGET" --package mullvad-jni
 
-    STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/${LLVM_TRIPLE}-strip"
+    STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/llvm-strip"
     TARGET_LIB_PATH="$SCRIPT_DIR/android/app/build/extraJni/$ABI/libmullvad_jni.so"
     UNSTRIPPED_LIB_PATH="$CARGO_TARGET_DIR/$TARGET/$BUILD_TYPE/libmullvad_jni.so"
 

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -13,28 +13,28 @@ mkdir -p $GOPATH
 for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
     case "$arch" in
         "aarch64")
-            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android21-clang"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android26-clang"
             export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android-strip"
             export RUST_TARGET_TRIPLE="aarch64-linux-android"
             export ANDROID_ABI="arm64-v8a"
             export ANDROID_ARCH_NAME="arm64"
             ;;
         "x86_64")
-            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android21-clang"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android26-clang"
             export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android-strip"
             export RUST_TARGET_TRIPLE="x86_64-linux-android"
             export ANDROID_ABI="x86_64"
             export ANDROID_ARCH_NAME="x86_64"
             ;;
         "armv7")
-            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/armv7a-linux-androideabi21-clang"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/armv7a-linux-androideabi26-clang"
             export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/arm-linux-androideabi-strip"
             export RUST_TARGET_TRIPLE="armv7-linux-androideabi"
             export ANDROID_ABI="armeabi-v7a"
             export ANDROID_ARCH_NAME="arm"
             ;;
         "i686")
-            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/i686-linux-android21-clang"
+            export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/i686-linux-android26-clang"
             export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/i686-linux-android-strip"
             export RUST_TARGET_TRIPLE="i686-linux-android"
             export ANDROID_ABI="x86"
@@ -46,7 +46,7 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
     echo $(pwd)
     make -f Android.mk clean
 
-    export CFLAGS="-D__ANDROID_API__=21"
+    export CFLAGS="-D__ANDROID_API__=26"
 
     make -f Android.mk
 

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -14,28 +14,28 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
     case "$arch" in
         "aarch64")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android26-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/aarch64-linux-android-strip"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/llvm-strip"
             export RUST_TARGET_TRIPLE="aarch64-linux-android"
             export ANDROID_ABI="arm64-v8a"
             export ANDROID_ARCH_NAME="arm64"
             ;;
         "x86_64")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android26-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/x86_64-linux-android-strip"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/llvm-strip"
             export RUST_TARGET_TRIPLE="x86_64-linux-android"
             export ANDROID_ABI="x86_64"
             export ANDROID_ARCH_NAME="x86_64"
             ;;
         "armv7")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/armv7a-linux-androideabi26-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/arm-linux-androideabi-strip"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/llvm-strip"
             export RUST_TARGET_TRIPLE="armv7-linux-androideabi"
             export ANDROID_ABI="armeabi-v7a"
             export ANDROID_ARCH_NAME="arm"
             ;;
         "i686")
             export ANDROID_C_COMPILER="${NDK_TOOLCHAIN_DIR}/i686-linux-android26-clang"
-            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/i686-linux-android-strip"
+            export ANDROID_STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/llvm-strip"
             export RUST_TARGET_TRIPLE="i686-linux-android"
             export ANDROID_ABI="x86"
             export ANDROID_ARCH_NAME="x86"

--- a/wireguard/libwg/build-android.sh
+++ b/wireguard/libwg/build-android.sh
@@ -46,8 +46,6 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
     echo $(pwd)
     make -f Android.mk clean
 
-    export CFLAGS="-D__ANDROID_API__=26"
-
     make -f Android.mk
 
     # Strip and copy the libray to `android/build/extraJni/$ANDROID_ABI` to be able to build the APK


### PR DESCRIPTION
This PR aims to bump the NDK version to `25c` in order to run on a supported NDK version as well as to support rust `1.68`.
See more here: https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html

**This PR is blocked on first upgrading the linux base image.**

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
