### PR TITLE
Change "Time left" on iOS to days and years

### DIFF
--- a/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
+++ b/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
@@ -16,10 +16,7 @@ extension CustomDateComponentsFormatting {
     /// The behaviour of that method differs from `DateComponentsFormatter`:
     ///
     /// 1. Intervals of two years or more are formatted in years quantity.
-    /// 2. Intervals between 23h 30m - 23h 59m are rounded to 1 day to fix the iOS SDK bug which
-    ///    results in the wrong output ("0 months").
-    /// 3. Produce "Less than a minute" message for intervals below 1 minute.
-    /// 4. Intervals matching none of the above are formatted in days quantity.
+    /// 2. Otherwise intervals matching none of the above are formatted in days quantity.
     ///
     static func localizedString(
         from start: Date,
@@ -30,33 +27,19 @@ extension CustomDateComponentsFormatting {
         let formatter = DateComponentsFormatter()
         formatter.calendar = calendar
         formatter.unitsStyle = unitsStyle
-        formatter.allowedUnits = [.minute, .hour, .day, .month, .year]
         formatter.maximumUnitCount = 1
 
-        let dateComponents = calendar
-            .dateComponents([.year, .day, .hour, .minute, .second], from: start, to: end)
-
+        let dateComponents = calendar.dateComponents([.year, .day], from: start, to: end)
         let years = dateComponents.year ?? 0
-        let days = dateComponents.day ?? 0
-        let hours = dateComponents.hour ?? 0
-        let minutes = dateComponents.minute ?? 0
-        let seconds = dateComponents.second ?? 0
+        var days = dateComponents.day ?? 0
 
         if years >= 2 {
             formatter.allowedUnits = [.year]
             return formatter.string(from: dateComponents)
-        } else if days == 0, hours == 23, minutes >= 30 {
-            return formatter.string(from: DateComponents(calendar: calendar, day: 1))
-        } else if days == 0, hours == 0, minutes == 0, seconds < 60 {
-            return NSLocalizedString(
-                "LESS_THAN_ONE_MINUTE",
-                tableName: "CustomDateComponentsFormatting",
-                value: "Less than a minute",
-                comment: "Phrase used for less than 1 minute duration."
-            )
-        } else {
+        } else if days > 0 {
             formatter.allowedUnits = [.day]
             return formatter.string(from: start, to: end)
         }
+        return formatter.string(from: DateComponents(calendar: calendar, day: 0))
     }
 }

--- a/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
+++ b/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
@@ -57,23 +57,7 @@ class CustomDateComponentsFormattingTests: XCTestCase {
             unitsStyle: .full
         )
 
-        XCTAssertEqual(result, "1 day")
-    }
-
-    func testLessThanOneMinuteFormatting() throws {
-        var dateComponents = DateComponents()
-        dateComponents.second = 59
-
-        let (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
-
-        let result = CustomDateComponentsFormatting.localizedString(
-            from: startDate,
-            to: endDate,
-            calendar: calendar,
-            unitsStyle: .full
-        )
-
-        XCTAssertEqual(result, "Less than a minute")
+        XCTAssertEqual(result, "0 days")
     }
 
     private func makeDateRange(addingComponents dateComponents: DateComponents) -> (Date, Date) {


### PR DESCRIPTION
In the app we have some platforms that round 5.99 months to 5 months, this is misleading and we want to be clear on how much time a user has left.

It was decided that we will use days and years only to display the time left:

- If a user has more than 2 years (730 days) left of time it should be displayed in whole years rounded down. (Divide the number of days with 365 and round down)

- If a user has less than 2 years left (e.g. 729 days) then this should be displayed in days.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4586)
<!-- Reviewable:end -->
