### PR TITLE
Remove daemon connection observer when disconnecting during suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix location search in desktop app only searching for English location names.
 - Fix automatic WireGuard key rotation not being initialized correctly when not running the GUI.
+- Fix duplicated notifications in some situations.
 
 #### Android
 - Fix adaptive app icon which previously had a displaced nose and some other oddities.


### PR DESCRIPTION
When disconnecting the daemon during suspend the `ConnectionObserver` wasn't removed resulting in multiple active observers. This is probably the cause of the issue where people receive multiple of the same notifications although I haven't been able to reproduce it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4566)
<!-- Reviewable:end -->
