### PR TITLE
Enable Cargo's sparse protocol

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -63,6 +63,11 @@ ENV PATH=/root/.cargo/bin:$PATH
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc" \
     PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu
 
+# Enable Cargo's sparse protocol. Allows fetching the index much faster.
+# Is targeted for being the default in Rust 1.70. If that happens, this can be removed.
+# https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
 # === mold (fast linker) ===
 # Allows linking Rust binaries significantly faster.
 


### PR DESCRIPTION
Enables Cargo's new sparse protocol for fetching the index. This saves significant amount of time in updating the crates.io index. Read more here: https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol

If this turns out to be fast enough, we could consider removing the complexity of mounting a registry cache into the containers. However, since we don't know the reliability and performance of the sparse protocol yet, let's wait with evaluating that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4478)
<!-- Reviewable:end -->
