### PR TITLE
Reset expiry notifications on logout

### DIFF
--- a/gui/src/main/account.ts
+++ b/gui/src/main/account.ts
@@ -181,6 +181,7 @@ export default class Account {
     try {
       await this.daemonRpc.logoutAccount();
 
+      this.delegate.closeNotificationsInCategory(SystemNotificationCategory.expiry);
       this.expiryNotificationFrequencyScheduler.cancel();
       this.firstExpiryNotificationScheduler.cancel();
     } catch (e) {


### PR DESCRIPTION
Currently expiry notifications aren't removed on logout. This means that the notification icon also stays in the tray menu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4521)
<!-- Reviewable:end -->
