### PR TITLE
 Refresh account/device data when user opens account settings IOS-172

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -642,8 +642,10 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
                 preferredContentSize: preferredFormSheetContentSize,
                 modalPresentationStyle: .formSheet
             )
-        ) {
+        ) { [weak self] in
             completion(coordinator)
+
+            self?.onShowAccount?()
         }
     }
 
@@ -772,10 +774,23 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
 
     // MARK: - Settings
 
+    /**
+     This closure is called each time when settings are presented or when navigating from any of sub-routes within
+     settings back to root.
+     */
     var onShowSettings: (() -> Void)?
 
+    /// This closure is called each time when account controller is being presented.
+    var onShowAccount: (() -> Void)?
+
+    /// Returns `true` if settings are being presented.
     var isPresentingSettings: Bool {
         return router.isPresenting(.settings)
+    }
+
+    /// Returns `true` if account controller is being presented.
+    var isPresentingAccount: Bool {
+        return router.isPresenting(.account)
     }
 
     // MARK: - UISplitViewControllerDelegate

--- a/ios/MullvadVPN/Coordinators/App/SettingsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/SettingsCoordinator.swift
@@ -117,7 +117,12 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
         willShow viewController: UIViewController,
         animated: Bool
     ) {
-        guard let route = route(for: viewController) else { return }
+        /*
+         Navigation controller tends to call this delegate method on `viewWillAppear`, for instance during cancellation
+         of interactive dismissal of a modally presented settings navigation controller, so it's important that we
+         ignore repeating routes.
+         */
+        guard let route = route(for: viewController), currentRoute != route else { return }
 
         logger.debug(
             "Navigate from \(currentRoute.map { "\($0)" } ?? "none") -> \(route)"

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -69,7 +69,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, SettingsMigrationUIHand
         )
 
         appCoordinator?.onShowSettings = { [weak self] in
-            // Refresh account data each time user opens settings
+            // Refresh account data and device each time user opens settings
+            self?.refreshDeviceAndAccountData(forceUpdate: true)
+        }
+
+        appCoordinator?.onShowAccount = { [weak self] in
+            // Refresh account data and device each time user opens account controller
             self?.refreshDeviceAndAccountData(forceUpdate: true)
         }
 
@@ -102,13 +107,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, SettingsMigrationUIHand
 
     private func refreshDeviceAndAccountData(forceUpdate: Bool) {
         let isPresentingSettings = appCoordinator?.isPresentingSettings ?? false
+        let isPresentingAccount = appCoordinator?.isPresentingAccount ?? false
 
         let condition: AccountDataThrottling.Condition
 
         if forceUpdate {
             condition = .always
         } else {
-            condition = isPresentingSettings ? .always : .whenCloseToExpiryAndBeyond
+            condition = isPresentingSettings || isPresentingAccount ? .always : .whenCloseToExpiryAndBeyond
         }
 
         accountDataThrottling?.requestUpdate(condition: condition)


### PR DESCRIPTION
- Add hook to app coordinator to be able to refresh account/device data when user opens account controller.

- Besides that it seems that cancellation of interactive dismissal of modally presented settings triggers navigation controller delegate that causes our code to report transition from root → root sub-route within settings which in turn causes account/device data refresh. This should be fixed to prevent unnecessary refresh.