### PR TITLE
Close GUI before daemon is killed when upgrading app version

### DIFF
--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -75,7 +75,10 @@ launchctl unload -w $DAEMON_PLIST_PATH
 cp "$LOG_DIR/daemon.log" "$LOG_DIR/old-install-daemon.log" \
   || echo "Failed to copy old daemon log"
 
-pkill -x "Mullvad VPN" || echo "Unable to kill GUI, not running?"
+# For compatibility with versions older than 2022.5, kill the GUI after the
+# upgrade. We now do this in preinstall instead. This code can be removed when
+# we drop support for app versions older than 2022.5.
+pkill -x "Mullvad VPN" || true
 sleep 1
 
 echo "$DAEMON_PLIST" > $DAEMON_PLIST_PATH

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -33,3 +33,12 @@ rm "$NEW_CACHE_DIR/api-ip-address.txt" || true
 
 # Remove deprecated exclusion group. This line can be removed when 2023.4 is no longer supported
 dscl . -delete /groups/mullvad-exclusion &>/dev/null || true
+
+# Kill the GUI before proceeding with the upgrade.
+#
+# When we drop support for all app versions older than 2022.5, we can skip this
+# check and always try to kill the GUI.
+if "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" is-older-version 2022.5; then
+    pkill -x "Mullvad VPN" || echo "Unable to kill GUI, not running?"
+    sleep 1
+fi


### PR DESCRIPTION
Closing the GUI shows the disconnected and unsecure notification and the tray icon switches to the unlocked state when it loses the connection to the daemon. For versions where the GUI don't disconnect when killed (`2022.5` and later) we want to kill the GUI first, but we want to keep it like it currently is when upgrading from older versions.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4799)
<!-- Reviewable:end -->
