### PR TITLE
Add custom deserialiser for RelayConstraints

### DIFF
--- a/ios/MullvadTypes/RelayConstraints.swift
+++ b/ios/MullvadTypes/RelayConstraints.swift
@@ -10,6 +10,8 @@ import Foundation
 
 public struct RelayConstraints: Codable, Equatable, CustomDebugStringConvertible {
     public var location: RelayConstraint<RelayLocation>
+
+    // Added in 2023.3
     public var port: RelayConstraint<UInt16>
 
     public var debugDescription: String {
@@ -22,5 +24,13 @@ public struct RelayConstraints: Codable, Equatable, CustomDebugStringConvertible
     ) {
         self.location = location
         self.port = port
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        location = try container.decode(RelayConstraint<RelayLocation>.self, forKey: .location)
+
+        // Added in 2023.3
+        port = try container.decodeIfPresent(RelayConstraint<UInt16>.self, forKey: .port) ?? .any
     }
 }


### PR DESCRIPTION
The addition of port field broke backward compatibility with the existing serialized data. A custom `init(from decoder: Decoder) throws` is implemented to handle that.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4773)
<!-- Reviewable:end -->
