### PR TITLE
Fix argument to `read` in build.sh that did not work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,7 +104,7 @@ if [[ "$SIGN" == "true" ]]; then
             exit 1
         fi
         if [[ -z ${CSC_KEY_PASSWORD-} ]]; then
-            read -spr "CSC_KEY_PASSWORD = " CSC_KEY_PASSWORD
+            read -rsp "CSC_KEY_PASSWORD = " CSC_KEY_PASSWORD
             echo ""
             export CSC_KEY_PASSWORD
         fi


### PR DESCRIPTION
The arguments here were in the wrong order, so the read would not work. Since this has been like this since forever, obviously we don't execute this code path very much :sweat_smile: But now I fix it so it's possible to do `./build.sh --sign` without running it from `ci/buildserver-build.sh`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4811)
<!-- Reviewable:end -->
