### PR TITLE
Formalize application targets IOS-194

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -251,6 +251,8 @@
 		58C3A4B222456F1B00340BDB /* AccountInputGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3A4B122456F1A00340BDB /* AccountInputGroupView.swift */; };
 		58C3F4F92964B08300D72515 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3F4F82964B08300D72515 /* MapViewController.swift */; };
 		58C3F4FB296C3AD500D72515 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3F4FA296C3AD500D72515 /* SettingsCoordinator.swift */; };
+		58C76A082A33850E00100D75 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
+		58C76A092A33850E00100D75 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
 		58C774BE29A7A249003A1A56 /* CustomNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C774BD29A7A249003A1A56 /* CustomNavigationController.swift */; };
 		58C8191829FAA2C400DEB1B4 /* NotificationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C8191729FAA2C400DEB1B4 /* NotificationConfiguration.swift */; };
 		58CAF9F82983D36800BE19F7 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CAF9F72983D36800BE19F7 /* Coordinator.swift */; };
@@ -1017,6 +1019,7 @@
 		58C3A4B122456F1A00340BDB /* AccountInputGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInputGroupView.swift; sourceTree = "<group>"; };
 		58C3F4F82964B08300D72515 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		58C3F4FA296C3AD500D72515 /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
+		58C76A072A33850E00100D75 /* ApplicationTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTarget.swift; sourceTree = "<group>"; };
 		58C774BD29A7A249003A1A56 /* CustomNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationController.swift; sourceTree = "<group>"; };
 		58C8191729FAA2C400DEB1B4 /* NotificationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfiguration.swift; sourceTree = "<group>"; };
 		58CAF9F72983D36800BE19F7 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -1829,6 +1832,7 @@
 			isa = PBXGroup;
 			children = (
 				58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */,
+				58C76A072A33850E00100D75 /* ApplicationTarget.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -2965,6 +2969,7 @@
 				5893C6FC29C311E9009090D1 /* ApplicationRouter.swift in Sources */,
 				58E25F812837BBBB002CFB2C /* SceneDelegate.swift in Sources */,
 				5867771629097C5B006F721F /* ProductState.swift in Sources */,
+				58C76A082A33850E00100D75 /* ApplicationTarget.swift in Sources */,
 				F07BF2622A26279100042943 /* RedeemVoucherOperation.swift in Sources */,
 				585E820327F3285E00939F0E /* SendStoreReceiptOperation.swift in Sources */,
 				5820676426E771DB00655B05 /* TunnelManagerErrors.swift in Sources */,
@@ -3086,6 +3091,7 @@
 				58E0729F28814ACC008902F8 /* WireGuardLogLevel+Logging.swift in Sources */,
 				580F8B8428197884002E0998 /* TunnelSettingsV2.swift in Sources */,
 				06410E08292D117800AFC18C /* SettingsStore.swift in Sources */,
+				58C76A092A33850E00100D75 /* ApplicationTarget.swift in Sources */,
 				583D86482A2678DC0060D63B /* DeviceStateAccessor.swift in Sources */,
 				58906DE02445C7A5002F0673 /* NEProviderStopReason+Debug.swift in Sources */,
 				068CE57229278F6D00A068BB /* MigrationFromV1ToV2.swift in Sources */,

--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>ApplicationSecurityGroupIdentifier</key>
 	<string>$(SECURITY_GROUP_IDENTIFIER)</string>
+	<key>MainApplicationIdentifier</key>
+	<string>$(APPLICATION_IDENTIFIER)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>net.mullvad.MullvadVPN.AppRefresh</string>

--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -121,8 +121,7 @@ class StartTunnelOperation: ResultOperation<Void> {
 
     private class func makeTunnelConfiguration() -> TunnelConfiguration {
         let protocolConfig = NETunnelProviderProtocol()
-        protocolConfig.providerBundleIdentifier = ApplicationConfiguration
-            .packetTunnelExtensionIdentifier
+        protocolConfig.providerBundleIdentifier = ApplicationTarget.packetTunnel.bundleIdentifier
         protocolConfig.serverAddress = ""
 
         let alwaysOnRule = NEOnDemandRuleConnect()

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
@@ -27,7 +27,9 @@ final class ProblemReportInteractor {
             redactContainerPathsForSecurityGroupIdentifiers: [securityGroupIdentifier]
         )
 
-        report.addLogFiles(fileURLs: ApplicationConfiguration.logFileURLs, includeLogBackups: true)
+        let logFileURLs = ApplicationTarget.allCases.map { ApplicationConfiguration.logFileURL(for: $0) }
+
+        report.addLogFiles(fileURLs: logFileURLs, includeLogBackups: true)
 
         return report
     }()

--- a/ios/PacketTunnel/Info.plist
+++ b/ios/PacketTunnel/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>ApplicationSecurityGroupIdentifier</key>
 	<string>$(SECURITY_GROUP_IDENTIFIER)</string>
+	<key>MainApplicationIdentifier</key>
+	<string>$(APPLICATION_IDENTIFIER)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -125,31 +125,18 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
 
     override init() {
         var loggerBuilder = LoggerBuilder()
-
         let pid = ProcessInfo.processInfo.processIdentifier
         loggerBuilder.metadata["pid"] = .string("\(pid)")
-
-        let bundleIdentifier = Bundle.main.bundleIdentifier!
-
-        try? loggerBuilder.addFileOutput(
-            securityGroupIdentifier: ApplicationConfiguration.securityGroupIdentifier,
-            basename: bundleIdentifier
-        )
-
+        loggerBuilder.addFileOutput(fileURL: ApplicationConfiguration.logFileURL(for: .packetTunnel))
         #if DEBUG
-        loggerBuilder.addOSLogOutput(subsystem: bundleIdentifier)
+        loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.packetTunnel.bundleIdentifier)
         #endif
-
         loggerBuilder.install()
 
         providerLogger = Logger(label: "PacketTunnelProvider")
         tunnelLogger = Logger(label: "WireGuard")
 
-        let containerURL = FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: ApplicationConfiguration.securityGroupIdentifier)!
-        let addressCache = REST.AddressCache(
-            canWriteToCache: false, cacheFolder: containerURL
-        )
+        let addressCache = REST.AddressCache(canWriteToCache: false, cacheFolder: ApplicationConfiguration.containerURL)
 
         let urlSession = REST.makeURLSession()
         let urlSessionTransport = URLSessionTransport(urlSession: urlSession)

