### PR TITLE
Add the device name and time left to the header

### DIFF
--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -26,6 +26,28 @@ class HeaderBarView: UIView {
         return imageView
     }()
 
+    private let deviceInfoHolder = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillProportionally
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private lazy var deviceName: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor(white: 1.0, alpha: 0.8)
+        return label
+    }()
+
+    private lazy var timeLeft: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = UIColor(white: 1.0, alpha: 0.8)
+        return label
+    }()
+
     let settingsButton = makeSettingsButton()
 
     class func makeSettingsButton() -> HeaderBarButton {
@@ -105,8 +127,8 @@ class HeaderBarView: UIView {
             ),
             brandNameImageView.heightAnchor.constraint(equalToConstant: 18),
             layoutMarginsGuide.bottomAnchor.constraint(
-                equalTo: brandNameImageView.bottomAnchor,
-                constant: 22
+                equalTo: deviceInfoHolder.bottomAnchor,
+                constant: 4
             ),
 
             settingsButton.leadingAnchor.constraint(
@@ -115,9 +137,14 @@ class HeaderBarView: UIView {
             ),
             settingsButton.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
             settingsButton.centerYAnchor.constraint(equalTo: brandNameImageView.centerYAnchor),
+
+            deviceInfoHolder.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            deviceInfoHolder.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            deviceInfoHolder.topAnchor.constraint(equalTo: logoImageView.bottomAnchor, constant: 7),
         ]
 
-        [logoImageView, brandNameImageView, settingsButton].forEach { addSubview($0) }
+        [logoImageView, brandNameImageView, settingsButton, deviceInfoHolder].forEach { addSubview($0) }
+        [deviceName, timeLeft].forEach { deviceInfoHolder.addArrangedSubview($0) }
 
         NSLayoutConstraint.activate(constraints)
     }
@@ -130,5 +157,37 @@ class HeaderBarView: UIView {
         super.layoutSubviews()
 
         borderLayer.frame = CGRect(x: 0, y: frame.maxY - 1, width: frame.width, height: 1)
+    }
+}
+
+extension HeaderBarView {
+    func update(deviceState: DeviceState) {
+        switch deviceState {
+        case let .loggedIn(storedAccountData, storedDeviceData):
+            let formattedDeviceName = NSLocalizedString(
+                "DEVICE_NAME_HEADER_VIEW",
+                tableName: nil,
+                value: "Device name : %@",
+                comment: ""
+            )
+            let formattedTimeLeft = NSLocalizedString(
+                "TIME_LEFT_HEADER_VIEW",
+                tableName: nil,
+                value: "Time left : %@",
+                comment: ""
+            )
+            deviceName.text = .init(format: formattedDeviceName, storedDeviceData.name)
+            timeLeft.text = .init(
+                format: formattedTimeLeft,
+                CustomDateComponentsFormatting.localizedString(
+                    from: Date(),
+                    to: storedAccountData.expiry,
+                    unitsStyle: .full
+                ) ?? ""
+            )
+            deviceInfoHolder.arrangedSubviews.forEach { $0.isHidden = false }
+        case .loggedOut, .revoked:
+            deviceInfoHolder.arrangedSubviews.forEach { $0.isHidden = true }
+        }
     }
 }

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -674,3 +674,9 @@ extension UIViewController {
         rootContainerController?.updateHeaderBarHiddenAppearance()
     }
 }
+
+extension RootContainerViewController {
+    func update(deviceState: DeviceState) {
+        headerBarView.update(deviceState: deviceState)
+    }
+}

--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -92,9 +92,9 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         self.devicesProxy = devicesProxy
 
         /*
-          Uncomment if you'd like to test TOS again
+         Uncomment if you'd like to test TOS again
          TermsOfService.unsetAgreed()
-          */
+         */
 
         super.init()
 
@@ -417,7 +417,6 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
 
     private func presentMain(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         precondition(!isPad)
-
         let tunnelCoordinator = makeTunnelCoordinator()
 
         horizontalFlowController.pushViewController(
@@ -587,11 +586,14 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         let tunnelObserver =
             TunnelBlockObserver(didUpdateDeviceState: { [weak self] manager, deviceState in
                 self?.deviceStateDidChange(deviceState)
+                self?.updateView(deviceState: deviceState)
             })
 
         tunnelManager.addObserver(tunnelObserver)
 
         self.tunnelObserver = tunnelObserver
+
+        updateView(deviceState: tunnelManager.deviceState)
 
         splitViewController.preferredDisplayMode = tunnelManager.deviceState.splitViewMode
     }
@@ -614,6 +616,11 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         case .loggedOut:
             cancelOutOfTimeTimer()
         }
+    }
+
+    private func updateView(deviceState: DeviceState) {
+        primaryNavigationContainer.update(deviceState: deviceState)
+        secondaryNavigationContainer.update(deviceState: deviceState)
     }
 
     // MARK: - Out of time
@@ -723,8 +730,11 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         case .pendingReconnect:
             break
         }
-
         return true
+    }
+
+    func rootContainerViewControllerShouldShowAccountInfo(_ controller: RootContainerViewController) -> DeviceState {
+        tunnelManager.deviceState
     }
 
     // MARK: - Presenting

--- a/ios/MullvadVPN/en.lproj/Localizable.strings
+++ b/ios/MullvadVPN/en.lproj/Localizable.strings
@@ -3,3 +3,4 @@
 
 /* Title for system account expiry notification, fired 3 days prior to account expiry. */
 "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE" = "Account credit expires soon";
+


### PR DESCRIPTION
Add the device name and time left labels to the header after the user has closed the in-app banner message (see referenced card), Confluence and Zeplin links in Parent card

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4559)
<!-- Reviewable:end -->
