### PR TITLE
Rework the address cache IOS-149

### DIFF
--- a/ios/MullvadREST/RESTAPIProxy.swift
+++ b/ios/MullvadREST/RESTAPIProxy.swift
@@ -37,10 +37,7 @@ extension REST {
                 )
             }
 
-            let responseHandler = REST.defaultResponseHandler(
-                decoding: [AnyIPEndpoint].self,
-                with: responseDecoder
-            )
+            let responseHandler = REST.apiFilterResponseHandler(with: responseDecoder)
 
             return addOperation(
                 name: "get-api-addrs",


### PR DESCRIPTION
This PR vastly simplifies the `AddressCache` class whilst keeping the rest of the architecture of the app intact to minimize changes.

As we are trying to deprecate port-forwarded addresses, we now ignore all but the first result when querying the `api-addrs` endpoint.
A new filter method has been added to do just that.
