### PR TITLE
Backport block based handler for UIBarButtonItem

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		586168692976F6BD00EF8598 /* DisplayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586168682976F6BD00EF8598 /* DisplayError.swift */; };
 		586250BB29E6F8F300F4B521 /* OperationCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586250BA29E6F8F300F4B521 /* OperationCancellationTests.swift */; };
 		5862805422428EF100F5A6E1 /* TranslucentButtonBlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */; };
+		5864211F29F04CED00822139 /* UIBarButtonItem+Blocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5864211E29F04CED00822139 /* UIBarButtonItem+Blocks.swift */; };
 		5864859929A0D028006C5743 /* FormsheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5864859829A0D028006C5743 /* FormsheetPresentationController.swift */; };
 		5864859B29A0EAF2006C5743 /* SecondaryContextPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5864859A29A0EAF2006C5743 /* SecondaryContextPresentationController.swift */; };
 		5864AF0729C78843005B0CD9 /* SettingsCellFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5864AF0029C7879B005B0CD9 /* SettingsCellFactory.swift */; };
@@ -749,6 +750,7 @@
 		586168682976F6BD00EF8598 /* DisplayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayError.swift; sourceTree = "<group>"; };
 		586250BA29E6F8F300F4B521 /* OperationCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCancellationTests.swift; sourceTree = "<group>"; };
 		5862805322428EF100F5A6E1 /* TranslucentButtonBlurView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslucentButtonBlurView.swift; sourceTree = "<group>"; };
+		5864211E29F04CED00822139 /* UIBarButtonItem+Blocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Blocks.swift"; sourceTree = "<group>"; };
 		5864859829A0D028006C5743 /* FormsheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormsheetPresentationController.swift; sourceTree = "<group>"; };
 		5864859A29A0EAF2006C5743 /* SecondaryContextPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryContextPresentationController.swift; sourceTree = "<group>"; };
 		5864AF0029C7879B005B0CD9 /* SettingsCellFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsCellFactory.swift; sourceTree = "<group>"; };
@@ -1437,6 +1439,7 @@
 				7A09C98029D99215000C2CAC /* String+FuzzyMatch.swift */,
 				5807E2BF2432038B00F5FF30 /* String+Split.swift */,
 				5891BF5025E66B1E006D6FB0 /* UIBarButtonItem+KeyboardNavigation.swift */,
+				5864211E29F04CED00822139 /* UIBarButtonItem+Blocks.swift */,
 				587CBFE222807F530028DED3 /* UIColor+Helpers.swift */,
 				7AD2DA1429DC4EB900250737 /* UISearchBar+Appearance.swift */,
 				5878F4FF29CDA742003D4BE2 /* UIView+AutoLayoutBuilder.swift */,
@@ -2600,6 +2603,7 @@
 				5867771429097BCD006F721F /* PaymentState.swift in Sources */,
 				587D96742886D87C00CD8F1C /* DeviceManagementContentView.swift in Sources */,
 				589A454C28DDF5E100565204 /* Swizzle.swift in Sources */,
+				5864211F29F04CED00822139 /* UIBarButtonItem+Blocks.swift in Sources */,
 				58C3F4FB296C3AD500D72515 /* SettingsCoordinator.swift in Sources */,
 				5846227126E229F20035F7C2 /* StoreSubscription.swift in Sources */,
 				58421030282D8A3C00F24E46 /* UpdateAccountDataOperation.swift in Sources */,

