### PR TITLE
Fix in-app notification equality and action button color

### DIFF
--- a/ios/MullvadVPN/Notifications/InAppNotificationDescriptor.swift
+++ b/ios/MullvadVPN/Notifications/InAppNotificationDescriptor.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit.UIImage
 
 /// Struct describing in-app notification.
-struct InAppNotificationDescriptor {
+struct InAppNotificationDescriptor: Equatable {
     /// Notification identifier.
     var identifier: String
 
@@ -23,19 +23,21 @@ struct InAppNotificationDescriptor {
     /// Notification body.
     var body: NSAttributedString
 
-    /// Notification action
+    /// Notification action.
     var action: InAppNotificationAction?
 }
 
-extension InAppNotificationDescriptor: Equatable {
-    static func == (lhs: InAppNotificationDescriptor, rhs: InAppNotificationDescriptor) -> Bool {
-        lhs.identifier == rhs.identifier
-    }
-}
-
-struct InAppNotificationAction {
+/// Type describing a specific in-app notification action.
+struct InAppNotificationAction: Equatable {
+    /// Image assigned to action button.
     var image: UIImage?
+
+    /// Action handler for button.
     var handler: (() -> Void)?
+
+    static func == (lhs: InAppNotificationAction, rhs: InAppNotificationAction) -> Bool {
+        return lhs.image == rhs.image
+    }
 }
 
 enum NotificationBannerStyle {

--- a/ios/MullvadVPN/Notifications/NotificationManager.swift
+++ b/ios/MullvadVPN/Notifications/NotificationManager.swift
@@ -204,9 +204,7 @@ final class NotificationManager: NotificationProviderDelegate {
             if let replaceNotificationDescriptor = notificationProvider.notificationDescriptor {
                 newNotificationDescriptors = notificationProviders
                     .compactMap { notificationProvider -> InAppNotificationDescriptor? in
-                        if replaceNotificationDescriptor.identifier == notificationProvider
-                            .identifier
-                        {
+                        if replaceNotificationDescriptor.identifier == notificationProvider.identifier {
                             return replaceNotificationDescriptor
                         } else {
                             return inAppNotificationDescriptors.first { descriptor in

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -89,7 +89,7 @@ final class NotificationBannerView: UIView {
 
     var actionHandler: InAppNotificationAction? {
         didSet {
-            actionButton.setImage(actionHandler?.image, for: .normal)
+            actionButton.setImage(actionHandler?.type.image, for: .normal)
             actionButton.addTarget(self, action: #selector(didPress), for: .touchUpInside)
         }
     }

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -88,9 +88,9 @@ final class NotificationBannerView: UIView {
         }
     }
 
-    var actionHandler: InAppNotificationAction? {
+    var action: InAppNotificationAction? {
         didSet {
-            actionButton.setImage(actionHandler?.type.image, for: .normal)
+            actionButton.setImage(action?.image, for: .normal)
             actionButton.addTarget(self, action: #selector(didPress), for: .touchUpInside)
         }
     }
@@ -149,7 +149,7 @@ final class NotificationBannerView: UIView {
     }
 
     @objc private func didPress() {
-        actionHandler?.handler?()
+        action?.handler?()
     }
 }
 

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -64,7 +64,8 @@ final class NotificationBannerView: UIView {
     }()
 
     private let actionButton: UIButton = {
-        let button = UIButton()
+        let button = UIButton(type: .system)
+        button.tintColor = UIColor.InAppNotificationBanner.actionButtonColor
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()

--- a/ios/MullvadVPN/Notifications/UI/NotificationController.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationController.swift
@@ -105,7 +105,7 @@ final class NotificationController: UIViewController {
         bannerView.title = notification.title
         bannerView.body = notification.body
         bannerView.style = notification.style
-        bannerView.actionHandler = notification.action
+        bannerView.action = notification.action
         bannerView.accessibilityLabel = "\(notification.title)\n\(notification.body.string)"
 
         if animated {

--- a/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
@@ -118,6 +118,7 @@ extension UIColor {
 
         static let titleColor = UIColor.white
         static let bodyColor = UIColor(white: 1.0, alpha: 0.6)
+        static let actionButtonColor = UIColor(white: 1.0, alpha: 0.6)
     }
 
     // Common colors


### PR DESCRIPTION
1. This PR reverts `Equatable` implementation for  `InAppNotificationDescriptor`. The same notification can be displayed many times with different attributes so checking notifications by `identifier` only does not always work. This proved to be the case with `RegisteredDeviceInAppNotification` which didn't disappear on logout and then didn't update after logging with new account. Maybe it's an edge case? In any case, please only call `invalidate()` on notification providers when external events result into new content being produced.
2. `InAppNotificationAction` implements `Equatable` but ignore block handler because there is no easy way to achieve that, but on other side we always produce new closures so it's pointless either way. In that regard let's focus equality check for properties that affect visual content representation and leave handlers out of it.
3. Instead of providing `UIImage`, `InAppNotifcationAction` now accepts a enum type (`InAppNotificationActionType`). More or less we're going to use a fixed list of actions so it's ok if we keep them limited and control graphics in one place and not in each individual provider.
4. Fix tint color for action button.

![image](https://user-images.githubusercontent.com/704044/234924511-c8bf7478-2d66-4fa5-ab4e-eb1f9b7d9861.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4629)
<!-- Reviewable:end -->
