### PR TITLE
Change dialog type to caution for bridge mode and multihop warnings

### DIFF
--- a/gui/src/renderer/components/OpenVpnSettings.tsx
+++ b/gui/src/renderer/components/OpenVpnSettings.tsx
@@ -350,7 +350,7 @@ function BridgeModeSelector() {
       </AriaInputGroup>
       <ModalAlert
         isOpen={confirmationDialogVisible}
-        type={ModalAlertType.info}
+        type={ModalAlertType.caution}
         message={messages.gettext('This setting increases latency. Use only if needed.')}
         buttons={[
           <AppButton.RedButton key="confirm" onClick={confirmBridgeState}>

--- a/gui/src/renderer/components/WireguardSettings.tsx
+++ b/gui/src/renderer/components/WireguardSettings.tsx
@@ -396,7 +396,7 @@ function MultihopSetting() {
       </AriaInputGroup>
       <ModalAlert
         isOpen={confirmationDialogVisible}
-        type={ModalAlertType.info}
+        type={ModalAlertType.caution}
         message={
           // TRANSLATORS: Warning text in a dialog that is displayed after a setting is toggled.
           messages.gettext('This setting increases latency. Use only if needed.')


### PR DESCRIPTION
The multihop and bridge mode dialogs that warns the user about latency had the info icon when it should have the alert icon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4683)
<!-- Reviewable:end -->
