### PR TITLE
Fix bug where VPN settings list is empty

### DIFF
--- a/ios/MullvadVPN/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/PreferencesDataSource.swift
@@ -147,10 +147,11 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
 
         if viewModel != mergedViewModel {
             viewModel = mergedViewModel
-
-            updateSnapshot()
-            reloadCustomDNSFooter()
         }
+
+        updateCellFactory(with: viewModel)
+        updateSnapshot()
+        reloadCustomDNSFooter()
     }
 
     // MARK: - UITableViewDataSource


### PR DESCRIPTION
VPN settings list is empty when opening the settings view. This fixes the bug.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4458)
<!-- Reviewable:end -->
