### PR TITLE
Add account info in the header bar

### DIFF
--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -25,6 +25,29 @@ class HeaderBarView: UIView {
         imageView.contentMode = .scaleAspectFill
         return imageView
     }()
+    
+    private let deviceInfoHolder = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillProportionally
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    
+    private lazy var deviceName : UILabel = {
+        let label = UILabel(frame: .zero)
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor(white: 1.0, alpha: 0.8)
+        return label
+    }()
+    
+    private lazy var timeLeft : UILabel = {
+        let label = UILabel(frame: .zero)
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor(white: 1.0, alpha: 0.8)
+        return label
+    }()
 
     let settingsButton = makeSettingsButton()
 
@@ -105,8 +128,8 @@ class HeaderBarView: UIView {
             ),
             brandNameImageView.heightAnchor.constraint(equalToConstant: 18),
             layoutMarginsGuide.bottomAnchor.constraint(
-                equalTo: brandNameImageView.bottomAnchor,
-                constant: 22
+                equalTo: deviceInfoHolder.bottomAnchor,
+                constant: 4
             ),
 
             settingsButton.leadingAnchor.constraint(
@@ -115,9 +138,15 @@ class HeaderBarView: UIView {
             ),
             settingsButton.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
             settingsButton.centerYAnchor.constraint(equalTo: brandNameImageView.centerYAnchor),
+            
+            deviceInfoHolder.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            deviceInfoHolder.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            deviceInfoHolder.topAnchor.constraint(equalTo: logoImageView.bottomAnchor,constant: 7)
         ]
 
-        [logoImageView, brandNameImageView, settingsButton].forEach { addSubview($0) }
+        [logoImageView, brandNameImageView, settingsButton,deviceInfoHolder].forEach { addSubview($0) }
+        [deviceName,timeLeft].forEach{ deviceInfoHolder.addArrangedSubview($0) }
+        
 
         NSLayoutConstraint.activate(constraints)
     }
@@ -130,5 +159,21 @@ class HeaderBarView: UIView {
         super.layoutSubviews()
 
         borderLayer.frame = CGRect(x: 0, y: frame.maxY - 1, width: frame.width, height: 1)
+    }
+}
+
+extension HeaderBarView {
+    func update(deviceState : DeviceState) {
+        switch deviceState {
+        case .loggedIn(let storedAccountData, let storedDeviceData):
+            let formattedDeviceName = NSLocalizedString("DEVICE_NAME_HEADER_VIEW", tableName: nil, value: "Device name : %@", comment: "")
+            let formattedTimeLeft = NSLocalizedString("TIME_LEFT_HEADER_VIEW", tableName: nil, value: "Time left : %@", comment: "")
+            deviceName.text = .init(format: formattedDeviceName, storedDeviceData.name)
+            timeLeft.text = .init(format: formattedTimeLeft,
+                                  CustomDateComponentsFormatting.localizedString( from: Date() ,to: storedAccountData.expiry, unitsStyle: .full) ?? "")
+            deviceInfoHolder.arrangedSubviews.forEach{ $0.isHidden = false }
+        case .loggedOut,.revoked:
+            deviceInfoHolder.arrangedSubviews.forEach{ $0.isHidden = true }
+        }
     }
 }

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -674,3 +674,9 @@ extension UIViewController {
         rootContainerController?.updateHeaderBarHiddenAppearance()
     }
 }
+
+extension RootContainerViewController {
+    func update(deviceState : DeviceState) {
+        headerBarView.update(deviceState: deviceState)
+    }
+}

--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -20,38 +20,38 @@ private let preferredFormSheetContentSize = CGSize(width: 480, height: 640)
  Application coordinator managing split view and two navigation contexts.
  */
 final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewControllerDelegate,
