### PR TITLE
Add Mullvad VPN typography font styles

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/theme/Type.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/theme/Type.kt
@@ -1,0 +1,33 @@
+package net.mullvad.mullvadvpn.compose.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+internal val MullvadMaterial3Typography =
+    Typography(
+        displayLarge = TextStyle(fontFamily = FontFamily.SansSerif),
+        displayMedium = TextStyle(fontFamily = FontFamily.SansSerif),
+        displaySmall = TextStyle(fontFamily = FontFamily.SansSerif),
+        headlineLarge = TextStyle(fontFamily = FontFamily.SansSerif, fontWeight = FontWeight.Black),
+        headlineMedium = TextStyle(fontFamily = FontFamily.SansSerif),
+        headlineSmall = TextStyle(fontFamily = FontFamily.SansSerif, fontWeight = FontWeight.Black),
+        titleLarge = TextStyle(fontFamily = FontFamily.SansSerif, fontWeight = FontWeight.Black),
+        titleMedium = TextStyle(fontFamily = FontFamily.SansSerif),
+        titleSmall = TextStyle(fontFamily = FontFamily.SansSerif),
+        bodyLarge = TextStyle(fontFamily = FontFamily.SansSerif),
+        bodyMedium = TextStyle(fontFamily = FontFamily.SansSerif, fontWeight = FontWeight.SemiBold),
+        bodySmall = TextStyle(fontFamily = FontFamily.SansSerif, fontWeight = FontWeight.SemiBold),
+        labelLarge =
+            TextStyle(
+                fontFamily = FontFamily.SansSerif,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 18.sp,
+                lineHeight = 23.sp
+            ),
+        labelMedium =
+            TextStyle(fontFamily = FontFamily.SansSerif, fontWeight = FontWeight.SemiBold),
+        labelSmall = TextStyle(fontFamily = FontFamily.SansSerif, fontWeight = FontWeight.SemiBold)
+    )


### PR DESCRIPTION
1. This PR simplifies the handling of typography within the Android code by removing the need for hard coded values such fontsize, fontweight, and fontfamily.
2. It is the start of the collaborative project between me and Jonatan for Hack day!

-----

Note: This **_only_** changes the components within the Android code that uses Material3, and most components within the code uses Material 1 or 2. For instance many imports are of:
`import androidx.compose.material` instead of `import androidx.compose.material3`.

So the typography changes will not affect the former components, they would need to be changed or the theme in `Theme.kt` would need to be changed to `import androidx.compose.material.MaterialTheme` instead of `import androidx.compose.material3.MaterialTheme`. 
However, this might create other issues instead.

----

CatJam out 🎤

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4758)
<!-- Reviewable:end -->
