### PR TITLE
Prevent using system-wide proxy settings in URLSession requests

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -31,6 +31,9 @@ Line wrap the file at 100 chars.                                              Th
 - Delay tunnel reconnection after a WireGuard private key rotates. Accounts for latency in key
   propagation to relays.
 
+### Fixed
+- Configure URLSession to ignore system proxy configuration.
+
 
 ## [2023.1] - 2023-03-21
 ### Added

--- a/ios/MullvadREST/RESTURLSession.swift
+++ b/ios/MullvadREST/RESTURLSession.swift
@@ -20,8 +20,11 @@ extension REST {
             trustedRootCertificates: [secCertificate]
         )
 
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.connectionProxyDictionary = [:]
+
         let session = URLSession(
-            configuration: .ephemeral,
+            configuration: sessionConfiguration,
             delegate: sessionDelegate,
             delegateQueue: nil
         )


### PR DESCRIPTION
URLSession configuration is initialized with option that enable it to use system wide proxy configuration. We should disable that to prevent users from proxying our API requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4565)
<!-- Reviewable:end -->