-    UISplitViewControllerDelegate, ApplicationRouterDelegate
+                                    UISplitViewControllerDelegate, ApplicationRouterDelegate
 {
     /**
      Application router.
      */
     private var router: ApplicationRouter!
-
+    
     /**
      Primary navigation container.
-
+     
      On iPhone, it is used as a container for horizontal flows (TOS, Login, Revoked, Out-of-time).
-
+     
      On iPad, it is used as a container to hold split view controller. Secondary navigation
      container presented modally is used for horizontal flows.
      */
     private let primaryNavigationContainer = RootContainerViewController()
-
+    
     /**
      Secondary navigation container.
-
+     
      On iPad, it is used in place of primary container for horizontal flows and displayed modally
      above primary container. Unused on iPhone.
      */
     private let secondaryNavigationContainer = RootContainerViewController()
-
+    
     private lazy var secondaryRootConfiguration = ModalPresentationConfiguration(
         preferredContentSize: preferredFormSheetContentSize,
         modalPresentationStyle: .custom,
         isModalInPresentation: true,
         transitioningDelegate: SecondaryContextTransitioningDelegate()
     )
-
+    
     private let splitViewController: CustomSplitViewController = {
         let svc = CustomSplitViewController()
         svc.minimumPrimaryColumnWidth = UIMetrics.minimumSplitViewSidebarWidth
@@ -60,24 +60,24 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         svc.primaryEdge = .trailing
         return svc
     }()
-
+    
     private var splitTunnelCoordinator: TunnelCoordinator?
     private var splitLocationCoordinator: SelectLocationCoordinator?
-
+    
     private let tunnelManager: TunnelManager
     private let storePaymentManager: StorePaymentManager
     private let relayCacheTracker: RelayCacheTracker
-
+    
     private let apiProxy: REST.APIProxy
     private let devicesProxy: REST.DevicesProxy
     private var tunnelObserver: TunnelObserver?
-
+    
     private var outOfTimeTimer: Timer?
-
+    
     var rootViewController: UIViewController {
         return primaryNavigationContainer
     }
-
+    
     init(
         tunnelManager: TunnelManager,
         storePaymentManager: StorePaymentManager,
@@ -90,32 +90,32 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         self.relayCacheTracker = relayCacheTracker
         self.apiProxy = apiProxy
         self.devicesProxy = devicesProxy
-
+        
         /*
-          Uncomment if you'd like to test TOS again
+         Uncomment if you'd like to test TOS again
          TermsOfService.unsetAgreed()
-          */
-
+         */
+        
         super.init()
-
+        
         primaryNavigationContainer.delegate = self
         secondaryNavigationContainer.delegate = self
-
+        
         router = ApplicationRouter(self)
-
+        
         addTunnelObserver()
     }
-
+    
     func start() {
         if isPad {
             setupSplitView()
         }
-
+        
         continueFlow(animated: false)
     }
-
+    
     // MARK: - ApplicationRouterDelegate
-
+    
     func applicationRouter(
         _ router: ApplicationRouter,
         route: AppRoute,
@@ -125,30 +125,30 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         switch route {
         case let .settings(subRoute):
             presentSettings(route: subRoute, animated: animated, completion: completion)
-
+            
         case .selectLocation:
             presentSelectLocation(animated: animated, completion: completion)
-
+            
         case .outOfTime:
             presentOutOfTime(animated: animated, completion: completion)
-
+            
         case .revoked:
             presentRevoked(animated: animated, completion: completion)
-
+            
         case .login:
             presentLogin(animated: animated, completion: completion)
-
+            
         case .changelog:
             presentChangeLog(animated: animated, completion: completion)
-
+            
         case .tos:
             presentTOS(animated: animated, completion: completion)
-
+            
         case .main:
             presentMain(animated: animated, completion: completion)
         }
     }
-
+    
     func applicationRouter(
         _ router: ApplicationRouter,
         dismissWithContext context: RouteDismissalContext,
@@ -156,29 +156,29 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     ) {
         if context.isClosing {
             let dismissedRoute = context.dismissedRoutes.first!
-
+            
             switch dismissedRoute.route.routeGroup {
             case .primary:
                 endHorizontalFlow(animated: context.isAnimated, completion: completion)
                 context.dismissedRoutes.forEach { $0.coordinator.removeFromParent() }
-
+                
             case .selectLocation, .settings:
                 let coordinator = dismissedRoute.coordinator as! Presentable
-
+                
                 coordinator.dismiss(animated: context.isAnimated, completion: completion)
             }
         } else {
             let dismissedRoute = context.dismissedRoutes.first!
             assert(context.dismissedRoutes.count == 1)
-
+            
             if case .outOfTime = dismissedRoute.route {
                 let coordinator = dismissedRoute.coordinator as! OutOfTimeCoordinator
-
+                
                 coordinator.popFromNavigationStack(
                     animated: context.isAnimated,
                     completion: completion
                 )
-
+                
                 coordinator.removeFromParent()
             } else {
                 assertionFailure("Unhandled dismissal for \(dismissedRoute.route)")
@@ -186,22 +186,22 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             }
         }
     }
-
+    
     func applicationRouter(_ router: ApplicationRouter, shouldPresent route: AppRoute) -> Bool {
         switch route {
         case .revoked:
             // Check if device is still revoked.
             return tunnelManager.deviceState == .revoked
-
+            
         case .outOfTime:
             // Check if device is still out of time.
             return tunnelManager.deviceState.accountData?.isExpired ?? false
-
+            
         default:
             return true
         }
     }
-
+    
     func applicationRouter(
         _ router: ApplicationRouter,
         shouldDismissWithContext context: RouteDismissalContext
@@ -213,14 +213,14 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
              */
             if dismissedRoute.route == .outOfTime {
                 let coordinator = dismissedRoute.coordinator as! OutOfTimeCoordinator
-
+                
                 return !coordinator.isMakingPayment
             }
-
+            
             return true
         }
     }
