### PR TITLE
Upgrade proc-macro2 to get rid of compiler error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
Solves ["unknown feature `proc_macro_span_shrink`"](https://github.com/mullvad/mullvadvpn-app/actions/runs/5420635163/jobs/9855041609?pr=4850#step:7:456) issue we have been getting in the CI.