### PR TITLE
Add workaround for tidy script issue on macOS

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -53,6 +53,12 @@ Command to format and check for any changes:
 scripts/tidy.sh formatAndCheckDiff
 ```
 
+#### macOS
+Since macOS is using a different version of `sed` running the tidy script (`scripts/tidy.sh`) will 
+lead to the creation of a large number of files ending with `-e`. The recommended fix for this 
+issue is to install the gnu version of `sed`. This can be done by running:
+`brew install gnu-sed` and then set `gnu-sed` as your default `sed`.
+
 ### Android Gradle Plugin lint tool
 
 The Android Gradle Plugin lint tool for linting of resources and code. The tool is configured to be


### PR DESCRIPTION
Add description to README on how to solve the issue of a lot of backup files being created while running the tidy script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4610)
<!-- Reviewable:end -->
