### PR TITLE
Exclude `android/` and `ios/` tags from desktop builds

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -214,9 +214,10 @@ while true; do
 
     git fetch --prune --tags 2> /dev/null || continue
 
+    # Exclude android/ and ios/ tags from being built.
     # Tags can't include spaces so SC2207 isn't a problem here
     # shellcheck disable=SC2207
-    tags=( $(git tag) )
+    tags=( $(git tag | grep -v -e "^android/.*\|^ios/.*") )
 
     for tag in "${tags[@]}"; do
         build_ref "refs/tags/$tag" "$tag" || echo "Failed to build tag $tag"


### PR DESCRIPTION
The commit message says it all :shrug:

Fixes DES-194 :package:

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4735)
<!-- Reviewable:end -->
