### PR TITLE
Cache the TransportStrategy counter and reuse it between processes

### DIFF
--- a/ios/MullvadREST/TransportStrategy.swift
+++ b/ios/MullvadREST/TransportStrategy.swift
@@ -1,5 +1,5 @@
 //
-//  RESTTransportStrategy.swift
+//  TransportStrategy.swift
 //  MullvadREST
 //
 //  Created by Marco Nikic on 2023-04-27.
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import MullvadTypes
 
-public struct TransportStrategy: Codable, Equatable {
+public struct TransportStrategy: Equatable {
     /// The different transports suggested by the strategy
     public enum Transport {
         /// Suggests using a direct connection
@@ -23,10 +24,17 @@ public struct TransportStrategy: Codable, Equatable {
     /// suggestion.
     ///
     /// `internal` instead of `private` for testing purposes.
-    internal var connectionAttempts: UInt
+    internal var connectionAttempts: Int
 
-    public init() {
-        connectionAttempts = 0
+    /// Enables recording of failed connection attempts.
+    private let userDefaults: UserDefaults
+
+    /// `UserDefaults` key shared by both processes. Used to cache and synchronize connection attempts between them.
+    internal static let connectionAttemptsSharedCacheKey = "ConnectionAttemptsSharedCacheKey"
+
+    public init(_ userDefaults: UserDefaults) {
+        self.connectionAttempts = userDefaults.integer(forKey: Self.connectionAttemptsSharedCacheKey)
+        self.userDefaults = userDefaults
     }
 
     /// Instructs the strategy that a network connection failed
@@ -34,8 +42,10 @@ public struct TransportStrategy: Codable, Equatable {
     /// Every third failure results in a direct transport suggestion.
     public mutating func didFail() {
         let (partial, isOverflow) = connectionAttempts.addingReportingOverflow(1)
-        // UInt.max is a multiple of 3, go directly to 1 when overflowing
-        connectionAttempts = isOverflow ? 1 : partial
+        // (Int.max - 1) is a multiple of 3, go directly to 2 when overflowing
+        // to keep the "every third failure" algorithm correct
+        connectionAttempts = isOverflow ? 2 : partial
+        userDefaults.set(connectionAttempts, forKey: Self.connectionAttemptsSharedCacheKey)
     }
 
     /// The suggested connection transport
@@ -43,5 +53,9 @@ public struct TransportStrategy: Codable, Equatable {
     /// - Returns: `.useURLSession` for every 3rd failed attempt, `.useShadowsocks` otherwise
     public func connectionTransport() -> Transport {
         connectionAttempts.isMultiple(of: 3) ? .useURLSession : .useShadowsocks
+    }
+
+    public static func == (lhs: TransportStrategy, rhs: TransportStrategy) -> Bool {
+        lhs.connectionAttempts == rhs.connectionAttempts
     }
 }

--- a/ios/MullvadTransport/TransportProvider.swift
+++ b/ios/MullvadTransport/TransportProvider.swift
@@ -31,7 +31,7 @@ public final class TransportProvider: RESTTransport {
         relayCache: RelayCache,
         addressCache: REST.AddressCache,
         shadowsocksCache: ShadowsocksConfigurationCache,
-        transportStrategy: TransportStrategy = .init(),
+        transportStrategy: TransportStrategy,
         constraintsUpdater: RelayConstraintsUpdater
     ) {
         self.urlSessionTransport = urlSessionTransport

--- a/ios/MullvadTypes/AttemptsRecording.swift
+++ b/ios/MullvadTypes/AttemptsRecording.swift
@@ -1,0 +1,16 @@
+//
+//  AttemptsRecording.swift
+//  MullvadTypes
+//
+//  Created by Marco Nikic on 2023-07-24.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+/// Defines a generic way to record an attempt.
+///
+/// Used by `TransportStrategy` to record failed connection attempts in cache.
+public protocol AttemptsRecording {
+    func record(_ attempts: Int)
+}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -399,7 +399,8 @@
 		7ABE318D2A1CDD4500DF4963 /* UIFont+Weight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ABE318C2A1CDD4500DF4963 /* UIFont+Weight.swift */; };
 		7AE47E522A17972A000418DA /* CustomAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE47E512A17972A000418DA /* CustomAlertViewController.swift */; };
 		7AF0419E29E957EB00D492DD /* AccountCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF0419D29E957EB00D492DD /* AccountCoordinator.swift */; };
-		A917351F29FAA9C400D5DCFD /* RESTTransportStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A917351E29FAA9C400D5DCFD /* RESTTransportStrategy.swift */; };
+		A90F9DEC2A6E91A5009DC8B3 /* AttemptsRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90F9DEB2A6E91A5009DC8B3 /* AttemptsRecording.swift */; };
+		A917351F29FAA9C400D5DCFD /* TransportStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A917351E29FAA9C400D5DCFD /* TransportStrategy.swift */; };
 		A917352129FAAA5200D5DCFD /* TransportStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A917352029FAAA5200D5DCFD /* TransportStrategyTests.swift */; };
 		A93D13782A1F60A6001EB0B1 /* shadowsocks.h in Headers */ = {isa = PBXBuildFile; fileRef = 586F2BE129F6916F009E6924 /* shadowsocks.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A9467E7F2A29DEFE000DC21F /* RelayCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9467E7E2A29DEFE000DC21F /* RelayCacheTests.swift */; };
