### PR TITLE
PacketTunnel: rotate private key on mismatch with server

### DIFF
--- a/ios/MullvadTypes/PacketTunnelStatus.swift
+++ b/ios/MullvadTypes/PacketTunnelStatus.swift
@@ -9,26 +9,48 @@
 import Foundation
 
 public struct DeviceCheck: Codable, Equatable {
-    /// Unique identifier for the device check.
-    /// Should only change when other fields in the struct are being changed.
-    public var identifier: UUID
-
-    /// Flag indicating whether device is revoked.
-    /// Set to `nil` when the device status is unknown yet.
-    public var isDeviceRevoked: Bool?
-
     /// Last known account expiry.
     /// Set to `nil` when account expiry is unknown yet.
     public var accountExpiry: Date?
 
+    /// Invalid account. Often happens when account is removed on our backend.
+    public var isInvalidAccount: Bool?
+
+    /// Device is revoked.
+    public var isRevokedDevice: Bool?
+
+    /// Whether the key stored on device does not match the key stored on backend.
+    public var isKeyMismatch: Bool?
+
+    /// Last time packet tunnel had an attempt to rotate the key whether successfully or not.
+    public var lastKeyRotationAttemptDate: Date?
+
     public init(
-        identifier: UUID = UUID(),
-        isDeviceRevoked: Bool? = nil,
-        accountExpiry: Date? = nil
+        accountExpiry: Date? = nil,
+        isInvalidAccount: Bool? = nil,
+        isRevokedDevice: Bool? = nil,
+        isKeyMismatch: Bool? = nil,
+        lastKeyRotationDate: Date? = nil
     ) {
-        self.identifier = identifier
-        self.isDeviceRevoked = isDeviceRevoked
         self.accountExpiry = accountExpiry
+        self.isInvalidAccount = isInvalidAccount
+        self.isRevokedDevice = isRevokedDevice
+        self.isKeyMismatch = isKeyMismatch
+        lastKeyRotationAttemptDate = lastKeyRotationDate
+    }
+
+    public func merged(with other: DeviceCheck) -> DeviceCheck {
+        var copyOfSelf = self
+        copyOfSelf.merge(with: other)
+        return copyOfSelf
+    }
+
+    public mutating func merge(with other: DeviceCheck) {
+        other.accountExpiry.flatMap { accountExpiry = $0 }
+        other.isInvalidAccount.flatMap { isInvalidAccount = $0 }
+        other.isRevokedDevice.flatMap { isRevokedDevice = $0 }
+        other.isKeyMismatch.flatMap { isKeyMismatch = $0 }
+        other.lastKeyRotationAttemptDate.flatMap { lastKeyRotationAttemptDate = $0 }
     }
 }
 

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		58CCA0162242560B004F3011 /* UIColor+Palette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA0152242560B004F3011 /* UIColor+Palette.swift */; };
 		58CCA01822426713004F3011 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA01722426713004F3011 /* AccountViewController.swift */; };
 		58CCA01E2242787B004F3011 /* AccountTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CCA01D2242787B004F3011 /* AccountTextField.swift */; };
+		58CCB4DA2A0CF7F8007EAA07 /* TunnelSettingsV2+REST.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58421033282E4B1500F24E46 /* TunnelSettingsV2+REST.swift */; };
 		58CE38C728992C8700A6D6E5 /* WireGuardAdapterError+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E07298288031D5008902F8 /* WireGuardAdapterError+Localization.swift */; };
 		58CE38C828992C9200A6D6E5 /* TunnelMonitorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E072A428814C28008902F8 /* TunnelMonitorDelegate.swift */; };
 		58CE5E64224146200008646E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CE5E63224146200008646E /* AppDelegate.swift */; };
@@ -359,6 +360,7 @@
 		58FC040A27B3EE03001C21F0 /* TunnelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FC040927B3EE03001C21F0 /* TunnelMonitor.swift */; };
 		58FD5BF024238EB300112C88 /* SKProduct+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */; };
 		58FD5BF42428C67600112C88 /* InAppPurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */; };
+		58FDF2D92A0BA11A00C2B061 /* CheckDeviceOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FDF2D82A0BA11900C2B061 /* CheckDeviceOperation.swift */; };
 		58FEEB58260B662E00A621A8 /* AutomaticKeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FEEB57260B662E00A621A8 /* AutomaticKeyboardResponder.swift */; };
 		58FF2C03281BDE02009EF542 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FF2C02281BDE02009EF542 /* SettingsManager.swift */; };
 		7A09C98129D99215000C2CAC /* String+FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A09C98029D99215000C2CAC /* String+FuzzyMatch.swift */; };
