### PR TITLE
Add RPC client that returns converted types

### DIFF
--- a/mullvad-cli/src/cmds/auto_connect.rs
+++ b/mullvad-cli/src/cmds/auto_connect.rs
@@ -1,4 +1,6 @@
-use crate::{new_rpc_client, Command, Result};
+use mullvad_management_interface::MullvadProxyClient;
+
+use crate::{Command, Result};
 
 pub struct AutoConnect;
 
@@ -38,15 +40,15 @@ impl Command for AutoConnect {
 
 impl AutoConnect {
     async fn set(&self, auto_connect: bool) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
+        let mut rpc = MullvadProxyClient::new().await?;
         rpc.set_auto_connect(auto_connect).await?;
         println!("Changed auto-connect setting");
         Ok(())
     }
 
     async fn get(&self) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
-        let auto_connect = rpc.get_settings(()).await?.into_inner().auto_connect;
+        let mut rpc = MullvadProxyClient::new().await?;
+        let auto_connect = rpc.get_settings().await?.auto_connect;
         println!("Autoconnect: {}", if auto_connect { "on" } else { "off" });
         Ok(())
     }

--- a/mullvad-cli/src/cmds/beta_program.rs
+++ b/mullvad-cli/src/cmds/beta_program.rs
@@ -1,4 +1,6 @@
-use crate::{new_rpc_client, Command, Error, Result};
+use mullvad_management_interface::MullvadProxyClient;
+
+use crate::{Command, Error, Result};
 
 pub struct BetaProgram;
 