--- a/ios/MullvadVPN/Extensions/UIBarButtonItem+Blocks.swift
+++ b/ios/MullvadVPN/Extensions/UIBarButtonItem+Blocks.swift
@@ -1,0 +1,43 @@
+//
+//  UIBarButtonItem+Blocks.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 19/04/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+private var actionHandlerAssociatedKey = 0
+
+extension UIBarButtonItem {
+    typealias ActionHandler = () -> Void
+
+    /**
+     Block handler assigned to bar button item.
+     */
+    var actionHandler: ActionHandler? {
+        get {
+            return objc_getAssociatedObject(self, &actionHandlerAssociatedKey) as? ActionHandler
+        }
+        set {
+            objc_setAssociatedObject(self, &actionHandlerAssociatedKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+            target = newValue == nil ? nil : self
+            action = newValue == nil ? nil : #selector(handleAction)
+        }
+    }
+
+    /**
+     Initialize bar button item with block handler.
+     */
+    convenience init(systemItem: UIBarButtonItem.SystemItem, actionHandler: @escaping ActionHandler) {
+        self.init(barButtonSystemItem: systemItem, target: nil, action: nil)
+
+        self.actionHandler = actionHandler
+    }
+
+    @objc private func handleAction() {
+        actionHandler?()
+    }
+}

--- a/ios/MullvadVPN/Extensions/UIBarButtonItem+KeyboardNavigation.swift
+++ b/ios/MullvadVPN/Extensions/UIBarButtonItem+KeyboardNavigation.swift
@@ -60,16 +60,8 @@ extension UIBarButtonItem {
         _ prevItem: UIBarButtonItem,
         _ nextItem: UIBarButtonItem
     ) -> Void) -> [UIBarButtonItem] {
-        let prevButton = UIBarButtonItem(
-            keyboardNavigationItemType: .previous,
-            target: nil,
-            action: nil
-        )
-        let nextButton = UIBarButtonItem(
-            keyboardNavigationItemType: .next,
-            target: nil,
-            action: nil
-        )
+        let prevButton = UIBarButtonItem(keyboardNavigationItemType: .previous, target: nil, action: nil)
+        let nextButton = UIBarButtonItem(keyboardNavigationItemType: .next, target: nil, action: nil)
 
         configurationBlock(prevButton, nextButton)
 

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
@@ -31,18 +31,14 @@ class ProblemReportReviewViewController: UIViewController {
             comment: ""
         )
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: self,
-            action: #selector(handleDismissButton(_:))
-        )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, actionHandler: { [weak self] in
+            self?.dismiss(animated: true)
+        })
 
         #if DEBUG
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .action,
-            target: self,
-            action: #selector(share(_:))
-        )
+        navigationItem.leftBarButtonItem = UIBarButtonItem(systemItem: .action, actionHandler: { [weak self] in
+            self?.share()
+        })
         #endif
 
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -71,18 +67,14 @@ class ProblemReportReviewViewController: UIViewController {
         textView.selectAll(sender)
     }
 
-    // MARK: - Actions
-
-    @objc func handleDismissButton(_ sender: Any) {
-        dismiss(animated: true)
-    }
-
     #if DEBUG
-    @objc func share(_ sender: Any) {
+    private func share() {
         let activityController = UIActivityViewController(
             activityItems: [reportString],
             applicationActivities: nil
         )
+
+        activityController.popoverPresentationController?.barButtonItem = navigationItem.leftBarButtonItem
 
         present(activityController, animated: true)
     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewController.swift
@@ -38,11 +38,9 @@ final class SelectLocationViewController: UIViewController {
             value: "Select location",
             comment: ""
         )
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: self,
-            action: #selector(handleDone)
-        )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, actionHandler: { [weak self] in
+            self?.didFinish?()
+        })
 
         setupDataSource()
         setupTableView()
@@ -81,10 +79,6 @@ final class SelectLocationViewController: UIViewController {
     }
 
     // MARK: - Private
-
-    @objc private func handleDone() {
-        didFinish?()
-    }
 
     private func setupDataSource() {
         dataSource = LocationDataSource(tableView: tableView)

--- a/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
@@ -44,11 +44,11 @@ class SettingsViewController: UITableViewController, SettingsDataSourceDelegate 
             value: "Settings",
             comment: ""
         )
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: self,
-            action: #selector(handleDismiss)
-        )
+        navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, actionHandler: { [weak self] in
+            guard let self = self else { return }
+
+            self.delegate?.settingsViewControllerDidFinish(self)
+        })
 
         tableView.backgroundColor = .secondaryColor
         tableView.separatorColor = .secondaryColor
@@ -57,12 +57,6 @@ class SettingsViewController: UITableViewController, SettingsDataSourceDelegate 
 
         dataSource = SettingsDataSource(tableView: tableView, interactor: interactor)
         dataSource?.delegate = self
-    }
-
-    // MARK: - IBActions
-
-    @IBAction func handleDismiss() {
-        delegate?.settingsViewControllerDidFinish(self)
     }
 
     // MARK: - SettingsDataSourceDelegate


### PR DESCRIPTION
Quality of life improvement for developers.  This PR adds `UIBarButtonItem` with block handlers on iOS. Keeping it draft because I am not entirely sure we need it nor do I have much time to spread too thin on other things right now. Sadly block based (`UIAction`) handlers are only available since iOS 14. So this is somewhat an attempt to ease pain of using Objective-C selectors in the meanwhile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4605)
<!-- Reviewable:end -->
