### PR TITLE
Replace usage of ENV with ARG in some containers

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -27,15 +27,15 @@ LABEL org.opencontainers.image.licenses=GPL-3.0
 
 # === Define toolchain versions and paths ===
 
-ENV SDK_VERSION=platforms;android-33 \
+ARG SDK_VERSION=platforms;android-33 \
     BUILD_TOOLS_VERSION=build-tools;30.0.3
 
 # Command line tools and checksum from: https://developer.android.com/studio#command-tools
-ENV COMMAND_LINE_TOOLS_VERSION=9123335 \
+ARG COMMAND_LINE_TOOLS_VERSION=9123335 \
     COMMAND_LINE_TOOLS_SHA256_CHECKSUM=0bebf59339eaa534f4217f8aa0972d14dc49e7207be225511073c661ae01da0a
 
 # NDK and checksum from: https://github.com/android/ndk/wiki/Unsupported-Downloads
-ENV NDK_VERSION=r20b \
+ARG NDK_VERSION=r20b \
     NDK_SHA1_CHECKSUM=d903fdf077039ad9331fb6c3bee78aa46d45527b \
     MIN_SDK_VERSION=21
 

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -28,11 +28,11 @@ LABEL org.opencontainers.image.licenses=GPL-3.0
 
 ENV CARGO_TARGET_DIR=/root/.cargo/target
 
-ENV GOLANG_VERSION=1.18.5 \
+ARG GOLANG_VERSION=1.18.5 \
     GOLANG_HASH=9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2
 
 # The pinned commit has this solved: https://github.com/rui314/mold/issues/1003.
-ARG MOLD_COMMIT_HASH=c4722fe5aed96295837d9150b20ef8698c7a28db
+ARG MOLD_COMMIT_REF=c4722fe5aed96295837d9150b20ef8698c7a28db
 
 # === Install/set up the image ===
 
@@ -71,7 +71,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* && \
     git clone https://github.com/rui314/mold.git && \
     mkdir mold/build && cd mold/build && \
-    git reset --hard "$MOLD_COMMIT_HASH" && \
+    git reset --hard "$MOLD_COMMIT_REF" && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ .. && \
     cmake --build . -j $(nproc) && \
     cmake --install . && \


### PR DESCRIPTION
Follow up to #4439 where we realized that `ARG` is better than `ENV` for variables that are only meant to be used in the `Dockerfile` itself, and not in the container when it's running later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4442)
<!-- Reviewable:end -->
