### PR TITLE
Improve behavior when there's no network

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -778,13 +778,13 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         guard tunnelManager.deviceState.isLoggedIn else { return false }
 
         switch tunnelManager.tunnelStatus.state {
-        case .connected, .connecting, .reconnecting, .waitingForConnectivity:
+        case .connected, .connecting, .reconnecting, .waitingForConnectivity(.noConnection):
             tunnelManager.reconnectTunnel(selectNewRelay: true)
 
         case .disconnecting, .disconnected:
             tunnelManager.startTunnel()
 
-        case .pendingReconnect:
+        case .pendingReconnect, .waitingForConnectivity(.noNetwork):
             break
         }
         return true

--- a/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
@@ -10,6 +10,7 @@ import Foundation
 
 final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotificationProvider {
     private var isWaitingForConnectivity = false
+    private var noNetwork = false
     private var packetTunnelError: String?
     private var tunnelManagerError: Error?
     private var tunnelObserver: TunnelBlockObserver?
@@ -25,6 +26,8 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
             return notificationDescription(for: tunnelManagerError)
         } else if isWaitingForConnectivity {
             return connectivityNotificationDescription()
+        } else if noNetwork {
+            return noNetworkNotificationDescription()
         } else {
             return nil
         }
@@ -57,8 +60,9 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
         )
         let invalidateForManagerError = updateTunnelManagerError(tunnelStatus.state)
         let invalidateForConnectivity = updateConnectivity(tunnelStatus.state)
+        let invalidateForNetwork = updateNetwork(tunnelStatus.state)
 
-        if invalidateForTunnelError || invalidateForManagerError || invalidateForConnectivity {
+        if invalidateForTunnelError || invalidateForManagerError || invalidateForConnectivity || invalidateForNetwork {
             invalidate()
         }
     }
@@ -74,10 +78,21 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
     }
 
     private func updateConnectivity(_ tunnelState: TunnelState) -> Bool {
-        let isWaitingState = tunnelState == .waitingForConnectivity
+        let isWaitingState = tunnelState == .waitingForConnectivity(.noConnection)
 
         if isWaitingForConnectivity != isWaitingState {
             isWaitingForConnectivity = isWaitingState
+            return true
+        }
+
+        return false
+    }
+
+    private func updateNetwork(_ tunnelState: TunnelState) -> Bool {
+        let isWaitingState = tunnelState == .waitingForConnectivity(.noNetwork)
+
+        if noNetwork != isWaitingState {
+            noNetwork = isWaitingState
             return true
         }
 
@@ -175,6 +190,28 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
                     value: """
                     Your device is offline. The tunnel will automatically connect once \
                     your device is back online.
+                    """,
+                    comment: ""
+                )
+            )
+        )
+    }
+
+    private func noNetworkNotificationDescription() -> InAppNotificationDescriptor {
+        return InAppNotificationDescriptor(
+            identifier: identifier,
+            style: .warning,
+            title: NSLocalizedString(
+                "TUNNEL_NO_NETWORK_INAPP_NOTIFICATION_TITLE",
+                value: "NETWORK ISSUES",
+                comment: ""
+            ),
+            body: .init(
+                string: NSLocalizedString(
+                    "TUNNEL_NO_NETWORK_INAPP_NOTIFICATION_BODY",
+                    value: """
+                    Your device is offline. Try connecting again when the device \
+                    has access to Internet.
                     """,
                     comment: ""
                 )

--- a/ios/MullvadVPN/Notifications/UI/NotificationController.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationController.swift
@@ -70,9 +70,9 @@ final class NotificationController: UIViewController {
             hideBannerConstraint?.isActive = true
         }
 
-        let finish = {
-            if !show {
-                self.bannerView.isHidden = true
+        let finish = { [weak self] in
+            if self?.lastNotification == nil {
+                self?.bannerView.isHidden = true
             }
             completion?()
         }
@@ -108,17 +108,6 @@ final class NotificationController: UIViewController {
         bannerView.action = notification.action
         bannerView.accessibilityLabel = "\(notification.title)\n\(notification.body.string)"
 
-        if animated {
-            let animator = UIViewPropertyAnimator(
-                duration: 0.25,
-                timingParameters: UICubicTimingParameters(animationCurve: .easeOut)
-            )
-            animator.addAnimations {
-                self.view.layoutIfNeeded()
-            }
-            animator.startAnimation()
-        }
-
         // Do not emit the .layoutChanged unless the banner is focused to avoid capturing
         // the voice over focus.
         if bannerView.accessibilityElementIsFocused() {
@@ -133,6 +122,7 @@ final class NotificationController: UIViewController {
             setNotification(notification, animated: showsBanner)
             toggleBanner(show: true, animated: true)
         } else {
+            lastNotification = nil
             toggleBanner(show: false, animated: animated)
         }
     }

--- a/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
@@ -35,7 +35,7 @@ class StopTunnelOperation: ResultOperation<Void> {
 
             finish(result: .success(()))
 
-        case .connected, .connecting, .reconnecting, .waitingForConnectivity:
+        case .connected, .connecting, .reconnecting, .waitingForConnectivity(.noConnection):
             guard let tunnel = interactor.tunnel else {
                 finish(result: .failure(UnsetTunnelError()))
                 return
@@ -55,7 +55,7 @@ class StopTunnelOperation: ResultOperation<Void> {
                 }
             }
 
-        case .disconnected, .disconnecting, .pendingReconnect:
+        case .disconnected, .disconnecting, .pendingReconnect, .waitingForConnectivity(.noNetwork):
             finish(result: .success(()))
         }
     }

--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -33,6 +33,13 @@ struct TunnelStatus: Equatable, CustomStringConvertible {
 
 /// An enum that describes the tunnel state.
 enum TunnelState: Equatable, CustomStringConvertible {
+    enum WaitingForConnectionReason {
+        /// Tunnel connection is down.
+        case noConnection
+        /// Network is down.
+        case noNetwork
+    }
+
     /// Pending reconnect after disconnect.
     case pendingReconnect
 
@@ -56,7 +63,7 @@ enum TunnelState: Equatable, CustomStringConvertible {
     case reconnecting(PacketTunnelRelay)
 
     /// Waiting for connectivity to come back up.
-    case waitingForConnectivity
+    case waitingForConnectivity(WaitingForConnectionReason)
 
     var description: String {
         switch self {
@@ -83,9 +90,9 @@ enum TunnelState: Equatable, CustomStringConvertible {
 
     var isSecured: Bool {
         switch self {
-        case .reconnecting, .connecting, .connected, .waitingForConnectivity:
+        case .reconnecting, .connecting, .connected, .waitingForConnectivity(.noConnection):
             return true
-        case .pendingReconnect, .disconnecting, .disconnected:
+        case .pendingReconnect, .disconnecting, .disconnected, .waitingForConnectivity(.noNetwork):
             return false
         }
     }


### PR DESCRIPTION
When an iOS device has no connectivity, iOS won't let us start a tunnel. From a UX perspective, this looks like the app is broken - it enters the connecting state and is immediately thrown back out of it. To improve the UX, a banner tells the user that there's no network and all action buttons are disabled.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4613)
<!-- Reviewable:end -->
