### PR TITLE
Fix string formatting of error message that causes exception in login view

### DIFF
--- a/ios/MullvadVPN/RESTError+Display.swift
+++ b/ios/MullvadVPN/RESTError+Display.swift
@@ -29,7 +29,7 @@ extension REST.Error: DisplayError {
                 return String(format: NSLocalizedString(
                     "INVALID_ACCOUNT_ERROR",
                     tableName: "REST",
-                    value: "Unexpected server response: %@",
+                    value: "Unexpected server response: %d",
                     comment: ""
                 ), statusCode)
             }


### PR DESCRIPTION
If the server response cannot be decoded properly (defaults to nil), `REST.Error.unhandledResponse(statusCode, serverResponse) ` can cause an expection when it tries to print an error message description. 

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4448)
<!-- Reviewable:end -->
