### PR TITLE
Align changelog entries

### DIFF
--- a/ios/MullvadVPN/Classes/ChangeLog.swift
+++ b/ios/MullvadVPN/Classes/ChangeLog.swift
@@ -44,9 +44,7 @@ enum ChangeLog {
             .compactMap { line in
                 let trimmedString = line.trimmingCharacters(in: .whitespaces)
 
-                guard !trimmedString.isEmpty else { return nil }
-
-                return "• \(trimmedString)"
+                return trimmedString.isEmpty ? nil : trimmedString
             }
             .joined(separator: "\n")
     }

--- a/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogContentView.swift
+++ b/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogContentView.swift
@@ -93,15 +93,23 @@ final class ChangeLogContentView: UIView {
     }
 
     func setChangeLogText(_ string: String) {
+        let bullet = "• "
+        let font = UIFont.systemFont(ofSize: 18)
+
+        let bulletList = string.split(whereSeparator: { $0.isNewline })
+            .map { "\(bullet)\($0)" }
+            .joined(separator: "\n")
+
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineHeightMultiple = 1.5
         paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.headIndent = bullet.size(withAttributes: [.font: font]).width
 
         textView.attributedText = NSAttributedString(
-            string: string,
+            string: bulletList,
             attributes: [
                 .paragraphStyle: paragraphStyle,
-                .font: UIFont.systemFont(ofSize: 18),
+                .font: font,
                 .foregroundColor: UIColor.white,
             ]
         )


### PR DESCRIPTION
This PR adds head indent to changelog entries to align wrapped lines.

<img width="927" alt="HeadIndentComparison" src="https://user-images.githubusercontent.com/704044/229073877-d40e448f-c23c-41cd-aee5-3ca0e0ecad24.png">
