### PR TITLE
Use rustsec's own github action to run cargo audit

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -6,12 +6,8 @@ on:
       - .github/workflows/cargo-audit.yml
       - Cargo.lock
   schedule:
-    # At 06:20 UTC every day.
-    # Notifications for scheduled workflows are sent to the user who last modified the cron
-    # syntax in the workflow file. If you update this you must have notifications for
-    # Github Actions enabled, so these don't go unnoticed.
-    # https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs
-    - cron: '20 6 * * *'
+    # At 12:00 UTC every day. Will create an issue if a CVE is found
+    - cron: '00 12 * * *'
   workflow_dispatch:
 jobs:
   audit:
@@ -32,4 +28,4 @@ jobs:
           # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
           # so it should be safe to ignore it. Stop ignoring the warning once
           # atty has been removed from our dependency tree.
-          ignore: RUSTSEC-2020-0071,RUSTSEC-2021-0145
+          ignore: RUSTSEC-2020-0071

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -16,30 +16,20 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+      - uses: actions-rust-lang/audit@v1
+        name: Audit Rust Dependencies
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install cargo-audit
-        uses: actions-rs/install@v0.1.2
-        with:
-          crate: cargo-audit
-          version: latest
-
-      - name: Audit
-        # RUSTSEC-2020-0071: Ignore the time segfault CVE since there are no known
-        # good workarounds, and we want logs etc to be in local time.
-        #
-        # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
-        # so it should be safe to ignore it. Stop ignoring the warning once
-        # atty has been replaced in clap (when we upgrade to clap 4):
-        # https://github.com/clap-rs/clap/pull/4249
-        run: |
-          cargo audit --deny warnings \
-            --ignore RUSTSEC-2020-0071 \
-            --ignore RUSTSEC-2021-0145
+          denyWarnings: true
+          # RUSTSEC-2020-0071: Ignore the time segfault CVE since there are no known
+          # good workarounds, and we want logs etc to be in local time.
+          #
+          # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
+          # so it should be safe to ignore it. Stop ignoring the warning once
+          # atty has been removed from our dependency tree.
+          ignore: RUSTSEC-2020-0071,RUSTSEC-2021-0145


### PR DESCRIPTION
I found there are multiple actually updated dedicated Github Actions for Rust dependency auditing. The ones I found so far are: https://github.com/rustsec/audit-check and https://github.com/actions-rust-lang/audit. The latter seems to have a bit more configurability, but the former comes from the official `rustsec` organization, so I will try that out first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4852)
<!-- Reviewable:end -->
