### PR TITLE
Add socks proxy argument to 'mullvad account login'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add `--help` and `--version` options to the desktop GUI application.
-- Add `mullvad account login --socks5` option to allow logging in via a local SOCKS5 proxy.
+- Add `mullvad account login --socks5` option to allow logging in via a SOCKS5 proxy.
 
 #### Android
 - Add UDP-over-TCP.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add `--help` and `--version` options to the desktop GUI application.
+- Add `mullvad account login --socks5` option to allow logging in via a local SOCKS5 proxy.
 
 #### Android
 - Add UDP-over-TCP.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
  "talpid-types",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
 ]
 
 [[package]]
@@ -3940,6 +3941,18 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -24,6 +24,7 @@ serde = "1"
 serde_json = "1.0"
 tokio = { version = "1.8", features = ["macros", "time", "rt-multi-thread", "net", "io-std", "io-util", "fs"] }
 tokio-rustls = "0.23"
+tokio-socks = "0.5.1"
 rustls-pemfile = "0.2"
 once_cell = "1.13"
 

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -396,6 +396,7 @@ impl AccountsProxy {
                 &format!("{ACCOUNTS_URL_PREFIX}/accounts/me"),
                 Method::GET,
                 Some((access_proxy, account)),
+                None,
                 &[StatusCode::OK],
             )
             .await;
@@ -417,6 +418,7 @@ impl AccountsProxy {
             service,
             &format!("{ACCOUNTS_URL_PREFIX}/accounts"),
             Method::POST,
+            None,
             None,
             &[StatusCode::CREATED],
         );
@@ -450,6 +452,7 @@ impl AccountsProxy {
                 Method::POST,
                 &submission,
                 Some((access_proxy, account_token)),
+                None,
                 &[StatusCode::OK],
             )
             .await;
@@ -477,6 +480,7 @@ impl AccountsProxy {
                 &format!("{APP_URL_PREFIX}/www-auth-token"),
                 Method::POST,
                 Some((access_proxy, account)),
+                None,
                 &[StatusCode::OK],
             )
             .await;
@@ -525,6 +529,7 @@ impl ProblemReportProxy {
             &format!("{APP_URL_PREFIX}/problem-report"),
             Method::POST,
             &report,
+            None,
             None,
             &[StatusCode::NO_CONTENT],
         );
@@ -604,6 +609,7 @@ impl ApiProxy {
             service,
             &format!("{APP_URL_PREFIX}/api-addrs"),
             Method::GET,
+            None,
             None,
             &[StatusCode::OK],
         )

--- a/mullvad-api/src/proxy.rs
+++ b/mullvad-api/src/proxy.rs
@@ -1,5 +1,6 @@
 use futures::Stream;
 use hyper::client::connect::Connected;