-
+    
     func applicationRouter(
         _ router: ApplicationRouter,
         handleSubNavigationWithContext context: RouteSubnavigationContext,
@@ -229,7 +229,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         switch context.route {
         case let .settings(subRoute):
             let coordinator = context.presentedRoute.coordinator as! SettingsCoordinator
-
+            
             if let subRoute = subRoute {
                 coordinator.navigate(
                     to: subRoute,
@@ -239,20 +239,20 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             } else {
                 completion()
             }
-
+            
         default:
             completion()
         }
     }
-
+    
     // MARK: - Private
-
+    
     /**
      Continues application flow by evaluating what route to present next.
      */
     private func continueFlow(animated: Bool) {
         let next = evaluateNextRoute()
-
+        
         /*
          On iPad the main route is always visible as it's a part of root controller hence we never
          ask router to navigate to it. Instead this is when we hide the primary horizontal
@@ -264,38 +264,38 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             router.present(next, animated: animated)
         }
     }
-
+    
     private func evaluateNextRoute() -> AppRoute {
         guard TermsOfService.isAgreed else {
             return .tos
         }
-
+        
         guard ChangeLog.isSeen else {
             return .changelog
         }
-
+        
         switch tunnelManager.deviceState {
         case .revoked:
             return .revoked
-
+            
         case .loggedOut:
             return .login
-
+            
         case let .loggedIn(accountData, _):
             return accountData.isExpired ? .outOfTime : .main
         }
     }
-
+    
     private func logoutRevokedDevice() {
         tunnelManager.unsetAccount { [weak self] in
             self?.continueFlow(animated: true)
         }
     }
-
+    
     private func didDismissSettings(_ reason: SettingsDismissReason) {
         if isPad {
             router.dismissAll(.settings, animated: true)
-
+            
             if reason == .userLoggedOut {
                 router.dismissAll(.primary, animated: true)
                 continueFlow(animated: true)
@@ -305,11 +305,11 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
                 router.dismissAll(.primary, animated: false)
                 continueFlow(animated: false)
             }
-
+            
             router.dismissAll(.settings, animated: true)
         }
     }
-
+    
     /**
      Navigation controller used for horizontal flows.
      */
@@ -320,19 +320,19 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             return primaryNavigationContainer
         }
     }
