### PR TITLE
Fix RPM package to not include build ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Fix tray window behaviour when opening mission control and switching between full-screen workspaces.
 
+#### Linux
+- Fix RPM package containing unecessary files causing conflicts with other electron-builder based
+  packages.
+
 
 ## [2023.3] - 2023-04-05
 ### Changed

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -202,6 +202,10 @@ const config = {
 
   rpm: {
     fpm: [
+      // Prevents RPM from packaging build-id metadata, some of which is the
+      // same across all electron-builder applications, which causes package
+      // conflicts
+      '--rpm-rpmbuild-define=_build_id_links none',
       '--directories=/opt/Mullvad VPN/',
       '--before-install',
       distAssets('linux/before-install.sh'),


### PR DESCRIPTION
This fixes #4534. I've tested this myself with the currently available Slack RPM package, and this does fix the issue. The folder `/usr/lib/.build-id` is no longer present in our package with my changes, but it's there in our current installers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4547)
<!-- Reviewable:end -->
