### PR TITLE
Fix increased touch areas for buttons in header bar view

### DIFF
--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -47,7 +47,6 @@ class HeaderBarView: UIView {
 
     private lazy var buttonContainer: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [accountButton, settingsButton])
-        stackView.spacing = UIMetrics.headerBarButtonSpacing
         return stackView
     }()
 
@@ -57,7 +56,7 @@ class HeaderBarView: UIView {
         return layer
     }()
 
-    let accountButton: IncreasedHitButton = {
+    let accountButton: UIButton = {
         let button = makeHeaderBarButton(with: UIImage(named: "IconAccount"))
         button.accessibilityIdentifier = "AccountButton"
         button.accessibilityLabel = NSLocalizedString(
@@ -66,10 +65,12 @@ class HeaderBarView: UIView {
             value: "Account",
             comment: ""
         )
+        button.heightAnchor.constraint(equalToConstant: UIMetrics.Button.barButtonSize).isActive = true
+        button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
         return button
     }()
 
-    let settingsButton: IncreasedHitButton = {
+    let settingsButton: UIButton = {
         let button = makeHeaderBarButton(with: UIImage(named: "IconSettings"))
         button.accessibilityIdentifier = "SettingsButton"
         button.accessibilityLabel = NSLocalizedString(
@@ -78,6 +79,8 @@ class HeaderBarView: UIView {
             value: "Settings",
             comment: ""
         )
+        button.heightAnchor.constraint(equalToConstant: UIMetrics.Button.barButtonSize).isActive = true
+        button.widthAnchor.constraint(equalTo: button.heightAnchor, multiplier: 1).isActive = true
         return button
     }()
 
@@ -164,8 +167,13 @@ class HeaderBarView: UIView {
 
         accessibilityContainerType = .semanticGroup
 
-        let imageSize = brandNameImage?.size ?? .zero
-        let brandNameAspectRatio = imageSize.width / max(imageSize.height, 1)
+        let brandImageSize = brandNameImage?.size ?? .zero
+        let brandNameAspectRatio = brandImageSize.width / max(brandImageSize.height, 1)
+
+        var buttonContainerTrailingAdjustment: CGFloat = 0
+        if let buttonImageWidth = settingsButton.currentImage?.size.width {
+            buttonContainerTrailingAdjustment = max((UIMetrics.Button.barButtonSize - buttonImageWidth) / 2, 0)
+        }
 
         [deviceNameLabel, timeLeftLabel].forEach { deviceInfoHolder.addArrangedSubview($0) }
 
@@ -190,7 +198,10 @@ class HeaderBarView: UIView {
             brandNameImageView.heightAnchor.constraint(equalToConstant: UIMetrics.headerBarBrandNameHeight)
 
             buttonContainer.centerYAnchor.constraint(equalTo: brandNameImageView.centerYAnchor)
-            buttonContainer.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
+            buttonContainer.trailingAnchor.constraint(
+                equalTo: layoutMarginsGuide.trailingAnchor,
+                constant: buttonContainerTrailingAdjustment
+            )
 
             deviceInfoHolder.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor)
             deviceInfoHolder.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)

--- a/ios/MullvadVPN/UI appearance/UIMetrics.swift
+++ b/ios/MullvadVPN/UI appearance/UIMetrics.swift
@@ -38,6 +38,10 @@ enum UIMetrics {
         static let cornerRadius = 8.0
         static let preferredContentSize = CGSize(width: 292, height: 263)
     }
+
+    enum Button {
+        static let barButtonSize: CGFloat = 44.0
+    }
 }
 
 extension UIMetrics {

--- a/ios/MullvadVPN/Views/IncreasedHitButton.swift
+++ b/ios/MullvadVPN/Views/IncreasedHitButton.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 final class IncreasedHitButton: UIButton {
-    private let defaultSize = 44.0
+    private let defaultSize = UIMetrics.Button.barButtonSize
 
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         let width = bounds.width


### PR DESCRIPTION
Since the settings and account buttons both reside in a stackview, their increased touch targets are limited by the size of the stackview. This should be reworked so that both buttons still get a 44x44 pixel touch target.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4871)
<!-- Reviewable:end -->
