### PR TITLE
Replace unmaintained dirs-next with maintained dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,24 +871,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2004,7 +2004,7 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
- "dirs-next",
+ "dirs",
  "duct",
  "err-derive",
  "fern",
@@ -2132,7 +2132,7 @@ name = "mullvad-problem-report"
 version = "0.0.0"
 dependencies = [
  "clap",
- "dirs-next",
+ "dirs",
  "duct",
  "env_logger 0.10.0",
  "err-derive",
@@ -2460,6 +2460,12 @@ dependencies = [
  "log",
  "serde",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_pipe"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -65,7 +65,7 @@ ctrlc = "3.0"
 duct = "0.13"
 windows-service = "0.6.0"
 winapi = { version = "0.3", features = ["winnt", "excpt"] }
-dirs-next = "2.0"
+dirs = "5.0.1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.45.0"

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -235,7 +235,7 @@ mod windows {
     pub async fn migrate_after_windows_update(
         destination_settings_dir: &Path,
     ) -> Result<bool, Error> {
-        let system_appdata_dir = dirs_next::data_local_dir().ok_or(Error::FindAppData)?;
+        let system_appdata_dir = dirs::data_local_dir().ok_or(Error::FindAppData)?;
         if !destination_settings_dir.starts_with(system_appdata_dir) {
             return Ok(false);
         }

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-dirs-next = "2.0"
+dirs = "5.0.1"
 err-derive = "0.3.1"
 lazy_static = "1.0"
 log = "0.4"

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -213,7 +213,7 @@ fn frontend_log_dir() -> Option<Result<PathBuf, LogError>> {
     #[cfg(target_os = "linux")]
     {
         Some(
-            dirs_next::home_dir()
+            dirs::home_dir()
                 .ok_or(LogError::NoHomeDir)
                 .map(|home_dir| home_dir.join(".config/Mullvad VPN/logs")),
         )
@@ -221,7 +221,7 @@ fn frontend_log_dir() -> Option<Result<PathBuf, LogError>> {
     #[cfg(target_os = "macos")]
     {
         Some(
-            dirs_next::home_dir()
+            dirs::home_dir()
                 .ok_or(LogError::NoHomeDir)
                 .map(|home_dir| home_dir.join("Library/Logs/Mullvad VPN")),
         )
@@ -420,7 +420,7 @@ impl ProblemReport {
     }
 
     fn redact_home_dir(input: &str) -> Cow<'_, str> {
-        redact_home_dir_inner(input, dirs_next::home_dir())
+        redact_home_dir_inner(input, dirs::home_dir())
     }
 
     fn redact_network_info(input: &str) -> Cow<'_, str> {


### PR DESCRIPTION
Ironically the `dirs`-fork `dirs-next` is unmaintained, but the original is maintained :sweat_smile: 

So this PR migrates back to `dirs`. There is no direct win or benefit for our app in doing this. Just some healthy cleanup/dependency management. One positive thing is that we get rid of one link to the unmaintained `winapi` crate. One tiny step closer towards getting it out of our dependency tree.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4941)
<!-- Reviewable:end -->