@@ -961,6 +963,7 @@
 		58FC040927B3EE03001C21F0 /* TunnelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitor.swift; sourceTree = "<group>"; };
 		58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Formatting.swift"; sourceTree = "<group>"; };
 		58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseButton.swift; sourceTree = "<group>"; };
+		58FDF2D82A0BA11900C2B061 /* CheckDeviceOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckDeviceOperation.swift; sourceTree = "<group>"; };
 		58FEEB57260B662E00A621A8 /* AutomaticKeyboardResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomaticKeyboardResponder.swift; sourceTree = "<group>"; };
 		58FF2C02281BDE02009EF542 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		7A09C98029D99215000C2CAC /* String+FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+FuzzyMatch.swift"; sourceTree = "<group>"; };
@@ -1825,6 +1828,7 @@
 				58E07298288031D5008902F8 /* WireGuardAdapterError+Localization.swift */,
 				58E0729E28814ACC008902F8 /* WireGuardLogLevel+Logging.swift */,
 				58906DDF2445C7A5002F0673 /* NEProviderStopReason+Debug.swift */,
+				58FDF2D82A0BA11900C2B061 /* CheckDeviceOperation.swift */,
 			);
 			path = PacketTunnel;
 			sourceTree = "<group>";
@@ -2819,6 +2823,8 @@
 				5877D70F282137E8002FCFC7 /* SettingsManager.swift in Sources */,
 				58CE38C728992C8700A6D6E5 /* WireGuardAdapterError+Localization.swift in Sources */,
 				58E511E828DDDF2400B0BCDE /* CodingErrors+CustomErrorDescription.swift in Sources */,
+				58CCB4DA2A0CF7F8007EAA07 /* TunnelSettingsV2+REST.swift in Sources */,
+				58FDF2D92A0BA11A00C2B061 /* CheckDeviceOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
@@ -116,9 +116,7 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
         return false
     }
 
-    private func notificationDescription(for packetTunnelError: String)
-        -> InAppNotificationDescriptor
-    {
+    private func notificationDescription(for packetTunnelError: String) -> InAppNotificationDescriptor {
         return InAppNotificationDescriptor(
             identifier: identifier,
             style: .error,

--- a/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
+++ b/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
@@ -140,6 +140,22 @@ struct StoredWgKeyData: Codable, Equatable {
     /// Next private key we're trying to rotate to.
     /// Added in 2023.3
     var nextPrivateKey: PrivateKey?
+
+    /// Returns next private key if set, otherwise creates new key, assigns next private key and then returns it.
+    mutating func getOrCreateNextPrivateKey() -> PrivateKey {
+        if let nextPrivateKey = nextPrivateKey {
+            return nextPrivateKey
+        } else {
+            let newKey = PrivateKey()
+            nextPrivateKey = newKey
+            return newKey
+        }
+    }
+
+    /// Assigns last rotation attempt to current date.
+    mutating func markRotationAttempt() {
+        lastRotationAttemptDate = Date()
+    }
 }
 
 extension StoredWgKeyData {
@@ -154,5 +170,35 @@ extension StoredWgKeyData {
             lastRotationAttemptDate?.addingTimeInterval(configuration.retryInterval) ?? creationDate
                 .addingTimeInterval(configuration.rotationInterval)
         )
+    }
+
+    /**
+     Returns `true` if packet tunnel should perform key rotation.
+
+     During the startup packet tunnel rotates the key immediately if it detected that the key stored on server does not
+     match the key stored on device. In that case it passes `shouldRotateImmediately = true`.
+
+     To dampen the effect of packet tunnel entering into a restart cycle and going on a key rotation rampage,
+     this function adds a cooldown interval to prevent it from pushing keys too often.
+     */
+    func isPacketTunnelShouldRotateTheKey(shouldRotateImmediately: Bool) -> Bool {
+        guard let lastRotationAttemptDate = lastRotationAttemptDate else { return true }
+
+        let retryInterval: TimeInterval = 60 * 60 * 24
+        let cooldownInterval: TimeInterval = 15
+
+        let now = Date()
+        let nextRotationAttempt = max(now, lastRotationAttemptDate.addingTimeInterval(retryInterval))
+
+        if nextRotationAttempt <= now {
+            return true
+        }
+
+        // Add cooldown interval when requested to rotate the key immediately.
+        if shouldRotateImmediately, lastRotationAttemptDate.distance(to: now) > cooldownInterval {
+            return true
+        }
+
+        return false
     }
 }

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
@@ -66,17 +66,11 @@ class SimulatorTunnelProviderDelegate {
         }
     }
 
