### PR TITLE
Enable Shadowsocks bridges selection via RelaySelector

### DIFF
--- a/ios/MullvadREST/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ServerRelaysResponse.swift
@@ -48,30 +48,6 @@ extension REST {
         public let ipv6AddrIn: IPv6Address
         public let publicKey: Data
         public let includeInCountry: Bool
-
-        public init(
-            hostname: String,
-            active: Bool,
-            owned: Bool,
-            location: String,
-            provider: String,
-            weight: UInt64,
-            ipv4AddrIn: IPv4Address,
-            ipv6AddrIn: IPv6Address,
-            publicKey: Data,
-            includeInCountry: Bool
-        ) {
-            self.hostname = hostname
-            self.active = active
-            self.owned = owned
-            self.location = location
-            self.provider = provider
-            self.weight = weight
-            self.ipv4AddrIn = ipv4AddrIn
-            self.ipv6AddrIn = ipv6AddrIn
-            self.publicKey = publicKey
-            self.includeInCountry = includeInCountry
-        }
     }
 
     public struct ServerWireguardTunnels: Codable, Equatable {
@@ -79,18 +55,6 @@ extension REST {
         public let ipv6Gateway: IPv6Address
         public let portRanges: [[UInt16]]
         public let relays: [ServerRelay]
-
-        public init(
-            ipv4Gateway: IPv4Address,
-            ipv6Gateway: IPv6Address,
-            portRanges: [[UInt16]],
-            relays: [REST.ServerRelay]
-        ) {
-            self.ipv4Gateway = ipv4Gateway
-            self.ipv6Gateway = ipv6Gateway
-            self.portRanges = portRanges
-            self.relays = relays
-        }
     }
 
     public struct ServerShadowsocks: Codable, Equatable {
@@ -98,38 +62,16 @@ extension REST {
         public let port: UInt16
         public let cipher: String
         public let password: String
-
-        public init(protocol: String, port: UInt16, cipher: String, password: String) {
-            self.protocol = `protocol`
-            self.port = port
-            self.cipher = cipher
-            self.password = password
-        }
     }
 
     public struct ServerBridges: Codable, Equatable {
         public let shadowsocks: [ServerShadowsocks]
         public let relays: [BridgeRelay]
-
-        public init(shadowsocks: [REST.ServerShadowsocks], relays: [BridgeRelay]) {
-            self.shadowsocks = shadowsocks
-            self.relays = relays
-        }
     }
 
     public struct ServerRelaysResponse: Codable, Equatable {
         public let locations: [String: ServerLocation]
         public let wireguard: ServerWireguardTunnels
         public let bridge: ServerBridges
-
-        public init(
-            locations: [String: REST.ServerLocation],
-            wireguard: REST.ServerWireguardTunnels,
-            bridge: ServerBridges
-        ) {
-            self.locations = locations
-            self.wireguard = wireguard
-            self.bridge = bridge
-        }
     }
 }

--- a/ios/MullvadTransport/TransportProvider.swift
+++ b/ios/MullvadTransport/TransportProvider.swift
@@ -23,19 +23,30 @@ public final class TransportProvider: RESTTransport {
 
     private var currentTransport: RESTTransport?
     private let parallelRequestsMutex = NSLock()
+    private var relayConstraints = RelayConstraints()
+    private let constraintsUpdater: RelayConstraintsUpdater
 
     public init(
         urlSessionTransport: URLSessionTransport,
         relayCache: RelayCache,
         addressCache: REST.AddressCache,
         shadowsocksCache: ShadowsocksConfigurationCache,
-        transportStrategy: TransportStrategy = .init()
+        transportStrategy: TransportStrategy = .init(),
+        constraintsUpdater: RelayConstraintsUpdater
     ) {
         self.urlSessionTransport = urlSessionTransport
         self.relayCache = relayCache
         self.addressCache = addressCache
         self.shadowsocksCache = shadowsocksCache
         self.transportStrategy = transportStrategy
+        self.constraintsUpdater = constraintsUpdater
+        constraintsUpdater.onNewConstraints = { [weak self] newConstraints in
+            self?.parallelRequestsMutex.lock()
+            defer {
+                self?.parallelRequestsMutex.unlock()
+            }
+            self?.relayConstraints = newConstraints
+        }
     }
 
     // MARK: -
@@ -75,10 +86,13 @@ public final class TransportProvider: RESTTransport {
     /// Returns a randomly selected shadowsocks configuration.
     private func makeNewShadowsocksConfiguration() throws -> ShadowsocksConfiguration {
         let cachedRelays = try relayCache.read()
-        let bridgeAddress = RelaySelector.getShadowsocksRelay(relays: cachedRelays.relays)?.ipv4AddrIn
-        let bridgeConfiguration = RelaySelector.getShadowsocksTCPBridge(relays: cachedRelays.relays)
+        let bridgeConfiguration = RelaySelector.shadowsocksTCPBridge(from: cachedRelays.relays)
+        let closestRelay = RelaySelector.closestShadowsocksRelayConstrained(
+            by: relayConstraints,
+            in: cachedRelays.relays
+        )
 
-        guard let bridgeAddress, let bridgeConfiguration else { throw POSIXError(.ENOENT) }
+        guard let bridgeAddress = closestRelay?.ipv4AddrIn, let bridgeConfiguration else { throw POSIXError(.ENOENT) }
 
         let newConfiguration = ShadowsocksConfiguration(
             bridgeAddress: bridgeAddress,

--- a/ios/MullvadTypes/RelayConstraints.swift
+++ b/ios/MullvadTypes/RelayConstraints.swift
@@ -8,6 +8,18 @@
 
 import Foundation
 
+public protocol ConstraintsPropagation {
+    var onNewConstraints: ((RelayConstraints) -> Void)? { get set }
+}
+
+public class RelayConstraintsUpdater: ConstraintsPropagation {
+    public var onNewConstraints: ((RelayConstraints) -> Void)?
+
+    public init(onNewConstraints: ((RelayConstraints) -> Void)? = nil) {
+        self.onNewConstraints = onNewConstraints
+    }
+}
+
 public struct RelayConstraints: Codable, Equatable, CustomDebugStringConvertible {
     public var location: RelayConstraint<RelayLocation>
 

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -40,6 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private(set) var relayCacheTracker: RelayCacheTracker!
     private(set) var storePaymentManager: StorePaymentManager!
     private var transportMonitor: TransportMonitor!
+    private var relayConstraintsObserver: TunnelBlockObserver!
 
     // MARK: - Application lifecycle
 
@@ -85,6 +86,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             apiProxy: apiProxy
         )
 
+        let constraintsUpdater = RelayConstraintsUpdater()
+        relayConstraintsObserver = TunnelBlockObserver(didUpdateTunnelSettings: { _, settings in
+            constraintsUpdater.onNewConstraints?(settings.relayConstraints)
+        })
+
         storePaymentManager = StorePaymentManager(
             application: application,
             queue: .default(),
@@ -98,8 +104,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             urlSessionTransport: urlSessionTransport,
             relayCache: relayCache,
             addressCache: addressCache,
-            shadowsocksCache: shadowsocksCache
+            shadowsocksCache: shadowsocksCache,
+            constraintsUpdater: constraintsUpdater
         )
+
+        tunnelManager.addObserver(relayConstraintsObserver)
 
         transportMonitor = TransportMonitor(
             tunnelManager: tunnelManager,

--- a/ios/MullvadVPNTests/RelayCacheTests.swift
+++ b/ios/MullvadVPNTests/RelayCacheTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
-import MullvadREST
+@testable import MullvadREST
 import MullvadTransport
 @testable import RelayCache
 import XCTest

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -105,6 +105,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
     /// Whether to use the cached device state.
     private var useCachedDeviceState = false
 
+    private let constraintsUpdater = RelayConstraintsUpdater()
+
     /// Returns `PacketTunnelStatus` used for sharing with main bundle process.
     private var packetTunnelStatus: PacketTunnelStatus {
         let errors: [PacketTunnelErrorWrapper?] = [
@@ -147,7 +149,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
             urlSessionTransport: urlSessionTransport,
             relayCache: relayCache,
             addressCache: addressCache,
-            shadowsocksCache: shadowsocksCache
+            shadowsocksCache: shadowsocksCache,
+            constraintsUpdater: constraintsUpdater
         )
 
         let proxyFactory = REST.ProxyFactory.makeProxyFactory(
@@ -569,6 +572,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
         case let .set(aSelectorResult):
             selectorResult = aSelectorResult
         }
+
+        constraintsUpdater.onNewConstraints?(tunnelSettings.relayConstraints)
 
         return PacketTunnelConfiguration(
             deviceState: deviceState,


### PR DESCRIPTION
This PR introduces the ability for `RelaySelector` to select a Shadowsocks bridge that is filtered using the User's prefered relay chosen via the UI.

Due to how we propagate `relayConstraints` in the application, as long as the users do not choose a relay, a Shadowsocks bridge close to Sweden will be chosen by default.

I tried to implement filtering by Haversine distance (as the desktop clients do) but I decided to do that in a future work instead as to keep the PR impact minimal for `RelaySelector` 

How to test ?

This will only affect Shadowsocks bridges, so it's not immediately obvious how to test this. 
I would recommend forcing Shadowsocks transports to be used by default (set the `connectionAttempts` to `1` in `TransportStrategy`) and then select a Relay.

Due to how we cache the current Shadowsocks connection and selected endpoint at the moment, this is more likely to have an impact when the user experiences poor connectivity (more chances to switch transports in that case).

To that effect, you could disable the Shadowsocks caching for testing purposes and break on the selected relay to check whether it's close to what was chosen in the UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4856)
<!-- Reviewable:end -->
