### PR TITLE
Move windows-sys to a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ tower = "0.4"
 prost = "0.11"
 prost-types = "0.11"
 
+windows-sys = "0.45.0"
+
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -40,7 +40,7 @@ winres = "0.1"
 mullvad-version = { path = "../mullvad-version" }
 
 [target.'cfg(windows)'.build-dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_System_SystemServices",
 ]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -68,7 +68,7 @@ winapi = { version = "0.3", features = ["winnt", "excpt"] }
 dirs = "5.0.1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Security",
@@ -85,7 +85,7 @@ winres = "0.1"
 mullvad-version = { path = "../mullvad-version" }
 
 [target.'cfg(windows)'.build-dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_System_SystemServices",
 ]

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -18,8 +18,8 @@ log = "0.4"
 widestring = "1.0"
 once_cell = "1.13"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.45.0"
+[target.'cfg(windows)'.dependencies.windows-sys]
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -35,7 +35,7 @@ winres = "0.1"
 mullvad-version = { path = "../mullvad-version" }
 
 [target.'cfg(windows)'.build-dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_System_SystemServices",
 ]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -81,7 +81,7 @@ windows-service = "0.6.0"
 talpid-windows-net = { path = "../talpid-windows-net" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Globalization",

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -34,7 +34,7 @@ winres = "0.1"
 mullvad-version = { path = "../mullvad-version" }
 
 [target.'cfg(windows)'.build-dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_System_SystemServices",
 ]

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -45,7 +45,7 @@ winreg = { version = "0.7", features = ["transactions"] }
 talpid-windows-net = { path = "../talpid-windows-net" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader",

--- a/talpid-platform-metadata/Cargo.toml
+++ b/talpid-platform-metadata/Cargo.toml
@@ -13,8 +13,8 @@ publish.workspace = true
 rs-release = "0.1.7"
 talpid-dbus = { path = "../talpid-dbus" }
 
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.45.0"
+[target.'cfg(windows)'.dependencies.windows-sys]
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader",

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -40,10 +40,13 @@ libc = "0.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 talpid-windows-net = { path = "../talpid-windows-net" }
 widestring = "1.0"
-windows-sys = { version = "0.45.0", features = [
-     "Win32_NetworkManagement_Ndis",
-      "Win32_Globalization"
-]}
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+workspace = true
+features = [
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Globalization"
+]
 
 [dev-dependencies]
 tokio = { workspace = true, features = [ "test-util" ] }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -21,10 +21,11 @@ pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024", "zeroize"] }
 zeroize = "1.5.7"
 libc = "0.2"
 
-[target.'cfg(target_os="windows")'.dependencies]
-windows-sys = { version = "0.45.0", features = [
-     "Win32_Networking_WinSock"
-]}
+[target.'cfg(windows)'.dependencies.windows-sys]
+workspace = true
+features = [
+    "Win32_Networking_WinSock"
+]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -35,7 +35,7 @@ tun = "0.5.1"
 talpid-windows-net = { path = "../talpid-windows-net" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",

--- a/talpid-windows-net/Cargo.toml
+++ b/talpid-windows-net/Cargo.toml
@@ -14,7 +14,10 @@ libc = "0.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 futures = "0.3.15"
 winapi = { version = "0.3.6", features = ["ws2def"] }
-windows-sys = { version = "0.45.0", features = [
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+workspace = true
+features = [
     "Win32_Foundation",
     "Win32_Globalization",
     "Win32_System_Com",
@@ -22,4 +25,4 @@ windows-sys = { version = "0.45.0", features = [
     "Win32_Networking_WinSock",
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",
-]}
+]

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -53,9 +53,9 @@ bitflags = "1.2"
 talpid-windows-net = { path = "../talpid-windows-net" }
 widestring = "1.0"
 
-# Figure out which features are needed and which are not
+# TODO: Figure out which features are needed and which are not
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Globalization",


### PR DESCRIPTION
Sort of a continuation of #4902. `windows-sys` is one of those dependencies that we depend in in a massive amount of crates, but we really only ever want to pull in a single version, and there are semver incompatible releases fairly often. So it makes a lot of sense to make this a workspace dependency. Will making upgrading to version `0.48` and later versions way easier later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4943)
<!-- Reviewable:end -->
