### PR TITLE
Disable VectorKit logging IOS-146

### DIFF
--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -67,5 +67,19 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>OSLogPreferences</key>
+	<dict>
+		<key>com.apple.VectorKit</key>
+		<dict>
+			<key>DEFAULT-OPTIONS</key>
+			<dict>
+				<key>Level</key>
+				<dict>
+					<key>Enable</key>
+					<string>Off</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This PR disables OSLogging facility for `com.apple.VectorKit` which has been spamming our console log with huge amounts of repeated information which we can't do much with anyway.

<img width="885" alt="Screenshot 2023-04-28 at 15 13 21" src="https://user-images.githubusercontent.com/704044/235159271-7620e61f-4f31-4e91-b44f-b8aa9e19cd83.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4634)
<!-- Reviewable:end -->
