### PR TITLE
Migrate connect view header bar to compose

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/Scaffolding.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/Scaffolding.kt
@@ -29,7 +29,8 @@ fun ScaffoldWithTopBar(
     topBarColor: Color,
     statusBarColor: Color,
     navigationBarColor: Color,
-    onSettingsClicked: (() -> Unit)?,
+    onAccountIconClick: (() -> Unit)?,
+    onSettingsIconClick: (() -> Unit)?,
     isIconAndLogoVisible: Boolean = true,
     content: @Composable (PaddingValues) -> Unit,
 ) {
@@ -41,7 +42,8 @@ fun ScaffoldWithTopBar(
         topBar = {
             TopBar(
                 backgroundColor = topBarColor,
-                onSettingsClicked = onSettingsClicked,
+                onAccountIconClick = onAccountIconClick,
+                onSettingsIconClick = onSettingsIconClick,
                 isIconAndLogoVisible = isIconAndLogoVisible
             )
         },

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/TopBar.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/TopBar.kt
@@ -24,13 +24,18 @@ import net.mullvad.mullvadvpn.R
 @Preview
 @Composable
 private fun PreviewTopBar() {
-    TopBar(backgroundColor = colorResource(R.color.blue), onSettingsClicked = {})
+    TopBar(
+        backgroundColor = colorResource(R.color.blue),
+        onAccountIconClick = {},
+        onSettingsIconClick = {}
+    )
 }
 
 @Composable
 fun TopBar(
     backgroundColor: Color,
-    onSettingsClicked: (() -> Unit)?,
+    onAccountIconClick: (() -> Unit)?,
+    onSettingsIconClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
     isIconAndLogoVisible: Boolean = true
 ) {
@@ -41,7 +46,7 @@ fun TopBar(
                 .background(backgroundColor)
                 .then(modifier),
     ) {
-        val (logo, appName, settingsIcon) = createRefs()
+        val (logo, appName, accountIcon, settingsIcon) = createRefs()
 
         if (isIconAndLogoVisible) {
             Image(
@@ -66,12 +71,24 @@ fun TopBar(
             )
         }
 
-        if (onSettingsClicked != null) {
+        if (onAccountIconClick != null) {
+            Image(
+                painter = painterResource(R.drawable.icon_account),
+                contentDescription = stringResource(id = R.string.settings_account),
+                modifier =
+                    Modifier.clickable { onAccountIconClick() }
+                        .fillMaxHeight()
+                        .padding(horizontal = 16.dp)
+                        .constrainAs(accountIcon) { end.linkTo(settingsIcon.start) }
+            )
+        }
+
+        if (onSettingsIconClick != null) {
             Image(
                 painter = painterResource(R.drawable.icon_settings),
                 contentDescription = stringResource(id = R.string.settings),
                 modifier =
-                    Modifier.clickable { onSettingsClicked() }
+                    Modifier.clickable { onSettingsIconClick() }
                         .fillMaxHeight()
                         .padding(horizontal = 16.dp)
                         .constrainAs(settingsIcon) { end.linkTo(parent.end) }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import net.mullvad.mullvadvpn.R
@@ -26,6 +27,7 @@ import net.mullvad.mullvadvpn.compose.button.ConnectionButton
 import net.mullvad.mullvadvpn.compose.button.SwitchLocationButton
 import net.mullvad.mullvadvpn.compose.component.ConnectionStatusText
 import net.mullvad.mullvadvpn.compose.component.LocationInfo
+import net.mullvad.mullvadvpn.compose.component.ScaffoldWithTopBar
 import net.mullvad.mullvadvpn.compose.state.ConnectUiState
 import net.mullvad.mullvadvpn.compose.test.CIRCULAR_PROGRESS_INDICATOR
 import net.mullvad.mullvadvpn.compose.test.CONNECT_BUTTON_TEST_TAG
@@ -34,6 +36,8 @@ import net.mullvad.mullvadvpn.compose.test.RECONNECT_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.SELECT_LOCATION_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.compose.theme.AppTheme
 import net.mullvad.mullvadvpn.compose.theme.Dimens
+import net.mullvad.mullvadvpn.compose.theme.MullvadGreen
+import net.mullvad.mullvadvpn.compose.theme.MullvadRed
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.talpid.tunnel.ActionAfterDisconnect
 
@@ -52,83 +56,101 @@ fun ConnectScreen(
     onConnectClick: () -> Unit = {},
     onCancelClick: () -> Unit = {},
     onSwitchLocationClick: () -> Unit = {},
-    onToggleTunnelInfo: () -> Unit = {}
+    onToggleTunnelInfo: () -> Unit = {},
+    onAccountIconClick: () -> Unit = {},
+    onSettingsIconClick: () -> Unit = {}
 ) {
-    val scrollState = rememberScrollState()
-    Column(
-        verticalArrangement = Arrangement.Bottom,
-        horizontalAlignment = Alignment.Start,
-        modifier =
-            Modifier.background(color = MaterialTheme.colorScheme.primary)
-                .fillMaxHeight()
-                .padding(horizontal = Dimens.sideMargin, vertical = Dimens.screenVerticalMargin)
-                .scrollable(scrollState, Orientation.Vertical)
+    val tunnelStateColor =
+        if (uiState.tunnelRealState.isSecured()) {
+            MullvadGreen
+        } else {
+            MullvadRed
+        }
+
+    ScaffoldWithTopBar(
+        topBarColor = tunnelStateColor,
+        statusBarColor = tunnelStateColor,
+        navigationBarColor = colorResource(id = R.color.darkBlue),
+        onAccountIconClick = onAccountIconClick,
+        onSettingsIconClick = onSettingsIconClick
     ) {
-        if (
-            uiState.tunnelRealState is TunnelState.Connecting ||
-                (uiState.tunnelRealState is TunnelState.Disconnecting &&
-                    uiState.tunnelRealState.actionAfterDisconnect ==
-                        ActionAfterDisconnect.Reconnect)
+        val scrollState = rememberScrollState()
+
+        Column(
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.Start,
+            modifier =
+                Modifier.background(color = MaterialTheme.colorScheme.primary)
+                    .fillMaxHeight()
+                    .padding(horizontal = Dimens.sideMargin, vertical = Dimens.screenVerticalMargin)
+                    .scrollable(scrollState, Orientation.Vertical)
         ) {
-            CircularProgressIndicator(
-                color = MaterialTheme.colorScheme.onPrimary,
+            if (
+                uiState.tunnelRealState is TunnelState.Connecting ||
+                    (uiState.tunnelRealState is TunnelState.Disconnecting &&
+                        uiState.tunnelRealState.actionAfterDisconnect ==
+                            ActionAfterDisconnect.Reconnect)
+            ) {
+                CircularProgressIndicator(
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier =
+                        Modifier.size(
+                                width = Dimens.progressIndicatorSize,
+                                height = Dimens.progressIndicatorSize
+                            )
+                            .align(Alignment.CenterHorizontally)
+                            .testTag(CIRCULAR_PROGRESS_INDICATOR)
+                )
+            }
+            Spacer(modifier = Modifier.height(Dimens.smallPadding))
+            ConnectionStatusText(state = uiState.tunnelRealState)
+            Text(
+                text = uiState.location?.country ?: "",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+            Text(
+                text = uiState.location?.city ?: "",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+            LocationInfo(
+                onToggleTunnelInfo = onToggleTunnelInfo,
+                isVisible = uiState.tunnelRealState != TunnelState.Disconnected,
+                isExpanded = uiState.isTunnelInfoExpanded,
+                location = uiState.location,
+                inAddress = uiState.inAddress,
+                outAddress = uiState.outAddress,
+                modifier = Modifier.fillMaxWidth().testTag(LOCATION_INFO_TEST_TAG)
+            )
+            Spacer(modifier = Modifier.height(Dimens.buttonSeparation))
+            SwitchLocationButton(
                 modifier =
-                    Modifier.size(
-                            width = Dimens.progressIndicatorSize,
-                            height = Dimens.progressIndicatorSize
-                        )
-                        .align(Alignment.CenterHorizontally)
-                        .testTag(CIRCULAR_PROGRESS_INDICATOR)
+                    Modifier.fillMaxWidth()
+                        .height(Dimens.selectLocationButtonHeight)
+                        .testTag(SELECT_LOCATION_BUTTON_TEST_TAG),
+                onClick = onSwitchLocationClick,
+                showChevron = uiState.showLocation,
+                text =
+                    if (uiState.showLocation) {
+                        uiState.relayLocation?.locationName ?: ""
+                    } else {
+                        stringResource(id = R.string.switch_location)
+                    }
+            )
+            Spacer(modifier = Modifier.height(Dimens.buttonSeparation))
+            ConnectionButton(
+                state = uiState.tunnelUiState,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .height(Dimens.connectButtonHeight)
+                        .testTag(CONNECT_BUTTON_TEST_TAG),
+                disconnectClick = onDisconnectClick,
+                reconnectClick = onReconnectClick,
+                cancelClick = onCancelClick,
+                connectClick = onConnectClick,
+                reconnectButtonTestTag = RECONNECT_BUTTON_TEST_TAG
             )
         }
-        Spacer(modifier = Modifier.height(Dimens.smallPadding))
-        ConnectionStatusText(state = uiState.tunnelRealState)
-        Text(
-            text = uiState.location?.country ?: "",
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.onPrimary
-        )
-        Text(
-            text = uiState.location?.city ?: "",
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.onPrimary
-        )
-        LocationInfo(
-            onToggleTunnelInfo = onToggleTunnelInfo,
-            isVisible = uiState.tunnelRealState != TunnelState.Disconnected,
-            isExpanded = uiState.isTunnelInfoExpanded,
-            location = uiState.location,
-            inAddress = uiState.inAddress,
-            outAddress = uiState.outAddress,
-            modifier = Modifier.fillMaxWidth().testTag(LOCATION_INFO_TEST_TAG)
-        )
-        Spacer(modifier = Modifier.height(Dimens.buttonSeparation))
-        SwitchLocationButton(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .height(Dimens.selectLocationButtonHeight)
-                    .testTag(SELECT_LOCATION_BUTTON_TEST_TAG),
-            onClick = onSwitchLocationClick,
-            showChevron = uiState.showLocation,
-            text =
-                if (uiState.showLocation) {
-                    uiState.relayLocation?.locationName ?: ""
-                } else {
-                    stringResource(id = R.string.switch_location)
-                }
-        )
-        Spacer(modifier = Modifier.height(Dimens.buttonSeparation))
-        ConnectionButton(
-            state = uiState.tunnelUiState,
-            modifier =
-                Modifier.fillMaxWidth()
-                    .height(Dimens.connectButtonHeight)
-                    .testTag(CONNECT_BUTTON_TEST_TAG),
-            disconnectClick = onDisconnectClick,
-            reconnectClick = onReconnectClick,
-            cancelClick = onCancelClick,
-            connectClick = onConnectClick,
-            reconnectButtonTestTag = RECONNECT_BUTTON_TEST_TAG
-        )
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceListScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceListScreen.kt
@@ -94,7 +94,8 @@ fun DeviceListScreen(
         topBarColor = topColor,
         statusBarColor = topColor,
         navigationBarColor = colorResource(id = R.color.darkBlue),
-        onSettingsClicked = onSettingsClicked
+        onAccountIconClick = null,
+        onSettingsIconClick = onSettingsClicked
     ) {
         ConstraintLayout(
             modifier =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceRevokedScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceRevokedScreen.kt
@@ -53,7 +53,8 @@ fun DeviceRevokedScreen(
         topBarColor = topColor,
         statusBarColor = topColor,
         navigationBarColor = colorResource(id = R.color.darkBlue),
-        onSettingsClicked = onSettingsClicked,
+        onAccountIconClick = null,
+        onSettingsIconClick = onSettingsClicked,
     ) {
         ConstraintLayout(
             modifier =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoadingScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoadingScreen.kt
@@ -36,7 +36,8 @@ fun LoadingScreen(onSettingsCogClicked: () -> Unit = {}) {
         topBarColor = backgroundColor,
         statusBarColor = backgroundColor,
         navigationBarColor = backgroundColor,
-        onSettingsClicked = onSettingsCogClicked,
+        onAccountIconClick = null,
+        onSettingsIconClick = onSettingsCogClicked,
         isIconAndLogoVisible = false,
         content = {
             Box(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/PrivacyDisclaimerScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/PrivacyDisclaimerScreen.kt
@@ -50,7 +50,8 @@ fun PrivacyDisclaimerScreen(
         topBarColor = topColor,
         statusBarColor = topColor,
         navigationBarColor = colorResource(id = R.color.darkBlue),
-        onSettingsClicked = null
+        onAccountIconClick = null,
+        onSettingsIconClick = null
     ) {
         ConstraintLayout(
             modifier =


### PR DESCRIPTION
This PR aims to migrate the header/top bar of the connect/main view to compose.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4912)
<!-- Reviewable:end -->
