### PR TITLE
Remove negative top margin for search field

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewController.swift
@@ -48,12 +48,8 @@ final class SelectLocationViewController: UIViewController {
         setupTableView()
         setupSearchBar()
 
-        let searchBarTopMargin: CGFloat = splitViewController == nil ? -16 : 0
         view.addConstrainedSubviews([searchBar, tableView]) {
-            searchBar.pinEdges(
-                .init([.top(searchBarTopMargin), .leading(8), .trailing(8)]),
-                to: view.safeAreaLayoutGuide
-            )
+            searchBar.pinEdgesToSuperviewMargins(.all().excluding(.bottom))
 
             tableView.pinEdgesToSuperview(.all().excluding(.top))
             tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor)


### PR DESCRIPTION
The screenshot script does not run well with the margins of the search field (hides part of the field). We should remove the negative top value and pin it to the safeAreaLayoutGuide instead.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4603)
<!-- Reviewable:end -->
