### PR TITLE
Move split tunneling to the settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
   is turned off.
 - Add creation date below device name in the device list screen.
 - Changed `AdvancedSettings` page's name and title into `VPN Settings`.
+- Changed `SplitTunneling` menu location from `VPN Settings` to `Settings`.
 
 ### Changed
 - In the CLI, update the `tunnel` subcommand to resemble `relay` more. For example, by adding a

--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
@@ -49,7 +49,6 @@ class VpnSettingsScreenTest {
         composeTestRule.apply {
             onNodeWithText("WireGuard MTU").assertExists()
             onNodeWithText("Default").assertExists()
-            onNodeWithText("Split tunneling").assertExists()
             onNodeWithText("Use custom DNS server").assertExists()
             onNodeWithText("Add a server").assertDoesNotExist()
         }
@@ -211,26 +210,6 @@ class VpnSettingsScreenTest {
 
         // Assert
         composeTestRule.onNodeWithText("Cancel").performClick()
-
-        // Assert
-        verify { mockedClickHandler.invoke() }
-    }
-
-    @Test
-    @OptIn(ExperimentalMaterialApi::class)
-    fun testClickSplitTunneling() {
-        // Arrange
-        val mockedClickHandler: () -> Unit = mockk(relaxed = true)
-        composeTestRule.setContent {
-            VpnSettingsScreen(
-                uiState = VpnSettingsUiState.DefaultUiState(),
-                onSplitTunnelingNavigationClick = mockedClickHandler,
-                toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow()
-            )
-        }
-
-        // Act
-        composeTestRule.onNodeWithText("Split tunneling").performClick()
 
         // Assert
         verify { mockedClickHandler.invoke() }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
@@ -50,7 +50,6 @@ import net.mullvad.mullvadvpn.compose.cell.DnsCell
 import net.mullvad.mullvadvpn.compose.cell.ExpandableComposeCell
 import net.mullvad.mullvadvpn.compose.cell.InformationComposeCell
 import net.mullvad.mullvadvpn.compose.cell.MtuComposeCell
-import net.mullvad.mullvadvpn.compose.cell.NavigationComposeCell
 import net.mullvad.mullvadvpn.compose.cell.SwitchCellTitle
 import net.mullvad.mullvadvpn.compose.cell.SwitchComposeCell
 import net.mullvad.mullvadvpn.compose.component.CollapsableAwareToolbarScaffold
@@ -90,7 +89,6 @@ private fun PreviewVpnSettings() {
         onSaveMtuClick = {},
         onRestoreMtuClick = {},
         onCancelMtuDialogClicked = {},
-        onSplitTunnelingNavigationClick = {},
         onToggleAutoConnect = {},
         onToggleLocalNetworkSharing = {},
         onToggleDnsClick = {},
@@ -128,7 +126,6 @@ fun VpnSettingsScreen(
     onSaveMtuClick: () -> Unit = {},
     onRestoreMtuClick: () -> Unit = {},
     onCancelMtuDialogClicked: () -> Unit = {},
-    onSplitTunnelingNavigationClick: () -> Unit = {},
     onToggleAutoConnect: (Boolean) -> Unit = {},
     onToggleLocalNetworkSharing: (Boolean) -> Unit = {},
     onToggleDnsClick: (Boolean) -> Unit = {},
@@ -272,13 +269,6 @@ fun VpnSettingsScreen(
             item {
                 Spacer(modifier = Modifier.height(cellVerticalSpacing))
                 MtuComposeCell(mtuValue = uiState.mtu, onEditMtu = { onMtuCellClick() })
-            }
-
-            itemWithDivider {
-                NavigationComposeCell(
-                    title = stringResource(id = R.string.split_tunneling),
-                    onClick = { onSplitTunnelingNavigationClick.invoke() }
-                )
             }
 
             itemWithDivider {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/SettingsFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/SettingsFragment.kt
@@ -48,6 +48,7 @@ class SettingsFragment : BaseFragment(), StatusBarPainter, NavigationBarPainter 
     private lateinit var accountMenu: AccountCell
     private lateinit var appVersionMenu: AppVersionCell
     private lateinit var vpnSettingsMenu: View
+    private lateinit var splitTunnelingMenu: View
     private lateinit var titleController: CollapsibleTitleController
 
     @Deprecated("Refactor code to instead rely on Lifecycle.") private val jobTracker = JobTracker()
@@ -74,6 +75,11 @@ class SettingsFragment : BaseFragment(), StatusBarPainter, NavigationBarPainter 
         vpnSettingsMenu =
             view.findViewById<NavigateCell>(R.id.vpn_settings).apply {
                 targetFragment = VpnSettingsFragment::class
+            }
+
+        splitTunnelingMenu =
+            view.findViewById<NavigateCell>(R.id.split_tunneling).apply {
+                targetFragment = SplitTunnelingFragment::class
             }
 
         view.findViewById<NavigateCell>(R.id.report_a_problem).apply {
@@ -180,6 +186,7 @@ class SettingsFragment : BaseFragment(), StatusBarPainter, NavigationBarPainter 
 
         accountMenu.visibility = visibility
         vpnSettingsMenu.visibility = visibility
+        splitTunnelingMenu.visibility = visibility
     }
 
     private fun updateVersionInfo(versionInfo: VersionInfo) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/VpnSettingsFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/VpnSettingsFragment.kt
@@ -33,7 +33,6 @@ class VpnSettingsFragment : BaseFragment() {
                         onSaveMtuClick = vm::onSaveMtuClick,
                         onRestoreMtuClick = vm::onRestoreMtuClick,
                         onCancelMtuDialogClicked = vm::onCancelDialogClick,
-                        onSplitTunnelingNavigationClick = ::openSplitTunnelingFragment,
                         onToggleAutoConnect = vm::onToggleAutoConnect,
                         onToggleLocalNetworkSharing = vm::onToggleLocalNetworkSharing,
                         onToggleDnsClick = vm::onToggleDnsClick,

--- a/android/app/src/main/res/layout/settings.xml
+++ b/android/app/src/main/res/layout/settings.xml
@@ -53,6 +53,11 @@
                                                                android:layout_height="wrap_content"
                                                                android:layout_marginTop="1dp"
                                                                mullvad:text="@string/settings_vpn" />
+                <net.mullvad.mullvadvpn.ui.widget.NavigateCell android:id="@+id/split_tunneling"
+                                                               android:layout_width="match_parent"
+                                                               android:layout_height="wrap_content"
+                                                               android:layout_marginTop="@dimen/vertical_space"
+                                                               mullvad:text="@string/split_tunneling" />
                 <net.mullvad.mullvadvpn.ui.widget.AppVersionCell android:id="@+id/app_version"
                                                                  android:layout_width="match_parent"
                                                                  android:layout_height="wrap_content"


### PR DESCRIPTION
Change the split tunneling menu entry to the settings fragment

Fixes: DROID-137

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4702)
<!-- Reviewable:end -->
