### PR TITLE
Cancel all pending network operations when a logout action is triggered

### DIFF
--- a/ios/MullvadREST/RESTRetryStrategy.swift
+++ b/ios/MullvadREST/RESTRetryStrategy.swift
@@ -37,9 +37,9 @@ extension REST {
             applyJitter: false
         )
 
-        /// Startegy configured with 3 retry attempts and exponential backoff.
+        /// Strategy configured with 2 retry attempts and exponential backoff.
         public static var `default` = RetryStrategy(
-            maxRetryCount: 3,
+            maxRetryCount: 2,
             delay: defaultRetryDelay,
             applyJitter: true
         )

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -389,6 +389,12 @@ final class TunnelManager: StorePaymentObserver {
             MutuallyExclusive(category: OperationCategory.settingsUpdate.category)
         )
 
+        // Unsetting the account (ie. logging out) should cancel all other currently ongoing
+        // activity.
+        if case .unset = action {
+            operationQueue.cancelAllOperations()
+        }
+
         operationQueue.addOperation(operation)
     }
 


### PR DESCRIPTION
When the API is not available, logging out takes a very long time. Eg. going to the account screen will fetch account and device info, so if one would try to log out while those calls are in progress there will be additional retries and backoffs added to the queue. This can result in chained timeouts for get-my-account, get-device and delete-device, all in all adding minutes to the logout process. Cancelling all operations before triggering the logout action solves this.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4455)
<!-- Reviewable:end -->
