### PR TITLE
Fix changes.txt templates

### DIFF
--- a/gui/changes.txt
+++ b/gui/changes.txt
@@ -1,4 +1,5 @@
 CHANGE THIS BEFORE A RELEASE
 Each line is treated as a separate change item shown in the GUI the first time it runs after install.
 Start each line with a capital letter and end each line with a period.
+[macOS, Windows, linux] To make an entry platform specific, start the line with an angle bracket enclosed comma separated list of platforms to show the entry on.
 Only point out the major changes.

--- a/ios/Assets/changes.txt
+++ b/ios/Assets/changes.txt
@@ -1,5 +1,4 @@
 CHANGE THIS BEFORE A RELEASE
 Each line is treated as a separate change item shown in the GUI the first time it runs after install.
 Start each line with a capital letter and end each line with a period.
-[macOS, Windows, linux] To make an entry platform specific, start the line with an angle bracket enclosed comma separated list of platforms to show the entry on.
 Only point out the major changes.


### PR DESCRIPTION
The instructions for making items specific to a platform was removed from the desktop template when the iOS one was added. I beleive that was a mistake and that it should have been removed from the iOS template.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4673)
<!-- Reviewable:end -->
