### PR TITLE
Fix stable Android version code

### DIFF
--- a/mullvad-version/src/main.rs
+++ b/mullvad-version/src/main.rs
@@ -6,6 +6,8 @@ const ANDROID_VERSION: &str =
 
 const VERSION_REGEX: &str = r"^20([0-9]{2})\.([1-9][0-9]?)(-beta([1-9][0-9]?))?(-dev-[0-9a-f]+)?$";
 
+const ANDROID_STABLE_VERSION_CODE_SUFFIX: &str = "99";
+
 fn main() {
     let command = env::args().nth(1);
     match command.as_deref() {
@@ -41,19 +43,24 @@ fn to_semver(version: &str) -> String {
 /// Last two digits of the year (major)  ^^
 ///          Incrementing version (minor)  ^^
 ///                                  Unused  ^^
-///                 Beta number, 00 if stable  ^^
+///                 Beta number, 99 if stable  ^^
 ///
-/// # Example
+/// # Examples
 ///
 /// Version: 2021.34-beta5
 /// versionCode: 21340005
+///
+/// Version: 2021.34
+/// versionCode: 21340099
 fn to_android_version_code(version: &str) -> String {
     let version = parse_version(version);
     format!(
         "{}{:0>2}00{:0>2}",
         version.year,
         version.incremental,
-        version.beta.unwrap_or_default()
+        version
+            .beta
+            .unwrap_or(ANDROID_STABLE_VERSION_CODE_SUFFIX.to_string())
     )
 }
 


### PR DESCRIPTION
This PR aims to fix the automatically generated version code which is used to build the Android app.

The current behavior sets the last two digits of the version code to `00` for stable builds, which results in the stable code being lower than the beta code and therefore preventing upgrades beta->stable:
```
Version: 2021.34-beta5
versionCode: 21340005

Version: 2021.34
versionCode: 21340000
```

This fix sets the last two digits to `99` for stable builds which is the same used prior to using `mullvad-version` to generate the version code:
```
Version: 2021.34-beta5
versionCode: 21340005

Version: 2021.34
versionCode: 21340099
```

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4706)
<!-- Reviewable:end -->
