### PR TITLE
Display human readable error messages for throttled API calls

### DIFF
--- a/ios/MullvadREST/RESTError.swift
+++ b/ios/MullvadREST/RESTError.swift
@@ -106,6 +106,8 @@ extension REST {
         public static let maxDevicesReached = ServerResponseCode(rawValue: "MAX_DEVICES_REACHED")
         public static let invalidAccessToken = ServerResponseCode(rawValue: "INVALID_ACCESS_TOKEN")
         public static let deviceNotFound = ServerResponseCode(rawValue: "DEVICE_NOT_FOUND")
+        public static let serviceUnavailable = ServerResponseCode(rawValue: "SERVICE_UNAVAILABLE")
+        public static let tooManyRequests = ServerResponseCode(rawValue: "TOO_MANY_REQUESTS")
 
         public let rawValue: String
         public init(rawValue: String) {

--- a/ios/MullvadVPN/Extensions/RESTError+Display.swift
+++ b/ios/MullvadVPN/Extensions/RESTError+Display.swift
@@ -51,6 +51,22 @@ extension REST.Error: DisplayError {
                     comment: ""
                 )
 
+            case .serviceUnavailable:
+                return NSLocalizedString(
+                    "SERVICE_UNAVAILABLE",
+                    tableName: "REST",
+                    value: "We are having some issues, please try again later",
+                    comment: ""
+                )
+
+            case .tooManyRequests:
+                return NSLocalizedString(
+                    "TOO_MANY_REQUESTS",
+                    tableName: "REST",
+                    value: "We are having some issues, please try again later",
+                    comment: ""
+                )
+
             default:
                 return String(
                     format: NSLocalizedString(


### PR DESCRIPTION
Currently in the iOS app if you try to log in, and the API returns status code 429 (TOO MANY REQUESTS), there's a message being displayed:

Login failed
Unexpected server response: THROTTLED (HTTP status: 429)

Being throttled is not unexpected, but the app should handle these status codes more gracefully. The app should also handle status code 503 (SERVICE UNAVAILABLE) in the same way. Both 503 and 429 indicate that the service is overloaded/rate limited and should inform the user that they need to try again later.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4518)
<!-- Reviewable:end -->
