### PR TITLE
Silence OpenVPN 'replay attack' warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
   hostname as sole argument, inheriting the behavior of `mullvad relay set
   hostname`. This is in addition to accepting a geographical location as basis
   for filtering relays.
+- Silence OpenVPN "replay attack" warnings.
 
 #### Windows
 - In the CLI, add a unified `mullvad split-tunnel get` command to replace the old commands

--- a/talpid-openvpn/src/process/openvpn.rs
+++ b/talpid-openvpn/src/process/openvpn.rs
@@ -15,6 +15,7 @@ static BASE_ARGUMENTS: &[&[&str]] = &[
     &["--client"],
     &["--tls-client"],
     &["--nobind"],
+    &["--mute-replay-warnings"],
     #[cfg(not(windows))]
     &["--dev", "tun"],
     #[cfg(windows)]


### PR DESCRIPTION
Make the logs less verbose and easier to read by silencing 'replay attack' warnings.

There are lots of false positives showing up in regular UDP connections, and since we don’t act on potential replays or warn our users (it’s pretty hidden in the logs) they don’t really serve much purpose to be there. The warning should not pose any threat to the user.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description describes **what** this PR changes. **Why** this is wanted.
      And, if needed, **how** it does it.

👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4830)
<!-- Reviewable:end -->
