### PR TITLE
Use workspace dependencies for Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,12 @@ members = [
 
 [workspace.dependencies]
 tokio = { version = "1.8" }
+# Tonic and related crates
+tonic = "0.8"
+tonic-build = { version = "0.8", default-features = false }
+tower = "0.4"
+prost = "0.11"
+prost-types = "0.11"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ members = [
     "tunnel-obfuscation",
 ]
 
+[workspace.dependencies]
+tokio = { version = "1.8" }
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
+++ b/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
@@ -16,7 +16,7 @@ shadowsocks-service.git = "https://github.com/mullvad/shadowsocks-rust"
 shadowsocks-service.rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36"
 shadowsocks-service.features = [ "local", "stream-cipher", "local-http", "local-tunnel" ]
 
-tokio = "1"
+tokio = { workspace = true }
 libc = "0.2"
 log = "0.4"
 

--- a/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
+++ b/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 
 [target.'cfg(target_os = "ios")'.dependencies]
 tunnel-obfuscation = { path = "../../../tunnel-obfuscation" }
-tokio = { version = "1", features = ["sync"] }
+tokio = { workspace = true, features = ["sync"] }
 libc = "0.2"
 log = "0.4"
 oslog = "0.2"

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 regex = "1"
 serde = "1"
 serde_json = "1.0"
-tokio = { version = "1.8", features = ["macros", "time", "rt-multi-thread", "net", "io-std", "io-util", "fs"] }
+tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread", "net", "io-std", "io-util", "fs"] }
 tokio-rustls = "0.23"
 rustls-pemfile = "0.2"
 once_cell = "1.13"

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -30,7 +30,7 @@ mullvad-version = { path = "../mullvad-version" }
 talpid-types = { path = "../talpid-types" }
 
 mullvad-management-interface = { path = "../mullvad-management-interface" }
-tokio = { version = "1.8", features =  [ "rt-multi-thread" ] }
+tokio = { workspace = true, features =  [ "rt-multi-thread" ] }
 
 [target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 clap_complete = { version = "4.2.1" }

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8.5"
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.8", features =  ["fs", "io-util", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features =  ["fs", "io-util", "rt-multi-thread", "sync", "time"] }
 tokio-stream = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/mullvad-fs/Cargo.toml
+++ b/mullvad-fs/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 
 [dependencies]
 log = "0.4"
-tokio = { version = "1.8", features = ["fs"] }
+tokio = { workspace = true, features = ["fs"] }
 uuid = { version = "0.8", features = ["v4"] }
 
 talpid-types = { path = "../talpid-types" }

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 log-panics = "2"
 nix = "0.23"
 rand = "0.8.5"
-tokio = "1.8"
+tokio = { workspace = true }
 
 mullvad-daemon = { path = "../mullvad-daemon" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -20,7 +20,7 @@ prost = "0.11"
 prost-types = "0.11"
 parity-tokio-ipc = "0.9"
 futures = "0.3"
-tokio = { version = "1.8", features =  ["rt"] }
+tokio = { workspace = true, features =  ["rt"] }
 log = "0.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -14,10 +14,10 @@ err-derive = "0.3.1"
 mullvad-types = { path = "../mullvad-types" }
 mullvad-paths = { path = "../mullvad-paths" }
 talpid-types = { path = "../talpid-types" }
-tonic = "0.8"
-tower = "0.4"
-prost = "0.11"
-prost-types = "0.11"
+tonic = { workspace = true }
+tower = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
 parity-tokio-ipc = "0.9"
 futures = "0.3"
 tokio = { workspace = true, features =  ["rt"] }
@@ -28,4 +28,4 @@ nix = "0.23"
 lazy_static = "1.0"
 
 [build-dependencies]
-tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"] }
+tonic-build = { workspace = true, default-features = false, features = ["transport", "prost"] }

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = "1.0"
 log = "0.4"
 regex = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
-tokio = { version = "1.8", features = ["rt"] }
+tokio = { workspace = true, features = ["rt"] }
 
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-api = { path = "../mullvad-api" }

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -18,7 +18,7 @@ parking_lot = "0.12.0"
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.8", features =  ["fs", "io-util", "time"] }
+tokio = { workspace = true, features =  ["fs", "io-util", "time"] }
 tokio-stream = "0.1"
 
 talpid-core = { path = "../talpid-core" }

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.1.0"
 
 mullvad-management-interface = { path = "../mullvad-management-interface" }
 
-tokio = { version = "1.8", features =  ["rt-multi-thread"] }
+tokio = { workspace = true, features =  ["rt-multi-thread"] }
 
 mullvad-daemon = { path = "../mullvad-daemon" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -39,11 +39,11 @@ byteorder = "1"
 internet-checksum = "0.2"
 shell-escape = "0.1"
 socket2 = { version = "0.4.2", features = ["all"] }
-prost = "0.11"
 parity-tokio-ipc = "0.9"
 talpid-openvpn = { path = "../talpid-openvpn" }
 triggered = "0.1.1"
-tonic = "0.8"
+tonic = { workspace = true }
+prost = { workspace = true }
 uuid = { version = "0.8", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
@@ -107,8 +107,7 @@ features = [
 ]
 
 [build-dependencies]
-tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"] }
-
+tonic-build = { workspace = true, default-features = false, features = ["transport", "prost"] }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -31,7 +31,7 @@ talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-wireguard = { path = "../talpid-wireguard" }
 zeroize = "1"
 chrono = "0.4.21"
-tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 rand = "0.8.5"
 
 [target.'cfg(not(target_os="android"))'.dependencies]
@@ -114,4 +114,4 @@ tonic-build = { version = "0.8", default-features = false, features = ["transpor
 tempfile = "3.0"
 quickcheck = { version = "1.0", default-features = false }
 quickcheck_macros = "1.0"
-tokio = { version = "1", features = [ "test-util" ] }
+tokio = { workspace = true, features = [ "test-util" ] }

--- a/talpid-dbus/Cargo.toml
+++ b/talpid-dbus/Cargo.toml
@@ -13,4 +13,4 @@ err-derive = "0.3.1"
 lazy_static = "1.0"
 log = "0.4"
 libc = "0.2"
-tokio = { version = "1.8", features = ["rt"] }
+tokio = { workspace = true, features = ["rt"] }

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -16,7 +16,7 @@ err-derive = "0.3.1"
 log = "0.4"
 env_logger = "0.10.0"
 parity-tokio-ipc = "0.9"
-tokio = { version = "1.8", features =  ["rt"] }
+tokio = { workspace = true, features =  ["rt"] }
 
 openvpn-plugin = { version = "0.4.2", features = ["serde", "log", "auth-failed-event"] }
 talpid-types = { path = "../talpid-types" }

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -21,12 +21,12 @@ tokio = { workspace = true, features =  ["rt"] }
 openvpn-plugin = { version = "0.4.2", features = ["serde", "log", "auth-failed-event"] }
 talpid-types = { path = "../talpid-types" }
 
-tonic = "0.8"
-tower = "0.4"
-prost = "0.11"
+tonic = { workspace = true }
+tower = { workspace = true }
+prost = { workspace = true }
 
 [build-dependencies]
-tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"] }
+tonic-build = { workspace = true, default-features = false, features = ["transport", "prost"] }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -33,8 +33,8 @@ shadowsocks-service = { git = "https://github.com/mullvad/shadowsocks-rust", rev
 socket2 = { version = "0.4.2", features = ["all"] }
 parity-tokio-ipc = "0.9"
 triggered = "0.1.1"
-tonic = "0.8"
-prost = "0.11"
+tonic = { workspace = true }
+prost = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 which = { version = "4.0", default-features = false }
@@ -54,7 +54,7 @@ features = [
 ]
 
 [build-dependencies]
-tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"] }
+tonic-build = { workspace = true, default-features = false, features = ["transport", "prost"] }
 
 
 [dev-dependencies]

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -26,7 +26,7 @@ talpid-routing = { path = "../talpid-routing" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-types = { path = "../talpid-types" }
 uuid = { version = "0.8", features = ["v4"] }
-tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 shadowsocks-service = { git = "https://github.com/mullvad/shadowsocks-rust", rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36",  features = [ "local", "stream-cipher" ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
@@ -58,4 +58,4 @@ tonic-build = { version = "0.8", default-features = false, features = ["transpor
 
 
 [dev-dependencies]
-tokio = { version = "1", features = [ "test-util" ] }
+tokio = { workspace = true, features = [ "test-util" ] }

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.15"
 ipnetwork = "0.16"
 log = "0.4"
 talpid-types = { path = "../talpid-types" }
-tokio = { version = "1.8", features = ["process", "rt-multi-thread", "net"] }
+tokio = { workspace = true, features = ["process", "rt-multi-thread", "net"] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
 talpid-types = { path = "../talpid-types" }
@@ -46,4 +46,4 @@ windows-sys = { version = "0.45.0", features = [
 ]}
 
 [dev-dependencies]
-tokio = { version = "1", features = [ "test-util" ] }
+tokio = { workspace = true, features = [ "test-util" ] }

--- a/talpid-time/Cargo.toml
+++ b/talpid-time/Cargo.toml
@@ -9,5 +9,5 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-tokio = { version = "1.8", features = ["time"] }
+tokio = { workspace = true, features = ["time"] }
 libc = "0.2"

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -12,9 +12,9 @@ publish.workspace = true
 log = "0.4"
 rand = "0.8"
 talpid-types = { path = "../talpid-types" }
-tonic = "0.8"
-prost = "0.11"
-tower = "0.4"
+tonic = { workspace = true }
+tower = { workspace = true }
+prost = { workspace = true }
 tokio = { workspace = true }
 classic-mceliece-rust = { version = "2.0.0", features = ["mceliece460896f", "zeroize"] }
 pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024", "zeroize"] }
@@ -30,4 +30,4 @@ windows-sys = { version = "0.45.0", features = [
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [build-dependencies]
-tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"] }
+tonic-build = { workspace = true, default-features = false, features = ["transport", "prost"] }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -15,7 +15,7 @@ talpid-types = { path = "../talpid-types" }
 tonic = "0.8"
 prost = "0.11"
 tower = "0.4"
-tokio = "1"
+tokio = { workspace = true }
 classic-mceliece-rust = { version = "2.0.0", features = ["mceliece460896f", "zeroize"] }
 pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024", "zeroize"] }
 zeroize = "1.5.7"
@@ -27,7 +27,7 @@ windows-sys = { version = "0.45.0", features = [
 ]}
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [build-dependencies]
 tonic-build = { version = "0.8", default-features = false, features = ["transport", "prost"] }

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -15,7 +15,7 @@ ipnetwork = "0.16"
 talpid-routing = { path = "../talpid-routing" }
 talpid-types = { path = "../talpid-types" }
 futures = "0.3.15"
-tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 
 [target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 duct = "0.13"

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -24,7 +24,7 @@ talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 zeroize = "1"
 chrono = "0.4.21"
-tokio = { version = "1.8", features = ["process", "rt-multi-thread", "fs"] }
+tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 rand = "0.8.5"
 

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -12,5 +12,5 @@ publish.workspace = true
 async-trait = "0.1"
 err-derive = "0.3.0"
 futures = "0.3.5"
-tokio = { version = "1.8", features = ["rt-multi-thread", "macros", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util"] }
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "87936ac29b68b902565955f138ab02294bcc8593" }


### PR DESCRIPTION
Trying out the `[workspace.dependencies]` functionality of Cargo. It's pretty neat to be able to declare dependencies at the workspace level. Then we only have a single place to bump the version when we upgrade dependencies.

You could argue that we are almost never going to bump tokio. And when we do, it will be such a large re-write anyway that this "optimization" is not important. And that's correct. But there are plenty of other crates that we do upgrade fairly regularly that might benefit more from this. So maybe starting with `tokio` was wrong. For `tonic` it makes more sense. Because we will need to upgrade it (there is already `0.9` out), and there are a bunch of related crates that goes with it. So there is one place to bump all the five crates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4902)
<!-- Reviewable:end -->
