### PR TITLE
Change WireGuard key rotation interval to 14 days on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Changed
 - Update Electron from 21.1.1 to 23.2.0.
-
-#### Android
-- Change Android key rotation interval to 7 days instead of 4.
+- Change WireGuard key rotation interval to 14 days. It was 7 days on desktop and 4 days on
+  Android.
 
 ### Deprecated
 #### Linux

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -24,7 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Changed
-- Changed key rotation interval from 4 to 7 days.
+- Changed key rotation interval from 4 to 14 days.
 - Delay tunnel reconnection after a WireGuard private key rotates. Accounts for latency in key
   propagation to relays.
 

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -28,7 +28,7 @@ private let establishingTunnelStatusPollInterval: TimeInterval = 3
 private let establishedTunnelStatusPollInterval: TimeInterval = 5
 
 /// Private key rotation interval (in seconds).
-private let privateKeyRotationInterval: TimeInterval = 60 * 60 * 24 * 7
+private let privateKeyRotationInterval: TimeInterval = 60 * 60 * 24 * 14
 
 /// Private key rotation retry interval (in seconds).
 private let privateKeyRotationFailureRetryInterval: TimeInterval = 60 * 15

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -7,7 +7,7 @@ use std::{convert::TryFrom, fmt, time::Duration};
 use talpid_types::net::wireguard;
 
 pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_secs(1 * 24 * 60 * 60);
-pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(14 * 24 * 60 * 60);
 pub const DEFAULT_ROTATION_INTERVAL: Duration = MAX_ROTATION_INTERVAL;
 
 /// Whether to enable or disable quantum resistant tunnels when the setting


### PR DESCRIPTION
Basically just doing what #4456 did, but again. And this time to 14 days.

The main issue here is that we stress the API too much. The goal is to lower the rotation interval again once the API behaves better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4512)
<!-- Reviewable:end -->
