### PR TITLE
Fix clipboard permission request after electron upgrade

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -841,8 +841,8 @@ class ApplicationMain
   }
 
   private blockPermissionRequests() {
-    session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
-      callback(false);
+    session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+      callback(ALLOWED_PERMISSIONS.includes(permission));
     });
     session.defaultSession.setPermissionCheckHandler((_webContents, permission) =>
       ALLOWED_PERMISSIONS.includes(permission),


### PR DESCRIPTION
Apparently the clipboard permission handling changed a bit in Electron 23. This PR addresses that and makes the copy account number button work again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4579)
<!-- Reviewable:end -->