@@ -418,9 +419,9 @@
 		A9D99BA52A1F808900DE27D3 /* RelayCache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 063F02732902B63F001FA09F /* RelayCache.framework */; };
 		A9D99BA62A1F809C00DE27D3 /* libRelaySelector.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5898D29829017DAC00EB5EBA /* libRelaySelector.a */; };
 		A9D99BA92A1F81B700DE27D3 /* MullvadTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A97F1F412A1F4E1A00ECEFDE /* MullvadTransport.framework */; };
-		A9EC20F02A5D79ED0040D56E /* TunnelObfuscation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5840231F2A406BF5007B27AC /* TunnelObfuscation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9EC20E62A5C488D0040D56E /* Haversine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC20E52A5C488D0040D56E /* Haversine.swift */; };
 		A9EC20E82A5D3A8C0040D56E /* CoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC20E72A5D3A8C0040D56E /* CoordinatesTests.swift */; };
+		A9EC20F02A5D79ED0040D56E /* TunnelObfuscation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5840231F2A406BF5007B27AC /* TunnelObfuscation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9EC20F42A5D96030040D56E /* Midpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC20F32A5D96030040D56E /* Midpoint.swift */; };
 		E1187ABC289BBB850024E748 /* OutOfTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1187ABA289BBB850024E748 /* OutOfTimeViewController.swift */; };
 		E1187ABD289BBB850024E748 /* OutOfTimeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */; };
@@ -1184,7 +1185,8 @@
 		7ABE318C2A1CDD4500DF4963 /* UIFont+Weight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Weight.swift"; sourceTree = "<group>"; };
 		7AE47E512A17972A000418DA /* CustomAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertViewController.swift; sourceTree = "<group>"; };
 		7AF0419D29E957EB00D492DD /* AccountCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCoordinator.swift; sourceTree = "<group>"; };
-		A917351E29FAA9C400D5DCFD /* RESTTransportStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTTransportStrategy.swift; sourceTree = "<group>"; };
+		A90F9DEB2A6E91A5009DC8B3 /* AttemptsRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttemptsRecording.swift; sourceTree = "<group>"; };
+		A917351E29FAA9C400D5DCFD /* TransportStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportStrategy.swift; sourceTree = "<group>"; };
 		A917352029FAAA5200D5DCFD /* TransportStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportStrategyTests.swift; sourceTree = "<group>"; };
 		A9467E7E2A29DEFE000DC21F /* RelayCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCacheTests.swift; sourceTree = "<group>"; };
 		A9467E872A2DCD57000DC21F /* ShadowsocksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksConfiguration.swift; sourceTree = "<group>"; };
@@ -1435,10 +1437,10 @@
 				5897F1732913EAF800AF5695 /* ExponentialBackoff.swift */,
 				06FAE67528F83CA40033DD93 /* RESTTaskIdentifier.swift */,
 				06FAE67D28F83CA50033DD93 /* RESTTransport.swift */,
-				A917351E29FAA9C400D5DCFD /* RESTTransportStrategy.swift */,
 				06FAE66528F83CA30033DD93 /* RESTURLSession.swift */,
 				06FAE67728F83CA40033DD93 /* ServerRelaysResponse.swift */,
 				06FAE66B28F83CA30033DD93 /* SSLPinningURLSessionDelegate.swift */,