--- a/ios/Shared/ApplicationConfiguration.swift
+++ b/ios/Shared/ApplicationConfiguration.swift
@@ -9,46 +9,20 @@
 import Foundation
 import struct Network.IPv4Address
 
-class ApplicationConfiguration {
+enum ApplicationConfiguration {
     /// Shared container security group identifier.
     static var securityGroupIdentifier: String {
-        let securityGroupIdentifier = Bundle(for: Self.self)
-            .object(forInfoDictionaryKey: "ApplicationSecurityGroupIdentifier") as? String
-        return securityGroupIdentifier!
+        return Bundle.main.object(forInfoDictionaryKey: "ApplicationSecurityGroupIdentifier") as! String
     }
 
-    /// The application identifier for packet tunnel extension.
-    static var packetTunnelExtensionIdentifier: String {
-        let mainBundleIdentifier = Bundle.main.bundleIdentifier!
-
-        return "\(mainBundleIdentifier).PacketTunnel"
+    /// Container URL for security group.
+    static var containerURL: URL {
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: securityGroupIdentifier)!
     }
 
-    /// Container URL for security group
-    static var containerURL: URL? {
-        return FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: Self.securityGroupIdentifier)
-    }
-
-    /// The main application log file located in a shared container
-    static var mainApplicationLogFileURL: URL? {
-        return Self.containerURL?.appendingPathComponent(
-            "Logs/net.mullvad.MullvadVPN.log",
-            isDirectory: false
-        )
-    }
-
-    /// The packet tunnel log file located in a shared container
-    static var packetTunnelLogFileURL: URL? {
-        return Self.containerURL?.appendingPathComponent(
-            "Logs/net.mullvad.MullvadVPN.PacketTunnel.log",
-            isDirectory: false
-        )
-    }
-
-    /// All log files located in a shared container
-    static var logFileURLs: [URL] {
-        return [mainApplicationLogFileURL, packetTunnelLogFileURL].compactMap { $0 }
+    /// Returns URL for log file associated with application target and located within shared container.
+    static func logFileURL(for target: ApplicationTarget) -> URL {
+        return containerURL.appendingPathComponent("\(target.bundleIdentifier).log", isDirectory: false)
     }
 
     /// Privacy policy URL.
@@ -68,6 +42,4 @@ class ApplicationConfiguration {
 
     /// API address background task identifier
     static let addressCacheUpdateTaskIdentifier = "net.mullvad.MullvadVPN.AddressCacheUpdate"
-
-    private init() {}
 }

--- a/ios/Shared/ApplicationTarget.swift
+++ b/ios/Shared/ApplicationTarget.swift
@@ -1,0 +1,24 @@
+//
+//  ApplicationTarget.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 09/06/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+enum ApplicationTarget: CaseIterable {
+    case mainApp, packetTunnel
+
+    /// Returns target bundle identifier.
+    var bundleIdentifier: String {
+        let mainBundleIdentifier = Bundle.main.object(forInfoDictionaryKey: "MainApplicationIdentifier") as! String
+        switch self {
+        case .mainApp:
+            return mainBundleIdentifier
+        case .packetTunnel:
+            return "\(mainBundleIdentifier).PacketTunnel"
+        }
+    }
+}


### PR DESCRIPTION
1. Add `ApplicationTarget` that can be used to query bundle identifier or log file `URL` (via `ApplicationConfiguration`)
2. Store main bundle identifier in `Info.plist`s under `MainApplicationIdentifier` key to be able to access main bundle identifier without making additional assumptions. Note that `Bundle.main` within packet tunnel points to the packet tunnel's bundle and not the UIKit app bundle.
3. Access shared container URL via `ApplicationConfiguration.containerURL` instead of `FileManager` in code where it's strictly not necessary to do so in any other way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4779)
<!-- Reviewable:end -->
