### PR TITLE
Fix missing app verison in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.
+- Fix app version sometimes missing in the settings menu.
 
 #### macOS
 - Fix tray window behaviour when opening mission control and switching between full-screen workspaces.

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/VersionInfo.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/VersionInfo.kt
@@ -1,7 +1,7 @@
 package net.mullvad.mullvadvpn.ui
 
 data class VersionInfo(
-    val currentVersion: String?,
+    @Deprecated(message = "Use BuildConfig.VERSION_NAME") val currentVersion: String?,
     val upgradeVersion: String?,
     val isOutdated: Boolean,
     val isSupported: Boolean

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/SettingsFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/SettingsFragment.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.DeviceState
 import net.mullvad.mullvadvpn.repository.AccountRepository
@@ -114,6 +115,7 @@ class SettingsFragment : BaseFragment(), StatusBarPainter, NavigationBarPainter 
     private fun initializeUiState() {
         updateLoggedInStatus(deviceRepository.deviceState.value is DeviceState.LoggedIn)
         accountMenu.accountExpiry = accountRepository.accountExpiryState.value.date()
+        appVersionMenu.version = BuildConfig.VERSION_NAME
         serviceConnectionManager.appVersionInfoCache().let { cache ->
             updateVersionInfo(
                 if (cache != null) {
@@ -189,6 +191,5 @@ class SettingsFragment : BaseFragment(), StatusBarPainter, NavigationBarPainter 
 
     private fun updateVersionInfo(versionInfo: VersionInfo) {
         appVersionMenu.updateAvailable = versionInfo.isOutdated || !versionInfo.isSupported
-        appVersionMenu.version = versionInfo.currentVersion ?: ""
     }
 }


### PR DESCRIPTION
This PR aims to fix an issue where the app version isn't available in settings if the app can't connect to the daemon.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4522)
<!-- Reviewable:end -->
