### PR TITLE
Only build the Rust artifacts we need on desktop

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -214,7 +214,17 @@ function build {
     if [[ -n $current_target ]]; then
         cargo_target_arg+=(--target="$current_target")
     fi
-    cargo build "${cargo_target_arg[@]}" "${CARGO_ARGS[@]}"
+    local cargo_crates_to_build=(
+        -p mullvad-daemon --bin mullvad-daemon
+        -p mullvad-cli --bin mullvad
+        -p mullvad-setup --bin mullvad-setup
+        -p mullvad-problem-report --bin mullvad-problem-report
+        -p talpid-openvpn-plugin --lib
+    )
+    if [[ ("$(uname -s)" == "Linux") ]]; then
+        cargo_crates_to_build+=(-p mullvad-exclude --bin mullvad-exclude)
+    fi
+    cargo build "${cargo_target_arg[@]}" "${CARGO_ARGS[@]}" "${cargo_crates_to_build[@]}"
 
     ################################################################################
     # Move binaries to correct locations in dist-assets

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -7,6 +7,10 @@ license = "GPL-3.0"
 edition = "2021"
 publish = false
 
+[features]
+# Allow the API server to use to be configured
+api-override = ["mullvad-api/api-override"]
+
 [dependencies]
 cfg-if = "1.0"
 chrono = { version = "0.4.19", features = ["serde"] }


### PR DESCRIPTION
I have realized that our `build.sh` for building the desktop app builds more Rust code than needed. It builds the entire workspace. Historically this has not really mattered much at all since basically all Rust crates/code was used on desktop anyway. But that is becoming less and less true. For example the Android `translations-converter` is one binary we don't need. And recently added is the `ios/MullvadREST/shadowsocks-proxy` which we don't need on desktop. The dependencies overlap a lot, so the actual **compile** part is not shortened a lot by not building them. But each binary that we need to **link** cost significant amount of time.

By specifying just what we need to build here, we save a bunch of time. On my laptop, when building in debug mode, the `cargo build ...` part goes down from ~1m50s to ~1m10s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4738)
<!-- Reviewable:end -->
