### PR TITLE
Improve operation cancellation

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		585E820327F3285E00939F0E /* SendStoreReceiptOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585E820227F3285E00939F0E /* SendStoreReceiptOperation.swift */; };
 		58607A4D2947287800BC467D /* AccountExpiryInAppNotificationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58607A4C2947287800BC467D /* AccountExpiryInAppNotificationProvider.swift */; };
 		586168692976F6BD00EF8598 /* DisplayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586168682976F6BD00EF8598 /* DisplayError.swift */; };
+		586250BB29E6F8F300F4B521 /* OperationCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586250BA29E6F8F300F4B521 /* OperationCancellationTests.swift */; };
 		5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */; };
 		5864859929A0D028006C5743 /* FormsheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5864859829A0D028006C5743 /* FormsheetPresentationController.swift */; };
 		5864859B29A0EAF2006C5743 /* SecondaryContextPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5864859A29A0EAF2006C5743 /* SecondaryContextPresentationController.swift */; };
@@ -743,6 +744,7 @@
 		585E820227F3285E00939F0E /* SendStoreReceiptOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendStoreReceiptOperation.swift; sourceTree = "<group>"; };
 		58607A4C2947287800BC467D /* AccountExpiryInAppNotificationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExpiryInAppNotificationProvider.swift; sourceTree = "<group>"; };
 		586168682976F6BD00EF8598 /* DisplayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayError.swift; sourceTree = "<group>"; };
+		586250BA29E6F8F300F4B521 /* OperationCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCancellationTests.swift; sourceTree = "<group>"; };
 		5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslucentButtonBlurView.swift; sourceTree = "<group>"; };
 		5864859829A0D028006C5743 /* FormsheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormsheetPresentationController.swift; sourceTree = "<group>"; };
 		5864859A29A0EAF2006C5743 /* SecondaryContextPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryContextPresentationController.swift; sourceTree = "<group>"; };
@@ -943,9 +945,6 @@
 		58FF2C02281BDE02009EF542 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		7A09C98029D99215000C2CAC /* String+FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FuzzyMatch.swift"; sourceTree = "<group>"; };
 		7AD2DA1429DC4EB900250737 /* UISearchBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchBar+Appearance.swift"; sourceTree = "<group>"; };
-		7AD8490C29BA1EC500878E53 /* SettingsCellFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCellFactory.swift; sourceTree = "<group>"; };
-		7AD8490E29BA26B000878E53 /* CellFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellFactoryProtocol.swift; sourceTree = "<group>"; };
-		7AD8491029BA316500878E53 /* PreferencesCellFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesCellFactory.swift; sourceTree = "<group>"; };
 		E1187ABA289BBB850024E748 /* OutOfTimeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeViewController.swift; sourceTree = "<group>"; };
 		E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeContentView.swift; sourceTree = "<group>"; };
 		E158B35F285381C60002F069 /* String+AccountFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+AccountFormatting.swift"; sourceTree = "<group>"; };
@@ -1539,16 +1538,6 @@
 			path = "Presentation controllers";
 			sourceTree = "<group>";
 		};
-		5864AEFF29C78760005B0CD9 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				7AD8490C29BA1EC500878E53 /* SettingsCellFactory.swift */,
-				7AD8491029BA316500878E53 /* PreferencesCellFactory.swift */,
-				7AD8490E29BA26B000878E53 /* CellFactoryProtocol.swift */,
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		5864AF0629C78816005B0CD9 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
@@ -1641,6 +1630,7 @@
 				58DF5B772852178600E92647 /* OperationInputInjectionTests.swift */,
 				583E1E292848DF67004838B3 /* OperationObserverTests.swift */,
 				580CBFB72848D503007878F0 /* OperationConditionTests.swift */,
+				586250BA29E6F8F300F4B521 /* OperationCancellationTests.swift */,
 			);
 			path = OperationsTests;
 			sourceTree = "<group>";
@@ -1734,7 +1724,6 @@
 				58CE5E7A224146470008646E /* PacketTunnel */,
 				58CE5E61224146200008646E /* Products */,
 				584F991F2902CBDD001F858D /* Frameworks */,
