### PR TITLE
Set retry interval to 24 hours for automatic key rotation

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -31,7 +31,7 @@ private let establishedTunnelStatusPollInterval: TimeInterval = 5
 private let privateKeyRotationInterval: TimeInterval = 60 * 60 * 24 * 14
 
 /// Private key rotation retry interval (in seconds).
-private let privateKeyRotationFailureRetryInterval: TimeInterval = 60 * 15
+private let privateKeyRotationFailureRetryInterval: TimeInterval = 60 * 60 * 24
 
 /// A class that provides a convenient interface for VPN tunnels configuration, manipulation and
 /// monitoring.

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -206,7 +206,7 @@ impl DeviceService {
                 ))
             },
             should_retry_backoff,
-            retry_strategy(),
+            rotate_retry_strategy(),
         )
         .await
         .map_err(map_rest_error)?;
@@ -442,4 +442,8 @@ fn retry_strategy() -> Jittered<ExponentialBackoff> {
         )
         .max_delay(RETRY_BACKOFF_INTERVAL_MAX),
     )
+}
+
+fn rotate_retry_strategy() -> impl Iterator<Item = Duration> {
+    std::iter::repeat(RETRY_BACKOFF_INTERVAL_MAX)
 }


### PR DESCRIPTION
We currently start off by retrying after 4 seconds and cap the retry interval at 24 hours. This sometimes taxes the API greatly. For now, let's change the interval to 24 hours.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4511)
<!-- Reviewable:end -->
