### PR TITLE
Fix the settings being reset when upgrading from 2023.3 or lower

### DIFF
--- a/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
+++ b/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
@@ -43,12 +43,26 @@ struct StoredAccountData: Codable, Equatable {
     /// Account expiry.
     var expiry: Date
 
-    /// be set `true` when account is created and  be flipped to `false` when user adds more credit
+    /// Set to `true` when the account is created and flipped to `false` when the user adds more credit.
     var isNew = false
 
     /// Returns `true` if account has expired.
     var isExpired: Bool {
         expiry <= Date()
+    }
+}
+
+extension StoredAccountData {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.number = try container.decode(String.self, forKey: .number)
+        self.expiry = try container.decode(Date.self, forKey: .expiry)
+
+        // When the app is upgraded from 2023.3 or below, this field won't exist, and the auto synthesized init will fail.
+        // This leads to a reset of the settings. If the key isn't present, consider the account not new to avoid the issue.
+        let isNewAccount = try? container.decode(Bool.self, forKey: .isNew)
+        self.isNew = isNewAccount ?? false
     }
 }
 


### PR DESCRIPTION
This PR introduces a custom `init(from decoder: Decoder)` in `StoredAccountData` that doesn't fail if the `isNew` flag is missing. 

When upgrading from the current release (2023.3) or lower, this will lead to a log out / reset of the settings when upgrading the app.

This PR fixes this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4918)
<!-- Reviewable:end -->
