### PR TITLE
Remove atty dependency

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -24,8 +24,4 @@ jobs:
           denyWarnings: true
           # RUSTSEC-2020-0071: Ignore the time segfault CVE since there are no known
           # good workarounds, and we want logs etc to be in local time.
-          #
-          # RUSTSEC-2021-0145: The vulnerability affects custom global allocators,
-          # so it should be safe to ignore it. Stop ignoring the warning once
-          # atty has been removed from our dependency tree.
-          ignore: RUSTSEC-2020-0071,RUSTSEC-2021-0145
+          ignore: RUSTSEC-2020-0071

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,17 +200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,11 +537,11 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "5a5f741c91823341bebf717d4c71bda820630ce065443b58bd1b7451af008355"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
  "winapi",
 ]
@@ -1312,15 +1301,6 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/deny.toml
+++ b/deny.toml
@@ -86,6 +86,8 @@ deny = [
     { name = "openssl-probe" },
     { name = "clap", version = "2" },
     { name = "clap", version = "3" },
+    # `atty` is an unmaintained crate with a CVE: RUSTSEC-2021-0145
+    { name = "atty" }
 ]
 skip = []
 skip-tree = []


### PR DESCRIPTION
We have long ignored [`RUSTSEC-2021-0145`](https://rustsec.org/advisories/RUSTSEC-2021-0145.html) in our `cargo-audit.yml` action. And even if our app is not really affected by this vulnerability at all, it has been  a bit irritating. I have been somewhat on the hunt to get rid of `atty` for a long while. Opening issues on some of our dependencies that in turn depend on `atty`. And finally we have reached the point where the [last dependency using it](https://github.com/daboross/fern/issues/113) has released an upgraded version, switching to `is-terminal`.

I now ban `atty` from our dependency tree completely via `deny.toml`, so we don't accidentally add it again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4936)
<!-- Reviewable:end -->
