### PR TITLE
update-handling-of-device-concept-and-time-left-ios-198

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -335,10 +335,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func setupNotifications() {
         NotificationManager.shared.notificationProviders = [
-            RegisteredDeviceInAppNotificationProvider(tunnelManager: tunnelManager),
             TunnelStatusNotificationProvider(tunnelManager: tunnelManager),
             AccountExpirySystemNotificationProvider(tunnelManager: tunnelManager),
             AccountExpiryInAppNotificationProvider(tunnelManager: tunnelManager),
+            RegisteredDeviceInAppNotificationProvider(tunnelManager: tunnelManager),
         ]
         UNUserNotificationCenter.current().delegate = self
     }

--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -29,7 +29,7 @@ class HeaderBarView: UIView {
         return stackView
     }()
 
-    private lazy var deviceName: UILabel = {
+    private lazy var deviceNameLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = UIColor(white: 1.0, alpha: 0.8)
@@ -37,7 +37,7 @@ class HeaderBarView: UIView {
         return label
     }()
 
-    private lazy var timeLeft: UILabel = {
+    private lazy var timeLeftLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = UIColor(white: 1.0, alpha: 0.8)
@@ -106,6 +106,53 @@ class HeaderBarView: UIView {
         }
     }
 
+    private var isAccountButtonHidden = false {
+        didSet {
+            accountButton.isHidden = isAccountButtonHidden
+        }
+    }
+
+    private var timeLeft: Date? {
+        didSet {
+            if let timeLeft {
+                timeLeftLabel.isHidden = false
+                let formattedTimeLeft = NSLocalizedString(
+                    "TIME_LEFT_HEADER_VIEW",
+                    tableName: "Account",
+                    value: "Time left: %@",
+                    comment: ""
+                )
+                timeLeftLabel.text = String(
+                    format: formattedTimeLeft,
+                    CustomDateComponentsFormatting.localizedString(
+                        from: Date(),
+                        to: timeLeft,
+                        unitsStyle: .full
+                    ) ?? ""
+                )
+            } else {
+                timeLeftLabel.isHidden = true
+            }
+        }
+    }
+
+    private var deviceName: String? {
+        didSet {
+            if let deviceName {
+                deviceNameLabel.isHidden = false
+                let formattedDeviceName = NSLocalizedString(
+                    "DEVICE_NAME_HEADER_VIEW",
+                    tableName: "Account",
+                    value: "Device name: %@",
+                    comment: ""
+                )
+                deviceNameLabel.text = String(format: formattedDeviceName, deviceName)
+            } else {
+                deviceNameLabel.isHidden = true
+            }
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         directionalLayoutMargins = NSDirectionalEdgeInsets(
@@ -120,7 +167,7 @@ class HeaderBarView: UIView {
         let imageSize = brandNameImage?.size ?? .zero
         let brandNameAspectRatio = imageSize.width / max(imageSize.height, 1)
 
-        [deviceName, timeLeft].forEach { deviceInfoHolder.addArrangedSubview($0) }
+        [deviceNameLabel, timeLeftLabel].forEach { deviceInfoHolder.addArrangedSubview($0) }
 
         addConstrainedSubviews([logoImageView, brandNameImageView, buttonContainer, deviceInfoHolder]) {
             logoImageView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor)
@@ -173,38 +220,10 @@ class HeaderBarView: UIView {
 
         return brandNameRect.intersects(buttonContainerRect)
     }
-}
 
-extension HeaderBarView {
     func update(configuration: RootConfiguration) {
-        if let name = configuration.deviceName {
-            let formattedDeviceName = NSLocalizedString(
-                "DEVICE_NAME_HEADER_VIEW",
-                tableName: "Account",
-                value: "Device name: %@",
-                comment: ""
-            )
-            deviceName.text = .init(format: formattedDeviceName, name)
-        }
-
-        if let expiry = configuration.expiry {
-            let formattedTimeLeft = NSLocalizedString(
-                "TIME_LEFT_HEADER_VIEW",
-                tableName: "Account",
-                value: "Time left: %@",
-                comment: ""
-            )
-            timeLeft.text = .init(
-                format: formattedTimeLeft,
-                CustomDateComponentsFormatting.localizedString(
-                    from: Date(),
-                    to: expiry,
-                    unitsStyle: .full
-                ) ?? ""
-            )
-        }
-
-        deviceInfoHolder.arrangedSubviews.forEach { $0.isHidden = !configuration.showsDeviceInfo }
-        accountButton.isHidden = !configuration.showsAccountButton
+        deviceName = configuration.deviceName
+        timeLeft = configuration.expiry
+        isAccountButtonHidden = !configuration.showsAccountButton
     }
 }

--- a/ios/MullvadVPN/Containers/Root/RootConfiguration.swift
+++ b/ios/MullvadVPN/Containers/Root/RootConfiguration.swift
@@ -12,5 +12,4 @@ struct RootConfiguration {
     var deviceName: String?
     var expiry: Date?
     var showsAccountButton: Bool
-    let showsDeviceInfo: Bool
 }

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -70,7 +70,7 @@ class RootContainerViewController: UIViewController {
     let transitionContainer = UIView(frame: UIScreen.main.bounds)
     private var presentationContainerAccountButton: UIButton?
     private var presentationContainerSettingsButton: UIButton?
-    private var configuration = RootConfiguration(showsAccountButton: false, showsDeviceInfo: true)
+    private var configuration = RootConfiguration(showsAccountButton: false)
 
     private(set) var headerBarPresentation = HeaderBarPresentation.default
     private(set) var headerBarHidden = false
@@ -789,8 +789,11 @@ extension UIViewController {
 extension RootContainerViewController {
     func update(configuration: RootConfiguration) {
         self.configuration = configuration
-
         presentationContainerAccountButton?.isHidden = !configuration.showsAccountButton
         headerBarView.update(configuration: configuration)
+    }
+
+    func hideDeviceInfo() {
+        update(configuration: RootConfiguration(showsAccountButton: false))
     }
 }


### PR DESCRIPTION
after discussion design, we are supposed to change the priority of notifications based on these orders : 

1. tunnel status notification (highest priority)
2. close to expiry date  system notification
3. close to expiry date  in-app notification
4. creation device in app notification

changing these orders raised up another problem. currently in the app we don't show the device name and time left when the `new device created`  in-app banner notification is shown.therefore when user comes from logged out to logged and if the  `time left` is less than 3 days, `close to expiry date`  in-app notification shows while the `new device created` is below that and user is not able to figure out the `device name` till adding more credit to dismiss `close to expiry date`  in-app notification.

for solving the problem, the decision is made to show device name when user is logged in and show `time left` when user has credit more than 3 days.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4803)
<!-- Reviewable:end -->