@@ -27,8 +29,8 @@ impl Command for BetaProgram {
     async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
         match matches.subcommand() {
             Some(("get", _)) => {
-                let mut rpc = new_rpc_client().await?;
-                let settings = rpc.get_settings(()).await?.into_inner();
+                let mut rpc = MullvadProxyClient::new().await?;
+                let settings = rpc.get_settings().await?;
                 let enabled_str = if settings.show_beta_releases {
                     "on"
                 } else {
@@ -47,7 +49,7 @@ impl Command for BetaProgram {
                     ));
                 }
 
-                let mut rpc = new_rpc_client().await?;
+                let mut rpc = MullvadProxyClient::new().await?;
                 rpc.set_show_beta_releases(enable).await?;
 
                 println!("Beta program: {enable_str}");

--- a/mullvad-cli/src/cmds/block_when_disconnected.rs
+++ b/mullvad-cli/src/cmds/block_when_disconnected.rs
@@ -1,4 +1,4 @@
-use crate::{new_rpc_client, Command, Result};
+use crate::{Command, MullvadProxyClient, Result};
 
 pub struct BlockWhenDisconnected;
 
@@ -41,7 +41,7 @@ impl Command for BlockWhenDisconnected {
 
 impl BlockWhenDisconnected {
     async fn set(&self, block_when_disconnected: bool) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
+        let mut rpc = MullvadProxyClient::new().await?;
         rpc.set_block_when_disconnected(block_when_disconnected)
             .await?;
         println!("Changed lockdown mode setting");
@@ -49,12 +49,8 @@ impl BlockWhenDisconnected {
     }
 
     async fn get(&self) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
-        let block_when_disconnected = rpc
-            .get_settings(())
-            .await?
-            .into_inner()
-            .block_when_disconnected;
+        let mut rpc = MullvadProxyClient::new().await?;
+        let block_when_disconnected = rpc.get_settings().await?.block_when_disconnected;
         println!(
             "Network traffic will be {} when the VPN is disconnected",
             if block_when_disconnected {

--- a/mullvad-cli/src/cmds/connect.rs
+++ b/mullvad-cli/src/cmds/connect.rs
@@ -1,4 +1,4 @@
-use crate::{format, new_rpc_client, state, Command, Error, Result};
+use crate::{format, state, Command, Error, MullvadProxyClient, Result};
 use futures::StreamExt;
 use mullvad_types::states::TunnelState;
 
@@ -22,7 +22,7 @@ impl Command for Connect {
     }
 
     async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
+        let mut rpc = MullvadProxyClient::new().await?;
 
         let receiver_option = if matches.is_present("wait") {
             Some(state::state_listen(rpc.clone()))
@@ -30,7 +30,7 @@ impl Command for Connect {
             None
         };
 
-        if rpc.connect_tunnel(()).await?.into_inner() {
+        if rpc.connect_tunnel().await? {
             if let Some(mut receiver) = receiver_option {
                 while let Some(state) = receiver.next().await {
                     let state = state?;

--- a/mullvad-cli/src/cmds/disconnect.rs
+++ b/mullvad-cli/src/cmds/disconnect.rs
@@ -1,4 +1,4 @@
-use crate::{format, new_rpc_client, state, Command, Error, Result};
+use crate::{format, state, Command, Error, MullvadProxyClient, Result};
 use futures::StreamExt;
 
 pub struct Disconnect;
@@ -21,7 +21,7 @@ impl Command for Disconnect {
     }
 
     async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
+        let mut rpc = MullvadProxyClient::new().await?;
 
         let receiver_option = if matches.is_present("wait") {
             Some(state::state_listen(rpc.clone()))
@@ -29,7 +29,7 @@ impl Command for Disconnect {
             None
         };
 
-        if rpc.disconnect_tunnel(()).await?.into_inner() {
+        if rpc.disconnect_tunnel().await? {
             if let Some(mut receiver) = receiver_option {
                 while let Some(state) = receiver.next().await {
                     let state = state?;

--- a/mullvad-cli/src/cmds/lan.rs
+++ b/mullvad-cli/src/cmds/lan.rs
@@ -1,4 +1,4 @@
-use crate::{new_rpc_client, Command, Result};
+use crate::{Command, MullvadProxyClient, Result};
 
 pub struct Lan;
 
@@ -38,15 +38,15 @@ impl Command for Lan {
 
 impl Lan {
     async fn set(&self, allow_lan: bool) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
+        let mut rpc = MullvadProxyClient::new().await?;
         rpc.set_allow_lan(allow_lan).await?;
         println!("Changed local network sharing setting");
         Ok(())
     }
 
     async fn get(&self) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
-        let allow_lan = rpc.get_settings(()).await?.into_inner().allow_lan;
+        let mut rpc = MullvadProxyClient::new().await?;
+        let allow_lan = rpc.get_settings().await?.allow_lan;
         println!(
             "Local network sharing setting: {}",
             if allow_lan { "allow" } else { "block" }

--- a/mullvad-cli/src/cmds/reconnect.rs
+++ b/mullvad-cli/src/cmds/reconnect.rs
@@ -1,4 +1,4 @@
-use crate::{format, new_rpc_client, state, Command, Error, Result};
+use crate::{format, state, Command, Error, MullvadProxyClient, Result};
 use futures::StreamExt;
 use mullvad_types::states::TunnelState;
 
@@ -22,7 +22,7 @@ impl Command for Reconnect {
     }
 
     async fn run(&self, matches: &clap::ArgMatches) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
+        let mut rpc = MullvadProxyClient::new().await?;
 
         let receiver_option = if matches.is_present("wait") {
             Some(state::state_listen(rpc.clone()))
@@ -30,7 +30,7 @@ impl Command for Reconnect {
             None
         };
 
-        if rpc.reconnect_tunnel(()).await?.into_inner() {
+        if rpc.reconnect_tunnel().await? {
             if let Some(mut receiver) = receiver_option {
                 while let Some(state) = receiver.next().await {
                     let state = state?;

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -1,15 +1,23 @@
-use crate::{location, new_rpc_client, Command, Error, Result};
+use crate::{location, Command, Error, MullvadProxyClient, Result};
 use itertools::Itertools;
 use std::{
-    convert::TryFrom,
     io::{self, BufRead},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
 };
 
-use mullvad_management_interface::{types, ManagementServiceClient};
-use mullvad_types::relay_constraints::{Constraint, RelaySettings};
-use talpid_types::net::all_of_the_internet;
+use mullvad_types::{
+    relay_constraints::{
+        Constraint, LocationConstraint, Match, OpenVpnConstraints, Ownership, Providers,
+        RelayConstraintsUpdate, RelaySettings, RelaySettingsUpdate, TransportPort,
+        WireguardConstraints,
+    },
+    relay_list::{RelayEndpointData, RelayListCountry},
+    ConnectionConfig, CustomTunnelEndpoint,
+};
+use talpid_types::net::{
+    all_of_the_internet, openvpn, wireguard, Endpoint, IpVersion, TransportProtocol, TunnelType,
+};
 
 pub struct Relay;
 
@@ -219,11 +227,9 @@ impl Command for Relay {
 }
 
 impl Relay {
-    async fn update_constraints(&self, update: types::RelaySettingsUpdate) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
-        rpc.update_relay_settings(update)
-            .await
-            .map_err(|error| Error::RpcFailedExt("Failed to update relay settings", error))?;
+    async fn update_constraints(&self, update: RelaySettingsUpdate) -> Result<()> {
+        let mut rpc = MullvadProxyClient::new().await?;
+        rpc.update_relay_settings(update).await?;
         println!("Relay constraints updated");
         Ok(())
     }
@@ -257,17 +263,14 @@ impl Relay {
     async fn set_custom(&self, matches: &clap::ArgMatches) -> Result<()> {
         let custom_endpoint = match matches.subcommand() {
             Some(("openvpn", openvpn_matches)) => Self::read_custom_openvpn_relay(openvpn_matches),
-            Some(("wireguard", wg_matches)) => Self::read_custom_wireguard_relay(wg_matches),
+            Some(("wireguard", wg_matches)) => Self::read_custom_wireguard_relay(wg_matches)?,
             _ => unreachable!("No set relay command given"),
         };
-
-        self.update_constraints(types::RelaySettingsUpdate {
-            r#type: Some(types::relay_settings_update::Type::Custom(custom_endpoint)),
-        })
-        .await
+        self.update_constraints(RelaySettingsUpdate::CustomTunnelEndpoint(custom_endpoint))
+            .await
     }
 
-    fn read_custom_openvpn_relay(matches: &clap::ArgMatches) -> types::CustomRelaySettings {
+    fn read_custom_openvpn_relay(matches: &clap::ArgMatches) -> CustomTunnelEndpoint {
         let host = matches.value_of_t_or_exit("host");
         let port = matches.value_of_t_or_exit("port");
         let username = matches.value_of_t_or_exit("username");
@@ -276,25 +279,20 @@ impl Relay {
 
         let protocol = Self::validate_transport_protocol(&protocol);
 
-        types::CustomRelaySettings {
+        CustomTunnelEndpoint {
             host,
-            config: Some(types::ConnectionConfig {
-                config: Some(types::connection_config::Config::Openvpn(
-                    types::connection_config::OpenvpnConfig {
-                        address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
-                            .to_string(),
-                        protocol: protocol as i32,
-                        username,
-                        password,
-                    },
-                )),
+            config: ConnectionConfig::OpenVpn(openvpn::ConnectionConfig {
+                endpoint: Endpoint::from_socket_address(
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+                    protocol,
+                ),
+                username,
+                password,
             }),
         }
     }
 
-    fn read_custom_wireguard_relay(matches: &clap::ArgMatches) -> types::CustomRelaySettings {
-        use types::connection_config::wireguard_config;
-
+    fn read_custom_wireguard_relay(matches: &clap::ArgMatches) -> Result<CustomTunnelEndpoint> {
         let host = matches.value_of_t_or_exit("host");
         let port = matches.value_of_t_or_exit("port");
         let addresses: Vec<IpAddr> = matches.values_of_t_or_exit("addr");
@@ -313,64 +311,38 @@ impl Relay {
         if private_key_str.trim().is_empty() {
             eprintln!("Expected to read private key from standard input");
         }
-        let private_key = Self::validate_wireguard_key(&private_key_str);
-        let peer_public_key = Self::validate_wireguard_key(&peer_key_str);
+        let peer_public_key = wireguard::PublicKey::from_base64(&peer_key_str)
+            .map_err(|_| Error::InvalidCommand("invalid public key"))?;
+        let private_key = wireguard::PrivateKey::from_base64(&private_key_str)
+            .map_err(|_| Error::InvalidCommand("invalid private key"))?;
 
-        types::CustomRelaySettings {
+        Ok(CustomTunnelEndpoint {
             host,
-            config: Some(types::ConnectionConfig {
-                config: Some(types::connection_config::Config::Wireguard(
-                    types::connection_config::WireguardConfig {
-                        tunnel: Some(wireguard_config::TunnelConfig {
-                            private_key: private_key.to_vec(),
-                            addresses: addresses
-                                .iter()
-                                .map(|address| address.to_string())
-                                .collect(),
-                        }),
-                        peer: Some(wireguard_config::PeerConfig {
-                            public_key: peer_public_key.to_vec(),
-                            allowed_ips: all_of_the_internet()
-                                .iter()
-                                .map(|address| address.to_string())
-                                .collect(),
-                            endpoint: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
-                                .to_string(),
-                        }),
-                        ipv4_gateway: ipv4_gateway.to_string(),
-                        ipv6_gateway: ipv6_gateway
-                            .as_ref()
-                            .map(|addr| addr.to_string())
-                            .unwrap_or_default(),
-                    },
-                )),
+            config: ConnectionConfig::Wireguard(wireguard::ConnectionConfig {
+                tunnel: wireguard::TunnelConfig {
+                    private_key,
+                    addresses,
+                },
+                peer: wireguard::PeerConfig {
+                    public_key: peer_public_key,
+                    allowed_ips: all_of_the_internet(),
+                    endpoint: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+                    psk: None,
+                },
+                exit_peer: None,
+                ipv4_gateway,
+                ipv6_gateway,
+                // NOTE: Ignored in gRPC
+                #[cfg(target_os = "linux")]
+                fwmark: None,
             }),
-        }
+        })
     }
 
-    fn validate_wireguard_key(key_str: &str) -> [u8; 32] {
-        let key_bytes = base64::decode(key_str.trim()).unwrap_or_else(|e| {
-            eprintln!("Failed to decode wireguard key: {e}");
-            std::process::exit(1);
-        });
-
-        let mut key = [0u8; 32];
-        if key_bytes.len() != 32 {
-            eprintln!(
-                "Expected key length to be 32 bytes, got {}",
-                key_bytes.len()
-            );
-            std::process::exit(1);
-        }
-
-        key.copy_from_slice(&key_bytes);
-        key
-    }
-
-    fn validate_transport_protocol(protocol: &str) -> types::TransportProtocol {
+    fn validate_transport_protocol(protocol: &str) -> TransportProtocol {
         match protocol {
-            "udp" => types::TransportProtocol::Udp,
-            "tcp" => types::TransportProtocol::Tcp,
+            "udp" => TransportProtocol::Udp,
+            "tcp" => TransportProtocol::Tcp,
             _ => clap::Error::raw(
                 clap::ErrorKind::ValueValidation,
                 "invalid transport protocol",
@@ -388,11 +360,11 @@ impl Relay {
                 for city in country.cities {
                     for relay in city.relays {
                         if relay.hostname.to_lowercase() == hostname.to_lowercase() {
-                            return Some(types::RelayLocation {
-                                country: country.code,
-                                city: city.code,
-                                hostname: relay.hostname,
-                            });
+                            return Some(LocationConstraint::Hostname(
+                                country.code,
+                                city.code,
+                                relay.hostname,
+                            ));
                         }
                     }
                 }
@@ -401,19 +373,11 @@ impl Relay {
         };
 
         if let Some(location) = find_relay() {
-            println!(
-                "Setting location constraint to {} in {}, {}",
-                location.hostname, location.city, location.country
-            );
-
-            self.update_constraints(types::RelaySettingsUpdate {
-                r#type: Some(types::relay_settings_update::Type::Normal(
-                    types::NormalRelaySettingsUpdate {
-                        location: Some(location),
-                        ..Default::default()
-                    },
-                )),
-            })
+            println!("Setting location constraint to {location}");
+            self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+                location: Some(Constraint::Only(location)),
+                ..Default::default()
+            }))
             .await
         } else {
             clap::Error::raw(clap::ErrorKind::ValueValidation, "No matching server found").exit()
@@ -422,249 +386,151 @@ impl Relay {
 
     async fn set_location(&self, matches: &clap::ArgMatches) -> Result<()> {
         let location_constraint = location::get_constraint_from_args(matches);
-        let mut found = false;
+        match &location_constraint {
+            Constraint::Any => (),
+            Constraint::Only(constraint) => {
+                let countries = Self::get_filtered_relays().await?;
 
-        if !location_constraint.country.is_empty() {
-            // TODO: `mullvad_types::relay_constraints::LocationConstraint::matches(&relay)`
-            //       could be used to guarantee consistency with the daemon.
-            let countries = Self::get_filtered_relays().await?;
-            for country in &countries {
-                if country.code != location_constraint.country {
-                    continue;
+                let found = countries
+                    .into_iter()
+                    .flat_map(|country| country.cities)
+                    .flat_map(|city| city.relays)
+                    .any(|relay| constraint.matches(&relay));
+
+                if !found {
+                    eprintln!("Warning: No matching relay was found.");
                 }
-
-                if location_constraint.city.is_empty() {
-                    found = true;
-                    break;
-                }
-
-                for city in &country.cities {
-                    if city.code != location_constraint.city {
-                        continue;
-                    }
-
-                    if location_constraint.hostname.is_empty() {
-                        found = true;
-                        break;
-                    }
-
-                    for relay in &city.relays {
-                        if relay.hostname != location_constraint.hostname {
-                            continue;
-                        }
-                        found = true;
-                        break;
-                    }
-
-                    break;
-                }
-                break;
-            }
-
-            if !found {
-                eprintln!("Warning: No matching relay was found.");
             }
         }
-
-        self.update_constraints(types::RelaySettingsUpdate {
-            r#type: Some(types::relay_settings_update::Type::Normal(
-                types::NormalRelaySettingsUpdate {
-                    location: Some(location_constraint),
-                    ..Default::default()
-                },
-            )),
-        })
+        self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+            location: Some(location_constraint),
+            ..Default::default()
+        }))
         .await
     }
 
     async fn set_providers(&self, matches: &clap::ArgMatches) -> Result<()> {
         let providers: Vec<String> = matches.values_of_t_or_exit("provider");
         let providers = if providers.get(0).map(String::as_str) == Some("any") {
-            vec![]
+            Constraint::Any
         } else {
-            providers
+            Constraint::Only(Providers::new(providers.into_iter()).unwrap())
         };
 
-        self.update_constraints(types::RelaySettingsUpdate {
-            r#type: Some(types::relay_settings_update::Type::Normal(
-                types::NormalRelaySettingsUpdate {
-                    providers: Some(types::ProviderUpdate { providers }),
-                    ..Default::default()
-                },
-            )),
-        })
+        self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+            providers: Some(providers),
+            ..Default::default()
+        }))
         .await
     }
 
     async fn set_ownership(&self, matches: &clap::ArgMatches) -> Result<()> {
         let ownership = parse_ownership_constraint(matches.value_of("ownership").unwrap());
-        self.update_constraints(types::RelaySettingsUpdate {
-            r#type: Some(types::relay_settings_update::Type::Normal(
-                types::NormalRelaySettingsUpdate {
-                    ownership: Some(types::OwnershipUpdate {
-                        ownership: ownership as i32,
-                    }),
-                    ..Default::default()
-                },
-            )),
-        })
+
+        self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+            ownership: Some(ownership),
+            ..Default::default()
+        }))
         .await
     }
 
     async fn set_openvpn_constraints(&self, matches: &clap::ArgMatches) -> Result<()> {
         let mut openvpn_constraints = {
-            let mut rpc = new_rpc_client().await?;
-            self.get_openvpn_constraints(&mut rpc).await?
+            let mut rpc = MullvadProxyClient::new().await?;
+            Self::get_openvpn_constraints(&mut rpc).await?
         };
         openvpn_constraints.port = parse_transport_port(matches, &mut openvpn_constraints.port)?;
 
-        self.update_constraints(types::RelaySettingsUpdate {
-            r#type: Some(types::relay_settings_update::Type::Normal(
-                types::NormalRelaySettingsUpdate {
-                    openvpn_constraints: Some(openvpn_constraints),
-                    ..Default::default()
-                },
-            )),
-        })
+        self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+            openvpn_constraints: Some(openvpn_constraints),
+            ..Default::default()
+        }))
         .await
     }
 
-    async fn get_openvpn_constraints(
-        &self,
-        rpc: &mut ManagementServiceClient,
-    ) -> Result<types::OpenvpnConstraints> {
-        match rpc
-            .get_settings(())
-            .await?
-            .into_inner()
-            .relay_settings
-            .unwrap()
-            .endpoint
-            .unwrap()
-        {
-            types::relay_settings::Endpoint::Normal(settings) => {
-                Ok(settings.openvpn_constraints.unwrap())
-            }
-            types::relay_settings::Endpoint::Custom(_settings) => {
+    async fn get_openvpn_constraints(rpc: &mut MullvadProxyClient) -> Result<OpenVpnConstraints> {
+        match rpc.get_settings().await?.relay_settings {
+            RelaySettings::Normal(settings) => Ok(settings.openvpn_constraints),
+            RelaySettings::CustomTunnelEndpoint(_settings) => {
                 println!("Clearing custom tunnel constraints");
-                Ok(types::OpenvpnConstraints::default())
+                Ok(OpenVpnConstraints::default())
             }
         }
     }
 
     async fn set_wireguard_constraints(&self, matches: &clap::ArgMatches) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
-        let relay_list = rpc
-            .get_relay_locations(())
-            .await?
-            .into_inner()
-            .wireguard
-            .unwrap();
-        let mut wireguard_constraints = self.get_wireguard_constraints(&mut rpc).await?;
+        let mut rpc = MullvadProxyClient::new().await?;
+        let wireguard = rpc.get_relay_locations().await?.wireguard;
+        let mut wireguard_constraints = Self::get_wireguard_constraints(&mut rpc).await?;
 
         if let Some(port) = matches.value_of("port") {
             wireguard_constraints.port = match parse_port_constraint(port)? {
-                Constraint::Any => 0,
+                Constraint::Any => Constraint::Any,
                 Constraint::Only(specific_port) => {
-                    let specific_port = u32::from(specific_port);
-
-                    let is_valid_port = relay_list
+                    let is_valid_port = wireguard
                         .port_ranges
-                        .iter()
-                        .any(|range| range.first <= specific_port && specific_port <= range.last);
+                        .into_iter()
+                        .any(|(first, last)| first <= specific_port && specific_port <= last);
                     if !is_valid_port {
                         return Err(Error::CommandFailed("The specified port is invalid"));
                     }
-
-                    specific_port
+                    Constraint::Only(specific_port)
                 }
             }
         }
 
         if let Some(ipv) = matches.value_of("ip version") {
-            wireguard_constraints.ip_version =
-                parse_ip_version_constraint(ipv).option().map(|protocol| {
-                    types::IpVersionConstraint {
-                        protocol: protocol as i32,
-                    }
-                });
+            wireguard_constraints.ip_version = parse_ip_version_constraint(ipv);
         }
         if let Some(entry) = matches.values_of("entry location") {
-            wireguard_constraints.entry_location = parse_entry_location_constraint(entry);
-            let use_multihop = wireguard_constraints.entry_location.is_some();
-            wireguard_constraints.use_multihop = use_multihop;
+            match parse_entry_location_constraint(entry) {
+                Some(location) => {
+                    wireguard_constraints.entry_location = location;
+                    wireguard_constraints.use_multihop = true;
+                }
+                None => {
+                    wireguard_constraints.use_multihop = false;
+                }
+            }
         }
 
-        self.update_constraints(types::RelaySettingsUpdate {
-            r#type: Some(types::relay_settings_update::Type::Normal(
-                types::NormalRelaySettingsUpdate {
-                    wireguard_constraints: Some(wireguard_constraints),
-                    ..Default::default()
-                },
-            )),
-        })
+        self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+            wireguard_constraints: Some(wireguard_constraints),
+            ..Default::default()
+        }))
         .await
     }
 
     async fn get_wireguard_constraints(
-        &self,
-        rpc: &mut ManagementServiceClient,
-    ) -> Result<types::WireguardConstraints> {
-        match rpc
-            .get_settings(())
-            .await?
-            .into_inner()
-            .relay_settings
-            .unwrap()
-            .endpoint
-            .unwrap()
-        {
-            types::relay_settings::Endpoint::Normal(settings) => {
-                Ok(settings.wireguard_constraints.unwrap())
-            }
-            types::relay_settings::Endpoint::Custom(_settings) => {
+        rpc: &mut MullvadProxyClient,
+    ) -> Result<WireguardConstraints> {
+        match rpc.get_settings().await?.relay_settings {
+            RelaySettings::Normal(settings) => Ok(settings.wireguard_constraints),
+            RelaySettings::CustomTunnelEndpoint(_settings) => {
                 println!("Clearing custom tunnel constraints");
-                Ok(types::WireguardConstraints::default())
+                Ok(WireguardConstraints::default())
             }
         }
     }
 
     async fn set_tunnel_protocol(&self, matches: &clap::ArgMatches) -> Result<()> {
-        let tunnel_type = match matches.value_of("tunnel protocol").unwrap() {
-            "wireguard" => Some(types::TunnelType::Wireguard),
-            "openvpn" => Some(types::TunnelType::Openvpn),
-            "any" => None,
+        let tunnel_protocol = match matches.value_of("tunnel protocol").unwrap() {
+            "wireguard" => Constraint::Only(TunnelType::Wireguard),
+            "openvpn" => Constraint::Only(TunnelType::OpenVpn),
+            "any" => Constraint::Any,
             _ => unreachable!(),
         };
-        self.update_constraints(types::RelaySettingsUpdate {
-            r#type: Some(types::relay_settings_update::Type::Normal(
-                types::NormalRelaySettingsUpdate {
-                    tunnel_type: Some(types::TunnelTypeUpdate {
-                        tunnel_type: tunnel_type.map(|tunnel_type| types::TunnelTypeConstraint {
-                            tunnel_type: tunnel_type as i32,
-                        }),
-                    }),
-                    ..Default::default()
-                },
-            )),
-        })
+        self.update_constraints(RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
+            tunnel_protocol: Some(tunnel_protocol),
+            ..Default::default()
+        }))
         .await
     }
 
     async fn get(&self) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
-        let relay_settings = rpc
-            .get_settings(())
-            .await?
-            .into_inner()
-            .relay_settings
-            .unwrap();
-
-        println!(
-            "Current constraints: {}",
-            RelaySettings::try_from(relay_settings).unwrap()
-        );
-
+        let mut rpc = MullvadProxyClient::new().await?;
+        let relay_settings = rpc.get_settings().await?.relay_settings;
+        println!("Current constraints: {relay_settings}");
         Ok(())
     }
 
@@ -684,9 +550,9 @@ impl Relay {
                     city.name, city.code, city.latitude, city.longitude
                 );
                 for relay in &city.relays {
-                    let support_msg = match relay.endpoint_type {
-                        i if i == i32::from(types::relay::RelayType::Openvpn) => "OpenVPN",
-                        i if i == i32::from(types::relay::RelayType::Wireguard) => "WireGuard",
+                    let support_msg = match relay.endpoint_data {
+                        RelayEndpointData::Openvpn => "OpenVPN",
+                        RelayEndpointData::Wireguard(_) => "WireGuard",
                         _ => unreachable!("Bug in relay filtering earlier on"),
                     };
                     let ownership = if relay.owned {
@@ -694,9 +560,9 @@ impl Relay {
                     } else {
                         "rented"
                     };
-                    let mut addresses = vec![&relay.ipv4_addr_in];
-                    if !relay.ipv6_addr_in.is_empty() {
-                        addresses.push(&relay.ipv6_addr_in);
+                    let mut addresses: Vec<IpAddr> = vec![relay.ipv4_addr_in.into()];
+                    if let Some(ipv6_addr) = relay.ipv6_addr_in {
+                        addresses.push(ipv6_addr.into());
                     }
                     println!(
                         "\t\t{} ({}) - {}, hosted by {} ({ownership})",
@@ -713,20 +579,19 @@ impl Relay {
     }
 
     async fn update(&self) -> Result<()> {
-        new_rpc_client().await?.update_relay_locations(()).await?;
+        MullvadProxyClient::new()
+            .await?
+            .update_relay_locations()
+            .await?;
         println!("Updating relay list in the background...");
         Ok(())
     }
 
-    async fn get_filtered_relays() -> Result<Vec<types::RelayListCountry>> {
-        let mut rpc = new_rpc_client().await?;
-        let relay_list = rpc
-            .get_relay_locations(())
-            .await
-            .map_err(|error| Error::RpcFailedExt("Failed to obtain relay locations", error))?
-            .into_inner();
+    async fn get_filtered_relays() -> Result<Vec<RelayListCountry>> {
+        let mut rpc = MullvadProxyClient::new().await?;
+        let relay_list = rpc.get_relay_locations().await?;
 
-        let mut countries = Vec::new();
+        let mut countries = vec![];
 
         for mut country in relay_list.countries {
             country.cities = country
@@ -734,8 +599,7 @@ impl Relay {
                 .into_iter()
                 .filter_map(|mut city| {
                     city.relays.retain(|relay| {
-                        relay.active
-                            && relay.endpoint_type != (types::relay::RelayType::Bridge as i32)
+                        relay.active && relay.endpoint_data != RelayEndpointData::Bridge
                     });
                     if !city.relays.is_empty() {
                         Some(city)
@@ -762,27 +626,27 @@ fn parse_port_constraint(raw_port: &str) -> Result<Constraint<u16>> {
     }
 }
 
-fn parse_protocol(raw_protocol: &str) -> Constraint<types::TransportProtocol> {
+fn parse_protocol(raw_protocol: &str) -> Constraint<TransportProtocol> {
     match raw_protocol {
         "any" => Constraint::Any,
-        "udp" => Constraint::Only(types::TransportProtocol::Udp),
-        "tcp" => Constraint::Only(types::TransportProtocol::Tcp),
+        "udp" => Constraint::Only(TransportProtocol::Udp),
+        "tcp" => Constraint::Only(TransportProtocol::Tcp),
         _ => unreachable!(),
     }
 }
 
-fn parse_ip_version_constraint(raw_protocol: &str) -> Constraint<types::IpVersion> {
+fn parse_ip_version_constraint(raw_protocol: &str) -> Constraint<IpVersion> {
     match raw_protocol {
         "any" => Constraint::Any,
-        "4" => Constraint::Only(types::IpVersion::V4),
-        "6" => Constraint::Only(types::IpVersion::V6),
+        "4" => Constraint::Only(IpVersion::V4),
+        "6" => Constraint::Only(IpVersion::V6),
         _ => unreachable!(),
     }
 }
 
 fn parse_entry_location_constraint<'a, T: Iterator<Item = &'a str>>(
     mut location: T,
-) -> Option<types::RelayLocation> {
+) -> Option<Constraint<LocationConstraint>> {
     let country = location.next().unwrap();
 
     if country == "none" {
@@ -798,15 +662,13 @@ fn parse_entry_location_constraint<'a, T: Iterator<Item = &'a str>>(
 
 fn parse_transport_port(
     matches: &clap::ArgMatches,
-    current_constraint: &mut Option<types::TransportPort>,
-) -> Result<Option<types::TransportPort>> {
+    current_constraint: &mut Constraint<TransportPort>,
+) -> Result<Constraint<TransportPort>> {
     let protocol = match matches.value_of("transport protocol") {
         Some(protocol) => parse_protocol(protocol),
         None => {
-            if let Some(ref transport_port) = current_constraint {
-                Constraint::Only(
-                    types::TransportProtocol::from_i32(transport_port.protocol).unwrap(),
-                )
+            if let Constraint::Only(ref transport_port) = current_constraint {
+                Constraint::Only(transport_port.protocol)
             } else {
                 Constraint::Any
             }
@@ -814,17 +676,9 @@ fn parse_transport_port(
     };
     let mut port = match matches.value_of("port") {
         Some(port) => parse_port_constraint(port)?,
-        None => {
-            if let Some(ref transport_port) = current_constraint {
-                if transport_port.port != 0 {
-                    Constraint::Only(transport_port.port as u16)
-                } else {
-                    Constraint::Any
-                }
-            } else {
-                Constraint::Any
-            }
-        }
+        None => current_constraint
+            .map(|port| port.port)
+            .unwrap_or(Constraint::Any),
     };
     if port.is_only() && protocol.is_any() && !matches.is_present("port") {
         // Reset the port if the transport protocol is set to any.
@@ -832,27 +686,28 @@ fn parse_transport_port(
         port = Constraint::Any;
     }
     match (port, protocol) {
-        (Constraint::Any, Constraint::Any) => Ok(None),
-        (Constraint::Any, Constraint::Only(protocol)) => Ok(Some(types::TransportPort {
-            protocol: protocol as i32,
-            // If no port was specified, set it to "any"
-            ..types::TransportPort::default()
+        (Constraint::Any, Constraint::Any) => Ok(Constraint::Any),
+        (Constraint::Any, Constraint::Only(protocol)) => Ok(Constraint::Only(TransportPort {
+            protocol,
+            port: Constraint::Any,
         })),
-        (Constraint::Only(port), Constraint::Only(protocol)) => Ok(Some(types::TransportPort {
-            protocol: protocol as i32,
-            port: u32::from(port),
-        })),
+        (Constraint::Only(port), Constraint::Only(protocol)) => {
+            Ok(Constraint::Only(TransportPort {
+                protocol,
+                port: Constraint::Only(port),
+            }))
+        }
         (Constraint::Only(_), Constraint::Any) => Err(Error::InvalidCommand(
             "a transport protocol must be given to select a specific port",
         )),
     }
 }
 
-pub fn parse_ownership_constraint(constraint: &str) -> types::Ownership {
+pub fn parse_ownership_constraint(constraint: &str) -> Constraint<Ownership> {
     match constraint {
-        "any" => types::Ownership::Any,
-        "owned" => types::Ownership::MullvadOwned,
-        "rented" => types::Ownership::Rented,
+        "any" => Constraint::Any,
+        "owned" => Constraint::Only(Ownership::MullvadOwned),
+        "rented" => Constraint::Only(Ownership::Rented),
         _ => unreachable!(),
     }
 }

--- a/mullvad-cli/src/cmds/reset.rs
+++ b/mullvad-cli/src/cmds/reset.rs
@@ -1,4 +1,4 @@
-use crate::{new_rpc_client, Command, Error, Result};
+use crate::{Command, MullvadProxyClient, Result};
 use std::io::stdin;
 
 pub struct Reset;
@@ -13,11 +13,9 @@ impl Command for Reset {
     }
 
     async fn run(&self, _: &clap::ArgMatches) -> Result<()> {
-        let mut rpc = new_rpc_client().await?;
+        let mut rpc = MullvadProxyClient::new().await?;
         if Self::receive_confirmation() {
-            rpc.factory_reset(())
-                .await
-                .map_err(|error| Error::RpcFailedExt("FAILED TO PERFORM FACTORY RESET", error))?;
+            rpc.factory_reset().await?;
             #[cfg(target_os = "linux")]
             println!("If you're running systemd, to remove all logs, you must use journalctl");
         }

--- a/mullvad-cli/src/cmds/split_tunnel/linux.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/linux.rs
@@ -1,4 +1,4 @@
-use crate::{new_rpc_client, Command, Result};
+use crate::{Command, MullvadProxyClient, Result};
 
 pub struct SplitTunnel;
 
@@ -41,7 +41,7 @@ impl SplitTunnel {
         match matches.subcommand() {
             Some(("add", matches)) => {
                 let pid: i32 = matches.value_of_t_or_exit("pid");
-                new_rpc_client()
+                MullvadProxyClient::new()
                     .await?
                     .add_split_tunnel_process(pid)
                     .await?;
@@ -49,28 +49,27 @@ impl SplitTunnel {
             }
             Some(("delete", matches)) => {
                 let pid: i32 = matches.value_of_t_or_exit("pid");
-                new_rpc_client()
+                MullvadProxyClient::new()
                     .await?
                     .remove_split_tunnel_process(pid)
                     .await?;
                 Ok(())
             }
             Some(("clear", _)) => {
-                new_rpc_client()
+                MullvadProxyClient::new()
                     .await?
-                    .clear_split_tunnel_processes(())
+                    .clear_split_tunnel_processes()
                     .await?;
                 Ok(())
             }
             Some(("list", _)) => {
-                let mut pids_stream = new_rpc_client()
+                let pids = MullvadProxyClient::new()
                     .await?
-                    .get_split_tunnel_processes(())
-                    .await?
-                    .into_inner();
-                println!("Excluded PIDs:");
+                    .get_split_tunnel_processes()
+                    .await?;
 
-                while let Some(pid) = pids_stream.message().await? {
+                println!("Excluded PIDs:");
+                for pid in &pids {
                     println!("    {pid}");
                 }
 

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -7,7 +7,7 @@ use mullvad_management_interface::async_trait;
 use std::{collections::HashMap, io};
 use talpid_types::ErrorExt;
 
-pub use mullvad_management_interface::{self, new_rpc_client};
+pub use mullvad_management_interface::{self, MullvadProxyClient};
 
 mod cmds;
 mod format;

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -423,14 +423,7 @@ impl ManagementService for ManagementServiceImpl {
         self.send_command_to_daemon(DaemonCommand::GetAccountData(tx, account_token))?;
         let result = self.wait_for_result(rx).await?;
         result
-            .map(|account_data| {
-                Response::new(types::AccountData {
-                    expiry: Some(types::Timestamp {
-                        seconds: account_data.expiry.timestamp(),
-                        nanos: 0,
-                    }),
-                })
-            })
+            .map(|account_data| Response::new(types::AccountData::from(account_data)))
             .map_err(|error: RestError| {
                 log::error!(
                     "Unable to get account data from API: {}",
@@ -483,15 +476,7 @@ impl ManagementService for ManagementServiceImpl {
         self.send_command_to_daemon(DaemonCommand::SubmitVoucher(tx, voucher))?;
         let result = self.wait_for_result(rx).await?;
         result
-            .map(|submission| {
-                Response::new(types::VoucherSubmission {
-                    seconds_added: submission.time_added,
-                    new_expiry: Some(types::Timestamp {
-                        seconds: submission.new_expiry.timestamp(),
-                        nanos: 0,
-                    }),
-                })
-            })
+            .map(|submission| Response::new(types::VoucherSubmission::from(submission)))
             .map_err(map_daemon_error)
     }
 

--- a/mullvad-daemon/src/rpc_uniqueness_check.rs
+++ b/mullvad-daemon/src/rpc_uniqueness_check.rs
@@ -1,4 +1,4 @@
-use mullvad_management_interface::new_rpc_client;
+use mullvad_management_interface::MullvadProxyClient;
 use talpid_types::ErrorExt;
 
 /// Checks if there is another instance of the daemon running.
@@ -6,7 +6,7 @@ use talpid_types::ErrorExt;
 /// Tries to connect to another daemon and perform a simple RPC call. If it fails, assumes the
 /// other daemon has stopped.
 pub async fn is_another_instance_running() -> bool {
-    match new_rpc_client().await {
+    match MullvadProxyClient::new().await {
         Ok(_) => true,
         Err(error) => {
             let msg =

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -1,0 +1,548 @@
+//! Client that returns and takes mullvad types as arguments instead of prost-generated types
+
+use crate::types;
+use futures::TryStreamExt;
+use futures::{Stream, StreamExt};
+use mullvad_types::device::{DeviceEvent, RemoveDeviceEvent};
+use mullvad_types::relay_list::RelayList;
+use mullvad_types::version::AppVersionInfo;
+use mullvad_types::wireguard::PublicKey;
+use mullvad_types::{
+    account::{AccountData, AccountToken, VoucherSubmission},
+    device::{Device, DeviceId, DeviceState},
+    location::GeoIpLocation,
+    relay_constraints::{BridgeSettings, BridgeState, ObfuscationSettings, RelaySettingsUpdate},
+    settings::{DnsOptions, Settings},
+    states::TunnelState,
+    wireguard::{QuantumResistantState, RotationInterval},
+};
+#[cfg(target_os = "windows")]
+use std::path::Path;
+use tonic::{Code, Status};
+
+type Error = super::Error;
+
+pub type Result<T> = std::result::Result<T, super::Error>;
+
+#[derive(Debug, Clone)]
+pub struct MullvadProxyClient(crate::ManagementServiceClient);
+
+pub enum DaemonEvent {
+    TunnelState(TunnelState),
+    Settings(Settings),
+    RelayList(RelayList),
+    AppVersionInfo(AppVersionInfo),
+    Device(DeviceEvent),
+    RemoveDevice(RemoveDeviceEvent),
+}
+
+impl TryFrom<types::daemon_event::Event> for DaemonEvent {
+    type Error = Error;
+
+    fn try_from(value: types::daemon_event::Event) -> Result<Self> {
+        match value {
+            types::daemon_event::Event::TunnelState(state) => TunnelState::try_from(state)
+                .map(DaemonEvent::TunnelState)
+                .map_err(Error::InvalidResponse),
+            types::daemon_event::Event::Settings(settings) => Settings::try_from(settings)
+                .map(DaemonEvent::Settings)
+                .map_err(Error::InvalidResponse),
+            types::daemon_event::Event::RelayList(list) => RelayList::try_from(list)
+                .map(DaemonEvent::RelayList)
+                .map_err(Error::InvalidResponse),
+            types::daemon_event::Event::VersionInfo(info) => {
+                Ok(DaemonEvent::AppVersionInfo(AppVersionInfo::from(info)))
+            }
+            types::daemon_event::Event::Device(event) => DeviceEvent::try_from(event)
+                .map(DaemonEvent::Device)
+                .map_err(Error::InvalidResponse),
+            types::daemon_event::Event::RemoveDevice(event) => RemoveDeviceEvent::try_from(event)
+                .map(DaemonEvent::RemoveDevice)
+                .map_err(Error::InvalidResponse),
+        }
+    }
+}
+
+impl MullvadProxyClient {
+    pub async fn new() -> Result<Self> {
+        #[allow(deprecated)]
+        super::new_rpc_client().await.map(Self)
+    }
+
+    pub async fn connect_tunnel(&mut self) -> Result<bool> {
+        Ok(self
+            .0
+            .connect_tunnel(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner())
+    }
+
+    pub async fn disconnect_tunnel(&mut self) -> Result<bool> {
+        Ok(self
+            .0
+            .disconnect_tunnel(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner())
+    }
+
+    pub async fn reconnect_tunnel(&mut self) -> Result<bool> {
+        Ok(self
+            .0
+            .reconnect_tunnel(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner())
+    }
+
+    pub async fn get_tunnel_state(&mut self) -> Result<TunnelState> {
+        let state = self
+            .0
+            .get_tunnel_state(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        TunnelState::try_from(state).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn events_listen(&mut self) -> Result<impl Stream<Item = Result<DaemonEvent>>> {
+        let listener = self
+            .0
+            .events_listen(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+
+        Ok(listener.map(|item| {
+            let event = item
+                .map_err(Error::Rpc)?
+                .event
+                .ok_or(Error::MissingDaemonEvent)?;
+            DaemonEvent::try_from(event)
+        }))
+    }
+
+    pub async fn prepare_restart(&mut self) -> Result<()> {
+        self.0.prepare_restart(()).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn factory_reset(&mut self) -> Result<()> {
+        self.0.factory_reset(()).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn get_current_version(&mut self) -> Result<String> {
+        Ok(self
+            .0
+            .get_current_version(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner())
+    }
+
+    pub async fn get_version_info(&mut self) -> Result<AppVersionInfo> {
+        let version_info = self
+            .0
+            .get_version_info(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        Ok(AppVersionInfo::from(version_info))
+    }
+
+    pub async fn get_relay_locations(&mut self) -> Result<RelayList> {
+        let list = self
+            .0
+            .get_relay_locations(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        mullvad_types::relay_list::RelayList::try_from(list).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn update_relay_locations(&mut self) -> Result<()> {
+        self.0
+            .update_relay_locations(())
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn update_relay_settings(&mut self, update: RelaySettingsUpdate) -> Result<()> {
+        let update = types::RelaySettingsUpdate::from(update);
+        self.0
+            .update_relay_settings(update)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn get_current_location(&mut self) -> Result<GeoIpLocation> {
+        let location = self
+            .0
+            .get_current_location(())
+            .await
+            .map_err(map_location_error)?
+            .into_inner();
+        GeoIpLocation::try_from(location).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn set_bridge_settings(&mut self, settings: BridgeSettings) -> Result<()> {
+        let settings = types::BridgeSettings::from(settings);
+        self.0
+            .set_bridge_settings(settings)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_bridge_state(&mut self, state: BridgeState) -> Result<()> {
+        let state = types::BridgeState::from(state);
+        self.0.set_bridge_state(state).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_obfuscation_settings(&mut self, settings: ObfuscationSettings) -> Result<()> {
+        let settings = types::ObfuscationSettings::from(&settings);
+        self.0
+            .set_obfuscation_settings(settings)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn get_settings(&mut self) -> Result<Settings> {
+        let settings = self
+            .0
+            .get_settings(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        Settings::try_from(settings).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn set_allow_lan(&mut self, state: bool) -> Result<()> {
+        self.0.set_allow_lan(state).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_show_beta_releases(&mut self, state: bool) -> Result<()> {
+        self.0
+            .set_show_beta_releases(state)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_block_when_disconnected(&mut self, state: bool) -> Result<()> {
+        Ok(self
+            .0
+            .set_block_when_disconnected(state)
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner())
+    }
+
+    pub async fn set_auto_connect(&mut self, state: bool) -> Result<()> {
+        self.0.set_auto_connect(state).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_openvpn_mssfix(&mut self, mssfix: Option<u16>) -> Result<()> {
+        self.0
+            .set_openvpn_mssfix(mssfix.map(u32::from).unwrap_or(0))
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_wireguard_mtu(&mut self, mtu: Option<u16>) -> Result<()> {
+        self.0
+            .set_wireguard_mtu(mtu.map(u32::from).unwrap_or(0))
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_enable_ipv6(&mut self, state: bool) -> Result<()> {
+        self.0.set_enable_ipv6(state).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_quantum_resistant_tunnel(
+        &mut self,
+        state: QuantumResistantState,
+    ) -> Result<()> {
+        let state = types::QuantumResistantState::from(state);
+        self.0
+            .set_quantum_resistant_tunnel(state)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_dns_options(&mut self, options: DnsOptions) -> Result<()> {
+        let options = types::DnsOptions::from(&options);
+        self.0.set_dns_options(options).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn create_new_account(&mut self) -> Result<AccountToken> {
+        Ok(self
+            .0
+            .create_new_account(())
+            .await
+            .map_err(map_device_error)?
+            .into_inner())
+    }
+
+    pub async fn login_account(&mut self, account: AccountToken) -> Result<()> {
+        self.0
+            .login_account(account)
+            .await
+            .map_err(map_device_error)?;
+        Ok(())
+    }
+
+    pub async fn logout_account(&mut self) -> Result<()> {
+        self.0.logout_account(()).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn get_account_data(&mut self, account: AccountToken) -> Result<AccountData> {
+        let data = self
+            .0
+            .get_account_data(account)
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        AccountData::try_from(data).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn get_account_history(&mut self) -> Result<Option<AccountToken>> {
+        let history = self
+            .0
+            .get_account_history(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        Ok(history.token)
+    }
+
+    pub async fn clear_account_history(&mut self) -> Result<()> {
+        self.0.clear_account_history(()).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    //get_www_auth_token
+
+    pub async fn submit_voucher(&mut self, voucher: String) -> Result<VoucherSubmission> {
+        let result = self
+            .0
+            .submit_voucher(voucher)
+            .await
+            .map_err(|error| match error.code() {
+                Code::NotFound => Error::InvalidVoucher,
+                Code::ResourceExhausted => Error::UsedVoucher,
+                _other => Error::Rpc(error),
+            })?
+            .into_inner();
+        VoucherSubmission::try_from(result).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn get_device(&mut self) -> Result<DeviceState> {
+        let state = self
+            .0
+            .get_device(())
+            .await
+            .map_err(map_device_error)?
+            .into_inner();
+        DeviceState::try_from(state).map_err(Error::InvalidResponse)
+    }
+
+    pub async fn update_device(&mut self) -> Result<()> {
+        self.0.update_device(()).await.map_err(map_device_error)?;
+        Ok(())
+    }
+
+    pub async fn list_devices(&mut self, account: AccountToken) -> Result<Vec<Device>> {
+        let list = self
+            .0
+            .list_devices(account)
+            .await
+            .map_err(map_device_error)?
+            .into_inner();
+        list.devices
+            .into_iter()
+            .map(|d| Device::try_from(d).map_err(Error::InvalidResponse))
+            .collect::<Result<_>>()
+    }
+
+    pub async fn remove_device(
+        &mut self,
+        account: AccountToken,
+        device_id: DeviceId,
+    ) -> Result<()> {
+        self.0
+            .remove_device(types::DeviceRemoval {
+                account_token: account,
+                device_id,
+            })
+            .await
+            .map_err(map_device_error)?;
+        Ok(())
+    }
+
+    pub async fn set_wireguard_rotation_interval(
+        &mut self,
+        interval: RotationInterval,
+    ) -> Result<()> {
+        let duration = types::Duration::try_from(*interval.as_duration())
+            .map_err(|_| Error::DurationTooLarge)?;
+        self.0
+            .set_wireguard_rotation_interval(duration)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn reset_wireguard_rotation_interval(&mut self) -> Result<()> {
+        self.0
+            .reset_wireguard_rotation_interval(())
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn rotate_wireguard_key(&mut self) -> Result<()> {
+        self.0.rotate_wireguard_key(()).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn get_wireguard_key(&mut self) -> Result<PublicKey> {
+        let key = self
+            .0
+            .get_wireguard_key(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        PublicKey::try_from(key).map_err(Error::InvalidResponse)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub async fn get_split_tunnel_processes(&mut self) -> Result<Vec<i32>> {
+        let procs = self
+            .0
+            .get_split_tunnel_processes(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        Ok(procs.try_collect().await.map_err(Error::Rpc)?)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub async fn add_split_tunnel_process(&mut self, pid: i32) -> Result<()> {
+        self.0
+            .add_split_tunnel_process(pid)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    pub async fn remove_split_tunnel_process(&mut self, pid: i32) -> Result<()> {
+        self.0
+            .remove_split_tunnel_process(pid)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    pub async fn clear_split_tunnel_processes(&mut self) -> Result<()> {
+        self.0
+            .clear_split_tunnel_processes(())
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn add_split_tunnel_app<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        let path = path.as_ref().to_str().ok_or(Error::PathMustBeUtf8)?;
+        self.0
+            .add_split_tunnel_app(path.to_owned())
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn remove_split_tunnel_app<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        let path = path.as_ref().to_str().ok_or(Error::PathMustBeUtf8)?;
+        self.0
+            .remove_split_tunnel_app(path.to_owned())
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn clear_split_tunnel_apps(&mut self) -> Result<()> {
+        self.0
+            .clear_split_tunnel_apps(())
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn set_split_tunnel_state(&mut self, state: bool) -> Result<()> {
+        self.0
+            .set_split_tunnel_state(state)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn get_excluded_processes(&mut self) -> Result<Vec<i32>> {
+        let procs = self
+            .0
+            .get_split_tunnel_processes(())
+            .await
+            .map_err(Error::Rpc)?
+            .into_inner();
+        Ok(procs.try_collect().await.map_err(Error::Rpc)?)
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn set_use_wireguard_nt(&mut self, state: bool) -> Result<()> {
+        self.0
+            .set_use_wireguard_nt(state)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    // check_volumes
+}
+
+fn map_device_error(status: Status) -> Error {
+    match status.code() {
+        Code::ResourceExhausted => Error::TooManyDevices,
+        Code::Unauthenticated => Error::InvalidAccount,
+        Code::AlreadyExists => Error::AlreadyLoggedIn,
+        Code::NotFound => Error::DeviceNotFound,
+        _other => Error::Rpc(status),
+    }
+}
+
+fn map_location_error(status: Status) -> Error {
+    match status.code() {
+        Code::NotFound => Error::NoLocationData,
+        _other => Error::Rpc(status),
+    }
+}

--- a/mullvad-management-interface/src/lib.rs
+++ b/mullvad-management-interface/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod types;
 
 use parity_tokio_ipc::Endpoint as IpcEndpoint;
@@ -51,8 +52,45 @@ pub enum Error {
     #[cfg(unix)]
     #[error(display = "Failed to set group ID")]
     SetGidError(#[error(source)] nix::Error),
+
+    #[error(display = "gRPC call returned error")]
+    Rpc(#[error(source)] tonic::Status),
+
+    #[error(display = "Failed to parse gRPC response")]
+    InvalidResponse(#[error(source)] types::FromProtobufTypeError),
+
+    #[error(display = "Duration is too large")]
+    DurationTooLarge,
+
+    #[error(display = "Unexpected non-UTF8 string")]
+    PathMustBeUtf8,
+
+    #[error(display = "Missing daemon event")]
+    MissingDaemonEvent,
+
+    #[error(display = "This voucher code is invalid")]
+    InvalidVoucher,
+
+    #[error(display = "This voucher code has already been used")]
+    UsedVoucher,
+
+    #[error(display = "There are too many devices on the account")]
+    TooManyDevices,
+
+    #[error(display = "You are already logged in")]
+    AlreadyLoggedIn,
+
+    #[error(display = "The account does not exist")]
+    InvalidAccount,
+
+    #[error(display = "There is no such device")]
+    DeviceNotFound,
+
+    #[error(display = "Location data is unavailable")]
+    NoLocationData,
 }
 
+#[deprecated(note = "Prefer MullvadProxyClient")]
 pub async fn new_rpc_client() -> Result<ManagementServiceClient, Error> {
     let ipc_path = mullvad_paths::get_rpc_socket_path();
 
@@ -66,6 +104,8 @@ pub async fn new_rpc_client() -> Result<ManagementServiceClient, Error> {
 
     Ok(ManagementServiceClient::new(channel))
 }
+
+pub use client::MullvadProxyClient;
 
 pub type ServerJoinHandle = tokio::task::JoinHandle<Result<(), Error>>;
 

--- a/mullvad-management-interface/src/types/conversions/account.rs
+++ b/mullvad-management-interface/src/types/conversions/account.rs
@@ -1,0 +1,59 @@
+use crate::types;
+use mullvad_types::account::{AccountData, VoucherSubmission};
+
+use super::FromProtobufTypeError;
+
+impl From<VoucherSubmission> for types::VoucherSubmission {
+    fn from(submission: VoucherSubmission) -> Self {
+        types::VoucherSubmission {
+            seconds_added: submission.time_added,
+            new_expiry: Some(types::Timestamp {
+                seconds: submission.new_expiry.timestamp(),
+                nanos: 0,
+            }),
+        }
+    }
+}
+
+impl TryFrom<types::VoucherSubmission> for VoucherSubmission {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(submission: types::VoucherSubmission) -> Result<Self, FromProtobufTypeError> {
+        let new_expiry = submission
+            .new_expiry
+            .ok_or(FromProtobufTypeError::InvalidArgument("missing expiry"))?;
+        let ndt =
+            chrono::NaiveDateTime::from_timestamp(new_expiry.seconds, new_expiry.nanos as u32);
+
+        Ok(VoucherSubmission {
+            new_expiry: chrono::DateTime::<chrono::Utc>::from_utc(ndt, chrono::Utc),
+            time_added: submission.seconds_added,
+        })
+    }
+}
+
+impl From<AccountData> for types::AccountData {
+    fn from(data: AccountData) -> Self {
+        types::AccountData {
+            expiry: Some(types::Timestamp {
+                seconds: data.expiry.timestamp(),
+                nanos: 0,
+            }),
+        }
+    }
+}
+
+impl TryFrom<types::AccountData> for AccountData {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(data: types::AccountData) -> Result<Self, FromProtobufTypeError> {
+        let expiry = data
+            .expiry
+            .ok_or(FromProtobufTypeError::InvalidArgument("missing expiry"))?;
+        let ndt = chrono::NaiveDateTime::from_timestamp(expiry.seconds, expiry.nanos as u32);
+
+        Ok(AccountData {
+            expiry: chrono::DateTime::<chrono::Utc>::from_utc(ndt, chrono::Utc),
+        })
+    }
+}

--- a/mullvad-management-interface/src/types/conversions/device.rs
+++ b/mullvad-management-interface/src/types/conversions/device.rs
@@ -51,6 +51,40 @@ impl From<mullvad_types::device::Device> for proto::Device {
     }
 }
 
+impl TryFrom<proto::DeviceState> for mullvad_types::device::DeviceState {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(state: proto::DeviceState) -> Result<Self, FromProtobufTypeError> {
+        let state_type = proto::device_state::State::from_i32(state.state).ok_or(
+            FromProtobufTypeError::InvalidArgument("invalid device state"),
+        )?;
+
+        match state_type {
+            proto::device_state::State::LoggedIn => {
+                let account = state.device.ok_or(FromProtobufTypeError::InvalidArgument(
+                    "missing account data",
+                ))?;
+                let device = account
+                    .device
+                    .ok_or(FromProtobufTypeError::InvalidArgument(
+                        "missing device data",
+                    ))?;
+
+                Ok(mullvad_types::device::DeviceState::LoggedIn(
+                    mullvad_types::device::AccountAndDevice {
+                        account_token: account.account_token,
+                        device: mullvad_types::device::Device::try_from(device)?,
+                    },
+                ))
+            }
+            proto::device_state::State::Revoked => Ok(mullvad_types::device::DeviceState::Revoked),
+            proto::device_state::State::LoggedOut => {
+                Ok(mullvad_types::device::DeviceState::LoggedOut)
+            }
+        }
+    }
+}
+
 impl From<mullvad_types::device::DevicePort> for proto::DevicePort {
     fn from(port: mullvad_types::device::DevicePort) -> Self {
         proto::DevicePort { id: port.id }
@@ -83,9 +117,25 @@ impl From<&mullvad_types::device::DeviceState> for proto::device_state::State {
 impl From<mullvad_types::device::DeviceEvent> for proto::DeviceEvent {
     fn from(event: mullvad_types::device::DeviceEvent) -> Self {
         proto::DeviceEvent {
-            cause: proto::device_event::Cause::from(event.cause) as i32,
+            cause: i32::from(proto::device_event::Cause::from(event.cause)),
             new_state: Some(proto::DeviceState::from(event.new_state)),
         }
+    }
+}
+
+impl TryFrom<proto::DeviceEvent> for mullvad_types::device::DeviceEvent {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(event: proto::DeviceEvent) -> Result<Self, Self::Error> {
+        let cause = proto::device_event::Cause::from_i32(event.cause)
+            .ok_or(FromProtobufTypeError::InvalidArgument("invalid event"))?;
+        let cause = mullvad_types::device::DeviceEventCause::from(cause);
+
+        let new_state = mullvad_types::device::DeviceState::try_from(event.new_state.ok_or(
+            FromProtobufTypeError::InvalidArgument("missing device state"),
+        )?)?;
+
+        Ok(mullvad_types::device::DeviceEvent { cause, new_state })
     }
 }
 
@@ -102,6 +152,19 @@ impl From<mullvad_types::device::DeviceEventCause> for proto::device_event::Caus
     }
 }
 
+impl From<proto::device_event::Cause> for mullvad_types::device::DeviceEventCause {
+    fn from(event: proto::device_event::Cause) -> Self {
+        use mullvad_types::device::DeviceEventCause as MullvadEvent;
+        match event {
+            proto::device_event::Cause::LoggedIn => MullvadEvent::LoggedIn,
+            proto::device_event::Cause::LoggedOut => MullvadEvent::LoggedOut,
+            proto::device_event::Cause::Revoked => MullvadEvent::Revoked,
+            proto::device_event::Cause::Updated => MullvadEvent::Updated,
+            proto::device_event::Cause::RotatedKey => MullvadEvent::RotatedKey,
+        }
+    }
+}
+
 impl From<mullvad_types::device::RemoveDeviceEvent> for proto::RemoveDeviceEvent {
     fn from(event: mullvad_types::device::RemoveDeviceEvent) -> Self {
         proto::RemoveDeviceEvent {
@@ -112,6 +175,22 @@ impl From<mullvad_types::device::RemoveDeviceEvent> for proto::RemoveDeviceEvent
                 .map(proto::Device::from)
                 .collect(),
         }
+    }
+}
+
+impl TryFrom<proto::RemoveDeviceEvent> for mullvad_types::device::RemoveDeviceEvent {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(event: proto::RemoveDeviceEvent) -> Result<Self, Self::Error> {
+        let new_devices = event
+            .new_device_list
+            .into_iter()
+            .map(mullvad_types::device::Device::try_from)
+            .collect::<Result<Vec<_>, FromProtobufTypeError>>()?;
+        Ok(mullvad_types::device::RemoveDeviceEvent {
+            account_token: event.account_token,
+            new_devices,
+        })
     }
 }
 

--- a/mullvad-management-interface/src/types/conversions/mod.rs
+++ b/mullvad-management-interface/src/types/conversions/mod.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+mod account;
 mod custom_tunnel;
 mod device;
 mod location;
@@ -11,8 +12,9 @@ mod states;
 mod version;
 mod wireguard;
 
-#[derive(Debug)]
+#[derive(err_derive::Error, Debug)]
 pub enum FromProtobufTypeError {
+    #[error(display = "Invalid argument for type conversion: {}", _0)]
     InvalidArgument(&'static str),
 }
 

--- a/mullvad-management-interface/src/types/conversions/version.rs
+++ b/mullvad-management-interface/src/types/conversions/version.rs
@@ -10,3 +10,20 @@ impl From<mullvad_types::version::AppVersionInfo> for proto::AppVersionInfo {
         }
     }
 }
+
+impl From<proto::AppVersionInfo> for mullvad_types::version::AppVersionInfo {
+    fn from(version_info: proto::AppVersionInfo) -> Self {
+        Self {
+            supported: version_info.supported,
+            latest_stable: version_info.latest_stable,
+            latest_beta: version_info.latest_beta,
+            suggested_upgrade: if version_info.suggested_upgrade.is_empty() {
+                None
+            } else {
+                Some(version_info.suggested_upgrade)
+            },
+            // NOTE: This field is meaningless when derived from the gRPC type
+            wg_migration_threshold: f32::NAN,
+        }
+    }
+}

--- a/mullvad-types/src/device.rs
+++ b/mullvad-types/src/device.rs
@@ -82,6 +82,17 @@ impl DeviceState {
             _ => None,
         }
     }
+
+    pub fn is_logged_in(&self) -> bool {
+        matches!(self, Self::LoggedIn(_))
+    }
+
+    pub fn get_account(&self) -> Option<&AccountAndDevice> {
+        match self {
+            DeviceState::LoggedIn(ref account) => Some(account),
+            _ => None,
+        }
+    }
 }
 
 /// A [Device] and its associated account token.

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -65,7 +65,7 @@ impl Serialize for SettingsVersion {
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct Settings {
-    relay_settings: RelaySettings,
+    pub relay_settings: RelaySettings,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub bridge_settings: BridgeSettings,
     #[cfg_attr(target_os = "android", jnix(skip))]
@@ -98,7 +98,7 @@ pub struct Settings {
     pub wg_migration_rand_num: f32,
     /// Specifies settings schema version
     #[cfg_attr(target_os = "android", jnix(skip))]
-    settings_version: SettingsVersion,
+    pub settings_version: SettingsVersion,
 }
 
 fn out_of_range_wg_migration_rand_num() -> f32 {
@@ -164,10 +164,6 @@ impl Settings {
 
             self.relay_settings = new_settings;
         }
-    }
-
-    pub fn get_settings_version(&self) -> SettingsVersion {
-        self.settings_version
     }
 }
 

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -22,6 +22,16 @@ pub enum QuantumResistantState {
     Off,
 }
 
+impl fmt::Display for QuantumResistantState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QuantumResistantState::Auto => f.write_str("auto"),
+            QuantumResistantState::On => f.write_str("on"),
+            QuantumResistantState::Off => f.write_str("off"),
+        }
+    }
+}
+
 /// Contains account specific wireguard data
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct WireguardData {

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -104,6 +104,16 @@ impl PrivateKey {
     pub fn to_base64(&self) -> String {
         base64::encode(self.0.to_bytes())
     }
+
+    pub fn from_base64(key: &str) -> Result<Self, InvalidKeyError> {
+        let bytes = base64::decode(key).map_err(|_| InvalidKeyError(()))?;
+        if bytes.len() != 32 {
+            return Err(InvalidKeyError(()));
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes);
+        Ok(From::from(key))
+    }
 }
 
 impl From<[u8; 32]> for PrivateKey {

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -154,7 +154,7 @@ impl<'de> Deserialize<'de> for PrivateKey {
 #[derive(Clone)]
 pub struct PublicKey(x25519_dalek::PublicKey);
 
-/// Error returned if a base64 string represents an invalid key
+/// Error returned if an input represents an invalid key
 #[derive(Debug)]
 pub struct InvalidKeyError(());
 
@@ -188,6 +188,15 @@ impl<'a> From<&'a x25519_dalek::StaticSecret> for PublicKey {
 impl From<[u8; 32]> for PublicKey {
     fn from(public_key: [u8; 32]) -> PublicKey {
         PublicKey(x25519_dalek::PublicKey::from(public_key))
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = InvalidKeyError;
+
+    fn try_from(public_key: &[u8]) -> Result<PublicKey, Self::Error> {
+        let key: [u8; 32] = <[u8; 32]>::try_from(public_key).map_err(|_| InvalidKeyError(()))?;
+        Ok(PublicKey(x25519_dalek::PublicKey::from(key)))
     }
 }
 


### PR DESCRIPTION
This cleans up the CLI by adding a wrapper for the RPC client that converts the types to the `{talpid,mullvad}-types` equivalents. There's unfortunately a huge amount boilerplate since the real (mullvad/talpid) types cannot be automagically derived from the prost-generated types, but it's mostly hidden.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4504)
<!-- Reviewable:end -->
