### PR TITLE
Add touch-target padding to dismiss button

### DIFF
--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -10,7 +10,6 @@ import UIKit
 
 final class NotificationBannerView: UIView {
     private static let indicatorViewSize = CGSize(width: 12, height: 12)
-    private static let buttonSize = CGSize(width: 18, height: 18)
 
     private let backgroundView: UIVisualEffectView = {
         let effect = UIBlurEffect(style: .dark)
@@ -136,11 +135,24 @@ final class NotificationBannerView: UIView {
             bodyLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
             bodyLabel.bottomAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.bottomAnchor),
 
-            actionButton.leadingAnchor.constraint(equalTo: bodyLabel.trailingAnchor),
-            actionButton.topAnchor.constraint(equalTo: bodyLabel.topAnchor),
-            actionButton.trailingAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.trailingAnchor),
-            actionButton.widthAnchor.constraint(equalToConstant: NotificationBannerView.buttonSize.width),
-            actionButton.heightAnchor.constraint(equalToConstant: NotificationBannerView.buttonSize.height),
+            actionButton.leadingAnchor.constraint(
+                equalTo: bodyLabel.trailingAnchor,
+                constant: UIMetrics.inAppBannerActionButtonPadding * -1
+            ),
+            actionButton.topAnchor.constraint(
+                equalTo: bodyLabel.topAnchor,
+                constant: UIMetrics.inAppBannerActionButtonPadding * -1
+            ),
+            actionButton.trailingAnchor.constraint(
+                equalTo: wrapperView.layoutMarginsGuide.trailingAnchor,
+                constant: UIMetrics.inAppBannerActionButtonPadding
+            ),
+            actionButton.widthAnchor.constraint(
+                equalToConstant: UIMetrics.inAppBannerActionButtonSize.width
+            ),
+            actionButton.heightAnchor.constraint(
+                equalToConstant: UIMetrics.inAppBannerActionButtonSize.height
+            ),
         ])
     }
 

--- a/ios/MullvadVPN/UI appearance/UIMetrics.swift
+++ b/ios/MullvadVPN/UI appearance/UIMetrics.swift
@@ -48,6 +48,12 @@ extension UIMetrics {
         trailing: 24
     )
 
+    /// Button frame
+    static let inAppBannerActionButtonSize = CGSize(width: 44, height: 44)
+
+    /// Spacing for the in-app banner anchor constraints for the button frame
+    static let inAppBannerActionButtonPadding: CGFloat = 14
+
     /// Spacing used in stack views of buttons
     static let interButtonSpacing: CGFloat = 16
 


### PR DESCRIPTION
Matilda added some padding for the touch target of  the _dismiss_ button for the in-app banner notification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4691)
<!-- Reviewable:end -->