-    func startTunnel(
-        options: [String: NSObject]?,
-        completionHandler: @escaping (Error?) -> Void
-    ) {
+    func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         completionHandler(nil)
     }
 
-    func stopTunnel(
-        with reason: NEProviderStopReason,
-        completionHandler: @escaping () -> Void
-    ) {
+    func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         completionHandler()
     }
 
@@ -107,10 +101,7 @@ final class SimulatorTunnelProvider {
 
     private init() {}
 
-    fileprivate func handleAppMessage(
-        _ messageData: Data,
-        completionHandler: ((Data?) -> Void)? = nil
-    ) {
+    fileprivate func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
         delegate.handleAppMessage(messageData, completionHandler: completionHandler)
     }
 }
@@ -223,9 +214,7 @@ class SimulatorVPNConnection: NSObject, VPNConnectionProtocol {
 
 // MARK: - NETunnelProviderSession stubs
 
-final class SimulatorTunnelProviderSession: SimulatorVPNConnection,
-    VPNTunnelProviderSessionProtocol
-{
+final class SimulatorTunnelProviderSession: SimulatorVPNConnection, VPNTunnelProviderSessionProtocol {
     func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
         SimulatorTunnelProvider.shared.handleAppMessage(
             messageData,
@@ -428,10 +417,7 @@ final class SimulatorTunnelProviderManager: NSObject, VPNTunnelProviderManagerPr
         completionHandler?(error)
     }
 
-    static func == (
-        lhs: SimulatorTunnelProviderManager,
-        rhs: SimulatorTunnelProviderManager
-    ) -> Bool {
+    static func == (lhs: SimulatorTunnelProviderManager, rhs: SimulatorTunnelProviderManager) -> Bool {
         lhs.identifier == rhs.identifier
     }
 }

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
@@ -68,10 +68,7 @@ final class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
         }
     }
 
-    override func stopTunnel(
-        with reason: NEProviderStopReason,
-        completionHandler: @escaping () -> Void
-    ) {
+    override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         dispatchQueue.async {
             self.selectorResult = nil
 
@@ -96,10 +93,7 @@ final class SimulatorTunnelProviderHost: SimulatorTunnelProviderDelegate {
         }
     }
 
-    private func handleProviderMessage(
-        _ message: TunnelProviderMessage,
-        completionHandler: ((Data?) -> Void)?
-    ) {
+    private func handleProviderMessage(_ message: TunnelProviderMessage, completionHandler: ((Data?) -> Void)?) {
         switch message {
         case .getTunnelStatus:
             var tunnelStatus = PacketTunnelStatus()

--- a/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
@@ -36,7 +36,8 @@ class RotateKeyOperation: ResultOperation<Bool> {
     }
 
     override func main() {
-        guard case .loggedIn(let accountData, var deviceData) = interactor.deviceState else {
+        var deviceState = interactor.deviceState
+        guard case .loggedIn(let accountData, var deviceData) = deviceState else {
             finish(result: .failure(InvalidDeviceStateError()))
             return
         }
@@ -51,23 +52,15 @@ class RotateKeyOperation: ResultOperation<Bool> {
             logger.debug("Private key is old enough, rotate right away.")
         }
 
-        deviceData.wgKeyData.lastRotationAttemptDate = Date()
-        interactor.setDeviceState(.loggedIn(accountData, deviceData), persist: true)
+        deviceData.wgKeyData.markRotationAttempt()
+        let newPrivateKey = deviceData.wgKeyData.getOrCreateNextPrivateKey()
+        deviceState.updateData { _, storedDeviceData in
+            storedDeviceData = deviceData
+        }
+
+        interactor.setDeviceState(deviceState, persist: true)
 
         logger.debug("Replacing old key with new key on server...")
-
-        let newPrivateKey: PrivateKey
-        if let nextPrivateKey = deviceData.wgKeyData.nextPrivateKey {
-            logger.debug("Next private key is already stored in Keychain. Using it.")
-
-            newPrivateKey = nextPrivateKey
-        } else {
-            logger.debug("Create next private key and store it in Keychain.")
-
-            newPrivateKey = PrivateKey()
-            deviceData.wgKeyData.nextPrivateKey = newPrivateKey
-            interactor.setDeviceState(.loggedIn(accountData, deviceData), persist: true)
-        }
 
         task = devicesProxy.rotateDeviceKey(
             accountNumber: accountData.number,
@@ -89,46 +82,32 @@ class RotateKeyOperation: ResultOperation<Bool> {
     private func didRotateKey(newPrivateKey: PrivateKey, result: Result<REST.Device, Error>) {
         switch result {
         case let .success(device):
-            logger.debug("Successfully rotated device key. Persisting settings...")
+            logger.debug("Successfully rotated device key. Persisting device state...")
 
-            switch interactor.deviceState {
-            case .loggedIn(let accountData, var deviceData):
-                deviceData.update(from: device)
-
-                deviceData.wgKeyData = StoredWgKeyData(
-                    creationDate: Date(),
-                    lastRotationAttemptDate: nil,
-                    privateKey: newPrivateKey
-                )
-
-                interactor.setDeviceState(.loggedIn(accountData, deviceData), persist: true)
-
-                if let tunnel = interactor.tunnel {
-                    _ = tunnel.notifyKeyRotation { [weak self] _ in
-                        self?.finish(result: .success(true))
-                    }
-                } else {
-                    finish(result: .success(true))
-                }
-            default:
+            var deviceState = interactor.deviceState
+            guard var deviceData = deviceState.deviceData else {
                 finish(result: .failure(InvalidDeviceStateError()))
+                return
+            }
+
+            deviceData.update(from: device)
+            deviceData.wgKeyData = StoredWgKeyData(creationDate: Date(), privateKey: newPrivateKey)
+            deviceState.updateData { _, storedDeviceData in
+                storedDeviceData = deviceData
+            }
+            interactor.setDeviceState(deviceState, persist: true)
+
+            if let tunnel = interactor.tunnel {
+                _ = tunnel.notifyKeyRotation { [weak self] _ in
+                    self?.finish(result: .success(true))
+                }
+            } else {
+                finish(result: .success(true))
             }
 
         case let .failure(error):
             if !error.isOperationCancellationError {
-                logger.error(
-                    error: error,
-                    message: "Failed to rotate device key."
-                )
-            }
-
-            switch interactor.deviceState {
-            case .loggedIn(let accountData, var deviceData):
-                deviceData.wgKeyData.lastRotationAttemptDate = Date()
-                interactor.setDeviceState(.loggedIn(accountData, deviceData), persist: true)
-
-            default:
-                finish(result: .failure(InvalidDeviceStateError()))
+                logger.error(error: error, message: "Failed to rotate device key.")
             }
 
             interactor.handleRestError(error)

--- a/ios/MullvadVPN/TunnelManager/TunnelInteractor.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelInteractor.swift
@@ -22,8 +22,7 @@ protocol TunnelInteractor {
     // MARK: - Tunnel status
 
     var tunnelStatus: TunnelStatus { get }
-    @discardableResult func updateTunnelStatus(_ block: (inout TunnelStatus) -> Void)
-        -> TunnelStatus
+    @discardableResult func updateTunnelStatus(_ block: (inout TunnelStatus) -> Void) -> TunnelStatus
 
     // MARK: - Configuration
 

--- a/ios/PacketTunnel/CheckDeviceOperation.swift
+++ b/ios/PacketTunnel/CheckDeviceOperation.swift
@@ -1,0 +1,269 @@
+//
+//  CheckDeviceOperation.swift
+//  PacketTunnel
+//
+//  Created by pronebird on 20/04/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+import MullvadREST
+import MullvadTypes
+import Operations
+import class WireGuardKit.PrivateKey
+import class WireGuardKit.PublicKey
+
+struct CheckDeviceResult {
+    var deviceCheck: DeviceCheck?
+    var isKeyRotated = false
+    var error: Error?
+}
+
+final class CheckDeviceOperation: AsyncOperation {
+    typealias CompletionHandler = (CheckDeviceResult) -> Void
+
+    private let logger = Logger(label: "CheckDeviceOperation")
+
+    private let accountsProxy: REST.AccountsProxy
+    private let devicesProxy: REST.DevicesProxy
+    private let shouldImmediatelyRotateKeyOnMismatch: Bool
+    private let completionHandler: CompletionHandler
+
+    private var accountTask: Cancellable?
+    private var deviceTask: Cancellable?
+    private var rotationTask: Cancellable?
+
+    init(
+        dispatchQueue: DispatchQueue,
+        accountsProxy: REST.AccountsProxy,
+        devicesProxy: REST.DevicesProxy,
+        shouldImmediatelyRotateKeyOnMismatch: Bool,
+        completionHandler: @escaping CompletionHandler
+    ) {
+        self.accountsProxy = accountsProxy
+        self.devicesProxy = devicesProxy
+        self.shouldImmediatelyRotateKeyOnMismatch = shouldImmediatelyRotateKeyOnMismatch
+        self.completionHandler = completionHandler
+
+        super.init(dispatchQueue: dispatchQueue)
+    }
+
+    override func main() {
+        startCheck { checkResult in
+            self.completionHandler(checkResult)
+
+            self.finish(error: checkResult.error)
+        }
+    }
+
+    override func operationDidCancel() {
+        accountTask?.cancel()
+        deviceTask?.cancel()
+        rotationTask?.cancel()
+    }
+
+    // MARK: - Flow
+
+    private func startCheck(completion: @escaping (CheckDeviceResult) -> Void) {
+        var checkResult = CheckDeviceResult()
+
+        do {
+            let deviceState = try SettingsManager.readDeviceState()
+            guard case let .loggedIn(accountData, deviceData) = deviceState else {
+                throw InvalidDeviceState()
+            }
+
+            fetchData(accountNumber: accountData.number, deviceIdentifier: deviceData.identifier) { result in
+                checkResult.deviceCheck = result.value
+                checkResult.error = result.error
+
+                // Attempt to rotate the key when key mismatch is detected.
+                if checkResult.deviceCheck?.isKeyMismatch == .some(true) {
+                    self.maybeRotateKey { isKeyRotated, error in
+                        if isKeyRotated {
+                            checkResult.deviceCheck?.isKeyMismatch = false
+                        }
+                        checkResult.deviceCheck?.lastKeyRotationAttemptDate = Date()
+                        checkResult.isKeyRotated = isKeyRotated
+                        checkResult.error = error
+                        completion(checkResult)
+                    }
+                } else {
+                    completion(checkResult)
+                }
+            }
+        } catch {
+            checkResult.error = error
+            completion(checkResult)
+        }
+    }
+
+    private func fetchData(
+        accountNumber: String,
+        deviceIdentifier: String,
+        completion: @escaping (Result<DeviceCheck, Error>) -> Void
+    ) {
+        var accountResult: Result<REST.AccountData, Error>?
+        var deviceResult: Result<REST.Device, Error>?
+
+        let dispatchGroup = DispatchGroup()
+
+        dispatchGroup.enter()
+        accountTask = accountsProxy.getAccountData(accountNumber: accountNumber, retryStrategy: .noRetry) { result in
+            accountResult = result
+            dispatchGroup.leave()
+        }
+
+        dispatchGroup.enter()
+        deviceTask = devicesProxy.getDevice(
+            accountNumber: accountNumber,
+            identifier: deviceIdentifier,
+            retryStrategy: .noRetry
+        ) { result in
+            deviceResult = result
+            dispatchGroup.leave()
+        }
+
+        dispatchGroup.notify(queue: dispatchQueue) {
+            guard let accountResult = accountResult, let deviceResult = deviceResult else { return }
+
+            let result = Result {
+                try self.mapResultsToDeviceCheck(accountResult: accountResult, deviceResult: deviceResult)
+            }
+
+            completion(result)
+        }
+    }
+
+    private func maybeRotateKey(completion: @escaping (Bool, Error?) -> Void) {
+        do {
+            var deviceState = try SettingsManager.readDeviceState()
+            guard case .loggedIn(let accountData, var deviceData) = deviceState else { throw InvalidDeviceState() }
+
+            guard deviceData.wgKeyData.isPacketTunnelShouldRotateTheKey(
+                shouldRotateImmediately: shouldImmediatelyRotateKeyOnMismatch
+            ) else {
+                completion(false, nil)
+                return
+            }
+
+            logger.debug("Rotate private key from packet tunnel.")
+
+            deviceData.wgKeyData.markRotationAttempt()
+            let nextPrivateKey = deviceData.wgKeyData.getOrCreateNextPrivateKey()
+
+            deviceState.updateData { _, storedDeviceData in
+                storedDeviceData = deviceData
+            }
+
+            try SettingsManager.writeDeviceState(deviceState)
+
+            rotationTask = devicesProxy.rotateDeviceKey(
+                accountNumber: accountData.number,
+                identifier: deviceData.identifier,
+                publicKey: nextPrivateKey.publicKey,
+                retryStrategy: .default
+            ) { result in
+                self.dispatchQueue.async {
+                    self.handleRotationResult(result, nextPrivateKey: nextPrivateKey, completion: completion)
+                }
+            }
+        } catch {
+            completion(false, error)
+        }
+    }
+
+    private func handleRotationResult(
+        _ result: Result<REST.Device, Error>,
+        nextPrivateKey: PrivateKey,
+        completion: @escaping (Bool, Error?) -> Void
+    ) {
+        switch result {
+        case let .success(device):
+            self.logger.debug("Successfully rotated device key. Persisting device state...")
+
+            do {
+                try self.saveNewPrivateKey(nextPrivateKey, device: device)
+
+                completion(true, nil)
+            } catch {
+                self.logger.error(error: error, message: "Failed to persist device state.")
+
+                completion(false, error)
+            }
+
+        case let .failure(error):
+            if !error.isOperationCancellationError {
+                self.logger.error(error: error, message: "Failed to rotate device key.")
+            }
+
+            completion(false, error)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func mapResultsToDeviceCheck(
+        accountResult: Result<REST.AccountData, Error>,
+        deviceResult: Result<REST.Device, Error>
+    ) throws -> DeviceCheck {
+        let deviceState = try SettingsManager.readDeviceState()
+        guard let deviceData = deviceState.deviceData else { throw InvalidDeviceState() }
+
+        var deviceCheck = DeviceCheck()
+
+        switch accountResult {
+        case let .success(serverAccountData):
+            deviceCheck.accountExpiry = serverAccountData.expiry
+            deviceCheck.isInvalidAccount = false
+
+        case let .failure(error):
+            if let error = error as? REST.Error, error.compareErrorCode(.invalidAccount) {
+                deviceCheck.isInvalidAccount = true
+            }
+
+            if !error.isOperationCancellationError {
+                logger.error(error: error, message: "Failed to fetch account data.")
+            }
+        }
+
+        switch deviceResult {
+        case let .success(serverDevice):
+            deviceCheck.isRevokedDevice = false
+            deviceCheck.isKeyMismatch = serverDevice.pubkey != deviceData.wgKeyData.privateKey.publicKey
+
+        case let .failure(error):
+            if let error = error as? REST.Error, error.compareErrorCode(.deviceNotFound) {
+                deviceCheck.isRevokedDevice = true
+            }
+
+            if !error.isOperationCancellationError {
+                logger.error(error: error, message: "Failed to fetch device data.")
+            }
+        }
+
+        return deviceCheck
+    }
+
+    private func saveNewPrivateKey(_ newPrivateKey: PrivateKey, device: REST.Device) throws {
+        var deviceState = try SettingsManager.readDeviceState()
+
+        guard var deviceData = deviceState.deviceData else { throw InvalidDeviceState() }
+
+        deviceData.wgKeyData = StoredWgKeyData(creationDate: Date(), privateKey: newPrivateKey)
+        deviceData.update(from: device)
+
+        deviceState.updateData { _, storedDeviceData in
+            storedDeviceData = deviceData
+        }
+
+        try SettingsManager.writeDeviceState(deviceState)
+    }
+}
+
+private struct InvalidDeviceState: LocalizedError {
+    var errorDescription: String? {
+        return "Cannot complete device check because device is no longer logged in."
+    }
+}

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -183,10 +183,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
         tunnelMonitor.delegate = self
     }
 
-    override func startTunnel(
-        options: [String: NSObject]?,
-        completionHandler: @escaping (Error?) -> Void
-    ) {
+    override func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         dispatchQueue.async {
             let tunnelOptions = PacketTunnelOptions(rawOptions: options ?? [:])
             var appSelectorResult: RelaySelectorResult?
@@ -256,6 +253,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
                     } else {
                         self.providerLogger.debug("Started the tunnel.")
 
+                        self.tunnelAdapterDidStart()
+
                         self.startTunnelCompletionHandler = { [weak self] in
                             self?.isConnected = true
                             completionHandler(nil)
@@ -270,10 +269,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
         }
     }
 
-    override func stopTunnel(
-        with reason: NEProviderStopReason,
-        completionHandler: @escaping () -> Void
-    ) {
+    override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
         dispatchQueue.async {
             self.providerLogger.debug("Stop the tunnel: \(reason)")
 
@@ -481,10 +477,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
             guard let self = self else { return }
 
             self.providerLogger.debug("Restart the tunnel that had startup failure.")
-            self.reconnectTunnel(
-                to: .automatic,
-                shouldStopTunnelMonitor: false
-            ) { [weak self] error in
+            self.reconnectTunnel(to: .automatic, shouldStopTunnelMonitor: false) { [weak self] error in
                 if error == nil {
                     self?.cancelTunnelStartupFailureRecovery()
                 }
@@ -508,6 +501,15 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
         tunnelStartupFailureRecoveryTimer = nil
     }
 
+    /**
+     Method that's called once the tunnel was able to read configuration and start WireGuard adapter.
+     */
+    private func tunnelAdapterDidStart() {
+        dispatchPrecondition(condition: .onQueue(dispatchQueue))
+
+        startDeviceCheck(shouldImmediatelyRotateKeyOnMismatch: true)
+    }
+
     private func startEmptyTunnel(completionHandler: @escaping (Error?) -> Void) {
         dispatchPrecondition(condition: .onQueue(dispatchQueue))
 
@@ -528,6 +530,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
                     completionHandler(error)
                 } else {
                     self.providerLogger.debug("Started an empty tunnel.")
+
+                    self.tunnelAdapterDidStart()
 
                     self.startTunnelCompletionHandler = { [weak self] in
                         self?.isConnected = true
@@ -608,10 +612,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
         operationQueue.addOperation(blockOperation)
     }
 
-    private func reconnectTunnelInner(
-        to nextRelay: NextRelay,
-        completionHandler: ((Error?) -> Void)? = nil
-    ) {
+    private func reconnectTunnelInner(to nextRelay: NextRelay, completionHandler: ((Error?) -> Void)? = nil) {
         dispatchPrecondition(condition: .onQueue(dispatchQueue))
 
         // Read tunnel configuration.
@@ -683,127 +684,40 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
 
     // MARK: - Device check
 
-    /// Fetch account and device data to verify account expiry and device status.
-    /// Saves the result into deviceCheck
-    private func startDeviceCheck() {
-        let deviceState: DeviceState
-        do {
-            deviceState = try SettingsManager.readDeviceState()
-        } catch {
-            providerLogger.error(
-                error: error,
-                message: "Failed to read device state."
-            )
-            return
-        }
+    /**
+     Start device diagnostics to determine the reason why the tunnel is not functional.
 
-        guard case let .loggedIn(storedAccountData, storedDeviceData) = deviceState else {
-            return
-        }
+     This involves the following steps:
 
-        providerLogger.debug("Start device check.")
-
-        let accountOperation = createGetAccountDataOperation(
-            accountNumber: storedAccountData.number
-        )
-        let deviceOperation = createGetDeviceDataOperation(
-            accountNumber: storedAccountData.number,
-            identifier: storedDeviceData.identifier
-        )
-
-        let completionOperation = AsyncBlockOperation(dispatchQueue: dispatchQueue) { [weak self] in
-            guard let self = self else { return }
-
-            var newAccountExpiry: Date?
-            var newDeviceRevoked: Bool?
-
-            switch accountOperation.result {
-            case let .failure(error):
-                if !error.isOperationCancellationError {
-                    self.providerLogger.error(
-                        error: error,
-                        message: "Failed to fetch account data."
-                    )
-                }
-
-            case let .success(accountData):
-                newAccountExpiry = accountData.expiry
-
-            case .none:
-                break
-            }
-
-            switch deviceOperation.result {
-            case let .failure(error):
-                if let restError = error as? REST.Error,
-                   restError.compareErrorCode(.deviceNotFound)
-                {
-                    newDeviceRevoked = true
-                } else if !error.isOperationCancellationError {
-                    self.providerLogger.error(
-                        error: error,
-                        message: "Failed to fetch device data."
-                    )
-                }
-
-            case .none, .success:
-                break
-            }
-
-            if var deviceCheck = self.deviceCheck {
-                deviceCheck.update(
-                    accountExpiry: newAccountExpiry,
-                    isDeviceRevoked: newDeviceRevoked
-                )
-
-                self.deviceCheck = deviceCheck
-            } else {
-                self.deviceCheck = DeviceCheck(
-                    identifier: UUID(),
-                    isDeviceRevoked: newDeviceRevoked,
-                    accountExpiry: newAccountExpiry
-                )
-            }
-
-            if newDeviceRevoked ?? false {
+     1. Fetch account and device data.
+     2. Check account validity and whether it has enough time left.
+     2. Verify that current device is registered with backend and that both device and backend point to the same public
+        key.
+     3. Rotate WireGuard key on key mismatch.
+     */
+    private func startDeviceCheck(shouldImmediatelyRotateKeyOnMismatch: Bool = false) {
+        let checkOperation = CheckDeviceOperation(
+            dispatchQueue: dispatchQueue,
+            accountsProxy: accountsProxy,
+            devicesProxy: devicesProxy,
+            shouldImmediatelyRotateKeyOnMismatch: shouldImmediatelyRotateKeyOnMismatch
+        ) { checkResult in
+            if checkResult.deviceCheck?.isInvalidAccount == .some(true) ||
+                checkResult.deviceCheck?.isRevokedDevice == .some(true)
+            {
+                // Stop tunnel monitor when device is revoked or account is invalid.
                 self.tunnelMonitor.stop()
+            } else if checkResult.isKeyRotated {
+                // Tell the tunnel to reconnect using new private key if key was rotated dring device check.
+                self.reconnectTunnel(to: .automatic, shouldStopTunnelMonitor: false)
+            }
+
+            if let newDeviceCheck = checkResult.deviceCheck {
+                self.deviceCheck = self.deviceCheck?.merged(with: newDeviceCheck) ?? newDeviceCheck
             }
         }
 
-        completionOperation.addDependencies([accountOperation, deviceOperation])
-
-        let groupOperation = GroupOperation(operations: [
-            accountOperation,
-            deviceOperation,
-            completionOperation,
-        ])
-        checkDeviceStateTask = groupOperation
-
-        operationQueue.addOperation(groupOperation)
-    }
-
-    private func createGetAccountDataOperation(accountNumber: String) -> ResultOperation<REST.AccountData> {
-        return ResultBlockOperation<REST.AccountData>(dispatchQueue: dispatchQueue) { finish -> Cancellable in
-            return self.accountsProxy.getAccountData(
-                accountNumber: accountNumber,
-                retryStrategy: .noRetry,
-                completion: finish
-            )
-        }
-    }
-
-    private func createGetDeviceDataOperation(
-        accountNumber: String,
-        identifier: String
-    ) -> ResultOperation<REST.Device> {
-        return ResultBlockOperation<REST.Device>(dispatchQueue: dispatchQueue) { finish -> Cancellable in
-            return self.devicesProxy.getDevice(
-                accountNumber: accountNumber,
-                identifier: identifier,
-                retryStrategy: .noRetry,
-                completion: finish
-            )
-        }
+        operationQueue.addOperation(checkOperation)
     }
 }
 
@@ -814,26 +728,6 @@ private enum NextRelay {
 
     /// Determine next relay using relay selector.
     case automatic
-}
-
-extension DeviceCheck {
-    mutating func update(accountExpiry: Date?, isDeviceRevoked: Bool?) {
-        var shouldChangeIdentifier = false
-
-        if let accountExpiry = accountExpiry, self.accountExpiry != accountExpiry {
-            shouldChangeIdentifier = true
-            self.accountExpiry = accountExpiry
-        }
-
-        if let isDeviceRevoked = isDeviceRevoked, self.isDeviceRevoked != isDeviceRevoked {
-            shouldChangeIdentifier = true
-            self.isDeviceRevoked = isDeviceRevoked
-        }
-
-        if shouldChangeIdentifier {
-            identifier = UUID()
-        }
-    }
 }
 
 extension PacketTunnelErrorWrapper {


### PR DESCRIPTION
This PR introduced private key rotation into packet tunnel, when the public key stored on backend does not match the public key derived from private key stored on device.

Key rotation can only happen once in 24 hours. However key rotation is enforced during the tunnel startup which should enable folks to unstuck the tunnel by simply restarting it and causing key rotation to kick in, that's given that keys don't match of course.

Additional 15 second cooldown is used  to prevent the tunnel from spamming our API in the potential scenario where packet tunnel enters into a restart cycle. So if the tunnel restarts within 15 second interval, then no key rotation will happen and packet tunnel will rely on 24 hour interval  between key rotation attempts. That's guaranteed by marking `lastRotationAttemptDate` before each key rotation.

Given that packet tunnel will mutate the keychain store before key rotation, to store the last rotation date, and after successful key rotation, to store the new private key; GUI counterpart will have to refresh device state from Keychain once it enters foreground. 

Polling the tunnel status also returns a `DeviceCheck` object that contains the date of last key rotation from within packet tunnel, which provides a hint for GUI counterpart to refresh device state from Keychain

I do expect races with approach, that's why I was hesitant to mutate settings from packet tunnel in the first place but it seems that there is no other way around that. 

I assume though that these races will be isolated to `DeviceState` only, since we decoupled the rest of settings from device state. Perhaps for the most part these races will be unnoticed or worst case automatically healed over time.
