### PR TITLE
Fix incorrect obfuscation mode name in CLI

### DIFF
--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -588,6 +588,7 @@ pub enum SelectedObfuscation {
     Auto,
     #[default]
     Off,
+    #[cfg_attr(feature = "clap", clap(name = "udp2tcp"))]
     Udp2Tcp,
 }
 


### PR DESCRIPTION
The mode was incorrectly named `udp2-tcp`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4701)
<!-- Reviewable:end -->
