### PR TITLE
Sometimes the device/time-left header disappears

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -372,7 +372,8 @@
 		E1187ABD289BBB850024E748 /* OutOfTimeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */; };
 		E158B360285381C60002F069 /* String+AccountFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E158B35F285381C60002F069 /* String+AccountFormatting.swift */; };
 		E1FD0DF528AA7CE400299DB4 /* StatusActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FD0DF428AA7CE400299DB4 /* StatusActivityView.swift */; };
-		F07CFF2029F2720E008C0343 /* RegisteredDeviceInAppNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07CFF1F29F2720E008C0343 /* RegisteredDeviceInAppNotification.swift */; };
+		F07CFF2029F2720E008C0343 /* RegisteredDeviceInAppNotificationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07CFF1F29F2720E008C0343 /* RegisteredDeviceInAppNotificationProvider.swift */; };
+		F0C2AEFD2A0BB5CC00986207 /* NotificationProviderIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C2AEFC2A0BB5CC00986207 /* NotificationProviderIdentifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -972,7 +973,8 @@
 		E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeContentView.swift; sourceTree = "<group>"; };
 		E158B35F285381C60002F069 /* String+AccountFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+AccountFormatting.swift"; sourceTree = "<group>"; };
 		E1FD0DF428AA7CE400299DB4 /* StatusActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusActivityView.swift; sourceTree = "<group>"; };
-		F07CFF1F29F2720E008C0343 /* RegisteredDeviceInAppNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisteredDeviceInAppNotification.swift; sourceTree = "<group>"; };
+		F07CFF1F29F2720E008C0343 /* RegisteredDeviceInAppNotificationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisteredDeviceInAppNotificationProvider.swift; sourceTree = "<group>"; };
+		F0C2AEFC2A0BB5CC00986207 /* NotificationProviderIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationProviderIdentifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1598,7 +1600,7 @@
 				58C8191729FAA2C400DEB1B4 /* NotificationConfiguration.swift */,
 				587B75402668FD7700DEF7E9 /* AccountExpirySystemNotificationProvider.swift */,
 				58607A4C2947287800BC467D /* AccountExpiryInAppNotificationProvider.swift */,
-				F07CFF1F29F2720E008C0343 /* RegisteredDeviceInAppNotification.swift */,
+				F07CFF1F29F2720E008C0343 /* RegisteredDeviceInAppNotificationProvider.swift */,
 				58A94AE326CFD945001CB97C /* TunnelStatusNotificationProvider.swift */,
 			);
 			path = "Notification Providers";
@@ -1694,6 +1696,7 @@
 				58B26E20294351A600D5980C /* UI */,
 				587B75422669034500DEF7E9 /* Notification Providers */,
 				58B26E232943520C00D5980C /* NotificationProviderProtocol.swift */,
+				F0C2AEFC2A0BB5CC00986207 /* NotificationProviderIdentifier.swift */,
 				58B26E252943522400D5980C /* NotificationProvider.swift */,
 				58B26E1D2943514300D5980C /* InAppNotificationDescriptor.swift */,
 				58B26E21294351EA00D5980C /* InAppNotificationProvider.swift */,
@@ -2621,6 +2624,7 @@
 				5896CEF226972DEB00B0FAE8 /* AccountContentView.swift in Sources */,
 				7AF0419E29E957EB00D492DD /* AccountCoordinator.swift in Sources */,
 				5867771429097BCD006F721F /* PaymentState.swift in Sources */,
+				F0C2AEFD2A0BB5CC00986207 /* NotificationProviderIdentifier.swift in Sources */,
 				587D96742886D87C00CD8F1C /* DeviceManagementContentView.swift in Sources */,
 				589A454C28DDF5E100565204 /* Swizzle.swift in Sources */,
 				5864211F29F04CED00822139 /* UIBarButtonItem+Blocks.swift in Sources */,
@@ -2721,7 +2725,7 @@
 				582BB1AF229566420055B6EF /* SettingsCell.swift in Sources */,
 				58F3C0A4249CB069003E76BE /* HeaderBarView.swift in Sources */,
 				5864AF0829C78849005B0CD9 /* CellFactoryProtocol.swift in Sources */,