-
+    
     /**
      Begins horizontal flow presenting a navigation controller suitable for current user interface
      idiom.
-
+     
      On iPad this takes care of presenting a secondary navigation context using modal presentation.
-
+     
      On iPhone this does nothing.
      */
     private func beginHorizontalFlow(animated: Bool, completion: @escaping () -> Void) {
         if isPad, secondaryNavigationContainer.presentingViewController == nil {
             secondaryRootConfiguration.apply(to: secondaryNavigationContainer)
-
+            
             primaryNavigationContainer.present(
                 secondaryNavigationContainer,
                 animated: animated,
@@ -342,13 +342,13 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             completion()
         }
     }
-
+    
     /**
      Marks the end of horizontal flow.
-
+     
      On iPad this method dismisses the modally presented  secondary navigation container and
      releases all child view controllers from it.
-
+     
      Does nothing on iPhone.
      */
     private func endHorizontalFlow(animated: Bool = true, completion: (() -> Void)? = nil) {
@@ -358,190 +358,189 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             completion?()
         }
     }
-
+    
     private var isPad: Bool {
         return UIDevice.current.userInterfaceIdiom == .pad
     }
-
+    
     private func setupSplitView() {
         let tunnelCoordinator = makeTunnelCoordinator()
         let selectLocationCoordinator = makeSelectLocationCoordinator(forModalPresentation: false)
-
+        
         addChild(tunnelCoordinator)
         addChild(selectLocationCoordinator)
-
+        
         splitTunnelCoordinator = tunnelCoordinator
         splitLocationCoordinator = selectLocationCoordinator
-
+        
         splitViewController.delegate = self
         splitViewController.viewControllers = [
             selectLocationCoordinator.navigationController,
             tunnelCoordinator.rootViewController,
         ]
-
+        
         primaryNavigationContainer.setViewControllers([splitViewController], animated: false)
-
+        
         tunnelCoordinator.start()
         selectLocationCoordinator.start()
     }
