### PR TITLE
Temporary fix to avoid the reported vuln: GHSA-x5vj-ch4c-g3jr

### DIFF
--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -29,8 +29,9 @@ jobs:
         run: |-
           commits=${{ github.event.pull_request.commits }}
           if [[ -n "$commits" ]]; then
-              # Prepare enough depth for diffs with main, currently hard-coded but should probably be
-              # whatever branch is merged into
-              git fetch --depth="$(( commits + 1 ))" origin ${{ github.head_ref }} main
+              echo "Fetching $commits commits"
+              # FIXME: Temporarily simplified to avoid:
+              # https://securitylab.github.com/research/github-actions-untrusted-input/#script-injections
+              git fetch --depth="$(( commits + 1 ))"
           fi
           ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/main


### PR DESCRIPTION
Since `github.head_ref` is user controlled input we can't use it like this in a shell command.

See https://securitylab.github.com/research/github-actions-untrusted-input/#script-injections

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4625)
<!-- Reviewable:end -->