-				F07CFF2029F2720E008C0343 /* RegisteredDeviceInAppNotification.swift in Sources */,
+				F07CFF2029F2720E008C0343 /* RegisteredDeviceInAppNotificationProvider.swift in Sources */,
 				587A01FC23F1F0BE00B68763 /* SimulatorTunnelProviderHost.swift in Sources */,
 				58CAF9F82983D36800BE19F7 /* Coordinator.swift in Sources */,
 				5819C2172729595500D6EC38 /* SettingsAddDNSEntryCell.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -347,7 +347,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func setupNotificationHandler() {
         NotificationManager.shared.notificationProviders = [
-            RegisteredDeviceInAppNotification(tunnelManager: tunnelManager),
+            RegisteredDeviceInAppNotificationProvider(tunnelManager: tunnelManager),
             TunnelStatusNotificationProvider(tunnelManager: tunnelManager),
             AccountExpirySystemNotificationProvider(tunnelManager: tunnelManager),
             AccountExpiryInAppNotificationProvider(tunnelManager: tunnelManager),

--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -180,7 +180,7 @@ class HeaderBarView: UIView {
 }
 
 extension HeaderBarView {
-    func update(configuration: RootConfigration) {
+    func update(configuration: RootConfiguration) {
         if let name = configuration.deviceName {
             let formattedDeviceName = NSLocalizedString(
                 "DEVICE_NAME_HEADER_VIEW",

--- a/ios/MullvadVPN/Containers/Root/RootConfiguration.swift
+++ b/ios/MullvadVPN/Containers/Root/RootConfiguration.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct RootConfigration {
+struct RootConfiguration {
     var deviceName: String?
     var expiry: Date?
     var showsAccountButton: Bool

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -70,7 +70,7 @@ class RootContainerViewController: UIViewController {
     let transitionContainer = UIView(frame: UIScreen.main.bounds)
     private var presentationContainerAccountButton: UIButton?
     private var presentationContainerSettingsButton: UIButton?
-    private var configuration = RootConfigration(showsAccountButton: false, showsDeviceInfo: true)
+    private var configuration = RootConfiguration(showsAccountButton: false, showsDeviceInfo: true)
 
     private(set) var headerBarPresentation = HeaderBarPresentation.default
     private(set) var headerBarHidden = false
@@ -787,7 +787,7 @@ extension UIViewController {
 }
 
 extension RootContainerViewController {
-    func update(configuration: RootConfigration) {
+    func update(configuration: RootConfiguration) {
         self.configuration = configuration
 
         presentationContainerAccountButton?.isHidden = !configuration.showsAccountButton

--- a/ios/MullvadVPN/Notifications/InAppNotificationDescriptor.swift
+++ b/ios/MullvadVPN/Notifications/InAppNotificationDescriptor.swift
@@ -12,7 +12,7 @@ import UIKit.UIImage
 /// Struct describing in-app notification.
 struct InAppNotificationDescriptor: Equatable {
     /// Notification identifier.
-    var identifier: String
+    var identifier: NotificationProviderIdentifier
 
     /// Notification banner style.
     var style: NotificationBannerStyle

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiryInAppNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiryInAppNotificationProvider.swift
@@ -29,8 +29,8 @@ final class AccountExpiryInAppNotificationProvider: NotificationProvider, InAppN
         tunnelManager.addObserver(tunnelObserver)
     }
 
-    override var identifier: String {
-        return "net.mullvad.MullvadVPN.AccountExpiryInAppNotification"
+    override var identifier: NotificationProviderIdentifier {
+        .accountExpiryInAppNotification
     }
 
     // MARK: - InAppNotificationProvider

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
@@ -13,8 +13,6 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
     private var accountExpiry: Date?
     private var tunnelObserver: TunnelBlockObserver?
 
-    static let identifier = "net.mullvad.MullvadVPN.AccountExpiryNotification"
-
     init(tunnelManager: TunnelManager) {
         super.init()
 
@@ -32,8 +30,8 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
         self.tunnelObserver = tunnelObserver
     }
 
-    override var identifier: String {
-        return Self.identifier
+    override var identifier: NotificationProviderIdentifier {
+        .accountExpirySystemNotification
     }
 
     // MARK: - SystemNotificationProvider
@@ -62,7 +60,7 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
         content.sound = UNNotificationSound.default
 
         return UNNotificationRequest(
-            identifier: identifier,
+            identifier: identifier.domainIdentifier,
             content: content,
             trigger: trigger
         )

--- a/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
@@ -15,8 +15,8 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
     private var tunnelManagerError: Error?
     private var tunnelObserver: TunnelBlockObserver?
 
-    override var identifier: String {
-        return "net.mullvad.MullvadVPN.TunnelStatusNotificationProvider"
+    override var identifier: NotificationProviderIdentifier {
+        return .tunnelStatusNotificationProvider
     }
 
     var notificationDescriptor: InAppNotificationDescriptor? {

--- a/ios/MullvadVPN/Notifications/NotificationManager.swift
+++ b/ios/MullvadVPN/Notifications/NotificationManager.swift
@@ -63,11 +63,11 @@ final class NotificationManager: NotificationProviderDelegate {
         for notificationProvider in notificationProviders {
             if let notificationProvider = notificationProvider as? SystemNotificationProvider {
                 if notificationProvider.shouldRemovePendingRequests {
-                    pendingRequestIdentifiersToRemove.append(notificationProvider.identifier)
+                    pendingRequestIdentifiersToRemove.append(notificationProvider.identifier.domainIdentifier)
                 }
 
                 if notificationProvider.shouldRemoveDeliveredRequests {
-                    deliveredRequestIdentifiersToRemove.append(notificationProvider.identifier)
+                    deliveredRequestIdentifiersToRemove.append(notificationProvider.identifier.domainIdentifier)
                 }
 
                 if let request = notificationProvider.notificationRequest {
@@ -120,7 +120,7 @@ final class NotificationManager: NotificationProviderDelegate {
         guard let sourceProvider = notificationProviders.first(where: { notificationProvider in
             guard let notificationProvider = notificationProvider as? SystemNotificationProvider else { return false }
 
-            return response.notification.request.identifier == notificationProvider.identifier
+            return response.notification.request.identifier == notificationProvider.identifier.domainIdentifier
         }) else {
             logger.warning(
                 "Received response with request identifier: \(response.notification.request.identifier) that didn't map to any notification provider"
@@ -179,13 +179,13 @@ final class NotificationManager: NotificationProviderDelegate {
 
             if notificationProvider.shouldRemovePendingRequests {
                 notificationCenter.removePendingNotificationRequests(withIdentifiers: [
-                    notificationProvider.identifier,
+                    notificationProvider.identifier.domainIdentifier,
                 ])
             }
 
             if notificationProvider.shouldRemoveDeliveredRequests {
                 notificationCenter.removeDeliveredNotifications(withIdentifiers: [
-                    notificationProvider.identifier,
+                    notificationProvider.identifier.domainIdentifier,
                 ])
             }
 

--- a/ios/MullvadVPN/Notifications/NotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/NotificationProvider.swift
@@ -25,8 +25,8 @@ class NotificationProvider: NotificationProviderProtocol {
      Override in subclasses and make sure each provider has unique identifier. It's preferred that identifiers use
      reverse domain name, for instance: `com.example.app.ProviderName`.
      */
