### PR TITLE
Add a UI for wireguard obfuscation preferences

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1618,6 +1618,7 @@
 				5867770F290975E8006F721F /* SettingsInteractorFactory.swift */,
 				58ACF64A26553C3F00ACE4B7 /* SettingsSwitchCell.swift */,
 				58CCA01122424D11004F3011 /* SettingsViewController.swift */,
+				7A42DEC82A05164100B209BE /* SettingsInputCell.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
@@ -245,6 +245,53 @@ final class PreferencesCellFactory: CellFactoryProtocol {
                 isEditing: isEditing,
                 preferredFont: .systemFont(ofSize: 14)
             )
+        case .wireGuardObfuscationAutomatic:
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "WIRE_GUARD_OBFUSCATION_AUTOMATIC_LABEL",
+                tableName: "Preferences",
+                value: "Automatic",
+                comment: ""
+            )
+            cell.accessibilityHint = nil
+            cell.applySubCellStyling()
+        case .wireGuardObfuscationOn:
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "WIRE_GUARD_OBFUSCATION_ON_LABEL",
+                tableName: "Preferences",
+                value: "On (UDP-over-TCP)",
+                comment: ""
+            )
+            cell.accessibilityHint = nil
+            cell.applySubCellStyling()
+        case .wireGuardObfuscationOff:
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "WIRE_GUARD_OBFUSCATION_OFF_LABEL",
+                tableName: "Preferences",
+                value: "Off",
+                comment: ""
+            )
+            cell.accessibilityHint = nil
+            cell.applySubCellStyling()
+
+        case let .wireGuardObfuscationPort(port):
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            let portValue = port == 0 ? "Automatic" : "\(port)"
+
+            cell.titleLabel.text = NSLocalizedString(
+                "WIRE_GUARD_OBFUSCATION_PORT_LABEL",
+                tableName: "Preferences",
+                value: portValue,
+                comment: ""
+            )
+            cell.accessibilityHint = nil
+            cell.applySubCellStyling()
         }
     }
 

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
@@ -409,6 +409,10 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         }
     }
 
+    func tableView(_ tableView: UITableView, willDeselectRowAt indexPath: IndexPath) -> IndexPath? {
+        nil
+    }
+
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let sectionIdentifier = snapshot().sectionIdentifiers[section]
 

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
@@ -774,21 +774,24 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         apply(snapshot, animatingDifferences: true)
     }
 
-    private func configureContentBlockersHeader(_ reusableView: SettingsHeaderView) {
-        reusableView.titleLabel.text = NSLocalizedString(
+    private func configureContentBlockersHeader(_ header: SettingsHeaderView) {
+        let title = NSLocalizedString(
             "CONTENT_BLOCKERS_HEADER_LABEL",
             tableName: "Preferences",
             value: "DNS content blockers",
             comment: ""
         )
 
-        reusableView.infoButtonHandler = { [weak self] in
+        header.titleLabel.text = title
+        header.accessibilityCustomActionName = title
+
+        header.infoButtonHandler = { [weak self] in
             if let self {
                 self.delegate?.preferencesDataSource(self, showInfo: .contentBlockers)
             }
         }
 
-        reusableView.didCollapseHandler = { [weak self] headerView in
+        header.didCollapseHandler = { [weak self] headerView in
             guard let self else { return }
 
             var snapshot = self.snapshot()
@@ -804,21 +807,23 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         }
     }
 
-    private func configureWireguardPortsHeader(_ reusableView: SettingsHeaderView) {
-        reusableView.titleLabel.text = NSLocalizedString(
+    private func configureWireguardPortsHeader(_ header: SettingsHeaderView) {
+        let title = NSLocalizedString(
             "WIRE_GUARD_PORTS_HEADER_LABEL",
             tableName: "Preferences",
             value: "WireGuard ports",
             comment: ""
         )
 
-        reusableView.infoButtonHandler = { [weak self] in
+        header.titleLabel.text = title
+        header.accessibilityCustomActionName = title
+        header.infoButtonHandler = { [weak self] in
             if let self {
                 self.delegate?.preferencesDataSource(self, showInfo: .wireGuardPorts)
             }
         }
 
-        reusableView.didCollapseHandler = { [weak self] headerView in
+        header.didCollapseHandler = { [weak self] headerView in
             guard let self else { return }
 
             var snapshot = self.snapshot()
@@ -846,13 +851,15 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
     }
 
     private func configureObfuscationHeader(_ header: SettingsHeaderView) {
-        header.titleLabel.text = NSLocalizedString(
+        let title = NSLocalizedString(
             "OBFUSCATION_HEADER_LABEL",
             tableName: "Preferences",
             value: "WireGuard Obfuscation",
             comment: ""
         )
 
+        header.titleLabel.text = title
+        header.accessibilityCustomActionName = title
         header.didCollapseHandler = { [weak self] header in
             guard let self else { return }
 
@@ -872,13 +879,15 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
     }
 
     private func configureObfuscationPortHeader(_ header: SettingsHeaderView) {
-        header.titleLabel.text = NSLocalizedString(
+        let title = NSLocalizedString(
             "OBFUSCATION_PORT_HEADER_LABEL",
             tableName: "Preferences",
             value: "UDP-over-TCP Port",
             comment: ""
         )
 
+        header.titleLabel.text = title
+        header.accessibilityCustomActionName = title
         header.didCollapseHandler = { [weak self] header in
             guard let self else { return }
 

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesViewController.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesViewController.swift
@@ -35,6 +35,7 @@ class PreferencesViewController: UITableViewController, PreferencesDataSourceDel
         tableView.estimatedRowHeight = 60
         tableView.estimatedSectionHeaderHeight = tableView.estimatedRowHeight
         tableView.allowsSelectionDuringEditing = true
+        tableView.allowsMultipleSelection = true
 
         dataSource = PreferencesDataSource(tableView: tableView)
         dataSource?.delegate = self
@@ -161,6 +162,21 @@ class PreferencesViewController: UITableViewController, PreferencesDataSourceDel
                 portsString
             )
 
+        case .wireGuardObfuscation:
+            message = NSLocalizedString(
+                "PREFERENCES_WIRE_GUARD_OBFUSCATION_GENERAL",
+                tableName: "WireGuardObfuscation",
+                value: "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connect would be blocked.",
+                comment: ""
+            )
+
+        case .wireGuardObfuscationPort:
+            message = NSLocalizedString(
+                "PREFERENCES_WIRE_GUARD_OBFUSCATION_PORT_GENERAL",
+                tableName: "WireGuardObfuscation",
+                value: "Which TCP port the UDP-over-TCP obfuscation protocol should connect to on the VPN server.",
+                comment: ""
+            )
         default:
             assertionFailure("No matching InfoButtonItem")
         }

--- a/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
@@ -44,6 +44,12 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
         }
     }
 
+    var accessibilityCustomActionName = "" {
+        didSet {
+            updateAccessibilityCustomActions()
+        }
+    }
+
     var didCollapseHandler: CollapseHandler?
     var infoButtonHandler: InfoButtonHandler?
 
@@ -92,7 +98,6 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
         }
 
         updateCollapseImage()
-        updateAccessibilityCustomActions()
     }
 
     required init?(coder: NSCoder) {
@@ -119,20 +124,17 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
     }
 
     private func updateAccessibilityCustomActions() {
-        #warning(
-            "SettingsHeaderView is reused for more than content blockers now, this code doesn't seem correct anymore."
-        )
         let actionName = isExpanded
             ? NSLocalizedString(
-                "CONTENT_BLOCKERS_COLLAPSE_ACCESSIBILITY_ACTION",
+                "SETTINGS_HEADER_COLLAPSE_ACCESSIBILITY_ACTION",
                 tableName: "Settings",
-                value: "Collapse content blockers",
+                value: "Collapse \(accessibilityCustomActionName)",
                 comment: ""
             )
             : NSLocalizedString(
-                "CONTENT_BLOCKERS_EXPAND_ACCESSIBILITY_ACTION",
+                "SETTINGS_HEADER_EXPAND_ACCESSIBILITY_ACTION",
                 tableName: "Settings",
-                value: "Expand content blockers",
+                value: "Expand \(accessibilityCustomActionName)",
                 comment: ""
             )
 

--- a/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
@@ -119,6 +119,9 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
     }
 
     private func updateAccessibilityCustomActions() {
+        #warning(
+            "SettingsHeaderView is reused for more than content blockers now, this code doesn't seem correct anymore."
+        )
         let actionName = isExpanded
             ? NSLocalizedString(
                 "CONTENT_BLOCKERS_COLLAPSE_ACCESSIBILITY_ACTION",


### PR DESCRIPTION
Part 2 of adding UDP-over-TCP obfuscation.

This PR only creates a UI for the upcoming WireGuard obfuscation settings.
There is no change to the `PreferencesViewModel` yet because I first want to refactor
`TunnelSettingsV2` to become generic in a different pull request.

The same goes for disabling the port selection when obfuscation is turned off.
It will all come in different PRs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4929)
<!-- Reviewable:end -->
