### PR TITLE
Bump shadowsocks commit to prevent misaligned reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "shadowsocks"
 version = "1.15.3"
-source = "git+https://github.com/mullvad/shadowsocks-rust?rev=8f6afd081a9440fff2dda565908eddc27a3295f1#8f6afd081a9440fff2dda565908eddc27a3295f1"
+source = "git+https://github.com/mullvad/shadowsocks-rust?rev=c45980bb22d0d50ac888813c59a1edf0cff14a36#c45980bb22d0d50ac888813c59a1edf0cff14a36"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "shadowsocks-service"
 version = "1.15.3"
-source = "git+https://github.com/mullvad/shadowsocks-rust?rev=8f6afd081a9440fff2dda565908eddc27a3295f1#8f6afd081a9440fff2dda565908eddc27a3295f1"
+source = "git+https://github.com/mullvad/shadowsocks-rust?rev=c45980bb22d0d50ac888813c59a1edf0cff14a36#c45980bb22d0d50ac888813c59a1edf0cff14a36"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
+++ b/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 
 [dependencies]
 shadowsocks-service.git = "https://github.com/mullvad/shadowsocks-rust"
-shadowsocks-service.rev = "8f6afd081a9440fff2dda565908eddc27a3295f1"
+shadowsocks-service.rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36"
 shadowsocks-service.features = [ "local", "stream-cipher", "local-http", "local-tunnel" ]
 
 tokio = "1"

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -32,4 +32,4 @@ mullvad-types = { path = "../mullvad-types" }
 talpid-types = { path = "../talpid-types" }
 talpid-time = { path = "../talpid-time" }
 
-shadowsocks = { git = "https://github.com/mullvad/shadowsocks-rust", rev = "8f6afd081a9440fff2dda565908eddc27a3295f1",  features = [ "stream-cipher" ] }
+shadowsocks = { git = "https://github.com/mullvad/shadowsocks-rust", rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36",  features = [ "stream-cipher" ] }

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -26,7 +26,7 @@ talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-types = { path = "../talpid-types" }
 uuid = { version = "0.8", features = ["v4"] }
 tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
-shadowsocks-service = { git = "https://github.com/mullvad/shadowsocks-rust", rev = "8f6afd081a9440fff2dda565908eddc27a3295f1",  features = [ "local", "stream-cipher" ] }
+shadowsocks-service = { git = "https://github.com/mullvad/shadowsocks-rust", rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36",  features = [ "local", "stream-cipher" ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
 byteorder = "1"


### PR DESCRIPTION
Our shadowsocks fork is a fair bit out of date, and it seems like it has been misbehaving on macOS for a while now due to unaligned reads. I've backported a [fix](https://github.com/shadowsocks/shadowsocks-rust/commit/c45980bb22d0d50ac888813c59a1edf0cff14a36) from upstream to our branch, and updated our crates to use the new commit.