### PR TITLE
Use full CLI path in GUI tests

### DIFF
--- a/gui/test/e2e/installed/installed-utils.ts
+++ b/gui/test/e2e/installed/installed-utils.ts
@@ -16,3 +16,16 @@ function getAppInstallPath(): string {
       throw new Error('Platform not supported');
   }
 }
+
+export function getMullvadBin(): string {
+  switch (process.platform) {
+    case 'win32':
+      return 'C:\\Program Files\\Mullvad VPN\\resources\\mullvad.exe';
+    case 'linux':
+      return '/usr/bin/mullvad';
+    case 'darwin':
+      return '/usr/local/bin/mullvad';
+    default:
+      throw new Error('Platform not supported');
+  }
+}

--- a/gui/test/e2e/installed/state-dependent/login.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/login.spec.ts
@@ -4,7 +4,7 @@ import { Locator, Page } from 'playwright';
 import { RoutePath } from '../../../../src/renderer/lib/routes';
 import { TestUtils } from '../../utils';
 
-import { startInstalledApp } from '../installed-utils';
+import { getMullvadBin, startInstalledApp } from '../installed-utils';
 import { expectDisconnected } from '../../shared/tunnel-state';
 
 // This test expects the daemon to be logged out.
@@ -66,7 +66,7 @@ test('App should create account', async () => {
 
 test('App should become logged out', async () => {
   expect(await util.waitForNavigation(() => {
-    exec('mullvad account logout');
+    exec(`${getMullvadBin()} account logout`);
   })).toEqual(RoutePath.login);
 });
 
@@ -126,7 +126,7 @@ test('App should log in to expired account', async () => {
   const outOfTimeTitle = page.getByTestId('title');
   await expect(outOfTimeTitle).toHaveText('Out of time');
 
-  execSync('mullvad account logout');
+  execSync(`${getMullvadBin()} account logout`);
 });
 
 function getInput(page: Page): Locator {

--- a/gui/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -9,7 +9,7 @@ import {
   expectError,
 } from '../../shared/tunnel-state';
 
-import { startInstalledApp } from '../installed-utils';
+import { getMullvadBin, startInstalledApp } from '../installed-utils';
 import { escapeRegExp } from '../../utils';
 
 const exec = promisify(execAsync);
@@ -59,86 +59,94 @@ test('App should connect', async () => {
 
 test('App should show correct WireGuard port', async () => {
   const inData = page.getByTestId('in-ip');
+  const mullvadBin = getMullvadBin();
 
   await expect(inData).toContainText(new RegExp(':[0-9]+'));
 
-  await exec('mullvad relay set tunnel wireguard --port=53');
+  await exec(`${mullvadBin} relay set tunnel wireguard --port=53`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':53'));
 
-  await exec('mullvad relay set tunnel wireguard --port=51820');
+  await exec(`${mullvadBin} relay set tunnel wireguard --port=51820`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':51820'));
 
-  await exec('mullvad relay set tunnel wireguard --port=any');
+  await exec(`${mullvadBin} relay set tunnel wireguard --port=any`);
 });
 
 test('App should show correct WireGuard transport protocol', async () => {
   const inData = page.getByTestId('in-ip');
+  const mullvadBin = getMullvadBin();
 
-  await exec('mullvad obfuscation set mode udp2tcp');
+  await exec(`${mullvadBin} obfuscation set mode udp2tcp`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp('TCP'));
 
-  await exec('mullvad obfuscation set mode off');
+  await exec(`${mullvadBin} obfuscation set mode off`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp('UDP$'));
 });
 
 test('App should show correct tunnel protocol', async () => {
   const tunnelProtocol = page.getByTestId('tunnel-protocol');
+  const mullvadBin = getMullvadBin();
+
   await expect(tunnelProtocol).toHaveText('WireGuard');
 
-  await exec('mullvad relay set tunnel-protocol openvpn');
-  await exec('mullvad relay set location se');
+  await exec(`${mullvadBin} relay set tunnel-protocol openvpn`);
+  await exec(`${mullvadBin} relay set location se`);
   await expectConnected(page);
   await expect(tunnelProtocol).toHaveText('OpenVPN');
 });
 
 test('App should show correct OpenVPN transport protocol and port', async () => {
   const inData = page.getByTestId('in-ip');
+  const mullvadBin = getMullvadBin();
 
   await expect(inData).toContainText(new RegExp(':[0-9]+'));
   await expect(inData).toContainText(new RegExp('(TCP|UDP)$'));
-  await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1195');
+  await exec(`${mullvadBin} relay set tunnel openvpn --transport-protocol udp --port 1195`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':1195'));
 
-  await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1300');
+  await exec(`${mullvadBin} relay set tunnel openvpn --transport-protocol udp --port 1300`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':1300'));
 
-  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port any');
+  await exec(`${mullvadBin} relay set tunnel openvpn --transport-protocol tcp --port any`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':[0-9]+'));
   await expect(inData).toContainText(new RegExp('TCP$'));
 
-  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port 80');
+  await exec(`${mullvadBin} relay set tunnel openvpn --transport-protocol tcp --port 80`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':80'));
 
-  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port 443');
+  await exec(`${mullvadBin} relay set tunnel openvpn --transport-protocol tcp --port 443`);
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':443'));
 
