### PR TITLE
Investigate CI issue where it complains that folded commit is unsigned

### DIFF
--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -30,4 +30,5 @@ jobs:
           base_ref=${{ github.event.pull_request.base.sha }}
           head_ref=${{ github.event.pull_request.head.sha }}
           git fetch --no-recurse-submodules --shallow-exclude=main origin main $base_ref $head_ref
+          git fetch --deepen=1
           ci/verify-locked-down-signatures.sh --import-gpg-keys --whitelist origin/main

--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -67,7 +67,7 @@ for locked_path in $locked_down_paths; do
         "$REPO_DIR/$locked_path" | awk '{print $1}')
 
     for commit in $locked_path_commit_hashes; do
-        echo -e "\tin $commit.."
+        echo -e "\tfound a change in $commit.."
         if ! git verify-commit "$commit" 2> /dev/null; then
             echo "Commit $commit which changed $locked_path is not signed."
             unsigned_commits_exist=1


### PR DESCRIPTION
The locked-down CI script will complain that a single commit modifies a bunch of locked down files at the same time. The commit it complains about isn't responsible for modifying these and it likely has to do with there being a folded commit for the entire git history.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4766)
<!-- Reviewable:end -->
