### PR TITLE
Upgrade h2 crate to avoid RUSTSEC-2023-0034

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
What the title says. `cargo deny` started reporting this CVE in my other PR, so we better upgrade this asap. I do not believe the CVE affects our app in any way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4599)
<!-- Reviewable:end -->
