### PR TITLE
Prevent exotic characters to be input in the account text field

### DIFF
--- a/ios/MullvadVPN/View controllers/Login/AccountTokenInput.swift
+++ b/ios/MullvadVPN/View controllers/Login/AccountTokenInput.swift
@@ -149,7 +149,13 @@ extension AccountTokenInput: UITextFieldDelegate, UITextPasteDelegate {
         replacementString string: String
     ) -> Bool {
         let emptySelection = textField.selectedTextRange?.isEmpty ?? false
-        let stringRange = Range(range, in: formattedString)!
+
+        // Certain characters such as a backtick can pass through the textField, and appear as an empty string, with a
+        // range outside of the boundaries of the `formattedString`. Such characters are ignored.
+        guard let stringRange = Range(range, in: formattedString) else {
+            updateTextField(textField, notifyDelegate: true)
+            return false
+        }
 
         replaceCharacters(
             in: stringRange,
@@ -177,7 +183,7 @@ extension AccountTokenInput: UITextFieldDelegate, UITextPasteDelegate {
         let length = textField.offset(from: textRange.start, to: textRange.end)
         let nsRange = NSRange(location: location, length: length)
 
-        let stringRange = Range(nsRange, in: formattedString)!
+        guard let stringRange = Range(nsRange, in: formattedString) else { return textRange }
 
         replaceCharacters(
             in: stringRange,

--- a/ios/MullvadVPNTests/AccountTokenInputTests.swift
+++ b/ios/MullvadVPNTests/AccountTokenInputTests.swift
@@ -90,6 +90,16 @@ class AccountTokenInputTests: XCTestCase {
         XCTAssertEqual(input.formattedString, "1234 0000")
         XCTAssertEqual(input.caretPosition, 9)
     }
+
+    func testInvalidCharactersReplacesTextFieldTextWithFormattedString() {
+        let input = AccountTokenInput(string: kSampleToken)
+        let invalidRange = NSRange(location: 5, length: 0)
+        let textField = UITextField()
+
+        _ = input.textField(textField, shouldChangeCharactersIn: invalidRange, replacementString: "")
+
+        XCTAssertEqual(textField.text, input.formattedString)
+    }
 }
 
 private extension String {

--- a/ios/MullvadVPNTests/AccountTokenInputTests.swift
+++ b/ios/MullvadVPNTests/AccountTokenInputTests.swift
@@ -93,12 +93,32 @@ class AccountTokenInputTests: XCTestCase {
 
     func testInvalidCharactersReplacesTextFieldTextWithFormattedString() {
         let input = AccountTokenInput(string: kSampleToken)
-        let invalidRange = NSRange(location: 5, length: 0)
+        let invalidRange = NSRange(location: kSampleToken.count + 1, length: 0)
+        let textField = UITextField()
+
+        _ = input.textField(textField, shouldChangeCharactersIn: invalidRange, replacementString: "´")
+
+        XCTAssertEqual(textField.text, input.formattedString)
+    }
+
+    func testDeleteCharacterOutsideOfTokenBoundaryDoesNotDeleteAnything() {
+        let input = AccountTokenInput(string: kSampleToken)
+        let invalidRange = NSRange(location: kSampleToken.count + 1, length: 1)
         let textField = UITextField()
 
         _ = input.textField(textField, shouldChangeCharactersIn: invalidRange, replacementString: "")
 
         XCTAssertEqual(textField.text, input.formattedString)
+    }
+
+    func testDeleteLastCharacter() {
+        let input = AccountTokenInput(string: kSampleToken)
+        let lastCharacterRange = NSRange(location: kSampleToken.count, length: 1)
+        let textField = UITextField()
+
+        _ = input.textField(textField, shouldChangeCharactersIn: lastCharacterRange, replacementString: "")
+
+        XCTAssertEqual(textField.text, "1234 567")
     }
 }
 


### PR DESCRIPTION
This PR adds a check in `AccountTokenInput.swift` to avoid crashing the application when certain invalid characters are either input (via an external keyboard) or pasted in the account text field on the login screen.

Instead of crashing, the text field is now updated with the currently parsed formatted string that contains the account number.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4554)
<!-- Reviewable:end -->
