### PR TITLE
Add tunnel interface to output of `mullvad status -v`

### DIFF
--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -14,6 +14,11 @@ pub fn print_state(state: &TunnelState, verbose: bool) {
                 "Connected to {}",
                 format_relay_connection(endpoint, location.as_ref(), verbose)
             );
+            if verbose {
+                if let Some(tunnel_interface) = &endpoint.tunnel_interface {
+                    println!("Tunnel interface: {tunnel_interface}")
+                }
+            }
         }
         Connecting { endpoint, location } => {
             let ellipsis = if !verbose { "..." } else { "" };

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -194,6 +194,7 @@ message TunnelEndpoint {
   ProxyEndpoint proxy = 5;
   ObfuscationEndpoint obfuscation = 6;
   Endpoint entry_endpoint = 7;
+  TunnelMetadata tunnel_metadata = 8;
 }
 
 enum ObfuscationType {
@@ -236,6 +237,8 @@ message GeoIpLocation {
   string entry_hostname = 10;
   string obfuscator_hostname = 11;
 }
+
+message TunnelMetadata { string tunnel_interface = 1; }
 
 enum Ownership {
   ANY = 0;

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -38,6 +38,9 @@ impl From<talpid_types::net::TunnelEndpoint> for proto::TunnelEndpoint {
                 address: entry.address.to_string(),
                 protocol: i32::from(proto::TransportProtocol::from(entry.protocol)),
             }),
+            tunnel_metadata: endpoint
+                .tunnel_interface
+                .map(|tunnel_interface| proto::TunnelMetadata { tunnel_interface }),
         }
     }
 }
@@ -118,6 +121,9 @@ impl TryFrom<proto::TunnelEndpoint> for talpid_types::net::TunnelEndpoint {
                     })
                 })
                 .transpose()?,
+            tunnel_interface: endpoint
+                .tunnel_metadata
+                .map(|tunnel_metadata| tunnel_metadata.tunnel_interface),
         })
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -323,7 +323,11 @@ impl TunnelState for ConnectedState {
         bootstrap: Self::Bootstrap,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
         let connected_state = ConnectedState::from(bootstrap);
-        let tunnel_endpoint = connected_state.tunnel_parameters.get_tunnel_endpoint();
+        let tunnel_interface = Some(connected_state.metadata.interface.clone());
+        let tunnel_endpoint = talpid_types::net::TunnelEndpoint {
+            tunnel_interface,
+            ..connected_state.tunnel_parameters.get_tunnel_endpoint()
+        };
 
         if let Err(error) = connected_state.set_firewall_policy(shared_values) {
             DisconnectingState::enter(

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -34,6 +34,7 @@ impl TunnelParameters {
                 proxy: params.proxy.as_ref().map(|proxy| proxy.get_endpoint()),
                 obfuscation: None,
                 entry_endpoint: None,
+                tunnel_interface: None,
             },
             TunnelParameters::Wireguard(params) => TunnelEndpoint {
                 tunnel_type: TunnelType::Wireguard,
@@ -48,6 +49,7 @@ impl TunnelParameters {
                     .connection
                     .get_exit_endpoint()
                     .map(|_| params.connection.get_endpoint()),
+                tunnel_interface: None,
             },
         }
     }
@@ -145,7 +147,7 @@ pub struct TunnelTypeParseError;
 
 /// A tunnel endpoint is broadcast during the connecting and connected states of the tunnel state
 /// machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.talpid.net"))]
 pub struct TunnelEndpoint {
@@ -159,6 +161,8 @@ pub struct TunnelEndpoint {
     pub obfuscation: Option<ObfuscationEndpoint>,
     #[cfg_attr(target_os = "android", jnix(skip))]
     pub entry_endpoint: Option<Endpoint>,
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub tunnel_interface: Option<String>,
 }
 
 impl fmt::Display for TunnelEndpoint {


### PR DESCRIPTION
With this change, `mullvad status -v` will print the name of the tunnel interface when the app is in a connected state. This PR aims to implement the feature requested in #4676.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4726)
<!-- Reviewable:end -->