-    var identifier: String {
-        return "default"
+    var identifier: NotificationProviderIdentifier {
+        .default
     }
 
     /**

--- a/ios/MullvadVPN/Notifications/NotificationProviderIdentifier.swift
+++ b/ios/MullvadVPN/Notifications/NotificationProviderIdentifier.swift
@@ -1,0 +1,21 @@
+//
+//  NotificationProviderIdentifier.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2023-05-10.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+enum NotificationProviderIdentifier: String {
+    case accountExpirySystemNotification = "AccountExpiryNotification"
+    case accountExpiryInAppNotification = "AccountExpiryInAppNotification"
+    case registeredDeviceInAppNotification = "RegisteredDeviceInAppNotification"
+    case tunnelStatusNotificationProvider = "TunnelStatusNotificationProvider"
+    case `default` = "default"
+
+    var domainIdentifier: String {
+        "net.mullvad.MullvadVPN.\(rawValue)"
+    }
+}

--- a/ios/MullvadVPN/Notifications/NotificationProviderProtocol.swift
+++ b/ios/MullvadVPN/Notifications/NotificationProviderProtocol.swift
@@ -12,7 +12,7 @@ import Foundation
 protocol NotificationProviderProtocol {
     /// Unique provider identifier used to identify notification providers and notifications
     /// produced by them.
-    var identifier: String { get }
+    var identifier: NotificationProviderIdentifier { get }
 
     /// Tell notification manager to update the associated notification.
     func invalidate()

--- a/ios/MullvadVPN/Notifications/NotificationResponse.swift
+++ b/ios/MullvadVPN/Notifications/NotificationResponse.swift
@@ -14,7 +14,7 @@ import UserNotifications
  */
 struct NotificationResponse {
     /// Provider identifier.
-    var providerIdentifier: String
+    var providerIdentifier: NotificationProviderIdentifier
 
     /// Action identifier, i.e UNNotificationDefaultActionIdentifier or any custom.
     var actionIdentifier: String

--- a/ios/MullvadVPN/TunnelManager/TunnelBlockObserver.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelBlockObserver.swift
@@ -14,7 +14,7 @@ final class TunnelBlockObserver: TunnelObserver {
     typealias DidUpdateDeviceStateHandler = (
         _ tunnelManager: TunnelManager,
         _ deviceState: DeviceState,
-        _ previousDeviceStaate: DeviceState
+        _ previousDeviceState: DeviceState
     ) -> Void
     typealias DidUpdateTunnelSettingsHandler = (TunnelManager, TunnelSettingsV2) -> Void
     typealias DidFailWithErrorHandler = (TunnelManager, Error) -> Void


### PR DESCRIPTION
Sometimes the device header disappears in the no time left view, possibly in others. This obviously shouldn't happen.

- Trigger device name in app banner in just case user state is changed from logged out to logged in
- Invalidate itself for hiding banner when user goes from logged in into logged out or revoked
- Take notification identifiers into enum
-  Fix spelling mistakes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4666)
<!-- Reviewable:end -->
