### PR TITLE
Clippy fix windows 3

### DIFF
--- a/talpid-core/src/ffi.rs
+++ b/talpid-core/src/ffi.rs
@@ -17,9 +17,9 @@ macro_rules! ffi_error {
             }
         }
 
-        impl Into<Result<(), Error>> for $result {
-            fn into(self) -> Result<(), Error> {
-                self.into_result()
+        impl From<$result> for Result<(), Error> {
+            fn from(result: $result) -> Self {
+                result.into_result()
             }
         }
     };

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -231,7 +231,9 @@ impl Firewall {
         // has returned.
         drop(endpoint1_ip);
         drop(endpoint2_ip);
+        #[allow(clippy::drop_non_drop)]
         drop(endpoint1);
+        #[allow(clippy::drop_non_drop)]
         drop(endpoint2);
         res
     }

--- a/talpid-core/src/split_tunnel/windows/path_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/path_monitor.rs
@@ -419,7 +419,7 @@ struct StrippedPath {
 }
 
 impl StrippedPath {
-    fn new(path: &PathBuf) -> io::Result<StrippedPath> {
+    fn new(path: &Path) -> io::Result<StrippedPath> {
         let mut iter = path.components();
         let prefix = iter.next().ok_or(io::Error::new(
             io::ErrorKind::InvalidInput,

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -109,13 +109,8 @@ impl TunnelMonitor {
         let resource_dir = resource_dir.to_path_buf();
         let process_string = match params {
             TunnelParameters::OpenVpn(params) => {
-                if let Some(proxy) = &params.proxy {
-                    match proxy {
-                        openvpn_types::ProxySettings::Shadowsocks(..) => {
-                            return std::env::current_exe().unwrap()
-                        }
-                        _ => "openvpn.exe",
-                    }
+                if let Some(openvpn_types::ProxySettings::Shadowsocks(..)) = &params.proxy {
+                    return std::env::current_exe().unwrap();
                 } else {
                     "openvpn.exe"
                 }

--- a/talpid-windows-net/src/net.rs
+++ b/talpid-windows-net/src/net.rs
@@ -138,6 +138,7 @@ impl AddressFamily {
 /// Context for [`notify_ip_interface_change`]. When it is dropped,
 /// the callback is unregistered.
 pub struct IpNotifierHandle<'a> {
+    #[allow(clippy::type_complexity)]
     callback: Mutex<Box<dyn FnMut(&MIB_IPINTERFACE_ROW, i32) + Send + 'a>>,
     handle: HANDLE,
 }

--- a/talpid-wireguard/src/wireguard_go.rs
+++ b/talpid-wireguard/src/wireguard_go.rs
@@ -437,7 +437,7 @@ extern "C" {
         iface_name: *const i8,
         mtu: i64,
         settings: *const i8,
-        iface_name_out: *const *mut std::os::raw::c_char,
+        iface_name_out: *mut *mut std::os::raw::c_char,
         iface_luid_out: *mut u64,
         logging_callback: Option<LoggingCallback>,
         logging_context: *mut libc::c_void,

--- a/talpid-wireguard/src/wireguard_nt.rs
+++ b/talpid-wireguard/src/wireguard_nt.rs
@@ -597,6 +597,7 @@ impl WgNtAdapter {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     fn get_config(&self) -> Result<(WgInterface, Vec<(WgPeer, Vec<WgAllowedIp>)>)> {
         unsafe {
             deserialize_config(
@@ -881,6 +882,7 @@ fn serialize_config(config: &Config) -> Result<Vec<MaybeUninit<u8>>> {
     Ok(buffer)
 }
 
+#[allow(clippy::type_complexity)]
 unsafe fn deserialize_config(
     config: &[MaybeUninit<u8>],
 ) -> Result<(WgInterface, Vec<(WgPeer, Vec<WgAllowedIp>)>)> {


### PR DESCRIPTION
Follow up to #4601. Fixing the remaining *warnings* from Clippy when running it towards the target `x86_64-pc-windows-gnu`. There are two *errors* left that Clippy complains about. But I left those out from this PR. They should definitely be looked at.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4606)
<!-- Reviewable:end -->
