### PR TITLE
Add CI job for vendoring Rust dependencies

### DIFF
--- a/.github/workflows/cargo-vendor.yml
+++ b/.github/workflows/cargo-vendor.yml
@@ -1,0 +1,28 @@
+---
+# The reason why we check for vendorability is not because we at Mullvad usually vendor
+# dependencies ourselves. But it can help some third party packagers of this project.
+# It also is a sanity check on our dependency tree. Vendoring will fail if a single
+# dependency has multiple sources: https://github.com/mullvad/mullvadvpn-app/issues/4848
+name: Rust - Vendor dependencies
+on:
+  pull_request:
+    paths:
+      - .github/workflows/cargo-vendor.yml
+      - Cargo.lock
+      - '**/Cargo.toml'
+  workflow_dispatch:
+jobs:
+  cargo-vendor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          default: true
+
+      - name: Vendor Rust dependencies
+        run: cargo vendor


### PR DESCRIPTION
Add a CI job for checking if `cargo vendor` works. Since it's part of cargo upstream there is no need to install anything except the Rust toolchain. Vendoring is nothing we use at Mullvad ourselves. But it can help third party package maintainers to build and package stuff.

My main motivation for adding this is the dependency tree cleanliness checks it implicitly imposes. Vendoring will fail if a dependency comes from multiple sources. Something we have had an issue with in for example version `2023.4` (see linked issue)

I think it's enough to run this on a single platform. It looks like `cargo vendor` on Linux also vendors macOS and Windows specific dependencies. So hopefully this very simple CI job should be enough.

Fixes DES-264
Fixes #4848

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4849)
<!-- Reviewable:end -->
