### PR TITLE
Change key rotation interval on Android and iOS to 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Line wrap the file at 100 chars.                                              Th
 - Update OpenSSL to 1.1.1t from 1.1.1j.
 - Post-Quantum secure tunnels and multihop can now be used at the same time.
 
+#### Android
+- Change Android key rotation interval to 7 days instead of 4.
+
 #### Windows
 - Remove automatic fallback to wireguard-go. This is done as a first step before fully
   deprecating it on Windows.

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -43,6 +43,7 @@ with the option to buy more time.
 - Swap vertical position of country and city labels on connection view.
 - Display remaining account time in years if equal to or more than two years,
   otherwise display days.
+- Changed key rotation interval from 4 to 7 days.
 
 ### Fixed
 - Improve random port distribution. Should be less biased towards port 53.

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -28,7 +28,7 @@ private let establishingTunnelStatusPollInterval: TimeInterval = 3
 private let establishedTunnelStatusPollInterval: TimeInterval = 5
 
 /// Private key rotation interval (in seconds).
-private let privateKeyRotationInterval: TimeInterval = 60 * 60 * 24 * 4
+private let privateKeyRotationInterval: TimeInterval = 60 * 60 * 24 * 7
 
 /// Private key rotation retry interval (in seconds).
 private let privateKeyRotationFailureRetryInterval: TimeInterval = 60 * 15

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -8,11 +8,7 @@ use talpid_types::net::wireguard;
 
 pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_secs(1 * 24 * 60 * 60);
 pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-pub const DEFAULT_ROTATION_INTERVAL: Duration = if cfg!(target_os = "android") {
-    Duration::from_secs(4 * 24 * 60 * 60)
-} else {
-    Duration::from_secs(7 * 24 * 60 * 60)
-};
+pub const DEFAULT_ROTATION_INTERVAL: Duration = MAX_ROTATION_INTERVAL;
 
 /// Whether to enable or disable quantum resistant tunnels when the setting
 /// is set to `QuantumResistantState::Auto`.


### PR DESCRIPTION
To be consistent across all platforms, the key rotation interval on iOS and Android is bumped to 7 days instead of 4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4456)
<!-- Reviewable:end -->
