### PR TITLE
Swiftformat: increase swift version IOS-163

### DIFF
--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -2,7 +2,7 @@
 --exclude Build, .spm, MullvadVPNScreenshots/SnapshotHelper.swift
 
 # general options
---swiftversion 5.5
+--swiftversion 5.8
 
 # format options
 --indent 4

--- a/ios/MullvadLogging/Logger+Errors.swift
+++ b/ios/MullvadLogging/Logger+Errors.swift
@@ -11,8 +11,8 @@ import Logging
 import MullvadTypes
 
 extension Logger {
-    public func error<T: Error>(
-        error: T,
+    public func error(
+        error: some Error,
         message: @autoclosure () -> String? = nil,
         metadata: @autoclosure () -> Logger.Metadata? = nil,
         source: @autoclosure () -> String? = nil,

--- a/ios/MullvadREST/ExponentialBackoff.swift
+++ b/ios/MullvadREST/ExponentialBackoff.swift
@@ -23,7 +23,7 @@ struct ExponentialBackoff: IteratorProtocol {
     mutating func next() -> REST.Duration? {
         let next = _next
 
-        if let maxDelay = maxDelay, next > maxDelay {
+        if let maxDelay, next > maxDelay {
             return maxDelay
         }
 

--- a/ios/MullvadREST/RESTAPIProxy.swift
+++ b/ios/MullvadREST/RESTAPIProxy.swift
@@ -63,7 +63,7 @@ extension REST {
                     pathTemplate: "relays"
                 )
 
-                if let etag = etag {
+                if let etag {
                     requestBuilder.setETagHeader(etag: etag)
                 }
 

--- a/ios/MullvadREST/RESTNetworkOperation.swift
+++ b/ios/MullvadREST/RESTNetworkOperation.swift
@@ -147,7 +147,7 @@ extension REST {
                 ? transportProvider?.shadowSocksTransport()
                 : transportProvider?.transport()
 
-            guard let transport = transport else {
+            guard let transport else {
                 logger.error("Failed to obtain transport.")
                 finish(result: .failure(REST.Error.transport(NoTransportError())))
                 return
@@ -161,9 +161,9 @@ extension REST {
             )
 
             networkTask = transport.sendRequest(restRequest.urlRequest) { [weak self] data, response, error in
-                guard let self = self else { return }
-                self.dispatchQueue.async {
-                    if let error = error {
+                guard let self else { return }
+                dispatchQueue.async {
+                    if let error {
                         self.didReceiveError(
                             error,
                             transport: transport,

--- a/ios/MullvadREST/RESTRequestFactory.swift
+++ b/ios/MullvadREST/RESTRequestFactory.swift
@@ -99,7 +99,7 @@ extension REST {
             self.bodyEncoder = bodyEncoder
         }
 
-        mutating func setHTTPBody<T: Encodable>(value: T) throws {
+        mutating func setHTTPBody(value: some Encodable) throws {
             restRequest.urlRequest.httpBody = try bodyEncoder.encode(value)
         }
 
@@ -180,7 +180,7 @@ extension REST {
                 withAllowedCharacters: allowedCharacters
             )
 
-            if let encoded = encoded {
+            if let encoded {
                 replacements[name] = encoded
             } else {
                 throw Error.percentEncoding

--- a/ios/MullvadTypes/AnyIPEndpoint.swift
+++ b/ios/MullvadTypes/AnyIPEndpoint.swift
@@ -31,7 +31,7 @@ public enum AnyIPEndpoint: Hashable, Equatable, Codable, CustomStringConvertible
         }
     }
 
-    public init?<S>(string: S) where S: StringProtocol {
+    public init?(string: some StringProtocol) {
         if let ipv4Endpoint = IPv4Endpoint(string: string) {
             self = .ipv4(ipv4Endpoint)
         } else if let ipv6Endpoint = IPv6Endpoint(string: string) {

--- a/ios/MullvadTypes/IPv4Endpoint.swift
+++ b/ios/MullvadTypes/IPv4Endpoint.swift
@@ -18,7 +18,7 @@ public struct IPv4Endpoint: Hashable, Equatable, Codable, CustomStringConvertibl
         self.port = port
     }
 
-    public init?<S>(string: S) where S: StringProtocol {
+    public init?(string: some StringProtocol) {
         let components = string.split(
             separator: ":",
             maxSplits: 2,

--- a/ios/MullvadTypes/IPv6Endpoint.swift
+++ b/ios/MullvadTypes/IPv6Endpoint.swift
@@ -18,7 +18,7 @@ public struct IPv6Endpoint: Hashable, Equatable, Codable, CustomStringConvertibl
         self.port = port
     }
 
-    public init?<S>(string: S) where S: StringProtocol {
+    public init?(string: some StringProtocol) {
         guard let lastColon = string.lastIndex(of: ":"), lastColon != string.endIndex else {
             return nil
         }

--- a/ios/MullvadTypes/Promise.swift
+++ b/ios/MullvadTypes/Promise.swift
@@ -21,7 +21,7 @@ public final class Promise<Success, Failure: Error> {
 
     public func observe(_ completion: @escaping (Result) -> Void) {
         nslock.lock()
-        if let result = result {
+        if let result {
             nslock.unlock()
             completion(result)
         } else {

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -365,7 +365,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         let loadTunnelStoreOperation = AsyncBlockOperation(dispatchQueue: .main) { finish in
             self.tunnelStore.loadPersistentTunnels { error in
-                if let error = error {
+                if let error {
                     self.logger.error(
                         error: error,
                         message: "Failed to load persistent tunnels."
@@ -398,7 +398,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let initTunnelManagerOperation = AsyncBlockOperation(dispatchQueue: .main) { finish in
             self.tunnelManager.loadConfiguration { error in
                 // TODO: avoid throwing fatal error and show the problem report UI instead.
-                if let error = error {
+                if let error {
                     fatalError(error.localizedDescription)
                 }
 

--- a/ios/MullvadVPN/Classes/AutomaticKeyboardResponder.swift
+++ b/ios/MullvadVPN/Classes/AutomaticKeyboardResponder.swift
@@ -97,10 +97,10 @@ class AutomaticKeyboardResponder {
             \.frame,
             options: [.new],
             changeHandler: { [weak self] containingView, change in
-                guard let self = self,
-                      let keyboardFrameValue = self.lastKeyboardRect else { return }
+                guard let self,
+                      let keyboardFrameValue = lastKeyboardRect else { return }
 
-                self.adjustContentInsets(keyboardRect: keyboardFrameValue)
+                adjustContentInsets(keyboardRect: keyboardFrameValue)
             }
         )
     }
@@ -153,7 +153,7 @@ class AutomaticKeyboardResponder {
     }
 
     private func adjustContentInsets(keyboardRect: CGRect) {
-        guard let targetView = targetView, let superview = targetView.superview else { return }
+        guard let targetView, let superview = targetView.superview else { return }
 
         // Compute the target view frame within screen coordinates
         let screenRect = superview.convert(targetView.frame, to: nil)
@@ -168,7 +168,7 @@ class AutomaticKeyboardResponder {
 extension AutomaticKeyboardResponder {
     /// A convenience initializer that automatically assigns the offset to the scroll view
     /// subclasses
-    convenience init<T: UIScrollView>(targetView: T) {
+    convenience init(targetView: some UIScrollView) {
         self.init(targetView: targetView) { scrollView, offset in
             if scrollView.canBecomeFirstResponder {
                 scrollView.contentInset.bottom = targetView.isFirstResponder ? offset : 0

--- a/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
+++ b/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
@@ -73,7 +73,7 @@ class ConsolidatedApplicationLog: TextOutputStreamable {
         return body
     }
 
-    func write<Target: TextOutputStream>(to stream: inout Target) {
+    func write(to stream: inout some TextOutputStream) {
         print("System information:", to: &stream)
         for (key, value) in metadata {
             print("\(key.rawValue): \(value)", to: &stream)

--- a/ios/MullvadVPN/Classes/ObserverList.swift
+++ b/ios/MullvadVPN/Classes/ObserverList.swift
@@ -53,7 +53,7 @@ final class ObserverList<T> {
             return box == observer
         }
 
-        if let index = index {
+        if let index {
             observers.remove(at: index)
         }
 

--- a/ios/MullvadVPN/Containers/CustomSplitViewController.swift
+++ b/ios/MullvadVPN/Containers/CustomSplitViewController.swift
@@ -56,7 +56,7 @@ class CustomSplitViewController: UISplitViewController, RootContainment {
     }
 
     private func updateDividerColor() {
-        guard let dividerColor = dividerColor else { return }
+        guard let dividerColor else { return }
 
         dividerView?.backgroundColor = dividerColor
     }

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -316,7 +316,7 @@ class RootContainerViewController: UIViewController {
     func setOverrideHeaderBarHidden(_ isHidden: Bool?, animated: Bool) {
         overrideHeaderBarHidden = isHidden
 
-        if let isHidden = isHidden {
+        if let isHidden {
             setHeaderBarHidden(isHidden, animated: animated)
         } else {
             updateHeaderBarHiddenFromChildPreferences(animated: animated)
@@ -458,13 +458,13 @@ class RootContainerViewController: UIViewController {
              otherwise `endAppearanceTransition()` will fire `didMove(to:)` twice.
              */
             if shouldHandleAppearanceEvents {
-                if let targetViewController = targetViewController,
+                if let targetViewController,
                    sourceViewController != targetViewController
                 {
                     self.endChildControllerTransition(targetViewController)
                 }
 
-                if let sourceViewController = sourceViewController,
+                if let sourceViewController,
                    sourceViewController != targetViewController
                 {
                     self.endChildControllerTransition(sourceViewController)
@@ -528,7 +528,7 @@ class RootContainerViewController: UIViewController {
 
         // Begin appearance transition
         if shouldHandleAppearanceEvents {
-            if let sourceViewController = sourceViewController,
+            if let sourceViewController,
                sourceViewController != targetViewController
             {
                 beginChildControllerTransition(
@@ -537,7 +537,7 @@ class RootContainerViewController: UIViewController {
                     animated: shouldAnimate
                 )
             }
-            if let targetViewController = targetViewController,
+            if let targetViewController,
                sourceViewController != targetViewController
             {
                 beginChildControllerTransition(

--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -240,7 +240,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         case let .settings(subRoute):
             let coordinator = context.presentedRoute.coordinator as! SettingsCoordinator
 
-            if let subRoute = subRoute {
+            if let subRoute {
                 coordinator.navigate(
                     to: subRoute,
                     animated: context.isAnimated,
@@ -535,12 +535,12 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         )
 
         coordinator.didFinishPayment = { [weak self] coordinator in
-            guard let self = self else { return }
+            guard let self else { return }
 
-            if self.shouldDismissOutOfTime() {
-                self.router.dismiss(.outOfTime, animated: true)
+            if shouldDismissOutOfTime() {
+                router.dismiss(.outOfTime, animated: true)
 
-                self.continueFlow(animated: true)
+                continueFlow(animated: true)
             }
         }
 

--- a/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
@@ -572,7 +572,7 @@ final class ApplicationRouter {
             return !skipRouteGroups.contains(pendingRoute.operation.routeGroup)
         }
 
-        guard let pendingRoute = pendingRoute else {
+        guard let pendingRoute else {
             isProcessingPendingRoutes = false
             return
         }

--- a/ios/MullvadVPN/Coordinators/App/ChangeLogCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ChangeLogCoordinator.swift
@@ -34,11 +34,11 @@ final class ChangeLogCoordinator: Coordinator {
         }
 
         controller.onFinish = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             ChangeLog.markAsSeen()
 
-            self.didFinish?(self)
+            didFinish?(self)
         }
 
         navigationController.pushViewController(controller, animated: animated)

--- a/ios/MullvadVPN/Coordinators/App/LoginCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/LoginCoordinator.swift
@@ -58,7 +58,7 @@ final class LoginCoordinator: Coordinator, DeviceManagementViewControllerDelegat
     // MARK: - Private
 
     private func didFinishLogin(action: LoginAction, error: Error?) -> EndLoginAction {
-        guard let error = error else {
+        guard let error else {
             callDidFinishAfterDelay()
             return .nothing
         }
@@ -82,13 +82,13 @@ final class LoginCoordinator: Coordinator, DeviceManagementViewControllerDelegat
 
     private func callDidFinishAfterDelay() {
         DispatchQueue.main.asyncAfter(wallDeadline: .now() + .seconds(1)) { [weak self] in
-            guard let self = self else { return }
-            self.didFinish?(self)
+            guard let self else { return }
+            didFinish?(self)
         }
     }
 
     private func returnToLogin(repeatLogin: Bool) {
-        guard let loginController = loginController else { return }
+        guard let loginController else { return }
 
         navigationController.popToViewController(loginController, animated: true) {
             if let lastLoginAction = self.lastLoginAction, repeatLogin {
@@ -105,11 +105,11 @@ final class LoginCoordinator: Coordinator, DeviceManagementViewControllerDelegat
         let controller = DeviceManagementViewController(interactor: interactor)
         controller.delegate = self
         controller.fetchDevices(animateUpdates: false) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success:
-                self.navigationController.pushViewController(controller, animated: true) {
+                navigationController.pushViewController(controller, animated: true) {
                     completion(nil)
                 }
 

--- a/ios/MullvadVPN/Coordinators/App/OutOfTimeCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/OutOfTimeCoordinator.swift
@@ -42,7 +42,7 @@ class OutOfTimeCoordinator: Coordinator, OutOfTimeViewControllerDelegate {
     }
 
     func popFromNavigationStack(animated: Bool, completion: @escaping () -> Void) {
-        guard let viewController = viewController else {
+        guard let viewController else {
             completion()
             return
         }

--- a/ios/MullvadVPN/Coordinators/App/RevokedCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/RevokedCoordinator.swift
@@ -24,9 +24,9 @@ final class RevokedCoordinator: Coordinator {
         let controller = RevokedDeviceViewController(interactor: interactor)
 
         controller.didFinish = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
-            self.didFinish?(self)
+            didFinish?(self)
         }
 
         navigationController.pushViewController(controller, animated: animated)

--- a/ios/MullvadVPN/Coordinators/App/SelectLocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/SelectLocationCoordinator.swift
@@ -36,21 +36,21 @@ class SelectLocationCoordinator: Coordinator, Presentable, RelayCacheTrackerObse
         let controller = SelectLocationViewController()
 
         controller.didSelectRelay = { [weak self] relay in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let newConstraints = RelayConstraints(location: .only(relay))
 
-            self.tunnelManager.setRelayConstraints(newConstraints) {
+            tunnelManager.setRelayConstraints(newConstraints) {
                 self.tunnelManager.startTunnel()
             }
 
-            self.didFinish?(self, relay)
+            didFinish?(self, relay)
         }
 
         controller.didFinish = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
-            self.didFinish?(self, nil)
+            didFinish?(self, nil)
         }
 
         relayCacheTracker.addObserver(self)

--- a/ios/MullvadVPN/Coordinators/App/SettingsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/SettingsCoordinator.swift
@@ -60,7 +60,7 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
             navigationController.pushViewController(rootController, animated: false)
         }
 
-        if let initialRoute = initialRoute, initialRoute != .root,
+        if let initialRoute, initialRoute != .root,
            let nextController = makeViewController(for: initialRoute)
         {
             navigationController.pushViewController(nextController, animated: false)
@@ -102,7 +102,7 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
                     [rootController, nextViewController].compactMap { $0 },
                     animated: animated
                 )
-            } else if let nextViewController = nextViewController {
+            } else if let nextViewController {
                 navigationController.pushViewController(nextViewController, animated: animated)
             }
 

--- a/ios/MullvadVPN/Coordinators/App/TermsOfServiceCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/TermsOfServiceCoordinator.swift
@@ -29,11 +29,11 @@ class TermsOfServiceCoordinator: Coordinator, Presenting {
         }
 
         controller.completionHandler = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             TermsOfService.setAgreed()
 
-            self.didFinish?(self)
+            didFinish?(self)
         }
 
         navigationController.pushViewController(controller, animated: false)

--- a/ios/MullvadVPN/Coordinators/Base/Coordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Base/Coordinator.swift
@@ -106,8 +106,8 @@ extension Presenting {
 
      Automatically adds child and removes it upon interactive dismissal.
      */
-    func presentChild<T: Presentable>(
-        _ child: T,
+    func presentChild(
+        _ child: some Presentable,
         animated: Bool,
         configuration: ModalPresentationConfiguration = ModalPresentationConfiguration(),
         completion: (() -> Void)? = nil
@@ -115,7 +115,7 @@ extension Presenting {
         var configuration = configuration
 
         configuration.notifyInteractiveDismissal { [weak child] in
-            guard let child = child else { return }
+            guard let child else { return }
 
             child.modalConfiguration = nil
             child.removeFromParent()

--- a/ios/MullvadVPN/Coordinators/Base/ModalPresentationConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Base/ModalPresentationConfiguration.swift
@@ -21,15 +21,15 @@ struct ModalPresentationConfiguration {
     func apply(to vc: UIViewController) {
         vc.transitioningDelegate = transitioningDelegate
 
-        if let modalPresentationStyle = modalPresentationStyle {
+        if let modalPresentationStyle {
             vc.modalPresentationStyle = modalPresentationStyle
         }
 
-        if let preferredContentSize = preferredContentSize {
+        if let preferredContentSize {
             vc.preferredContentSize = preferredContentSize
         }
 
-        if let isModalInPresentation = isModalInPresentation {
+        if let isModalInPresentation {
             vc.isModalInPresentation = isModalInPresentation
         }
 

--- a/ios/MullvadVPN/Extensions/CodingErrors+CustomErrorDescription.swift
+++ b/ios/MullvadVPN/Extensions/CodingErrors+CustomErrorDescription.swift
@@ -42,7 +42,7 @@ extension EncodingError: CustomErrorDescriptionProtocol {
     }
 }
 
-private extension Array where Element == CodingKey {
+private extension [CodingKey] {
     var codingPathString: String {
         if isEmpty {
             return "<root>"

--- a/ios/MullvadVPN/Extensions/RESTError+Display.swift
+++ b/ios/MullvadVPN/Extensions/RESTError+Display.swift
@@ -25,7 +25,7 @@ extension REST.Error: DisplayError {
             )
 
         case let .unhandledResponse(statusCode, serverResponse):
-            guard let serverResponse = serverResponse else {
+            guard let serverResponse else {
                 return String(format: NSLocalizedString(
                     "UNEXPECTED_RESPONSE",
                     tableName: "REST",

--- a/ios/MullvadVPN/Extensions/UIView+AutoLayoutBuilder.swift
+++ b/ios/MullvadVPN/Extensions/UIView+AutoLayoutBuilder.swift
@@ -41,7 +41,7 @@ extension UIView {
      Pin edges to superview edges.
      */
     func pinEdgesToSuperview(_ edges: PinnableEdges = .all()) -> [NSLayoutConstraint] {
-        guard let superview = superview else { return [] }
+        guard let superview else { return [] }
 
         return pinEdges(edges, to: superview)
     }
@@ -50,7 +50,7 @@ extension UIView {
      Pin edges to superview margins.
      */
     func pinEdgesToSuperviewMargins(_ edges: PinnableEdges = .all()) -> [NSLayoutConstraint] {
-        guard let superview = superview else { return [] }
+        guard let superview else { return [] }
 
         return pinEdges(edges, to: superview.layoutMarginsGuide)
     }

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiryInAppNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiryInAppNotificationProvider.swift
@@ -37,7 +37,7 @@ final class AccountExpiryInAppNotificationProvider: NotificationProvider, InAppN
 
     var notificationDescriptor: InAppNotificationDescriptor? {
         let now = Date()
-        guard let accountExpiry = accountExpiry, let triggerDate = triggerDate, now >= triggerDate,
+        guard let accountExpiry, let triggerDate, now >= triggerDate,
               now < accountExpiry
         else {
             return nil
@@ -59,7 +59,7 @@ final class AccountExpiryInAppNotificationProvider: NotificationProvider, InAppN
             duration = formatter.string(from: now, to: accountExpiry)
         }
 
-        guard let duration = duration else { return nil }
+        guard let duration else { return nil }
 
         return InAppNotificationDescriptor(
             identifier: identifier,
@@ -82,7 +82,7 @@ final class AccountExpiryInAppNotificationProvider: NotificationProvider, InAppN
     // MARK: - Private
 
     private var triggerDate: Date? {
-        guard let accountExpiry = accountExpiry else { return nil }
+        guard let accountExpiry else { return nil }
 
         return Calendar.current.date(
             byAdding: .day,
@@ -104,7 +104,7 @@ final class AccountExpiryInAppNotificationProvider: NotificationProvider, InAppN
     private func updateTimer() {
         timer?.cancel()
 
-        guard let triggerDate = triggerDate else {
+        guard let triggerDate else {
             return
         }
 

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
@@ -37,7 +37,7 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
     // MARK: - SystemNotificationProvider
 
     var notificationRequest: UNNotificationRequest? {
-        guard let trigger = trigger else { return nil }
+        guard let trigger else { return nil }
 
         _ = NSLocalizedString(
             "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE",
@@ -79,7 +79,7 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
     // MARK: - Private
 
     private var trigger: UNNotificationTrigger? {
-        guard let accountExpiry = accountExpiry else { return nil }
+        guard let accountExpiry else { return nil }
 
         guard let triggerDate = Calendar.current.date(
             byAdding: .day,

--- a/ios/MullvadVPN/Notifications/Notification Providers/RegisteredDeviceInAppNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/RegisteredDeviceInAppNotificationProvider.swift
@@ -54,9 +54,9 @@ final class RegisteredDeviceInAppNotificationProvider: NotificationProvider,
                 image: .init(named: "IconCloseSml"),
                 handler: { [weak self] in
                     guard let self else { return }
-                    self.isNewDeviceRegistered = false
-                    self.sendAction()
-                    self.invalidate()
+                    isNewDeviceRegistered = false
+                    sendAction()
+                    invalidate()
                 }
             )
         )

--- a/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
@@ -20,9 +20,9 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
     }
 
     var notificationDescriptor: InAppNotificationDescriptor? {
-        if let packetTunnelError = packetTunnelError {
+        if let packetTunnelError {
             return notificationDescription(for: packetTunnelError)
-        } else if let tunnelManagerError = tunnelManagerError {
+        } else if let tunnelManagerError {
             return notificationDescription(for: tunnelManagerError)
         } else if isWaitingForConnectivity {
             return connectivityNotificationDescription()

--- a/ios/MullvadVPN/Notifications/NotificationManager.swift
+++ b/ios/MullvadVPN/Notifications/NotificationManager.swift
@@ -96,7 +96,7 @@ final class NotificationManager: NotificationProviderDelegate {
 
             for newRequest in newSystemNotificationRequests {
                 notificationCenter.add(newRequest) { error in
-                    guard let error = error else { return }
+                    guard let error else { return }
 
                     self.logger.error(
                         error: error,
@@ -147,7 +147,7 @@ final class NotificationManager: NotificationProviderDelegate {
             switch notificationSettings.authorizationStatus {
             case .notDetermined:
                 userNotificationCenter.requestAuthorization(options: authorizationOptions) { granted, error in
-                    if let error = error {
+                    if let error {
                         self.logger.error(
                             error: error,
                             message: "Failed to obtain user notifications authorization"
@@ -194,7 +194,7 @@ final class NotificationManager: NotificationProviderDelegate {
                     guard granted else { return }
 
                     notificationCenter.add(request) { error in
-                        if let error = error {
+                        if let error {
                             self.logger.error(
                                 """
                                 Failed to add notification request with identifier \

--- a/ios/MullvadVPN/Presentation controllers/FormsheetPresentationController.swift
+++ b/ios/MullvadVPN/Presentation controllers/FormsheetPresentationController.swift
@@ -58,7 +58,7 @@ class FormsheetPresentationController: UIPresentationController {
     }
 
     override var frameOfPresentedViewInContainerView: CGRect {
-        guard let containerView = containerView else {
+        guard let containerView else {
             return super.frameOfPresentedViewInContainerView
         }
 

--- a/ios/MullvadVPN/Presentation controllers/SecondaryContextPresentationController.swift
+++ b/ios/MullvadVPN/Presentation controllers/SecondaryContextPresentationController.swift
@@ -18,7 +18,7 @@ class SecondaryContextPresentationController: FormsheetPresentationController {
 
         updateHeaderBarHidden()
 
-        if let containerView = containerView,
+        if let containerView,
            let rootContainer = presentingViewController as? RootContainerViewController
         {
             rootContainer.addTrailingButtonsToPresentationContainer(containerView)

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -130,7 +130,7 @@ final class RelayCacheTracker {
         nslock.lock()
         defer { nslock.unlock() }
 
-        if let cachedRelays = cachedRelays {
+        if let cachedRelays {
             return cachedRelays
         } else {
             throw NoCachedRelaysError()
@@ -159,7 +159,7 @@ final class RelayCacheTracker {
     private func _getNextUpdateDate() -> Date {
         let now = Date()
 
-        guard let cachedRelays = cachedRelays else {
+        guard let cachedRelays else {
             return now
         }
 

--- a/ios/MullvadVPN/SettingsManager/Migrations/MigrationFromV1ToV2.swift
+++ b/ios/MullvadVPN/SettingsManager/Migrations/MigrationFromV1ToV2.swift
@@ -111,7 +111,7 @@ final class MigrationFromV1ToV2: Migration {
         }
 
         let newDeviceState: DeviceState
-        if let device = device {
+        if let device {
             logger.debug("Found device matching public key stored in legacy settings.")
 
             // Match private key.

--- a/ios/MullvadVPN/SettingsManager/SettingsManager.swift
+++ b/ios/MullvadVPN/SettingsManager/SettingsManager.swift
@@ -51,7 +51,7 @@ enum SettingsManager {
     }
 
     static func setLastUsedAccount(_ string: String?) throws {
-        if let string = string {
+        if let string {
             guard let data = string.data(using: .utf8) else {
                 throw StringEncodingError(string: string)
             }
@@ -227,7 +227,7 @@ enum SettingsManager {
         )
 
         migration.migrate(with: store, parser: parser) { error in
-            if let error = error {
+            if let error {
                 let migrationError = SettingsMigrationError(
                     sourceVersion: .v1,
                     targetVersion: .v2,
@@ -303,7 +303,7 @@ enum SettingsManager {
             return settings.accountNumber == storedAccountNumber
         }
 
-        guard let matchingSettings = matchingSettings else {
+        guard let matchingSettings else {
             logger.debug(
                 "Could not find legacy settings matching the legacy account number."
             )

--- a/ios/MullvadVPN/SettingsManager/SettingsParser.swift
+++ b/ios/MullvadVPN/SettingsManager/SettingsParser.swift
@@ -34,12 +34,12 @@ struct SettingsParser {
     }
 
     /// Produces versioned data encoded as the given type
-    func producePayload<T: Codable>(_ payload: T, version: Int) throws -> Data {
+    func producePayload(_ payload: some Codable, version: Int) throws -> Data {
         return try encoder.encode(VersionedPayload(version: version, data: payload))
     }
 
     /// Produces unversioned data encoded as the given type
-    func produceUnversionedPayload<T: Codable>(_ payload: T) throws -> Data {
+    func produceUnversionedPayload(_ payload: some Codable) throws -> Data {
         return try encoder.encode(payload)
     }
 

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
@@ -126,7 +126,7 @@ final class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
 
         case let .reconnectTunnel(aSelectorResult):
             reasserting = true
-            if let aSelectorResult = aSelectorResult {
+            if let aSelectorResult {
                 selectorResult = aSelectorResult
             }
             reasserting = false

--- a/ios/MullvadVPN/StorePaymentManager/StorePaymentManager.swift
+++ b/ios/MullvadVPN/StorePaymentManager/StorePaymentManager.swift
@@ -127,7 +127,7 @@ final class StorePaymentManager: NSObject, SKPaymentTransactionObserver {
     func addPayment(_ payment: SKPayment, for accountNumber: String) {
         // Validate account token before adding new payment to the queue.
         validateAccount(accountNumber: accountNumber) { error in
-            if let error = error {
+            if let error {
                 let event = StorePaymentEvent.failure(
                     StorePaymentFailure(
                         transaction: nil,
@@ -336,7 +336,7 @@ final class StorePaymentManager: NSObject, SKPaymentTransactionObserver {
                 break
             }
 
-            if let event = event {
+            if let event {
                 self.observerList.forEach { observer in
                     observer.storePaymentManager(self, didReceiveEvent: event)
                 }

--- a/ios/MullvadVPN/StorePaymentManager/StoreSubscription.swift
+++ b/ios/MullvadVPN/StorePaymentManager/StoreSubscription.swift
@@ -32,7 +32,7 @@ extension SKProduct {
     }
 }
 
-extension Set where Element == StoreSubscription {
+extension Set<StoreSubscription> {
     var productIdentifiersSet: Set<String> {
         return Set<String>(map { $0.rawValue })
     }

--- a/ios/MullvadVPN/TransportMonitor/PacketTunnelTransport.swift
+++ b/ios/MullvadVPN/TransportMonitor/PacketTunnelTransport.swift
@@ -36,7 +36,7 @@ struct PacketTunnelTransport: RESTTransport {
         )
 
         // If the URL provided to the proxy request was invalid, indicate failure via `.badURL` and return a no-op.
-        guard let proxyRequest = proxyRequest else {
+        guard let proxyRequest else {
             completion(nil, nil, URLError(.badURL))
             return AnyCancellable {}
         }

--- a/ios/MullvadVPN/TransportMonitor/TransportMonitor.swift
+++ b/ios/MullvadVPN/TransportMonitor/TransportMonitor.swift
@@ -43,8 +43,8 @@ final class TransportMonitor: RESTTransportProvider {
             let shadowSocksConfiguration = RelaySelector.getShadowsocksTCPBridge(relays: cachedRelays.relays)
             let shadowSocksBridgeRelay = RelaySelector.getShadowSocksRelay(relays: cachedRelays.relays)
 
-            guard let shadowSocksConfiguration = shadowSocksConfiguration,
-                  let shadowSocksBridgeRelay = shadowSocksBridgeRelay
+            guard let shadowSocksConfiguration,
+                  let shadowSocksBridgeRelay
             else {
                 logger.error("Could not get shadow socks bridge information.")
                 return nil
@@ -90,7 +90,7 @@ final class TransportMonitor: RESTTransportProvider {
                 tunnel.status == .connected
         }
 
-        if let tunnel = tunnel, shouldByPassVPN(tunnel: tunnel) {
+        if let tunnel, shouldByPassVPN(tunnel: tunnel) {
             return PacketTunnelTransport(
                 tunnel: tunnel,
                 useShadowsocksTransport: useShadowsocksTransport

--- a/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
@@ -33,11 +33,11 @@ class LoadTunnelConfigurationOperation: ResultOperation<Void> {
         interactor.setSettings(settings ?? TunnelSettingsV2(), persist: false)
         interactor.setDeviceState(deviceState ?? .loggedOut, persist: false)
 
-        if let tunnel = tunnel, deviceState == nil {
+        if let tunnel, deviceState == nil {
             logger.debug("Remove orphaned VPN configuration.")
 
             tunnel.removeFromPreferences { error in
-                if let error = error {
+                if let error {
                     self.logger.error(
                         error: error,
                         message: "Failed to remove VPN configuration."

--- a/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
@@ -146,9 +146,9 @@ class MapConnectionStatusOperation: AsyncOperation {
         mapToState: @escaping (PacketTunnelStatus) -> TunnelState?
     ) {
         request = tunnel.getTunnelStatus { [weak self] completion in
-            guard let self = self else { return }
+            guard let self else { return }
 
-            self.dispatchQueue.async {
+            dispatchQueue.async {
                 if case let .success(packetTunnelStatus) = completion, !self.isCancelled {
                     self.interactor.updateTunnelStatus { tunnelStatus in
                         tunnelStatus.packetTunnelStatus = packetTunnelStatus

--- a/ios/MullvadVPN/TunnelManager/SendTunnelProviderMessageOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SendTunnelProviderMessageOperation.swift
@@ -201,9 +201,9 @@ final class SendTunnelProviderMessageOperation<Output>: ResultOperation<Output> 
         // Send IPC message.
         do {
             try tunnel.sendProviderMessage(messageData) { [weak self] responseData in
-                guard let self = self else { return }
+                guard let self else { return }
 
-                self.dispatchQueue.async {
+                dispatchQueue.async {
                     let decodingResult = Result { try self.decoderHandler(responseData) }
 
                     self.finish(result: decodingResult)
@@ -231,7 +231,7 @@ extension SendTunnelProviderMessageOperation where Output: Codable {
             message: message,
             timeout: timeout,
             decoderHandler: { data in
-                if let data = data {
+                if let data {
                     return try TunnelProviderReply(messageData: data).value
                 } else {
                     throw EmptyTunnelProviderResponseError()

--- a/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
@@ -48,9 +48,9 @@ private struct SetAccountContext: OperationInputContext {
     var device: REST.Device?
 
     func reduce() -> SetAccountResult? {
-        guard let accountData = accountData,
-              let privateKey = privateKey,
-              let device = device
+        guard let accountData,
+              let privateKey,
+              let device
         else {
             return nil
         }
@@ -294,7 +294,7 @@ class SetAccountOperation: ResultOperation<StoredAccountData?> {
             tunnel.removeFromPreferences { error in
                 self.dispatchQueue.async {
                     // Ignore error but log it.
-                    if let error = error {
+                    if let error {
                         self.logger.error(
                             error: error,
                             message: "Failed to remove VPN configuration."

--- a/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
@@ -46,7 +46,7 @@ class StopTunnelOperation: ResultOperation<Void> {
 
             tunnel.saveToPreferences { error in
                 self.dispatchQueue.async {
-                    if let error = error {
+                    if let error {
                         self.finish(result: .failure(error))
                     } else {
                         tunnel.stop()

--- a/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
+++ b/ios/MullvadVPN/TunnelManager/Tunnel+Messaging.swift
@@ -74,7 +74,7 @@ extension Tunnel {
         )
 
         operation.onCancel { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let cancelOperation = SendTunnelProviderMessageOperation(
                 dispatchQueue: dispatchQueue,

--- a/ios/MullvadVPN/TunnelManager/Tunnel.swift
+++ b/ios/MullvadVPN/TunnelManager/Tunnel.swift
@@ -119,7 +119,7 @@ final class Tunnel: Equatable {
 
     func saveToPreferences(_ completion: @escaping (Error?) -> Void) {
         tunnelProvider.saveToPreferences { error in
-            if let error = error {
+            if let error {
                 completion(error)
             } else {
                 // Refresh connection status after saving the tunnel preferences.
@@ -220,7 +220,7 @@ final class TunnelStatusBlockObserver: TunnelStatusObserver {
             self.handler(tunnel, status)
         }
 
-        if let queue = queue {
+        if let queue {
             queue.async(execute: block)
         } else {
             block()

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -168,7 +168,7 @@ final class TunnelManager: StorePaymentObserver {
         )
         loadTunnelOperation.completionQueue = .main
         loadTunnelOperation.completionHandler = { [weak self] completion in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if case let .failure(error) = completion {
                 self.logger.error(
@@ -203,7 +203,7 @@ final class TunnelManager: StorePaymentObserver {
             dispatchQueue: internalQueue,
             interactor: TunnelInteractorProxy(self),
             completionHandler: { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 DispatchQueue.main.async {
                     if let error = result.error {
@@ -239,7 +239,7 @@ final class TunnelManager: StorePaymentObserver {
             dispatchQueue: internalQueue,
             interactor: TunnelInteractorProxy(self)
         ) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             DispatchQueue.main.async {
                 if let error = result.error {
@@ -437,7 +437,7 @@ final class TunnelManager: StorePaymentObserver {
 
         operation.completionQueue = .main
         operation.completionHandler = { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.updatePrivateKeyRotationTimer()
 
@@ -594,7 +594,7 @@ final class TunnelManager: StorePaymentObserver {
         nslock.lock()
         defer { nslock.unlock() }
 
-        if let tunnel = tunnel {
+        if let tunnel {
             subscribeVPNStatusObserver(tunnel: tunnel)
         } else {
             unsubscribeVPNStatusObserver()
@@ -774,7 +774,7 @@ final class TunnelManager: StorePaymentObserver {
         nslock.lock()
         defer { nslock.unlock() }
 
-        if let error = error, !error.isOperationCancellationError {
+        if let error, !error.isOperationCancellationError {
             logger.error(error: error, message: "Failed to reconnect the tunnel.")
         }
 
@@ -799,7 +799,7 @@ final class TunnelManager: StorePaymentObserver {
 
         statusObserver = tunnel
             .addBlockObserver(queue: internalQueue) { [weak self] tunnel, status in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.logger.debug("VPN connection status changed to \(status).")
 

--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -70,7 +70,7 @@ enum TunnelState: Equatable, CustomStringConvertible {
         case .pendingReconnect:
             return "pending reconnect after disconnect"
         case let .connecting(tunnelRelay):
-            if let tunnelRelay = tunnelRelay {
+            if let tunnelRelay {
                 return "connecting to \(tunnelRelay.hostname)"
             } else {
                 return "connecting, fetching relay"

--- a/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
@@ -286,7 +286,7 @@ class AccountNumberRow: UIView {
     }
 
     private var displayAccountNumber: String? {
-        guard let accountNumber = accountNumber else {
+        guard let accountNumber else {
             return nil
         }
 
@@ -310,7 +310,7 @@ class AccountNumberRow: UIView {
     }
 
     private var _accessibilityAttributedValue: NSAttributedString? {
-        guard let accountNumber = accountNumber else {
+        guard let accountNumber else {
             return nil
         }
 
@@ -417,7 +417,7 @@ class AccountExpiryRow: UIView {
         didSet {
             let expiry = value
 
-            if let expiry = expiry, expiry <= Date() {
+            if let expiry, expiry <= Date() {
                 let localizedString = NSLocalizedString(
                     "ACCOUNT_OUT_OF_TIME_LABEL",
                     tableName: "Account",

--- a/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
@@ -334,20 +334,20 @@ class AccountViewController: UIViewController {
         setPaymentState(.restoringPurchases, animated: true)
 
         _ = interactor.restorePurchases(for: accountData.number) { [weak self] completion in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch completion {
             case let .success(response):
-                self.showTimeAddedConfirmationAlert(with: response, context: .restoration)
+                showTimeAddedConfirmationAlert(with: response, context: .restoration)
 
             case let .failure(error as StorePaymentManagerError):
-                self.showRestorePurchasesErrorAlert(error: error)
+                showRestorePurchasesErrorAlert(error: error)
 
             default:
                 break
             }
 
-            self.setPaymentState(.none, animated: true)
+            setPaymentState(.none, animated: true)
         }
     }
 }

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
@@ -88,10 +88,10 @@ class DeviceManagementViewController: UIViewController, RootContainment {
         completionHandler: ((Result<Void, Error>) -> Void)? = nil
     ) {
         interactor.getDevices { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if let devices = result.value {
-                self.setDevices(devices, animated: animateUpdates)
+                setDevices(devices, animated: animateUpdates)
             }
 
             completionHandler?(result.map { _ in () })
@@ -122,15 +122,15 @@ class DeviceManagementViewController: UIViewController, RootContainment {
         completionHandler: @escaping () -> Void
     ) {
         showDeleteConfirmation(deviceName: device.name) { [weak self] shouldDelete in
-            guard let self = self else { return }
+            guard let self else { return }
 
             guard shouldDelete else {
                 completionHandler()
                 return
             }
 
-            self.deleteDevice(identifier: device.id) { error in
-                if let error = error {
+            deleteDevice(identifier: device.id) { error in
+                if let error {
                     self.showErrorAlert(
                         title: NSLocalizedString(
                             "LOGOUT_DEVICE_ERROR_ALERT_TITLE",
@@ -232,11 +232,11 @@ class DeviceManagementViewController: UIViewController, RootContainment {
 
     private func deleteDevice(identifier: String, completionHandler: @escaping (Error?) -> Void) {
         interactor.deleteDevice(identifier) { [weak self] completion in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch completion {
             case .success:
-                self.fetchDevices(animateUpdates: true) { completion in
+                fetchDevices(animateUpdates: true) { completion in
                     completionHandler(completion.error)
                 }
 
@@ -244,7 +244,7 @@ class DeviceManagementViewController: UIViewController, RootContainment {
                 if error.isOperationCancellationError {
                     completionHandler(nil)
                 } else {
-                    self.logger.error(
+                    logger.error(
                         error: error,
                         message: "Failed to delete device."
                     )

--- a/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
@@ -299,9 +299,9 @@ final class AccountInputGroupView: UIView {
     }
 
     func setOnReturnKey(_ onReturnKey: ((AccountInputGroupView) -> Bool)?) {
-        if let onReturnKey = onReturnKey {
+        if let onReturnKey {
             privateTextField.onReturnKey = { [weak self] _ -> Bool in
-                guard let self = self else { return true }
+                guard let self else { return true }
 
                 return onReturnKey(self)
             }
@@ -321,7 +321,7 @@ final class AccountInputGroupView: UIView {
     }
 
     func setLastUsedAccount(_ accountNumber: String?, animated: Bool) {
-        if let accountNumber = accountNumber {
+        if let accountNumber {
             let formattedNumber = accountNumber.formattedAccountNumber
 
             lastUsedAccountButton.accessibilityAttributedValue = NSAttributedString(
@@ -380,7 +380,7 @@ final class AccountInputGroupView: UIView {
     }
 
     @objc private func didTapLastUsedAccount() {
-        guard let lastUsedAccount = lastUsedAccount else { return }
+        guard let lastUsedAccount else { return }
 
         setAccount(lastUsedAccount)
         privateTextField.resignFirstResponder()

--- a/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
@@ -133,9 +133,9 @@ class LoginViewController: UIViewController, RootContainment {
         }
 
         contentView.accountInputGroup.setOnReturnKey { [weak self] _ in
-            guard let self = self else { return true }
+            guard let self else { return true }
 
-            return self.attemptLogin()
+            return attemptLogin()
         }
 
         // There is no need to set the input accessory toolbar on iPad since it has a dedicated

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
@@ -324,21 +324,21 @@ class OutOfTimeViewController: UIViewController, RootContainment {
         paymentState = .restoringPurchases
 
         _ = interactor.restorePurchases(for: accountData.number) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case let .success(response):
-                self.showAlertIfNoTimeAdded(with: response, context: .restoration) {
+                showAlertIfNoTimeAdded(with: response, context: .restoration) {
                     self.paymentState = .none
                 }
 
             case let .failure(error as StorePaymentManagerError):
-                self.showRestorePurchasesErrorAlert(error: error) {
+                showRestorePurchasesErrorAlert(error: error) {
                     self.paymentState = .none
                 }
 
             default:
-                self.paymentState = .none
+                paymentState = .none
             }
         }
     }

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
@@ -344,8 +344,8 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             return indexPath(for: item)
         }
 
-        guard let indexPathForFirstRow = indexPathForFirstRow,
-              let indexPathForLastRow = indexPathForLastRow else { return sourceIndexPath }
+        guard let indexPathForFirstRow,
+              let indexPathForLastRow else { return sourceIndexPath }
 
         if proposedDestinationIndexPath.section == sourceIndexPath.section {
             return min(max(proposedDestinationIndexPath, indexPathForFirstRow), indexPathForLastRow)
@@ -524,7 +524,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                     }
                 }
 
-            if let lastDNSEntry = lastDNSEntry,
+            if let lastDNSEntry,
                let indexPath = self?.indexPath(for: lastDNSEntry)
             {
                 let cell = self?.tableView?.cellForRow(at: indexPath) as? SettingsDNSTextCell
@@ -542,7 +542,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             return entry.identifier == entryIdentifier
         }
 
-        guard let entryIndex = entryIndex else { return }
+        guard let entryIndex else { return }
 
         viewModel.customDNSDomains.remove(at: entryIndex)
 
@@ -574,13 +574,13 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         )
 
         reusableView.infoButtonHandler = { [weak self] in
-            if let self = self {
+            if let self {
                 self.delegate?.preferencesDataSource(self, didPressInfoButton: nil)
             }
         }
 
         reusableView.didCollapseHandler = { [weak self] headerView in
-            guard let self = self else { return }
+            guard let self else { return }
 
             var snapshot = self.snapshot()
 

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
@@ -169,7 +169,7 @@ struct PreferencesViewModel: Equatable {
                 return entry.address == otherEntry.address
             }
 
-            if let sameEntryIndex = sameEntryIndex {
+            if let sameEntryIndex {
                 let sourceEntry = oldDNSDomains[sameEntryIndex]
 
                 mergedViewModel.customDNSDomains.append(sourceEntry)

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
@@ -233,7 +233,7 @@ final class LocationDataSource: UITableViewDiffableDataSource<Int, RelayLocation
         selectedRelayLocation = relayLocation
         var locationList = snapshot().itemIdentifiers
 
-        guard let selectedRelayLocation = selectedRelayLocation,
+        guard let selectedRelayLocation,
               !locationList.contains(selectedRelayLocation) else { return }
 
         let selectedLocationTree = selectedRelayLocation.ascendants + [selectedRelayLocation]
@@ -507,7 +507,7 @@ private func fileSortComparator(_ a: String, _ b: String) -> Bool {
     return a.localizedStandardCompare(b) == .orderedAscending
 }
 
-private extension Array where Element == RelayLocation {
+private extension [RelayLocation] {
     mutating func addLocations(_ locations: [RelayLocation], at index: Int) {
         if index < count {
             insert(contentsOf: locations, at: index)

--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewController.swift
@@ -88,7 +88,7 @@ final class SelectLocationViewController: UIViewController {
 
         dataSource?.selectedRelayLocation = relayLocation
 
-        if let cachedRelays = cachedRelays {
+        if let cachedRelays {
             dataSource?.setRelays(cachedRelays.relays)
         }
     }

--- a/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
@@ -45,7 +45,7 @@ class SettingsCell: UITableViewCell {
                 renderingMode: .alwaysOriginal
             )
 
-            if let image = image {
+            if let image {
                 disclosureImageView.image = image
                 disclosureImageView.sizeToFit()
                 accessoryView = disclosureImageView

--- a/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
@@ -45,9 +45,9 @@ class SettingsViewController: UITableViewController, SettingsDataSourceDelegate 
             comment: ""
         )
         navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, actionHandler: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
-            self.delegate?.settingsViewControllerDidFinish(self)
+            delegate?.settingsViewControllerDidFinish(self)
         })
 
         tableView.backgroundColor = .secondaryColor

--- a/ios/MullvadVPN/View controllers/Tunnel/MapViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/MapViewController.swift
@@ -248,13 +248,13 @@ final class MapViewController: UIViewController, MKMapViewDelegate {
     }
 
     private func makeRegion(center: CLLocationCoordinate2D?) -> MKCoordinateRegion {
-        guard let center = center else {
+        guard let center else {
             return makeZoomedOutRegion()
         }
 
         let sourceRegion = makeZoomedInRegion(center: center)
 
-        guard let alignmentView = alignmentView else {
+        guard let alignmentView else {
             return sourceRegion
         }
 

--- a/ios/MullvadVPN/Views/CustomTextView.swift
+++ b/ios/MullvadVPN/Views/CustomTextView.swift
@@ -136,7 +136,7 @@ class CustomTextView: UITextView {
     }
 
     deinit {
-        if let notificationObserver = notificationObserver {
+        if let notificationObserver {
             NotificationCenter.default.removeObserver(notificationObserver)
         }
     }

--- a/ios/MullvadVPN/Views/SpinnerActivityIndicatorView.swift
+++ b/ios/MullvadVPN/Views/SpinnerActivityIndicatorView.swift
@@ -116,7 +116,7 @@ class SpinnerActivityIndicatorView: UIView {
     }
 
     private func unregisterSceneActivationObserver() {
-        if let sceneActivationObserver = sceneActivationObserver {
+        if let sceneActivationObserver {
             NotificationCenter.default.removeObserver(sceneActivationObserver)
             self.sceneActivationObserver = nil
         }

--- a/ios/Operations/BackgroundObserver.swift
+++ b/ios/Operations/BackgroundObserver.swift
@@ -42,7 +42,7 @@ public final class BackgroundObserver: OperationObserver {
     }
 
     public func operationDidFinish(_ operation: Operation, error: Error?) {
-        if let taskIdentifier = taskIdentifier {
+        if let taskIdentifier {
             application.endBackgroundTask(taskIdentifier)
         }
     }

--- a/ios/Operations/ResultOperation.swift
+++ b/ios/Operations/ResultOperation.swift
@@ -131,7 +131,7 @@ open class ResultOperation<Success>: AsyncOperation, OutputOperation {
             super.finish(error: error)
         }
 
-        if let completionQueue = completionQueue {
+        if let completionQueue {
             completionQueue.async(execute: block)
         } else {
             block()

--- a/ios/Operations/TransformOperation.swift
+++ b/ios/Operations/TransformOperation.swift
@@ -74,7 +74,7 @@ public final class TransformOperation<Input, Output>: ResultOperation<Output>, I
     }
 
     override public func main() {
-        if let inputBlock = inputBlock {
+        if let inputBlock {
             _input = inputBlock()
         }
 

--- a/ios/OperationsTests/OperationInputInjectionTests.swift
+++ b/ios/OperationsTests/OperationInputInjectionTests.swift
@@ -54,7 +54,7 @@ class OperationInputInjectionTests: XCTestCase {
             var b: Int?
 
             func reduce() -> Int? {
-                guard let a = a, let b = b else { return nil }
+                guard let a, let b else { return nil }
 
                 return a + b
             }

--- a/ios/PacketTunnel/MullvadEndpoint+WgEndpoint.swift
+++ b/ios/PacketTunnel/MullvadEndpoint+WgEndpoint.swift
@@ -16,7 +16,7 @@ extension MullvadEndpoint {
     }
 
     var ipv6RelayEndpoint: Endpoint? {
-        guard let ipv6Relay = ipv6Relay else { return nil }
+        guard let ipv6Relay else { return nil }
 
         return Endpoint(host: .ipv6(ipv6Relay.ip), port: .init(integerLiteral: ipv6Relay.port))
     }

--- a/ios/PacketTunnel/TunnelMonitor/Pinger.swift
+++ b/ios/PacketTunnel/TunnelMonitor/Pinger.swift
@@ -86,7 +86,7 @@ final class Pinger {
             IPPROTO_ICMP,
             CFSocketCallBackType.readCallBack.rawValue,
             { socket, callbackType, address, data, info in
-                guard let socket = socket, let info = info, callbackType == .readCallBack else {
+                guard let socket, let info, callbackType == .readCallBack else {
                     return
                 }
 
@@ -104,7 +104,7 @@ final class Pinger {
             CFSocketSetSocketFlags(newSocket, flags | kCFSocketCloseOnInvalidate)
         }
 
-        if let interfaceName = interfaceName {
+        if let interfaceName {
             try bindSocket(newSocket, to: interfaceName)
         }
 
@@ -121,7 +121,7 @@ final class Pinger {
         stateLock.lock()
         defer { stateLock.unlock() }
 
-        if let socket = socket {
+        if let socket {
             CFSocketInvalidate(socket)
 
             self.socket = nil
@@ -134,7 +134,7 @@ final class Pinger {
         stateLock.lock()
         defer { stateLock.unlock() }
 
-        guard let socket = socket else {
+        guard let socket else {
             throw Error.closedSocket
         }
 
@@ -406,7 +406,7 @@ extension Pinger {
     }
 }
 
-private func in_chksum<S>(_ data: S) -> UInt16 where S: Sequence, S.Element == UInt8 {
+private func in_chksum(_ data: some Sequence<UInt8>) -> UInt16 {
     var iterator = data.makeIterator()
     var words = [UInt16]()
 

--- a/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
@@ -130,7 +130,7 @@ final class TunnelMonitor: PingerDelegate {
                     return .retryHeartbeatPing
                 }
 
-                guard let lastSeenRx = lastSeenRx, let lastSeenTx = lastSeenTx else { return .ok }
+                guard let lastSeenRx, let lastSeenTx else { return .ok }
 
                 let rxTimeElapsed = now.timeIntervalSince(lastSeenRx)
                 let txTimeElapsed = now.timeIntervalSince(lastSeenTx)
@@ -360,7 +360,7 @@ final class TunnelMonitor: PingerDelegate {
     }
 
     private func addDefaultPathObserver() {
-        guard let packetTunnelProvider = packetTunnelProvider else { return }
+        guard let packetTunnelProvider else { return }
 
         defaultPathObserver?.invalidate()
 
@@ -368,14 +368,14 @@ final class TunnelMonitor: PingerDelegate {
 
         defaultPathObserver = packetTunnelProvider
             .observe(\.defaultPath, options: [.new]) { [weak self] _, change in
-                guard let self = self else { return }
+                guard let self else { return }
 
-                self.nslock.lock()
+                nslock.lock()
                 defer { self.nslock.unlock() }
 
                 let newValue = change.newValue.flatMap { $0 }
                 if let newPath = newValue {
-                    self.handleNetworkPathUpdate(newPath)
+                    handleNetworkPathUpdate(newPath)
                 }
             }
 
@@ -385,7 +385,7 @@ final class TunnelMonitor: PingerDelegate {
     }
 
     private func removeDefaultPathObserver() {
-        guard let defaultPathObserver = defaultPathObserver else { return }
+        guard let defaultPathObserver else { return }
 
         logger.trace("Remove default path observer.")
 
@@ -397,7 +397,7 @@ final class TunnelMonitor: PingerDelegate {
         nslock.lock()
         defer { nslock.unlock() }
 
-        guard let probeAddress = probeAddress, let newStats = getStats(),
+        guard let probeAddress, let newStats = getStats(),
               state.connectionState == .connecting || state.connectionState == .connected
         else { return }
 
@@ -523,7 +523,7 @@ final class TunnelMonitor: PingerDelegate {
         nslock.lock()
         defer { nslock.unlock() }
 
-        guard let probeAddress = probeAddress else { return }
+        guard let probeAddress else { return }
 
         if sender.rawValue != probeAddress.rawValue {
             logger.trace("Got reply from unknown sender: \(sender), expected: \(probeAddress).")
@@ -602,7 +602,7 @@ final class TunnelMonitor: PingerDelegate {
     }
 
     private func stopConnectivityCheckTimer() {
-        guard let timer = timer else { return }
+        guard let timer else { return }
 
         logger.trace("Stop connectivity check timer.")
 
@@ -658,7 +658,7 @@ final class TunnelMonitor: PingerDelegate {
             return nil
         }
 
-        guard let result = result else {
+        guard let result else {
             logger.debug("Received nil string for stats.")
             return nil
         }

--- a/ios/PacketTunnel/TunnelMonitor/WgStats.swift
+++ b/ios/PacketTunnel/TunnelMonitor/WgStats.swift
@@ -33,7 +33,7 @@ struct WgStats {
             }
         }
 
-        guard let _bytesReceived = _bytesReceived, let _bytesSent = _bytesSent else {
+        guard let _bytesReceived, let _bytesSent else {
             return nil
         }
 

--- a/ios/PacketTunnel/TunnelTransportProvider.swift
+++ b/ios/PacketTunnel/TunnelTransportProvider.swift
@@ -32,8 +32,8 @@ final class TunnelTransportProvider: RESTTransportProvider {
             let shadowSocksConfiguration = RelaySelector.getShadowsocksTCPBridge(relays: cachedRelays.relays)
             let shadowSocksBridgeRelay = RelaySelector.getShadowSocksRelay(relays: cachedRelays.relays)
 
-            guard let shadowSocksConfiguration = shadowSocksConfiguration,
-                  let shadowSocksBridgeRelay = shadowSocksBridgeRelay
+            guard let shadowSocksConfiguration,
+                  let shadowSocksBridgeRelay
             else {
                 logger.error("Could not get shadow socks bridge information.")
                 return nil

--- a/ios/RelayCache/RelayCache.swift
+++ b/ios/RelayCache/RelayCache.swift
@@ -61,7 +61,7 @@ public final class RelayCache {
             byAccessor: accessor
         )
 
-        if let error = error {
+        if let error {
             result = .failure(error)
         }
 
@@ -88,7 +88,7 @@ public final class RelayCache {
             byAccessor: accessor
         )
 
-        if let error = error {
+        if let error {
             result = .failure(error)
         }
 

--- a/ios/RelaySelector/RelaySelector.swift
+++ b/ios/RelaySelector/RelaySelector.swift
@@ -43,7 +43,7 @@ public enum RelaySelector {
             numberOfFailedAttempts: numberOfFailedAttempts
         )
 
-        guard let relayWithLocation = pickRandomRelay(relays: filteredRelays), let port = port else {
+        guard let relayWithLocation = pickRandomRelay(relays: filteredRelays), let port else {
             throw NoRelaysSatisfyingConstraintsError()
         }
 

--- a/ios/TunnelProviderMessaging/PacketTunnelOptions.swift
+++ b/ios/TunnelProviderMessaging/PacketTunnelOptions.swift
@@ -52,7 +52,7 @@ public struct PacketTunnelOptions {
     }
 
     /// Encode custom parameter value
-    private static func encode<T: Codable>(_ value: T) throws -> Data {
+    private static func encode(_ value: some Codable) throws -> Data {
         return try JSONEncoder().encode(value)
     }
 

--- a/ios/TunnelProviderMessaging/ProxyURLResponse.swift
+++ b/ios/TunnelProviderMessaging/ProxyURLResponse.swift
@@ -31,7 +31,7 @@ public struct URLErrorWrapper: Codable {
     }
 
     public var originalError: Error? {
-        guard let code = code else { return nil }
+        guard let code else { return nil }
 
         return URLError(URLError.Code(rawValue: code))
     }
@@ -53,7 +53,7 @@ public struct HTTPURLResponseWrapper: Codable {
     }
 
     public var originalResponse: HTTPURLResponse? {
-        guard let url = url else { return nil }
+        guard let url else { return nil }
 
         return HTTPURLResponse(
             url: url,

--- a/ios/TunnelProviderMessaging/URLRequestProxy.swift
+++ b/ios/TunnelProviderMessaging/URLRequestProxy.swift
@@ -37,13 +37,13 @@ public final class URLRequestProxy {
             let transport = proxyRequest.useShadowsocksTransport
                 ? transportProvider?.shadowSocksTransport()
                 : transportProvider?.transport()
-            guard let transport = transport else { return }
+            guard let transport else { return }
             // The task sent by `transport.sendRequest` comes in an already resumed state
             let task = transport.sendRequest(proxyRequest.urlRequest) { [weak self] data, response, error in
-                guard let self = self else { return }
+                guard let self else { return }
                 // However there is no guarantee about which queue the execution resumes on
                 // Use `dispatchQueue` to guarantee thread safe access to `proxiedRequests`
-                self.dispatchQueue.async {
+                dispatchQueue.async {
                     let response = ProxyURLResponse(data: data, response: response, error: error)
                     _ = self.removeRequest(identifier: proxyRequest.id)
 


### PR DESCRIPTION
This PR increases swiftformat swift version to 5.8 which should enable formatter to use newer syntax.

Most prominent changes:

```swift,diff
- if let foo = foo {
+ if let foo {
      print(foo)
  }

- guard let self = self else {
+ guard let self else {
      return
  }
```

and

```swift,diff
- func handle<T: Fooable>(_ value: T) {
+ func handle(_ value: some Fooable) {
      print(value)
  }

- func handle<T>(_ value: T) where T: Fooable, T: Barable {
+ func handle(_ value: some Fooable & Barable) {
      print(value)
  }

- func handle<T: Collection>(_ value: T) where T.Element == Foo {
+ func handle(_ value: some Collection<Foo>) {
      print(value)
  }

// With `--someAny enabled` (the default)
- func handle<T>(_ value: T) {
+ func handle(_ value: some Any) {
      print(value)
  }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4675)
<!-- Reviewable:end -->
