### PR TITLE
Trigger audit check daily and on lockfile changes

### DIFF
--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -2,7 +2,7 @@
 name: Android - Audit dependencies
 on:
   pull_request:
-    paths: [.github/workflows/android-audit.yml, android/**]
+    paths: [.github/workflows/android-audit.yml, android/gradle/verification-metadata.xml]
   workflow_dispatch:
 jobs:
   owasp-dependency-check:

--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: |-
+      - name: Run gradle audit task
+        run: |-
           cd android
           ./gradlew dependencyCheckAnalyze

--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -3,6 +3,13 @@ name: Android - Audit dependencies
 on:
   pull_request:
     paths: [.github/workflows/android-audit.yml, android/gradle/verification-metadata.xml]
+  schedule:
+    # At 06:20 UTC every day.
+    # Notifications for scheduled workflows are sent to the user who last modified the cron
+    # syntax in the workflow file. If you update this you must have notifications for
+    # Github Actions enabled, so these don't go unnoticed.
+    # https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs
+    - cron: '20 6 * * *'
   workflow_dispatch:
 jobs:
   owasp-dependency-check:


### PR DESCRIPTION
This PR aims to change when the gradle owasp audit check runs. Rather than running on any changes in the android sub-tree, it will now trigger daily and on changes to the gradle lockfile.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4754)
<!-- Reviewable:end -->
