### PR TITLE
Remove `x_threshold_wg_default` code

### DIFF
--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -547,16 +547,6 @@ pub struct AppVersionResponse {
     pub latest: AppVersion,
     pub latest_stable: Option<AppVersion>,
     pub latest_beta: AppVersion,
-    #[serde(default = "default_wg_threshold")]
-    pub x_threshold_wg_default: f32,
-}
-
-/// Temporary function that will be removed later. Used to generate default wg_threshold.
-/// In case there is no `x_threshold_wg_default` returned by the API result we interpret that to
-/// mean that the migration is done and WireGuard should be the default. In that case the threshold
-/// value should be 1.0
-fn default_wg_threshold() -> f32 {
-    1.0
 }
 
 impl AppVersionProxy {

--- a/mullvad-daemon/src/custom_lists.rs
+++ b/mullvad-daemon/src/custom_lists.rs
@@ -62,7 +62,7 @@ where
                     self.event_listener
                         .notify_settings(self.settings.to_settings());
                     self.relay_selector
-                        .set_config(new_selector_config(&self.settings, &self.app_version_info));
+                        .set_config(new_selector_config(&self.settings));
 
                     if need_to_reconnect {
                         log::info!(
@@ -100,7 +100,7 @@ where
             self.event_listener
                 .notify_settings(self.settings.to_settings());
             self.relay_selector
-                .set_config(new_selector_config(&self.settings, &self.app_version_info));
+                .set_config(new_selector_config(&self.settings));
         }
 
         settings_changed.map(|_| ())
@@ -148,10 +148,8 @@ where
 
                         self.event_listener
                             .notify_settings(self.settings.to_settings());
-                        self.relay_selector.set_config(new_selector_config(
-                            &self.settings,
-                            &self.app_version_info,
-                        ));
+                        self.relay_selector
+                            .set_config(new_selector_config(&self.settings));
 
                         if should_reconnect {
                             log::info!(
@@ -207,10 +205,8 @@ where
 
                         self.event_listener
                             .notify_settings(self.settings.to_settings());
-                        self.relay_selector.set_config(new_selector_config(
-                            &self.settings,
-                            &self.app_version_info,
-                        ));
+                        self.relay_selector
+                            .set_config(new_selector_config(&self.settings));
 
                         if should_reconnect {
                             log::info!(
@@ -263,10 +259,8 @@ where
                     if let Ok(true) = settings_changed {
                         self.event_listener
                             .notify_settings(self.settings.to_settings());
-                        self.relay_selector.set_config(new_selector_config(
-                            &self.settings,
-                            &self.app_version_info,
-                        ));
+                        self.relay_selector
+                            .set_config(new_selector_config(&self.settings));
                     }
 
                     Ok(())

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -278,20 +278,11 @@ impl VersionUpdater {
             self.show_beta_releases || is_beta_version(),
         );
 
-        let wg_migration_threshold = if response.x_threshold_wg_default.is_nan() {
-            // If the value should for some strange reason be NaN then safe default to 0.0
-            0.0
-        } else {
-            // Make sure that the returned value is between 0% and 100%
-            response.x_threshold_wg_default.clamp(0.0, 1.0)
-        };
-
         AppVersionInfo {
             supported: response.supported,
             latest_stable: response.latest_stable.unwrap_or_else(|| "".to_owned()),
             latest_beta: response.latest_beta,
             suggested_upgrade,
-            wg_migration_threshold,
         }
     }
 
@@ -377,7 +368,6 @@ impl VersionUpdater {
                                     latest_stable: last_app_version_info.latest_stable,
                                     latest_beta: last_app_version_info.latest_beta,
                                     suggested_upgrade,
-                                    wg_migration_threshold: last_app_version_info.wg_migration_threshold,
                                 }).await;
                             }
                         }
@@ -471,10 +461,6 @@ fn dev_version_cache() -> AppVersionInfo {
         latest_stable: mullvad_version::VERSION.to_owned(),
         latest_beta: mullvad_version::VERSION.to_owned(),
         suggested_upgrade: None,
-        // Use WireGuard on 75% of dev builds. So we can manually modify
-        // wg_migration_rand_num in the settings and verify that the migration
-        // works as expected.
-        wg_migration_threshold: 0.75,
     }
 }
 

--- a/mullvad-management-interface/src/types/conversions/version.rs
+++ b/mullvad-management-interface/src/types/conversions/version.rs
@@ -22,8 +22,6 @@ impl From<proto::AppVersionInfo> for mullvad_types::version::AppVersionInfo {
             } else {
                 Some(version_info.suggested_upgrade)
             },
-            // NOTE: This field is meaningless when derived from the gRPC type
-            wg_migration_threshold: f32::NAN,
         }
     }
 }

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -35,11 +35,6 @@ pub struct AppVersionInfo {
     pub latest_beta: AppVersion,
     /// Whether should update to newer version
     pub suggested_upgrade: Option<AppVersion>,
-    /// Temporary field provided by the API used to decide if a user should default to Wireguard or
-    /// OpenVpn. Represents the percentage of users which should use Wireguard.
-    /// NOTE: This field will be removed completely in future versions.
-    #[cfg_attr(target_os = "android", jnix(skip))]
-    pub wg_migration_threshold: f32,
 }
 
 pub type AppVersion = String;


### PR DESCRIPTION
Since we migrated to using Wireguard as the definitive default protocol, we can stop reading the `x_threshold_wg_default` field from the API and remove all daemon code related to using it

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4891)
<!-- Reviewable:end -->
