### PR TITLE
Clippy fix windows 2

### DIFF
--- a/mullvad-daemon/src/migrations/v6.rs
+++ b/mullvad-daemon/src/migrations/v6.rs
@@ -91,7 +91,6 @@ fn version_matches(settings: &mut serde_json::Value) -> bool {
 #[cfg(test)]
 mod test {
     use super::{migrate, migrate_pq_setting, version_matches};
-    use serde_json;
 
     pub const V6_SETTINGS: &str = r#"
 {

--- a/mullvad-paths/src/windows.rs
+++ b/mullvad-paths/src/windows.rs
@@ -153,7 +153,7 @@ fn adjust_token_privilege(
         return Err(std::io::Error::last_os_error());
     }
 
-    let mut privileges = TOKEN_PRIVILEGES {
+    let privileges = TOKEN_PRIVILEGES {
         PrivilegeCount: 1,
         Privileges: [LUID_AND_ATTRIBUTES {
             Luid: privilege_luid,
@@ -164,7 +164,7 @@ fn adjust_token_privilege(
         AdjustTokenPrivileges(
             token_handle,
             0,
-            &mut privileges,
+            &privileges,
             0,
             ptr::null_mut(),
             ptr::null_mut(),

--- a/talpid-core/src/dns/windows/auto.rs
+++ b/talpid-core/src/dns/windows/auto.rs
@@ -44,13 +44,11 @@ impl DnsMonitorT for DnsMonitor {
     type Error = super::Error;
 
     fn new() -> Result<Self, Self::Error> {
-        let current_monitor;
-
-        if iphlpapi::DnsMonitor::is_supported() {
-            current_monitor = InnerMonitor::Iphlpapi(iphlpapi::DnsMonitor::new()?);
+        let current_monitor = if iphlpapi::DnsMonitor::is_supported() {
+            InnerMonitor::Iphlpapi(iphlpapi::DnsMonitor::new()?)
         } else {
-            current_monitor = InnerMonitor::Netsh(netsh::DnsMonitor::new()?);
-        }
+            InnerMonitor::Netsh(netsh::DnsMonitor::new()?)
+        };
 
         Ok(Self { current_monitor })
     }

--- a/talpid-core/src/dns/windows/auto.rs
+++ b/talpid-core/src/dns/windows/auto.rs
@@ -84,7 +84,7 @@ impl DnsMonitor {
             Err(super::Error::Iphlpapi(iphlpapi::Error::SetInterfaceDnsSettings(error))) => {
                 *error == RPC_S_SERVER_UNAVAILABLE
             }
-            Err(super::Error::Netsh(netsh::Error::NetshError(Some(1)))) => true,
+            Err(super::Error::Netsh(netsh::Error::Netsh(Some(1)))) => true,
             _ => false,
         };
         if is_dnscache_error {

--- a/talpid-core/src/dns/windows/iphlpapi.rs
+++ b/talpid-core/src/dns/windows/iphlpapi.rs
@@ -29,11 +29,11 @@ use windows_sys::{
 pub enum Error {
     /// Failure to obtain an interface LUID given an alias.
     #[error(display = "Failed to obtain LUID for the interface alias")]
-    InterfaceLuidError(#[error(source)] io::Error),
+    ObtainInterfaceLuid(#[error(source)] io::Error),
 
     /// Failure to obtain an interface GUID.
     #[error(display = "Failed to obtain GUID for the interface")]
-    InterfaceGuidError(#[error(source)] io::Error),
+    ObtainInterfaceGuid(#[error(source)] io::Error),
 
     /// Failed to set DNS settings on interface.
     #[error(display = "Failed to set DNS settings on interface: {}", _0)]
@@ -41,7 +41,7 @@ pub enum Error {
 
     /// Failure to flush DNS cache.
     #[error(display = "Failed to flush DNS resolver cache")]
-    FlushResolverCacheError(#[error(source)] super::dnsapi::Error),
+    FlushResolverCache(#[error(source)] super::dnsapi::Error),
 
     /// Failed to load iphlpapi.dll.
     #[error(display = "Failed to load iphlpapi.dll")]
@@ -117,8 +117,8 @@ impl DnsMonitorT for DnsMonitor {
     }
 
     fn set(&mut self, interface: &str, servers: &[IpAddr]) -> Result<(), Error> {
-        let guid = guid_from_luid(&luid_from_alias(interface).map_err(Error::InterfaceLuidError)?)
-            .map_err(Error::InterfaceGuidError)?;
+        let guid = guid_from_luid(&luid_from_alias(interface).map_err(Error::ObtainInterfaceLuid)?)
+            .map_err(Error::ObtainInterfaceGuid)?;
 
         let mut v4_servers = vec![];
         let mut v6_servers = vec![];
@@ -208,5 +208,5 @@ fn set_interface_dns_servers<T: ToString>(
 }
 
 fn flush_dns_cache() -> Result<(), Error> {
-    super::dnsapi::flush_resolver_cache().map_err(Error::FlushResolverCacheError)
+    super::dnsapi::flush_resolver_cache().map_err(Error::FlushResolverCache)
 }

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -338,7 +338,6 @@ pub extern "system" fn log_sink(
     if msg.is_null() {
         log::error!("Log message from FFI boundary is NULL");
     } else {
-        let rust_log_level = log::Level::from(level);
         let target = if context.is_null() {
             "UNKNOWN".into()
         } else {
@@ -355,7 +354,7 @@ pub extern "system" fn log_sink(
 
         log::logger().log(
             &log::Record::builder()
-                .level(rust_log_level)
+                .level(level)
                 .target(&target)
                 .args(format_args!("{}", managed_msg))
                 .build(),

--- a/talpid-core/src/split_tunnel/windows/path_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/path_monitor.rs
@@ -667,11 +667,11 @@ impl PathMonitor {
 
     /// Find the index of the `DirContext` that owns the `OVERLAPPED` object, or None.
     fn find_context(&self, overlapped: *const OVERLAPPED) -> Option<usize> {
-        if overlapped == ptr::null_mut() {
+        if overlapped.is_null() {
             return None;
         }
-        for i in 0..self.dir_contexts.len() {
-            if ((&*self.dir_contexts[i].overlapped) as *const _) == overlapped {
+        for (i, dir_context) in self.dir_contexts.iter().enumerate() {
+            if (&*dir_context.overlapped as *const _) == overlapped {
                 return Some(i);
             }
         }

--- a/talpid-core/src/split_tunnel/windows/path_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/path_monitor.rs
@@ -680,7 +680,7 @@ impl PathMonitor {
 
     /// Remove the element in `discarded_contexts` that owns the `OVERLAPPED` object, if it exists.
     fn free_discarded_context(&mut self, overlapped: *const OVERLAPPED) -> bool {
-        if overlapped == ptr::null_mut() {
+        if overlapped.is_null() {
             return false;
         }
         let mut was_discarded = false;
@@ -773,7 +773,7 @@ impl PathMonitor {
                 Err((error, result)) => {
                     if error.raw_os_error() != Some(ERROR_OPERATION_ABORTED as i32) {
                         log::error!("GetQueuedCompletionStatus failed: {:?}", error);
-                        if result.used_overlapped == ptr::null_mut() {
+                        if result.used_overlapped.is_null() {
                             continue;
                         }
                     }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -528,10 +528,7 @@ fn should_retry(error: &tunnel::Error, retry_attempt: u32) -> bool {
 
 #[cfg(windows)]
 fn is_recoverable_routing_error(error: &talpid_routing::Error) -> bool {
-    match error {
-        talpid_routing::Error::AddRoutesFailed(_) => true,
-        _ => false,
-    }
+    matches!(error, talpid_routing::Error::AddRoutesFailed(_))
 }
 
 impl TunnelState for ConnectingState {

--- a/talpid-openvpn/src/wintun.rs
+++ b/talpid-openvpn/src/wintun.rs
@@ -260,7 +260,7 @@ impl WintunDll {
             None => ptr::null_mut(),
         };
         let handle = unsafe { (self.func_create)(name.as_ptr(), tunnel_type.as_ptr(), guid_ptr) };
-        if handle == ptr::null_mut() {
+        if handle.is_null() {
             return Err(io::Error::last_os_error());
         }
         Ok(handle)

--- a/talpid-tunnel/src/tun_provider/stub.rs
+++ b/talpid-tunnel/src/tun_provider/stub.rs
@@ -15,3 +15,9 @@ impl StubTunProvider {
         unimplemented!();
     }
 }
+
+impl Default for StubTunProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/talpid-windows-net/src/net.rs
+++ b/talpid-windows-net/src/net.rs
@@ -129,9 +129,8 @@ impl AddressFamily {
     /// Convert an [`AddressFamily`] to one of the `AF_*` constants.
     pub fn to_af_family(&self) -> u16 {
         match self {
-            // These values are both small enough to fit in a u16
-            Self::Ipv4 => u16::try_from(AF_INET).unwrap(),
-            Self::Ipv6 => u16::try_from(AF_INET6).unwrap(),
+            Self::Ipv4 => AF_INET,
+            Self::Ipv6 => AF_INET6,
         }
     }
 }

--- a/talpid-windows-net/src/net.rs
+++ b/talpid-windows-net/src/net.rs
@@ -230,8 +230,8 @@ fn ip_interface_entry_exists(family: AddressFamily, luid: &NET_LUID_LH) -> io::R
 pub async fn wait_for_interfaces(luid: NET_LUID_LH, ipv4: bool, ipv6: bool) -> io::Result<()> {
     let (tx, rx) = futures::channel::oneshot::channel();
 
-    let mut found_ipv4 = if ipv4 { false } else { true };
-    let mut found_ipv6 = if ipv6 { false } else { true };
+    let mut found_ipv4 = !ipv4;
+    let mut found_ipv6 = !ipv6;
 
     let mut tx = Some(tx);
 

--- a/talpid-wireguard/src/wireguard_nt.rs
+++ b/talpid-wireguard/src/wireguard_nt.rs
@@ -735,7 +735,7 @@ impl WgNtDll {
             None => ptr::null_mut(),
         };
         let handle = unsafe { (self.func_create)(name.as_ptr(), tunnel_type.as_ptr(), guid_ptr) };
-        if handle == ptr::null_mut() {
+        if handle.is_null() {
             return Err(io::Error::last_os_error());
         }
         Ok(handle)

--- a/talpid-wireguard/src/wireguard_nt.rs
+++ b/talpid-wireguard/src/wireguard_nt.rs
@@ -113,35 +113,35 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// Failed to load WireGuardNT
     #[error(display = "Failed to load mullvad-wireguard.dll")]
-    DllError(#[error(source)] io::Error),
+    LoadDll(#[error(source)] io::Error),
 
     /// Failed to create tunnel interface
     #[error(display = "Failed to create WireGuard device")]
-    CreateTunnelDeviceError(#[error(source)] io::Error),
+    CreateTunnelDevice(#[error(source)] io::Error),
 
     /// Failed to obtain tunnel interface alias
     #[error(display = "Failed to obtain interface name")]
-    ObtainAliasError(#[error(source)] io::Error),
+    ObtainAlias(#[error(source)] io::Error),
 
     /// Failed to get WireGuard tunnel config for device
     #[error(display = "Failed to get tunnel WireGuard config")]
-    GetWireGuardConfigError(#[error(source)] io::Error),
+    GetWireGuardConfig(#[error(source)] io::Error),
 
     /// Failed to set WireGuard tunnel config on device
     #[error(display = "Failed to set tunnel WireGuard config")]
-    SetWireGuardConfigError(#[error(source)] io::Error),
+    SetWireGuardConfig(#[error(source)] io::Error),
 
     /// Error listening to tunnel IP interfaces
     #[error(display = "Failed to wait on tunnel IP interfaces")]
-    IpInterfacesError(#[error(source)] io::Error),
+    IpInterfaces(#[error(source)] io::Error),
 
     /// Failed to set MTU and metric on tunnel device
     #[error(display = "Failed to set tunnel interface MTU")]
-    SetTunnelMtuError(#[error(source)] io::Error),
+    SetTunnelMtu(#[error(source)] io::Error),
 
     /// Failed to set the tunnel state to up
     #[error(display = "Failed to enable the tunnel adapter")]
-    EnableTunnelError(#[error(source)] io::Error),
+    EnableTunnel(#[error(source)] io::Error),
 
     /// Unknown address family
     #[error(display = "Unknown address family: {}", _0)]
@@ -149,7 +149,7 @@ pub enum Error {
 
     /// Failure to set up logging
     #[error(display = "Failed to set up logging")]
-    InitLoggingError(#[error(source)] logging::Error),
+    InitLogging(#[error(source)] logging::Error),
 
     /// Invalid allowed IP
     #[error(display = "Invalid CIDR prefix")]
@@ -419,9 +419,7 @@ impl WgNtTunnel {
             );
 
             match error {
-                Error::CreateTunnelDeviceError(_) => {
-                    super::TunnelError::RecoverableStartWireguardError
-                }
+                Error::CreateTunnelDevice(_) => super::TunnelError::RecoverableStartWireguardError,
                 _ => super::TunnelError::FatalStartWireguardError,
             }
         })
@@ -436,12 +434,9 @@ impl WgNtTunnel {
         let dll = load_wg_nt_dll(resource_dir)?;
         let logger_handle = LoggerHandle::new(dll.clone(), log_path)?;
         let device = WgNtAdapter::create(dll, &ADAPTER_ALIAS, &ADAPTER_TYPE, Some(ADAPTER_GUID))
-            .map_err(Error::CreateTunnelDeviceError)?;
+            .map_err(Error::CreateTunnelDevice)?;
 
-        let interface_name = device
-            .name()
-            .map_err(Error::ObtainAliasError)?
-            .to_string_lossy();
+        let interface_name = device.name().map_err(Error::ObtainAlias)?.to_string_lossy();
 
         if let Err(error) = device.set_logging(WireGuardAdapterLogState::On) {
             log::error!(
@@ -490,16 +485,16 @@ async fn setup_ip_listener(
     log::debug!("Waiting for tunnel IP interfaces to arrive");
     net::wait_for_interfaces(luid, true, has_ipv6)
         .await
-        .map_err(Error::IpInterfacesError)?;
+        .map_err(Error::IpInterfaces)?;
     log::debug!("Waiting for tunnel IP interfaces: Done");
 
     talpid_tunnel::network_interface::initialize_interfaces(luid, Some(mtu))
-        .map_err(Error::SetTunnelMtuError)?;
+        .map_err(Error::SetTunnelMtu)?;
 
     if let Some(device) = &*device.lock().unwrap() {
         device
             .set_state(WgAdapterState::Up)
-            .map_err(Error::EnableTunnelError)
+            .map_err(Error::EnableTunnel)
     } else {
         Ok(())
     }
@@ -522,7 +517,7 @@ struct LoggerHandle {
 
 impl LoggerHandle {
     fn new(dll: Arc<WgNtDll>, log_path: Option<&Path>) -> Result<Self> {
-        let context = logging::initialize_logging(log_path).map_err(Error::InitLoggingError)?;
+        let context = logging::initialize_logging(log_path).map_err(Error::InitLogging)?;
         {
             *(LOG_CONTEXT.lock().unwrap()) = Some(context);
         }
@@ -598,7 +593,7 @@ impl WgNtAdapter {
         unsafe {
             self.dll_handle
                 .set_config(self.handle, config_buffer.as_ptr(), config_buffer.len())
-                .map_err(Error::SetWireGuardConfigError)
+                .map_err(Error::SetWireGuardConfig)
         }
     }
 
@@ -608,7 +603,7 @@ impl WgNtAdapter {
                 &self
                     .dll_handle
                     .get_config(self.handle)
-                    .map_err(Error::GetWireGuardConfigError)?,
+                    .map_err(Error::GetWireGuardConfig)?,
             )
         }
     }
@@ -822,7 +817,7 @@ fn load_wg_nt_dll(resource_dir: &Path) -> Result<Arc<WgNtDll>> {
     match &*dll {
         Some(dll) => Ok(dll.clone()),
         None => {
-            let new_dll = Arc::new(WgNtDll::new(resource_dir).map_err(Error::DllError)?);
+            let new_dll = Arc::new(WgNtDll::new(resource_dir).map_err(Error::LoadDll)?);
             *dll = Some(new_dll.clone());
             Ok(new_dll)
         }


### PR DESCRIPTION
Continuation for #4598. Fixing the remaining stuff that `--fix` mostly fixed for us. And attacking a bunch of the warnings that normal `cargo clippy` emits but can't automatically fix.

This does not fix everything. I did not want the PR to grow too much. Me or someone else can look at the remaining issues later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4601)
<!-- Reviewable:end -->
