### PR TITLE
Hide notification bar at change log

### DIFF
--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -41,6 +41,15 @@ protocol RootContainment {
 
     /// Return true if the view controller prefers header bar hidden
     var prefersHeaderBarHidden: Bool { get }
+
+    /// Return true if the view controller prefers notification bar hidden
+    var prefersNotificationBarHidden: Bool { get }
+}
+
+extension RootContainment {
+    var prefersNotificationBarHidden: Bool {
+        false
+    }
 }
 
 protocol RootContainerViewControllerDelegate: AnyObject {
@@ -81,6 +90,16 @@ class RootContainerViewController: UIViewController {
     private var appearingController: UIViewController?
     private var disappearingController: UIViewController?
     private var interfaceOrientationMask: UIInterfaceOrientationMask?
+    private var isNavigationBarHidden = false {
+        didSet {
+            guard let notificationController else {
+                return
+            }
+            isNavigationBarHidden
+                ? removeNotificationController(notificationController)
+                : addNotificationController(notificationController)
+        }
+    }
 
     var topViewController: UIViewController? {
         viewControllers.last
@@ -450,6 +469,9 @@ class RootContainerViewController: UIViewController {
 
         let viewControllersToAdd = newViewControllers.filter { !viewControllers.contains($0) }
         let viewControllersToRemove = viewControllers.filter { !newViewControllers.contains($0) }
+
+        // hide in-App notificationBanner when the container decides to keep it invisible
+        isNavigationBarHidden = (targetViewController as? RootContainment)?.prefersNotificationBarHidden ?? false
 
         let finishTransition = {
             /*

--- a/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogViewController.swift
+++ b/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogViewController.swift
@@ -19,6 +19,10 @@ class ChangeLogViewController: UIViewController, RootContainment {
         false
     }
 
+    var prefersNotificationBarHidden: Bool {
+        true
+    }
+
     // MARK: - Public
 
     var onFinish: (() -> Void)?


### PR DESCRIPTION
in some views like `Change log` we don't aim to show in-app notification bar.for excluding some views we've decided to add the flag `prefersNotificationBarHidden` into `RootContainment` protocol  that defines whether the container prefers to hide that or not.
for preventing from reworking the default value for the flag was set `false`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4835)
<!-- Reviewable:end -->
