### PR TITLE
Formalize background tasks IOS-195

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		58C3F4FB296C3AD500D72515 /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3F4FA296C3AD500D72515 /* SettingsCoordinator.swift */; };
 		58C76A082A33850E00100D75 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
 		58C76A092A33850E00100D75 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
+		58C76A0B2A338E4300100D75 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A0A2A338E4300100D75 /* BackgroundTask.swift */; };
 		58C774BE29A7A249003A1A56 /* CustomNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C774BD29A7A249003A1A56 /* CustomNavigationController.swift */; };
 		58C8191829FAA2C400DEB1B4 /* NotificationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C8191729FAA2C400DEB1B4 /* NotificationConfiguration.swift */; };
 		58CAF9F82983D36800BE19F7 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CAF9F72983D36800BE19F7 /* Coordinator.swift */; };
@@ -1020,6 +1021,7 @@
 		58C3F4F82964B08300D72515 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		58C3F4FA296C3AD500D72515 /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		58C76A072A33850E00100D75 /* ApplicationTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTarget.swift; sourceTree = "<group>"; };
+		58C76A0A2A338E4300100D75 /* BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.swift; sourceTree = "<group>"; };
 		58C774BD29A7A249003A1A56 /* CustomNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationController.swift; sourceTree = "<group>"; };
 		58C8191729FAA2C400DEB1B4 /* NotificationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfiguration.swift; sourceTree = "<group>"; };
 		58CAF9F72983D36800BE19F7 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -1971,6 +1973,7 @@
 			isa = PBXGroup;
 			children = (
 				58CE5E63224146200008646E /* AppDelegate.swift */,
+				58C76A0A2A338E4300100D75 /* BackgroundTask.swift */,
 				58E25F802837BBBB002CFB2C /* SceneDelegate.swift */,
 				583FE02829C1B079006E85F9 /* Classes */,
 				5864AF0629C78816005B0CD9 /* Protocols */,
@@ -2871,6 +2874,7 @@
 				58BFA5CC22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */,
 				5891BF5125E66B1E006D6FB0 /* UIBarButtonItem+KeyboardNavigation.swift in Sources */,
 				58E511E628DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift in Sources */,
