### PR TITLE
Print the old account number even if device is revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Line wrap the file at 100 chars.                                              Th
   `mullvad tunnel ipv6 get`.
 - Update the CLI multihop settings to make it possible to set the entry location without toggling
   multihop on or off.
+- In the CLI, the `mullvad account get` command will now print the account
+  number (if there is one) after the device has been revoked.
 
 #### Windows
 - In the CLI, add a unified `mullvad split-tunnel get` command to replace the old commands

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -127,6 +127,9 @@ impl Account {
             }
             DeviceState::Revoked => {
                 println!("{REVOKED_MESSAGE}");
+                if let Some(account_token) = rpc.get_account_history().await? {
+                    println!("Mullvad account: {}", account_token);
+                }
             }
         }
 


### PR DESCRIPTION
`mullvad account get` will now print the old account number, even when the device has revoked. A minor QOL thing for the CLI users out there.

Previously:
```
$ mullvad account get
The current device has been revoked
```
Now:
```
$ mullvad account get
The current device has been revoked
Mullvad account: xxxxxxxxxxxxxxxx
```

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4800)
<!-- Reviewable:end -->
