### PR TITLE
Update PR template to recommend adding testing instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,13 @@
-<!--
 PR checklist (just intended as a reminder for the PR author. No need to fill it in):
 
 * [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
 * [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
-* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
-      And, if needed, **how** it does it.
+* [ ] The PR description should describe:
+  * **What** this PR changes
+  * **Why** this is wanted
+  * If necessary, **how** it's implemented
+  * How to **test** the change
+
 
 👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
   THIRD PARTY CONTRIBUTOR, PLEASE READ THIS

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 PR checklist (just intended as a reminder for the PR author. No need to fill it in):
 
 * [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.


### PR DESCRIPTION
In an attempt to help promote testing, I've changed the template to nudge people to include instructions on how to test their changes in their PR description.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4815)
<!-- Reviewable:end -->
