### PR TITLE
Hide action button when no action provided in notification banner IOS-168

### DIFF
--- a/ios/MullvadVPN/Extensions/NSLayoutConstraint+Helpers.swift
+++ b/ios/MullvadVPN/Extensions/NSLayoutConstraint+Helpers.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 extension NSLayoutConstraint {
+    /// Sets constraint priority and returns `self`
     func withPriority(_ priority: UILayoutPriority) -> Self {
         self.priority = priority
         return self

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -125,10 +125,8 @@ final class NotificationBannerView: UIView {
             indicatorView.heightAnchor.constraint(equalToConstant: Self.indicatorViewSize.height),
 
             titleLabel.topAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.topAnchor),
-            titleLabel.leadingAnchor.constraint(
-                equalToSystemSpacingAfter: indicatorView.trailingAnchor,
-                multiplier: 1
-            ),
+            titleLabel.leadingAnchor.constraint(equalToSystemSpacingAfter: indicatorView.trailingAnchor, multiplier: 1),
+            titleLabel.trailingAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.trailingAnchor),
 
             bodyLabel.topAnchor.constraint(
                 equalToSystemSpacingBelow: titleLabel.bottomAnchor,

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -9,9 +9,6 @@
 import UIKit
 
 final class NotificationBannerView: UIView {
-    private static let indicatorViewSize = CGSize(width: 12, height: 12)
-    private static let buttonSize = CGSize(width: 18, height: 18)
-
     private let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
 
     private let titleLabel: UILabel = {
@@ -43,7 +40,7 @@ final class NotificationBannerView: UIView {
     private let indicatorView: UIView = {
         let view = UIView()
         view.backgroundColor = .dangerColor
-        view.layer.cornerRadius = NotificationBannerView.indicatorViewSize.width * 0.5
+        view.layer.cornerRadius = UIMetrics.inAppBannerSeverityIndicatorSize.width * 0.5
         view.layer.cornerCurve = .circular
         return view
     }()
@@ -119,8 +116,8 @@ final class NotificationBannerView: UIView {
         NSLayoutConstraint.activate([
             indicatorView.bottomAnchor.constraint(equalTo: titleLabel.firstBaselineAnchor),
             indicatorView.leadingAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.leadingAnchor),
-            indicatorView.widthAnchor.constraint(equalToConstant: Self.indicatorViewSize.width),
-            indicatorView.heightAnchor.constraint(equalToConstant: Self.indicatorViewSize.height),
+            indicatorView.widthAnchor.constraint(equalToConstant: UIMetrics.inAppBannerSeverityIndicatorSize.width),
+            indicatorView.heightAnchor.constraint(equalToConstant: UIMetrics.inAppBannerSeverityIndicatorSize.height),
 
             titleLabel.topAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.topAnchor),
             titleLabel.leadingAnchor.constraint(equalToSystemSpacingAfter: indicatorView.trailingAnchor, multiplier: 1),

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -95,7 +95,7 @@ final class NotificationBannerView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        actionButton.addTarget(self, action: #selector(didPress), for: .touchUpInside)
+        actionButton.addTarget(self, action: #selector(handleActionTap), for: .touchUpInside)
 
         actionButton.setContentCompressionResistancePriority(.defaultHigh + 1, for: .horizontal)
         actionButton.setContentCompressionResistancePriority(.defaultHigh + 1, for: .vertical)
@@ -136,7 +136,7 @@ final class NotificationBannerView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    @objc private func didPress() {
+    @objc private func handleActionTap() {
         action?.handler?()
     }
 }

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -91,7 +91,6 @@ final class NotificationBannerView: UIView {
     var action: InAppNotificationAction? {
         didSet {
             actionButton.setImage(action?.image, for: .normal)
-            actionButton.addTarget(self, action: #selector(didPress), for: .touchUpInside)
         }
     }
 
@@ -104,6 +103,8 @@ final class NotificationBannerView: UIView {
 
         backgroundView.contentView.addSubview(wrapperView)
         addSubview(backgroundView)
+
+        actionButton.addTarget(self, action: #selector(didPress), for: .touchUpInside)
 
         NSLayoutConstraint.activate([
             backgroundView.topAnchor.constraint(equalTo: topAnchor),

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -12,16 +12,10 @@ final class NotificationBannerView: UIView {
     private static let indicatorViewSize = CGSize(width: 12, height: 12)
     private static let buttonSize = CGSize(width: 18, height: 18)
 
-    private let backgroundView: UIVisualEffectView = {
-        let effect = UIBlurEffect(style: .dark)
-        let visualEffectView = UIVisualEffectView(effect: effect)
-        visualEffectView.translatesAutoresizingMaskIntoConstraints = false
-        return visualEffectView
-    }()
+    private let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
 
     private let titleLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
         textLabel.font = UIFont.systemFont(ofSize: 17, weight: .bold)
         textLabel.textColor = UIColor.InAppNotificationBanner.titleColor
         textLabel.numberOfLines = 0
@@ -35,7 +29,6 @@ final class NotificationBannerView: UIView {
 
     private let bodyLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.translatesAutoresizingMaskIntoConstraints = false
         textLabel.font = UIFont.systemFont(ofSize: 17)
         textLabel.textColor = UIColor.InAppNotificationBanner.bodyColor
         textLabel.numberOfLines = 0
@@ -49,7 +42,6 @@ final class NotificationBannerView: UIView {
 
     private let indicatorView: UIView = {
         let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .dangerColor
         view.layer.cornerRadius = NotificationBannerView.indicatorViewSize.width * 0.5
         view.layer.cornerCurve = .circular
@@ -58,15 +50,20 @@ final class NotificationBannerView: UIView {
 
     private let wrapperView: UIView = {
         let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
         view.directionalLayoutMargins = UIMetrics.inAppBannerNotificationLayoutMargins
         return view
     }()
 
+    private let bodyStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.alignment = .top
+        stackView.distribution = .fill
+        return stackView
+    }()
+
     private let actionButton: IncreasedHitButton = {
-        let button = IncreasedHitButton()
+        let button = IncreasedHitButton(type: .system)
         button.tintColor = UIColor.InAppNotificationBanner.actionButtonColor
-        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
 
@@ -90,37 +87,38 @@ final class NotificationBannerView: UIView {
 
     var action: InAppNotificationAction? {
         didSet {
-            actionButton.setImage(action?.image, for: .normal)
+            let image = action?.image
+            let showsAction = image != nil
+
+            actionButton.setImage(image, for: .normal)
+            actionButton.isHidden = !showsAction
         }
     }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        for subview in [titleLabel, bodyLabel, indicatorView, actionButton] {
-            wrapperView.addSubview(subview)
-        }
-
-        backgroundView.contentView.addSubview(wrapperView)
-        addSubview(backgroundView)
-
         actionButton.addTarget(self, action: #selector(didPress), for: .touchUpInside)
 
+        actionButton.setContentCompressionResistancePriority(.defaultHigh + 1, for: .horizontal)
+        actionButton.setContentCompressionResistancePriority(.defaultHigh + 1, for: .vertical)
+        actionButton.setContentHuggingPriority(.defaultHigh + 1, for: .horizontal)
+        actionButton.setContentHuggingPriority(.defaultHigh + 1, for: .vertical)
+
+        wrapperView.addConstrainedSubviews([titleLabel, indicatorView, bodyStackView])
+        backgroundView.contentView.addConstrainedSubviews([wrapperView]) {
+            wrapperView.pinEdgesToSuperview()
+        }
+        addConstrainedSubviews([backgroundView]) {
+            backgroundView.pinEdgesToSuperview()
+        }
+
+        bodyStackView.addArrangedSubview(bodyLabel)
+        bodyStackView.addArrangedSubview(actionButton)
+
         NSLayoutConstraint.activate([
-            backgroundView.topAnchor.constraint(equalTo: topAnchor),
-            backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            wrapperView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
-            wrapperView.leadingAnchor.constraint(equalTo: backgroundView.contentView.leadingAnchor),
-            wrapperView.trailingAnchor
-                .constraint(equalTo: backgroundView.contentView.trailingAnchor),
-            wrapperView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor),
-
             indicatorView.bottomAnchor.constraint(equalTo: titleLabel.firstBaselineAnchor),
-            indicatorView.leadingAnchor
-                .constraint(equalTo: wrapperView.layoutMarginsGuide.leadingAnchor),
+            indicatorView.leadingAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.leadingAnchor),
             indicatorView.widthAnchor.constraint(equalToConstant: Self.indicatorViewSize.width),
             indicatorView.heightAnchor.constraint(equalToConstant: Self.indicatorViewSize.height),
 
@@ -128,18 +126,10 @@ final class NotificationBannerView: UIView {
             titleLabel.leadingAnchor.constraint(equalToSystemSpacingAfter: indicatorView.trailingAnchor, multiplier: 1),
             titleLabel.trailingAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.trailingAnchor),
 
-            bodyLabel.topAnchor.constraint(
-                equalToSystemSpacingBelow: titleLabel.bottomAnchor,
-                multiplier: 1
-            ),
-            bodyLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-            bodyLabel.bottomAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.bottomAnchor),
-
-            actionButton.leadingAnchor.constraint(equalTo: bodyLabel.trailingAnchor),
-            actionButton.topAnchor.constraint(equalTo: bodyLabel.topAnchor),
-            actionButton.trailingAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.trailingAnchor),
-            actionButton.widthAnchor.constraint(equalToConstant: NotificationBannerView.buttonSize.width),
-            actionButton.heightAnchor.constraint(equalToConstant: NotificationBannerView.buttonSize.height),
+            bodyStackView.topAnchor.constraint(equalToSystemSpacingBelow: titleLabel.bottomAnchor, multiplier: 1),
+            bodyStackView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            bodyStackView.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            bodyStackView.bottomAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.bottomAnchor),
         ])
     }
 

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -40,14 +40,14 @@ final class NotificationBannerView: UIView {
     private let indicatorView: UIView = {
         let view = UIView()
         view.backgroundColor = .dangerColor
-        view.layer.cornerRadius = UIMetrics.inAppBannerSeverityIndicatorSize.width * 0.5
+        view.layer.cornerRadius = UIMetrics.InAppBannerNotification.indicatorSize.width * 0.5
         view.layer.cornerCurve = .circular
         return view
     }()
 
     private let wrapperView: UIView = {
         let view = UIView()
-        view.directionalLayoutMargins = UIMetrics.inAppBannerNotificationLayoutMargins
+        view.directionalLayoutMargins = UIMetrics.InAppBannerNotification.layoutMargins
         return view
     }()
 
@@ -116,8 +116,10 @@ final class NotificationBannerView: UIView {
         NSLayoutConstraint.activate([
             indicatorView.bottomAnchor.constraint(equalTo: titleLabel.firstBaselineAnchor),
             indicatorView.leadingAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.leadingAnchor),
-            indicatorView.widthAnchor.constraint(equalToConstant: UIMetrics.inAppBannerSeverityIndicatorSize.width),
-            indicatorView.heightAnchor.constraint(equalToConstant: UIMetrics.inAppBannerSeverityIndicatorSize.height),
+            indicatorView.widthAnchor
+                .constraint(equalToConstant: UIMetrics.InAppBannerNotification.indicatorSize.width),
+            indicatorView.heightAnchor
+                .constraint(equalToConstant: UIMetrics.InAppBannerNotification.indicatorSize.height),
 
             titleLabel.topAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.topAnchor),
             titleLabel.leadingAnchor.constraint(equalToSystemSpacingAfter: indicatorView.trailingAnchor, multiplier: 1),

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -55,6 +55,7 @@ final class NotificationBannerView: UIView {
         let stackView = UIStackView()
         stackView.alignment = .top
         stackView.distribution = .fill
+        stackView.spacing = UIStackView.spacingUseSystem
         return stackView
     }()
 

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -51,8 +51,8 @@ final class NotificationBannerView: UIView {
         return view
     }()
 
-    private let bodyStackView: UIStackView = {
-        let stackView = UIStackView()
+    private lazy var bodyStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [bodyLabel, actionButton])
         stackView.alignment = .top
         stackView.distribution = .fill
         stackView.spacing = UIStackView.spacingUseSystem
@@ -96,13 +96,20 @@ final class NotificationBannerView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
+        addActionHandlers()
+        addSubviews()
+        addConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func addActionHandlers() {
         actionButton.addTarget(self, action: #selector(handleActionTap), for: .touchUpInside)
+    }
 
-        actionButton.setContentCompressionResistancePriority(.defaultHigh + 1, for: .horizontal)
-        actionButton.setContentCompressionResistancePriority(.defaultHigh + 1, for: .vertical)
-        actionButton.setContentHuggingPriority(.defaultHigh + 1, for: .horizontal)
-        actionButton.setContentHuggingPriority(.defaultHigh + 1, for: .vertical)
-
+    private func addSubviews() {
         wrapperView.addConstrainedSubviews([titleLabel, indicatorView, bodyStackView])
         backgroundView.contentView.addConstrainedSubviews([wrapperView]) {
             wrapperView.pinEdgesToSuperview()
@@ -110,9 +117,14 @@ final class NotificationBannerView: UIView {
         addConstrainedSubviews([backgroundView]) {
             backgroundView.pinEdgesToSuperview()
         }
+    }
 
-        bodyStackView.addArrangedSubview(bodyLabel)
-        bodyStackView.addArrangedSubview(actionButton)
+    private func addConstraints() {
+        let actionButtonPriority: UILayoutPriority = .defaultHigh + 1
+        actionButton.setContentCompressionResistancePriority(actionButtonPriority, for: .horizontal)
+        actionButton.setContentCompressionResistancePriority(actionButtonPriority, for: .vertical)
+        actionButton.setContentHuggingPriority(actionButtonPriority, for: .horizontal)
+        actionButton.setContentHuggingPriority(actionButtonPriority, for: .vertical)
 
         NSLayoutConstraint.activate([
             indicatorView.bottomAnchor.constraint(equalTo: titleLabel.firstBaselineAnchor),
@@ -131,10 +143,6 @@ final class NotificationBannerView: UIView {
             bodyStackView.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
             bodyStackView.bottomAnchor.constraint(equalTo: wrapperView.layoutMarginsGuide.bottomAnchor),
         ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 
     @objc private func handleActionTap() {

--- a/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
@@ -118,7 +118,7 @@ extension UIColor {
 
         static let titleColor = UIColor.white
         static let bodyColor = UIColor(white: 1.0, alpha: 0.6)
-        static let actionButtonColor = UIColor(white: 1.0, alpha: 0.6)
+        static let actionButtonColor = UIColor(white: 1.0, alpha: 0.8)
     }
 
     // Common colors

--- a/ios/MullvadVPN/UI appearance/UIMetrics.swift
+++ b/ios/MullvadVPN/UI appearance/UIMetrics.swift
@@ -22,20 +22,10 @@ extension UIMetrics {
     static let rowViewLayoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 24)
 
     /// Common layout margins for settings cell presentation
-    static let settingsCellLayoutMargins = NSDirectionalEdgeInsets(
-        top: 16,
-        leading: 24,
-        bottom: 16,
-        trailing: 12
-    )
+    static let settingsCellLayoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 12)
 
     /// Common layout margins for location cell presentation
-    static let selectLocationCellLayoutMargins = NSDirectionalEdgeInsets(
-        top: 16,
-        leading: 28,
-        bottom: 16,
-        trailing: 12
-    )
+    static let selectLocationCellLayoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 28, bottom: 16, trailing: 12)
 
     /// Common cell indentation width
     static let cellIndentationWidth: CGFloat = 16
@@ -47,6 +37,9 @@ extension UIMetrics {
         bottom: 16,
         trailing: 24
     )
+
+    /// Size of little round indicator presented in in-app notification banner.
+    static let inAppBannerSeverityIndicatorSize = CGSize(width: 12, height: 12)
 
     /// Spacing used in stack views of buttons
     static let interButtonSpacing: CGFloat = 16

--- a/ios/MullvadVPN/UI appearance/UIMetrics.swift
+++ b/ios/MullvadVPN/UI appearance/UIMetrics.swift
@@ -30,16 +30,14 @@ extension UIMetrics {
     /// Common cell indentation width
     static let cellIndentationWidth: CGFloat = 16
 
-    /// Layout margins for in-app notification banner presentation
-    static let inAppBannerNotificationLayoutMargins = NSDirectionalEdgeInsets(
-        top: 16,
-        leading: 24,
-        bottom: 16,
-        trailing: 24
-    )
+    /// Group of constants related to in-app notifications banner.
+    enum InAppBannerNotification {
+        /// Layout margins for contents presented within the banner.
+        static let layoutMargins = NSDirectionalEdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 24)
 
-    /// Size of little round indicator presented in in-app notification banner.
-    static let inAppBannerSeverityIndicatorSize = CGSize(width: 12, height: 12)
+        /// Size of little round severity indicator.
+        static let indicatorSize = CGSize(width: 12, height: 12)
+    }
 
     /// Spacing used in stack views of buttons
     static let interButtonSpacing: CGFloat = 16


### PR DESCRIPTION
1. Update constraints that pin the body label to the trailing layout margin when no action provided, otherwise pin the trailing edge to the leading edge of action button.
2. Add helper to store constraint into array `NSLayoutConstraint.store(into: inout [NSLayoutConstraint])` that provides chained call semantics.
3. Modernize constraint creation by using `addConstrainedSubviews` and autolayout helpers we use to reduce amount of boilerplate code.
4. Add missing trailing anchor for title label.
    <img width="570" alt="HasAction" src="https://github.com/mullvad/mullvadvpn-app/assets/704044/bb728406-f1d8-4909-9a14-f0cbd2593c78">
    <img width="557" alt="NoAction" src="https://github.com/mullvad/mullvadvpn-app/assets/704044/cad370f8-f949-4f00-bbe4-09e598de53c1">
5. Set action button opacity to 80%
6. Add system spacing button the body label and action button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4695)
<!-- Reviewable:end -->