-  await exec('mullvad relay set tunnel openvpn --transport-protocol any');
+  await exec(`${mullvadBin} relay set tunnel openvpn --transport-protocol any`);
 });
 
 test('App should show bridge mode', async () => {
-  await exec('mullvad bridge set state on');
+  const mullvadBin = getMullvadBin();
+
+  await exec(`${mullvadBin} bridge set state on`);
   await expectConnected(page);
   const relay = page.getByTestId('hostname-line');
   await expect(relay).toHaveText(new RegExp(' via ', 'i'));
-  await exec('mullvad bridge set state off');
+  await exec(`${mullvadBin} bridge set state off`);
 
-  await exec('mullvad relay set tunnel-protocol wireguard');
+  await exec(`${mullvadBin} relay set tunnel-protocol wireguard`);
 });
 
 test('App should enter blocked state', async () => {
-  await exec('mullvad relay set location xx');
+  const mullvadBin = getMullvadBin();
+  await exec(`${mullvadBin} relay set location xx`);
   await expectError(page);
 
-  await exec(`mullvad relay set location ${process.env.HOSTNAME}`);
+  await exec(`${mullvadBin} relay set location ${process.env.HOSTNAME}`);
   await expectConnected(page);
 });
 
@@ -148,29 +156,34 @@ test('App should disconnect', async () => {
 });
 
 test('App should create quantum secure connection', async () => {
-  await exec('mullvad tunnel set wireguard --quantum-resistant on');
+  const mullvadBin = getMullvadBin();
+  await exec(`${mullvadBin} tunnel set wireguard --quantum-resistant on`);
   await page.getByText('Secure my connection').click();
 
   await expectConnectedPq(page);
 });
 
 test('App should show multihop', async () => {
-  await exec('mullvad relay set tunnel wireguard --use-multihop=on');
+  const mullvadBin = getMullvadBin();
+
+  await exec(`${mullvadBin} relay set tunnel wireguard --use-multihop=on`);
   await expectConnectedPq(page);
   const relay = page.getByTestId('hostname-line');
   await expect(relay).toHaveText(new RegExp('^' + escapeRegExp(`${process.env.HOSTNAME} via`), 'i'));
-  await exec('mullvad relay set tunnel wireguard --use-multihop=off');
+  await exec(`${mullvadBin} relay set tunnel wireguard --use-multihop=off`);
 
-  await exec('mullvad tunnel set wireguard --quantum-resistant off');
+  await exec(`${mullvadBin} tunnel set wireguard --quantum-resistant off`);
   await page.getByText('Disconnect').click();
 });
 
 
 test('App should become connected when other frontend connects', async () => {
+  const mullvadBin = getMullvadBin();
+
   await expectDisconnected(page);
-  await exec('mullvad connect');
+  await exec(`${mullvadBin} connect`);
   await expectConnected(page);
 
-  await exec('mullvad disconnect');
+  await exec(`${mullvadBin} disconnect`);
   await expectDisconnected(page);
 });


### PR DESCRIPTION
The test runner starts before `PATH` has been updated, so let's not rely on `PATH`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4886)
<!-- Reviewable:end -->
