### PR TITLE
Prevent overwriting relay constraints when selecting a relay location

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/SelectLocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/SelectLocationCoordinator.swift
@@ -38,9 +38,10 @@ class SelectLocationCoordinator: Coordinator, Presentable, RelayCacheTrackerObse
         controller.didSelectRelay = { [weak self] relay in
             guard let self else { return }
 
-            let newConstraints = RelayConstraints(location: .only(relay))
+            var relayConstraints = tunnelManager.settings.relayConstraints
+            relayConstraints.location = .only(relay)
 
-            tunnelManager.setRelayConstraints(newConstraints) {
+            tunnelManager.setRelayConstraints(relayConstraints) {
                 self.tunnelManager.startTunnel()
             }
 


### PR DESCRIPTION
Selecting a relay in location selection view overwrites whatever port selection has been made prior. We need to update current relay constraints rather than overwriting them with new.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4795)
<!-- Reviewable:end -->
