### PR TITLE
Fix `too-many-devices` end-to-end test

### DIFF
--- a/gui/test/e2e/installed/state-dependent/too-many-devices.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/too-many-devices.spec.ts
@@ -40,10 +40,16 @@ test('App should show too many devices', async () => {
 
   await expect(loginButton).toBeEnabled();
 
+  // Trigger transition: too-many-devices -> login -> main
   expect(await util.waitForNavigation(() => {
     loginButton.click();
   })).toEqual(RoutePath.login);
-  expect(await util.waitForNavigation()).toEqual(RoutePath.main);
+
+  // Note: `util.waitForNavigation` won't return the navigation event when
+  // transitioning from login -> main, so we need to observe the state of the
+  // app after the entire transition chain has finished.
+  await util.waitForNoTransition();
+  await expect(page.getByTestId(RoutePath.main)).toBeVisible();
 });
 
 function getInput(page: Page): Locator {

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -9,6 +9,7 @@ export interface StartAppResponse {
 export interface TestUtils {
   currentRoute: () => Promise<string>;
   waitForNavigation: (initiateNavigation?: () => Promise<void> | void) =>  Promise<string>;
+  waitForNoTransition: () => Promise<void>;
 }
 
 interface History {
@@ -31,6 +32,7 @@ export const startApp = async (options: LaunchOptions): Promise<StartAppResponse
   const util: TestUtils = {
     currentRoute: currentRouteFactory(app),
     waitForNavigation: waitForNavigationFactory(app, page),
+    waitForNoTransition: () => waitForNoTransition(page),
   };
 
   return { app, page, util };


### PR DESCRIPTION
Fix a failing end-to-end test that was caused due to missing navigation events.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4842)
<!-- Reviewable:end -->
