### PR TITLE
Revert the temporary test on the cargo audit CI

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -6,8 +6,8 @@ on:
       - .github/workflows/cargo-audit.yml
       - Cargo.lock
   schedule:
-    # At 12:00 UTC every day. Will create an issue if a CVE is found
-    - cron: '00 12 * * *'
+    # At 06:20 UTC every day. Will create an issue if a CVE is found.
+    - cron: '20 6 * * *'
   workflow_dispatch:
 jobs:
   audit:
@@ -28,4 +28,4 @@ jobs:
           # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
           # so it should be safe to ignore it. Stop ignoring the warning once
           # atty has been removed from our dependency tree.
-          ignore: RUSTSEC-2020-0071
+          ignore: RUSTSEC-2020-0071,RUSTSEC-2021-0145


### PR DESCRIPTION
Fixes the temporary "flaw" introduced in 37ffc541b in order to test the CI.

The action did not run at 12:00 UTC as I expected it to. But when I manually triggered it via workflow_dispatch it did create an issue, so that part works.

Fixes #4854

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4855)
<!-- Reviewable:end -->
