### PR TITLE
Switch Linux build container over to mullvadvpn-app-build:8d7df5659

### DIFF
--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:3461d7d2c
+ghcr.io/mullvad/mullvadvpn-app-build:8d7df5659


### PR DESCRIPTION
* Fixes `cargo clean`
* Enables Cargo's sparse registry download
* Upgrades node 16 -> 18 and npm 8 -> 9
