### PR TITLE
Make close icon smaller in too many devices view

### DIFF
--- a/gui/src/renderer/components/TooManyDevices.tsx
+++ b/gui/src/renderer/components/TooManyDevices.tsx
@@ -230,6 +230,8 @@ function Device(props: IDeviceProps) {
             )}>
             <ImageView
               source="icon-close"
+              width={18}
+              height={18}
               tintColor={colors.white40}
               tintHoverColor={colors.white60}
             />


### PR DESCRIPTION
The icon was previously 24x24 when it should be 18x18.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4681)
<!-- Reviewable:end -->
