### PR TITLE
Upgrade trust-dns-server to avoid RUSTSEC-2023-0041

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4219,9 +4219,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-server"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cf9f8a359c9f16fdf760b79cb2be3f261b98db8027f81959c7a4f6645e2c"
+checksum = "99022f9befa6daec2a860be68ac28b1f0d9d7ccf441d8c5a695e35a58d88840d"
 dependencies = [
  "async-trait",
  "bytes",


### PR DESCRIPTION
Just upgrading the dependency to fix [RUSTSEC-2023-0041](https://rustsec.org/advisories/RUSTSEC-2023-0041). I don't think this could have affected our users to any serious degree, so not going to mention in the changelog unless there is good reason to. Our DNS resolver should only be accessible on localhost anyway. So worst case a local program could have DoSed the local machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4761)
<!-- Reviewable:end -->
