### PR TITLE
Set package fields in workspace and inherit in packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "translations-converter"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "derive_more",
  "htmlize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
+[workspace.package]
+version = "0.0.0"
+authors = ["Mullvad VPN"]
+repository = "https://github.com/mullvad/mullvadvpn-app/"
+license = "GPL-3.0"
+edition = "2021"
+publish = false
+
 [workspace]
 resolver = "2"
 members = [

--- a/android/translations-converter/Cargo.toml
+++ b/android/translations-converter/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "translations-converter"
-version = "0.1.0"
-authors = ["Mullvad VPN"]
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+description = "Converts between PO and Android style localization formats"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 derive_more = "0.99"

--- a/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
+++ b/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "shadowsocks-proxy"
-version = "0.0.0"
-edition = "2021"
-license = "GPL-3.0"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lib]
 crate-type = [ "rlib", "staticlib" ]

--- a/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
+++ b/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "tunnel-obfuscator-proxy"
-version = "0.0.0"
-edition = "2021"
-license = "GPL-3.0"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lib]
 crate-type = [ "rlib", "staticlib" ]

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-api"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Mullvad VPN API clients. Providing an interface to query our infrastructure for information."
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [features]
 # Allow the API server to use to be configured via MULLVAD_API_HOST and MULLVAD_API_ADDR.

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "mullvad-cli"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Manage the Mullvad VPN daemon via a convenient CLI"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
+
 
 [[bin]]
 name = "mullvad"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-daemon"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [features]
 # Allow the API server to use to be configured

--- a/mullvad-exclude/Cargo.toml
+++ b/mullvad-exclude/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "mullvad-exclude"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+description = "Runs programs outside the Mullvad VPN tunnel on Linux"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.23"

--- a/mullvad-fs/Cargo.toml
+++ b/mullvad-fs/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-fs"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "File utility library"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 log = "0.4"

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-jni"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "JNI interface for the Mullvad daemon"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [features]
 # Allow the API server to use to be configured

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-management-interface"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Mullvad VPN IPC. Contains types and functions for IPC clients and servers."
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 chrono = { version = "0.4.26" }

--- a/mullvad-nsis/Cargo.toml
+++ b/mullvad-nsis/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-nsis"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Helper library used by Mullvad NSIS plugins"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lib]
 crate_type = ["staticlib"]

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-paths"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Mullvad VPN application paths and directories"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 err-derive = "0.3.1"

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-problem-report"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Collect Mullvad VPN logs into a report and send it to support"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 dirs-next = "2.0"

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-relay-selector"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Mullvad VPN relay selector"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 chrono = "0.4.21"

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-setup"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Tool used to manage daemon setup"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [[bin]]
 name = "mullvad-setup"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "mullvad-types"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Common base data structures for Mullvad VPN client"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 chrono = { version = "0.4.26", features = ["serde"] }

--- a/mullvad-version/Cargo.toml
+++ b/mullvad-version/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "mullvad-version"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
-license = "GPL-3.0"
-edition = "2021"
-publish = false
-
 description = """
 Computes the Mullvad VPN app product version. This crate is the single source of truth for
 what version string a build should have. This crate is responsible for computing the
 `-dev-$git_hash` suffix as well as transforming the version into semver, Android versionCode
 and other formats.
 """
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
+
 
 [target.'cfg(not(target_os="android"))'.dependencies]
 regex = "1.6.0"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-core"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Privacy preserving and secure VPN client library"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 bitflags = "1.2"

--- a/talpid-dbus/Cargo.toml
+++ b/talpid-dbus/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "talpid-dbus"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9"

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-openvpn-plugin"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "OpenVPN shared library plugin for relaying OpenVPN events to talpid_core"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-openvpn"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Library for creating OpenVPN tunnels"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 
 [dependencies]

--- a/talpid-platform-metadata/Cargo.toml
+++ b/talpid-platform-metadata/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-platform-metadata"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Platform metadata detection functions"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-routing"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Library for managing routing tables"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 
 [dependencies]

--- a/talpid-time/Cargo.toml
+++ b/talpid-time/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-time"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Time functions"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 tokio = { version = "1.8", features = ["time"] }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-tunnel-config-client"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Uses the relay RPC service to set up PQ-safe peers, etc."
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 log = "0.4"

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-tunnel"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Library for creating tunnel devices and interfacing with various VPN tunnels"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 err-derive = "0.3.1"

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-types"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Common base structures for talpid"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/talpid-windows-net/Cargo.toml
+++ b/talpid-windows-net/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-windows-net"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Work with Windows network interfaces and their configuration"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 err-derive = "0.3.1"

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "talpid-wireguard"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Library for creating various WireGuard tunnels"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 
 [dependencies]

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tunnel-obfuscation"
-version = "0.0.0"
-authors = ["Mullvad VPN"]
 description = "Provides different types of obfuscation layers for WireGuard"
-license = "GPL-3.0"
-edition = "2021"
-publish = false
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
When researching denying `rustc` lints in a config file instead of repeating `#![deny(rust_2018_idioms)]` in every `lib.rs` and `main.rs` (that is a nightly feature and probably nothing we can use right now) I stumbled upon the `[workspace.package]` feature of Cargo. I had completely missed this feature! Apparently we can define a lot of common fields directly in the top level `Cargo.toml` and have all packages underneath inherit the value.

With this feature we run a slightly lower risk of forgetting `publish = false` in new crates. We can also bump the Rust edition in a single place instead of a million places.

It's a bit verbose to have to declare `<field>.workspace = true` for every field in the packages. I wished it automatically inherited everything not explicitly overridden in the fields. But it is what it is. And since Rust 1.71.0 `cargo new` automatically inserts these inherit fields when creating new packages. So makes it harder to forget setting some of them.

This is a draft PR because I did not finish migrating all packages to inherit fields. I wanted to first publish this and get some feedback on the feature overall.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4901)
<!-- Reviewable:end -->
