### PR TITLE
Add GUI test for device revoked view

### DIFF
--- a/gui/src/renderer/components/DeviceRevokedView.tsx
+++ b/gui/src/renderer/components/DeviceRevokedView.tsx
@@ -66,7 +66,7 @@ export function DeviceRevokedView() {
             <StyledStatusIcon>
               <ImageView source="icon-fail" height={60} width={60} />
             </StyledStatusIcon>
-            <StyledTitle>
+            <StyledTitle data-testid="title">
               {messages.pgettext('device-management', 'Device is inactive')}
             </StyledTitle>
             <StyledMessage>

--- a/gui/test/e2e/installed/state-dependent/device-revoked.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/device-revoked.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import { Page } from 'playwright';
+import { RoutePath } from '../../../../src/renderer/lib/routes';
+import { TestUtils } from '../../utils';
+
+import { startInstalledApp } from '../installed-utils';
+
+// This test expects the daemon to be logged in to a revoked device.
+
+let page: Page;
+let util: TestUtils;
+
+test.beforeAll(async () => {
+  ({ page, util } = await startInstalledApp());
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test('App should fail to login', async () => {
+  expect(await util.currentRoute()).toEqual(RoutePath.deviceRevoked);
+
+  await expect(page.getByTestId('title')).toHaveText('Device is inactive');
+
+  expect(await util.waitForNavigation(() => {
+    page.getByText('Go to login').click();
+  })).toEqual(RoutePath.login);
+});


### PR DESCRIPTION
Thi PR adds a small GUI test for the device revoked view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4582)
<!-- Reviewable:end -->
