### PR TITLE
Run new CLI before stopping old daemon on macOS

### DIFF
--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -10,6 +10,16 @@ exec 2>&1 > $LOG_DIR/postinstall.log
 echo "Running postinstall at $(date)"
 
 INSTALL_DIR=$2
+
+# Run CLI to force macOS to check the certificate, and shut down the already running daemon, if one
+# exists.
+# This is a temporary workaround. After 2023.3, we switched from signing with Amagicom AB to
+# Mullvad VPN AB certificates. This could potentially be removed when older versions are no longer
+# supported.
+"$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad" || true
+"$TMPDIR/mullvad-setup" prepare-restart || \
+    echo "Failed to send 'prepare-restart' command to old mullvad-daemon"
+
 # NOTE: This path must be kept in sync with the path defined
 # in mullvad-daemon/src/macos_launch_daemon.rs
 DAEMON_PLIST_PATH="/Library/LaunchDaemons/net.mullvad.daemon.plist"

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -11,9 +11,9 @@ exec 2>&1 > $LOG_DIR/preinstall.log
 
 echo "Running preinstall at $(date)"
 
-# Notify the running daemon that we are going to kill it and replace it with a newer version.
-"$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" prepare-restart || \
-    echo "Failed to send 'prepare-restart' command to old mullvad-daemon"
+# We need to run this is after extracting the new files and running "mullvad" in postinstall rather
+# than in preinstall.
+cp "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" "$TMPDIR/" || echo "Failed to copy mullvad-setup"
 
 # Migrate cache files from <=2020.8-beta2 paths
 OLD_CACHE_DIR="/var/root/Library/Caches/mullvad-vpn"


### PR DESCRIPTION
This PR updates the macOS installer scripts to run the new CLI before blocking the internet during upgrades. We hope that it may force macOS to check the validity of the certificate.

Fixes DES-210.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4699)
<!-- Reviewable:end -->
