### PR TITLE
Update when we fetch account expiry

### DIFF
--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import { sprintf } from 'sprintf-js';
 import { promisify } from 'util';
 
-import { closeToExpiry, hasExpired } from '../shared/account-expiry';
 import { connectEnabled, disconnectEnabled, reconnectEnabled } from '../shared/connect-helper';
 import { IAccountData, ILocation, TunnelState } from '../shared/daemon-rpc-types';
 import { messages, relayLocations } from '../shared/gettext';
@@ -325,10 +324,7 @@ export default class UserInterface implements WindowControllerDelegate {
       // cancel notifications when window appears
       this.delegate.dismissActiveNotifications();
 
-      const accountData = this.delegate.getAccountData();
-      if (!accountData || closeToExpiry(accountData.expiry, 4) || hasExpired(accountData.expiry)) {
-        this.delegate.updateAccountData();
-      }
+      this.delegate.updateAccountData();
     });
 
     this.windowController.window?.on('blur', () => {

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 
 import { colors, links } from '../../config.json';
 import { messages } from '../../shared/gettext';
@@ -22,13 +22,6 @@ import {
 
 export default function Support() {
   const history = useHistory();
-  const { updateAccountData } = useAppContext();
-
-  useEffect(() => {
-    if (history.action === 'PUSH') {
-      updateAccountData();
-    }
-  }, []);
 
   const loginState = useSelector((state) => state.account.status);
   const connectedToDaemon = useSelector((state) => state.userInterface.connectedToDaemon);


### PR DESCRIPTION
As part of https://github.com/mullvad/mullvadvpn-app/pull/4792 the account time left was added to the header in the main view. To make sure this value is always up to date we need to fetch the account data every time the app is opened. I also removed the fetch that was performed when opening the settings view since the time left isn't shown there anymore.
