### PR TITLE
Reduce code duplication in data sources IOS-123

### DIFF
--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
@@ -26,36 +26,14 @@ final class PreferencesCellFactory: CellFactoryProtocol {
     }
 
     func makeCell(for item: PreferencesDataSource.Item, indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell
-
-        switch item {
-        case .addDNSServer:
-            cell = tableView.dequeueReusableCell(
-                withIdentifier: PreferencesDataSource.CellReuseIdentifiers.addDNSServer.rawValue,
-                for: indexPath
-            )
-        case .dnsServer:
-            cell = tableView.dequeueReusableCell(
-                withIdentifier: PreferencesDataSource.CellReuseIdentifiers.dnsServer.rawValue,
-                for: indexPath
-            )
-        default:
-            cell = tableView.dequeueReusableCell(
-                withIdentifier: PreferencesDataSource.CellReuseIdentifiers.settingSwitch.rawValue,
-                for: indexPath
-            )
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: item.reuseIdentifier.rawValue, for: indexPath)
 
         configureCell(cell, item: item, indexPath: indexPath)
 
         return cell
     }
 
-    func configureCell(
-        _ cell: UITableViewCell,
-        item: PreferencesDataSource.Item,
-        indexPath: IndexPath
-    ) {
+    func configureCell(_ cell: UITableViewCell, item: PreferencesDataSource.Item, indexPath: IndexPath) {
         switch item {
         case .blockAdvertising:
             guard let cell = cell as? SettingsSwitchCell else { return }

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
@@ -86,6 +86,17 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                 return false
             }
         }
+
+        var reuseIdentifier: PreferencesDataSource.CellReuseIdentifiers {
+            switch self {
+            case .addDNSServer:
+                return .addDNSServer
+            case .dnsServer:
+                return .dnsServer
+            default:
+                return .settingSwitch
+            }
+        }
     }
 
     private var isEditing = false

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCellFactory.swift
@@ -34,11 +34,7 @@ final class LocationCellFactory: CellFactoryProtocol {
         return cell
     }
 
-    func configureCell(
-        _ cell: UITableViewCell,
-        item: RelayLocation,
-        indexPath: IndexPath
-    ) {
+    func configureCell(_ cell: UITableViewCell, item: RelayLocation, indexPath: IndexPath) {
         guard let cell = cell as? SelectLocationCell,
               let node = nodeByLocation[item] else { return }
 

--- a/ios/MullvadVPN/View controllers/Settings/SettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCellFactory.swift
@@ -18,31 +18,14 @@ struct SettingsCellFactory: CellFactoryProtocol {
     }
 
     func makeCell(for item: SettingsDataSource.Item, indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell
-
-        switch item {
-        case .account:
-            cell = tableView.dequeueReusableCell(
-                withIdentifier: SettingsDataSource.CellReuseIdentifiers.accountCell.rawValue,
-                for: indexPath
-            )
-        default:
-            cell = tableView.dequeueReusableCell(
-                withIdentifier: SettingsDataSource.CellReuseIdentifiers.basicCell.rawValue,
-                for: indexPath
-            )
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: item.reuseIdentifier.rawValue, for: indexPath)
 
         configureCell(cell, item: item, indexPath: indexPath)
 
         return cell
     }
 
-    func configureCell(
-        _ cell: UITableViewCell,
-        item: SettingsDataSource.Item,
-        indexPath: IndexPath
-    ) {
+    func configureCell(_ cell: UITableViewCell, item: SettingsDataSource.Item, indexPath: IndexPath) {
         switch item {
         case .account:
             guard let cell = cell as? SettingsAccountCell else { return }

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
@@ -49,6 +49,15 @@ final class SettingsDataSource: UITableViewDiffableDataSource<
         case version
         case problemReport
         case faq
+
+        var reuseIdentifier: CellReuseIdentifiers {
+            switch self {
+            case .account:
+                return .accountCell
+            default:
+                return .basicCell
+            }
+        }
     }
 
     private let interactor: SettingsInteractor


### PR DESCRIPTION
This is something that came up today during one of code reviews. 

We have a lot of code paths where we keep repeating ourselves. This is especially the case when it comes to dequeuing reusable cells.

This PR makes sure that data source items can return the corresponding `CellReuseIdentifiers` identifier. The code that resolves reuse identifier is located in the data source next to `CellReuseIdentifiers`.  That's because they seem to be very well connected and better be kept together for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4595)
<!-- Reviewable:end -->
