### PR TITLE
Fix crash in VPN settings when footer is updated

### DIFF
--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
@@ -170,8 +170,9 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             viewModel = mergedViewModel
         }
 
-        updateSnapshot()
-        reloadCustomDNSFooter()
+        updateSnapshot { [weak self] in
+            self?.reloadCustomDNSFooter()
+        }
     }
 
     // MARK: - UITableViewDataSource
@@ -558,11 +559,9 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         let sectionIndex = snapshot().indexOfSection(.customDNS)!
 
         UIView.performWithoutAnimation {
-            tableView?.performBatchUpdates({
-                if let reusableView = tableView?.footerView(forSection: sectionIndex) as? SettingsStaticTextFooterView {
-                    configureFooterView(reusableView)
-                }
-            })
+            if let reusableView = tableView?.footerView(forSection: sectionIndex) as? SettingsStaticTextFooterView {
+                configureFooterView(reusableView)
+            }
         }
     }
 
@@ -601,6 +600,8 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
 
         reusableView.titleLabel.attributedText = viewModel.customDNSPrecondition
             .attributedLocalizedDescription(isEditing: isEditing, preferredFont: font)
+
+        reusableView.titleLabel.sizeToFit()
     }
 }
 


### PR DESCRIPTION
Diffable data sources don't like `UITableView.performBatchUpdates`.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4632)
<!-- Reviewable:end -->
