### PR TITLE
Add option to disable in-app version notifications

### DIFF
--- a/android/BuildInstructions.md
+++ b/android/BuildInstructions.md
@@ -236,3 +236,10 @@ To avoid or override the rust based version generation, the `OVERRIDE_VERSION_CO
 OVERRIDE_VERSION_CODE=123
 OVERRIDE_VERSION_NAME=1.2.3
 ```
+
+### Disable version in-app notifications
+To disable in-app notifications related to the app version during development or testing,
+the `ENABLE_IN_APP_VERSION_NOTIFICATIONS` property can be set in `local.properties`:
+```
+ENABLE_IN_APP_VERSION_NOTIFICATIONS=false
+```

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -37,13 +37,6 @@ android {
         versionName = generateVersionName(localProperties)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        val alwaysShowChangelog = localProperties.getProperty("ALWAYS_SHOW_CHANGELOG") ?: "false"
-        buildConfigField(
-            type = "boolean",
-            name = "ALWAYS_SHOW_CHANGELOG",
-            value = alwaysShowChangelog
-        )
-
         lint {
             lintConfig = file("${rootProject.projectDir}/config/lint.xml")
             baseline = file("lint-baseline.xml")
@@ -156,6 +149,17 @@ android {
                 "META-INF/LICENSE-notice.md"
             )
         }
+    }
+
+    applicationVariants.configureEach {
+        val alwaysShowChangelog = gradleLocalProperties(rootProject.projectDir)
+            .getProperty("ALWAYS_SHOW_CHANGELOG") ?: "false"
+
+        buildConfigField(
+            "boolean",
+            "ALWAYS_SHOW_CHANGELOG",
+            alwaysShowChangelog
+        )
     }
 
     project.tasks.preBuild.dependsOn("ensureJniDirectoryExist")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -160,6 +160,15 @@ android {
             "ALWAYS_SHOW_CHANGELOG",
             alwaysShowChangelog
         )
+
+        val enableInAppVersionNotifications = gradleLocalProperties(rootProject.projectDir)
+            .getProperty("ENABLE_IN_APP_VERSION_NOTIFICATIONS") ?: "true"
+
+        buildConfigField(
+            "boolean",
+            "ENABLE_IN_APP_VERSION_NOTIFICATIONS",
+            enableInAppVersionNotifications
+        )
     }
 
     project.tasks.preBuild.dependsOn("ensureJniDirectoryExist")

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -66,7 +66,7 @@ val uiModule = module {
 
     single { AccountExpiryNotification(get()) }
     single { TunnelStateNotification(get()) }
-    single { VersionInfoNotification(get()) }
+    single { VersionInfoNotification(BuildConfig.ENABLE_IN_APP_VERSION_NOTIFICATIONS, get()) }
 
     single { AccountRepository(get()) }
     single { DeviceRepository(get()) }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
@@ -4,13 +4,18 @@ import android.content.Context
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.ui.VersionInfo
 
-class VersionInfoNotification(context: Context) :
-    NotificationWithUrl(context, R.string.download_url) {
+class VersionInfoNotification(
+    val isEnabled: Boolean,
+    context: Context
+) : NotificationWithUrl(context, R.string.download_url) {
     private val unsupportedVersion = context.getString(R.string.unsupported_version)
     private val updateAvailable = context.getString(R.string.update_available)
 
     fun updateVersionInfo(versionInfo: VersionInfo) {
-        if (versionInfo.isOutdated || !versionInfo.isSupported) {
+        val shouldShowNotification =
+            isEnabled && (versionInfo.isOutdated || !versionInfo.isSupported)
+
+        if (shouldShowNotification) {
             if (versionInfo.upgradeVersion != null) {
                 message =
                     if (versionInfo.isSupported) {


### PR DESCRIPTION
This PR aims to add a simple way to disable in-app version notifications during development or testing.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
