### PR TITLE
Remove port 443 from WireGuard over TCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Line wrap the file at 100 chars.                                              Th
 - Deprecated support for Debian 10. This also means dropping support for glibc older
   than 2.31 and Linux kernels older than 5.10.
 
+### Removed
+- Remove port 443 as valid port for WireGuard over TCP. Keep only port 80 and 5001. The reason is
+  to free up port 443 for other TCP based obfuscation later.
+
 ### Fixed
 - Fix close to expiry notification not showing unless app is opened once within the last three days
   in the desktop app.

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -37,7 +37,7 @@ import SettingsHeader, { HeaderTitle } from './SettingsHeader';
 const MIN_WIREGUARD_MTU_VALUE = 1280;
 const MAX_WIREGUARD_MTU_VALUE = 1420;
 const WIREUGARD_UDP_PORTS = [51820, 53];
-const UDP2TCP_PORTS = [80, 443, 5001];
+const UDP2TCP_PORTS = [80, 5001];
 
 function mapPortToSelectorItem(value: number): SelectorItem<number> {
   return { label: value.toString(), value };

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -43,7 +43,7 @@ const RELAYS_FILENAME: &str = "relays.json";
 const WIREGUARD_EXIT_PORT: Constraint<u16> = Constraint::Only(51820);
 const WIREGUARD_EXIT_IP_VERSION: Constraint<IpVersion> = Constraint::Only(IpVersion::V4);
 
-const UDP2TCP_PORTS: [u16; 3] = [80, 443, 5001];
+const UDP2TCP_PORTS: [u16; 2] = [80, 5001];
 
 /// Minimum number of bridges to keep for selection when filtering by distance.
 const MIN_BRIDGE_COUNT: usize = 5;


### PR DESCRIPTION
We want to free up port 443 for other TCP based protocols (fake TCP). So we need to make the app stop using it asap to get people away from this port.

The plan is to backport this fix to the `prepare-2023.3` branch when it's approved, to get it out in the coming release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4467)
<!-- Reviewable:end -->
