### PR TITLE
Fix view state when disconnecting from out-of-time view

### DIFF
--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
@@ -105,6 +105,13 @@ class OutOfTimeContentView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func enableDisconnectButton(_ enabled: Bool, animated: Bool) {
+        disconnectButton.isEnabled = enabled
+        UIView.animate(withDuration: animated ? 0.25 : 0) {
+            self.disconnectButton.alpha = enabled ? 1 : 0
+        }
+    }
+
     // MARK: - Private Functions
 
     func setUpSubviews() {

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeInteractor.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeInteractor.swift
@@ -7,20 +7,27 @@
 //
 
 import Foundation
+import MullvadLogging
 import MullvadREST
 import MullvadTypes
 import Operations
 import StoreKit
 
+/// Interval used for periodic polling account updates.
+private let accountUpdateTimerInterval: TimeInterval = 60
+
 final class OutOfTimeInteractor {
     private let storePaymentManager: StorePaymentManager
     private let tunnelManager: TunnelManager
 
-    var didReceivePaymentEvent: ((StorePaymentEvent) -> Void)?
-    var didReceiveTunnelStatus: ((TunnelStatus) -> Void)?
-
     private var tunnelObserver: TunnelObserver?
     private var paymentObserver: StorePaymentObserver?
+
+    private let logger = Logger(label: "OutOfTimeInteractor")
+    private var accountUpdateTimer: DispatchSourceTimer?
+
+    var didReceivePaymentEvent: ((StorePaymentEvent) -> Void)?
+    var didReceiveTunnelStatus: ((TunnelStatus) -> Void)?
 
     init(storePaymentManager: StorePaymentManager, tunnelManager: TunnelManager) {
         self.storePaymentManager = storePaymentManager
@@ -80,5 +87,22 @@ final class OutOfTimeInteractor {
             with: productIdentifiers,
             completionHandler: completionHandler
         )
+    }
+
+    func startAccountUpdateTimer() {
+        logger.debug(
+            "Start polling account updates every \(accountUpdateTimerInterval) second(s)."
+        )
+
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.setEventHandler { [weak self] in
+            self?.tunnelManager.updateAccountData()
+        }
+
+        accountUpdateTimer?.cancel()
+        accountUpdateTimer = timer
+
+        timer.schedule(wallDeadline: .now() + accountUpdateTimerInterval, repeating: accountUpdateTimerInterval)
+        timer.activate()
     }
 }

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
@@ -99,6 +99,7 @@ class OutOfTimeViewController: UIViewController, RootContainment {
 
         interactor.didReceiveTunnelStatus = { [weak self] tunnelStatus in
             self?.setNeedsHeaderBarStyleAppearanceUpdate()
+            self?.applyViewState()
         }
 
         if StorePaymentManager.canMakePayments {
@@ -106,6 +107,8 @@ class OutOfTimeViewController: UIViewController, RootContainment {
         } else {
             productState = .cannotMakePurchases
         }
+
+        interactor.startAccountUpdateTimer()
     }
 
     // MARK: - Private
@@ -136,8 +139,8 @@ class OutOfTimeViewController: UIViewController, RootContainment {
         purchaseButton.isEnabled = productState.isReceived && isInteractionEnabled && !tunnelState
             .isSecured
         contentView.restoreButton.isEnabled = isInteractionEnabled
-        contentView.disconnectButton.isEnabled = tunnelState.isSecured
-        contentView.disconnectButton.alpha = tunnelState.isSecured ? 1 : 0
+
+        contentView.enableDisconnectButton(tunnelState.isSecured, animated: true)
 
         if tunnelState.isSecured {
             contentView.setBodyLabelText(
@@ -341,6 +344,7 @@ class OutOfTimeViewController: UIViewController, RootContainment {
     }
 
     @objc private func handleDisconnect(_ sender: Any) {
+        contentView.disconnectButton.isEnabled = false
         interactor.stopTunnel()
     }
 }


### PR DESCRIPTION
When in the out-of-time view, the app will fail to update its view state on disconnect, blocking the user from accessing the add time button.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4620)
<!-- Reviewable:end -->
