### PR TITLE
Disable IP address cache for staging environment

### DIFF
--- a/ios/MullvadREST/RESTDefaults.swift
+++ b/ios/MullvadREST/RESTDefaults.swift
@@ -16,6 +16,9 @@ extension REST {
     /// Default API endpoint.
     public static let defaultAPIEndpoint = AnyIPEndpoint(string: "45.83.223.196:443")!
 
+    /// Disables API IP address cache when in staging environment and sticks to using default API endpoint instead.
+    public static let isStagingEnvironment = false
+
     /// Default network timeout for API requests.
     public static let defaultAPINetworkTimeout: TimeInterval = 10
 }

--- a/ios/MullvadREST/RESTNetworkOperation.swift
+++ b/ios/MullvadREST/RESTNetworkOperation.swift
@@ -112,7 +112,7 @@ extension REST {
                 return
             }
 
-            let endpoint = addressCacheStore.getCurrentEndpoint()
+            let endpoint = REST.isStagingEnvironment ? REST.defaultAPIEndpoint : addressCacheStore.getCurrentEndpoint()
 
             do {
                 let request = try requestHandler.createURLRequest(
@@ -211,7 +211,9 @@ extension REST {
                     break
 
                 default:
-                    _ = addressCacheStore.selectNextEndpoint(endpoint)
+                    if !REST.isStagingEnvironment {
+                        _ = addressCacheStore.selectNextEndpoint(endpoint)
+                    }
                 }
             }
 

--- a/ios/MullvadVPN/SettingsManager/SettingsManager.swift
+++ b/ios/MullvadVPN/SettingsManager/SettingsManager.swift
@@ -130,7 +130,7 @@ enum SettingsManager {
         let handleCompletion = { (result: SettingsMigrationResult) in
             // Reset store upon failure to migrate settings.
             if case .failure = result {
-                self.resetStore()
+                resetStore()
             }
             completion(result)
         }

--- a/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
@@ -141,8 +141,7 @@ class LoginViewController: UIViewController, RootContainment {
         // There is no need to set the input accessory toolbar on iPad since it has a dedicated
         // button to dismiss the keyboard.
         if case .phone = UIDevice.current.userInterfaceIdiom {
-            contentView.accountInputGroup.textField.inputAccessoryView = self
-                .accountInputAccessoryToolbar
+            contentView.accountInputGroup.textField.inputAccessoryView = accountInputAccessoryToolbar
         } else {
             contentView.accountInputGroup.textField.inputAccessoryView = nil
         }

--- a/ios/RelaySelector/RelaySelector.swift
+++ b/ios/RelaySelector/RelaySelector.swift
@@ -130,7 +130,7 @@ public enum RelaySelector {
             let endPort = inputRange[1]
 
             if startPort <= endPort {
-                return (startPort ... endPort)
+                return startPort ... endPort
             } else {
                 return nil
             }


### PR DESCRIPTION
This PR introduces additional `REST.isStagingEnvironment` flag that makes it possible to disable API IP address cache when working on staging environment and stick to default API IP endpoint instead. This seems to work great with existing SSL certificate that we use for pinning.

In order to configure the app to work with staging environment, modify `defaultAPIEndpoint`, `defaultAPIHostname` accordingly and set `isStagingEnvironment = true` in `MullvadREST/RESTDefaults.swift`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4542)
<!-- Reviewable:end -->
