### PR TITLE
Account manager now always rotates key if needed-des-113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix location search in desktop app only searching for English location names.
+- Fix automatic WireGuard key rotation not being initialized correctly when not running the GUI.
 
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -448,6 +448,12 @@ impl AccountManager {
         let mut current_api_call = api::CurrentApiCall::new();
 
         loop {
+            if current_api_call.is_idle() {
+                if let Some(timed_rotation) = self.spawn_timed_key_rotation() {
+                    current_api_call.set_timed_rotation(Box::pin(timed_rotation))
+                }
+            }
+
             futures::select! {
                 api_result = current_api_call => {
                     self.consume_api_result(api_result, &mut current_api_call).await;
@@ -521,12 +527,6 @@ impl AccountManager {
                             break;
                         }
                     }
-                }
-            }
-
-            if current_api_call.is_idle() {
-                if let Some(timed_rotation) = self.spawn_timed_key_rotation() {
-                    current_api_call.set_timed_rotation(Box::pin(timed_rotation))
                 }
             }
         }


### PR DESCRIPTION
Previously the account manager would not rotate the wireguard key unless any account manager command was given. This resulted in old keys not being rotated sometimes when not using the GUI. This fixes this by always starting a key rotation when the account manager starts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4490)
<!-- Reviewable:end -->