-				5864AEFF29C78760005B0CD9 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2561,6 +2550,7 @@
 			files = (
 				589A455F28E094BF00565204 /* OperationConditionTests.swift in Sources */,
 				589A455E28E094BF00565204 /* OperationInputInjectionTests.swift in Sources */,
+				586250BB29E6F8F300F4B521 /* OperationCancellationTests.swift in Sources */,
 				589A455C28E094BF00565204 /* OperationSmokeTests.swift in Sources */,
 				589A455D28E094BF00565204 /* OperationObserverTests.swift in Sources */,
 			);

--- a/ios/MullvadVPN/TunnelManager/SendTunnelProviderMessageOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SendTunnelProviderMessageOperation.swift
@@ -78,9 +78,7 @@ final class SendTunnelProviderMessageOperation<Output>: ResultOperation<Output> 
     }
 
     override func operationDidCancel() {
-        if isExecuting {
-            finish(result: .failure(OperationError.cancelled))
-        }
+        finish(result: .failure(OperationError.cancelled))
     }
 
     override func finish(result: Result<Output, Error>) {

--- a/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
@@ -122,11 +122,9 @@ class SetAccountOperation: ResultOperation<StoredAccountData?> {
                     })
                     .reduce()
 
-                saveSettingsOperation.addBlockObserver(
-                    OperationBlockObserver(didFinish: { operation, error in
-                        self.completeOperation(accountData: operation.output)
-                    })
-                )
+                saveSettingsOperation.onFinish { operation, error in
+                    self.completeOperation(accountData: operation.output)
+                }
 
                 return [accountOperation, createDeviceOperation, saveSettingsOperation]
             } ?? []

--- a/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
+++ b/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
@@ -73,21 +73,19 @@ extension Tunnel {
             completionHandler: completionHandler
         )
 
-        operation.addBlockObserver(
-            OperationBlockObserver(didCancel: { [weak self] _ in
-                guard let self = self else { return }
+        operation.onCancel { [weak self] _ in
+            guard let self = self else { return }
 
-                let cancelOperation = SendTunnelProviderMessageOperation(
-                    dispatchQueue: dispatchQueue,
-                    application: .shared,
-                    tunnel: self,
-                    message: .cancelURLRequest(proxyRequest.id),
-                    completionHandler: nil
-                )
+            let cancelOperation = SendTunnelProviderMessageOperation(
+                dispatchQueue: dispatchQueue,
+                application: .shared,
+                tunnel: self,
+                message: .cancelURLRequest(proxyRequest.id),
+                completionHandler: nil
+            )
 
-                operationQueue.addOperation(cancelOperation)
-            })
-        )
+            operationQueue.addOperation(cancelOperation)
+        }
 
         operationQueue.addOperation(operation)
 

