### PR TITLE
Add device and account to header

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -35,33 +35,11 @@ msgid_plural "%d years left"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "a day ago"
-msgid_plural "%d days ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "a minute ago"
-msgid_plural "%d minutes ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "a month ago"
-msgid_plural "%d months ago"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "a year ago"
-msgid_plural "%d years ago"
-msgstr[0] ""
-msgstr[1] ""
-
 msgid "Account paid until %(expiry)s."
 msgstr ""
 
-msgid "an hour ago"
-msgid_plural "%d hours ago"
-msgstr[0] ""
-msgstr[1] ""
+msgid "Account settings"
+msgstr ""
 
 msgid "Any"
 msgstr ""
@@ -165,9 +143,6 @@ msgid "less than a day"
 msgstr ""
 
 msgid "less than a day left"
-msgstr ""
-
-msgid "less than a minute ago"
 msgstr ""
 
 msgid "Next"
@@ -533,6 +508,10 @@ msgstr ""
 #. Further information about consequences of logging out device.
 msgctxt "device-management"
 msgid "This will delete all forwarded ports. Local settings will be saved."
+msgstr ""
+
+msgctxt "device-management"
+msgid "Time left: %(timeLeft)s"
 msgstr ""
 
 #. Page title informing user that the login failed due to too many registered
@@ -1069,21 +1048,12 @@ msgctxt "select-location-view"
 msgid "While connected, your traffic will be routed through two secure locations, the entry point and the exit point (needs to be two different VPN servers)."
 msgstr ""
 
-#. Navigation button to the 'Account' view
-msgctxt "settings-view"
-msgid "Account"
-msgstr ""
-
 msgctxt "settings-view"
 msgid "App is out of sync. Please quit and restart."
 msgstr ""
 
 msgctxt "settings-view"
 msgid "App version"
-msgstr ""
-
-msgctxt "settings-view"
-msgid "OUT OF TIME"
 msgstr ""
 
 #. Navigation button to the 'Split tunneling' view
@@ -1818,6 +1788,9 @@ msgstr ""
 msgid "You are running an unsupported app version."
 msgstr ""
 
+msgid "less than a minute ago"
+msgstr ""
+
 msgid "Account credit expires in a day"
 msgid_plural "Account credit expires in %d days"
 msgstr[0] ""
@@ -1825,5 +1798,30 @@ msgstr[1] ""
 
 msgid "Account credit expires in an hour"
 msgid_plural "Account credit expires in %d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a day ago"
+msgid_plural "%d days ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a minute ago"
+msgid_plural "%d minutes ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a month ago"
+msgid_plural "%d months ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "a year ago"
+msgid_plural "%d years ago"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "an hour ago"
+msgid_plural "%d hours ago"
 msgstr[0] ""
 msgstr[1] ""

--- a/gui/src/renderer/components/AppRouter.tsx
+++ b/gui/src/renderer/components/AppRouter.tsx
@@ -70,9 +70,9 @@ export default function AppRouter() {
             <Route exact path={RoutePath.voucherSuccess} component={VoucherVerificationSuccess} />
             <Route exact path={RoutePath.timeAdded} component={TimeAdded} />
             <Route exact path={RoutePath.setupFinished} component={SetupFinished} />
+            <Route exact path={RoutePath.account} component={Account} />
             <Route exact path={RoutePath.settings} component={Settings} />
             <Route exact path={RoutePath.selectLanguage} component={SelectLanguage} />
-            <Route exact path={RoutePath.accountSettings} component={Account} />
             <Route exact path={RoutePath.userInterfaceSettings} component={UserInterfaceSettings} />
             <Route exact path={RoutePath.vpnSettings} component={VpnSettings} />
             <Route exact path={RoutePath.wireguardSettings} component={WireguardSettings} />

--- a/gui/src/renderer/components/ExpiredAccountAddTime.tsx
+++ b/gui/src/renderer/components/ExpiredAccountAddTime.tsx
@@ -151,7 +151,9 @@ export function TimeAdded(props: ITimeAddedProps) {
   }, [history, finish]);
 
   const duration =
