### PR TITLE
Add support for quantum resistant tunneling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 - Prevent incoming connections from outside the VPN in Android 11+ when Local Network Sharing
   is turned off.
 - Add creation date below device name in the device list screen.
+- Add quantum resistant tunneling.
 
 ### Changed
 - In the CLI, update the `tunnel` subcommand to resemble `relay` more. For example, by adding a

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ the current state of the latest code in git, not necessarily any existing releas
 |-------------------------------|:-------:|:-----:|:-----:|:-------:|:---:|
 | OpenVPN                       |    ✓    |   ✓   |   ✓   |         |     |
 | WireGuard                     |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| Quantum-resistant tunnels     |    ✓    |   ✓   |   ✓   |         |     |
+| Quantum-resistant tunnels     |    ✓    |   ✓   |   ✓   |    ✓    |     |
 | WireGuard multihop            |    ✓    |   ✓   |   ✓   |         |     |
 | WireGuard over TCP            |    ✓    |   ✓   |   ✓   |    ✓    |     |
 | OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |

--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/Finders.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/Finders.kt
@@ -1,0 +1,19 @@
+package net.mullvad.mullvadvpn
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.hasAnyChild
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+
+fun SemanticsNodeInteractionsProvider.onNodeWithTagAndChildrenText(
+    testTag: String,
+    text: String,
+    substring: Boolean = false,
+    ignoreCase: Boolean = false,
+    useUnmergedTree: Boolean = false
+): SemanticsNodeInteraction =
+    onNode(
+        hasTestTag(testTag).and(hasAnyChild(hasText(text, substring, ignoreCase))),
+        useUnmergedTree
+    )

--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
@@ -44,6 +44,9 @@ class VpnSettingsScreenTest {
                 toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow()
             )
         }
+        composeTestRule
+            .onNodeWithTag(LAZY_LIST_TEST_TAG)
+            .performScrollToNode(hasTestTag(LAZY_LIST_LAST_ITEM_TEST_TAG))
 
         // Assert
         composeTestRule.apply {
@@ -348,6 +351,9 @@ class VpnSettingsScreenTest {
                 toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow()
             )
         }
