### PR TITLE
Fix logout transition

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -285,10 +285,22 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         }
     }
 
-    private func didLogout() {
-        router.dismissAll(.primary, animated: false)
+    private func didDismissSettings(_ reason: SettingsDismissReason) {
+        if isPad {
+            router.dismissAll(.settings, animated: true)
 
-        continueFlow(animated: true)
+            if reason == .userLoggedOut {
+                router.dismissAll(.primary, animated: true)
+                continueFlow(animated: true)
+            }
+        } else {
+            if reason == .userLoggedOut {
+                router.dismissAll(.primary, animated: false)
+                continueFlow(animated: false)
+            }
+
+            router.dismissAll(.settings, animated: true)
+        }
     }
 
     /**
@@ -532,11 +544,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         )
 
         coordinator.didFinish = { [weak self] coordinator, reason in
-            self?.router.dismissAll(.settings, animated: true)
-
-            if reason == .userLoggedOut {
-                self?.didLogout()
-            }
+            self?.didDismissSettings(reason)
         }
 
         coordinator.willNavigate = { [weak self] coordinator, from, to in

--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -324,21 +324,17 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
      On iPhone this function simply passes the primary navigation container to the `block` and
      nothing else.
      */
-    private func beginHorizontalFlow(_ completion: (() -> Void)? = nil) {
-        if isPad {
-            if secondaryNavigationContainer.presentingViewController == nil {
-                secondaryRootConfiguration.apply(to: secondaryNavigationContainer)
+    private func beginHorizontalFlow(animated: Bool, completion: @escaping () -> Void) {
+        if isPad, secondaryNavigationContainer.presentingViewController == nil {
+            secondaryRootConfiguration.apply(to: secondaryNavigationContainer)
 
-                primaryNavigationContainer.present(
-                    secondaryNavigationContainer,
-                    animated: true,
-                    completion: completion
-                )
-            } else {
-                completion?()
-            }
+            primaryNavigationContainer.present(
+                secondaryNavigationContainer,
+                animated: animated,
+                completion: completion
+            )
         } else {
-            completion?()
+            completion()
         }
     }
 
@@ -394,7 +390,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         addChild(coordinator)
         coordinator.start()
 
-        beginHorizontalFlow {
+        beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
@@ -412,7 +408,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         addChild(tunnelCoordinator)
         tunnelCoordinator.start()
 
-        beginHorizontalFlow {
+        beginHorizontalFlow(animated: animated) {
             completion(tunnelCoordinator)
         }
     }
@@ -430,7 +426,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         addChild(coordinator)
         coordinator.start(animated: animated)
 
-        beginHorizontalFlow {
+        beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
@@ -455,7 +451,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         addChild(coordinator)
         coordinator.start(animated: animated)
 
-        beginHorizontalFlow {
+        beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
@@ -490,7 +486,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         addChild(coordinator)
         coordinator.start(animated: animated)
 
-        beginHorizontalFlow {
+        beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }

--- a/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
@@ -425,7 +425,7 @@ final class ApplicationRouter {
          Check if route can be presented above the last route in the modal stack.
          */
         if let lastRouteGroup = modalStack.last, lastRouteGroup >= route.routeGroup,
-           route.routeGroup.isModal
+           route.routeGroup.isModal, route.isExclusive
         {
             completion(.blockedByModalContext)
             return


### PR DESCRIPTION
1. Fix logout transition so that Login appears beneath Settings on iPhone. Circumvents issue where an empty map is shown first.
2. Fix issue in router where transition from TOS > Login on iPad would assume that the route cannot be presented. Checking for `isExclusive` flag here to remedy this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4469)
<!-- Reviewable:end -->
