### PR TITLE
Use mold linker by default (USE_MOLD=true)

### DIFF
--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -16,9 +16,8 @@ CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
 GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
 ANDROID_CREDENTIALS_DIR=${ANDROID_CREDENTIALS_DIR:-""}
 CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
-# Don't use mold by default until we have published the images with mold in
-# and swapped our builds to use them.
-USE_MOLD=${USE_MOLD:-"false"}
+# Use mold for linking by default. Build servers opt out of this and use GNU ld
+USE_MOLD=${USE_MOLD:-"true"}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"


### PR DESCRIPTION
Follow up to #4443. Since both the Linux and Android builds now use the containers that have `mold` installed in them, we can enable it by default. This should speed up linking times by quite a lot *in debug builds*.

This will sadly not benefit the CI yet. The CI uses the containers, but are not executed through `container-run.sh` and mold is not the default linker in the containers. Fixing that is left as an exercise for the future.

Build servers still link with GNU ld by explicitly opting out with `USE_MOLD=false`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4457)
<!-- Reviewable:end -->
