### PR TITLE
Device name and time left should be closer together on large devices

### DIFF
--- a/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
+++ b/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
@@ -16,10 +16,7 @@ extension CustomDateComponentsFormatting {
     /// The behaviour of that method differs from `DateComponentsFormatter`:
     ///
     /// 1. Intervals of two years or more are formatted in years quantity.
-    /// 2. Intervals between 23h 30m - 23h 59m are rounded to 1 day to fix the iOS SDK bug which
-    ///    results in the wrong output ("0 months").
-    /// 3. Produce "Less than a minute" message for intervals below 1 minute.
-    /// 4. Intervals matching none of the above are formatted in days quantity.
+    /// 2. Otherwise intervals matching  are formatted in days quantity.
     ///
     static func localizedString(
         from start: Date,
@@ -37,23 +34,10 @@ extension CustomDateComponentsFormatting {
             .dateComponents([.year, .day, .hour, .minute, .second], from: start, to: end)
 
         let years = dateComponents.year ?? 0
-        let days = dateComponents.day ?? 0
-        let hours = dateComponents.hour ?? 0
-        let minutes = dateComponents.minute ?? 0
-        let seconds = dateComponents.second ?? 0
 
         if years >= 2 {
             formatter.allowedUnits = [.year]
             return formatter.string(from: dateComponents)
-        } else if days == 0, hours == 23, minutes >= 30 {
-            return formatter.string(from: DateComponents(calendar: calendar, day: 1))
-        } else if days == 0, hours == 0, minutes == 0, seconds < 60 {
-            return NSLocalizedString(
-                "LESS_THAN_ONE_MINUTE",
-                tableName: "CustomDateComponentsFormatting",
-                value: "Less than a minute",
-                comment: "Phrase used for less than 1 minute duration."
-            )
         } else {
             formatter.allowedUnits = [.day]
             return formatter.string(from: start, to: end)

--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -29,7 +29,8 @@ class HeaderBarView: UIView {
     private let deviceInfoHolder: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.distribution = .fillProportionally
+        stackView.distribution = .fill
+        stackView.spacing = 16.0
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -38,6 +39,7 @@ class HeaderBarView: UIView {
         let label = UILabel(frame: .zero)
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = UIColor(white: 1.0, alpha: 0.8)
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return label
     }()
 
@@ -45,6 +47,7 @@ class HeaderBarView: UIView {
         let label = UILabel(frame: .zero)
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = UIColor(white: 1.0, alpha: 0.8)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return label
     }()
 
@@ -128,7 +131,7 @@ class HeaderBarView: UIView {
             brandNameImageView.heightAnchor.constraint(equalToConstant: 18),
             layoutMarginsGuide.bottomAnchor.constraint(
                 equalTo: deviceInfoHolder.bottomAnchor,
-                constant: 4
+                constant: 8
             ),
 
             settingsButton.leadingAnchor.constraint(
@@ -138,9 +141,9 @@ class HeaderBarView: UIView {
             settingsButton.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
             settingsButton.centerYAnchor.constraint(equalTo: brandNameImageView.centerYAnchor),
 
-            deviceInfoHolder.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            deviceInfoHolder.leadingAnchor.constraint(equalTo: logoImageView.leadingAnchor),
             deviceInfoHolder.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
-            deviceInfoHolder.topAnchor.constraint(equalTo: logoImageView.bottomAnchor, constant: 7),
+            deviceInfoHolder.topAnchor.constraint(equalTo: logoImageView.bottomAnchor, constant: 8.0),
         ]
 
         [logoImageView, brandNameImageView, settingsButton, deviceInfoHolder].forEach { addSubview($0) }

--- a/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
+++ b/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
@@ -43,39 +43,6 @@ class CustomDateComponentsFormattingTests: XCTestCase {
         XCTAssertEqual(result, "\(expectedDays) days")
     }
 
-    func testCloseToOneDayFormatting() throws {
-        var dateComponents = DateComponents()
-        dateComponents.hour = 23
-        dateComponents.minute = 30
-
-        let (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
-
-        let result = CustomDateComponentsFormatting.localizedString(
-            from: startDate,
-            to: endDate,
-            calendar: calendar,
-            unitsStyle: .full
-        )
-
-        XCTAssertEqual(result, "1 day")
-    }
-
-    func testLessThanOneMinuteFormatting() throws {
-        var dateComponents = DateComponents()
-        dateComponents.second = 59
-
-        let (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
-
-        let result = CustomDateComponentsFormatting.localizedString(
-            from: startDate,
-            to: endDate,
-            calendar: calendar,
-            unitsStyle: .full
-        )
-
-        XCTAssertEqual(result, "Less than a minute")
-    }
-
     private func makeDateRange(addingComponents dateComponents: DateComponents) -> (Date, Date) {
         let startDate = Date()
         let endDate = calendar.date(byAdding: dateComponents, to: startDate)!


### PR DESCRIPTION
The gap between the two look good on a phone, but on eg. an iPad the gap is very wide.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4577)
<!-- Reviewable:end -->
