### PR TITLE
Change build container CARGO_TARGET_DIR to allow cargo clean

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -3,9 +3,10 @@
 #
 # To build using the image:
 # podman run --rm \
-#     -v /path/to/container_cache/target:/root/.cargo/target:Z \
-#     -v /path/to/container_cache/registry:/root/.cargo/registry:Z \
-#     -v /path/to/container_cache/gradle:/root/.gradle:Z \
+#     -v $CARGO_TARGET_VOLUME_NAME:/cargo-target:Z \
+#     -v $CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z \
+#     -v $GRADLE_CACHE_VOLUME_NAME:/root/.gradle:Z \
+#     -v $ANDROID_CREDENTIALS_DIR:/build/android/credentials:Z \
 #     -v /path/to/repository_root:/build:Z \
 #     mullvadvpn-app-build-android ./build-apk.sh --dev-build --no-docker
 #

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -7,9 +7,9 @@
 # dependencies and building everything.
 #
 # podman run --rm \
-#     -v /path/to/container_cache/target:/root/.cargo/target:Z \
-#     -v /path/to/container_cache/registry:/root/.cargo/registry:Z \
-#     -v .:/build:Z \
+#     -v $CARGO_TARGET_VOLUME_NAME:/cargo-target:Z \
+#     -v $CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z \
+#     -v /path/to/repository_root:/build:Z \
 #     mullvadvpn-app-build ./build.sh
 #
 # And add -e TARGETS="aarch64-unknown-linux-gnu" to build for ARM64
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.licenses=GPL-3.0
 
 # === Define toolchain versions and paths ===
 
-ENV CARGO_TARGET_DIR=/root/.cargo/target
+ENV CARGO_TARGET_DIR=/cargo-target/target
 
 ARG GOLANG_VERSION=1.18.5 \
     GOLANG_HASH=9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2

--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -53,7 +53,7 @@ fi
 set -x
 exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$REPO_DIR:$REPO_MOUNT_TARGET:Z" \
-    -v "$CARGO_TARGET_VOLUME_NAME:/root/.cargo/target:Z" \
+    -v "$CARGO_TARGET_VOLUME_NAME:/cargo-target:Z" \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \
     "${optional_android_credentials_volume[@]}" \


### PR DESCRIPTION
Updated fix instead of #4473. With this change `cargo clean` should work without errors and non-zero exit codes in the build containers. Making them nicer to use both in interactive mode, but also makes `build.sh` not fail to make production releases.

I updated some documentation also. Since the dockerfile comments were not in line with how we used them ourselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4477)
<!-- Reviewable:end -->
