### PR TITLE
Use `rm` instead of `cargo clean` to work better in containers

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -59,7 +59,7 @@ fi
 
 if [[ "$BUILD_TYPE" == "release" && "$PRODUCT_VERSION" != *"-dev-"* ]]; then
     echo "Removing old Rust build artifacts"
-    cargo clean
+    (shopt -s dotglob; rm -r "${CARGO_TARGET_DIR:?}/*")
     CARGO_ARGS+=" --locked"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,7 @@ fi
 
 if [[ "$IS_RELEASE" == "true" ]]; then
     log_info "Removing old Rust build artifacts..."
-    cargo clean
+    (shopt -s dotglob; rm -r "${CARGO_TARGET_DIR:?}/*")
 
     # Will not allow an outdated lockfile in releases
     CARGO_ARGS+=(--locked)


### PR DESCRIPTION
Since the target dir is a container mount, cargo clean fails to remove the directory, causing the entire build to fail. To my knowledge, all `cargo clean` does is remove the target directory. We can do that manually in a way that does not fail when the actual target dir can't be deleted. Here we remove all the content and not the dir itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4473)
<!-- Reviewable:end -->
