### PR TITLE
Add login error messages to localization templates

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -675,8 +675,20 @@ msgctxt "login-view"
 msgid "Failed to create account"
 msgstr ""
 
+#. Error message shown above login input when trying to login but the app fails
+#. to fetch the list of registered devices.
+msgctxt "login-view"
+msgid "Failed to fetch list of devices"
+msgstr ""
+
 msgctxt "login-view"
 msgid "Finishing upgrade."
+msgstr ""
+
+#. Error message shown above login input when trying to login with a non-existent
+#. account number.
+msgctxt "login-view"
+msgid "Invalid account number"
 msgstr ""
 
 msgctxt "login-view"
@@ -705,6 +717,8 @@ msgctxt "login-view"
 msgid "Please wait"
 msgstr ""
 
+#. Error message shown above login input when trying to login to an account with
+#. too many registered devices.
 msgctxt "login-view"
 msgid "Too many devices"
 msgstr ""
@@ -1649,9 +1663,6 @@ msgid "Enter MTU"
 msgstr ""
 
 msgid "Excluded applications"
-msgstr ""
-
-msgid "Failed to fetch list of devices"
 msgstr ""
 
 msgid "Going to login will unblock the internet on this device."

--- a/gui/src/main/errors.ts
+++ b/gui/src/main/errors.ts
@@ -1,6 +1,12 @@
+import { messages } from '../shared/gettext';
+
 export class InvalidAccountError extends Error {
   constructor() {
-    super('Invalid account number');
+    super(
+      // TRANSLATORS: Error message shown above login input when trying to login with a non-existent
+      // TRANSLATORS: account number.
+      messages.pgettext('login-view', 'Invalid account number'),
+    );
   }
 }
 
@@ -12,12 +18,20 @@ export class CommunicationError extends Error {
 
 export class TooManyDevicesError extends Error {
   constructor() {
-    super('Too many devices');
+    super(
+      // TRANSLATORS: Error message shown above login input when trying to login to an account with
+      // TRANSLATORS: too many registered devices.
+      messages.pgettext('login-view', 'Too many devices'),
+    );
   }
 }
 
 export class ListDevicesError extends Error {
   constructor() {
-    super('Failed to fetch list of devices');
+    super(
+      // TRANSLATORS: Error message shown above login input when trying to login but the app fails
+      // TRANSLATORS: to fetch the list of registered devices.
+      messages.pgettext('login-view', 'Failed to fetch list of devices'),
+    );
   }
 }


### PR DESCRIPTION
Previously the login error messages haven't been translated. This PR adds them to the localization templates to solve this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4583)
<!-- Reviewable:end -->
