### PR TITLE
Disable API bridges while connected

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -926,10 +926,16 @@ where
         &mut self,
         tunnel_state_transition: &TunnelStateTransition,
     ) {
+        let svc = self.api_handle.service();
         match (&self.tunnel_state, &tunnel_state_transition) {
-            // Only reset the API sockets when entering or leaving the connected state
-            (&TunnelState::Connected { .. }, _) | (_, &TunnelStateTransition::Connected(_)) => {
-                self.api_handle.service().reset();
+            // Close API sockets when entering or leaving the connected state
+            (&TunnelState::Connected { .. }, _) => {
+                svc.force_direct_mode(false);
+                svc.reset();
+            }
+            (_, &TunnelStateTransition::Connected(_)) => {
+                svc.force_direct_mode(true);
+                svc.reset();
             }
             _ => (),
         };

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -161,7 +161,8 @@ impl TryFrom<proto::Settings> for mullvad_types::settings::Settings {
             )?,
             // NOTE: This field is meaningless when obtained from gRPC
             wg_migration_rand_num: std::f32::NAN,
-            // NOTE: This field is set based on mullvad-types. It's not based on the actual settings version.
+            // NOTE: This field is set based on mullvad-types. It's not based on the actual settings
+            // version.
             settings_version: CURRENT_SETTINGS_VERSION,
         })
     }


### PR DESCRIPTION
This prevents the API from being reached from bridges in the connected state. There's no real harm in that, but it's a pointless detour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4724)
<!-- Reviewable:end -->
