### PR TITLE
Support wayland on GNOME and KDE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add creation date below device name in the device list screen.
 - Add quantum resistant tunneling.
 
+#### Linux
+- Add wayland support on KDE and GNOME.
+
 ### Changed
 - In the CLI, update the `tunnel` subcommand to resemble `relay` more. For example, by adding a
   unified `mullvad tunnel get` command and removing individual `get` subcommands like

--- a/dist-assets/linux/mullvad-gui-launcher.sh
+++ b/dist-assets/linux/mullvad-gui-launcher.sh
@@ -8,7 +8,7 @@ else
     SANDBOX_FLAG=""
 fi
 
-SUPPORTED_COMPOSITORS="sway river Hyprland"
+SUPPORTED_COMPOSITORS="sway river Hyprland KDE GNOME"
 if [ "${XDG_SESSION_TYPE:-""}"  = "wayland" ] && \
     echo " $SUPPORTED_COMPOSITORS " | \
     grep -qi -e " ${XDG_CURRENT_DESKTOP:-""} " -e " ${XDG_SESSION_DESKTOP:-""} "


### PR DESCRIPTION
This PR adds KDE and GNOME to the list of Wayland compatible compositors, it should resolve issue #3062 for the majority of users.

I have mostly tested it on KDE (Arch Linux, plasma 5.27.5), but it was fine for the small amount of testing I did on GNOME (Arch Linux, gnome 44).
