### PR TITLE
Add an hourly device state read to update the header bar view

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -157,12 +157,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     @objc private func didBecomeActive(_ notification: Notification) {
         tunnelManager.startPeriodicPrivateKeyRotation()
+        tunnelManager.startPeriodicStateRefresh()
         relayCacheTracker.startPeriodicUpdates()
         addressCacheTracker.startPeriodicUpdates()
     }
 
     @objc private func willResignActive(_ notification: Notification) {
         tunnelManager.stopPeriodicPrivateKeyRotation()
+        tunnelManager.stopPeriodicStateRefresh()
         relayCacheTracker.stopPeriodicUpdates()
         addressCacheTracker.stopPeriodicUpdates()
     }

--- a/ios/MullvadVPN/TunnelManager/TunnelBlockObserver.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelBlockObserver.swift
@@ -18,25 +18,29 @@ final class TunnelBlockObserver: TunnelObserver {
     ) -> Void
     typealias DidUpdateTunnelSettingsHandler = (TunnelManager, TunnelSettingsV2) -> Void
     typealias DidFailWithErrorHandler = (TunnelManager, Error) -> Void
+    typealias DidPeriodicallyReadDeviceStateHandler = (TunnelManager, DeviceState) -> Void
 
     private let didLoadConfiguration: DidLoadConfigurationHandler?
     private let didUpdateTunnelStatus: DidUpdateTunnelStatusHandler?
     private let didUpdateDeviceState: DidUpdateDeviceStateHandler?
     private let didUpdateTunnelSettings: DidUpdateTunnelSettingsHandler?
     private let didFailWithError: DidFailWithErrorHandler?
+    private let didPeriodicallyReadDeviceState: DidPeriodicallyReadDeviceStateHandler?
 
     init(
         didLoadConfiguration: DidLoadConfigurationHandler? = nil,
         didUpdateTunnelStatus: DidUpdateTunnelStatusHandler? = nil,
         didUpdateDeviceState: DidUpdateDeviceStateHandler? = nil,
         didUpdateTunnelSettings: DidUpdateTunnelSettingsHandler? = nil,
-        didFailWithError: DidFailWithErrorHandler? = nil
+        didFailWithError: DidFailWithErrorHandler? = nil,
+        didPeriodicallyReadDeviceState: DidPeriodicallyReadDeviceStateHandler? = nil
     ) {
         self.didLoadConfiguration = didLoadConfiguration
         self.didUpdateTunnelStatus = didUpdateTunnelStatus
         self.didUpdateDeviceState = didUpdateDeviceState
         self.didUpdateTunnelSettings = didUpdateTunnelSettings
         self.didFailWithError = didFailWithError
+        self.didPeriodicallyReadDeviceState = didPeriodicallyReadDeviceState
     }
 
     func tunnelManagerDidLoadConfiguration(_ manager: TunnelManager) {
@@ -61,5 +65,9 @@ final class TunnelBlockObserver: TunnelObserver {
 
     func tunnelManager(_ manager: TunnelManager, didFailWithError error: Error) {
         didFailWithError?(manager, error)
+    }
+
+    func tunnelManager(_ manager: TunnelManager, didPeriodicallyRead deviceState: DeviceState) {
+        didPeriodicallyReadDeviceState?(manager, deviceState)
     }
 }

--- a/ios/MullvadVPN/TunnelManager/TunnelObserver.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelObserver.swift
@@ -18,4 +18,5 @@ protocol TunnelObserver: AnyObject {
     )
     func tunnelManager(_ manager: TunnelManager, didUpdateTunnelSettings tunnelSettings: TunnelSettingsV2)
     func tunnelManager(_ manager: TunnelManager, didFailWithError error: Error)
+    func tunnelManager(_ manager: TunnelManager, didPeriodicallyRead deviceState: DeviceState)
 }


### PR DESCRIPTION
This PR introduces a new method in the `TunnelObserver` protocol.
`func tunnelManager(_ manager: TunnelManager, didPeriodicallyRead deviceState: DeviceState)` 

As the name implies, periodic reads from the `DeviceState` are now scheduled when the app becomes active via
`func didBecomeActive(_ notification: Notification)` 

Right now, the timer will fire once, and then every hour. It is only active when the app is running, otherwise the timer is cancelled. This is to avoid impact on the battery.

Whenever users now resume the app, the `HeaderBarView` should display the most recent information it has available.