### PR TITLE
Add derive feature for clap in daemon

### DIFF
--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -41,7 +41,7 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 talpid-time = { path = "../talpid-time" }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-clap = { version = "4.2.7", features = ["cargo"] }
+clap = { version = "4.2.7", features = ["cargo", "derive"] }
 log-panics = "2.0.0"
 mullvad-management-interface = { path = "../mullvad-management-interface" }
 mullvad-paths = { path = "../mullvad-paths" }


### PR DESCRIPTION
`cargo build -p mullvad-daemon` fails without this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4739)
<!-- Reviewable:end -->
