### PR TITLE
Add creation date to device name in Too many devices view

### DIFF
--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
@@ -104,7 +104,12 @@ class DeviceManagementViewController: UIViewController, RootContainment {
         let viewModels = devices.map { restDevice -> DeviceViewModel in
             return DeviceViewModel(
                 id: restDevice.id,
-                name: restDevice.name.capitalized
+                name: restDevice.name.capitalized,
+                creationDate: DateFormatter.localizedString(
+                    from: restDevice.created,
+                    dateStyle: .short,
+                    timeStyle: .none
+                )
             )
         }
 
@@ -263,4 +268,5 @@ class DeviceManagementViewController: UIViewController, RootContainment {
 struct DeviceViewModel {
     let id: String
     let name: String
+    let creationDate: String
 }

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
@@ -26,6 +26,14 @@ class DeviceRowView: UIView {
         return activityIndicator
     }()
 
+    let creationDateLabel: UILabel = {
+        let creationDateLabel = UILabel()
+        creationDateLabel.translatesAutoresizingMaskIntoConstraints = false
+        creationDateLabel.font = UIFont.systemFont(ofSize: 14)
+        creationDateLabel.textColor = .white.withAlphaComponent(0.6)
+        return creationDateLabel
+    }()
+
     let removeButton: UIButton = {
         let image = UIImage(named: "IconClose")?
             .withTintColor(
@@ -65,21 +73,35 @@ class DeviceRowView: UIView {
         backgroundColor = .primaryColor
         directionalLayoutMargins = UIMetrics.rowViewLayoutMargins
 
-        for subview in [textLabel, removeButton, activityIndicator] {
+        for subview in [textLabel, removeButton, activityIndicator, creationDateLabel] {
             addSubview(subview)
         }
 
         textLabel.text = viewModel.name
+        creationDateLabel.text = .init(
+            format:
+            NSLocalizedString(
+                "CREATED_DEVICE_LABEL",
+                tableName: "DeviceManagement",
+                value: "Created: %@",
+                comment: ""
+            ),
+            viewModel.creationDate
+        )
 
         removeButton.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
 
         NSLayoutConstraint.activate([
             textLabel.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
             textLabel.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-            textLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
-                .withPriority(.defaultLow),
 
-            removeButton.centerYAnchor.constraint(equalTo: textLabel.centerYAnchor),
+            creationDateLabel.leadingAnchor.constraint(equalTo: textLabel.leadingAnchor),
+            creationDateLabel.topAnchor.constraint(equalTo: textLabel.bottomAnchor, constant: 4.0),
+            creationDateLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
+                .withPriority(.defaultLow),
+            creationDateLabel.trailingAnchor.constraint(equalTo: textLabel.trailingAnchor),
+
+            removeButton.centerYAnchor.constraint(equalTo: layoutMarginsGuide.centerYAnchor),
             removeButton.leadingAnchor.constraint(
                 greaterThanOrEqualTo: textLabel.trailingAnchor,
                 constant: 8


### PR DESCRIPTION
Users has been requesting to see the device creation date in the Too many devices view and so their request has been granted. 🎉 The creation date for the device is to be shown underneath the device name.

The list-items height has been made higher, but only in this specific view!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4626)
<!-- Reviewable:end -->
