### PR TITLE
Increase timeout for expensive requests IOS-89

### DIFF
--- a/ios/MullvadREST/RESTDefaults.swift
+++ b/ios/MullvadREST/RESTDefaults.swift
@@ -16,6 +16,9 @@ extension REST {
     /// Default API endpoint.
     public static let defaultAPIEndpoint = AnyIPEndpoint(string: "45.83.223.196:443")!
 
-    /// Default network timeout for API requests.
-    public static let defaultAPINetworkTimeout: TimeInterval = 10
+    /// Network timeout for API requests that usually execute quickly.
+    public static let defaultRequestNetworkTimeout: TimeInterval = 10
+
+    /// Network timeout for API requests that may take time to execute.
+    public static let expensiveRequestNetworkTimeout: TimeInterval = 30
 }

--- a/ios/MullvadREST/RESTDevicesProxy.swift
+++ b/ios/MullvadREST/RESTDevicesProxy.swift
@@ -132,7 +132,8 @@ extension REST {
                     var requestBuilder = try self.requestFactory.createRequestBuilder(
                         endpoint: endpoint,
                         method: .post,
-                        pathTemplate: "devices"
+                        pathTemplate: "devices",
+                        networkTimeout: REST.expensiveRequestNetworkTimeout
                     )
                     requestBuilder.setAuthorization(authorization)
 
@@ -176,12 +177,12 @@ extension REST {
                         allowedCharacters: .urlPathAllowed
                     )
 
-                    var requestBuilder = try self.requestFactory
-                        .createRequestBuilder(
-                            endpoint: endpoint,
-                            method: .delete,
-                            pathTemplate: path
-                        )
+                    var requestBuilder = try self.requestFactory.createRequestBuilder(
+                        endpoint: endpoint,
+                        method: .delete,
+                        pathTemplate: path,
+                        networkTimeout: REST.expensiveRequestNetworkTimeout
+                    )
 
                     requestBuilder.setAuthorization(authorization)
 
@@ -238,12 +239,12 @@ extension REST {
                         allowedCharacters: .urlPathAllowed
                     )
 
-                    var requestBuilder = try self.requestFactory
-                        .createRequestBuilder(
-                            endpoint: endpoint,
-                            method: .put,
-                            pathTemplate: path
-                        )
+                    var requestBuilder = try self.requestFactory.createRequestBuilder(
+                        endpoint: endpoint,
+                        method: .put,
+                        pathTemplate: path,
+                        networkTimeout: REST.expensiveRequestNetworkTimeout
+                    )
 
                     requestBuilder.setAuthorization(authorization)
 

--- a/ios/MullvadREST/RESTDevicesProxy.swift
+++ b/ios/MullvadREST/RESTDevicesProxy.swift
@@ -132,8 +132,7 @@ extension REST {
                     var requestBuilder = try self.requestFactory.createRequestBuilder(
                         endpoint: endpoint,
                         method: .post,
-                        pathTemplate: "devices",
-                        networkTimeout: REST.expensiveRequestNetworkTimeout
+                        pathTemplate: "devices"
                     )
                     requestBuilder.setAuthorization(authorization)
 
@@ -180,8 +179,7 @@ extension REST {
                     var requestBuilder = try self.requestFactory.createRequestBuilder(
                         endpoint: endpoint,
                         method: .delete,
-                        pathTemplate: path,
-                        networkTimeout: REST.expensiveRequestNetworkTimeout
+                        pathTemplate: path
                     )
 
                     requestBuilder.setAuthorization(authorization)

--- a/ios/MullvadREST/RESTRequestFactory.swift
+++ b/ios/MullvadREST/RESTRequestFactory.swift
@@ -18,12 +18,13 @@ extension REST {
 
         class func withDefaultAPICredentials(
             pathPrefix: String,
-            bodyEncoder: JSONEncoder
+            bodyEncoder: JSONEncoder,
+            networkTimeout: TimeInterval = REST.defaultRequestNetworkTimeout
         ) -> RequestFactory {
             return RequestFactory(
                 hostname: defaultAPIHostname,
                 pathPrefix: pathPrefix,
-                networkTimeout: defaultAPINetworkTimeout,
+                networkTimeout: networkTimeout,
                 bodyEncoder: bodyEncoder
             )
         }
@@ -43,7 +44,8 @@ extension REST {
         func createRequest(
             endpoint: AnyIPEndpoint,
             method: HTTPMethod,
-            pathTemplate: URLPathTemplate
+            pathTemplate: URLPathTemplate,
+            networkTimeout: TimeInterval? = nil
         ) throws -> REST.Request {
             var urlComponents = URLComponents()
             urlComponents.scheme = "https"
@@ -57,7 +59,7 @@ extension REST {
             var request = URLRequest(
                 url: requestURL,
                 cachePolicy: .useProtocolCachePolicy,
-                timeoutInterval: networkTimeout
+                timeoutInterval: networkTimeout ?? self.networkTimeout
             )
             request.httpShouldHandleCookies = false
             request.addValue(hostname, forHTTPHeaderField: HTTPHeader.host)
@@ -75,12 +77,14 @@ extension REST {
         func createRequestBuilder(
             endpoint: AnyIPEndpoint,
             method: HTTPMethod,
-            pathTemplate: URLPathTemplate
+            pathTemplate: URLPathTemplate,
+            networkTimeout: TimeInterval? = nil
         ) throws -> RequestBuilder {
             let request = try createRequest(
                 endpoint: endpoint,
                 method: method,
-                pathTemplate: pathTemplate
+                pathTemplate: pathTemplate,
+                networkTimeout: networkTimeout
             )
 
             return RequestBuilder(

--- a/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
+++ b/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import MullvadREST
 import MullvadTypes
 import Operations
 import RelaySelector
@@ -19,8 +18,8 @@ private let operationQueue = AsyncOperationQueue()
 /// Shared queue used by IPC operations.
 private let dispatchQueue = DispatchQueue(label: "Tunnel.dispatchQueue")
 
-/// Timeout for proxy requests.
-private let proxyRequestTimeout = REST.defaultAPINetworkTimeout + 2
+/// Timeout overhead for proxy requests to account for IPC delays in handling requests and responses.
+private let proxyRequestTimeoutOverhead: TimeInterval = 2
 
 extension Tunnel {
     /// Request packet tunnel process to reconnect the tunnel with the given relay selector result.
@@ -69,7 +68,7 @@ extension Tunnel {
             application: .shared,
             tunnel: self,
             message: .sendURLRequest(proxyRequest),
-            timeout: proxyRequestTimeout,
+            timeout: proxyRequest.timeoutInterval + proxyRequestTimeoutOverhead,
             completionHandler: completionHandler
         )
 

--- a/ios/TunnelProviderMessaging/ProxyURLRequest.swift
+++ b/ios/TunnelProviderMessaging/ProxyURLRequest.swift
@@ -15,12 +15,14 @@ public struct ProxyURLRequest: Codable {
     public let method: String?
     public let httpBody: Data?
     public let httpHeaders: [String: String]?
+    public let timeoutInterval: TimeInterval
 
     public var urlRequest: URLRequest {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
         urlRequest.httpBody = httpBody
         urlRequest.allHTTPHeaderFields = httpHeaders
+        urlRequest.timeoutInterval = timeoutInterval
         return urlRequest
     }
 
@@ -34,6 +36,7 @@ public struct ProxyURLRequest: Codable {
         method = urlRequest.httpMethod
         httpBody = urlRequest.httpBody
         httpHeaders = urlRequest.allHTTPHeaderFields
+        timeoutInterval = urlRequest.timeoutInterval
     }
 }
 


### PR DESCRIPTION
This is a draft PR for increasing timeout intervals for expensive API requests from 10s to 30s. Exact timeouts aren't finalized yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4524)
<!-- Reviewable:end -->
