### PR TITLE
Fix out-of-time formatter *again*

### DIFF
--- a/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
+++ b/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
@@ -32,6 +32,6 @@ extension CustomDateComponentsFormatting {
         formatter.maximumUnitCount = 1
         formatter.allowedUnits = years >= 2 ? .year : .day
 
-        return formatter.string(from: start, to: end)
+        return formatter.string(from: start, to: max(start, end))
     }
 }

--- a/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
+++ b/ios/MullvadVPNTests/CustomDateComponentsFormattingTests.swift
@@ -25,6 +25,22 @@ class CustomDateComponentsFormattingTests: XCTestCase {
         XCTAssertEqual(result, "2 years")
     }
 
+    func testTimeIsPassedFormatting() throws {
+        var dateComponents = DateComponents()
+        dateComponents.day = -1
+
+        let (startDate, endDate) = makeDateRange(addingComponents: dateComponents)
+
+        let result = CustomDateComponentsFormatting.localizedString(
+            from: startDate,
+            to: endDate,
+            calendar: calendar,
+            unitsStyle: .full
+        )
+
+        XCTAssertEqual(result, "0 days")
+    }
+
     func testLessThanTwoYearsFormatting() throws {
         var dateComponents = DateComponents()
         dateComponents.day = 365


### PR DESCRIPTION
Currently, the out of time label will show negative days. The amount of time left should never be less than 0 - it should be clamped to 0 or more days. We should have unit tests for this.

- compare the end date with current date and change it in case it's passed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4667)
<!-- Reviewable:end -->
