### PR TITLE
Add shadowsocks bridges parsing

### DIFF
--- a/ios/MullvadREST/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ServerRelaysResponse.swift
@@ -82,16 +82,41 @@ extension REST {
         }
     }
 
+    public struct ServerShadowsocks: Codable {
+        public let `protocol`: String
+        public let port: UInt16
+        public let cipher: String
+        public let password: String
+
+        public init(protocol: String, port: UInt16, cipher: String, password: String) {
+            self.protocol = `protocol`
+            self.port = port
+            self.cipher = cipher
+            self.password = password
+        }
+    }
+
+    public struct ServerBridges: Codable {
+        public let shadowsocks: [ServerShadowsocks]
+
+        public init(shadowsocks: [REST.ServerShadowsocks]) {
+            self.shadowsocks = shadowsocks
+        }
+    }
+
     public struct ServerRelaysResponse: Codable {
         public let locations: [String: ServerLocation]
         public let wireguard: ServerWireguardTunnels
+        public let bridge: ServerBridges
 
         public init(
             locations: [String: REST.ServerLocation],
-            wireguard: REST.ServerWireguardTunnels
+            wireguard: REST.ServerWireguardTunnels,
+            bridge: ServerBridges
         ) {
             self.locations = locations
             self.wireguard = wireguard
+            self.bridge = bridge
         }
     }
 }

--- a/ios/MullvadVPNTests/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/RelaySelectorTests.swift
@@ -112,5 +112,6 @@ private let sampleRelays = REST.ServerRelaysResponse(
                 includeInCountry: true
             ),
         ]
-    )
+    ),
+    bridge: REST.ServerBridges(shadowsocks: [])
 )

--- a/ios/RelaySelector/RelaySelector.swift
+++ b/ios/RelaySelector/RelaySelector.swift
@@ -11,6 +11,13 @@ import MullvadREST
 import MullvadTypes
 
 public enum RelaySelector {
+    /**
+     Returns random shadowsocks TCP bridge, otherwise `nil` if there are no shadowdsocks bridges.
+     */
+    public static func getShadowsocksTCPBridge(relays: REST.ServerRelaysResponse) -> REST.ServerShadowsocks? {
+        return relays.bridge.shadowsocks.filter { $0.protocol == "tcp" }.randomElement()
+    }
+
     public static func evaluate(
         relays: REST.ServerRelaysResponse,
         constraints: RelayConstraints

--- a/ios/RelaySelector/RelaySelector.swift
+++ b/ios/RelaySelector/RelaySelector.swift
@@ -144,10 +144,7 @@ public enum RelaySelector {
         }
     }
 
-    private static func parseRelaysResponse(
-        _ response: REST
-            .ServerRelaysResponse
-    ) -> [RelayWithLocation] {
+    private static func parseRelaysResponse(_ response: REST.ServerRelaysResponse) -> [RelayWithLocation] {
         return response.wireguard.relays.compactMap { serverRelay -> RelayWithLocation? in
             guard let serverLocation = response.locations[serverRelay.location] else { return nil }
 

--- a/ios/RelaySelector/RelaySelector.swift
+++ b/ios/RelaySelector/RelaySelector.swift
@@ -18,6 +18,10 @@ public enum RelaySelector {
         return relays.bridge.shadowsocks.filter { $0.protocol == "tcp" }.randomElement()
     }
 
+    /**
+     Filters relay list using given constraints and selects random relay.
+     Throws an error if there are no relays satisfying the given constraints.
+     */
     public static func evaluate(
         relays: REST.ServerRelaysResponse,
         constraints: RelayConstraints


### PR DESCRIPTION
This PR adds shadowsocks parsing from relay list and exposes a function to fetch random shadowsocks TCP bridge via `RelaySelector`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4590)
<!-- Reviewable:end -->