-
+    
     private func presentTOS(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         let coordinator = TermsOfServiceCoordinator(navigationController: horizontalFlowController)
-
+        
         coordinator.didFinish = { [weak self] coordinator in
             self?.continueFlow(animated: true)
         }
-
+        
         addChild(coordinator)
         coordinator.start()
-
+        
         beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
-
+    
     private func presentChangeLog(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         let coordinator = ChangeLogCoordinator(navigationController: horizontalFlowController)
-
+        
         coordinator.didFinish = { [weak self] coordinator in
             self?.continueFlow(animated: true)
         }
-
+        
         addChild(coordinator)
         coordinator.start(animated: animated)
-
+        
         beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
-
+    
     private func presentMain(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         precondition(!isPad)
-
         let tunnelCoordinator = makeTunnelCoordinator()
-
+        
         horizontalFlowController.pushViewController(
             tunnelCoordinator.rootViewController,
             animated: animated
         )
-
+        
         addChild(tunnelCoordinator)
         tunnelCoordinator.start()
-
+        
         beginHorizontalFlow(animated: animated) {
             completion(tunnelCoordinator)
         }
     }
-
+    
     private func presentRevoked(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         let coordinator = RevokedCoordinator(
             navigationController: horizontalFlowController,
             tunnelManager: tunnelManager
         )
-
+        
         coordinator.didFinish = { [weak self] coordinator in
             self?.logoutRevokedDevice()
         }
-
+        
         addChild(coordinator)
         coordinator.start(animated: animated)
-
+        
         beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
-
+    
     private func presentOutOfTime(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         let coordinator = OutOfTimeCoordinator(
             navigationController: horizontalFlowController,
             storePaymentManager: storePaymentManager,
             tunnelManager: tunnelManager
         )
-
+        
         coordinator.didFinishPayment = { [weak self] coordinator in
             guard let self = self else { return }
-
+            
             if self.shouldDismissOutOfTime() {
                 self.router.dismiss(.outOfTime, animated: true)
-
+                
                 self.continueFlow(animated: true)
             }
         }
-
+        
         addChild(coordinator)
         coordinator.start(animated: animated)
-
+        
         beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
-
+    
     private func shouldDismissOutOfTime() -> Bool {
         return !(tunnelManager.deviceState.accountData?.isExpired ?? false)
     }
-
+    
     private func presentSelectLocation(
         animated: Bool,
         completion: @escaping (Coordinator) -> Void
     ) {
         let coordinator = makeSelectLocationCoordinator(forModalPresentation: true)
         coordinator.start()
-
+        
         presentChild(coordinator, animated: animated) {
             completion(coordinator)
         }
     }
-
+    
     private func presentLogin(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         let coordinator = LoginCoordinator(
             navigationController: horizontalFlowController,
             tunnelManager: tunnelManager,
             devicesProxy: devicesProxy
         )
-
+        
         coordinator.didFinish = { [weak self] coordinator in
             self?.continueFlow(animated: true)
         }
-
+        
         addChild(coordinator)
         coordinator.start(animated: animated)
-
+        
         beginHorizontalFlow(animated: animated) {
             completion(coordinator)
         }
     }
-
+    
     private func makeTunnelCoordinator() -> TunnelCoordinator {
         let tunnelCoordinator = TunnelCoordinator(tunnelManager: tunnelManager)
-
+        
         tunnelCoordinator.showSelectLocationPicker = { [weak self] in
             self?.router.present(.selectLocation, animated: true)
         }
-
+        
         return tunnelCoordinator
     }
-
+    
     private func makeSelectLocationCoordinator(forModalPresentation isModalPresentation: Bool)
-        -> SelectLocationCoordinator
+    -> SelectLocationCoordinator
     {
         let navigationController = CustomNavigationController()
         navigationController.isNavigationBarHidden = !isModalPresentation
-
+        
         let selectLocationCoordinator = SelectLocationCoordinator(
             navigationController: navigationController,
             tunnelManager: tunnelManager,
             relayCacheTracker: relayCacheTracker
         )
-
+        
         selectLocationCoordinator.didFinish = { [weak self] coordinator, relay in
             if isModalPresentation {
                 self?.router.dismiss(.selectLocation, animated: true)
             }
         }
-
+        
         return selectLocationCoordinator
     }
-
+    
     private func presentSettings(
         route: SettingsNavigationRoute?,
         animated: Bool,
@@ -552,25 +551,26 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             tunnelManager: tunnelManager,
             apiProxy: apiProxy
         )
-
+        
         let navigationController = CustomNavigationController()
         let coordinator = SettingsCoordinator(
             navigationController: navigationController,
             interactorFactory: interactorFactory
         )
-
+        
         coordinator.didFinish = { [weak self] coordinator, reason in
             self?.didDismissSettings(reason)
         }
-
+        
         coordinator.willNavigate = { [weak self] coordinator, from, to in
             if to == .root {
                 self?.onShowSettings?()
+                
             }
         }
-
+        
         coordinator.start(initialRoute: route)
-
+        
         presentChild(
             coordinator,
             animated: animated,
@@ -582,93 +582,101 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             completion(coordinator)
         }
     }
-
+    
     private func addTunnelObserver() {
         let tunnelObserver =
-            TunnelBlockObserver(didUpdateDeviceState: { [weak self] manager, deviceState in
-                self?.deviceStateDidChange(deviceState)
-            })
-
+        TunnelBlockObserver(didUpdateDeviceState: { [weak self] manager, deviceState in
+            self?.deviceStateDidChange(deviceState)
+            self?.updateView(deviceState: deviceState)
+        })
+        
         tunnelManager.addObserver(tunnelObserver)
-
+        
         self.tunnelObserver = tunnelObserver
-
+        
+        updateView(deviceState: tunnelManager.deviceState)
+        
         splitViewController.preferredDisplayMode = tunnelManager.deviceState.splitViewMode
     }
-
+    
     private func deviceStateDidChange(_ deviceState: DeviceState) {
         splitViewController.preferredDisplayMode = deviceState.splitViewMode
-
+        
         switch deviceState {
         case let .loggedIn(accountData, _):
             updateOutOfTimeTimer()
-
+            
             if !accountData.isExpired {
                 router.dismiss(.outOfTime, animated: true)
             }
-
+            
         case .revoked:
             cancelOutOfTimeTimer()
             router.present(.revoked, animated: true)
-
+            
         case .loggedOut:
             cancelOutOfTimeTimer()
         }
     }
-
+    
+    private func updateView(deviceState : DeviceState){
+        primaryNavigationContainer.update(deviceState: deviceState)
+        secondaryNavigationContainer.update(deviceState: deviceState)
+    }
+    
     // MARK: - Out of time
-
+    
     private func updateOutOfTimeTimer() {
         cancelOutOfTimeTimer()
-
+        
         guard let expiry = tunnelManager.deviceState.accountData?.expiry else { return }
-
+        
         let timer = Timer(fire: expiry, interval: 0, repeats: false, block: { [weak self] _ in
             self?.outOfTimeTimerDidFire()
         })
-
+        
         RunLoop.main.add(timer, forMode: .common)
-
+        
         outOfTimeTimer = timer
     }
-
+    
     private func outOfTimeTimerDidFire() {
         router.present(.outOfTime, animated: true)
     }
-
+    
     private func cancelOutOfTimeTimer() {
         outOfTimeTimer?.invalidate()
         outOfTimeTimer = nil
     }
-
+    
     // MARK: - Settings
-
+    
     var onShowSettings: (() -> Void)?
-
+    
     var isPresentingSettings: Bool {
         return router.isPresenting(.settings)
     }
-
+    
     // MARK: - Deep link
-
+    
     func showAccountSettings() {
         router.present(.settings(.account))
     }
-
+    
     // MARK: - UISplitViewControllerDelegate
-
+    
     func primaryViewController(forExpanding splitViewController: UISplitViewController)
-        -> UIViewController?
+    -> UIViewController?
     {
         return splitLocationCoordinator?.navigationController
     }
-
+    
     func primaryViewController(forCollapsing splitViewController: UISplitViewController)
-        -> UIViewController?
+    -> UIViewController?
     {
         return splitTunnelCoordinator?.rootViewController
     }
-
+    
     func splitViewController(
         _ splitViewController: UISplitViewController,
         collapseSecondary secondaryViewController: UIViewController,
@@ -676,20 +684,20 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     ) -> Bool {
         return true
     }
-
+    
     func splitViewController(
         _ splitViewController: UISplitViewController,
         separateSecondaryFrom primaryViewController: UIViewController
     ) -> UIViewController? {
         return nil
     }
-
+    
     func splitViewControllerDidExpand(_ svc: UISplitViewController) {
         router.dismissAll(.selectLocation, animated: false)
     }
-
+    
     // MARK: - RootContainerViewControllerDelegate
-
+    
     func rootContainerViewControllerShouldShowSettings(
         _ controller: RootContainerViewController,
         navigateTo route: SettingsNavigationRoute?,
@@ -697,9 +705,9 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     ) {
         router.present(.settings(route), animated: animated)
     }
-
+    
     func rootContainerViewSupportedInterfaceOrientations(_ controller: RootContainerViewController)
-        -> UIInterfaceOrientationMask
+    -> UIInterfaceOrientationMask
     {
         if isPad {
             return [.landscape, .portrait]
@@ -707,28 +715,31 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             return [.portrait]
         }
     }
-
+    
     func rootContainerViewAccessibilityPerformMagicTap(_ controller: RootContainerViewController)
-        -> Bool
+    -> Bool
     {
         guard tunnelManager.deviceState.isLoggedIn else { return false }
-
+        
         switch tunnelManager.tunnelStatus.state {
         case .connected, .connecting, .reconnecting, .waitingForConnectivity:
             tunnelManager.reconnectTunnel(selectNewRelay: true)
-
+            
         case .disconnecting, .disconnected:
             tunnelManager.startTunnel()
-
+            
         case .pendingReconnect:
             break
         }
-
         return true
     }
-
+    
+    func rootContainerViewControllerShouldShowAccountInfo(_ controller: RootContainerViewController) -> DeviceState {
+        tunnelManager.deviceState
+    }
+    
     // MARK: - Presenting
-
+    
     var presentationContext: UIViewController {
         return primaryNavigationContainer.presentedViewController ?? primaryNavigationContainer
     }

--- a/ios/MullvadVPN/en.lproj/Localizable.strings
+++ b/ios/MullvadVPN/en.lproj/Localizable.strings
@@ -3,3 +3,4 @@
 
 /* Title for system account expiry notification, fired 3 days prior to account expiry. */
 "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE" = "Account credit expires soon";
+


### PR DESCRIPTION
Add the device name and time left labels to the header after the user has closed the in-app banner message (see referenced card), Confluence and Zeplin links in Parent card

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4558)
<!-- Reviewable:end -->
