### PR TITLE
Add help and version command line flags to the electron app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Log select settings on each connection attempt.
+- Add `--help` and `--version` options to the desktop GUI application.
 
 #### Android
 - Add DNS content blockers.

--- a/gui/src/main/command-line-options.ts
+++ b/gui/src/main/command-line-options.ts
@@ -1,17 +1,47 @@
-enum CommandLineOptions {
-  showChanges = '--show-changes',
-  disableResetNavigation = '--disable-reset-navigation', // development only
-  disableDevtoolsOpen = '--disable-devtools-open', // development only
-  forwardRendererLog = '--forward-renderer-log', // development only
+class CommandLineOption {
+  private options: string[];
+
+  public constructor(private description: string, ...options: string[]) {
+    this.options = options;
+  }
+
+  public get match(): boolean {
+    return this.options.some((option) => process.argv.includes(option));
+  }
+
+  public format(): string {
+    return formatOption(this.description, ...this.options);
+  }
 }
 
-export const SHOULD_SHOW_CHANGES = process.argv.includes(CommandLineOptions.showChanges);
-export const SHOULD_DISABLE_RESET_NAVIGATION = process.argv.includes(
-  CommandLineOptions.disableResetNavigation,
-);
-export const SHOULD_DISABLE_DEVTOOLS_OPEN = process.argv.includes(
-  CommandLineOptions.disableDevtoolsOpen,
-);
-export const SHOULD_FORWARD_RENDERER_LOG = process.argv.includes(
-  CommandLineOptions.forwardRendererLog,
-);
+class DevelopmentCommandLineOption extends CommandLineOption {
+  public constructor(...options: string[]) {
+    super('', ...options);
+  }
+
+  public get match(): boolean {
+    return process.env.NODE_ENV === 'development' && super.match;
+  }
+}
+
+export const CommandLineOptions = {
+  showChanges: new CommandLineOption('Show changes dialog', '--show-changes'),
+  disableResetNavigation: new DevelopmentCommandLineOption('--disable-reset-navigation'),
+  disableDevtoolsOpen: new DevelopmentCommandLineOption('--disable-devtools-open'),
+  forwardRendererLog: new DevelopmentCommandLineOption('--forward-renderer-log'),
+} as const;
+
+export function printCommandLineOptions() {
+  Object.values(CommandLineOptions).forEach((option) => {
+    if (!(option instanceof DevelopmentCommandLineOption)) {
+      console.log(option.format());
+    }
+  });
+}
+
+function formatOption(description: string, ...options: string[]) {
+  const joinedOptions = options.join(', ');
+  const padding = '                    ';
+  const paddedOptions = (joinedOptions + padding).slice(0, -joinedOptions.length);
+  return '    ' + paddedOptions + description;
+}

--- a/gui/src/main/command-line-options.ts
+++ b/gui/src/main/command-line-options.ts
@@ -26,6 +26,7 @@ class DevelopmentCommandLineOption extends CommandLineOption {
 
 export const CommandLineOptions = {
   help: new CommandLineOption('Print this help text', '--help', '-h'),
+  version: new CommandLineOption('Print the app version', '--version'),
   showChanges: new CommandLineOption('Show changes dialog', '--show-changes'),
   disableResetNavigation: new DevelopmentCommandLineOption('--disable-reset-navigation'),
   disableDevtoolsOpen: new DevelopmentCommandLineOption('--disable-devtools-open'),

--- a/gui/src/main/command-line-options.ts
+++ b/gui/src/main/command-line-options.ts
@@ -1,22 +1,22 @@
 class CommandLineOption {
-  private options: string[];
+  private flags: string[];
 
-  public constructor(private description: string, ...options: string[]) {
-    this.options = options;
+  public constructor(private description: string, ...flags: string[]) {
+    this.flags = flags;
   }
 
   public get match(): boolean {
-    return this.options.some((option) => process.argv.includes(option));
+    return this.flags.some((flag) => process.argv.includes(flag));
   }
 
   public format(): string {
-    return formatOption(this.description, ...this.options);
+    return formatOption(this.description, ...this.flags);
   }
 }
 
 class DevelopmentCommandLineOption extends CommandLineOption {
-  public constructor(...options: string[]) {
-    super('', ...options);
+  public constructor(...flags: string[]) {
+    super('', ...flags);
   }
 
   public get match(): boolean {
@@ -25,6 +25,7 @@ class DevelopmentCommandLineOption extends CommandLineOption {
 }
 
 export const CommandLineOptions = {
+  help: new CommandLineOption('Print this help text', '--help', '-h'),
   showChanges: new CommandLineOption('Show changes dialog', '--show-changes'),
   disableResetNavigation: new DevelopmentCommandLineOption('--disable-reset-navigation'),
   disableDevtoolsOpen: new DevelopmentCommandLineOption('--disable-devtools-open'),
@@ -39,9 +40,18 @@ export function printCommandLineOptions() {
   });
 }
 
-function formatOption(description: string, ...options: string[]) {
-  const joinedOptions = options.join(', ');
+export function printElectronOptions() {
+  console.log(formatOption('Run without renderer process sandboxed', '--no-sandbox'));
+  console.log(formatOption('Run without hardware acceleration for graphics', '--disable-gpu'));
+}
+
+// This functions format options into one line, e.g.
+//     --help              Print this help text
+// The line starts with 4 spaces and the flags and description are separated with spaces to align
+// the descriptions
+function formatOption(description: string, ...flags: string[]) {
+  const joinedFlags = flags.join(', ');
   const padding = '                    ';
-  const paddedOptions = (joinedOptions + padding).slice(0, -joinedOptions.length);
-  return '    ' + paddedOptions + description;
+  const paddedFlags = (joinedFlags + padding).slice(0, -joinedFlags.length);
+  return '    ' + paddedFlags + description;
 }

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -27,7 +27,11 @@ import {
 import Account, { AccountDelegate, LocaleProvider } from './account';
 import { getOpenAtLogin } from './autostart';
 import { readChangelog } from './changelog';
-import { CommandLineOptions, printCommandLineOptions } from './command-line-options';
+import {
+  CommandLineOptions,
+  printCommandLineOptions,
+  printElectronOptions,
+} from './command-line-options';
 import { ConnectionObserver, DaemonRpc, SubscriptionListener } from './daemon-rpc';
 import Expectation from './expectation';
 import { IpcMainEventChannel } from './ipc-event-channel';
@@ -1040,5 +1044,20 @@ class ApplicationMain
   /* eslint-enable @typescript-eslint/member-ordering */
 }
 
-const applicationMain = new ApplicationMain();
-applicationMain.run();
+if (CommandLineOptions.help.match) {
+  console.log('Mullvad VPN');
+  console.log('Graphical interface for managing the Mullvad VPN daemon');
+
+  console.log('');
+  console.log('OPTIONS:');
+  printCommandLineOptions();
+
+  console.log('');
+  console.log('USEFUL ELECTRON/CHROMIUM OPTIONS:');
+  printElectronOptions();
+
+  process.exit(0);
+} else {
+  const applicationMain = new ApplicationMain();
+  applicationMain.run();
+}

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -27,7 +27,7 @@ import {
 import Account, { AccountDelegate, LocaleProvider } from './account';
 import { getOpenAtLogin } from './autostart';
 import { readChangelog } from './changelog';
-import { SHOULD_DISABLE_RESET_NAVIGATION, SHOULD_SHOW_CHANGES } from './command-line-options';
+import { CommandLineOptions, printCommandLineOptions } from './command-line-options';
 import { ConnectionObserver, DaemonRpc, SubscriptionListener } from './daemon-rpc';
 import Expectation from './expectation';
 import { IpcMainEventChannel } from './ipc-event-channel';
@@ -400,7 +400,7 @@ class ApplicationMain
       this,
       this.daemonRpc,
       SANDBOX_DISABLED,
-      SHOULD_DISABLE_RESET_NAVIGATION,
+      CommandLineOptions.disableResetNavigation.match,
     );
 
     this.tunnelStateExpectation = new Expectation(async () => {
@@ -720,7 +720,7 @@ class ApplicationMain
       windowsSplitTunnelingApplications: this.windowsSplitTunnelingApplications,
       macOsScrollbarVisibility: this.macOsScrollbarVisibility,
       changelog: this.changelog ?? [],
-      forceShowChanges: SHOULD_SHOW_CHANGES,
+      forceShowChanges: CommandLineOptions.showChanges.match,
       navigationHistory: this.navigationHistory,
     }));
 

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -60,7 +60,7 @@ import TunnelStateHandler, {
   TunnelStateProvider,
 } from './tunnel-state';
 import UserInterface, { UserInterfaceDelegate } from './user-interface';
-import Version from './version';
+import Version, { GUI_VERSION } from './version';
 
 const execAsync = util.promisify(exec);
 
@@ -1055,6 +1055,11 @@ if (CommandLineOptions.help.match) {
   console.log('');
   console.log('USEFUL ELECTRON/CHROMIUM OPTIONS:');
   printElectronOptions();
+
+  process.exit(0);
+} else if (CommandLineOptions.version.match) {
+  console.log(GUI_VERSION);
+  console.log('Electron version:', process.versions.electron);
 
   process.exit(0);
 } else {

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -10,7 +10,7 @@ import { IAccountData, ILocation, TunnelState } from '../shared/daemon-rpc-types
 import { messages, relayLocations } from '../shared/gettext';
 import log from '../shared/logging';
 import { Scheduler } from '../shared/scheduler';
-import { SHOULD_DISABLE_DEVTOOLS_OPEN, SHOULD_FORWARD_RENDERER_LOG } from './command-line-options';
+import { CommandLineOptions } from './command-line-options';
 import { DaemonRpc } from './daemon-rpc';
 import {
   changeIpcWebContents,
@@ -110,12 +110,12 @@ export default class UserInterface implements WindowControllerDelegate {
     if (process.env.NODE_ENV === 'development') {
       await this.installDevTools();
 
-      if (!SHOULD_DISABLE_DEVTOOLS_OPEN) {
+      if (!CommandLineOptions.disableDevtoolsOpen.match) {
         // The devtools doesn't open on Windows if openDevTools is called without a delay here.
         window.once('ready-to-show', () => window.webContents.openDevTools({ mode: 'detach' }));
       }
 
-      if (SHOULD_FORWARD_RENDERER_LOG) {
+      if (CommandLineOptions.forwardRendererLog.match) {
         log.addInput(new WebContentsConsoleInput(window.webContents));
       }
     }

--- a/gui/src/main/version.ts
+++ b/gui/src/main/version.ts
@@ -13,7 +13,7 @@ import { DaemonRpc } from './daemon-rpc';
 import { IpcMainEventChannel } from './ipc-event-channel';
 import { NotificationSender } from './notification-controller';
 
-const GUI_VERSION = app.getVersion().replace('.0', '');
+export const GUI_VERSION = app.getVersion().replace('.0', '');
 /// Mirrors the beta check regex in the daemon. Matches only well formed beta versions
 const IS_BETA = /^(\d{4})\.(\d+)-beta(\d+)$/;
 


### PR DESCRIPTION
This PR adds help and version output when `--help`/`-h` and `--version` is provided. Closes https://github.com/mullvad/mullvadvpn-app/issues/3161.

```
$ /opt/Mullvad\ VPN/mullvad-vpn --help
Mullvad VPN
Graphical interface for managing the Mullvad VPN daemon

OPTIONS:
    --help, -h          Print this help text
    --version           Print the app version
    --show-changes      Show changes dialog

USEFUL ELECTRON/CHROMIUM OPTIONS:
    --no-sandbox        Run without renderer process sandboxed
    --disable-gpu       Run without hardware acceleration for graphics
```

```
$ /opt/Mullvad\ VPN/mullvad-vpn --version
2023.3-dev-87dab7
Electron version: 23.2.0
```
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4589)
<!-- Reviewable:end -->
