### PR TITLE
Persist next private key instead of creating it during each rotation

### DIFF
--- a/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
+++ b/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
@@ -116,4 +116,8 @@ struct StoredWgKeyData: Codable, Equatable {
 
     /// Private key.
     var privateKey: PrivateKey
+
+    /// Next private key we're trying to rotate to.
+    /// Added in 2023.3
+    var nextPrivateKey: PrivateKey?
 }

--- a/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
@@ -32,15 +32,11 @@ class RotateKeyOperation: ResultOperation<Bool> {
         self.devicesProxy = devicesProxy
         self.rotationInterval = rotationInterval
 
-        super.init(
-            dispatchQueue: dispatchQueue,
-            completionQueue: nil,
-            completionHandler: nil
-        )
+        super.init(dispatchQueue: dispatchQueue, completionQueue: nil, completionHandler: nil)
     }
 
     override func main() {
-        guard case let .loggedIn(accountData, deviceData) = interactor.deviceState else {
+        guard case .loggedIn(let accountData, var deviceData) = interactor.deviceState else {
             finish(result: .failure(InvalidDeviceStateError()))
             return
         }
@@ -63,7 +59,18 @@ class RotateKeyOperation: ResultOperation<Bool> {
 
         logger.debug("Replacing old key with new key on server...")
 
-        let newPrivateKey = PrivateKey()
+        let newPrivateKey: PrivateKey
+        if let nextPrivateKey = deviceData.wgKeyData.nextPrivateKey {
+            logger.debug("Next private key is already stored in Keychain. Using it.")
+
+            newPrivateKey = nextPrivateKey
+        } else {
+            logger.debug("Create next private key and store it in Keychain.")
+
+            newPrivateKey = PrivateKey()
+            deviceData.wgKeyData.nextPrivateKey = newPrivateKey
+            interactor.setDeviceState(.loggedIn(accountData, deviceData), persist: true)
+        }
 
         task = devicesProxy.rotateDeviceKey(
             accountNumber: accountData.number,
@@ -72,10 +79,7 @@ class RotateKeyOperation: ResultOperation<Bool> {
             retryStrategy: .default
         ) { result in
             self.dispatchQueue.async {
-                self.didRotateKey(
-                    newPrivateKey: newPrivateKey,
-                    result: result
-                )
+                self.didRotateKey(newPrivateKey: newPrivateKey, result: result)
             }
         }
     }


### PR DESCRIPTION
This PR persists next private key we're rotating to, so that even if we fail to rotate the key during current rotation task, we can pick up where we left during next rotation task.