+        composeTestRule
+            .onNodeWithTag(LAZY_LIST_TEST_TAG)
+            .performScrollToNode(hasTestTag(LAZY_LIST_LAST_ITEM_TEST_TAG))
 
         // Assert
         composeTestRule.apply {

--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
@@ -19,7 +19,11 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import net.mullvad.mullvadvpn.compose.state.VpnSettingsUiState
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_LAST_ITEM_TEST_TAG
+import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG
+import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_QUANTUM_ITEM_ON_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_TEST_TAG
+import net.mullvad.mullvadvpn.model.QuantumResistantState
+import net.mullvad.mullvadvpn.onNodeWithTagAndChildrenText
 import net.mullvad.mullvadvpn.viewmodel.CustomDnsItem
 import net.mullvad.mullvadvpn.viewmodel.StagedDns
 import org.junit.Before
@@ -561,6 +565,71 @@ class VpnSettingsScreenTest {
 
         // Assert
         composeTestRule.onNodeWithText("Submit").assertIsNotEnabled()
+    }
+
+    @Test
+    @OptIn(ExperimentalMaterialApi::class)
+    fun testShowSelectedTunnelQuantumOption() {
+        // Arrange
+        composeTestRule.setContent {
+            VpnSettingsScreen(
+                uiState =
+                    VpnSettingsUiState.DefaultUiState(quantumResistant = QuantumResistantState.On),
+                toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow()
+            )
+        }
+        composeTestRule
+            .onNodeWithTag(LAZY_LIST_TEST_TAG)
+            .performScrollToNode(hasTestTag(LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG))
+
+        // Assert
+        composeTestRule
+            .onNodeWithTagAndChildrenText(testTag = LAZY_LIST_QUANTUM_ITEM_ON_TEST_TAG, text = "On")
+            .assertExists()
+    }
+
+    @Test
+    @OptIn(ExperimentalMaterialApi::class)
+    fun testSelectTunnelQuantumOption() {
+        // Arrange
+        val mockSelectQuantumResistantSettingListener: (QuantumResistantState) -> Unit =
+            mockk(relaxed = true)
+        composeTestRule.setContent {
+            VpnSettingsScreen(
+                uiState =
+                    VpnSettingsUiState.DefaultUiState(
+                        quantumResistant = QuantumResistantState.Auto,
+                    ),
+                onSelectQuantumResistanceSetting = mockSelectQuantumResistantSettingListener,
+                toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow()
+            )
+        }
+        composeTestRule
+            .onNodeWithTag(LAZY_LIST_TEST_TAG)
+            .performScrollToNode(hasTestTag(LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG))
+
+        // Assert
+        composeTestRule
+            .onNodeWithTagAndChildrenText(testTag = LAZY_LIST_QUANTUM_ITEM_ON_TEST_TAG, text = "On")
+            .performClick()
+        verify(exactly = 1) {
+            mockSelectQuantumResistantSettingListener.invoke(QuantumResistantState.On)
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalMaterialApi::class)
+    fun testShowTunnelQuantumInfo() {
+        // Arrange
+        composeTestRule.setContent {
+            VpnSettingsScreen(
+                uiState = VpnSettingsUiState.QuantumResistanceInfoDialogUiState(),
+                toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow()
+            )
+        }
+
+        // Assert
+        composeTestRule.onNodeWithText("Got it!").assertExists()
     }
 
     companion object {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,9 +63,13 @@ internal fun BaseCell(
     subtitleModifier: Modifier = Modifier,
     background: Color = MaterialTheme.colorScheme.primary,
     startPadding: Dp = Dimens.cellStartPadding,
-    endPadding: Dp = Dimens.cellEndPadding
+    endPadding: Dp = Dimens.cellEndPadding,
+    testTag: String = ""
 ) {
-    Column(modifier = Modifier.fillMaxWidth().wrapContentHeight().background(background)) {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().background(background).testTag(testTag)
+    ) {
         val rowModifier =
             Modifier.let {
                 if (isRowEnabled) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
@@ -27,7 +27,7 @@ import net.mullvad.mullvadvpn.compose.theme.Dimens
 
 @Preview
 @Composable
-fun PreviewBaseCell() {
+private fun PreviewBaseCell() {
     AppTheme {
         SpacedColumn {
             BaseCell(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/MtuComposeCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/MtuComposeCell.kt
@@ -20,7 +20,7 @@ import net.mullvad.mullvadvpn.constant.MTU_MIN_VALUE
 
 @Preview
 @Composable
-fun MtuComposeCellPreview() {
+private fun PreviewMtuComposeCell() {
     AppTheme { MtuComposeCell(mtuValue = "1300", onEditMtu = {}) }
 }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SelectableCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SelectableCell.kt
@@ -49,7 +49,8 @@ fun SelectableCell(
     startPadding: Dp = Dimens.cellStartPadding,
     selectedColor: Color = MaterialTheme.colorScheme.surface,
     backgroundColor: Color = MaterialTheme.colorScheme.secondaryContainer,
-    onCellClicked: () -> Unit = {}
+    onCellClicked: () -> Unit = {},
+    testTag: String = ""
 ) {
     BaseCell(
         onCellClicked = onCellClicked,
@@ -61,6 +62,7 @@ fun SelectableCell(
                 backgroundColor
             },
         startPadding = startPadding,
-        iconView = selectedIcon
+        iconView = selectedIcon,
+        testTag = testTag
     )
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/QuantumResistanceInfoDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/QuantumResistanceInfoDialog.kt
@@ -1,0 +1,14 @@
+package net.mullvad.mullvadvpn.compose.dialog
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import net.mullvad.mullvadvpn.R
+
+@Composable
+fun QuantumResistanceInfoDialog(onDismiss: () -> Unit) {
+    InfoDialog(
+        message = stringResource(id = R.string.quantum_resistant_info_first_paragaph),
+        additionalInfo = stringResource(id = R.string.quantum_resistant_info_second_paragaph),
+        onDismiss = onDismiss
+    )
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
@@ -68,6 +68,8 @@ import net.mullvad.mullvadvpn.compose.dialog.QuantumResistanceInfoDialog
 import net.mullvad.mullvadvpn.compose.extensions.itemWithDivider
 import net.mullvad.mullvadvpn.compose.state.VpnSettingsUiState
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_LAST_ITEM_TEST_TAG
+import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG
+import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_QUANTUM_ITEM_ON_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_TEST_TAG
 import net.mullvad.mullvadvpn.compose.theme.AppTheme
 import net.mullvad.mullvadvpn.compose.theme.Dimens
@@ -407,6 +409,7 @@ fun VpnSettingsScreen(
             itemWithDivider {
                 SelectableCell(
                     title = stringResource(id = R.string.on),
+                    testTag = LAZY_LIST_QUANTUM_ITEM_ON_TEST_TAG,
                     isSelected = uiState.quantumResistant == QuantumResistantState.On,
                     onCellClicked = { onSelectQuantumResistanceSetting(QuantumResistantState.On) }
                 )
@@ -414,6 +417,7 @@ fun VpnSettingsScreen(
             itemWithDivider {
                 SelectableCell(
                     title = stringResource(id = R.string.off),
+                    testTag = LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG,
                     isSelected = uiState.quantumResistant == QuantumResistantState.Off,
                     onCellClicked = { onSelectQuantumResistanceSetting(QuantumResistantState.Off) }
                 )

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
@@ -64,12 +64,14 @@ import net.mullvad.mullvadvpn.compose.dialog.LocalNetworkSharingInfoDialog
 import net.mullvad.mullvadvpn.compose.dialog.MalwareInfoDialog
 import net.mullvad.mullvadvpn.compose.dialog.MtuDialog
 import net.mullvad.mullvadvpn.compose.dialog.ObfuscationInfoDialog
+import net.mullvad.mullvadvpn.compose.dialog.QuantumResistanceInfoDialog
 import net.mullvad.mullvadvpn.compose.extensions.itemWithDivider
 import net.mullvad.mullvadvpn.compose.state.VpnSettingsUiState
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_LAST_ITEM_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_TEST_TAG
 import net.mullvad.mullvadvpn.compose.theme.AppTheme
 import net.mullvad.mullvadvpn.compose.theme.Dimens
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 import net.mullvad.mullvadvpn.model.SelectedObfuscation
 import net.mullvad.mullvadvpn.viewmodel.CustomDnsItem
 
@@ -113,7 +115,9 @@ private fun PreviewVpnSettings() {
             toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow(),
             onStopEvent = {},
             onSelectObfuscationSetting = {},
-            onObfuscationInfoClick = {}
+            onObfuscationInfoClick = {},
+            onSelectQuantumResistanceSetting = {},
+            onQuantumResistanceInfoClicked = {}
         )
     }
 }
@@ -151,7 +155,9 @@ fun VpnSettingsScreen(
     onStopEvent: () -> Unit = {},
     toastMessagesSharedFlow: SharedFlow<String>,
     onSelectObfuscationSetting: (selectedObfuscation: SelectedObfuscation) -> Unit = {},
-    onObfuscationInfoClick: () -> Unit = {}
+    onObfuscationInfoClick: () -> Unit = {},
+    onSelectQuantumResistanceSetting: (quantumResistant: Boolean?) -> Unit = {},
+    onQuantumResistanceInfoClicked: () -> Unit = {}
 ) {
     val cellVerticalSpacing = dimensionResource(id = R.dimen.cell_label_vertical_padding)
     val cellHorizontalSpacing = dimensionResource(id = R.dimen.cell_left_padding)
@@ -190,6 +196,9 @@ fun VpnSettingsScreen(
         }
         is VpnSettingsUiState.ObfuscationInfoDialogUiState -> {
             ObfuscationInfoDialog(onDismissInfoClick)
+        }
+        is VpnSettingsUiState.QuantumResistanceInfoDialogUiState -> {
+            QuantumResistanceInfoDialog(onDismissInfoClick)
         }
         else -> {
             // NOOP
@@ -378,6 +387,35 @@ fun VpnSettingsScreen(
                     title = stringResource(id = R.string.off),
                     isSelected = uiState.selectedObfuscation == SelectedObfuscation.Off,
                     onCellClicked = { onSelectObfuscationSetting(SelectedObfuscation.Off) }
+                )
+            }
+
+            itemWithDivider {
+                Spacer(modifier = Modifier.height(cellVerticalSpacing))
+                InformationComposeCell(
+                    title = stringResource(R.string.quantum_resistant_title),
+                    onInfoClicked = { onQuantumResistanceInfoClicked() }
+                )
+            }
+            itemWithDivider {
+                SelectableCell(
+                    title = stringResource(id = R.string.automatic),
+                    isSelected = uiState.quantumResistant == QuantumResistantState.Auto,
+                    onCellClicked = { onSelectQuantumResistanceSetting(QuantumResistantState.Auto) }
+                )
+            }
+            itemWithDivider {
+                SelectableCell(
+                    title = stringResource(id = R.string.on),
+                    isSelected = uiState.quantumResistant == QuantumResistantState.On,
+                    onCellClicked = { onSelectQuantumResistanceSetting(QuantumResistantState.On) }
+                )
+            }
+            itemWithDivider {
+                SelectableCell(
+                    title = stringResource(id = R.string.off),
+                    isSelected = uiState.quantumResistant == QuantumResistantState.Off,
+                    onCellClicked = { onSelectQuantumResistanceSetting(QuantumResistantState.Off) }
                 )
             }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
@@ -156,7 +156,7 @@ fun VpnSettingsScreen(
     toastMessagesSharedFlow: SharedFlow<String>,
     onSelectObfuscationSetting: (selectedObfuscation: SelectedObfuscation) -> Unit = {},
     onObfuscationInfoClick: () -> Unit = {},
-    onSelectQuantumResistanceSetting: (quantumResistant: Boolean?) -> Unit = {},
+    onSelectQuantumResistanceSetting: (quantumResistant: QuantumResistantState) -> Unit = {},
     onQuantumResistanceInfoClicked: () -> Unit = {}
 ) {
     val cellVerticalSpacing = dimensionResource(id = R.dimen.cell_label_vertical_padding)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/VpnSettingsUiState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/VpnSettingsUiState.kt
@@ -14,6 +14,7 @@ sealed interface VpnSettingsUiState {
     val contentBlockersOptions: DefaultDnsOptions
     val isAllowLanEnabled: Boolean
     val selectedObfuscation: SelectedObfuscation
+    val quantumResistant: Boolean?
 
     data class DefaultUiState(
         override val mtu: String = "",
@@ -23,7 +24,8 @@ sealed interface VpnSettingsUiState {
         override val isAllowLanEnabled: Boolean = false,
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 
     data class MtuDialogUiState(
@@ -35,7 +37,8 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         val mtuEditValue: String,
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 
     data class DnsDialogUiState(
@@ -47,7 +50,8 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         val stagedDns: StagedDns,
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 
     data class LocalNetworkSharingInfoDialogUiState(
@@ -58,7 +62,8 @@ sealed interface VpnSettingsUiState {
         override val isAllowLanEnabled: Boolean = false,
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 
     data class ContentBlockersInfoDialogUiState(
@@ -69,7 +74,8 @@ sealed interface VpnSettingsUiState {
         override val isAllowLanEnabled: Boolean = false,
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 
     data class CustomDnsInfoDialogUiState(
@@ -80,7 +86,8 @@ sealed interface VpnSettingsUiState {
         override val isAllowLanEnabled: Boolean = false,
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 
     data class MalwareInfoDialogUiState(
@@ -91,7 +98,8 @@ sealed interface VpnSettingsUiState {
         override val isAllowLanEnabled: Boolean = false,
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 
     data class ObfuscationInfoDialogUiState(
@@ -102,6 +110,19 @@ sealed interface VpnSettingsUiState {
         override val isAllowLanEnabled: Boolean = false,
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
-        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
+    ) : VpnSettingsUiState
+
+    data class QuantumResistanceInfoDialogUiState(
+        override val mtu: String = "",
+        override val isAutoConnectEnabled: Boolean = false,
+        override val isLocalNetworkSharingEnabled: Boolean = false,
+        override val isCustomDnsEnabled: Boolean = false,
+        override val isAllowLanEnabled: Boolean = false,
+        override val customDnsItems: List<CustomDnsItem> = listOf(),
+        override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
+        override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
+        override val quantumResistant: Boolean? = null
     ) : VpnSettingsUiState
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/VpnSettingsUiState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/VpnSettingsUiState.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.compose.state
 
 import net.mullvad.mullvadvpn.model.DefaultDnsOptions
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 import net.mullvad.mullvadvpn.model.SelectedObfuscation
 import net.mullvad.mullvadvpn.viewmodel.CustomDnsItem
 import net.mullvad.mullvadvpn.viewmodel.StagedDns
@@ -14,7 +15,7 @@ sealed interface VpnSettingsUiState {
     val contentBlockersOptions: DefaultDnsOptions
     val isAllowLanEnabled: Boolean
     val selectedObfuscation: SelectedObfuscation
-    val quantumResistant: Boolean?
+    val quantumResistant: QuantumResistantState
 
     data class DefaultUiState(
         override val mtu: String = "",
@@ -25,7 +26,7 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class MtuDialogUiState(
@@ -38,7 +39,7 @@ sealed interface VpnSettingsUiState {
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         val mtuEditValue: String,
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class DnsDialogUiState(
@@ -51,7 +52,7 @@ sealed interface VpnSettingsUiState {
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         val stagedDns: StagedDns,
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class LocalNetworkSharingInfoDialogUiState(
@@ -63,7 +64,7 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class ContentBlockersInfoDialogUiState(
@@ -75,7 +76,7 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class CustomDnsInfoDialogUiState(
@@ -87,7 +88,7 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class MalwareInfoDialogUiState(
@@ -99,7 +100,7 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class ObfuscationInfoDialogUiState(
@@ -111,7 +112,7 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 
     data class QuantumResistanceInfoDialogUiState(
@@ -123,6 +124,6 @@ sealed interface VpnSettingsUiState {
         override val customDnsItems: List<CustomDnsItem> = listOf(),
         override val contentBlockersOptions: DefaultDnsOptions = DefaultDnsOptions(),
         override val selectedObfuscation: SelectedObfuscation = SelectedObfuscation.Off,
-        override val quantumResistant: Boolean? = null
+        override val quantumResistant: QuantumResistantState = QuantumResistantState.Off
     ) : VpnSettingsUiState
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/test/ComposeTestTagConstants.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/test/ComposeTestTagConstants.kt
@@ -2,3 +2,5 @@ package net.mullvad.mullvadvpn.compose.test
 
 const val LAZY_LIST_TEST_TAG = "lazy_list_test_tag"
 const val LAZY_LIST_LAST_ITEM_TEST_TAG = "lazy_list_last_item_test_tag"
+const val LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG = "lazy_list_quantum_item_off_test_tag"
+const val LAZY_LIST_QUANTUM_ITEM_ON_TEST_TAG = "lazy_list_quantum_item_on_test_tag"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -7,6 +7,7 @@ import kotlinx.parcelize.Parcelize
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.LocationConstraint
 import net.mullvad.mullvadvpn.model.ObfuscationSettings
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 
 // Requests that the service can handle
 sealed class Request : Message.RequestMessage() {
@@ -85,7 +86,9 @@ sealed class Request : Message.RequestMessage() {
 
     @Parcelize data class SetObfuscationSettings(val settings: ObfuscationSettings?) : Request()
 
-    @Parcelize data class SetWireGuardQuantumResistant(val quantumResistant: Boolean?) : Request()
+    @Parcelize
+    data class SetWireGuardQuantumResistant(val quantumResistant: QuantumResistantState) :
+        Request()
 
     companion object {
         private const val MESSAGE_KEY = "request"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ipc/Request.kt
@@ -85,6 +85,8 @@ sealed class Request : Message.RequestMessage() {
 
     @Parcelize data class SetObfuscationSettings(val settings: ObfuscationSettings?) : Request()
 
+    @Parcelize data class SetWireGuardQuantumResistant(val quantumResistant: Boolean?) : Request()
+
     companion object {
         private const val MESSAGE_KEY = "request"
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/QuantumResistantState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/model/QuantumResistantState.kt
@@ -4,5 +4,8 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class WireguardTunnelOptions(val mtu: Int?, val quantumResistant: QuantumResistantState) :
-    Parcelable
+enum class QuantumResistantState : Parcelable {
+    Auto,
+    On,
+    Off
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/SettingsRepository.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/SettingsRepository.kt
@@ -14,6 +14,7 @@ import net.mullvad.mullvadvpn.model.DefaultDnsOptions
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.DnsState
 import net.mullvad.mullvadvpn.model.ObfuscationSettings
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.customDns
@@ -54,7 +55,7 @@ class SettingsRepository(
         serviceConnectionManager.settingsListener()?.wireguardMtu = value
     }
 
-    fun setWireguardQuantumResistant(value: Boolean?) {
+    fun setWireguardQuantumResistant(value: QuantumResistantState) {
         serviceConnectionManager.settingsListener()?.wireguardQuantumResistant = value
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/SettingsRepository.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/SettingsRepository.kt
@@ -54,6 +54,10 @@ class SettingsRepository(
         serviceConnectionManager.settingsListener()?.wireguardMtu = value
     }
 
+    fun setWireguardQuantumResistant(value: Boolean?) {
+        serviceConnectionManager.settingsListener()?.wireguardQuantumResistant = value
+    }
+
     fun setObfuscationOptions(value: ObfuscationSettings) {
         serviceConnectionManager.settingsListener()?.obfuscationSettings = value
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -14,6 +14,7 @@ import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.GetAccountDataResult
 import net.mullvad.mullvadvpn.model.LoginResult
 import net.mullvad.mullvadvpn.model.ObfuscationSettings
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 import net.mullvad.mullvadvpn.model.RelayList
 import net.mullvad.mullvadvpn.model.RelaySettingsUpdate
 import net.mullvad.mullvadvpn.model.RemoveDeviceEvent
@@ -178,6 +179,10 @@ class MullvadDaemon(
         setObfuscationSettings(daemonInterfaceAddress, settings)
     }
 
+    fun setQuantumResistant(quantumResistant: QuantumResistantState) {
+        setQuantumResistantTunnel(daemonInterfaceAddress, quantumResistant)
+    }
+
     fun onDestroy() {
         onSettingsChange.unsubscribeAll()
         onTunnelStateChange.unsubscribeAll()
@@ -253,6 +258,11 @@ class MullvadDaemon(
     private external fun setObfuscationSettings(
         daemonInterfaceAddress: Long,
         settings: ObfuscationSettings?
+    )
+
+    private external fun setQuantumResistantTunnel(
+        daemonInterfaceAddress: Long,
+        quantumResistant: QuantumResistantState
     )
 
     private fun notifyAppVersionInfoEvent(appVersionInfo: AppVersionInfo) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/SettingsListener.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.service.endpoint
 
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
@@ -58,6 +59,11 @@ class SettingsListener(endpoint: ServiceEndpoint) {
 
             registerHandler(Request.SetObfuscationSettings::class) { request ->
                 commandChannel.trySendBlocking(Command.SetObfuscationSettings(request.settings))
+            }
+
+            registerHandler(Request.SetWireGuardQuantumResistant::class) { request ->
+                // TODO
+                Log.d("Remove this", "Set quantum resistant ${request.quantumResistant}")
             }
         }
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectionStatus.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/ConnectionStatus.kt
@@ -7,7 +7,7 @@ import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
-class ConnectionStatus(val parentView: View, context: Context) {
+class ConnectionStatus(parentView: View, context: Context) {
     private val spinner: View = parentView.findViewById(R.id.connecting_spinner)
     private val text: TextView = parentView.findViewById(R.id.connection_status)
 
@@ -20,13 +20,13 @@ class ConnectionStatus(val parentView: View, context: Context) {
             is TunnelState.Disconnecting -> {
                 when (state.actionAfterDisconnect) {
                     ActionAfterDisconnect.Nothing -> disconnected()
-                    ActionAfterDisconnect.Block -> connected()
-                    ActionAfterDisconnect.Reconnect -> connecting()
+                    ActionAfterDisconnect.Block -> connected(false)
+                    ActionAfterDisconnect.Reconnect -> connecting(state.isSecured())
                 }
             }
             is TunnelState.Disconnected -> disconnected()
-            is TunnelState.Connecting -> connecting()
-            is TunnelState.Connected -> connected()
+            is TunnelState.Connecting -> connecting(state.endpoint?.quantumResistant == true)
+            is TunnelState.Connected -> connected(state.endpoint.quantumResistant)
             is TunnelState.Error -> errorState(state.errorState.isBlocking)
         }
     }
@@ -38,18 +38,30 @@ class ConnectionStatus(val parentView: View, context: Context) {
         text.setText(R.string.unsecured_connection)
     }
 
-    private fun connecting() {
+    private fun connecting(isQuantumResistant: Boolean) {
         spinner.visibility = View.VISIBLE
 
         text.setTextColor(connectingTextColor)
-        text.setText(R.string.creating_secure_connection)
+        text.setText(
+            if (isQuantumResistant) {
+                R.string.quantum_creating_secure_connection
+            } else {
+                R.string.creating_secure_connection
+            }
+        )
     }
 
-    private fun connected() {
+    private fun connected(isQuantumResistant: Boolean) {
         spinner.visibility = View.GONE
 
         text.setTextColor(securedTextColor)
-        text.setText(R.string.secure_connection)
+        text.setText(
+            if (isQuantumResistant) {
+                R.string.quantum_secure_connection
+            } else {
+                R.string.secure_connection
+            }
+        )
     }
 
     private fun errorState(isBlocking: Boolean) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/VpnSettingsFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/VpnSettingsFragment.kt
@@ -55,24 +55,12 @@ class VpnSettingsFragment : BaseFragment() {
                         onStopEvent = vm::onStopEvent,
                         toastMessagesSharedFlow = vm.toastMessages,
                         onSelectObfuscationSetting = vm::onSelectObfuscationSetting,
-                        onObfuscationInfoClick = vm::onObfuscationInfoClick
+                        onObfuscationInfoClick = vm::onObfuscationInfoClick,
+                        onSelectQuantumResistanceSetting = vm::onSelectQuantumResistanceSetting,
+                        onQuantumResistanceInfoClicked = vm::onQuantumResistanceInfoClicked
                     )
                 }
             }
-        }
-    }
-
-    private fun openSplitTunnelingFragment() {
-        parentFragmentManager.beginTransaction().apply {
-            setCustomAnimations(
-                R.anim.fragment_enter_from_right,
-                R.anim.fragment_exit_to_left,
-                R.anim.fragment_half_enter_from_left,
-                R.anim.fragment_exit_to_right
-            )
-            replace(R.id.main_fragment, SplitTunnelingFragment())
-            addToBackStack(null)
-            commitAllowingStateLoss()
         }
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -35,6 +35,12 @@ class SettingsListener(private val connection: Messenger, eventDispatcher: Event
             connection.send(Request.SetWireGuardMtu(value).message)
         }
 
+    var wireguardQuantumResistant: Boolean?
+        get() = settingsNotifier.latestEvent?.tunnelOptions?.wireguard?.quantumResistant
+        set(value) {
+            connection.send(Request.SetWireGuardQuantumResistant(value).message)
+        }
+
     var obfuscationSettings: ObfuscationSettings?
         get() = settingsNotifier.latestEvent?.obfuscationSettings
         set(value) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/SettingsListener.kt
@@ -6,6 +6,7 @@ import net.mullvad.mullvadvpn.ipc.EventDispatcher
 import net.mullvad.mullvadvpn.ipc.Request
 import net.mullvad.mullvadvpn.model.DnsOptions
 import net.mullvad.mullvadvpn.model.ObfuscationSettings
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 import net.mullvad.mullvadvpn.model.RelaySettings
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.talpid.util.EventNotifier
@@ -35,8 +36,10 @@ class SettingsListener(private val connection: Messenger, eventDispatcher: Event
             connection.send(Request.SetWireGuardMtu(value).message)
         }
 
-    var wireguardQuantumResistant: Boolean?
-        get() = settingsNotifier.latestEvent?.tunnelOptions?.wireguard?.quantumResistant
+    var wireguardQuantumResistant: QuantumResistantState
+        get() =
+            settingsNotifier.latestEvent?.tunnelOptions?.wireguard?.quantumResistant
+                ?: QuantumResistantState.Off
         set(value) {
             connection.send(Request.SetWireGuardQuantumResistant(value).message)
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModel.kt
@@ -55,7 +55,8 @@ class VpnSettingsViewModel(
                     isAllowLanEnabled = settings?.allowLan ?: false,
                     selectedObfuscation = settings?.selectedObfuscationSettings()
                             ?: SelectedObfuscation.Off,
-                    dialogState = dialogState
+                    dialogState = dialogState,
+                    quantumResistant = settings?.quantumResistant()
                 )
             }
             .stateIn(
@@ -305,6 +306,16 @@ class VpnSettingsViewModel(
         dialogState.update { VpnSettingsDialogState.ObfuscationInfoDialog }
     }
 
+    fun onSelectQuantumResistanceSetting(quantumResistant: Boolean?) {
+        viewModelScope.launch(dispatcher) {
+            repository.setWireguardQuantumResistant(quantumResistant)
+        }
+    }
+
+    fun onQuantumResistanceInfoClicked() {
+        dialogState.update { VpnSettingsDialogState.QuantumResistanceInfoDialog }
+    }
+
     private fun updateDefaultDnsOptionsViaRepository(contentBlockersOption: DefaultDnsOptions) =
         viewModelScope.launch(dispatcher) {
             repository.setDnsOptions(
@@ -340,6 +351,8 @@ class VpnSettingsViewModel(
     }
 
     private fun Settings.mtuString() = tunnelOptions.wireguard.mtu?.toString() ?: EMPTY_STRING
+
+    private fun Settings.quantumResistant() = tunnelOptions.wireguard.quantumResistant
 
     private fun Settings.isCustomDnsEnabled() = tunnelOptions.dnsOptions.state == DnsState.Custom
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModel.kt
@@ -22,6 +22,7 @@ import net.mullvad.mullvadvpn.model.Constraint
 import net.mullvad.mullvadvpn.model.DefaultDnsOptions
 import net.mullvad.mullvadvpn.model.DnsState
 import net.mullvad.mullvadvpn.model.ObfuscationSettings
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 import net.mullvad.mullvadvpn.model.SelectedObfuscation
 import net.mullvad.mullvadvpn.model.Settings
 import net.mullvad.mullvadvpn.model.Udp2TcpObfuscationSettings
@@ -56,7 +57,7 @@ class VpnSettingsViewModel(
                     selectedObfuscation = settings?.selectedObfuscationSettings()
                             ?: SelectedObfuscation.Off,
                     dialogState = dialogState,
-                    quantumResistant = settings?.quantumResistant()
+                    quantumResistant = settings?.quantumResistant() ?: QuantumResistantState.Off
                 )
             }
             .stateIn(
@@ -306,7 +307,7 @@ class VpnSettingsViewModel(
         dialogState.update { VpnSettingsDialogState.ObfuscationInfoDialog }
     }
 
-    fun onSelectQuantumResistanceSetting(quantumResistant: Boolean?) {
+    fun onSelectQuantumResistanceSetting(quantumResistant: QuantumResistantState) {
         viewModelScope.launch(dispatcher) {
             repository.setWireguardQuantumResistant(quantumResistant)
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelState.kt
@@ -13,7 +13,8 @@ data class VpnSettingsViewModelState(
     val customDnsList: List<CustomDnsItem>,
     val contentBlockersOptions: DefaultDnsOptions,
     val selectedObfuscation: SelectedObfuscation,
-    val dialogState: VpnSettingsDialogState
+    val dialogState: VpnSettingsDialogState,
+    val quantumResistant: Boolean?
 ) {
     fun toUiState(): VpnSettingsUiState {
         return when (dialogState) {
@@ -27,7 +28,8 @@ data class VpnSettingsViewModelState(
                     customDnsItems = customDnsList,
                     contentBlockersOptions = contentBlockersOptions,
                     mtuEditValue = dialogState.mtuEditValue,
-                    selectedObfuscation = selectedObfuscation
+                    selectedObfuscation = selectedObfuscation,
+                    quantumResistant = quantumResistant
                 )
             is VpnSettingsDialogState.DnsDialog ->
                 VpnSettingsUiState.DnsDialogUiState(
@@ -39,7 +41,8 @@ data class VpnSettingsViewModelState(
                     customDnsItems = customDnsList,
                     contentBlockersOptions = contentBlockersOptions,
                     stagedDns = dialogState.stagedDns,
-                    selectedObfuscation = selectedObfuscation
+                    selectedObfuscation = selectedObfuscation,
+                    quantumResistant = quantumResistant
                 )
             is VpnSettingsDialogState.LocalNetworkSharingInfoDialog ->
                 VpnSettingsUiState.LocalNetworkSharingInfoDialogUiState(
@@ -49,7 +52,8 @@ data class VpnSettingsViewModelState(
                     isCustomDnsEnabled = isCustomDnsEnabled,
                     isAllowLanEnabled = isAllowLanEnabled,
                     customDnsItems = customDnsList,
-                    contentBlockersOptions = contentBlockersOptions
+                    contentBlockersOptions = contentBlockersOptions,
+                    quantumResistant = quantumResistant
                 )
             is VpnSettingsDialogState.ContentBlockersInfoDialog ->
                 VpnSettingsUiState.ContentBlockersInfoDialogUiState(
@@ -60,7 +64,8 @@ data class VpnSettingsViewModelState(
                     isAllowLanEnabled = isAllowLanEnabled,
                     customDnsItems = customDnsList,
                     contentBlockersOptions = contentBlockersOptions,
-                    selectedObfuscation = selectedObfuscation
+                    selectedObfuscation = selectedObfuscation,
+                    quantumResistant = quantumResistant
                 )
             is VpnSettingsDialogState.CustomDnsInfoDialog ->
                 VpnSettingsUiState.CustomDnsInfoDialogUiState(
@@ -70,7 +75,8 @@ data class VpnSettingsViewModelState(
                     isCustomDnsEnabled = isCustomDnsEnabled,
                     isAllowLanEnabled = isAllowLanEnabled,
                     customDnsItems = customDnsList,
-                    contentBlockersOptions = contentBlockersOptions
+                    contentBlockersOptions = contentBlockersOptions,
+                    quantumResistant = quantumResistant
                 )
             is VpnSettingsDialogState.MalwareInfoDialog ->
                 VpnSettingsUiState.MalwareInfoDialogUiState(
@@ -81,7 +87,8 @@ data class VpnSettingsViewModelState(
                     isAllowLanEnabled = isAllowLanEnabled,
                     customDnsItems = customDnsList,
                     contentBlockersOptions = contentBlockersOptions,
-                    selectedObfuscation = selectedObfuscation
+                    selectedObfuscation = selectedObfuscation,
+                    quantumResistant = quantumResistant
                 )
             is VpnSettingsDialogState.ObfuscationInfoDialog ->
                 VpnSettingsUiState.ObfuscationInfoDialogUiState(
@@ -90,8 +97,20 @@ data class VpnSettingsViewModelState(
                     isAllowLanEnabled = isAllowLanEnabled,
                     customDnsItems = customDnsList,
                     contentBlockersOptions = contentBlockersOptions,
-                    selectedObfuscation = selectedObfuscation
+                    selectedObfuscation = selectedObfuscation,
+                    quantumResistant = quantumResistant
                 )
+            is VpnSettingsDialogState.QuantumResistanceInfoDialog -> {
+                VpnSettingsUiState.QuantumResistanceInfoDialogUiState(
+                    mtu = mtuValue,
+                    isCustomDnsEnabled = isCustomDnsEnabled,
+                    isAllowLanEnabled = isAllowLanEnabled,
+                    customDnsItems = customDnsList,
+                    contentBlockersOptions = contentBlockersOptions,
+                    selectedObfuscation = selectedObfuscation,
+                    quantumResistant = quantumResistant
+                )
+            }
             else ->
                 VpnSettingsUiState.DefaultUiState(
                     mtu = mtuValue,
@@ -101,7 +120,8 @@ data class VpnSettingsViewModelState(
                     isAllowLanEnabled = isAllowLanEnabled,
                     customDnsItems = customDnsList,
                     contentBlockersOptions = contentBlockersOptions,
-                    selectedObfuscation = selectedObfuscation
+                    selectedObfuscation = selectedObfuscation,
+                    quantumResistant = quantumResistant
                 )
         }
     }
@@ -119,7 +139,8 @@ data class VpnSettingsViewModelState(
                 contentBlockersOptions = DefaultDnsOptions(),
                 isAllowLanEnabled = false,
                 dialogState = VpnSettingsDialogState.NoDialog,
-                selectedObfuscation = SelectedObfuscation.Auto
+                selectedObfuscation = SelectedObfuscation.Auto,
+                quantumResistant = null
             )
     }
 }
@@ -140,6 +161,8 @@ sealed class VpnSettingsDialogState {
     object MalwareInfoDialog : VpnSettingsDialogState()
 
     object ObfuscationInfoDialog : VpnSettingsDialogState()
+
+    object QuantumResistanceInfoDialog : VpnSettingsDialogState()
 }
 
 sealed interface StagedDns {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelState.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.viewmodel
 
 import net.mullvad.mullvadvpn.compose.state.VpnSettingsUiState
 import net.mullvad.mullvadvpn.model.DefaultDnsOptions
+import net.mullvad.mullvadvpn.model.QuantumResistantState
 import net.mullvad.mullvadvpn.model.SelectedObfuscation
 
 data class VpnSettingsViewModelState(
@@ -14,7 +15,7 @@ data class VpnSettingsViewModelState(
     val contentBlockersOptions: DefaultDnsOptions,
     val selectedObfuscation: SelectedObfuscation,
     val dialogState: VpnSettingsDialogState,
-    val quantumResistant: Boolean?
+    val quantumResistant: QuantumResistantState
 ) {
     fun toUiState(): VpnSettingsUiState {
         return when (dialogState) {
@@ -140,7 +141,7 @@ data class VpnSettingsViewModelState(
                 isAllowLanEnabled = false,
                 dialogState = VpnSettingsDialogState.NoDialog,
                 selectedObfuscation = SelectedObfuscation.Auto,
-                quantumResistant = null
+                quantumResistant = QuantumResistantState.Off
             )
     }
 }

--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Tilsløring skjuler WireGuard-trafikken inden i en anden protokol. Det kan bruges til at hjælpe med at omgå censur og andre typer filtrering, hvor en almindelig WireGuard-forbindelse ville blive blokeret.</string>
     <string name="obfuscation_on_udp_over_tcp">Til (UDP-over-TCP)</string>
     <string name="off">Fra</string>
+    <string name="on">Til</string>
     <string name="out_address">Ud</string>
     <string name="out_of_time">Tid udløbet</string>
     <string name="paid_until">Betalt indtil</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Dette vil slette alle videresendte porte. Lokale indstillinger vil blive gemt.</string>
     <string name="privacy_policy_label">Fortrolighedspolitik</string>
     <string name="problem_report_description">For at vi bedre kan hjælpe dig, bedes du vedhæfte din apps logfil til denne meddelelse. Dine data vil forblive sikre og private, da de anonymiseres, før de sendes via en krypteret kanal.</string>
+    <string name="quantum_creating_secure_connection">OPRETTER KVANTESIKKER FORBINDELSE</string>
+    <string name="quantum_resistant_info_first_paragaph">Denne funktion gør WireGuard-tunnelen modstandsdygtig over for potentielle angreb fra kvantecomputere.</string>
+    <string name="quantum_resistant_info_second_paragaph">Det gør den ved at udføre en ekstra nøgleudveksling ved hjælp af en kvantesikker algoritme og blande resultatet med WireGuards almindelige kryptering. Dette ekstra trin bruger cirka 500 kB trafik, hver gang en ny tunnel etableres.</string>
+    <string name="quantum_resistant_title">Kvante-modstandsdygtig tunnel</string>
+    <string name="quantum_secure_connection">KVANTESIKKER FORBINDELSE</string>
     <string name="reconnecting">Genopretter forbindelse</string>
     <string name="redeem">Indløs</string>
     <string name="redeem_voucher">Indløs kupon</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Bei der Verschleierung wird der WireGuard-Datenverkehr in einem anderen Protokoll versteckt. Sie kann dazu verwendet werden, Zensur und andere Arten von Filtern zu umgehen, bei denen eine reine WireGuard-Verbindung blockiert würde.</string>
     <string name="obfuscation_on_udp_over_tcp">An (UDP über TCP)</string>
     <string name="off">Aus</string>
+    <string name="on">Ein</string>
     <string name="out_address">Ausgehend</string>
     <string name="out_of_time">Zeit abgelaufen</string>
     <string name="paid_until">Bezahlt bis</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Dadurch werden alle weitergeleiteten Ports gelöscht. Die lokalen Einstellungen werden gespeichert.</string>
     <string name="privacy_policy_label">Datenschutzrichtlinie</string>
     <string name="problem_report_description">Damit wir Ihnen besser helfen können, wird die Protokolldatei Ihrer App an diese Nachricht angehängt. Ihre Daten bleiben sicher und privat, da sie vor dem Senden über einen verschlüsselten Kanal anonymisiert werden.</string>
+    <string name="quantum_creating_secure_connection">QUANTENSICHERE VERBINDUNG WIRD ERSTELLT</string>
+    <string name="quantum_resistant_info_first_paragaph">Diese Funktion macht den WireGuard-Tunnel resistent gegen mögliche Angriffe von Quantencomputern.</string>
+    <string name="quantum_resistant_info_second_paragaph">Dazu wird ein zusätzlicher Schlüsselaustausch mit einem quantensicheren Algorithmus durchgeführt und das Ergebnis mit der regulären Verschlüsselung von WireGuard vermischt. Dieser zusätzliche Schritt verbraucht jedes Mal, wenn ein neuer Tunnel aufgebaut wird, etwa 500 KiB an Datenverkehr.</string>
+    <string name="quantum_resistant_title">Quantenresistenter Tunnel</string>
+    <string name="quantum_secure_connection">QUANTENSICHERE VERBINDUNG</string>
     <string name="reconnecting">Wiederherstellen der Verbindung</string>
     <string name="redeem">Einlösen</string>
     <string name="redeem_voucher">Gutschein einlösen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">La ofuscación oculta el tráfico de WireGuard dentro de otro protocolo. Puede usarse para sortear la censura y otros tipos de filtrado donde podría bloquearse una conexión de WireGuard normal.</string>
     <string name="obfuscation_on_udp_over_tcp">Activado (UDP sobre TCP)</string>
     <string name="off">Desactivado</string>
+    <string name="on">Activado</string>
     <string name="out_address">Salida</string>
     <string name="out_of_time">Tiempo agotado</string>
     <string name="paid_until">Pagado hasta</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Se eliminarán todos los puertos reenviados. La configuración local se guardará.</string>
     <string name="privacy_policy_label">Política de privacidad</string>
     <string name="problem_report_description">Para ayudarle de una forma más eficiente, se adjuntará el archivo de registro de la aplicación a este mensaje. Sus datos permanecerán protegidos y privados, ya que se anonimizan antes de enviarse a través de un canal cifrado.</string>
+    <string name="quantum_creating_secure_connection">CREANDO CONEXIÓN CON SEGURIDAD CUÁNTICA</string>
+    <string name="quantum_resistant_info_first_paragaph">Esta característica permite que el túnel de WireGuard resista posibles ataques de ordenadores cuánticos.</string>
+    <string name="quantum_resistant_info_second_paragaph">Lo hace al realizar un intercambio de claves adicional usando un algoritmo cuántico seguro y combinando el resultado en el cifrado normal de WireGuard. Este paso extra utiliza aproximadamente 500 kiB de tráfico cada vez que se establece un nuevo túnel.</string>
+    <string name="quantum_resistant_title">Túnel con resistencia cuántica</string>
+    <string name="quantum_secure_connection">CONEXIÓN CON SEGURIDAD CUÁNTICA</string>
     <string name="reconnecting">Volviendo a establecer la conexión</string>
     <string name="redeem">Canjear</string>
     <string name="redeem_voucher">Canjear cupón</string>

--- a/android/app/src/main/res/values-fi/strings.xml
+++ b/android/app/src/main/res/values-fi/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Hämäysteknologian käyttäminen piilottaa WireGuard-liikenteen toisen protokollan sisään. Sitä voidaan käyttää kiertämään sensuuria ja muita suodatuksia niissä tapauksissa, kun tavallinen WireGuard-yhteys muutoin estettäisi.</string>
     <string name="obfuscation_on_udp_over_tcp">Käytössä (UDP TCP:n kautta)</string>
     <string name="off">Pois</string>
+    <string name="on">Päällä</string>
     <string name="out_address">Lähtevä</string>
     <string name="out_of_time">Ei käyttöaikaa</string>
     <string name="paid_until">Maksu ennen</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Toiminto poistaa kaikki välitetyt portit. Paikalliset asetukset tallennetaan.</string>
     <string name="privacy_policy_label">Tietosuojakäytäntö</string>
     <string name="problem_report_description">Jotta voimme olla avuksi parhaamme mukaan, sovelluksesi lokitiedosto liitetään tähän viestiin. Tietosi pysyvät suojattuina ja yksityisinä, ja ne anonymisoidaan salatun kanavan kautta ennen lähetystä.</string>
+    <string name="quantum_creating_secure_connection">LUODAAN KVANTTISUOJATTU YHTEYS</string>
+    <string name="quantum_resistant_info_first_paragaph">Tämä ominaisuus tekee WireGuard-tunnelista kestävän kvanttitietokoneiden mahdollisia hyökkäyksiä vastaan.</string>
+    <string name="quantum_resistant_info_second_paragaph">Tunneli torjuu hyökkäykset suorittamalla ylimääräisen avaimenvaihdon käyttämällä ensin kvanttiturvallista algoritmia, jonka tuloksen se sekoittaa WireGuardin tavalliseen salaukseen. Tämä ylimääräinen vaihe käyttää noin 500 kiB liikennettä joka kerta, kun uusi tunneli luodaan.</string>
+    <string name="quantum_resistant_title">Kvanttihyökkäyksiä kestävä tunneli</string>
+    <string name="quantum_secure_connection">KVANTTISUOJATTU YHTEYS</string>
     <string name="reconnecting">Yhdistetään uudelleen</string>
     <string name="redeem">Lunasta</string>
     <string name="redeem_voucher">Lunasta kuponki</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">La dissimulation cache le trafic WireGuard à l\'intérieur d\'un autre protocole. Elle peut être utilisée pour aider à contourner la censure et d\'autres types de filtrage, où une connexion WireGuard simple serait bloquée.</string>
     <string name="obfuscation_on_udp_over_tcp">Activé (UDP sur TCP)</string>
     <string name="off">Désactivé</string>
+    <string name="on">Activé</string>
     <string name="out_address">Sortante</string>
     <string name="out_of_time">Plus de temps</string>
     <string name="paid_until">Payé jusqu\'au</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Ceci supprimera tous les ports transférés. Les paramètres locaux seront enregistrés.</string>
     <string name="privacy_policy_label">Politique de confidentialité</string>
     <string name="problem_report_description">Pour mieux vous aider, le fichier journal de l\'application est joint à ce message. Vos données restent privées et en sécurité dans la mesure où elles sont rendues anonymes avant d\'être envoyées via un canal chiffré.</string>
+    <string name="quantum_creating_secure_connection">CRÉATION D\'UNE CONNEXION QUANTIQUE SÉCURISÉE</string>
+    <string name="quantum_resistant_info_first_paragaph">Cette fonctionnalité rend le tunnel WireGuard résistant aux attaques potentielles des ordinateurs quantiques.</string>
+    <string name="quantum_resistant_info_second_paragaph">Pour ce faire, il effectue un échange de clés supplémentaire à l\'aide d\'un algorithme à sécurité quantique et mélange le résultat au chiffrement habituel de WireGuard. Cette étape supplémentaire utilise environ 500 kiB de trafic chaque fois qu\'un nouveau tunnel est établi.</string>
+    <string name="quantum_resistant_title">Tunnel résistant aux attaques quantiques</string>
+    <string name="quantum_secure_connection">CONNEXION QUANTIQUE SÉCURISÉE</string>
     <string name="reconnecting">Reconnexion</string>
     <string name="redeem">Échanger</string>
     <string name="redeem_voucher">Échanger un bon</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">L\'offuscamento nasconde il traffico WireGuard all\'interno di un altro protocollo. Può essere utilizzato per aggirare la censura e altri tipi di filtraggio, in cui una semplice connessione WireGuard verrebbe bloccata.</string>
     <string name="obfuscation_on_udp_over_tcp">On (UDP-over-TCP)</string>
     <string name="off">Off</string>
+    <string name="on">On</string>
     <string name="out_address">Invio</string>
     <string name="out_of_time">Scaduto</string>
     <string name="paid_until">Pagato fino al</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Questa operazione eliminerà tutte le porte inoltrate. Le impostazioni locali verranno salvate.</string>
     <string name="privacy_policy_label">Informativa sulla privacy</string>
     <string name="problem_report_description">Per aiutarti in modo più efficace, il file di registro della tua app sarà allegato a questo messaggio. I tuoi dati rimarranno protetti e privati, e saranno anonimizzati prima di essere inviati tramite un canale crittografato.</string>
+    <string name="quantum_creating_secure_connection">CREAZIONE CONNESSIONE QUANTISTICA PROTETTA</string>
+    <string name="quantum_resistant_info_first_paragaph">Questa funzionalità rende il tunnel WireGuard resistente ai potenziali attacchi dei computer quantistici.</string>
+    <string name="quantum_resistant_info_second_paragaph">L\'operazione viene effettuata eseguendo uno scambio di chiavi aggiuntivo con un algoritmo di sicurezza quantistica e mescolando il risultato nella normale crittografia di WireGuard. Questo passaggio aggiuntivo utilizza circa 500 kiB di traffico ogni volta che viene stabilito un nuovo tunnel.</string>
+    <string name="quantum_resistant_title">Tunnel resistente agli attacchi quantistici</string>
+    <string name="quantum_secure_connection">CONNESSIONE QUANTISTICA PROTETTA</string>
     <string name="reconnecting">Riconnessione</string>
     <string name="redeem">Riscatta</string>
     <string name="redeem_voucher">Riscatta voucher</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">難読化は、WireGuardトラフィックを別のプロトコル内に隠します。プレーンなWireGuard接続がブロックされる検閲やその他のフィルタリングを回避するために使用できます。</string>
     <string name="obfuscation_on_udp_over_tcp">オン (UDP-over-TCP)</string>
     <string name="off">オフ</string>
+    <string name="on">オン</string>
     <string name="out_address">外側</string>
     <string name="out_of_time">時間切れ</string>
     <string name="paid_until">次の日時まで支払い済み</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">これにより、転送されたポートがすべて削除されます。ローカル設定は保存されます。</string>
     <string name="privacy_policy_label">プライバシーポリシー</string>
     <string name="problem_report_description">さらに効率よく問題解決できるよう、お使いのアプリのログファイルがこのメッセージに添付されます。個人データは匿名化された後に暗号化されたチャネルで送信されるため、その安全は確保され、公開されることはありません。</string>
+    <string name="quantum_creating_secure_connection">量子セキュア保護接続を確立中</string>
+    <string name="quantum_resistant_info_first_paragaph">この機能は、WireGuardトンネルに量子コンピューターからの潜在的な攻撃に対する耐性を与えます。</string>
+    <string name="quantum_resistant_info_second_paragaph">耐量子アルゴリズムで追加の鍵の交換を実行し、結果をWireGuardの通常の暗号化に混合させることで行われます。この追加ステップでは、新しいトンネルが確立されるたびに約500kiBのトラフィックが使用されます。</string>
+    <string name="quantum_resistant_title">耐量子トンネル</string>
+    <string name="quantum_secure_connection">量子セキュア保護接続</string>
     <string name="reconnecting">再接続中</string>
     <string name="redeem">使用する</string>
     <string name="redeem_voucher">バウチャーを使用する</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">난독 처리는 다른 프로토콜 내에서 WireGuard 트래픽을 숨깁니다. 일반 WireGuard 연결이 차단되는 상황에서 검열 및 기타 유형의 필터링을 우회하는 데 사용할 수 있습니다.</string>
     <string name="obfuscation_on_udp_over_tcp">켜기(UDP-over-TCP)</string>
     <string name="off">끄기</string>
+    <string name="on">켜기</string>
     <string name="out_address">아웃</string>
     <string name="out_of_time">시간 초과</string>
     <string name="paid_until">유효 기간</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">전달된 모든 포트가 삭제됩니다. 로컬 설정이 저장됩니다.</string>
     <string name="privacy_policy_label">개인정보 보호정책</string>
     <string name="problem_report_description">보다 효과적인 문제 해결을 위해 앱의 로그 파일이 이 메시지에 첨부됩니다. 사용자 데이터는 암호화된 채널을 통해 전송되기 전에 익명 처리되므로 안전하고 비공개로 유지됩니다.</string>
+    <string name="quantum_creating_secure_connection">양자 보안 연결 생성 중</string>
+    <string name="quantum_resistant_info_first_paragaph">이 기능은 WireGuard 터널이 양자 컴퓨터의 잠재적인 공격에 맞서도록 합니다.</string>
+    <string name="quantum_resistant_info_second_paragaph">이를 위해 양자 안전 알고리즘을 사용하여 추가 키 교환을 수행하고 결과를 WireGuard의 일반 암호화에 혼합하는 방법이 이용됩니다. 이 추가 단계는 새 터널이 설정될 때마다 약 500kiB의 트래픽을 사용합니다.</string>
+    <string name="quantum_resistant_title">양자 저항 터널</string>
+    <string name="quantum_secure_connection">양자 보안 연결</string>
     <string name="reconnecting">다시 연결 중</string>
     <string name="redeem">사용</string>
     <string name="redeem_voucher">바우처 사용</string>

--- a/android/app/src/main/res/values-my/strings.xml
+++ b/android/app/src/main/res/values-my/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Obfuscation သည် အခြားပရိုတိုကောလ်အတွင်းရှိ WireGuard ကူးလူးမှုကို ဝှက်ထားပေးပါသည်။ သာမန် WireGuard ချိတ်ဆက်မှုကို ပိတ်ဆို့မည့် အခြားသော စစ်ထုတ်မှု အမျိုးအစားများနှင့် ဆင်ဆာဖြတ်တောက်ခြင်းကို ရှောင်လွှဲနိုင်စေရာတွင် ကူညီနိုင်စေရန် ဤသည်ကို သုံးနိုင်ပါသည်။</string>
     <string name="obfuscation_on_udp_over_tcp">ဖွင့် (UDP-over-TCP)</string>
     <string name="off">ပိတ်</string>
+    <string name="on">ဖွင့်</string>
     <string name="out_address">အထွက်</string>
     <string name="out_of_time">အချိန်စေ့သွားပါပြီ</string>
     <string name="paid_until">ဖော်ပြပါအထိ ပေးချေထားပြီး</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">၎င်းသည် ပေးပို့ထားသော ports ကို ဖျက်ပါမည်။ စက်တွင်းဆက်တင်ကို သိမ်းထားပါမည်။</string>
     <string name="privacy_policy_label">ကိုယ်ပိုင်အချက်အလက် မူဝါဒ</string>
     <string name="problem_report_description">သင့်အား ပိုမိုထိရောက်စွာ ကူညီနိုင်ရန် သင့်အက်ပ်၏ မှတ်တမ်းဖိုင်ကို ဤမက်ဆေ့ချ်နှင့်အတူ တွဲပေးသွားပါမည်။ ကုဒ်ပြောင်းဝှက်ထားသည့် ချန်နယ်မှတစ်ဆင့် မပေးပို့မီ သင့်ဒေတာများကို အမည်မဖော်ဘဲ ထားမည်ဖြစ်သောကြောင့် လျှို့ဝှက်လုံခြုံလျက် ရှိနေပါမည်။</string>
+    <string name="quantum_creating_secure_connection">QUANTUM လုံခြုံသည့် ချိတ်ဆက်မှုကို ဖန်တီးခြင်း</string>
+    <string name="quantum_resistant_info_first_paragaph">ဤလုပ်ဆောင်ချက်သည် Quantum ကွန်ပျူတာများမှ ဖြစ်လာနိုင်ခြေရှိသော တိုက်ခိုက်မှုများကို ခုခံနိုင်သည့် WireGuard Tunnel ကို ပြုလုပ်သည်။</string>
+    <string name="quantum_resistant_info_second_paragaph">Quantum Safe အယ်လဂိုရီသမ်တစ်ခုကို သုံး၍ ထပ်ဆောင်း ကီးဖလှယ်မှုတစ်ခုကို ဆောင်ရွက်ပြီး WireGuard ၏ ပုံမှန် ကုဒ်ပြောင်းဝှက်မှုအတွင်း ရလဒ်ကို ရောနှောခြင်းအားဖြင့် ဤသည်ကို လုပ်ဆောင်ပါသည်။ ဤထပ်ဆောင်းအဆင့်သည် Tunnel အသစ်တစ်ခု တည်ဆောက်တိုင်း ဒေတာ 500 kiB ခန့်ကို သုံးပါသည်။</string>
+    <string name="quantum_resistant_title">Quantum-resistant Tunnel</string>
+    <string name="quantum_secure_connection">QUANTUM လုံခြုံသည့် ချိတ်ဆက်မှု</string>
     <string name="reconnecting">ပြန်ချိတ်ဆက်နေပါသည်</string>
     <string name="redeem">လဲယူရန်</string>
     <string name="redeem_voucher">ဘောက်ချာဖြင့် လဲယူရန်</string>

--- a/android/app/src/main/res/values-nb/strings.xml
+++ b/android/app/src/main/res/values-nb/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Tilsløring skjuler WireGuard-trafikken i en annen protokoll. Man kan på den måten omgå sensur og andre typer filter i tilfeller der en vanlig WireGuard-tilkobling ville blitt blokkert.</string>
     <string name="obfuscation_on_udp_over_tcp">På (UDP-over-TCP)</string>
     <string name="off">Av</string>
+    <string name="on">På</string>
     <string name="out_address">Utgående</string>
     <string name="out_of_time">Tiden har utløpt</string>
     <string name="paid_until">Betalt fram til</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Dette vil slette alle formidlede porter. Lokale innstillinger blir lagret.</string>
     <string name="privacy_policy_label">Retningslinjer for personvern</string>
     <string name="problem_report_description">For å kunne gi deg god nok hjelp vil loggfilen til appen ligge som vedlegg til meldingen. All data forblir beskyttet og privat gjennom anonymisering før det sendes gjennom en kryptert kanal.</string>
+    <string name="quantum_creating_secure_connection">OPPRETTER KVANTESIKKER TILKOBLING</string>
+    <string name="quantum_resistant_info_first_paragaph">Denne funksjonen gjør WireGuard-tunnelen motstandsdyktig mot potensielle angrep fra kvantemaskiner.</string>
+    <string name="quantum_resistant_info_second_paragaph">Det gjøres ved at å utføre en ekstra nøkkelutveksling med en kvantesikker algoritme og kombinere resultatet med WireGuard sin vanlige kryptering. Dette ekstratrinnet bruker omtrent 500 kiB trafikk hver gang det opprettes en ny tunnel.</string>
+    <string name="quantum_resistant_title">Kvantebestandig tunnel</string>
+    <string name="quantum_secure_connection">KVANTESIKKER TILKOBLING</string>
     <string name="reconnecting">Kobler til på nytt</string>
     <string name="redeem">Løs inn</string>
     <string name="redeem_voucher">Løs inn kupong</string>

--- a/android/app/src/main/res/values-nl/strings.xml
+++ b/android/app/src/main/res/values-nl/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Obfuscatie verbergt het WireGuard-verkeer in een ander protocol. Het kan worden gebruikt om censuur en andere soorten filtering te omzeilen, waar een gewone WireGuard-verbinding zou worden geblokkeerd.</string>
     <string name="obfuscation_on_udp_over_tcp">Aan (UDP-over-TCP)</string>
     <string name="off">Uit</string>
+    <string name="on">Aan</string>
     <string name="out_address">Uit</string>
     <string name="out_of_time">Geen tijd meer</string>
     <string name="paid_until">Betaald tot</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Hiermee worden alle doorgestuurde poorten verwijderd. De lokale instellingen worden opgeslagen.</string>
     <string name="privacy_policy_label">Privacybeleid</string>
     <string name="problem_report_description">Het logboekbestand van uw app wordt aan dit bericht gekoppeld zodat we u beter kunnen helpen. Uw gegevens blijven veilig en privé, omdat ze worden geanonimiseerd voordat ze over een versleuteld kanaal worden verzonden.</string>
+    <string name="quantum_creating_secure_connection">BEVEILIGDE QUANTUMVERBINDING AANMAKEN</string>
+    <string name="quantum_resistant_info_first_paragaph">Deze eigenschap maakt de WireGuard-tunnel bestand tegen mogelijke aanvallen met kwantumcomputers.</string>
+    <string name="quantum_resistant_info_second_paragaph">Het doet dit door een extra sleuteluitwisseling uit te voeren met een kwantumveilig algoritme en het resultaat te mengen met de reguliere versleuteling van WireGuard. Deze extra stap gebruikt ongeveer 500 kiB aan verkeer elke keer dat een nieuwe tunnel wordt opgezet.</string>
+    <string name="quantum_resistant_title">Kwantumbestendige tunnel</string>
+    <string name="quantum_secure_connection">QUANTUMVEILIGE VERBINDING</string>
     <string name="reconnecting">Opnieuw verbinden</string>
     <string name="redeem">Inwisselen</string>
     <string name="redeem_voucher">Voucher inwisselen</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Zaciemnianie ukrywa ruch WireGuard w innym protokole. Można go użyć do obchodzenia cenzury i innych typów filtrowania, w których zwykłe połączenie WireGuard byłoby blokowane.</string>
     <string name="obfuscation_on_udp_over_tcp">Wł. (UDP-przez-TCP)</string>
     <string name="off">Wył.</string>
+    <string name="on">Wł.</string>
     <string name="out_address">Wyjście</string>
     <string name="out_of_time">Koniec czasu</string>
     <string name="paid_until">Płatne do</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Spowoduje to usunięcie wszystkich przekierowanych portów. Ustawienia lokalne zostaną zapisane.</string>
     <string name="privacy_policy_label">Polityka prywatności</string>
     <string name="problem_report_description">Aby można było pomóc Ci skuteczniej, do tej wiadomości dołączony zostanie plik dziennika aplikacji. Twoje dane pozostaną bezpieczne i prywatne, ponieważ przed wysłaniem zaszyfrowanym kanałem zostają one zanonimizowane.</string>
+    <string name="quantum_creating_secure_connection">TWORZENIE KWANTOWO BEZPIECZNEGO POŁĄCZENIA</string>
+    <string name="quantum_resistant_info_first_paragaph">Ta funkcja sprawia, że tunel WireGuard jest odporny na potencjalne ataki ze strony komputerów kwantowych.</string>
+    <string name="quantum_resistant_info_second_paragaph">Jest to wykonywane poprzez dodatkową wymianę kluczy przy użyciu algorytmu odpornego na ataki z użyciem komputerów kwantowych i zmieszanie wyniku ze zwykłym szyfrowaniem WireGuard. Ten dodatkowy krok zużywa około 500 kB ruchu za każdym razem, gdy ustanawiany jest nowy tunel.</string>
+    <string name="quantum_resistant_title">Tunel odporny na ataki z użyciem komputerów kwantowych</string>
+    <string name="quantum_secure_connection">KWANTOWO BEZPIECZNE POŁĄCZENIE</string>
     <string name="reconnecting">Ponowne łączenie</string>
     <string name="redeem">Zrealizuj</string>
     <string name="redeem_voucher">Zrealizuj kupon</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">A ofuscação oculta o tráfego do WireGuard dentro de outro protocolo. Pode ser utilizado para ajudar a contornar a censura e outros tipos de filtragem, onde uma simples ligação WireGuard seria bloqueada.</string>
     <string name="obfuscation_on_udp_over_tcp">Ligado (UDP sobre TCP)</string>
     <string name="off">Desligado</string>
+    <string name="on">Ligado</string>
     <string name="out_address">Saída</string>
     <string name="out_of_time">Sem tempo</string>
     <string name="paid_until">Pago até</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Esta ação irá apagar todas as portas reencaminhadas. As definições locais serão guardadas.</string>
     <string name="privacy_policy_label">Política de privacidade</string>
     <string name="problem_report_description">Para ajudarmos de forma mais eficaz, o ficheiro de registo da sua aplicação será anexado a esta mensagem. Os seus dados permanecerão seguros e privados, pois são tornados anónimos antes de serem enviados através de um canal encriptado.</string>
+    <string name="quantum_creating_secure_connection">A CRIAR LIGAÇÃO COM SEGURANÇA QUÂNTICA</string>
+    <string name="quantum_resistant_info_first_paragaph">Esta funcionalidade torna o túnel do WireGuard resistente a potenciais ataques de computadores quânticos.</string>
+    <string name="quantum_resistant_info_second_paragaph">Fá-lo ao realizar uma troca de chaves adicional utilizando um algoritmo de segurança quântica e misturando o resultado na encriptação regular do WireGuard. Este passo adicional utiliza aproximadamente 500 kiB de tráfego sempre que um novo túnel é estabelecido.</string>
+    <string name="quantum_resistant_title">Túnel com resistência quântica</string>
+    <string name="quantum_secure_connection">LIGAÇÃO COM SEGURANÇA QUÂNTICA</string>
     <string name="reconnecting">A religar</string>
     <string name="redeem">Reclamar</string>
     <string name="redeem_voucher">Reclamar voucher</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Обфускация скрывает трафик WireGuard внутри другого протокола. Это может использоваться для обхода цензуры и других видов фильтрации, когда обычное соединение WireGuard было бы заблокировано.</string>
     <string name="obfuscation_on_udp_over_tcp">Вкл. (UDP через TCP)</string>
     <string name="off">Выключен</string>
+    <string name="on">Включен</string>
     <string name="out_address">Выход</string>
     <string name="out_of_time">Закончилось время</string>
     <string name="paid_until">Оплачено до</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Будут удалены все перенаправленные порты. Локальные настройки сохранятся.</string>
     <string name="privacy_policy_label">Политика конфиденциальности</string>
     <string name="problem_report_description">Чтобы помощь была эффективнее, к этому сообщению будет прикреплен файл журнала из приложения. Ваши данные останутся защищенными и конфиденциальными: они обезличиваются и отправляются по зашифрованному каналу.</string>
+    <string name="quantum_creating_secure_connection">СОЗДАНИЕ ПОДКЛЮЧЕНИЯ С ЗАЩИТОЙ ОТ КВАНТОВЫХ АТАК</string>
+    <string name="quantum_resistant_info_first_paragaph">Эта функция делает туннель WireGuard устойчивым к потенциальным атакам с использованием квантовых компьютеров.</string>
+    <string name="quantum_resistant_info_second_paragaph">Для этого функция выполняет дополнительный обмен ключами с использованием квантово-устойчивого алгоритма и добавляет результат к обычному шифрованию WireGuard. Эта дополнительная мера использует примерно 500 КиБ трафика при каждом создании нового туннеля.</string>
+    <string name="quantum_resistant_title">Квантово-устойчивый туннель</string>
+    <string name="quantum_secure_connection">ПОДКЛЮЧЕНИЕ С ЗАЩИТОЙ ОТ КВАНТОВЫХ АТАК</string>
     <string name="reconnecting">Идет переподключение</string>
     <string name="redeem">Погасить</string>
     <string name="redeem_voucher">Погасить ваучер</string>

--- a/android/app/src/main/res/values-sv/strings.xml
+++ b/android/app/src/main/res/values-sv/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Obfuskering döljer WireGuard-trafik inne i ett annat protokoll. Det kan användas för att kringgå censur och andra filtertyper där en vanlig WireGuard-anslutning skulle blockeras.</string>
     <string name="obfuscation_on_udp_over_tcp">På (UDP över TCP)</string>
     <string name="off">Av</string>
+    <string name="on">På</string>
     <string name="out_address">Ut</string>
     <string name="out_of_time">Ingen tid kvar</string>
     <string name="paid_until">Betalat till</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Detta tar bort alla vidarebefordrade portar. Lokala inställningar sparas.</string>
     <string name="privacy_policy_label">Sekretesspolicy</string>
     <string name="problem_report_description">För att hjälpa dig mer effektivt kommer appens loggfil att bifogas i detta meddelande. Dina uppgifter förblir säkra och privata, eftersom de anonymiseras innan de skickas över en krypterad kanal.</string>
+    <string name="quantum_creating_secure_connection">SKAPAR KVANTSÄKER ANSLUTNING</string>
+    <string name="quantum_resistant_info_first_paragaph">Den här funktionen gör WireGuard-tunneln resistent mot potentiella attacker från kvantdatorer.</string>
+    <string name="quantum_resistant_info_second_paragaph">Den gör det genom att göra ett extra nyckelutbyte med en kvantsäker algoritm och kombinera resultatet med WireGuards vanliga kryptering. Det här extra steget använder ungefär 500 KiB i trafik varje gång en ny tunnel upprättas.</string>
+    <string name="quantum_resistant_title">Kvantresistent tunnel</string>
+    <string name="quantum_secure_connection">KVANTSÄKER ANSLUTNING</string>
     <string name="reconnecting">Återansluter</string>
     <string name="redeem">Lös in</string>
     <string name="redeem_voucher">Lös in kupong</string>

--- a/android/app/src/main/res/values-th/strings.xml
+++ b/android/app/src/main/res/values-th/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">ข้อมูลที่คลุมเครือจะซ่อนการรับส่งข้อมูล WireGuard ภายในอีกโพรโทคอลหนึ่ง ซึ่งใช้เพื่อช่วยหลบเลี่ยงการเซ็นเซอร์ และการกรองประเภทอื่นๆ ที่การเชื่อมต่อ WireGuard แบบธรรมดาจะถูกบล็อกได้</string>
     <string name="obfuscation_on_udp_over_tcp">เปิด (UDP-ผ่าน-TCP)</string>
     <string name="off">ปิด</string>
+    <string name="on">เปิด</string>
     <string name="out_address">ออก</string>
     <string name="out_of_time">หมดเวลา</string>
     <string name="paid_until">ชำระเงินแล้วจนถึง</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">นี่จะเป็นการลบพอร์ตที่ส่งต่อทั้งหมด และการตั้งค่าบนอุปกรณ์จะได้รับการบันทึกไว้</string>
     <string name="privacy_policy_label">นโยบายความเป็นส่วนตัว</string>
     <string name="problem_report_description">ไฟล์บันทึกล็อกของแอปของคุณจะถูกแนบไปกับข้อความนี้ เพื่อที่เราจะช่วยเหลือคุณได้อย่างมีประสิทธิภาพมากขึ้น ข้อมูลของคุณจะยังคงมีความปลอดภัยและเป็นส่วนตัว เนื่องจากจะไม่มีการระบุตัวตนก่อนส่งข้อมูลผ่านช่องทางที่มีการเข้ารหัส</string>
+    <string name="quantum_creating_secure_connection">กำลังสร้างการเชื่อมต่อควอนตัมที่ปลอดภัย</string>
+    <string name="quantum_resistant_info_first_paragaph">ฟีเจอร์นี้จะช่วยให้ช่องทาง WireGuard สามารถสกัดกั้นการโจมตีที่อาจมาจากคอมพิวเตอร์ควอนตัมได้</string>
+    <string name="quantum_resistant_info_second_paragaph">ระบบจะดำเนินการสิ่งนี้ผ่านการแลกเปลี่ยนคีย์เพิ่มเติม โดยการใช้อัลกอริทึมแบบควอนตัมที่ปลอดภัย และผสมผลลัพธ์เข้ากับการเข้ารหัสตามปกติของ WireGuard และขั้นตอนพิเศษนี้ใช้การรับส่งข้อมูลประมาณ 500 kiB ในทุกครั้งที่สร้างช่องทางใหม่</string>
+    <string name="quantum_resistant_title">ช่องทางการสกัดกั้นควอนตัม</string>
+    <string name="quantum_secure_connection">การเชื่อมต่อควอนตัมที่ปลอดภัย</string>
     <string name="reconnecting">กำลังเชื่อมต่อใหม่</string>
     <string name="redeem">แลกรับ</string>
     <string name="redeem_voucher">แลกบัตรกำนัล</string>

--- a/android/app/src/main/res/values-tr/strings.xml
+++ b/android/app/src/main/res/values-tr/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">Gizleme, WireGuard trafiğini başka bir protokolün içinde gizler. Normal bir WireGuard bağlantısının engelleneceği sansürü ve diğer filtreleme türlerini aşmaya yardımcı olmak için kullanılabilir.</string>
     <string name="obfuscation_on_udp_over_tcp">Açık (TCP üzerinden UDP)</string>
     <string name="off">Kapalı</string>
+    <string name="on">Açık</string>
     <string name="out_address">Çıkış</string>
     <string name="out_of_time">Süre doldu</string>
     <string name="paid_until">Şu tarihe kadar ödendi:</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">Bu işlem, yönlendirilen tüm portları silecek. Yerel ayarlar kaydedilecektir.</string>
     <string name="privacy_policy_label">Gizlilik politikası</string>
     <string name="problem_report_description">Size daha etkili bir şekilde yardımcı olmak için uygulamanızın günlük dosyası bu mesaja eklenecektir. Verileriniz şifrelenmiş bir kanal üzerinden gönderilmeden önce anonimleştirildiği için güvenli ve gizli kalacaktır.</string>
+    <string name="quantum_creating_secure_connection">KUANTUM GÜVENLİ BAĞLANTISI OLUŞTURULUYOR</string>
+    <string name="quantum_resistant_info_first_paragaph">Bu özellik, WireGuard tünelini kuantum bilgisayarlardan gelebilecek potansiyel saldırılara karşı dayanıklı hale getirir.</string>
+    <string name="quantum_resistant_info_second_paragaph">Bu işlemi, bir kuantum güvenlik algoritmasıyla ekstra bir anahtar değişimi gerçekleştirdikten sonra sonucu WireGuard\'ın normal şifrelemesiyle karıştırarak yapar. Bu ekstra adım, her yeni tünel kurulduğunda yaklaşık 500 kiB trafik kullanır.</string>
+    <string name="quantum_resistant_title">Kuantuma dayanıklı tünel</string>
+    <string name="quantum_secure_connection">KUANTUM GÜVENLİ BAĞLANTISI</string>
     <string name="reconnecting">Yeniden Bağlanılıyor</string>
     <string name="redeem">Kullan</string>
     <string name="redeem_voucher">Kuponu kullan</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">混淆将 WireGuard 流量隐藏在另一个协议中。它可用于帮助规避审查和其他类型的过滤，在这些过滤中，普通的 WireGuard 连接将被阻止。</string>
     <string name="obfuscation_on_udp_over_tcp">开 (UDP-over-TCP)</string>
     <string name="off">关</string>
+    <string name="on">开</string>
     <string name="out_address">外部</string>
     <string name="out_of_time">已没有时间</string>
     <string name="paid_until">到期时间</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">这将删除所有转发的端口。将保存本地设置。</string>
     <string name="privacy_policy_label">隐私政策</string>
     <string name="problem_report_description">为了更有效地帮助您，您应用的日志文件将被附加到此消息。您的数据将保持安全和私密，因为所有数据在发送之前都将通过加密通道进行匿名处理。</string>
+    <string name="quantum_creating_secure_connection">正在创建量子安全连接</string>
+    <string name="quantum_resistant_info_first_paragaph">借助此功能，WireGuard 隧道能够抵抗可能通过量子计算机发起的攻击。</string>
+    <string name="quantum_resistant_info_second_paragaph">实现方法是使用量子安全算法执行额外的密钥交换，并将结果混合到 WireGuard 的常规加密中。每次建立新隧道时，这一额外步骤都会使用约 500 kiB 的流量。</string>
+    <string name="quantum_resistant_title">抗量子隧道</string>
+    <string name="quantum_secure_connection">量子安全连接</string>
     <string name="reconnecting">正在重新连接</string>
     <string name="redeem">兑换</string>
     <string name="redeem_voucher">兑换优惠券</string>

--- a/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -111,6 +111,7 @@
     <string name="obfuscation_info">藉由混淆，WireGuard 的流量能隱藏在另一個通訊協定中。這有助於規避審查或其他類型的篩選。在這類篩選中，普通 WireGuard 連線將遭到封鎖。</string>
     <string name="obfuscation_on_udp_over_tcp">開 (UDP-over-TCP)</string>
     <string name="off">關閉</string>
+    <string name="on">開啟</string>
     <string name="out_address">出境</string>
     <string name="out_of_time">逾時</string>
     <string name="paid_until">支付至</string>
@@ -118,6 +119,11 @@
     <string name="port_removal_notice">這將刪除所有轉送的連接埠。將儲存本機設定。</string>
     <string name="privacy_policy_label">隱私權政策</string>
     <string name="problem_report_description">為了更有效協助您，會將應用程式的日誌檔將附加到此郵件。您的資料會保持安全和私密性，因為這些資料會先經過匿名處理，再透過加密通道傳送。</string>
+    <string name="quantum_creating_secure_connection">正在建立量子安全連線</string>
+    <string name="quantum_resistant_info_first_paragaph">借助此功能，WireGuard 通道便能夠抵抗可能從量子電腦發起的攻擊。</string>
+    <string name="quantum_resistant_info_second_paragaph">實現方法是使用量子安全演算法執行額外的金鑰交換，並將結果混合至 WireGuard 的常規加密。每次建立新通道時，這一額外步驟都會使用約 500 kiB 流量。</string>
+    <string name="quantum_resistant_title">抗量子通道</string>
+    <string name="quantum_secure_connection">量子安全連線</string>
     <string name="reconnecting">正在重新連線</string>
     <string name="redeem">兌換</string>
     <string name="redeem_voucher">兌換憑證</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -196,4 +196,10 @@
     <string name="created_x">Created: %s</string>
     <string name="local_network_sharing_info">This feature allows access to other devices on the local network, such as for sharing, printing, streaming, etc.</string>
     <string name="local_network_sharing_additional_info">It does this by allowing network communication outside the tunnel to local multicast and broadcast ranges as well as to and from these private IP ranges:</string>
+    <string name="quantum_resistant_title">Quantum-resistant tunnel</string>
+    <string name="quantum_resistant_info_first_paragaph">This feature makes the WireGuard tunnel resistant to potential attacks from quantum computers.</string>
+    <string name="quantum_resistant_info_second_paragaph">It does this by performing an extra key exchange using a quantum safe algorithm and mixing the result into WireGuard’s regular encryption. This extra step uses approximately 500 kiB of traffic every time a new tunnel is established.</string>
+    <string name="on">On</string>
+    <string name="quantum_creating_secure_connection">CREATING QUANTUM SECURE CONNECTION</string>
+    <string name="quantum_secure_connection">QUANTUM SECURE CONNECTION</string>
 </resources>

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelTest.kt
@@ -1,0 +1,95 @@
+package net.mullvad.mullvadvpn.viewmodel
+
+import android.content.res.Resources
+import androidx.lifecycle.viewModelScope
+import app.cash.turbine.test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.assertEquals
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.mullvad.mullvadvpn.TestCoroutineRule
+import net.mullvad.mullvadvpn.model.QuantumResistantState
+import net.mullvad.mullvadvpn.model.Settings
+import net.mullvad.mullvadvpn.model.TunnelOptions
+import net.mullvad.mullvadvpn.model.WireguardTunnelOptions
+import net.mullvad.mullvadvpn.repository.SettingsRepository
+import org.apache.commons.validator.routines.InetAddressValidator
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class VpnSettingsViewModelTest {
+    @get:Rule val testCoroutineRule = TestCoroutineRule()
+
+    private val mockSettingsRepository: SettingsRepository = mockk()
+    private val mockInetAddressValidator: InetAddressValidator = mockk()
+    private val mockResources: Resources = mockk()
+
+    private val mockSettingsUpdate = MutableStateFlow<Settings?>(null)
+
+    private lateinit var viewModel: VpnSettingsViewModel
+
+    @Before
+    fun setUp() {
+        every { mockSettingsRepository.settingsUpdates } returns mockSettingsUpdate
+
+        viewModel =
+            VpnSettingsViewModel(
+                repository = mockSettingsRepository,
+                inetAddressValidator = mockInetAddressValidator,
+                resources = mockResources,
+                dispatcher = UnconfinedTestDispatcher()
+            )
+    }
+
+    @After
+    fun tearDown() {
+        viewModel.viewModelScope.coroutineContext.cancel()
+        unmockkAll()
+    }
+
+    @Test
+    fun test_select_quantum_resistant_state_select() = runTest {
+        val quantumResistantState = QuantumResistantState.On
+        every {
+            mockSettingsRepository.setWireguardQuantumResistant(quantumResistantState)
+        } returns Unit
+        viewModel.onSelectQuantumResistanceSetting(quantumResistantState)
+        verify(exactly = 1) {
+            mockSettingsRepository.setWireguardQuantumResistant(quantumResistantState)
+        }
+    }
+
+    @Test
+    fun test_update_quantum_resistant_default_state() = runTest {
+        val expectedResistantState = QuantumResistantState.Off
+        viewModel.uiState.test {
+            assertEquals(expectedResistantState, awaitItem().quantumResistant)
+        }
+    }
+
+    @Test
+    fun test_update_quantum_resistant_update_state() = runTest {
+        val defaultResistantState = QuantumResistantState.Off
+        val expectedResistantState = QuantumResistantState.On
+        val mockSettings: Settings = mockk(relaxed = true)
+        val mockTunnelOptions: TunnelOptions = mockk(relaxed = true)
+        val mockWireguardTunnelOptions: WireguardTunnelOptions = mockk(relaxed = true)
+
+        every { mockSettings.tunnelOptions } returns mockTunnelOptions
+        every { mockTunnelOptions.wireguard } returns mockWireguardTunnelOptions
+        every { mockWireguardTunnelOptions.quantumResistant } returns expectedResistantState
+
+        viewModel.uiState.test {
+            assertEquals(defaultResistantState, awaitItem().quantumResistant)
+            mockSettingsUpdate.value = mockSettings
+            assertEquals(expectedResistantState, awaitItem().quantumResistant)
+        }
+    }
+}

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModelTest.kt
@@ -57,9 +57,8 @@ class VpnSettingsViewModelTest {
     @Test
     fun test_select_quantum_resistant_state_select() = runTest {
         val quantumResistantState = QuantumResistantState.On
-        every {
-            mockSettingsRepository.setWireguardQuantumResistant(quantumResistantState)
-        } returns Unit
+        every { mockSettingsRepository.setWireguardQuantumResistant(quantumResistantState) } returns
+            Unit
         viewModel.onSelectQuantumResistanceSetting(quantumResistantState)
         verify(exactly = 1) {
             mockSettingsRepository.setWireguardQuantumResistant(quantumResistantState)

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -30,6 +30,7 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/mullvadvpn/model/LocationConstraint$Hostname",
     "net/mullvad/mullvadvpn/model/ObfuscationSettings",
     "net/mullvad/mullvadvpn/model/PublicKey",
+    "net/mullvad/mullvadvpn/model/QuantumResistantState",
     "net/mullvad/mullvadvpn/model/Relay",
     "net/mullvad/mullvadvpn/model/RelayConstraints",
     "net/mullvad/mullvadvpn/model/RelayEndpointData$Bridge",

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -10,6 +10,7 @@ use mullvad_types::{
     states::{TargetState, TunnelState},
     version::AppVersionInfo,
     wireguard,
+    wireguard::QuantumResistantState,
 };
 
 #[derive(Debug, err_derive::Error)]
@@ -320,6 +321,22 @@ impl DaemonInterface {
         let (tx, rx) = oneshot::channel();
 
         self.send_command(DaemonCommand::SetObfuscationSettings(tx, settings))?;
+
+        block_on(rx)
+            .map_err(|_| Error::NoResponse)?
+            .map_err(|_| Error::UpdateSettings)
+    }
+
+    pub fn set_quantum_resistant_tunnel(
+        &self,
+        quantum_resistant: QuantumResistantState,
+    ) -> Result<()> {
+        let (tx, rx) = oneshot::channel();
+
+        self.send_command(DaemonCommand::SetQuantumResistantTunnel(
+            tx,
+            quantum_resistant,
+        ))?;
 
         block_on(rx)
             .map_err(|_| Error::NoResponse)?

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -1238,6 +1238,29 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_setObfu
     }
 }
 
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_setQuantumResistantTunnel(
+    env: JNIEnv<'_>,
+    _: JObject<'_>,
+    daemon_interface_address: jlong,
+    quantumResistantState: JObject<'_>,
+) {
+    let env = JnixEnv::from(env);
+
+    // SAFETY: The address points to an instance valid for the duration of this function call
+    if let Some(daemon_interface) = unsafe { get_daemon_interface(daemon_interface_address) } {
+        let quantum_resistant = FromJava::from_java(&env, quantumResistantState);
+
+        if let Err(error) = daemon_interface.set_quantum_resistant_tunnel(quantum_resistant) {
+            log::error!(
+                "{}",
+                error.display_chain_with_msg("Failed to update quantum resistant tunnel state")
+            );
+        }
+    }
+}
+
 fn log_request_error(request: &str, error: &daemon_interface::Error) {
     match error {
         daemon_interface::Error::Api(RestError::Aborted) => {

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::identity_op)]
 use chrono::{offset::Utc, DateTime};
 #[cfg(target_os = "android")]
-use jnix::IntoJava;
+use jnix::{FromJava, IntoJava};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{convert::TryFrom, fmt, str::FromStr, time::Duration};
 use talpid_types::net::wireguard;
@@ -15,6 +15,8 @@ pub const DEFAULT_ROTATION_INTERVAL: Duration = MAX_ROTATION_INTERVAL;
 const QUANTUM_RESISTANT_AUTO_STATE: bool = false;
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(target_os = "android", derive(IntoJava, FromJava))]
+#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum QuantumResistantState {
@@ -201,14 +203,6 @@ pub struct TunnelOptions {
     #[serde(rename = "wireguard_nt")]
     pub use_wireguard_nt: bool,
     /// Obtain a PSK using the relay config client.
-    #[cfg_attr(
-        target_os = "android",
-        jnix(map = "|state| match state {
-            QuantumResistantState::Auto => None,
-            QuantumResistantState::On => Some(true),
-            QuantumResistantState::Off => Some(false),
-        }")
-    )]
     pub quantum_resistant: QuantumResistantState,
     /// Interval used for automatic key rotation
     #[cfg_attr(target_os = "android", jnix(skip))]


### PR DESCRIPTION
- Show if quantum resistant tunneling is used in connect fragment
- Add Options (Auto, On, Off) for quantum resistant tunneling in VPN Settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4742)
<!-- Reviewable:end -->
