### PR TITLE
Missing header in problem report view

### DIFF
--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
@@ -340,7 +340,7 @@ final class ProblemReportViewController: UIViewController, UITextFieldDelegate {
 
     private func addConstraints() {
         activeMessageTextViewConstraints = [
-            messageTextView.topAnchor.constraint(equalTo: view.topAnchor),
+            messageTextView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             messageTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             messageTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             messageTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor),


### PR DESCRIPTION
As of 14/04/23, main has a broken text input for problem reports - none of the controls are shown. Can reproduce on iPhone Xr and an iPhone 13. The controls should be rendered as in the second screenshot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4575)
<!-- Reviewable:end -->
