### PR TITLE
Swap Linux builds over to Debian 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ Line wrap the file at 100 chars.                                              Th
 - Remove automatic fallback to wireguard-go. This is done as a first step before fully
   deprecating it on Windows.
 
+### Deprecated
+#### Linux
+- Deprecated support for Debian 10. This also means dropping support for glibc older
+  than 2.31 and Linux kernels older than 5.10.
+
 ### Fixed
 - Fix close to expiry notification not showing unless app is opened once within the last three days
   in the desktop app.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ security.
 | macOS       | The three latest major releases |
 | Linux (Ubuntu)| The two latest LTS releases and the latest non-LTS releases |
 | Linux (Fedora) | The versions that are not yet [EOL](https://fedoraproject.org/wiki/End_of_life) |
-| Linux (Debian) | The versions that are not yet [EOL](https://wiki.debian.org/DebianReleases) |
+| Linux (Debian) | 11 and newer    |
 | Android     | 8 and newer        |
 | iOS         | 13 and newer       |
 

--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:20d7550f1
+ghcr.io/mullvad/mullvadvpn-app-build:3461d7d2c


### PR DESCRIPTION
Bumps the Linux container image to use the new Debian 11 based image. Also upgrades Rust from 1.67.1 to 1.68.0.

I'm not yet toggling `USE_MOLD` over to `true` by default since the Android images does not yet have mold installed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4443)
<!-- Reviewable:end -->
