### PR TITLE
Add alert if user disconnects when there's no connectivity

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/TunnelCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/TunnelCoordinator.swift
@@ -11,6 +11,7 @@ import UIKit
 class TunnelCoordinator: Coordinator {
     private let tunnelManager: TunnelManager
     private let controller: TunnelViewController
+    private let alertPresenter = AlertPresenter()
 
     private var tunnelObserver: TunnelObserver?
 
@@ -31,6 +32,10 @@ class TunnelCoordinator: Coordinator {
         controller.shouldShowSelectLocationPicker = { [weak self] in
             self?.showSelectLocationPicker?()
         }
+
+        controller.shouldShowCancelTunnelAlert = { [weak self] in
+            self?.showCancelTunnelAlert()
+        }
     }
 
     func start() {
@@ -50,5 +55,46 @@ class TunnelCoordinator: Coordinator {
         let deviceState = tunnelManager.deviceState
 
         controller.setMainContentHidden(!deviceState.isLoggedIn, animated: animated)
+    }
+
+    private func showCancelTunnelAlert() {
+        let alertController = UIAlertController(
+            title: nil,
+            message: NSLocalizedString(
+                "CANCEL_TUNNEL_ALERT_MESSAGE",
+                tableName: "Main",
+                value: "If you disconnect now, you won’t be able to secure your connection until the device is online.",
+                comment: ""
+            ),
+            preferredStyle: .alert
+        )
+
+        alertController.addAction(
+            UIAlertAction(
+                title: NSLocalizedString(
+                    "CANCEL_TUNNEL_ALERT_DISCONNECT_ACTION",
+                    tableName: "Main",
+                    value: "Disconnect",
+                    comment: ""
+                ),
+                style: .destructive,
+                handler: { [weak self] _ in
+                    self?.tunnelManager.stopTunnel()
+                }
+            )
+        )
+
+        alertController.addAction(
+            UIAlertAction(
+                title: NSLocalizedString(
+                    "CANCEL_TUNNEL_ALERT_CANCEL_ACTION",
+                    tableName: "Main",
+                    value: "Cancel",
+                    comment: ""
+                ), style: .cancel
+            )
+        )
+
+        alertPresenter.enqueue(alertController, presentingController: rootViewController)
     }
 }

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
@@ -187,7 +187,7 @@ final class TunnelControlView: UIView {
             NSLocalizedString(
                 "CANCEL_BUTTON_TITLE",
                 tableName: "Main",
-                value: "Cancel",
+                value: tunnelState == .waitingForConnectivity(.noConnection) ? "Disconnect" : "Cancel",
                 comment: ""
             ), for: .normal
         )
@@ -313,7 +313,7 @@ final class TunnelControlView: UIView {
         )
         cancelButton.addTarget(
             self,
-            action: #selector(handleDisconnect),
+            action: #selector(handleCancel),
             for: .touchUpInside
         )
         splitDisconnectButton.primaryButton.addTarget(
@@ -415,6 +415,10 @@ final class TunnelControlView: UIView {
 
     @objc private func handleConnect() {
         actionHandler?(.connect)
+    }
+
+    @objc private func handleCancel() {
+        actionHandler?(.cancel)
     }
 
     @objc private func handleDisconnect() {

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -19,6 +19,7 @@ class TunnelViewController: UIViewController, RootContainment {
     private var tunnelState: TunnelState = .disconnected
 
     var shouldShowSelectLocationPicker: (() -> Void)?
+    var shouldShowCancelTunnelAlert: (() -> Void)?
 
     private let mapViewController = MapViewController()
 
@@ -68,7 +69,14 @@ class TunnelViewController: UIViewController, RootContainment {
             case .connect:
                 self?.interactor.startTunnel()
 
-            case .disconnect, .cancel:
+            case .cancel:
+                if case .waitingForConnectivity(.noConnection) = self?.interactor.tunnelStatus.state {
+                    self?.shouldShowCancelTunnelAlert?()
+                } else {
+                    self?.interactor.stopTunnel()
+                }
+
+            case .disconnect:
                 self?.interactor.stopTunnel()
 
             case .reconnect:


### PR DESCRIPTION
If the app has no network access and the user disconnects the tunnel, the "Secure my connection" and "Switch location" buttons will be disabled until network access is restored. This puts the user in a vulnerable state and leaking traffic. To make sure the user understands this and does not accidentally disconnect, a new alert will be shown before disconnecting the tunnel.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4709)
<!-- Reviewable:end -->
