### PR TITLE
Change 'Preferences' to 'VPN Settings'

### DIFF
--- a/ios/MullvadVPN/PreferencesViewController.swift
+++ b/ios/MullvadVPN/PreferencesViewController.swift
@@ -39,7 +39,7 @@ class PreferencesViewController: UITableViewController, PreferencesDataSourceDel
         navigationItem.title = NSLocalizedString(
             "NAVIGATION_TITLE",
             tableName: "Preferences",
-            value: "Preferences",
+            value: "VPN settings",
             comment: ""
         )
         navigationItem.rightBarButtonItem = editButtonItem

--- a/ios/MullvadVPN/PreferencesViewModel.swift
+++ b/ios/MullvadVPN/PreferencesViewModel.swift
@@ -64,7 +64,7 @@ enum CustomDNSPrecondition {
                 string: NSLocalizedString(
                     "CUSTOM_DNS_DISABLE_CONTENT_BLOCKERS_FOOTNOTE",
                     tableName: "Preferences",
-                    value: "Disable all content blockers (under Preferences) to activate this setting.",
+                    value: "Disable all content blockers (under VPN settings) to activate this setting.",
                     comment: "Foot note displayed when custom DNS cannot be enabled, because content blockers should be disabled first."
                 ),
                 attributes: [.font: preferredFont]

--- a/ios/MullvadVPN/SettingsCellFactory.swift
+++ b/ios/MullvadVPN/SettingsCellFactory.swift
@@ -63,7 +63,7 @@ struct SettingsCellFactory: CellFactoryProtocol {
             cell.titleLabel.text = NSLocalizedString(
                 "PREFERENCES_CELL_LABEL",
                 tableName: "Settings",
-                value: "Preferences",
+                value: "VPN settings",
                 comment: ""
             )
             cell.detailTitleLabel.text = nil


### PR DESCRIPTION
The menu names in Settings on Desktop has been changed from Preferences and Advanced to User interface settings and VPN settings.

On iOS we don't have the same amount of settings as on Desktop, so the only change that is needed is to change the name "Preferences" in settings to "VPN settings".

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4450)
<!-- Reviewable:end -->
