### PR TITLE
Ensure all keychain operations are done on a background queue

### DIFF
--- a/ios/MullvadVPN/SettingsManager/KeychainSettingsStore.swift
+++ b/ios/MullvadVPN/SettingsManager/KeychainSettingsStore.swift
@@ -13,6 +13,7 @@ import Security
 class KeychainSettingsStore: SettingsStore {
     let serviceName: String
     let accessGroup: String
+    let dispatchQueue = DispatchQueue(label: "KeychainSettingsStore.dispatchqueue")
 
     init(serviceName: String, accessGroup: String) {
         self.serviceName = serviceName
@@ -20,15 +21,27 @@ class KeychainSettingsStore: SettingsStore {
     }
 
     func read(key: SettingsKey) throws -> Data {
-        try readItemData(key)
+        try readDataInBackground { [weak self] in
+            guard let self = self else { throw KeychainError.itemNotFound }
+
+            return try self.readItemData(key)
+        }
     }
 
     func write(_ data: Data, for key: SettingsKey) throws {
-        try addOrUpdateItem(key, data: data)
+        try mutateDataInBackground { [weak self] in
+            guard let self = self else { return }
+
+            return try self.addOrUpdateItem(key, data: data)
+        }
     }
 
     func delete(key: SettingsKey) throws {
-        try deleteItem(key)
+        try mutateDataInBackground { [weak self] in
+            guard let self = self else { return }
+
+            return try self.deleteItem(key)
+        }
     }
 
     private func addItem(_ item: SettingsKey, data: Data) throws {
@@ -101,5 +114,46 @@ class KeychainSettingsStore: SettingsStore {
             kSecAttrAccessGroup: accessGroup,
             kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
         ]
+    }
+
+    private func readDataInBackground(completion: @escaping () throws -> Data) throws -> Data {
+        var result: Result<Data, KeychainError> = .failure(.itemNotFound)
+
+        let workItem = DispatchWorkItem {
+            do {
+                result = .success(try completion())
+            } catch let keychainError as KeychainError {
+                result = .failure(keychainError)
+            } catch {
+                // Fall back on .failure(.itemNotFound)
+            }
+        }
+
+        dispatchQueue.asyncAndWait(execute: workItem)
+
+        switch result {
+        case let .success(data):
+            return data
+        case let .failure(error):
+            throw error
+        }
+    }
+
+    private func mutateDataInBackground(completion: @escaping () throws -> Void) throws {
+        var keychainError: KeychainError?
+
+        let workItem = DispatchWorkItem {
+            do {
+                try completion()
+            } catch {
+                keychainError = error as? KeychainError ?? .itemNotFound
+            }
+        }
+
+        dispatchQueue.asyncAndWait(execute: workItem)
+
+        if let error = keychainError {
+            throw error
+        }
     }
 }

--- a/ios/MullvadVPN/SettingsManager/SettingsManager.swift
+++ b/ios/MullvadVPN/SettingsManager/SettingsManager.swift
@@ -170,7 +170,7 @@ enum SettingsManager {
         }
     }
 
-    /// Removes all legacy settings, device state and tunnel settings but keeps the last used
+    /// Removes all legacy settings, device state and tunnel settings but (optionally) keeps the last used
     /// account number stored.
     static func resetStore(completely: Bool = false) {
         logger.debug("Reset store.")


### PR DESCRIPTION
We run operations that will block the main thread during app startup, which means we can get killed by the startup watch dog.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4602)
<!-- Reviewable:end -->
