### PR TITLE
Upgrade duct and os_pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,13 +907,13 @@ dependencies = [
 
 [[package]]
 name = "duct"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc6a0a59ed0888e0041cf708e66357b7ae1a82f1c67247e1f93b5e0818f7d8d"
+checksum = "37ae3fc31835f74c2a7ceda3aeede378b0ae2e74c8f1c36559fcc9ae2a4e7d3e"
 dependencies = [
  "libc",
  "once_cell",
- "os_pipe",
+ "os_pipe 1.1.4",
  "shared_child",
 ]
 
@@ -2500,6 +2500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "oslog"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,9 +3451,9 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
 dependencies = [
  "libc",
  "winapi",
@@ -3657,7 +3667,7 @@ dependencies = [
  "nftnl",
  "nix 0.23.1",
  "once_cell",
- "os_pipe",
+ "os_pipe 0.9.2",
  "parity-tokio-ipc",
  "parking_lot",
  "pfctl",
@@ -3722,7 +3732,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "log",
- "os_pipe",
+ "os_pipe 0.9.2",
  "parity-tokio-ipc",
  "parking_lot",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,7 @@ checksum = "37ae3fc31835f74c2a7ceda3aeede378b0ae2e74c8f1c36559fcc9ae2a4e7d3e"
 dependencies = [
  "libc",
  "once_cell",
- "os_pipe 1.1.4",
+ "os_pipe",
  "shared_child",
 ]
 
@@ -2491,16 +2491,6 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "os_pipe"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
@@ -3667,7 +3657,7 @@ dependencies = [
  "nftnl",
  "nix 0.23.1",
  "once_cell",
- "os_pipe 0.9.2",
+ "os_pipe",
  "parity-tokio-ipc",
  "parking_lot",
  "pfctl",
@@ -3732,7 +3722,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "log",
- "os_pipe 0.9.2",
+ "os_pipe",
  "parity-tokio-ipc",
  "parking_lot",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3657,7 +3657,6 @@ dependencies = [
  "nftnl",
  "nix 0.23.1",
  "once_cell",
- "os_pipe",
  "parity-tokio-ipc",
  "parking_lot",
  "pfctl",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -20,7 +20,6 @@ lazy_static = "1.0"
 once_cell = "1.13"
 libc = "0.2"
 log = "0.4"
-os_pipe = "1.1.4"
 parking_lot = "0.12.0"
 regex = "1.1.0"
 talpid-routing = { path = "../talpid-routing" }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.0"
 once_cell = "1.13"
 libc = "0.2"
 log = "0.4"
-os_pipe = "0.9"
+os_pipe = "1.1.4"
 parking_lot = "0.12.0"
 regex = "1.1.0"
 talpid-routing = { path = "../talpid-routing" }

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.15"
 is-terminal = "0.4.2"
 lazy_static = "1.0"
 log = "0.4"
-os_pipe = "0.9"
+os_pipe = "1.1.4"
 parking_lot = "0.12.0"
 shell-escape = "0.1"
 talpid-routing = { path = "../talpid-routing" }


### PR DESCRIPTION
Upgrades `duct` to latest version. This makes it use `os_pipe ^1` and `shared_child ^1` instead of `0.x` versions.

Then upgrade `os_pipe` as direct dependency also, to end up with the same version as duct (latest). Keeps our dependency tree tidier and brings us up to the latest versions.

Also found we had one unused instance of `os_pipe`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4876)
<!-- Reviewable:end -->
