### PR TITLE
Change to directional layout margins

### DIFF
--- a/ios/MullvadVPN/Containers/Navigation/UINavigationBar+Appearance.swift
+++ b/ios/MullvadVPN/Containers/Navigation/UINavigationBar+Appearance.swift
@@ -10,11 +10,11 @@ import UIKit
 
 extension UINavigationBar {
     func configureCustomAppeareance() {
-        var margins = layoutMargins
-        margins.left = UIMetrics.contentLayoutMargins.left
-        margins.right = UIMetrics.contentLayoutMargins.right
+        var directionalMargins = directionalLayoutMargins
+        directionalMargins.leading = UIMetrics.contentLayoutMargins.leading
+        directionalMargins.trailing = UIMetrics.contentLayoutMargins.trailing
 
-        layoutMargins = margins
+        directionalLayoutMargins = directionalMargins
         tintColor = UIColor.NavigationBar.titleColor
 
         standardAppearance = makeNavigationBarAppearance(isTransparent: false)

--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -108,12 +108,11 @@ class HeaderBarView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-
-        layoutMargins = UIEdgeInsets(
+        directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 0,
-            left: UIMetrics.contentLayoutMargins.left,
+            leading: UIMetrics.contentLayoutMargins.leading,
             bottom: 0,
-            right: UIMetrics.contentLayoutMargins.right
+            trailing: UIMetrics.contentLayoutMargins.trailing
         )
 
         accessibilityContainerType = .semanticGroup

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -109,10 +109,10 @@ class RootContainerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        var margins = view.layoutMargins
-        margins.left = UIMetrics.contentLayoutMargins.left
-        margins.right = UIMetrics.contentLayoutMargins.right
-        view.layoutMargins = margins
+        var margins = view.directionalLayoutMargins
+        margins.leading = UIMetrics.contentLayoutMargins.leading
+        margins.trailing = UIMetrics.contentLayoutMargins.trailing
+        view.directionalLayoutMargins = margins
 
         definesPresentationContext = true
 

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -59,7 +59,7 @@ final class NotificationBannerView: UIView {
     private let wrapperView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.layoutMargins = UIMetrics.inAppBannerNotificationLayoutMargins
+        view.directionalLayoutMargins = UIMetrics.inAppBannerNotificationLayoutMargins
         return view
     }()
 

--- a/ios/MullvadVPN/UI appearance/UIMetrics.swift
+++ b/ios/MullvadVPN/UI appearance/UIMetrics.swift
@@ -12,32 +12,40 @@ enum UIMetrics {}
 
 extension UIMetrics {
     /// Common layout margins for content presentation
-    static let contentLayoutMargins = UIEdgeInsets(top: 24, left: 24, bottom: 24, right: 24)
+    static let contentLayoutMargins = NSDirectionalEdgeInsets(top: 24, leading: 24, bottom: 24, trailing: 24)
+
+    /// Common content margins for content presentation
+    static let contentInsets = UIEdgeInsets(top: 24, left: 24, bottom: 24, right: 24)
 
     /// Common layout margins for row views presentation
     /// Similar to `settingsCellLayoutMargins` however maintains equal horizontal spacing
-    static let rowViewLayoutMargins = UIEdgeInsets(top: 16, left: 24, bottom: 16, right: 24)
+    static let rowViewLayoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 24)
 
     /// Common layout margins for settings cell presentation
-    static let settingsCellLayoutMargins = UIEdgeInsets(top: 16, left: 24, bottom: 16, right: 12)
+    static let settingsCellLayoutMargins = NSDirectionalEdgeInsets(
+        top: 16,
+        leading: 24,
+        bottom: 16,
+        trailing: 12
+    )
 
     /// Common layout margins for location cell presentation
-    static let selectLocationCellLayoutMargins = UIEdgeInsets(
+    static let selectLocationCellLayoutMargins = NSDirectionalEdgeInsets(
         top: 16,
-        left: 28,
+        leading: 28,
         bottom: 16,
-        right: 12
+        trailing: 12
     )
 
     /// Common cell indentation width
     static let cellIndentationWidth: CGFloat = 16
 
     /// Layout margins for in-app notification banner presentation
-    static let inAppBannerNotificationLayoutMargins = UIEdgeInsets(
+    static let inAppBannerNotificationLayoutMargins = NSDirectionalEdgeInsets(
         top: 16,
-        left: 24,
+        leading: 24,
         bottom: 16,
-        right: 24
+        trailing: 24
     )
 
     /// Spacing used in stack views of buttons

--- a/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
@@ -85,7 +85,7 @@ class AccountContentView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        layoutMargins = UIMetrics.contentLayoutMargins
+        directionalLayoutMargins = UIMetrics.contentLayoutMargins
 
         addSubview(contentStackView)
         addSubview(buttonStackView)

--- a/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogContentView.swift
+++ b/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogContentView.swift
@@ -48,7 +48,7 @@ final class ChangeLogContentView: UIView {
         textView.backgroundColor = .clear
         textView.isEditable = false
         textView.isSelectable = false
-        textView.textContainerInset = UIMetrics.contentLayoutMargins
+        textView.textContainerInset = UIMetrics.contentInsets
         return textView
     }()
 
@@ -66,7 +66,7 @@ final class ChangeLogContentView: UIView {
 
     private let footerContainer: UIView = {
         let container = UIView()
-        container.layoutMargins = UIMetrics.contentLayoutMargins
+        container.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         container.backgroundColor = .secondaryColor
         return container
     }()
@@ -77,7 +77,7 @@ final class ChangeLogContentView: UIView {
         super.init(frame: frame)
 
         backgroundColor = .primaryColor
-        layoutMargins = UIMetrics.contentLayoutMargins
+        directionalLayoutMargins = UIMetrics.contentLayoutMargins
 
         okButton.addTarget(self, action: #selector(handleButtonTap), for: .touchUpInside)
 

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
@@ -17,7 +17,7 @@ class DeviceManagementContentView: UIView {
 
     let scrollContentView: UIView = {
         let view = UIView()
-        view.layoutMargins = UIMetrics.contentLayoutMargins
+        view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -138,11 +138,11 @@ class DeviceManagementContentView: UIView {
             ),
             buttonStackView.leadingAnchor.constraint(
                 equalTo: leadingAnchor,
-                constant: UIMetrics.contentLayoutMargins.left
+                constant: UIMetrics.contentLayoutMargins.leading
             ),
             buttonStackView.trailingAnchor.constraint(
                 equalTo: trailingAnchor,
-                constant: -UIMetrics.contentLayoutMargins.right
+                constant: -UIMetrics.contentLayoutMargins.trailing
             ),
             buttonStackView.bottomAnchor.constraint(
                 equalTo: safeAreaLayoutGuide.bottomAnchor,

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
@@ -63,7 +63,7 @@ class DeviceRowView: UIView {
         super.init(frame: .zero)
 
         backgroundColor = .primaryColor
-        layoutMargins = UIMetrics.rowViewLayoutMargins
+        directionalLayoutMargins = UIMetrics.rowViewLayoutMargins
 
         for subview in [textLabel, removeButton, activityIndicator] {
             addSubview(subview)

--- a/ios/MullvadVPN/View controllers/Login/LoginContentView.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginContentView.swift
@@ -49,21 +49,21 @@ class LoginContentView: UIView {
     let contentContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.layoutMargins = UIMetrics.contentLayoutMargins
+        view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         return view
     }()
 
     let formContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.layoutMargins = UIMetrics.contentLayoutMargins
+        view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         return view
     }()
 
     let footerContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.layoutMargins = UIMetrics.contentLayoutMargins
+        view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         view.backgroundColor = .secondaryColor
         return view
     }()
@@ -101,7 +101,7 @@ class LoginContentView: UIView {
         super.init(frame: frame)
 
         backgroundColor = .primaryColor
-        layoutMargins = UIMetrics.contentLayoutMargins
+        directionalLayoutMargins = UIMetrics.contentLayoutMargins
 
         accountInputGroup.textField.accessibilityIdentifier = "LoginTextField"
 

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
@@ -97,7 +97,7 @@ class OutOfTimeContentView: UIView {
         super.init(frame: frame)
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .secondaryColor
-        layoutMargins = UIMetrics.contentLayoutMargins
+        directionalLayoutMargins = UIMetrics.contentLayoutMargins
         setUpSubviews()
     }
 

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportSubmissionOverlayView.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportSubmissionOverlayView.swift
@@ -177,7 +177,7 @@ class ProblemReportSubmissionOverlayView: UIView {
         addSubviews()
         transitionToState(state)
 
-        layoutMargins = UIMetrics.contentLayoutMargins
+        directionalLayoutMargins = UIMetrics.contentLayoutMargins
     }
 
     required init?(coder: NSCoder) {

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
@@ -29,7 +29,7 @@ final class ProblemReportViewController: UIViewController, UITextFieldDelegate {
     private lazy var containerView: UIView = {
         let containerView = UIView()
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.layoutMargins = UIMetrics.contentLayoutMargins
+        containerView.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         containerView.backgroundColor = .clear
         return containerView
     }()

--- a/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
+++ b/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
@@ -110,7 +110,7 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
         super.viewDidLoad()
 
         view.backgroundColor = .secondaryColor
-        view.layoutMargins = UIMetrics.contentLayoutMargins
+        view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
 
         for subview in [imageView, titleLabel, bodyLabel, footerLabel, logoutButton] {
             view.addSubview(subview)

--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationCell.swift
@@ -73,9 +73,9 @@ class SelectLocationCell: UITableViewCell {
         let indentation = CGFloat(indentationLevel) * indentationWidth
 
         var contentMargins = UIMetrics.selectLocationCellLayoutMargins
-        contentMargins.left += indentation
+        contentMargins.leading += indentation
 
-        contentView.layoutMargins = contentMargins
+        contentView.directionalLayoutMargins = contentMargins
     }
 
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
@@ -156,8 +156,8 @@ class SelectLocationCell: UITableViewCell {
 
             collapseButton.widthAnchor
                 .constraint(
-                    equalToConstant: UIMetrics.contentLayoutMargins.left + UIMetrics
-                        .contentLayoutMargins.right + kCollapseButtonWidth
+                    equalToConstant: UIMetrics.contentLayoutMargins.leading + UIMetrics
+                        .contentLayoutMargins.trailing + kCollapseButtonWidth
                 ),
             collapseButton.topAnchor.constraint(equalTo: contentView.topAnchor),
             collapseButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),

--- a/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
@@ -100,7 +100,8 @@ class SettingsCell: UITableViewCell {
 
         setLayoutMargins()
 
-        let buttonAreaWidth = UIMetrics.contentLayoutMargins.left + UIMetrics.contentLayoutMargins.right + buttonWidth
+        let buttonAreaWidth = UIMetrics.contentLayoutMargins.leading + UIMetrics
+            .contentLayoutMargins.trailing + buttonWidth
 
         contentView.addConstrainedSubviews([titleLabel, infoButton, detailTitleLabel]) {
             switch style {
@@ -153,9 +154,9 @@ class SettingsCell: UITableViewCell {
 
     private func setLayoutMargins() {
         // Set layout margins for standard acceessories added into the cell (reorder control, etc..)
-        layoutMargins = UIMetrics.settingsCellLayoutMargins
+        directionalLayoutMargins = UIMetrics.settingsCellLayoutMargins
 
         // Set layout margins for cell content
-        contentView.layoutMargins = UIMetrics.settingsCellLayoutMargins
+        contentView.directionalLayoutMargins = UIMetrics.settingsCellLayoutMargins
     }
 }

--- a/ios/MullvadVPN/View controllers/Settings/SettingsContentBlockersHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsContentBlockersHeaderView.swift
@@ -66,10 +66,11 @@ class SettingsContentBlockersHeaderView: UITableViewHeaderFooterView {
             for: .touchUpInside
         )
 
-        contentView.layoutMargins = UIMetrics.settingsCellLayoutMargins
+        contentView.directionalLayoutMargins = UIMetrics.settingsCellLayoutMargins
         contentView.backgroundColor = UIColor.Cell.backgroundColor
 
-        let buttonAreaWidth = UIMetrics.contentLayoutMargins.left + UIMetrics.contentLayoutMargins.right + buttonWidth
+        let buttonAreaWidth = UIMetrics.contentLayoutMargins.leading + UIMetrics
+            .contentLayoutMargins.trailing + buttonWidth
 
         contentView.addConstrainedSubviews([titleLabel, infoButton, collapseButton]) {
             titleLabel.pinEdgesToSuperviewMargins(.all().excluding(.trailing).excluding(.bottom))

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDNSTextCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDNSTextCell.swift
@@ -28,7 +28,7 @@ class SettingsDNSTextCell: SettingsCell, UITextFieldDelegate {
         textField.font = UIFont.systemFont(ofSize: 17)
         textField.backgroundColor = .clear
         textField.textColor = UIColor.TextField.textColor
-        textField.textMargins = UIMetrics.settingsCellLayoutMargins
+        textField.textMargins = UIMetrics.contentInsets
         textField.placeholder = NSLocalizedString(
             "DNS_TEXT_CELL_PLACEHOLDER",
             tableName: "Settings",

--- a/ios/MullvadVPN/View controllers/Settings/SettingsStaticTextFooterView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsStaticTextFooterView.swift
@@ -21,7 +21,7 @@ class SettingsStaticTextFooterView: UITableViewHeaderFooterView {
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
 
-        contentView.layoutMargins = UIMetrics.settingsCellLayoutMargins
+        contentView.directionalLayoutMargins = UIMetrics.settingsCellLayoutMargins
         contentView.addSubview(titleLabel)
 
         contentView.addConstraints([

--- a/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceContentView.swift
+++ b/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceContentView.swift
@@ -80,14 +80,14 @@ class TermsOfServiceContentView: UIView {
     let scrollContentContainer: UIView = {
         let contentView = UIView()
         contentView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.layoutMargins = UIMetrics.contentLayoutMargins
+        contentView.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         return contentView
     }()
 
     let footerContainer: UIView = {
         let container = UIView()
         container.translatesAutoresizingMaskIntoConstraints = false
-        container.layoutMargins = UIMetrics.contentLayoutMargins
+        container.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         container.backgroundColor = .secondaryColor
         return container
     }()

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
@@ -113,7 +113,7 @@ final class TunnelControlView: UIView {
         super.init(frame: frame)
 
         backgroundColor = .clear
-        layoutMargins = UIMetrics.contentLayoutMargins
+        directionalLayoutMargins = UIMetrics.contentLayoutMargins
         accessibilityContainerType = .semanticGroup
 
         addSubviews()


### PR DESCRIPTION
Since iOS 11 views support directional layout margins that automatically handle RTL (right-to-left) environments. We do use writing direction agnostic UI elsewhere including in AutoLayout constraints, so it would be a quality improvement to switch from UIView.layoutMargins to UIView.directionalLayoutMargins (NSDirectionalEdgeInsets). All our UI metrics and dimensions stored in UIMetrics.swift should be migrated from UIEdgeInsets to NSDirectionalEdgeInsets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4621)
<!-- Reviewable:end -->
