### PR TITLE
Disable App version cell click on release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix RPM package containing unecessary files causing conflicts with other electron-builder based
   packages.
 
+#### Android
+- Prevent opening download page in Google Play builds.
+
 
 ## [android/2023.3] - 2023-06-27
 ### Changed

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrl.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/NotificationWithUrl.kt
@@ -18,4 +18,9 @@ abstract class NotificationWithUrl(protected val context: Context, urlString: St
         onClick = openUrl
         showIcon = true
     }
+
+    internal fun disableExternalLink() {
+        showIcon = false
+        onClick = null
+    }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/notification/VersionInfoNotification.kt
@@ -1,7 +1,9 @@
 package net.mullvad.mullvadvpn.ui.notification
 
 import android.content.Context
+import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.constant.BuildTypes
 import net.mullvad.mullvadvpn.ui.VersionInfo
 import net.mullvad.mullvadvpn.util.appendHideNavOnReleaseBuild
 
@@ -36,6 +38,9 @@ class VersionInfoNotification(context: Context) :
             }
 
             shouldShow = true
+            if (BuildTypes.RELEASE == BuildConfig.BUILD_TYPE) {
+                disableExternalLink()
+            }
         } else {
             shouldShow = false
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/AppVersionCell.kt
@@ -9,7 +9,9 @@ import android.view.Gravity
 import android.widget.ImageView
 import android.widget.TextView
 import kotlin.properties.Delegates.observable
+import net.mullvad.mullvadvpn.BuildConfig
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.constant.BuildTypes
 import net.mullvad.mullvadvpn.util.appendHideNavOnReleaseBuild
 
 class AppVersionCell : UrlCell {
@@ -66,7 +68,9 @@ class AppVersionCell : UrlCell {
     init {
         cell.addView(warningIcon, 0)
         cell.addView(versionLabel, cell.getChildCount() - 1)
-
+        if (BuildTypes.RELEASE == BuildConfig.BUILD_TYPE) {
+            disableExternalLink()
+        }
         if (url == null) {
             url = Uri.parse(context.getString(R.string.download_url).appendHideNavOnReleaseBuild())
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/widget/UrlCell.kt
@@ -33,6 +33,11 @@ open class UrlCell : Cell {
         onClickListener = { openLink() }
     }
 
+    internal fun disableExternalLink() {
+        externalLinkIcon.visibility = GONE
+        onClickListener = null
+    }
+
     private fun loadAttributes(attributes: AttributeSet?) {
         context.theme.obtainStyledAttributes(attributes, R.styleable.Url, 0, 0).apply {
             try {


### PR DESCRIPTION
Disable click and hide external link icon from App version cell on google play version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4907)
<!-- Reviewable:end -->
