### PR TITLE
Move Safari related handling into its own coordinator

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		5867771429097BCD006F721F /* PaymentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5867771329097BCD006F721F /* PaymentState.swift */; };
 		5867771629097C5B006F721F /* ProductState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5867771529097C5B006F721F /* ProductState.swift */; };
 		5868585524054096000B8131 /* AppButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5868585424054096000B8131 /* AppButton.swift */; };
+		586891CD29D452E4002A8278 /* SafariCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586891CC29D452E4002A8278 /* SafariCoordinator.swift */; };
 		586A950C290125EE007BAF2B /* AlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B9EB122488ED2100095626 /* AlertPresenter.swift */; };
 		586A950D290125F0007BAF2B /* PresentAlertOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5820675D26E6839900655B05 /* PresentAlertOperation.swift */; };
 		586A950E290125F3007BAF2B /* ProductsRequestOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5846226426E0D9630035F7C2 /* ProductsRequestOperation.swift */; };
@@ -758,6 +759,7 @@
 		5867771329097BCD006F721F /* PaymentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentState.swift; sourceTree = "<group>"; };
 		5867771529097C5B006F721F /* ProductState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductState.swift; sourceTree = "<group>"; };
 		5868585424054096000B8131 /* AppButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppButton.swift; sourceTree = "<group>"; };
+		586891CC29D452E4002A8278 /* SafariCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariCoordinator.swift; sourceTree = "<group>"; };
 		586A95112901321B007BAF2B /* IPv6Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPv6Endpoint.swift; sourceTree = "<group>"; };
 		586A951329013235007BAF2B /* AnyIPEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyIPEndpoint.swift; sourceTree = "<group>"; };
 		586E54FA27A2DF6D0029B88B /* SendTunnelProviderMessageOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendTunnelProviderMessageOperation.swift; sourceTree = "<group>"; };
@@ -1601,6 +1603,7 @@
 				5847D58C29B7740F008C3808 /* RevokedCoordinator.swift */,
 				583FE00D29C0D586006E85F9 /* OutOfTimeCoordinator.swift */,
 				5878F50129CDB989003D4BE2 /* ChangeLogCoordinator.swift */,
+				586891CC29D452E4002A8278 /* SafariCoordinator.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2725,6 +2728,7 @@
 				5878A27329091D6D0096FC88 /* TunnelBlockObserver.swift in Sources */,
 				5872D6E8286304DE00DB5F4E /* TermsOfService.swift in Sources */,
 				58E0A98827C8F46300FE6BDD /* Tunnel.swift in Sources */,
+				586891CD29D452E4002A8278 /* SafariCoordinator.swift in Sources */,
 				58ACF64F26567A7100ACE4B7 /* CustomSwitchContainer.swift in Sources */,
 				5857F24324C8662600CF6F47 /* SelectLocationHeaderView.swift in Sources */,
 				58EE2E3A272FF814003BFF93 /* SettingsDataSource.swift in Sources */,

--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -569,9 +569,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             }
         }
 
-        coordinator.navigate(to: route ?? .root, animated: false)
-
-        coordinator.start()
+        coordinator.start(initialRoute: route)
 
         presentChild(
             coordinator,

--- a/ios/MullvadVPN/Coordinators/App/SafariCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/SafariCoordinator.swift
@@ -1,0 +1,39 @@
+//
+//  SafariCoordinator.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 29/03/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import SafariServices
+
+class SafariCoordinator: Coordinator, Presentable, SFSafariViewControllerDelegate {
+    var didFinish: (() -> Void)?
+
+    var presentedViewController: UIViewController {
+        return safariController
+    }
+
+    private let safariController: SFSafariViewController
+
+    init(url: URL) {
+        safariController = SFSafariViewController(url: url)
+        super.init()
+
+        safariController.delegate = self
+    }
+
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        dismiss(animated: true) {
+            self.didFinish?()
+        }
+    }
+
+    func safariViewControllerWillOpenInBrowser(_ controller: SFSafariViewController) {
+        dismiss(animated: false) {
+            self.didFinish?()
+        }
+    }
+}

--- a/ios/MullvadVPN/Coordinators/App/TermsOfServiceCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/TermsOfServiceCoordinator.swift
@@ -8,8 +8,12 @@
 
 import UIKit
 
-class TermsOfServiceCoordinator: Coordinator {
+class TermsOfServiceCoordinator: Coordinator, Presenting {
     private let navigationController: RootContainerViewController
+
+    var presentationContext: UIViewController {
+        return navigationController
+    }
 
     var didFinish: ((TermsOfServiceCoordinator) -> Void)?
 
@@ -20,7 +24,11 @@ class TermsOfServiceCoordinator: Coordinator {
     func start() {
         let controller = TermsOfServiceViewController()
 
-        controller.completionHandler = { [weak self] controller in
+        controller.showPrivacyPolicy = { [weak self] in
+            self?.presentChild(SafariCoordinator(url: ApplicationConfiguration.privacyPolicyURL), animated: true)
+        }
+
+        controller.completionHandler = { [weak self] in
             guard let self = self else { return }
 
             TermsOfService.setAgreed()

--- a/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceViewController.swift
+++ b/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceViewController.swift
@@ -6,13 +6,11 @@
 //  Copyright © 2020 Mullvad VPN AB. All rights reserved.
 //
 
-import SafariServices
 import UIKit
 
-class TermsOfServiceViewController: UIViewController, RootContainment,
-    SFSafariViewControllerDelegate
-{
-    var completionHandler: ((UIViewController) -> Void)?
+class TermsOfServiceViewController: UIViewController, RootContainment {
+    var showPrivacyPolicy: (() -> Void)?
+    var completionHandler: (() -> Void)?
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
@@ -58,26 +56,10 @@ class TermsOfServiceViewController: UIViewController, RootContainment,
     // MARK: - Actions
 
     @objc private func handlePrivacyPolicyButton(_ sender: Any) {
-        let safariController = SFSafariViewController(
-            url: ApplicationConfiguration
-                .privacyPolicyURL
-        )
-        safariController.delegate = self
-
-        present(safariController, animated: true)
+        showPrivacyPolicy?()
     }
 
     @objc private func handleAgreeButton(_ sender: Any) {
-        completionHandler?(self)
-    }
-
-    // MARK: - SFSafariViewControllerDelegate
-
-    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        controller.dismiss(animated: true)
-    }
-
-    func safariViewControllerWillOpenInBrowser(_ controller: SFSafariViewController) {
-        controller.dismiss(animated: false)
+        completionHandler?()
     }
 }


### PR DESCRIPTION
1. Move Safari handling into SafariCoordinator that can be presented modally.
2. Move Safari presentation from `TermsOfServiceViewController` into coordinator.
3. Extend `SettingsCoordinator.start()` to accept initial route.
4. Make sure that `SettingsCoordinator.navigate(to:)` always calls completion handler.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4503)
<!-- Reviewable:end -->
