### PR TITLE
Enable universal builds on M1/M2 Macs

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -30,6 +30,12 @@ case "$ENV_TARGET" in
     ;;
   x86_64-*-darwin*)
     export MACOSX_DEPLOYMENT_TARGET="10.7"
+
+    if [[ $HOST != "$ENV_TARGET" ]]; then
+        # Required for building daemon
+        SDKROOT=$(xcrun --show-sdk-path)
+        export SDKROOT
+    fi
     ;;
   aarch64-*-darwin*)
     export MACOSX_DEPLOYMENT_TARGET="11.0"

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -55,7 +55,7 @@
         "chai-spies": "^1.0.0",
         "cross-env": "^7.0.3",
         "electron": "^23.2.0",
-        "electron-builder": "^23.3.3",
+        "electron-builder": "^23.6.0",
         "electron-devtools-installer": "^3.2.0",
         "electron-mocha": "^11.0.2",
         "electron-notarize": "^1.2.1",

--- a/gui/package.json
+++ b/gui/package.json
@@ -61,7 +61,7 @@
     "chai-spies": "^1.0.0",
     "cross-env": "^7.0.3",
     "electron": "^23.2.0",
-    "electron-builder": "^23.3.3",
+    "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "electron-mocha": "^11.0.2",
     "electron-notarize": "^1.2.1",

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -57,6 +57,7 @@ const config = {
     'node_modules/',
     '!node_modules/grpc-tools',
     '!node_modules/@types',
+    '!node_modules/nseventmonitor/build/Release',
   ],
 
   // Make sure that all files declared in "extraResources" exists and abort if they don't.
@@ -283,6 +284,16 @@ function packMac() {
         }
 
         return true;
+      },
+      beforePack: async (context) => {
+        try {
+          // `@electron/universal` tries to lipo together libraries built for the same architecture
+          // if they're present for both targets. So make sure we remove libraries for other archs.
+          // Remove the workaround once the issue has been fixed:
+          // https://github.com/electron/universal/issues/41#issuecomment-1496288834
+          await fs.promises.rm('node_modules/nseventmonitor/lib/binding/Release', { recursive: true });
+        } catch {}
+        config.beforePack?.(context);
       },
       afterPack: (context) => {
         config.afterPack?.(context);

--- a/wireguard/build-wireguard-go.sh
+++ b/wireguard/build-wireguard-go.sh
@@ -97,16 +97,23 @@ function build_unix {
             export CC=aarch64-linux-gnu-gcc
         fi
 
-        # Apple silicon
-        if [[ "$1" == "aarch64-apple-darwin" ]]; then
+        # Environment flags for cross compiling on macOS
+        if [[ "$1" == *-apple-darwin ]]; then
             export CGO_ENABLED=1
             export GOOS=darwin
-            export GOARCH=arm64
-            export CC="$(xcrun -sdk $SDKROOT --find clang) -arch $GOARCH -isysroot $SDKROOT"
-            export CFLAGS="-isysroot $SDKROOT -arch $GOARCH -I$SDKROOT/usr/include"
+
+            local arch=x86_64
+            export GOARCH=amd64
+            if [[ "$1" == aarch64-* ]]; then
+                arch=arm64
+                export GOARCH=arm64
+            fi
+
+            export CC="$(xcrun -sdk $SDKROOT --find clang) -arch $arch -isysroot $SDKROOT"
+            export CFLAGS="-isysroot $SDKROOT -arch $arch -I$SDKROOT/usr/include"
             export LD_LIBRARY_PATH="$SDKROOT/usr/lib"
-            export CGO_CFLAGS="-isysroot $SDKROOT -arch $GOARCH"
-            export CGO_LDFLAGS="-isysroot $SDKROOT -arch $GOARCH"
+            export CGO_CFLAGS="-isysroot $SDKROOT -arch $arch"
+            export CGO_LDFLAGS="-isysroot $SDKROOT -arch $arch"
         fi
     fi
 


### PR DESCRIPTION
Previously, this was only possible on Intel Macs.

Fixes DES-136.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4732)
<!-- Reviewable:end -->
