### PR TITLE
Bump Linux build container to mullvadvpn-app-build:cf1a3c951

### DIFF
--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:8d7df5659
+ghcr.io/mullvad/mullvadvpn-app-build:cf1a3c951


### PR DESCRIPTION
This uses the newly produced build container. Bringing Rust up from 1.68.1 to 1.70.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4812)
<!-- Reviewable:end -->
