### PR TITLE
Use C drive for build artifacts in CI

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -165,4 +165,9 @@ jobs:
 
       - name: Build and test crates
         shell: bash
+        env:
+          # On Windows, the checkout is on the D drive, which is very small.
+          # Moving the target directory to the C drive ensures that the runner
+          # doesn't run out of space on the D drive.
+          CARGO_TARGET_DIR: "C:/cargo-target"
         run: ./ci/check-rust.sh


### PR DESCRIPTION
To relive ourselves of situations like [these](https://github.com/mullvad/mullvadvpn-app/actions/runs/5007859154/jobs/8975025001#step:11:1263), I've set the `CARGO_TARGET_DIR` to `C:\cargo-target`. Otherwise, our Windows runner runs out of space on the `D:\` drive and it fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4713)
<!-- Reviewable:end -->