--- a/ios/Operations/AsyncBlockOperation.swift
+++ b/ios/Operations/AsyncBlockOperation.swift
@@ -74,7 +74,7 @@ public class AsyncBlockOperation: AsyncOperation {
 
     public func addCancellationBlock(_ block: @escaping () -> Void) {
         dispatchQueue.async {
-            if self.isCancelled {
+            if self.isCancelled, self.isExecuting {
                 block()
             } else {
                 self.cancellationBlocks.append(block)

--- a/ios/Operations/AsyncOperation.swift
+++ b/ios/Operations/AsyncOperation.swift
@@ -422,6 +422,17 @@ public protocol OperationBlockObserverSupport {}
 extension AsyncOperation: OperationBlockObserverSupport {}
 
 extension OperationBlockObserverSupport where Self: AsyncOperation {
+    /// Add observer responding to cancellation event.
+    public func onCancel(_ fn: @escaping (Self) -> Void) {
+        addBlockObserver(OperationBlockObserver(didCancel: fn))
+    }
+
+    /// Add observer responding to finish event.
+    public func onFinish(_ fn: @escaping (Self, Error?) -> Void) {
+        addBlockObserver(OperationBlockObserver(didFinish: fn))
+    }
+
+    /// Add block-based observer.
     public func addBlockObserver(_ observer: OperationBlockObserver<Self>) {
         addObserver(observer)
     }

--- a/ios/Operations/AsyncOperationQueue.swift
+++ b/ios/Operations/AsyncOperationQueue.swift
@@ -73,11 +73,9 @@ private final class ExclusivityManager {
 
             operationsByCategory[category] = operations
 
-            let blockObserver = OperationBlockObserver(didFinish: { [weak self] op, error in
+            operation.onFinish { [weak self] op, error in
                 self?.removeOperation(op, categories: categories)
-            })
-
-            operation.addObserver(blockObserver)
+            }
         }
     }
 

--- a/ios/Operations/NoFailedDependenciesCondition.swift
+++ b/ios/Operations/NoFailedDependenciesCondition.swift
@@ -24,11 +24,15 @@ public final class NoFailedDependenciesCondition: OperationCondition {
 
     public func evaluate(for operation: Operation, completion: @escaping (Bool) -> Void) {
         let satisfy = operation.dependencies.allSatisfy { operation in
-            if let operation = operation as? AsyncOperation, operation.error != nil {
+            let operationError = (operation as? AsyncOperation)?.error
+            let isCancellationError = operationError?.isOperationCancellationError ?? false
+
+            if operationError != nil, !isCancellationError {
                 return false
             }
 
-            if operation.isCancelled, !self.ignoreCancellations {
+            // Treat OperationError.cancelled and isCancelled equally.
+            if operation.isCancelled || isCancellationError, !self.ignoreCancellations {
                 return false
             }
 

--- a/ios/Operations/ResultBlockOperation.swift
+++ b/ios/Operations/ResultBlockOperation.swift
@@ -88,7 +88,7 @@ public final class ResultBlockOperation<Success>: ResultOperation<Success> {
 
     public func addCancellationBlock(_ block: @escaping () -> Void) {
         dispatchQueue.async {
-            if self.isCancelled {
+            if self.isCancelled, self.isExecuting {
                 block()
             } else {
                 self.cancellationBlocks.append(block)

--- a/ios/Operations/TransformOperation.swift
+++ b/ios/Operations/TransformOperation.swift
@@ -102,7 +102,7 @@ public final class TransformOperation<Input, Output>: ResultOperation<Output>, I
 
     public func addCancellationBlock(_ block: @escaping () -> Void) {
         dispatchQueue.async {
-            if self.isCancelled {
+            if self.isCancelled, self.isExecuting {
                 block()
             } else {
                 self.cancellationBlocks.append(block)

--- a/ios/OperationsTests/OperationCancellationTests.swift
+++ b/ios/OperationsTests/OperationCancellationTests.swift
@@ -1,0 +1,35 @@
+//
+//  OperationCancellationTests.swift
+//  OperationsTests
+//
+//  Created by pronebird on 12/04/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Operations
+import XCTest
+
+final class OperationCancellationTests: XCTestCase {
+    func testCancellationShouldNotFireBeforeOperationIsEnqueued() throws {
+        let expect = expectation(description: "Cancellation should not fire.")
+        expect.isInverted = true
+
+        let operation = AsyncBlockOperation {}
+        operation.onCancel { _ in expect.fulfill() }
+        operation.cancel()
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancellationShouldFireAfterCancelledOperationIsEnqueued() throws {
+        let expect = expectation(description: "Cancellation should fire.")
+
+        let operationQueue = AsyncOperationQueue()
+        let operation = AsyncBlockOperation {}
+        operation.onCancel { _ in expect.fulfill() }
+        operation.cancel()
+        operationQueue.addOperation(operation)
+
+        waitForExpectations(timeout: 1)
+    }
+}


### PR DESCRIPTION
1. Add helpers to attach operation cancellation and completion observers (`AsyncOperation.onFinish` and `AsyncOperation.onCancel`)
2. Do not fire `operationDidCancel` if operation isn't executing yet. This way `start()` can dispatch cancellation in the same order in which operations are scheduled.
3. Add cancellation related tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4553)
<!-- Reviewable:end -->
