### PR TITLE
Join `set location` and `set hostname` into one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Line wrap the file at 100 chars.                                              Th
   multihop on or off.
 - In the CLI, the `mullvad account get` command will now print the account
   number (if there is one) after the device has been revoked.
+- Update the CLI relay, multihop & bridge selection interface to accept a
+  hostname as sole argument, inheriting the behavior of `mullvad relay set
+  hostname`. This is in addition to accepting a geographical location as basis
+  for filtering relays.
 
 #### Windows
 - In the CLI, add a unified `mullvad split-tunnel get` command to replace the old commands
@@ -62,6 +66,8 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Fix inability to sync iCloud and Safari bookmarks while connected to the VPN.
 
+### Removed
+- Remove the CLI subcommand `mullvad relay set hostname`.
 
 ## [android/2023.2] - 2023-05-22
 ### Changed

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -610,7 +610,7 @@ fn parse_transport_port(
 
 /// Lookup a relay among a list of [`RelayListCountry`]s by hostname.
 /// The matching is exact, bar capitalization.
-fn find_relay_by_hostname(
+pub fn find_relay_by_hostname(
     countries: &[RelayListCountry],
     hostname: &str,
 ) -> Option<LocationConstraint> {

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -261,6 +261,7 @@ impl Relay {
         Ok(())
     }
 
+    /// Get active relays which are not bridges.
     async fn get_filtered_relays() -> Result<Vec<RelayListCountry>> {
         let mut rpc = MullvadProxyClient::new().await?;
         let relay_list = rpc.get_relay_locations().await?;


### PR DESCRIPTION
This PR merges the functionallity of `mullvad relay set hostname` into the `mullvad relay set location` command.

The `relay set location` command used to require the full format of `<COUNTRY> <CITY> <HOSTNAME>` to select a specific relay, while `relay set hostname`  only received a hostname and figured the country and city out. 

Now, the arguments to `relay set location` are *either* a geographical location or a hostname: `relay set location <COUNTRY> <CITY> <HOSTNAME> | <HOSTNAME>` . The command will keep working as it used to, while being a bit smarter about hostnames.

E.g., here I select one of the relays in Gothenburg:
```bash
$ mullvad relay set location se-got-wg-004
Relay constraints updated

$ mullvad status
Connected to se-got-wg-004 in Gothenburg, Sweden
```

This logic also applies to the multihop option, so one can specify a relay as an entry point directly by its hostname.
E.g., here I select another one of the relays in Gothenburg as entry point:

```bash
$ mullvad relay set tunnel wireguard --use-multihop on entry-location se-got-wg-101
Relay constraints updated

$ mullvad status
Connected to se-got-wg-004 in Gothenburg, Sweden via se-got-wg-101
```

The help messages for both `mullvad relay set location` and `mullvad relay set tunnel wireguard` has been augmented with examples to clarify how the commands can be used.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4804)
<!-- Reviewable:end -->
