### PR TITLE
Add informational dialog for local network sharing

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1359,10 +1359,6 @@ msgid "Adult content"
 msgstr ""
 
 msgctxt "vpn-settings-view"
-msgid "Allows access to other devices on the same network for sharing, printing etc."
-msgstr ""
-
-msgctxt "vpn-settings-view"
 msgid "Attention: enabling this will always require a Mullvad VPN connection in order to reach the internet."
 msgstr ""
 
@@ -1428,6 +1424,10 @@ msgid "Increases anonymity by routing your traffic into one %(wireguard)s server
 msgstr ""
 
 msgctxt "vpn-settings-view"
+msgid "It does this by allowing network communication outside the tunnel to local multicast and broadcast ranges as well as to and from these private IP ranges:"
+msgstr ""
+
+msgctxt "vpn-settings-view"
 msgid "Kill switch"
 msgstr ""
 
@@ -1473,6 +1473,10 @@ msgstr ""
 
 msgctxt "vpn-settings-view"
 msgid "This built-in feature prevents your traffic from leaking outside of the VPN tunnel if your network suddenly stops working or if the tunnel fails, it does this by blocking your traffic until your connection is reestablished."
+msgstr ""
+
+msgctxt "vpn-settings-view"
+msgid "This feature allows access to other devices on the local network, such as for sharing, printing, streaming, etc."
 msgstr ""
 
 msgctxt "vpn-settings-view"
@@ -1612,6 +1616,9 @@ msgid "Agree and continue"
 msgstr ""
 
 msgid "All applications"
+msgstr ""
+
+msgid "Allows access to other devices on the same network for sharing, printing etc."
 msgstr ""
 
 msgid "Always-on VPN assigned to other app"

--- a/gui/src/renderer/components/VpnSettings.tsx
+++ b/gui/src/renderer/components/VpnSettings.tsx
@@ -55,6 +55,11 @@ const StyledSectionItem = styled(Cell.Container)({
   backgroundColor: colors.blue40,
 });
 
+const LanIpRanges = styled.ul({
+  listStyle: 'disc outside',
+  marginLeft: '20px',
+});
+
 export default function VpnSettings() {
   const { pop } = useHistory();
 
@@ -197,20 +202,34 @@ function AllowLan() {
             {messages.pgettext('vpn-settings-view', 'Local network sharing')}
           </Cell.InputLabel>
         </AriaLabel>
+        <AriaDetails>
+          <InfoButton>
+            <ModalMessage>
+              {messages.pgettext(
+                'vpn-settings-view',
+                'This feature allows access to other devices on the local network, such as for sharing, printing, streaming, etc.',
+              )}
+            </ModalMessage>
+            <ModalMessage>
+              {messages.pgettext(
+                'vpn-settings-view',
+                'It does this by allowing network communication outside the tunnel to local multicast and broadcast ranges as well as to and from these private IP ranges:',
+              )}
+              <LanIpRanges>
+                <li>10.0.0.0/8</li>
+                <li>172.16.0.0/12</li>
+                <li>192.168.0.0/16</li>
+                <li>169.254.0.0/16</li>
+                <li>0xfe80::/10</li>
+                <li>0xfc00::/7</li>
+              </LanIpRanges>
+            </ModalMessage>
+          </InfoButton>
+        </AriaDetails>
         <AriaInput>
           <Cell.Switch isOn={allowLan} onChange={setAllowLan} />
         </AriaInput>
       </Cell.Container>
-      <Cell.CellFooter>
-        <AriaDescription>
-          <Cell.CellFooterText>
-            {messages.pgettext(
-              'vpn-settings-view',
-              'Allows access to other devices on the same network for sharing, printing etc.',
-            )}
-          </Cell.CellFooterText>
-        </AriaDescription>
-      </Cell.CellFooter>
     </AriaInputGroup>
   );
 }


### PR DESCRIPTION
This PR adds an informational dialog for the local network sharing setting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4576)
<!-- Reviewable:end -->
