### PR TITLE
Fix date interval formatting and update tests

### DIFF
--- a/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
+++ b/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
@@ -24,22 +24,14 @@ extension CustomDateComponentsFormatting {
         calendar: Calendar = Calendar.current,
         unitsStyle: DateComponentsFormatter.UnitsStyle
     ) -> String? {
+        let years = calendar.dateComponents([.year], from: start, to: max(start, end)).year ?? 0
+
         let formatter = DateComponentsFormatter()
         formatter.calendar = calendar
         formatter.unitsStyle = unitsStyle
         formatter.maximumUnitCount = 1
+        formatter.allowedUnits = years >= 2 ? .year : .day
 
-        let dateComponents = calendar.dateComponents([.year, .day], from: start, to: end)
-        let years = dateComponents.year ?? 0
-        let days = dateComponents.day ?? 0
-
-        if years >= 2 {
-            formatter.allowedUnits = [.year]
-            return formatter.string(from: dateComponents)
-        } else if days > 0 {
-            formatter.allowedUnits = [.day]
-            return formatter.string(from: start, to: end)
-        }
-        return formatter.string(from: DateComponents(calendar: calendar, day: 0))
+        return formatter.string(from: start, to: end)
     }
 }

--- a/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
+++ b/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
@@ -27,10 +27,9 @@ class CustomDateComponentsFormattingTests: XCTestCase {
 
     func testLessThanTwoYearsFormatting() throws {
         var dateComponents = DateComponents()
-        dateComponents.year = 2
+        dateComponents.day = 365
 
-        var (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
-        endDate = endDate.addingTimeInterval(-1)
+        let (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
 
         let result = CustomDateComponentsFormatting.localizedString(
             from: startDate,
@@ -39,8 +38,7 @@ class CustomDateComponentsFormattingTests: XCTestCase {
             unitsStyle: .full
         )
 
-        let expectedDays = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
-        XCTAssertEqual(result, "\(expectedDays) days")
+        XCTAssertEqual(result, "365 days")
     }
 
     func testCloseToOneDayFormatting() throws {


### PR DESCRIPTION
When querying multiple date components, `Calendar` tends to collapse to the largest unit. That's the problem because for dates < 2 years we'd only display the number of days that's less than a year, after computing number of whole years. So when formatting a date that's exactly 365 days, we'd print 0 days instead because the largest unit a year in that case.

This PR also clamps the `end` date so that we don't have to handle "0 days" as a special case, instead when `start > end`, the `end = start`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4654)
<!-- Reviewable:end -->