+use mullvad_types::api::RpcProxySettings;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt, io,
@@ -22,6 +23,16 @@ pub enum ApiConnectionMode {
     Direct,
     /// Connect to the destination via a proxy.
     Proxied(ProxyConfig),
+}
+
+impl From<RpcProxySettings> for ApiConnectionMode {
+    fn from(value: RpcProxySettings) -> Self {
+        match value {
+            RpcProxySettings::LocalSocks5Settings(settings) => {
+                ApiConnectionMode::Proxied(ProxyConfig::LocalSocks(settings.port))
+            }
+        }
+    }
 }
 
 impl fmt::Display for ApiConnectionMode {

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -185,7 +185,7 @@ impl<
                 let tx = self.command_tx.upgrade();
                 let timeout = request.timeout();
 
-                let hyper_request = request.into_request();
+                let hyper_request = request.into_hyper_request();
 
                 let api_availability = self.api_availability.clone();
                 let suspend_fut = api_availability.wait_for_unsuspend();
@@ -355,7 +355,7 @@ impl RestRequest {
     }
 
     /// Converts into a `hyper::Request<hyper::Body>`
-    fn into_request(self) -> Request {
+    fn into_hyper_request(self) -> Request {
         let Self {
             mut request, auth, ..
         } = self;

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -570,6 +570,7 @@ pub fn send_request(
     uri: &str,
     method: Method,
     auth: Option<(AccessTokenProxy, AccountToken)>,
+    connection_mode_override: Option<ApiConnectionMode>,
     expected_statuses: &'static [hyper::StatusCode],
 ) -> impl Future<Output = Result<Response>> {
     let request = factory.request(uri, method);
@@ -580,6 +581,8 @@ pub fn send_request(
             let access_token = store.get_token(account).await?;
             request.set_auth(Some(access_token))?;
         }
+        request.set_connection_mode(connection_mode_override);
+
         let response = service.request(request).await?;
         let result = parse_rest_response(response, expected_statuses).await;
 
@@ -598,6 +601,7 @@ pub fn send_json_request<B: serde::Serialize>(
     method: Method,
     body: &B,
     auth: Option<(AccessTokenProxy, AccountToken)>,
+    connection_mode_override: Option<ApiConnectionMode>,
     expected_statuses: &'static [hyper::StatusCode],
 ) -> impl Future<Output = Result<Response>> {
     let request = factory.json_request(method, uri, body);
@@ -607,6 +611,8 @@ pub fn send_json_request<B: serde::Serialize>(
             let access_token = store.get_token(account).await?;
             request.set_auth(Some(access_token))?;
         }
+        request.set_connection_mode(connection_mode_override);
+
         let response = service.request(request).await?;
         let result = parse_rest_response(response, expected_statuses).await;
 

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -4,10 +4,13 @@ use itertools::Itertools;
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::{
     account::AccountToken,
-    api::{LocalSocks5Settings, RpcProxySettings},
+    api::{RpcProxySettings, Socks5Settings},
     device::DeviceState,
 };
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    net::SocketAddr,
+};
 
 const NOT_LOGGED_IN_MESSAGE: &str = "Not logged in on any account";
 const REVOKED_MESSAGE: &str = "The current device has been revoked";
@@ -21,9 +24,9 @@ pub enum Account {
     Login {
         /// The Mullvad account token to configure the client with
         account: Option<String>,
-        /// Connect using a SOCKS5 proxy running on the specified port on localhost
+        /// Connect using a SOCKS5 proxy on the specified address
         #[arg(long)]
-        socks5: Option<u16>,
+        socks5: Option<SocketAddr>,
     },
 
     /// Log out of the current account
@@ -98,12 +101,10 @@ impl Account {
     async fn login(
         rpc: &mut MullvadProxyClient,
         token: AccountToken,
-        socks5_port: Option<u16>,
+        socks5_addr: Option<SocketAddr>,
     ) -> Result<()> {
-        let proxy_settings = match socks5_port {
-            Some(port) => Some(RpcProxySettings::LocalSocks5Settings(LocalSocks5Settings {
-                port,
-            })),
+        let proxy_settings = match socks5_addr {
+            Some(address) => Some(RpcProxySettings::Socks5(Socks5Settings { address })),
             None => None,
         };
 

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -12,6 +12,7 @@ use talpid_types::net::wireguard::PrivateKey;
 use super::{Error, PrivateAccountAndDevice, PrivateDevice};
 use mullvad_api::{
     availability::ApiAvailabilityHandle,
+    proxy::ApiConnectionMode,
     rest::{self, Error as RestError, MullvadRestHandle},
     AccountsProxy, DevicesProxy,
 };
@@ -37,6 +38,10 @@ impl DeviceService {
             proxy: DevicesProxy::new(handle),
             api_availability,
         }
+    }
+
+    pub fn set_connection_mode(&mut self, mode: Option<ApiConnectionMode>) {
+        self.proxy.set_connection_mode(mode);
     }
 
     /// Generate a new device for a given token

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -195,7 +195,7 @@ impl DaemonInterface {
     pub fn login_account(&self, account_token: String) -> Result<()> {
         let (tx, rx) = oneshot::channel();
 
-        self.send_command(DaemonCommand::LoginAccount(tx, account_token))?;
+        self.send_command(DaemonCommand::LoginAccount(tx, account_token, None))?;
 
         block_on(rx)
             .map_err(|_| Error::NoResponse)?

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -49,6 +49,7 @@ service ManagementService {
   // Account management
   rpc CreateNewAccount(google.protobuf.Empty) returns (google.protobuf.StringValue) {}
   rpc LoginAccount(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
+  rpc LoginAccountV2(LoginRequest) returns (google.protobuf.Empty) {}
   rpc LogoutAccount(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc GetAccountData(google.protobuf.StringValue) returns (AccountData) {}
   rpc GetAccountHistory(google.protobuf.Empty) returns (AccountHistory) {}
@@ -86,6 +87,21 @@ service ManagementService {
   // Notify the split tunnel monitor that a volume was mounted or dismounted
   // (Windows).
   rpc CheckVolumes(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}
+
+message LoginRequest {
+  string account_token = 1;
+  RpcProxySettings proxy_settings = 2;
+}
+
+message RpcProxySettings {
+  oneof Type {
+    LocalSocks5Settings local_socks5 = 1;
+  }
+}
+
+message LocalSocks5Settings {
+  uint32 port = 1;
 }
 
 message RelaySettingsUpdate {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -96,12 +96,12 @@ message LoginRequest {
 
 message RpcProxySettings {
   oneof Type {
-    LocalSocks5Settings local_socks5 = 1;
+    Socks5Settings socks5 = 1;
   }
 }
 
-message LocalSocks5Settings {
-  uint32 port = 1;
+message Socks5Settings {
+  string proxy_endpoint = 1;
 }
 
 message RelaySettingsUpdate {

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -4,6 +4,7 @@ use crate::types;
 use futures::{Stream, StreamExt};
 use mullvad_types::{
     account::{AccountData, AccountToken, VoucherSubmission},
+    api::RpcProxySettings,
     device::{Device, DeviceEvent, DeviceId, DeviceState, RemoveDeviceEvent},
     location::GeoIpLocation,
     relay_constraints::{BridgeSettings, BridgeState, ObfuscationSettings, RelaySettingsUpdate},
@@ -296,9 +297,17 @@ impl MullvadProxyClient {
             .into_inner())
     }
 
-    pub async fn login_account(&mut self, account: AccountToken) -> Result<()> {
+    pub async fn login_account(
+        &mut self,
+        account: AccountToken,
+        proxy_settings: Option<RpcProxySettings>,
+    ) -> Result<()> {
+        let login_request = types::LoginRequest {
+            account_token: account,
+            proxy_settings: proxy_settings.map(types::RpcProxySettings::from),
+        };
         self.0
-            .login_account(account)
+            .login_account_v2(login_request)
             .await
             .map_err(map_device_error)?;
         Ok(())

--- a/mullvad-management-interface/src/types/conversions/api.rs
+++ b/mullvad-management-interface/src/types/conversions/api.rs
@@ -4,15 +4,13 @@ use crate::types::proto;
 impl From<mullvad_types::api::RpcProxySettings> for proto::RpcProxySettings {
     fn from(settings: mullvad_types::api::RpcProxySettings) -> Self {
         match settings {
-            mullvad_types::api::RpcProxySettings::LocalSocks5Settings(port) => {
-                proto::RpcProxySettings {
-                    r#type: Some(proto::rpc_proxy_settings::Type::LocalSocks5(
-                        proto::LocalSocks5Settings {
-                            port: u32::from(port.port),
-                        },
-                    )),
-                }
-            }
+            mullvad_types::api::RpcProxySettings::Socks5(socks5) => proto::RpcProxySettings {
+                r#type: Some(proto::rpc_proxy_settings::Type::Socks5(
+                    proto::Socks5Settings {
+                        proxy_endpoint: socks5.address.to_string(),
+                    },
+                )),
+            },
         }
     }
 }
@@ -22,14 +20,14 @@ impl TryFrom<proto::RpcProxySettings> for mullvad_types::api::RpcProxySettings {
 
     fn try_from(settings: proto::RpcProxySettings) -> Result<Self, Self::Error> {
         match settings.r#type {
-            Some(proto::rpc_proxy_settings::Type::LocalSocks5(socks5)) => {
-                Ok(mullvad_types::api::RpcProxySettings::LocalSocks5Settings(
-                    mullvad_types::api::LocalSocks5Settings {
-                        port: u16::try_from(socks5.port)
-                            .map_err(|_| FromProtobufTypeError::InvalidArgument("invalid port"))?,
-                    },
-                ))
-            }
+            Some(proto::rpc_proxy_settings::Type::Socks5(socks5)) => Ok(
+                mullvad_types::api::RpcProxySettings::Socks5(mullvad_types::api::Socks5Settings {
+                    address: socks5
+                        .proxy_endpoint
+                        .parse()
+                        .map_err(|_| FromProtobufTypeError::InvalidArgument("invalid endpoint"))?,
+                }),
+            ),
             _ => Err(FromProtobufTypeError::InvalidArgument("invalid proxy type")),
         }
     }

--- a/mullvad-management-interface/src/types/conversions/api.rs
+++ b/mullvad-management-interface/src/types/conversions/api.rs
@@ -1,0 +1,36 @@
+use super::FromProtobufTypeError;
+use crate::types::proto;
+
+impl From<mullvad_types::api::RpcProxySettings> for proto::RpcProxySettings {
+    fn from(settings: mullvad_types::api::RpcProxySettings) -> Self {
+        match settings {
+            mullvad_types::api::RpcProxySettings::LocalSocks5Settings(port) => {
+                proto::RpcProxySettings {
+                    r#type: Some(proto::rpc_proxy_settings::Type::LocalSocks5(
+                        proto::LocalSocks5Settings {
+                            port: u32::from(port.port),
+                        },
+                    )),
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<proto::RpcProxySettings> for mullvad_types::api::RpcProxySettings {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(settings: proto::RpcProxySettings) -> Result<Self, Self::Error> {
+        match settings.r#type {
+            Some(proto::rpc_proxy_settings::Type::LocalSocks5(socks5)) => {
+                Ok(mullvad_types::api::RpcProxySettings::LocalSocks5Settings(
+                    mullvad_types::api::LocalSocks5Settings {
+                        port: u16::try_from(socks5.port)
+                            .map_err(|_| FromProtobufTypeError::InvalidArgument("invalid port"))?,
+                    },
+                ))
+            }
+            _ => Err(FromProtobufTypeError::InvalidArgument("invalid proxy type")),
+        }
+    }
+}

--- a/mullvad-management-interface/src/types/conversions/mod.rs
+++ b/mullvad-management-interface/src/types/conversions/mod.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 mod account;
+mod api;
 mod custom_tunnel;
 mod device;
 mod location;

--- a/mullvad-types/src/api.rs
+++ b/mullvad-types/src/api.rs
@@ -1,9 +1,11 @@
+use std::net::SocketAddr;
+
 #[derive(Debug, Clone)]
 pub enum RpcProxySettings {
-    LocalSocks5Settings(LocalSocks5Settings),
+    Socks5(Socks5Settings),
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct LocalSocks5Settings {
-    pub port: u16,
+pub struct Socks5Settings {
+    pub address: SocketAddr,
 }

--- a/mullvad-types/src/api.rs
+++ b/mullvad-types/src/api.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone)]
+pub enum RpcProxySettings {
+    LocalSocks5Settings(LocalSocks5Settings),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LocalSocks5Settings {
+    pub port: u16,
+}

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms)]
 
 pub mod account;
+pub mod api;
 pub mod auth_failed;
 pub mod device;
 pub mod endpoint;


### PR DESCRIPTION
This PR adds a SOCKS5 proxy option to the REST client. It lets you to set a override the proxy when generating a device, e.g. `mullvad account login --socks5 127.0.0.1:1234`.

This can be useful when the API is blocked and not reachable from any of the bridges or where Shadowsocks is blocked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4760)
<!-- Reviewable:end -->
