### PR TITLE
Cache known good api mode ios 133

### DIFF
--- a/ios/MullvadREST/RESTNetworkOperation.swift
+++ b/ios/MullvadREST/RESTNetworkOperation.swift
@@ -30,6 +30,7 @@ extension REST {
         private var retryDelayIterator: AnyIterator<Duration>
         private var retryTimer: DispatchSourceTimer?
         private var retryCount = 0
+        private var transportStrategy = TransportStrategy()
 
         init(
             name: String,
@@ -140,7 +141,13 @@ extension REST {
         private func didReceiveURLRequest(_ restRequest: REST.Request, endpoint: AnyIPEndpoint) {
             dispatchPrecondition(condition: .onQueue(dispatchQueue))
 
-            guard let transport = transportProvider()?.transport() else {
+            let suggestedTransport = transportStrategy.connectionTransport()
+            let transportProvider = transportProvider()
+            let transport = suggestedTransport == .useShadowSocks
+                ? transportProvider?.shadowSocksTransport()
+                : transportProvider?.transport()
+
+            guard let transport = transport else {
                 logger.error("Failed to obtain transport.")
                 finish(result: .failure(REST.Error.transport(NoTransportError())))
                 return
@@ -207,7 +214,7 @@ extension REST {
                 default:
                     if !REST.isStagingEnvironment {
                         _ = addressCacheStore.selectNextEndpoint(endpoint)
-                        transportProvider()?.selectNextTransport()
+                        transportStrategy.didFail()
                     }
                 }
             }

--- a/ios/MullvadREST/RESTTransport.swift
+++ b/ios/MullvadREST/RESTTransport.swift
@@ -23,6 +23,7 @@ public protocol RESTTransportProvider {
     /// - Returns: A transport layer
     func transport() -> RESTTransport?
 
-    /// Requests the transport provider to select a different transport layer
-    func selectNextTransport()
+    /// Requests a Shadowsocks transport
+    /// - Returns: A transport layer that proxies the requests to a local Shadowsocks proxy instance
+    func shadowSocksTransport() -> RESTTransport?
 }

--- a/ios/MullvadREST/RESTTransportStrategy.swift
+++ b/ios/MullvadREST/RESTTransportStrategy.swift
@@ -1,0 +1,47 @@
+//
+//  RESTTransportStrategy.swift
+//  MullvadREST
+//
+//  Created by Marco Nikic on 2023-04-27.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+extension REST {
+    public struct TransportStrategy: Codable {
+        /// The different transports suggested by the strategy
+        public enum Transport {
+            /// Suggests using a direct connection
+            case useURLSession
+            /// Suggests connecting via Shadowsocks proxy
+            case useShadowSocks
+        }
+
+        /// The internal counter for suggested transports.
+        ///
+        /// A value of `0` means  a direct transport suggestion, a value of `1` or `2` means a Shadowsocks transport
+        /// suggestion.
+        private var connectionAttempts: UInt
+
+        public init() {
+            connectionAttempts = 0
+        }
+
+        /// Instructs the strategy that a network connection failed
+        ///
+        /// Every third failure results in a direct transport suggestion.
+        public mutating func didFail() {
+            connectionAttempts += 1
+            // Avoid overflowing by resetting back to 0 every 3rd failure
+            connectionAttempts = connectionAttempts.isMultiple(of: 3) ? 0 : connectionAttempts
+        }
+
+        /// The suggested connection transport
+        ///
+        /// - Returns: `.useURLSession` for every 3rd failed attempt, `.useShadowSocks` otherwise
+        public func connectionTransport() -> Transport {
+            connectionAttempts.isMultiple(of: 3) ? .useURLSession : .useShadowSocks
+        }
+    }
+}

--- a/ios/MullvadRESTTests/TransportStrategyTests.swift
+++ b/ios/MullvadRESTTests/TransportStrategyTests.swift
@@ -1,0 +1,40 @@
+//
+//  TransportStrategyTests.swift
+//  MullvadRESTTests
+//
+//  Created by Marco Nikic on 2023-04-27.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadREST
+import XCTest
+
+final class TransportStrategyTests: XCTestCase {
+    func testEveryThirdConnectionAttemptsIsDirect() {
+        var strategy = REST.TransportStrategy()
+
+        for index in 0 ... 12 {
+            let expectedResult: REST.TransportStrategy.Transport
+            expectedResult = index.isMultiple(of: 3) ? .useURLSession : .useShadowSocks
+            XCTAssertEqual(strategy.connectionTransport(), expectedResult)
+            strategy.didFail()
+        }
+    }
+
+    func testLoadingFromCacheDoesNotImpactStrategy() throws {
+        var strategy = REST.TransportStrategy()
+
+        // Fail twice, the next suggested transport mode should be via Shadowsocks proxy
+        strategy.didFail()
+        strategy.didFail()
+        XCTAssertEqual(strategy.connectionTransport(), .useShadowSocks)
+
+        // Serialize the strategy and reload it from memory to simulate an application restart
+        let encodedRawStrategy = try JSONEncoder().encode(strategy)
+        var reloadedStrategy = try JSONDecoder().decode(REST.TransportStrategy.self, from: encodedRawStrategy)
+
+        // This should be the third failure, the next suggested transport will be a direct one
+        reloadedStrategy.didFail()
+        XCTAssertEqual(reloadedStrategy.connectionTransport(), .useURLSession)
+    }
+}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -366,6 +366,8 @@
 		7A818F1F29F0305800C7F0F4 /* RootConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A818F1E29F0305800C7F0F4 /* RootConfiguration.swift */; };
 		7AD2DA1529DC4EB900250737 /* UISearchBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD2DA1429DC4EB900250737 /* UISearchBar+Appearance.swift */; };
 		7AF0419E29E957EB00D492DD /* AccountCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF0419D29E957EB00D492DD /* AccountCoordinator.swift */; };
+		A917351F29FAA9C400D5DCFD /* RESTTransportStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A917351E29FAA9C400D5DCFD /* RESTTransportStrategy.swift */; };
+		A917352129FAAA5200D5DCFD /* TransportStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A917352029FAAA5200D5DCFD /* TransportStrategyTests.swift */; };
 		A92CAAC629F7D33C008ED922 /* TunnelTransportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92CAAC529F7D33C008ED922 /* TunnelTransportProvider.swift */; };
 		E1187ABC289BBB850024E748 /* OutOfTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1187ABA289BBB850024E748 /* OutOfTimeViewController.swift */; };
 		E1187ABD289BBB850024E748 /* OutOfTimeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */; };
