### PR TITLE
When trying to revoke a device from the `Too many devices view`, it doesn't happen 

### DIFF
--- a/ios/MullvadVPN/Classes/CustomAlertViewController.swift
+++ b/ios/MullvadVPN/Classes/CustomAlertViewController.swift
@@ -94,11 +94,6 @@ class CustomAlertViewController: UIViewController {
         }
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        handlers.removeAll()
-    }
-
     func addAction(title: String, style: ActionStyle, handler: (() -> Void)? = nil) {
         // The presence of a button should reset any custom button margin to default.
         containerView.directionalLayoutMargins.bottom = UIMetrics.CustomAlert.containerMargins.bottom
@@ -183,8 +178,9 @@ class CustomAlertViewController: UIViewController {
             if let handler = handlers[button] {
                 handler()
             }
-
             didDismiss?()
+            didDismiss = nil
+            handlers.removeAll()
         }
     }
 }

--- a/ios/MullvadVPN/Operations/PresentAlertOperation.swift
+++ b/ios/MullvadVPN/Operations/PresentAlertOperation.swift
@@ -37,8 +37,8 @@ final class PresentAlertOperation: AsyncOperation {
     }
 
     override func main() {
-        alertController.didDismiss = {
-            self.finish()
+        alertController.didDismiss = { [weak self] in
+            self?.finish()
         }
 
         presentingController.present(alertController, animated: true) {


### PR DESCRIPTION
When the number of device is exceeded and we are trying to revoke a device from the `Too many devices view`,nothing happens.
after checking the code I figured out we are removing the buttons handlers in `viewDidDisappear` while after dismissing the controller(the `viewDidDisappear ` will be called by view lifecycle sooner than dismiss's `completion `) we are looking for them at `completion`, therefore It causes the button callbacks never be accessible.
for solving the problem I did this step :

- removing handlers at `dismiss` callback

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4796)
<!-- Reviewable:end -->
