### PR TITLE
Upgrade rustls related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,23 +3121,33 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.2.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3982,13 +3992,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -4538,16 +4547,6 @@ checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -24,8 +24,8 @@ regex = "1"
 serde = "1"
 serde_json = "1.0"
 tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread", "net", "io-std", "io-util", "fs"] }
-tokio-rustls = "0.23"
-rustls-pemfile = "0.2"
+tokio-rustls = "0.24.1"
+rustls-pemfile = "1.0.3"
 once_cell = "1.13"
 
 mullvad-fs = { path = "../mullvad-fs" }


### PR DESCRIPTION
I saw `rustls-pemfile` had a significant version bump available. So I went ahead and upgraded it. Also saw that other rustls related crates (including rustls itself) had some semver incompatible upgrades available. So I went ahead and upgraded all of them.

I usually check changelogs when doing semver incompatible upgrades. Sadly I have a hard time checking what changed in `tokio-rustls` due to https://github.com/rustls/tokio-rustls/issues/8. But I suppose it should be fine. I downloaded both packages from crates.io and compared the sources there. I did not immediately see anything sticking out.

I have tried this upgrade on Linux, Windows and macOS quickly and the app seems to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4940)
<!-- Reviewable:end -->
