### PR TITLE
Prevent close notification close handler from running when closing by category

### DIFF
--- a/gui/src/main/notification-controller.ts
+++ b/gui/src/main/notification-controller.ts
@@ -130,7 +130,9 @@ export default class NotificationController {
   ) {
     this.activeNotifications.forEach((notification) => {
       if (notification.specification.category === category) {
+        notification.notification.removeAllListeners('close');
         notification.notification.close();
+        this.activeNotifications.delete(notification);
       }
     });
     this.dismissedNotifications.forEach((notification) => {
@@ -248,7 +250,7 @@ export default class NotificationController {
 
   private addActiveNotification(notification: Notification) {
     notification.notification.on('close', () => {
-      this.dismissedNotifications.add({ ...notification.specification });
+      this.dismissedNotifications.add(notification.specification);
       this.activeNotifications.delete(notification);
       this.updateNotificationIcon();
     });


### PR DESCRIPTION
Sometimes the notification dot doesn't disappear when it should. I haven't been able to reproduce it consistently but I think this will solve the issue. The problem was that the close handler added the notification to the dismissed notifications when it should just have been removed from all lists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4563)
<!-- Reviewable:end -->
