### PR TITLE
Fix app tunnel state tests

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -98,7 +98,7 @@
     "e2e": "npm run build && npm run e2e:no-build",
     "e2e:no-build": "xvfb-maybe -- playwright test mocked",
     "e2e:sequential": "npm run build && npm run e2e:sequential:no-build",
-    "e2e:sequential:no-build": "xvfb-maybe -- playwright test --workers 1",
+    "e2e:sequential:no-build": "xvfb-maybe -- playwright test -c test/e2e/installed/playwright.config.ts --workers 1",
     "e2e:update-snapshots": "npm run e2e:no-build -- --update-snapshots",
     "develop": "gulp develop",
     "test": "cross-env NODE_ENV=test electron-mocha --renderer --reporter spec --require ts-node/register --require \"test/unit/setup.ts\" \"test/unit/**/*.{ts,tsx}\"",

--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -111,7 +111,7 @@ export default class ConnectionPanel extends React.Component<IProps> {
             {entryPoint && (
               <Row>
                 <Caption>{messages.pgettext('connection-info', 'In')}</Caption>
-                <Text>
+                <Text data-testid="in-ip">
                   {`${entryPoint.ip}:${entryPoint.port} ${entryPoint.protocol.toUpperCase()}`}
                 </Text>
               </Row>

--- a/gui/test/e2e/installed/playwright.config.ts
+++ b/gui/test/e2e/installed/playwright.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   testDir: process.cwd(),
   timeout: 60_000,
   workers: 1,
+  reportSlowTests: null,
+  maxFailures: 1,
   expect: {
     timeout: 30_000,
   },

--- a/gui/test/e2e/installed/state-dependent/disconnected.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/disconnected.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { Page } from 'playwright';
-import { assertDisconnected } from '../../shared/tunnel-state';
+import { expectDisconnected } from '../../shared/tunnel-state';
 
 import { startInstalledApp } from '../installed-utils';
 
@@ -18,5 +18,5 @@ test.afterAll(async () => {
 });
 
 test('App should show disconnected tunnel state', async () => {
-  await assertDisconnected(page);
+  await expectDisconnected(page);
 });

--- a/gui/test/e2e/installed/state-dependent/login.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/login.spec.ts
@@ -5,7 +5,7 @@ import { RoutePath } from '../../../../src/renderer/lib/routes';
 import { TestUtils } from '../../utils';
 
 import { startInstalledApp } from '../installed-utils';
-import { assertDisconnected } from '../../shared/tunnel-state';
+import { expectDisconnected } from '../../shared/tunnel-state';
 
 // This test expects the daemon to be logged out.
 // Env parameters:
@@ -87,7 +87,7 @@ test('App should log in', async () => {
   await expect(subtitle).toHaveText('Valid account number');
 
   expect(await util.waitForNavigation()).toEqual(RoutePath.main);
-  await assertDisconnected(page);
+  await expectDisconnected(page);
 });
 
 test('App should log out', async () => {

--- a/gui/test/e2e/mocked/tunnel-state.spec.ts
+++ b/gui/test/e2e/mocked/tunnel-state.spec.ts
@@ -3,7 +3,7 @@ import { Page } from 'playwright';
 
 import { MockedTestUtils, startMockedApp } from './mocked-utils';
 import { ErrorStateCause, ILocation, ITunnelEndpoint, TunnelState } from '../../../src/shared/daemon-rpc-types';
-import { assertConnected, assertConnecting, assertDisconnected, assertDisconnecting, assertError } from '../shared/tunnel-state';
+import { expectConnected, expectConnecting, expectDisconnected, expectDisconnecting, expectError } from '../shared/tunnel-state';
 
 const mockLocation: ILocation = {
   country: 'Sweden',
@@ -36,7 +36,7 @@ test('App should show disconnected tunnel state', async () => {
     channel: 'tunnel-',
     response: { state: 'disconnected' },
   });
-  await assertDisconnected(page);
+  await expectDisconnected(page);
 });
 
 /**
@@ -51,7 +51,7 @@ test('App should show connecting tunnel state', async () => {
     channel: 'tunnel-',
     response: { state: 'connecting' },
   });
-  await assertConnecting(page);
+  await expectConnecting(page);
 });
 
 /**
@@ -75,7 +75,7 @@ test('App should show connected tunnel state', async () => {
     response: { state: 'connected', details: { endpoint, location } },
   });
 
-  await assertConnected(page);
+  await expectConnected(page);
 });
 
 /**
@@ -90,7 +90,7 @@ test('App should show disconnecting tunnel state', async () => {
     channel: 'tunnel-',
     response: { state: 'disconnecting', details: 'nothing' },
   });
-  await assertDisconnecting(page);
+  await expectDisconnecting(page);
 });
 
 /**
@@ -105,5 +105,5 @@ test('App should show error tunnel state', async () => {
     channel: 'tunnel-',
     response: { state: 'error', details: { cause: ErrorStateCause.isOffline } },
   });
-  await assertError(page);
+  await expectError(page);
 });

--- a/gui/test/e2e/shared/tunnel-state.ts
+++ b/gui/test/e2e/shared/tunnel-state.ts
@@ -13,8 +13,8 @@ const SECURE_BUTTON_COLOR = anyOf(colors.green, colors.green90);
 const getLabel = (page: Page) => page.locator('span[role="status"]');
 const getHeader = (page: Page) => page.locator('header');
 
-export async function assertDisconnected(page: Page) {
-  await assertTunnelState(page, {
+export async function expectDisconnected(page: Page) {
+  await expectTunnelState(page, {
     labelText: 'unsecured connection',
     labelColor: UNSECURED_COLOR,
     headerColor: UNSECURED_COLOR,
@@ -23,8 +23,8 @@ export async function assertDisconnected(page: Page) {
   });
 }
 
-export async function assertConnecting(page: Page) {
-  await assertTunnelState(page, {
+export async function expectConnecting(page: Page) {
+  await expectTunnelState(page, {
     labelText: 'creating secure connection',
     labelColor: WHITE_COLOR,
     headerColor: SECURE_COLOR,
@@ -33,8 +33,8 @@ export async function assertConnecting(page: Page) {
   });
 }
 
-export async function assertConnected(page: Page) {
-  await assertTunnelState(page, {
+export async function expectConnected(page: Page) {
+  await expectTunnelState(page, {
     labelText: 'secure connection',
     labelColor: SECURE_COLOR,
     headerColor: SECURE_COLOR,
@@ -43,24 +43,24 @@ export async function assertConnected(page: Page) {
   });
 }
 
-export async function assertDisconnecting(page: Page) {
-  await assertTunnelState(page, {
+export async function expectDisconnecting(page: Page) {
+  await expectTunnelState(page, {
     headerColor: UNSECURED_COLOR,
     buttonText: 'secure my connection',
     buttonColor: SECURE_BUTTON_COLOR,
   });
 }
 
-export async function assertError(page: Page) {
-  await assertTunnelState(page, {
+export async function expectError(page: Page) {
+  await expectTunnelState(page, {
     labelText: 'blocked connection',
     labelColor: WHITE_COLOR,
     headerColor: SECURE_COLOR,
   });
 }
 
-export async function assertConnectingPq(page: Page) {
-  await assertTunnelState(page, {
+export async function expectConnectingPq(page: Page) {
+  await expectTunnelState(page, {
     labelText: 'creating quantum secure connection',
     labelColor: WHITE_COLOR,
     headerColor: SECURE_COLOR,
@@ -69,8 +69,8 @@ export async function assertConnectingPq(page: Page) {
   });
 }
 
-export async function assertConnectedPq(page: Page) {
-  await assertTunnelState(page, {
+export async function expectConnectedPq(page: Page) {
+  await expectTunnelState(page, {
     labelText: 'quantum secure connection',
     labelColor: SECURE_COLOR,
     headerColor: SECURE_COLOR,
@@ -87,7 +87,7 @@ interface TunnelStateContent {
   buttonColor?: string | RegExp;
 }
 
-export async function assertTunnelState(page: Page, content: TunnelStateContent) {
+export async function expectTunnelState(page: Page, content: TunnelStateContent) {
   const statusLabel = getLabel(page);
   if (content.labelText && content.labelColor) {
     await expect(statusLabel).toContainText(new RegExp(content.labelText, 'i'));


### PR DESCRIPTION
The tunnel state tests included a few race conditions which led to them failing every now and then. This PR fixes those race conditions.

I've also made sure the playwright config is used when running the tests with `npm` and improved the config a bit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4857)
<!-- Reviewable:end -->
