### PR TITLE
Hide custom dns warning

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AdvancedSettingScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AdvancedSettingScreen.kt
@@ -252,19 +252,19 @@ fun AdvancedSettingScreen(
                             background = MullvadBlue20
                         )
                     }
-                }
 
-                if (uiState.isCustomDnsEnabled) {
-                    item {
-                        ContentBlockersDisableModeCellSubtitle(
-                            Modifier.background(MullvadDarkBlue)
-                                .padding(
-                                    start = cellHorizontalSpacing,
-                                    top = topPadding,
-                                    end = cellHorizontalSpacing,
-                                    bottom = cellVerticalSpacing,
-                                )
-                        )
+                    if (uiState.isCustomDnsEnabled) {
+                        item {
+                            ContentBlockersDisableModeCellSubtitle(
+                                Modifier.background(MullvadDarkBlue)
+                                    .padding(
+                                        start = cellHorizontalSpacing,
+                                        top = topPadding,
+                                        end = cellHorizontalSpacing,
+                                        bottom = cellVerticalSpacing,
+                                    )
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
This change hides the Custom DNS warning, which is part of the content blockers, when the content blockers are not expanded.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4544)
<!-- Reviewable:end -->
