### PR TITLE
Add mold linker to container

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -31,6 +31,9 @@ ENV CARGO_TARGET_DIR=/root/.cargo/target
 ENV GOLANG_VERSION=1.18.5 \
     GOLANG_HASH=9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2
 
+# The pinned commit has this solved: https://github.com/rui314/mold/issues/1003.
+ARG MOLD_COMMIT_HASH=c4722fe5aed96295837d9150b20ef8698c7a28db
+
 # === Install/set up the image ===
 
 RUN dpkg --add-architecture arm64 && apt-get update -y && apt-get install -y \
@@ -59,6 +62,21 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 ENV PATH=/root/.cargo/bin:$PATH
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc" \
     PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu
+
+# === mold (fast linker) ===
+# Allows linking Rust binaries significantly faster.
+
+RUN apt-get update -y && \
+    apt-get install -y --mark-auto cmake libssl-dev zlib1g-dev gcc g++ && \
+    rm -rf /var/lib/apt/lists/* && \
+    git clone https://github.com/rui314/mold.git && \
+    mkdir mold/build && cd mold/build && \
+    git reset --hard "$MOLD_COMMIT_HASH" && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ .. && \
+    cmake --build . -j $(nproc) && \
+    cmake --install . && \
+    cd ../.. && rm -rf mold && \
+    apt-get autoremove -y
 
 # === Volta for npm + node ===
 

--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -3,12 +3,10 @@
 # Gives you a shell or runs a given command in the Android or Linux build container,
 # as designated by the *-container-image.txt files. Uses podman unless overridden using the
 # environment variable `CONTAINER_RUNNER`. Note that this script uses named
-# docker volumes that can be overridden using enviornment variables (see the
+# docker volumes that can be overridden using environment variables (see the
 # beginning of the script).
 #
 # Usage: $ container-run.sh <linux/android> [command ...]
-#
-# Not supplying any command gives you a shell in the container.
 
 set -eu
 
@@ -18,6 +16,9 @@ CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
 GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
 ANDROID_CREDENTIALS_DIR=${ANDROID_CREDENTIALS_DIR:-""}
 CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
+# Don't use mold by default until we have published the images with mold in
+# and swapped our builds to use them.
+USE_MOLD=${USE_MOLD:-"false"}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -45,6 +46,11 @@ case ${1-:""} in
         exit 1
 esac
 
+optional_mold=""
+if [[ "$USE_MOLD" == "true" ]]; then
+    optional_mold="mold -run"
+fi
+
 set -x
 exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$REPO_DIR:$REPO_MOUNT_TARGET:Z" \
@@ -52,4 +58,4 @@ exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \
     "${optional_android_credentials_volume[@]}" \
-    "$container_image_name" bash -c "$*"
+    "$container_image_name" bash -c "$optional_mold $*"

--- a/ci/buildserver-build-android.sh
+++ b/ci/buildserver-build-android.sh
@@ -60,7 +60,9 @@ function build_ref {
     git clean -df
 
     echo "Building Android app"
-    ANDROID_CREDENTIALS_DIR=$ANDROID_CREDENTIALS_DIR ./building/containerized-build.sh android --app-bundle || return 0
+    ANDROID_CREDENTIALS_DIR=$ANDROID_CREDENTIALS_DIR \
+        USE_MOLD=false \
+        ./building/containerized-build.sh android --app-bundle || return 0
 
     # If there is a tag for this commit then we append that to the produced artifacts
     # A version suffix should only be created if there is a tag for this commit and it is not a release build

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -68,7 +68,7 @@ function upload {
 # means in a container on Linux, and straight up in the local shell elsewhere.
 function run_in_build_env {
     if [[ "$(uname -s)" == "Linux" ]]; then
-        ./building/container-run.sh linux "$@"
+        USE_MOLD=false ./building/container-run.sh linux "$@"
     else
         bash -c "$*"
     fi


### PR DESCRIPTION
Updates the Linux (and indirectly Android) build container to have the [`mold`](https://github.com/rui314/mold.git) linker installed in it. Then adjust the container helper scripts to be able to easily use it.

The reason for not using it [like recommended for Rust](https://github.com/rui314/mold#how-to-use) is because that requires me to install `clang`, which blows up the size of the container significantly. With this `LD_PRELOAD` hack way of running it it's much easier.

I have opted out of mold for the real builds. Partially because it does not cut down on build times anyway, and partially because it feels iffy to depend on this linker without knowing more about it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4439)
<!-- Reviewable:end -->
