### PR TITLE
Update Electron to 25.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Line wrap the file at 100 chars.                                              Th
   hostname`. This is in addition to accepting a geographical location as basis
   for filtering relays.
 - Silence OpenVPN "replay attack" warnings.
+- Update Electron from 23.2.0 to 25.2.0.
 
 #### Windows
 - In the CLI, add a unified `mullvad split-tunnel get` command to replace the old commands

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -36,7 +36,7 @@
         "@types/google-protobuf": "^3.15.6",
         "@types/history": "^4.7.11",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^16.11.65",
+        "@types/node": "^18.15.0",
         "@types/node-gettext": "^3.0.3",
         "@types/rbush": "^3.0.0",
         "@types/react": "^18.0.21",
@@ -54,7 +54,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
         "cross-env": "^7.0.3",
-        "electron": "^23.2.0",
+        "electron": "^25.2.0",
         "electron-builder": "^23.6.0",
         "electron-devtools-installer": "^3.2.0",
         "electron-mocha": "^11.0.2",
@@ -1503,9 +1503,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.65",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.65.tgz",
-      "integrity": "sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw=="
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
     },
     "node_modules/@types/node-gettext": {
       "version": "3.0.3",
@@ -4750,14 +4750,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.2.0.tgz",
-      "integrity": "sha512-De9e21cri0QYct/w6tTNOnKyCt9RVKUw5F8PEN4FPzGR9tr6IT53uyt42uH754uJWrZeLMCAdoXy6/0GmMmYZA==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
+      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -5237,6 +5237,12 @@
       "dependencies": {
         "is-electron-renderer": "^2.0.0"
       }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "18.16.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
+      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -15632,9 +15638,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.65",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.65.tgz",
-      "integrity": "sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw=="
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
     },
     "@types/node-gettext": {
       "version": "3.0.3",
@@ -18296,14 +18302,22 @@
       }
     },
     "electron": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.2.0.tgz",
-      "integrity": "sha512-De9e21cri0QYct/w6tTNOnKyCt9RVKUw5F8PEN4FPzGR9tr6IT53uyt42uH754uJWrZeLMCAdoXy6/0GmMmYZA==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
+      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.16.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
+          "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+          "dev": true
+        }
       }
     },
     "electron-builder": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -42,7 +42,7 @@
     "@types/google-protobuf": "^3.15.6",
     "@types/history": "^4.7.11",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^16.11.65",
+    "@types/node": "^18.15.0",
     "@types/node-gettext": "^3.0.3",
     "@types/rbush": "^3.0.0",
     "@types/react": "^18.0.21",
@@ -60,7 +60,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "cross-env": "^7.0.3",
-    "electron": "^23.2.0",
+    "electron": "^25.2.0",
     "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "electron-mocha": "^11.0.2",
@@ -112,7 +112,7 @@
     "npm": ">=8.3"
   },
   "volta": {
-    "node": "18.12.1",
-    "npm": "9.6.2"
+    "node": "18.15.0",
+    "npm": "9.7.2"
   }
 }

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -287,8 +287,8 @@ export default class UserInterface implements WindowControllerDelegate {
           backgroundColor: '#fff',
         });
         const WM_DEVICECHANGE = 0x0219;
-        const DBT_DEVICEARRIVAL = 0x8000;
-        const DBT_DEVICEREMOVECOMPLETE = 0x8004;
+        const DBT_DEVICEARRIVAL = 0x8000n;
+        const DBT_DEVICEREMOVECOMPLETE = 0x8004n;
         appWindow.hookWindowMessage(WM_DEVICECHANGE, (wParam) => {
           const wParamL = wParam.readBigInt64LE(0);
           if (wParamL != DBT_DEVICEARRIVAL && wParamL != DBT_DEVICEREMOVECOMPLETE) {
@@ -372,7 +372,7 @@ export default class UserInterface implements WindowControllerDelegate {
     // add inspect element on right click menu
     this.windowController.window?.webContents.on(
       'context-menu',
-      (_e: Event, props: { x: number; y: number; isEditable: boolean }) => {
+      (_e: Electron.Event, props: { x: number; y: number; isEditable: boolean }) => {
         const inspectTemplate = [
           {
             label: 'Inspect element',
@@ -512,7 +512,7 @@ export default class UserInterface implements WindowControllerDelegate {
     this.windowController.window?.on('close', this.windowCloseHandler);
   }
 
-  private windowCloseHandler = (closeEvent: Event) => {
+  private windowCloseHandler = (closeEvent: Electron.Event) => {
     closeEvent.preventDefault();
     this.windowController.hide();
   };


### PR DESCRIPTION
This PR upgrades Electron from 23.2.0 to 25.2.0. In the latest stable release we had a few issues related to the Electron version. At least the many tray icon issues seem to be improved in 25.2.0. I've also updated 

Changelog for major versions:
https://github.com/electron/electron/releases/tag/v24.0.0
https://github.com/electron/electron/releases/tag/v25.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4879)
<!-- Reviewable:end -->
