### PR TITLE
Update relay selector docs to include udp2tcp

### DIFF
--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -928,15 +928,6 @@ impl RelaySelector {
         })
     }
 
-    pub fn get_obfuscator(
-        &self,
-        relay: &Relay,
-        endpoint: &MullvadWireguardEndpoint,
-        retry_attempt: u32,
-    ) -> Result<Option<SelectedObfuscator>, Error> {
-        self.get_obfuscator_inner(&self.config.lock(), relay, endpoint, retry_attempt)
-    }
-
     fn get_obfuscator_inner(
         &self,
         config: &MutexGuard<'_, SelectorConfig>,
@@ -1310,6 +1301,17 @@ mod test {
     };
     use std::collections::HashSet;
     use talpid_types::net::{wireguard::PublicKey, Endpoint};
+
+    impl RelaySelector {
+        fn get_obfuscator(
+            &self,
+            relay: &Relay,
+            endpoint: &MullvadWireguardEndpoint,
+            retry_attempt: u32,
+        ) -> Result<Option<SelectedObfuscator>, Error> {
+            self.get_obfuscator_inner(&self.config.lock(), relay, endpoint, retry_attempt)
+        }
+    }
 
     lazy_static::lazy_static! {
         static ref RELAYS: RelayList = RelayList {


### PR DESCRIPTION
The relay selector docs didn't have a notion of an obfuscator, so I updated them.

I also found that a public method in the relay selector module was used solely in tests, so I made it private and only compiled for tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4834)
<!-- Reviewable:end -->
