### PR TITLE
Add notification controller into root container IOS-139

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/TunnelCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/TunnelCoordinator.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TunnelCoordinator: Coordinator, NotificationManagerDelegate {
+class TunnelCoordinator: Coordinator {
     private let tunnelManager: TunnelManager
     private let controller: TunnelViewController
 
@@ -44,22 +44,11 @@ class TunnelCoordinator: Coordinator, NotificationManagerDelegate {
         tunnelManager.addObserver(tunnelObserver)
 
         updateVisibility(animated: false)
-
-        NotificationManager.shared.delegate = self
     }
 
     private func updateVisibility(animated: Bool) {
         let deviceState = tunnelManager.deviceState
 
         controller.setMainContentHidden(!deviceState.isLoggedIn, animated: animated)
-    }
-
-    // MARK: - NotificationManagerDelegate
-
-    func notificationManagerDidUpdateInAppNotifications(
-        _ manager: NotificationManager,
-        notifications: [InAppNotificationDescriptor]
-    ) {
-        controller.notificationController.setNotifications(notifications, animated: true)
     }
 }

--- a/ios/MullvadVPN/Notifications/UI/NotificationController.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationController.swift
@@ -25,6 +25,7 @@ final class NotificationController: UIViewController {
 
     override func loadView() {
         view = NotificationContainerView(frame: UIScreen.main.bounds)
+        view.clipsToBounds = true
     }
 
     override func viewDidLoad() {

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -20,7 +20,6 @@ class TunnelViewController: UIViewController, RootContainment {
 
     var shouldShowSelectLocationPicker: (() -> Void)?
 
-    let notificationController = NotificationController()
     private let mapViewController = MapViewController()
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -82,7 +81,6 @@ class TunnelViewController: UIViewController, RootContainment {
 
         addMapController()
         addContentView()
-        addNotificationController()
 
         tunnelState = interactor.tunnelStatus.state
         updateContentView(animated: false)
@@ -177,22 +175,6 @@ class TunnelViewController: UIViewController, RootContainment {
             mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             mapView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
-    }
-
-    private func addNotificationController() {
-        let notificationView = notificationController.view!
-        notificationView.translatesAutoresizingMaskIntoConstraints = false
-
-        addChild(notificationController)
-        view.addSubview(notificationView)
-        notificationController.didMove(toParent: self)
-
-        NSLayoutConstraint.activate([
-            notificationView.topAnchor.constraint(equalTo: view.topAnchor),
-            notificationView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            notificationView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            notificationView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
 


### PR DESCRIPTION
1. Move `NotificationController` higher into `RootContainer`.
2. Make it possible to pin notification controller to a custom layout guide so that it doesn't overflow the entire split view controller but only a primary side.
3. Generate notifications from `FormSheetPresentationController` to tell `AppCoordinator` when presentation changes from formsheet to fullscreen and vice-versa.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4661)
<!-- Reviewable:end -->
