### PR TITLE
Upgrade hermit-abi to avoid yanked crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1643,7 +1643,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "io-lifetimes",
  "rustix 0.37.3",
  "windows-sys 0.48.0",


### PR DESCRIPTION
The upgrade is not important for us, since we don't target RustyHermit. But it's needed to keep `cargo audit` silent, and it's good hygiene.

The hermit-abi crate did not have a changelog. But the change is just a ffi function linking name change

https://github.com/hermitcore/rusty-hermit/issues/436

Fixes #4869

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4870)
<!-- Reviewable:end -->
