### PR TITLE
Allow dev builds to override location checking endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ See [this](Release.md) for instructions on how to make a new release.
 
 * `MULLVAD_API_DISABLE_TLS` - Use plain HTTP for API requests.
 
+* `MULLVAD_LOCATION_HOST` - Set the hostname to use in location requests. E.g. `am.i.mullvad.net`.
+
 ### Setting environment variables
 
 #### Windows

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -7,6 +7,11 @@ license = "GPL-3.0"
 edition = "2021"
 publish = false
 
+[features]
+# Allow the location server to use to be configured via the
+# MULLVAD_LOCATION_HOST environment variable.
+api-override = []
+
 [dependencies]
 cfg-if = "1.0"
 chrono = { version = "0.4.19", features = ["serde"] }


### PR DESCRIPTION
The new environment variable `MULLVAD_LOCATION_HOST` may be used to supply a different hostname for the location checking endpoint than the standard `am.i.mullvad.net`. This applies if `mullvad-daemon` was built with the `api-override` feature flag.

It is equivalent to replacing:
`curl https://ipv4.am.i.mullvad.net/json`

with:
`curl https://ipv4.{$MULLVAD_LOCATION_HOST}/json`

This change applies to both IPv4 and IPv6 endpoints.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
