### PR TITLE
Log settings summary when connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Log select settings on each connection attempt.
+
 #### Android
 - Add DNS content blockers.
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -894,9 +894,12 @@ where
             }
         }
 
-        match tunnel_state {
+        match &tunnel_state {
             TunnelState::Disconnected => self.state.disconnected(),
-            TunnelState::Error(ref error_state) => {
+            TunnelState::Connecting { .. } => {
+                log::debug!("Settings: {}", self.settings.summary());
+            }
+            TunnelState::Error(error_state) => {
                 if error_state.is_blocking() {
                     log::info!(
                         "Blocking all network connections, reason: {}",

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -31,6 +31,15 @@ pub enum Constraint<T: fmt::Debug + Clone + Eq + PartialEq> {
     Only(T),
 }
 
+impl<T: fmt::Debug + fmt::Display + Clone + Eq> fmt::Display for Constraint<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Constraint::Any => "any".fmt(f),
+            Constraint::Only(value) => fmt::Display::fmt(value, f),
+        }
+    }
+}
+
 impl<T: fmt::Debug + Clone + Eq + PartialEq> Constraint<T> {
     pub fn unwrap(self) -> T {
         match self {

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -26,12 +26,12 @@ pub trait Set<T> {
 #[cfg_attr(target_os = "android", derive(FromJava, IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 #[cfg_attr(target_os = "android", jnix(bounds = "T: android.os.Parcelable"))]
-pub enum Constraint<T: fmt::Debug + Clone + Eq + PartialEq> {
+pub enum Constraint<T> {
     Any,
     Only(T),
 }
 
-impl<T: fmt::Debug + fmt::Display + Clone + Eq> fmt::Display for Constraint<T> {
+impl<T: fmt::Display> fmt::Display for Constraint<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Constraint::Any => "any".fmt(f),
@@ -40,7 +40,7 @@ impl<T: fmt::Debug + fmt::Display + Clone + Eq> fmt::Display for Constraint<T> {
     }
 }
 
-impl<T: fmt::Debug + Clone + Eq + PartialEq> Constraint<T> {
+impl<T> Constraint<T> {
     pub fn unwrap(self) -> T {
         match self {
             Constraint::Any => panic!("called `Constraint::unwrap()` on an `Any` value"),
@@ -62,10 +62,7 @@ impl<T: fmt::Debug + Clone + Eq + PartialEq> Constraint<T> {
         }
     }
 
-    pub fn map<U: fmt::Debug + Clone + Eq + PartialEq, F: FnOnce(T) -> U>(
-        self,
-        f: F,
-    ) -> Constraint<U> {
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Constraint<U> {
         match self {
             Constraint::Any => Constraint::Any,
             Constraint::Only(value) => Constraint::Only(f(value)),
@@ -96,7 +93,9 @@ impl<T: fmt::Debug + Clone + Eq + PartialEq> Constraint<T> {
             Constraint::Only(value) => Some(value),
         }
     }
+}
 
+impl<T: PartialEq> Constraint<T> {
     pub fn matches_eq(&self, other: &T) -> bool {
         match self {
             Constraint::Any => true,
@@ -107,15 +106,15 @@ impl<T: fmt::Debug + Clone + Eq + PartialEq> Constraint<T> {
 
 // Using the default attribute fails on Android
 #[allow(clippy::derivable_impls)]
-impl<T: fmt::Debug + Clone + Eq + PartialEq> Default for Constraint<T> {
+impl<T> Default for Constraint<T> {
     fn default() -> Self {
         Constraint::Any
     }
 }
 
-impl<T: Copy + fmt::Debug + Clone + Eq + PartialEq> Copy for Constraint<T> {}
+impl<T: Copy> Copy for Constraint<T> {}
 
-impl<T: fmt::Debug + Clone + Eq + Match<U>, U> Match<U> for Constraint<T> {
+impl<T: Match<U>, U> Match<U> for Constraint<T> {
     fn matches(&self, other: &U) -> bool {
         match *self {
             Constraint::Any => true,
@@ -124,12 +123,10 @@ impl<T: fmt::Debug + Clone + Eq + Match<U>, U> Match<U> for Constraint<T> {
     }
 }
 
-impl<T: fmt::Debug + Clone + Eq + Set<U>, U: fmt::Debug + Clone + Eq> Set<Constraint<U>>
-    for Constraint<T>
-{
+impl<T: Set<U>, U> Set<Constraint<U>> for Constraint<T> {
     fn is_subset(&self, other: &Constraint<U>) -> bool {
         match self {
-            Constraint::Any => *other == Constraint::Any,
+            Constraint::Any => other.is_any(),
             Constraint::Only(ref constraint) => match other {
                 Constraint::Only(ref other_constraint) => constraint.is_subset(other_constraint),
                 _ => true,
@@ -138,7 +135,7 @@ impl<T: fmt::Debug + Clone + Eq + Set<U>, U: fmt::Debug + Clone + Eq> Set<Constr
     }
 }
 
-impl<T: fmt::Debug + Clone + Eq + PartialEq> From<Option<T>> for Constraint<T> {
+impl<T> From<Option<T>> for Constraint<T> {
     fn from(value: Option<T>) -> Self {
         match value {
             Some(value) => Constraint::Only(value),

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -22,6 +22,16 @@ pub enum QuantumResistantState {
     Off,
 }
 
+impl fmt::Display for QuantumResistantState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QuantumResistantState::Auto => f.write_str("auto"),
+            QuantumResistantState::On => f.write_str("on"),
+            QuantumResistantState::Off => f.write_str("off"),
+        }
+    }
+}
+
 /// Contains account specific wireguard data
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct WireguardData {

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -1,6 +1,5 @@
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use lazy_static::lazy_static;
-#[cfg(not(target_os = "android"))]
 use std::net::IpAddr;
 #[cfg(windows)]
 use std::path::PathBuf;
@@ -81,7 +80,6 @@ const DHCPV6_CLIENT_PORT: u16 = 546;
 #[cfg(all(unix, not(target_os = "android")))]
 const ROOT_UID: u32 = 0;
 
-#[cfg(any(all(unix, not(target_os = "android")), target_os = "windows"))]
 /// Returns whether an address belongs to a private subnet.
 pub fn is_local_address(address: &IpAddr) -> bool {
     let address = *address;

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -31,13 +31,13 @@ pub struct Config {
     pub obfuscator_config: Option<ObfuscatorConfig>,
 }
 
-#[cfg(not(target_os = "android"))]
-const DEFAULT_MTU: u16 = 1380;
-
 /// Set the MTU to the lowest possible whilst still allowing for IPv6 to help with wireless
 /// carriers that do a lot of encapsulation.
-#[cfg(target_os = "android")]
-const DEFAULT_MTU: u16 = 1280;
+const DEFAULT_MTU: u16 = if cfg!(target_os = "android") {
+    1280
+} else {
+    1380
+};
 
 /// Configuration errors
 #[derive(err_derive::Error, Debug)]

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -676,6 +676,8 @@ impl WireguardMonitor {
         #[cfg(windows)] route_manager_handle: crate::routing::RouteManagerHandle,
         #[cfg(windows)] setup_done_tx: mpsc::Sender<std::result::Result<(), BoxedError>>,
     ) -> Result<Box<dyn Tunnel>> {
+        log::debug!("Tunnel MTU: {}", config.mtu);
+
         #[cfg(target_os = "linux")]
         if !*FORCE_USERSPACE_WIREGUARD {
             if will_nm_manage_dns() {


### PR DESCRIPTION
For debugging purposes, log select settings whenever entering the connecting state.

The following settings are logged:
* mssfix/MTU
* WG over IPv6
* Multihop
* IPv6 (in tunnel)
* LAN sharing
* PQ
* Which content blockers are used and whether custom DNS is enabled
* Obfuscation state

> [mullvad_daemon][DEBUG] ovpn mssfix: unset, wg ip: any, wg mtu: 1420, multihop: off, ipv6 (tun): off, lan: on, pq: on, obfs: udp2tcp, dns: default

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4531)
<!-- Reviewable:end -->
