### PR TITLE
Enable pointer events on the new view when transitioning

### DIFF
--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -39,17 +39,11 @@ interface IState {
   nextItemTransition?: Partial<IItemStyle>;
 }
 
-export const StyledTransitionContainer = styled.div(
-  {},
-  (props: { disableUserInteraction: boolean }) => ({
-    flex: 1,
-    pointerEvents: props.disableUserInteraction ? 'none' : undefined,
-  }),
-);
+export const StyledTransitionContainer = styled.div({ flex: 1 });
 
 export const StyledTransitionContent = styled.div.attrs({ 'data-testid': 'transition-content' })(
   {},
-  (props: { transition?: IItemStyle }) => {
+  (props: { transition?: IItemStyle; disableUserInteraction?: boolean }) => {
     const x = `${props.transition?.x ?? 0}%`;
     const y = `${props.transition?.y ?? 0}%`;
     const duration = props.transition?.duration ?? 450;
@@ -66,6 +60,7 @@ export const StyledTransitionContent = styled.div.attrs({ 'data-testid': 'transi
       willChange: 'transform',
       transform: `translate3d(${x}, ${y}, 0)`,
       transition: `transform ${duration}ms ease-in-out`,
+      pointerEvents: props.disableUserInteraction ? 'none' : undefined,
     };
   },
 );
@@ -132,13 +127,14 @@ export default class TransitionContainer extends React.Component<IProps, IState>
     const willExit = this.state.queuedItem !== undefined || this.state.nextItem !== undefined;
 
     return (
-      <StyledTransitionContainer disableUserInteraction={willExit}>
+      <StyledTransitionContainer>
         {this.state.currentItem && (
           <WillExit key={this.state.currentItem.view.props.routePath} value={willExit}>
             <StyledTransitionContent
               ref={this.setCurrentContentRef}
               transition={this.state.currentItemStyle}
-              onTransitionEnd={this.onTransitionEnd}>
+              onTransitionEnd={this.onTransitionEnd}
+              disableUserInteraction={willExit}>
               {this.state.currentItem.view}
             </StyledTransitionContent>
           </WillExit>


### PR DESCRIPTION
Currently we prevent pointer events on both views when transitioning. This causes some issues on macOS where scrolling is disabled until you stop scrolling if you started scrolling on a view with `pointer-events: none`. This means that scrolling will be disabled until the user stops scrolling. I've solved this by enabling pointer events on the new view since I can only see reasons to prevent it for the previous view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4593)
<!-- Reviewable:end -->
