### PR TITLE
Improve UX of CLI when tries to connect while not logged in

### DIFF
--- a/mullvad-cli/src/cmds/tunnel_state.rs
+++ b/mullvad-cli/src/cmds/tunnel_state.rs
@@ -2,10 +2,14 @@ use crate::format;
 use anyhow::{anyhow, Result};
 use futures::{Stream, StreamExt};
 use mullvad_management_interface::{client::DaemonEvent, MullvadProxyClient};
+use mullvad_types::device::DeviceState;
 use mullvad_types::states::TunnelState;
 
 pub async fn connect(wait: bool) -> Result<()> {
     let mut rpc = MullvadProxyClient::new().await?;
+
+    let device_state = rpc.get_device().await?;
+    print_account_loggedout(&device_state);
 
     let listener = if wait {
         Some(rpc.events_listen().await?)
@@ -48,6 +52,9 @@ pub async fn disconnect(wait: bool) -> Result<()> {
 pub async fn reconnect(wait: bool) -> Result<()> {
     let mut rpc = MullvadProxyClient::new().await?;
 
+    let device_state = rpc.get_device().await?;
+    print_account_loggedout(&device_state);
+
     let listener = if wait {
         Some(rpc.events_listen().await?)
     } else {
@@ -82,4 +89,28 @@ async fn wait_for_tunnel_state(
         }
     }
     Err(anyhow!("Failed to wait for expected tunnel state"))
+}
+
+/// Checks the if the user is logged in. If not, we print a warning to get their
+/// attention.
+///
+/// When using the CLI, the user could potentially end up in a situation where
+/// they try to connect to a Mullvad relay without having successfully logged in
+/// to their account. In this case, we at least want to issue a warning to guide
+/// the user when they inevitably will go troubleshooting.
+fn print_account_loggedout(state: &DeviceState) {
+    match state {
+        DeviceState::LoggedOut => println!("Warning: You are not logged in to an account."),
+        DeviceState::Revoked => println!("Warning: This device has been revoked"),
+        DeviceState::LoggedIn(_) => return, // Normal case, do nothing.
+    };
+
+    println!(
+        "Mullvad is blocking all network traffic until you perform one of the following actions:
+
+1. Login to a Mullvad account with available time/credits.
+2. Disconnect from Mullvad VPN. This can either be done from the CLI or the Mullvad App.
+
+For more information, try 'mullvad account -h' or 'mullvad disconnect -h'"
+    );
 }


### PR DESCRIPTION
If the user is *not* logged in to an active account, we will from now on issue a warning if they try to connect to a relay using `mullvad-cli`. Intention is to improve upon the feedback in https://github.com/mullvad/mullvadvpn-app/issues/1112.

Previously, we would start blocking all internet traffic. This is well and good. The issue is that this happened silently, so the user would be unaware about the current status of their connection without running further CLI commands or checking the GUI. We might as well try to help the user if they run into this frustrating edge case.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4767)
<!-- Reviewable:end -->
