### PR TITLE
Reuse new private key when retrying key rotation

### DIFF
--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -46,6 +46,9 @@ const LOGOUT_TIMEOUT: Duration = Duration::from_secs(2);
 /// to set up a WireGuard tunnel.
 const WG_DEVICE_CHECK_THRESHOLD: usize = 2;
 
+/// How long to wait before rotating the key rotation timer starts, if the key is too old.
+const MIN_INITIAL_KEY_ROTATION_DELAY: Duration = Duration::from_secs(60);
+
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "The account already has a maximum number of devices")]
@@ -960,7 +963,7 @@ impl AccountManager {
             );
             let time_until_next_rotation = std::cmp::max(
                 rotation_interval.as_duration().saturating_sub(key_age),
-                Duration::from_secs(60),
+                MIN_INITIAL_KEY_ROTATION_DELAY,
             );
 
             log::trace!(

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -164,12 +164,11 @@ impl DeviceService {
         &self,
         token: AccountToken,
         device: DeviceId,
+        new_private_key: PrivateKey,
     ) -> Result<WireguardData, Error> {
-        let private_key = PrivateKey::new_from_random();
-
         let proxy = self.proxy.clone();
         let api_handle = self.api_availability.clone();
-        let pubkey = private_key.public_key();
+        let pubkey = new_private_key.public_key();
         let addresses = retry_future_n(
             move || proxy.replace_wg_key(token.clone(), device.clone(), pubkey.clone()),
             move |result| should_retry(result, &api_handle),
@@ -180,7 +179,7 @@ impl DeviceService {
         .map_err(map_rest_error)?;
 
         Ok(WireguardData {
-            private_key,
+            private_key: new_private_key,
             addresses,
             created: Utc::now(),
         })
@@ -190,12 +189,11 @@ impl DeviceService {
         &self,
         token: AccountToken,
         device: DeviceId,
+        new_private_key: PrivateKey,
     ) -> Result<WireguardData, Error> {
-        let private_key = PrivateKey::new_from_random();
-
         let proxy = self.proxy.clone();
         let api_handle = self.api_availability.clone();
-        let pubkey = private_key.public_key();
+        let pubkey = new_private_key.public_key();
 
         let addresses = retry_future(
             move || {
@@ -212,7 +210,7 @@ impl DeviceService {
         .map_err(map_rest_error)?;
 
         Ok(WireguardData {
-            private_key,
+            private_key: new_private_key,
             addresses,
             created: Utc::now(),
         })


### PR DESCRIPTION
If the API response for a successful rotation never makes it back to the client, this prevents it from unnecessarily replacing the key when retrying.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4527)
<!-- Reviewable:end -->