@@ -956,6 +958,8 @@
 		7A818F1E29F0305800C7F0F4 /* RootConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootConfiguration.swift; sourceTree = "<group>"; };
 		7AD2DA1429DC4EB900250737 /* UISearchBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchBar+Appearance.swift"; sourceTree = "<group>"; };
 		7AF0419D29E957EB00D492DD /* AccountCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCoordinator.swift; sourceTree = "<group>"; };
+		A917351E29FAA9C400D5DCFD /* RESTTransportStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTTransportStrategy.swift; sourceTree = "<group>"; };
+		A917352029FAAA5200D5DCFD /* TransportStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportStrategyTests.swift; sourceTree = "<group>"; };
 		A92CAAC529F7D33C008ED922 /* TunnelTransportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelTransportProvider.swift; sourceTree = "<group>"; };
 		E1187ABA289BBB850024E748 /* OutOfTimeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeViewController.swift; sourceTree = "<group>"; };
 		E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeContentView.swift; sourceTree = "<group>"; };
@@ -1146,6 +1150,7 @@
 				5897F1732913EAF800AF5695 /* ExponentialBackoff.swift */,
 				06FAE67528F83CA40033DD93 /* RESTTaskIdentifier.swift */,
 				06FAE67D28F83CA50033DD93 /* RESTTransport.swift */,
+				A917351E29FAA9C400D5DCFD /* RESTTransportStrategy.swift */,
 				06FAE66528F83CA30033DD93 /* RESTURLSession.swift */,
 				06FAE67728F83CA40033DD93 /* ServerRelaysResponse.swift */,
 				06FAE66B28F83CA30033DD93 /* SSLPinningURLSessionDelegate.swift */,
@@ -1920,6 +1925,7 @@
 			children = (
 				58FBFBF0291630700020E046 /* DurationTests.swift */,
 				58FBFBE8291622580020E046 /* ExponentialBackoffTests.swift */,
+				A917352029FAAA5200D5DCFD /* TransportStrategyTests.swift */,
 			);
 			path = MullvadRESTTests;
 			sourceTree = "<group>";
@@ -2557,6 +2563,7 @@
 				06799ADF28F98E4800ACD94E /* RESTDevicesProxy.swift in Sources */,
 				06799ADA28F98E4800ACD94E /* RESTResponseHandler.swift in Sources */,
 				062B45BC28FD8C3B00746E77 /* RESTDefaults.swift in Sources */,
+				A917351F29FAA9C400D5DCFD /* RESTTransportStrategy.swift in Sources */,
 				06799AE428F98E4800ACD94E /* RESTAccountsProxy.swift in Sources */,
 				5897F1742913EAF800AF5695 /* ExponentialBackoff.swift in Sources */,
 				06799AE328F98E4800ACD94E /* RESTNetworkOperation.swift in Sources */,
@@ -2919,6 +2926,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A917352129FAAA5200D5DCFD /* TransportStrategyTests.swift in Sources */,
 				58FBFBE9291622580020E046 /* ExponentialBackoffTests.swift in Sources */,
 				58FBFBF1291630700020E046 /* DurationTests.swift in Sources */,
 			);

--- a/ios/TunnelProviderMessaging/URLRequestProxy.swift
+++ b/ios/TunnelProviderMessaging/URLRequestProxy.swift
@@ -34,11 +34,10 @@ public final class URLRequestProxy {
         dispatchQueue.async {
             // Instruct the Packet Tunnel to try to reach the API via the local shadow socks proxy instance if needed
             let transportProvider = self.transportProvider()
-            if proxyRequest.useShadowsocksTransport {
-                transportProvider?.selectNextTransport()
-            }
-
-            guard let transport = transportProvider?.transport() else { return }
+            let transport = proxyRequest.useShadowsocksTransport
+                ? transportProvider?.shadowSocksTransport()
+                : transportProvider?.transport()
+            guard let transport = transport else { return }
             // The task sent by `transport.sendRequest` comes in an already resumed state
             let task = transport.sendRequest(proxyRequest.urlRequest) { [weak self] data, response, error in
                 guard let self = self else { return }


### PR DESCRIPTION
The scope of this ticket has slightly changed, this PR introduces a `TransportStrategy` that defines when to use a direct URLSession for reaching the API, or when to proxy requests via Shadowsocks.

At this moment, the selection of the Shadowsocks relay endpoint is still random, and the API is still hardcoded in the rust library.

Those modifications will come after we rework how the `AddressCache` works in IOS-149

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4641)
<!-- Reviewable:end -->
