### PR TITLE
Fix Rust 2018 idioms in `translations-converter`

### DIFF
--- a/android/translations-converter/src/android/plurals.rs
+++ b/android/translations-converter/src/android/plurals.rs
@@ -101,7 +101,7 @@ impl PluralResource {
 }
 
 impl Display for PluralResources {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         writeln!(formatter, r#"<?xml version="1.0" encoding="utf-8"?>"#)?;
         writeln!(formatter, "<resources>")?;
 
@@ -114,7 +114,7 @@ impl Display for PluralResources {
 }
 
 impl Display for PluralResource {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         writeln!(formatter, r#"    <plurals name="{}">"#, self.name)?;
 
         for item in &self.items {
@@ -126,7 +126,7 @@ impl Display for PluralResource {
 }
 
 impl Display for PluralVariant {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(
             formatter,
             r#"<item quantity="{}">{}</item>"#,
@@ -136,7 +136,7 @@ impl Display for PluralVariant {
 }
 
 impl Display for PluralQuantity {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         let quantity = match self {
             PluralQuantity::Zero => "zero",
             PluralQuantity::One => "one",

--- a/android/translations-converter/src/android/string_value.rs
+++ b/android/translations-converter/src/android/string_value.rs
@@ -93,7 +93,7 @@ impl Deref for StringValue {
 }
 
 impl Display for StringValue {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         write!(formatter, "{}", self.0)
     }
 }

--- a/android/translations-converter/src/android/strings.rs
+++ b/android/translations-converter/src/android/strings.rs
@@ -88,7 +88,7 @@ fn default_translatable() -> bool {
 
 // Unfortunately, direct serialization to XML isn't working correctly.
 impl Display for StringResources {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         writeln!(formatter, r#"<?xml version="1.0" encoding="utf-8"?>"#)?;
         writeln!(formatter, "<resources>")?;
 
@@ -101,7 +101,7 @@ impl Display for StringResources {
 }
 
 impl Display for StringResource {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         if self.translatable {
             write!(
                 formatter,

--- a/android/translations-converter/src/gettext/msg_string.rs
+++ b/android/translations-converter/src/gettext/msg_string.rs
@@ -38,7 +38,7 @@ impl MsgString {
 
 impl Display for MsgString {
     /// Write the ID message string with proper escaping.
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         self.0.fmt(formatter)
     }
 }

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -31,6 +31,8 @@
 //! most cases, it is important to keep in mind that this is just a helper tool and manual steps are
 //! likely to be needed from time to time.
 
+#![deny(rust_2018_idioms)]
+
 mod android;
 mod gettext;
 mod normalize;


### PR DESCRIPTION
Just a small PR to make all crates deny the `rust_2018_idioms` rule and honor it.

This is a cherry-pick from the stale old `stricter-rustc-flags` branch that I now aim to make something useful out of. I believe I might get somewhere if I break it up into some smaller chunks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4678)
<!-- Reviewable:end -->