-    props.secondsAdded !== undefined ? formatRelativeDate(props.secondsAdded * 1000, 0) : undefined;
+    props.secondsAdded !== undefined
+      ? formatRelativeDate(0, props.secondsAdded * 1000, { capitalize: true, displayMonths: true })
+      : undefined;
 
   let newExpiry = '';
   if (props.newExpiry !== undefined) {

--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -1,12 +1,16 @@
 import React, { useCallback } from 'react';
+import { sprintf } from 'sprintf-js';
 import styled from 'styled-components';
 
 import { colors } from '../../config.json';
+import { closeToExpiry, formatRemainingTime, hasExpired } from '../../shared/account-expiry';
 import { TunnelState } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
+import { capitalizeEveryWord } from '../../shared/string-helpers';
 import { transitions, useHistory } from '../lib/history';
 import { RoutePath } from '../lib/routes';
 import { useSelector } from '../redux/store';
+import { tinyText } from './common-styles';
 import { FocusFallback } from './Focus';
 import ImageView from './ImageView';
 
@@ -26,26 +30,32 @@ const headerBarStyleColorMap = {
 
 interface IHeaderBarContainerProps {
   barStyle?: HeaderBarStyle;
+  accountInfoVisible: boolean;
   unpinnedWindow: boolean;
 }
 
 const HeaderBarContainer = styled.header({}, (props: IHeaderBarContainerProps) => ({
-  padding: '12px 16px',
+  padding: '15px 16px 0px',
+  minHeight: props.accountInfoVisible ? '80px' : '68px',
+  height: props.accountInfoVisible ? '80px' : '68px',
   backgroundColor: headerBarStyleColorMap[props.barStyle ?? HeaderBarStyle.default],
+  transitionProperty: 'height, min-height',
+  transitionDuration: '250ms',
+  transitionTimingFunction: 'ease-in-out',
 }));
 
 const HeaderBarContent = styled.div({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'flex-end',
-  // In views without the brand components we still want the Header to have the same height.
-  minHeight: '51px',
+  height: '38px',
 });
 
 interface IHeaderBarProps {
   barStyle?: HeaderBarStyle;
   className?: string;
   children?: React.ReactNode;
+  showAccountInfo?: boolean;
 }
 
 export default function HeaderBar(props: IHeaderBarProps) {
@@ -55,8 +65,10 @@ export default function HeaderBar(props: IHeaderBarProps) {
     <HeaderBarContainer
       barStyle={props.barStyle}
       className={props.className}
+      accountInfoVisible={props.showAccountInfo ?? false}
       unpinnedWindow={unpinnedWindow}>
       <HeaderBarContent>{props.children}</HeaderBarContent>
+      {props.showAccountInfo && <HeaderBarDeviceInfo />}
     </HeaderBarContainer>
   );
 }
@@ -78,6 +90,62 @@ export function Brand(props: React.HTMLAttributes<HTMLDivElement>) {
       <ImageView width={38} height={38} source="logo-icon" />
       <Title height={15.4} source="logo-text" />
     </BrandContainer>
+  );
+}
+
+const StyledAccountInfo = styled.div({
+  display: 'flex',
+  marginTop: '2px',
+  maxWidth: '100%',
+});
+
+const StyledDeviceLabel = styled.div(tinyText, {
+  fontSize: '10px',
+  color: colors.white80,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+const StyledTimeLeftLabel = styled.div(tinyText, {
+  fontSize: '10px',
+  color: colors.white80,
+  marginLeft: '16px',
+  whiteSpace: 'nowrap',
+});
+
+function HeaderBarDeviceInfo() {
+  const deviceName = useSelector((state) => state.account.deviceName);
+  const accountExpiry = useSelector((state) => state.account.expiry);
+  const isOutOfTime = accountExpiry ? hasExpired(accountExpiry) : false;
+  const formattedExpiry = isOutOfTime
+    ? sprintf(messages.ngettext('1 day', '%d days', 0), 0)
+    : accountExpiry
+    ? formatRemainingTime(accountExpiry)
+    : '';
+
+  return (
+    <StyledAccountInfo>
+      <StyledDeviceLabel>
+        {sprintf(
+          // TRANSLATORS: A label that will display the newly created device name to inform the user
+          // TRANSLATORS: about it.
+          // TRANSLATORS: Available placeholders:
+          // TRANSLATORS: %(deviceName)s - The name of the current device
+          messages.pgettext('device-management', 'Device name: %(deviceName)s'),
+          {
+            deviceName: capitalizeEveryWord(deviceName ?? ''),
+          },
+        )}
+      </StyledDeviceLabel>
+      {accountExpiry && !closeToExpiry(accountExpiry) && !isOutOfTime && (
+        <StyledTimeLeftLabel>
+          {sprintf(messages.pgettext('device-management', 'Time left: %(timeLeft)s'), {
+            timeLeft: formattedExpiry,
+          })}
+        </StyledTimeLeftLabel>
+      )}
+    </StyledAccountInfo>
   );
 }
 
@@ -147,7 +215,7 @@ export function DefaultHeaderBar(props: IHeaderBarProps) {
   const loggedIn = useSelector((state) => state.account.status.type === 'ok');
 
   return (
-    <HeaderBar {...props}>
+    <HeaderBar showAccountInfo={loggedIn} {...props}>
       <FocusFallback>
         <Brand />
       </FocusFallback>

--- a/gui/src/renderer/components/HeaderBar.tsx
+++ b/gui/src/renderer/components/HeaderBar.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 
 import { colors } from '../../config.json';
@@ -7,7 +6,7 @@ import { TunnelState } from '../../shared/daemon-rpc-types';
 import { messages } from '../../shared/gettext';
 import { transitions, useHistory } from '../lib/history';
 import { RoutePath } from '../lib/routes';
-import { IReduxState } from '../redux/store';
+import { useSelector } from '../redux/store';
 import { FocusFallback } from './Focus';
 import ImageView from './ImageView';
 
@@ -50,9 +49,7 @@ interface IHeaderBarProps {
 }
 
 export default function HeaderBar(props: IHeaderBarProps) {
-  const unpinnedWindow = useSelector(
-    (state: IReduxState) => state.settings.guiSettings.unpinnedWindow,
-  );
+  const unpinnedWindow = useSelector((state) => state.settings.guiSettings.unpinnedWindow);
 
   return (
     <HeaderBarContainer
@@ -78,8 +75,8 @@ const Title = styled(ImageView)({
 export function Brand(props: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <BrandContainer {...props}>
-      <ImageView width={44} height={44} source="logo-icon" />
-      <Title height={18} source="logo-text" />
+      <ImageView width={38} height={38} source="logo-icon" />
+      <Title height={15.4} source="logo-text" />
     </BrandContainer>
   );
 }
@@ -90,6 +87,10 @@ const HeaderBarSettingsButtonContainer = styled.button({
   marginLeft: 8,
   backgroundColor: 'transparent',
   border: 'none',
+});
+
+const HeaderBarAccountButtonContainer = styled(HeaderBarSettingsButtonContainer)({
+  marginRight: '16px',
 });
 
 interface IHeaderBarSettingsButtonProps {
@@ -120,12 +121,37 @@ export function HeaderBarSettingsButton(props: IHeaderBarSettingsButtonProps) {
   );
 }
 
+export function HeaderBarAccountButton() {
+  const history = useHistory();
+  const openAccount = useCallback(
+    () => history.push(RoutePath.account, { transition: transitions.show }),
+    [history],
+  );
+
+  return (
+    <HeaderBarAccountButtonContainer
+      onClick={openAccount}
+      aria-label={messages.gettext('Account settings')}>
+      <ImageView
+        height={24}
+        width={24}
+        source="icon-account"
+        tintColor={colors.white60}
+        tintHoverColor={colors.white80}
+      />
+    </HeaderBarAccountButtonContainer>
+  );
+}
+
 export function DefaultHeaderBar(props: IHeaderBarProps) {
+  const loggedIn = useSelector((state) => state.account.status.type === 'ok');
+
   return (
     <HeaderBar {...props}>
       <FocusFallback>
         <Brand />
       </FocusFallback>
+      {loggedIn && <HeaderBarAccountButton />}
       <HeaderBarSettingsButton />
     </HeaderBar>
   );

--- a/gui/src/renderer/components/RedeemVoucher.tsx
+++ b/gui/src/renderer/components/RedeemVoucher.tsx
@@ -217,7 +217,10 @@ export function RedeemVoucherAlert(props: IRedeemVoucherAlertProps) {
   const locale = useSelector((state) => state.userInterface.locale);
 
   if (response?.type === 'success') {
-    const duration = formatRelativeDate(response.secondsAdded * 1000, 0);
+    const duration = formatRelativeDate(0, response.secondsAdded * 1000, {
+      capitalize: true,
+      displayMonths: true,
+    });
     const expiry = formatDate(response.newExpiry, locale);
 
     return (

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
 import { colors, links } from '../../config.json';
-import { formatRemainingTime, hasExpired } from '../../shared/account-expiry';
 import { messages } from '../../shared/gettext';
 import { useAppContext } from '../context';
 import { useHistory } from '../lib/history';
@@ -17,7 +16,6 @@ import {
   StyledCellIcon,
   StyledContent,
   StyledNavigationScrollbars,
-  StyledOutOfTimeSubText,
   StyledQuitButton,
   StyledSettingsContent,
 } from './SettingsStyles';
@@ -63,7 +61,6 @@ export default function Support() {
                   {showSubSettings ? (
                     <>
                       <Cell.Group>
-                        <AccountButton />
                         <UserInterfaceSettingsButton />
                         <VpnSettingsButton />
                       </Cell.Group>
@@ -99,30 +96,6 @@ export default function Support() {
         </SettingsContainer>
       </Layout>
     </BackAction>
-  );
-}
-
-function AccountButton() {
-  const history = useHistory();
-  const navigate = useCallback(() => history.push(RoutePath.accountSettings), [history]);
-
-  const accountExpiry = useSelector((state) => state.account.expiry);
-  const isOutOfTime = accountExpiry ? hasExpired(accountExpiry) : false;
-  const formattedExpiry = accountExpiry ? formatRemainingTime(accountExpiry).toUpperCase() : '';
-  const outOfTimeMessage = messages.pgettext('settings-view', 'OUT OF TIME');
-
-  return (
-    <Cell.CellNavigationButton onClick={navigate}>
-      <Cell.Label>
-        {
-          // TRANSLATORS: Navigation button to the 'Account' view
-          messages.pgettext('settings-view', 'Account')
-        }
-      </Cell.Label>
-      <StyledOutOfTimeSubText isOutOfTime={isOutOfTime}>
-        {isOutOfTime ? outOfTimeMessage : formattedExpiry}
-      </StyledOutOfTimeSubText>
-    </Cell.CellNavigationButton>
   );
 }
 

--- a/gui/src/renderer/components/SettingsStyles.tsx
+++ b/gui/src/renderer/components/SettingsStyles.tsx
@@ -1,14 +1,9 @@
 import styled from 'styled-components';
 
-import { colors } from '../../config.json';
 import * as AppButton from './AppButton';
 import * as Cell from './cell';
 import { measurements } from './common-styles';
 import { NavigationScrollbars } from './NavigationBar';
-
-export const StyledOutOfTimeSubText = styled(Cell.SubText)((props: { isOutOfTime: boolean }) => ({
-  color: props.isOutOfTime ? colors.red : undefined,
-}));
 
 export const StyledCellIcon = styled(Cell.UntintedIcon)({
   marginRight: '8px',

--- a/gui/src/renderer/lib/routes.ts
+++ b/gui/src/renderer/lib/routes.ts
@@ -10,7 +10,7 @@ export enum RoutePath {
   setupFinished = '/main/setup-finished',
   settings = '/settings',
   selectLanguage = '/settings/language',
-  accountSettings = '/settings/account',
+  account = '/account',
   userInterfaceSettings = '/settings/interface',
   vpnSettings = '/settings/vpn',
   wireguardSettings = '/settings/advanced/wireguard',

--- a/gui/src/shared/account-expiry.ts
+++ b/gui/src/shared/account-expiry.ts
@@ -1,5 +1,10 @@
-import { dateByAddingComponent, DateComponent, DateType, formatTimeLeft } from './date-helper';
-import { capitalize } from './string-helpers';
+import {
+  dateByAddingComponent,
+  DateComponent,
+  DateType,
+  FormatDateOptions,
+  formatRelativeDate,
+} from './date-helper';
 
 export function hasExpired(expiry: DateType): boolean {
   return new Date(expiry).getTime() < Date.now();
@@ -18,10 +23,6 @@ export function formatDate(date: DateType, locale: string): string {
   );
 }
 
-export function formatRemainingTime(
-  expiry: DateType,
-  shouldCapitalizeFirstLetter?: boolean,
-): string {
-  const remaining = formatTimeLeft(new Date(), expiry);
-  return shouldCapitalizeFirstLetter ? capitalize(remaining) : remaining;
+export function formatRemainingTime(expiry: DateType, options?: FormatDateOptions): string {
+  return formatRelativeDate(new Date(), expiry, options);
 }

--- a/gui/src/shared/notifications/close-to-account-expiry.ts
+++ b/gui/src/shared/notifications/close-to-account-expiry.ts
@@ -3,7 +3,6 @@ import { sprintf } from 'sprintf-js';
 import { links } from '../../config.json';
 import { messages } from '../../shared/gettext';
 import { closeToExpiry, formatRemainingTime } from '../account-expiry';
-import { formatRelativeDate } from '../date-helper';
 import {
   InAppNotification,
   InAppNotificationProvider,
@@ -34,7 +33,7 @@ export class CloseToAccountExpiryNotificationProvider
         'Account credit expires in %(duration)s. Buy more credit.',
       ),
       {
-        duration: formatRelativeDate(new Date(), this.context.accountExpiry),
+        duration: formatRemainingTime(this.context.accountExpiry),
       },
     );
 
@@ -54,7 +53,12 @@ export class CloseToAccountExpiryNotificationProvider
   public getInAppNotification(): InAppNotification {
     const subtitle = sprintf(
       messages.pgettext('in-app-notifications', '%(duration)s. Buy more credit.'),
-      { duration: formatRemainingTime(this.context.accountExpiry, true) },
+      {
+        duration: formatRemainingTime(this.context.accountExpiry, {
+          capitalize: true,
+          suffix: true,
+        }),
+      },
     );
 
     return {

--- a/gui/test/e2e/installed/state-dependent/login.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/login.spec.ts
@@ -92,12 +92,8 @@ test('App should log in', async () => {
 
 test('App should log out', async () => {
   expect(await util.waitForNavigation(() => {
-    void page.getByLabel('Settings').click();
-  })).toEqual(RoutePath.settings);
-
-  expect(await util.waitForNavigation(() => {
     void page.getByText('Account').click();
-  })).toEqual(RoutePath.accountSettings);
+  })).toEqual(RoutePath.account);
 
   expect(await util.waitForNavigation(() => {
     void page.getByText('Log out').click();

--- a/gui/test/e2e/mocked/settings.spec.ts
+++ b/gui/test/e2e/mocked/settings.spec.ts
@@ -9,27 +9,20 @@ let util: MockedTestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startMockedApp());
-  await util.waitForNavigation(() => page.click('button[aria-label="Settings"]'));
 });
 
 test.afterAll(async () => {
   await page.close();
 });
 
-test('Settings Page', async () => {
-  const title = page.locator('h1');
-  await expect(title).toContainText('Settings');
-
-  const closeButton = page.locator('button[aria-label="Close"]');
-  await expect(closeButton).toBeVisible();
+test('Account button should be displayed correctly', async () => {
+  const accountButton = page.getByLabel('Account settings');
+  await expect(accountButton).toBeVisible();
 });
 
-test('Account button should be displayed correctly', async () => {
-  const accountButton = page.locator('button:has-text("Account")');
-  await expect(accountButton).toBeVisible();
-
-  let expiryText = accountButton.locator('span');
-  await expect(expiryText).toContainText(/29 days left/i);
+test('Headerbar account info should be displayed correctly', async () => {
+  let expiryText = page.getByText(/^Time left:/);
+  await expect(expiryText).toContainText(/Time left: 29 days/i);
 
   /**
    * 729 days left
@@ -39,8 +32,7 @@ test('Account button should be displayed correctly', async () => {
     channel: 'account-',
     response: { expiry: new Date(Date.now() + 730 * 24 * 60 * 60 * 1000 - 1000).toISOString() },
   });
-  expiryText = accountButton.locator('span');
-  await expect(expiryText).toContainText(/729 days left/i);
+  await expect(expiryText).toContainText(/Time left: 729 days/i);
 
   /**
    * 2 years left
@@ -49,8 +41,7 @@ test('Account button should be displayed correctly', async () => {
     channel: 'account-',
     response: { expiry: new Date(Date.now() + 731 * 24 * 60 * 60 * 1000).toISOString() },
   });
-  expiryText = accountButton.locator('span');
-  await expect(expiryText).toContainText(/2 years left/i);
+  await expect(expiryText).toContainText(/Time left: 2 years/i);
 
   /**
    * Expiry 1 day ago should show 'out of time'
@@ -59,6 +50,15 @@ test('Account button should be displayed correctly', async () => {
     channel: 'account-',
     response: { expiry: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString() },
   });
-  expiryText = accountButton.locator('span');
-  await expect(expiryText).toContainText(/out of time/i);
+  await expect(expiryText).not.toBeVisible();
+});
+
+test('Settings Page', async () => {
+  await util.waitForNavigation(() => page.click('button[aria-label="Settings"]'));
+
+  const title = page.locator('h1');
+  await expect(title).toContainText('Settings');
+
+  const closeButton = page.locator('button[aria-label="Close"]');
+  await expect(closeButton).toBeVisible();
 });

--- a/gui/test/unit/date-helper.spec.ts
+++ b/gui/test/unit/date-helper.spec.ts
@@ -100,66 +100,89 @@ describe('Date helper', () => {
   });
 
   it('should format positive difference as string', () => {
-    const diff1 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-01-01 13:37:20');
+    const diff1 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-01-01 13:37:20',
+      { displayMonths: true },
+    );
     expect(diff1).to.equal('less than a day');
 
-    const diff2 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-01-02 13:37:20');
+    const diff2 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-01-02 13:37:20',
+      { displayMonths: true },
+    );
     expect(diff2).to.equal('1 day');
 
-    const diff3 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-02-25 13:37:20');
+    const diff3 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-02-25 13:37:20',
+      { displayMonths: true },
+    );
     expect(diff3).to.equal('55 days');
 
-    const diff4 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-04-25 13:37:20');
+    const diff4 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-04-25 13:37:20',
+      { displayMonths: true },
+    );
     expect(diff4).to.equal('3 months');
 
-    const diff5 = date.formatRelativeDate('2021-01-01 13:37:10', '2031-04-25 13:37:20');
+    const diff5 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2031-04-25 13:37:20',
+      { displayMonths: true },
+    );
     expect(diff5).to.equal('10 years');
   });
 
   it('should format positive difference as string suffixed with "left"', () => {
-    const diff1 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-01-01 13:37:20', true);
+    const diff1 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-01-01 13:37:20',
+      { suffix: true, displayMonths: true },
+    );
     expect(diff1).to.equal('less than a day left');
 
-    const diff2 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-01-02 13:37:20', true);
+    const diff2 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-01-02 13:37:20',
+      { suffix: true, displayMonths: true },
+    );
     expect(diff2).to.equal('1 day left');
 
-    const diff3 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-02-25 13:37:20', true);
+    const diff3 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-02-25 13:37:20',
+      { suffix: true, displayMonths: true },
+    );
     expect(diff3).to.equal('55 days left');
 
-    const diff4 = date.formatRelativeDate('2021-01-01 13:37:10', '2021-04-25 13:37:20', true);
+    const diff4 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2021-04-25 13:37:20',
+      { suffix: true, displayMonths: true },
+    );
     expect(diff4).to.equal('3 months left');
 
-    const diff5 = date.formatRelativeDate('2021-01-01 13:37:10', '2031-04-25 13:37:20', true);
+    const diff5 = date.formatRelativeDate(
+      '2021-01-01 13:37:10',
+      '2031-04-25 13:37:20',
+      { suffix: true, displayMonths: true },
+    );
     expect(diff5).to.equal('10 years left');
   });
 
-  it('should format negative difference as string', () => {
-    const diff1 = date.formatRelativeDate('2021-01-01 13:37:20', '2021-01-01 13:37:10', true);
-    expect(diff1).to.equal('less than a minute ago');
-
-    const diff2 = date.formatRelativeDate('2021-01-02 13:37:20', '2021-01-01 13:37:10', true);
-    expect(diff2).to.equal('a day ago');
-
-    const diff3 = date.formatRelativeDate('2021-02-25 13:37:20', '2021-01-01 13:37:10', true);
-    expect(diff3).to.equal('a month ago');
-
-    const diff4 = date.formatRelativeDate('2021-04-25 13:37:20', '2021-01-01 13:37:10', true);
-    expect(diff4).to.equal('3 months ago');
-
-    const diff5 = date.formatRelativeDate('2031-04-25 13:37:20', '2021-01-01 13:37:10', true);
-    expect(diff5).to.equal('10 years ago');
-  });
-
   it('should format time left correctly', () => {
-    expect(date.formatTimeLeft('2022-09-01', '2022-09-01')).to.equal('less than a day left');
-    expect(date.formatTimeLeft('2022-09-01', '2022-09-02')).to.equal('1 day left');
-    expect(date.formatTimeLeft('2022-09-01', '2022-09-05')).to.equal('4 days left');
-    expect(date.formatTimeLeft('2022-09-01', '2022-09-30')).to.equal('29 days left');
-    expect(date.formatTimeLeft('2022-09-01', '2023-09-01')).to.equal('365 days left');
-    expect(date.formatTimeLeft('2022-09-01', '2024-08-30')).to.equal('729 days left');
-    expect(date.formatTimeLeft('2022-09-01', '2024-08-31')).to.equal('2 years left');
-    expect(date.formatTimeLeft('2022-09-01', '2024-09-05')).to.equal('2 years left');
-    expect(date.formatTimeLeft('2022-09-01', '2025-08-31')).to.equal('2 years left');
-    expect(date.formatTimeLeft('2022-09-01', '2025-09-01')).to.equal('3 years left');
+    expect(date.formatRelativeDate('2022-09-01', '2022-09-01')).to.equal('less than a day');
+    expect(date.formatRelativeDate('2022-09-01', '2022-09-02')).to.equal('1 day');
+    expect(date.formatRelativeDate('2022-09-01', '2022-09-05')).to.equal('4 days');
+    expect(date.formatRelativeDate('2022-09-01', '2022-09-30')).to.equal('29 days');
+    expect(date.formatRelativeDate('2022-09-01', '2023-09-01')).to.equal('365 days');
+    expect(date.formatRelativeDate('2022-09-01', '2024-08-30')).to.equal('729 days');
+    expect(date.formatRelativeDate('2022-09-01', '2024-08-31')).to.equal('2 years');
+    expect(date.formatRelativeDate('2022-09-01', '2024-09-05')).to.equal('2 years');
+    expect(date.formatRelativeDate('2022-09-01', '2025-08-31')).to.equal('2 years');
+    expect(date.formatRelativeDate('2022-09-01', '2025-09-01')).to.equal('3 years');
   });
 });


### PR DESCRIPTION
This PR makes further improvements to the presentation of device and account info. The account view is now accessed from a button in the header bar and the device name and time left is displayed in the header bar under the logo.

To accomplish this I also refactored the time formatting functions to be a bit simpler. We still supported formatting time that was in the past which hasn't been necessary since we removed the wireguard key view.

Fixes DES-137, DES-139, DES-140.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4792)
<!-- Reviewable:end -->
