### PR TITLE
Fix Cargo file to rebuild shadowsocks.h on each build, and rebuild to…

### DIFF
--- a/ios/MullvadREST/shadowsocks-proxy/Cargo.toml
+++ b/ios/MullvadREST/shadowsocks-proxy/Cargo.toml
@@ -21,5 +21,5 @@ log = "0.4"
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 oslog = "0.2"
 
-[target.'cfg(target_os = "ios")'.build-dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.build-dependencies]
 cbindgen = "0.24"

--- a/ios/MullvadREST/shadowsocks-proxy/build.rs
+++ b/ios/MullvadREST/shadowsocks-proxy/build.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "ios")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn main() {
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
@@ -10,5 +10,5 @@ fn main() {
         .write_to_file("include/shadowsocks.h");
 }
 
-#[cfg(not(target_os = "ios"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn main() {}

--- a/ios/MullvadREST/shadowsocks-proxy/include/shadowsocks.h
+++ b/ios/MullvadREST/shadowsocks-proxy/include/shadowsocks.h
@@ -8,6 +8,14 @@ typedef struct ProxyHandle {
   uint16_t port;
 } ProxyHandle;
 
+/**
+ * # Safety
+ * `addr`, `password`, `cipher` must be valid for the lifetime of this function call and they must
+ * be backed by the amount of bytes as stored in the respective `*_len` parameters.
+ *
+ * `proxy_config` must be pointing to a valid memory region for the size of a `ProxyHandle`
+ * instance.
+ */
 int32_t start_shadowsocks_proxy(const uint8_t *addr,
                                 uintptr_t addr_len,
                                 uint16_t port,
@@ -17,4 +25,9 @@ int32_t start_shadowsocks_proxy(const uint8_t *addr,
                                 uintptr_t cipher_len,
                                 struct ProxyHandle *proxy_config);
 
+/**
+ * # Safety
+ * `proxy_config` must be pointing to a valid instance of a `ProxyInstance`, as instantiated by
+ * `start_shadowsocks_proxy`.
+ */
 int32_t stop_shadowsocks_proxy(struct ProxyHandle *proxy_config);


### PR DESCRIPTION
This PR ensures that `shadowsocks.h` will be properly regenerated when the rust interface changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4719)
<!-- Reviewable:end -->