+				A917351E29FAA9C400D5DCFD /* TransportStrategy.swift */,
 			);
 			path = MullvadREST;
 			sourceTree = "<group>";
@@ -1472,6 +1474,7 @@
 			children = (
 				584D26BE270C550B004EA533 /* AnyIPAddress.swift */,
 				586A951329013235007BAF2B /* AnyIPEndpoint.swift */,
+				A90F9DEB2A6E91A5009DC8B3 /* AttemptsRecording.swift */,
 				06AC113628F83FD70037AF9A /* Cancellable.swift */,
 				A9A8A8EA2A262AB30086D569 /* FileCache.swift */,
 				58E511E328DDDE8900B0BCDE /* CustomErrorDescriptionProtocol.swift */,
@@ -3092,7 +3095,7 @@
 				06799ADF28F98E4800ACD94E /* RESTDevicesProxy.swift in Sources */,
 				06799ADA28F98E4800ACD94E /* RESTResponseHandler.swift in Sources */,
 				062B45BC28FD8C3B00746E77 /* RESTDefaults.swift in Sources */,
-				A917351F29FAA9C400D5DCFD /* RESTTransportStrategy.swift in Sources */,
+				A917351F29FAA9C400D5DCFD /* TransportStrategy.swift in Sources */,
 				06799AE428F98E4800ACD94E /* RESTAccountsProxy.swift in Sources */,
 				5897F1742913EAF800AF5695 /* ExponentialBackoff.swift in Sources */,
 				06799AE328F98E4800ACD94E /* RESTNetworkOperation.swift in Sources */,
@@ -3475,6 +3478,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				58D22406294C90210029F5F8 /* IPv4Endpoint.swift in Sources */,
+				A90F9DEC2A6E91A5009DC8B3 /* AttemptsRecording.swift in Sources */,
 				58D22407294C90210029F5F8 /* IPv6Endpoint.swift in Sources */,
 				58CAFA032985367600BE19F7 /* Promise.swift in Sources */,
 				A97FF5502A0D2FFC00900996 /* NSFileCoordinator+Extensions.swift in Sources */,
@@ -4590,11 +4594,14 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CKG9MXH72F;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CKG9MXH72F;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = CKG9MXH72F;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = net.mullvad.MullvadVPN.MullvadRESTTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -100,11 +100,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         let urlSessionTransport = URLSessionTransport(urlSession: REST.makeURLSession())
         let shadowsocksCache = ShadowsocksConfigurationCache(cacheDirectory: containerURL)
+
+        // This init cannot fail as long as the security group identifier is valid
+        let sharedUserDefaults = UserDefaults(suiteName: ApplicationConfiguration.securityGroupIdentifier)!
+        let transportStrategy = TransportStrategy(sharedUserDefaults)
+
         let transportProvider = TransportProvider(
             urlSessionTransport: urlSessionTransport,
             relayCache: relayCache,
             addressCache: addressCache,
             shadowsocksCache: shadowsocksCache,
+            transportStrategy: transportStrategy,
             constraintsUpdater: constraintsUpdater
         )
 

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -145,11 +145,17 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
         let urlSession = REST.makeURLSession()
         let urlSessionTransport = URLSessionTransport(urlSession: urlSession)
         let shadowsocksCache = ShadowsocksConfigurationCache(cacheDirectory: containerURL)
+
+        // This init cannot fail as long as the security group identifier is valid
+        let sharedUserDefaults = UserDefaults(suiteName: ApplicationConfiguration.securityGroupIdentifier)!
+        let transportStrategy = TransportStrategy(sharedUserDefaults)
+
         let transportProvider = TransportProvider(
             urlSessionTransport: urlSessionTransport,
             relayCache: relayCache,
             addressCache: addressCache,
             shadowsocksCache: shadowsocksCache,
+            transportStrategy: transportStrategy,
             constraintsUpdater: constraintsUpdater
         )
 


### PR DESCRIPTION
This PR implements caching the `connectionAttempts` from the `TransportStrategy` in order to provide a better UX.

Suppose only network connections via shadowsocks would work.
The first request made by the application at launch time would always fail.

In this PR, we start recording the number of failures so that the next time the application (or network extension) is launched, we will directly select the last successful connection mode (i.e. one that did not fail)

The connection attempt cached value is shared by both processes via `UserDefaults` shared by the same application group.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4921)
<!-- Reviewable:end -->