+				58C76A0B2A338E4300100D75 /* BackgroundTask.swift in Sources */,
 				5864859B29A0EAF2006C5743 /* SecondaryContextPresentationController.swift in Sources */,
 				5864AF0729C78843005B0CD9 /* SettingsCellFactory.swift in Sources */,
 				587B75412668FD7800DEF7E9 /* AccountExpirySystemNotificationProvider.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -168,7 +168,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func registerAppRefreshTask() {
         let isRegistered = BGTaskScheduler.shared.register(
-            forTaskWithIdentifier: ApplicationConfiguration.appRefreshTaskIdentifier,
+            forTaskWithIdentifier: BackgroundTask.appRefresh.identifier,
             using: nil
         ) { [self] task in
             let handle = relayCacheTracker.updateRelays { result in
@@ -191,7 +191,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func registerKeyRotationTask() {
         let isRegistered = BGTaskScheduler.shared.register(
-            forTaskWithIdentifier: ApplicationConfiguration.privateKeyRotationTaskIdentifier,
+            forTaskWithIdentifier: BackgroundTask.privateKeyRotation.identifier,
             using: nil
         ) { [self] task in
             let handle = tunnelManager.rotatePrivateKey { [self] error in
@@ -214,7 +214,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func registerAddressCacheUpdateTask() {
         let isRegistered = BGTaskScheduler.shared.register(
-            forTaskWithIdentifier: ApplicationConfiguration.addressCacheUpdateTaskIdentifier,
+            forTaskWithIdentifier: BackgroundTask.addressCacheUpdate.identifier,
             using: nil
         ) { [self] task in
             let handle = addressCacheTracker.updateEndpoints { [self] result in
@@ -245,19 +245,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         do {
             let date = relayCacheTracker.getNextUpdateDate()
 
-            let request = BGAppRefreshTaskRequest(
-                identifier: ApplicationConfiguration.appRefreshTaskIdentifier
-            )
+            let request = BGAppRefreshTaskRequest(identifier: BackgroundTask.appRefresh.identifier)
             request.earliestBeginDate = date
 
             logger.debug("Schedule app refresh task at \(date.logFormatDate()).")
 
             try BGTaskScheduler.shared.submit(request)
         } catch {
-            logger.error(
-                error: error,
-                message: "Could not schedule app refresh task."
-            )
+            logger.error(error: error, message: "Could not schedule app refresh task.")
         }
     }
 
@@ -267,9 +262,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 return
             }
 
-            let request = BGProcessingTaskRequest(
-                identifier: ApplicationConfiguration.privateKeyRotationTaskIdentifier
-            )
+            let request = BGProcessingTaskRequest(identifier: BackgroundTask.privateKeyRotation.identifier)
             request.requiresNetworkConnectivity = true
             request.earliestBeginDate = date
 
@@ -277,10 +270,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
             try BGTaskScheduler.shared.submit(request)
         } catch {
-            logger.error(
-                error: error,
-                message: "Could not schedule private key rotation task."
-            )
+            logger.error(error: error, message: "Could not schedule private key rotation task.")
         }
     }
 
@@ -288,9 +278,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         do {
             let date = addressCacheTracker.nextScheduleDate()
 
-            let request = BGProcessingTaskRequest(
-                identifier: ApplicationConfiguration.addressCacheUpdateTaskIdentifier
-            )
+            let request = BGProcessingTaskRequest(identifier: BackgroundTask.addressCacheUpdate.identifier)
             request.requiresNetworkConnectivity = true
             request.earliestBeginDate = date
 
@@ -298,10 +286,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
             try BGTaskScheduler.shared.submit(request)
         } catch {
-            logger.error(
-                error: error,
-                message: "Could not schedule address cache update task."
-            )
+            logger.error(error: error, message: "Could not schedule address cache update task.")
         }
     }
 

--- a/ios/MullvadVPN/BackgroundTask.swift
+++ b/ios/MullvadVPN/BackgroundTask.swift
@@ -1,0 +1,35 @@
+//
+//  BackgroundTask.swift
+//  MullvadVPN
+//
+//  Created by pronebird on 09/06/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Background tasks defined by the app.
+
+ When adding new background tasks, don't forget to update `BGTaskSchedulerPermittedIdentifiers` key in `Info.plist` by adding a task identifier
+ using the following pattern:
+
+ ```
+ $(APPLICATION_IDENTIFIER).<TaskName>
+ ```
+
+ Note that `<TaskName>` is capitalized in plist, but the label for enum case should start with a lowercase letter.
+ */
+enum BackgroundTask: String {
+    case appRefresh, privateKeyRotation, addressCacheUpdate
+
+    /// Returns background task identifier.
+    /// Use it when registering or scheduling tasks with `BGTaskScheduler`.
+    var identifier: String {
+        return "\(ApplicationTarget.mainApp.bundleIdentifier).\(capitalizedRawValue)"
+    }
+
+    private var capitalizedRawValue: String {
+        return rawValue.prefix(1).uppercased() + rawValue.dropFirst()
+    }
+}

--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -8,9 +8,9 @@
 	<string>$(APPLICATION_IDENTIFIER)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>net.mullvad.MullvadVPN.AppRefresh</string>
-		<string>net.mullvad.MullvadVPN.PrivateKeyRotation</string>
-		<string>net.mullvad.MullvadVPN.AddressCacheUpdate</string>
+		<string>$(APPLICATION_IDENTIFIER).AppRefresh</string>
+		<string>$(APPLICATION_IDENTIFIER).PrivateKeyRotation</string>
+		<string>$(APPLICATION_IDENTIFIER).AddressCacheUpdate</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/ios/Shared/ApplicationConfiguration.swift
+++ b/ios/Shared/ApplicationConfiguration.swift
@@ -33,13 +33,4 @@ enum ApplicationConfiguration {
 
     /// Maximum number of devices per account.
     static let maxAllowedDevices = 5
-
-    /// App refresh background task identifier
-    static let appRefreshTaskIdentifier = "net.mullvad.MullvadVPN.AppRefresh"
-
-    /// Key rotation background task identifier
-    static let privateKeyRotationTaskIdentifier = "net.mullvad.MullvadVPN.PrivateKeyRotation"
-
-    /// API address background task identifier
-    static let addressCacheUpdateTaskIdentifier = "net.mullvad.MullvadVPN.AddressCacheUpdate"
 }


### PR DESCRIPTION
1. Add `BackgroundTask` to formalize all background tasks that the app defines.
2. Use `$(APPLICATION_IDENTIFIER)` variable supplied via `Configurations/Base.xcconfig` and in place of hardcoded string `net.mullvad.MullvadVPN` in `BGTaskSchedulerPermittedIdentifiers` key in `Info.plist`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4780)
<!-- Reviewable:end -->
