### PR TITLE
Fix login tests on slow machines

### DIFF
--- a/gui/standalone-tests.ts
+++ b/gui/standalone-tests.ts
@@ -8,16 +8,12 @@ import path from 'path';
 // assets and performs the tests. More info in /gui/README.md.
 
 const tmpDir = path.join(os.tmpdir(), 'mullvad-standalone-tests');
-const rootDir = path.join(__dirname, '..');
-const nodeModulesDir = path.join(rootDir, 'node_modules');
-const srcDir = path.join(rootDir, 'build', 'src');
-const testDir = path.join(rootDir, 'build', 'test');
-
-const nodeBin = process.argv[0];
-const playwrightBin = path.join(tmpDir, 'node_modules', '@playwright', 'test', 'cli.js');
 
 function main() {
   extract();
+
+  const nodeBin = process.argv[0];
+  const playwrightBin = path.join(tmpDir, 'node_modules', '@playwright', 'test', 'cli.js');
 
   // Tests need to be run sequentially since they interact with the same daemon instance.
   // Arguments are forwarded to playwright to make it possible to run specific tests.
@@ -29,6 +25,11 @@ function main() {
 }
 
 function extract() {
+  const rootDir = path.join(__dirname, '..');
+  const nodeModulesDir = path.join(rootDir, 'node_modules');
+  const srcDir = path.join(rootDir, 'build', 'src');
+  const testDir = path.join(rootDir, 'build', 'test');
+
   // Remove old directory if already existing and create new clean one
   removeTmpDir();
   fs.mkdirSync(tmpDir);

--- a/gui/standalone-tests.ts
+++ b/gui/standalone-tests.ts
@@ -71,7 +71,12 @@ function handleResult(result: SpawnSyncReturns<string>) {
 
 function removeTmpDir() {
   if (fs.existsSync(tmpDir)) {
-    fs.rmSync(tmpDir, { recursive: true });
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch (e) {
+      const error = e as Error;
+      console.error('Failed to remove tmp dir:', error.message);
+    }
   }
 }
 

--- a/gui/standalone-tests.ts
+++ b/gui/standalone-tests.ts
@@ -14,10 +14,11 @@ function main() {
 
   const nodeBin = process.argv[0];
   const playwrightBin = path.join(tmpDir, 'node_modules', '@playwright', 'test', 'cli.js');
+  const configPath = path.join(tmpDir, 'test', 'e2e', 'installed', 'playwright.config.js');
 
   // Tests need to be run sequentially since they interact with the same daemon instance.
   // Arguments are forwarded to playwright to make it possible to run specific tests.
-  const args = [playwrightBin, 'test', '--workers', '1', ...process.argv.slice(2)];
+  const args = [playwrightBin, 'test', '-c', configPath, ...process.argv.slice(2)];
   const result = spawnSync(nodeBin, args, { encoding: 'utf8', cwd: tmpDir });
 
   removeTmpDir();

--- a/gui/standalone-tests.ts
+++ b/gui/standalone-tests.ts
@@ -55,7 +55,7 @@ function runTests(): Promise<number> {
   return new Promise((resolve) => {
     // Tests need to be run sequentially since they interact with the same daemon instance.
     // Arguments are forwarded to playwright to make it possible to run specific tests.
-    const args = [playwrightBin, 'test', '-c', configPath, ...process.argv.slice(2)];
+    const args = [playwrightBin, 'test', '-x', '-c', configPath, ...process.argv.slice(2)];
     const proc = spawn(nodeBin, args, { cwd: tmpDir });
 
     proc.stdout.on('data', (data) => console.log(data.toString()));

--- a/gui/test/e2e/installed/playwright.config.ts
+++ b/gui/test/e2e/installed/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: process.cwd(),
+  timeout: 60_000,
+  workers: 1,
+  expect: {
+    timeout: 30_000,
+  },
+});

--- a/gui/test/e2e/installed/state-dependent/login.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/login.spec.ts
@@ -40,7 +40,7 @@ test('App should fail to login', async () => {
   await expect(title).toHaveText('Login failed');
   await expect(subtitle).toHaveText('Invalid account number');
 
-  loginInput.fill('');
+  await loginInput.fill('');
 });
 
 test('App should create account', async () => {

--- a/gui/test/e2e/installed/state-dependent/login.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/login.spec.ts
@@ -37,8 +37,6 @@ test('App should fail to login', async () => {
   await loginInput.fill('1234 1234 1324 1234');
   await loginInput.press('Enter');
 
-  await expect(title).toHaveText('Logging in...');
-  await expect(subtitle).toHaveText('Checking account number');
   await expect(title).toHaveText('Login failed');
   await expect(subtitle).toHaveText('Invalid account number');
 
@@ -52,8 +50,6 @@ test('App should create account', async () => {
   const subtitle = page.getByTestId('subtitle');
 
   await page.getByText('Create account').click();
-  await expect(title).toHaveText('Creating account...');
-  await expect(subtitle).toHaveText('Please wait');
 
   await expect(title).toHaveText('Account created');
   await expect(subtitle).toHaveText('Logged in');
@@ -87,8 +83,6 @@ test('App should log in', async () => {
   await loginInput.type(process.env.ACCOUNT_NUMBER!);
   await loginInput.press('Enter');
 
-  await expect(title).toHaveText('Logging in...');
-  await expect(subtitle).toHaveText('Checking account number');
   await expect(title).toHaveText('Logged in');
   await expect(subtitle).toHaveText('Valid account number');
 
@@ -132,8 +126,6 @@ test('App should log in to expired account', async () => {
   await loginInput.type(accountNumber);
   await loginInput.press('Enter');
 
-  await expect(title).toHaveText('Logging in...');
-  await expect(subtitle).toHaveText('Checking account number');
   await expect(title).toHaveText('Logged in');
   await expect(subtitle).toHaveText('Valid account number');
 


### PR DESCRIPTION
This PR fixes the issues we experienced when running the tests in the Windows VM. The cause was the responses arriving too quickly for it to have time to check the intermediate states. I've also done a bunch of other improvements. Here are the changes:
- Catch error when removing tmp directory
- Add playwright config for installed tests and increase timeouts
- Make playwright stop after first failure
- Forward playwright stdout while running
- Remove expects for intermediate states during login
- Add missing await when emptying login field in test

Closes DES-129.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4520)
<!-- Reviewable:end -->
