### PR TITLE
Hide brand name in header bar when buttons overlap it IOS-166

### DIFF
--- a/ios/MullvadVPN/UI appearance/UIMetrics.swift
+++ b/ios/MullvadVPN/UI appearance/UIMetrics.swift
@@ -68,4 +68,13 @@ extension UIMetrics {
 
     /// Maximum sidebar width in percentage points (0...1)
     static let maximumSplitViewSidebarWidthFraction: CGFloat = 0.3
+
+    /// Spacing between buttons in header bar.
+    static let headerBarButtonSpacing: CGFloat = 20
+
+    /// Size of a square logo image in header bar.
+    static let headerBarLogoSize: CGFloat = 44
+
+    /// Height of brand name. Width is automatically produced based on aspect ratio.
+    static let headerBarBrandNameHeight: CGFloat = 18
 }


### PR DESCRIPTION
1. Hide brand name in header bar when buttons container frame intersects with it. This is implemented by using a simple frame intersection check and should work universally in RTL and LTR environment from what I understand.
2. Refactor header bar a bit by using standard spacing where possible, we had 7pt, 8pt and 9pt spacing hardcoded which is roughly speaking about what standard spacing is (8pt) so it's reasonable to use that instead of hardcoded constants. A few constants were moved into `UIMetrics` as well.
  3. Remove calls to `translatesAutoresizingMaskIntoConstraints`. This is not needed when using `addConstrainedSubviews` or when using `UIStackView`.
  4. Many `UIView` subclasses support default `init()` initializer which has the same effect as `init(frame: CGRect.zero)`. Replaced as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4697)
<!-- Reviewable:end -->
