### PR TITLE
Remove cfg-if and use regular cfg! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,7 +3620,6 @@ dependencies = [
  "async-trait",
  "bitflags",
  "byteorder",
- "cfg-if",
  "chrono",
  "duct",
  "err-derive",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -11,7 +11,6 @@ publish.workspace = true
 [dependencies]
 bitflags = "1.2"
 async-trait = "0.1"
-cfg-if = "1.0"
 duct = "0.13"
 err-derive = "0.3.1"
 futures = "0.3.15"

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -7,7 +7,6 @@ use crate::{
     firewall::FirewallPolicy,
     tunnel::{TunnelEvent, TunnelMetadata},
 };
-use cfg_if::cfg_if;
 use futures::{
     channel::{mpsc, oneshot},
     stream::Fuse,
@@ -194,12 +193,10 @@ impl ConnectedState {
                 } else {
                     match self.set_firewall_policy(shared_values) {
                         Ok(()) => {
-                            cfg_if! {
-                                if #[cfg(target_os = "android")] {
-                                    self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                                } else {
-                                    SameState(self.into())
-                                }
+                            if cfg!(target_os = "android") {
+                                self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
+                            } else {
+                                SameState(self.into())
                             }
                         }
                         Err(error) => self.disconnect(

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -7,7 +7,6 @@ use crate::{
     firewall::FirewallPolicy,
     tunnel::{self, TunnelMonitor},
 };
-use cfg_if::cfg_if;
 use futures::{
     channel::{mpsc, oneshot},
     future::Fuse,
@@ -301,12 +300,10 @@ impl ConnectingState {
             self.allowed_tunnel_traffic.clone(),
         ) {
             Ok(()) => {
-                cfg_if! {
-                    if #[cfg(target_os = "android")] {
-                        self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                    } else {
-                        EventConsequence::SameState(self.into())
-                    }
+                if cfg!(target_os = "android") {
+                    self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
+                } else {
+                    EventConsequence::SameState(self.into())
                 }
             }
             Err(error) => self.disconnect(


### PR DESCRIPTION
As part of my dependency cleanup/upgrade spree today I found this little possible improvement. So we used `cfg_if!` macro where we could easily get by without it. I'd argue the code is better now, and we have one dependency less to clobber up our `Cargo.toml` files.

Why is it better? After macro evaluation the code previously looked like this:
```rust
// On Android:
                        Ok(()) => {
                            self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                        }

// On desktop:
                        Ok(()) => {
                            SameState(self.into())
                        }
```
After this PR the code after macro evaluation looks like this (the only thing different between Android and non-Android is the true/false constant:
```rust
                        Ok(()) => {
                            if true/false {
                                self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                            } else {
                                SameState(self.into())
                            }
                        }
```
This might slow down compilation a minuscule amount, due to there being more code to compile. The benefit is that both execution branches get type checked and verified by the compiler no matter which target you build for. So it's easier to edit code on one platform and not accidentally break code for another platform. The not-used if-branch will most likely be optimized away by the compiler anyway, so it's not going to add a cost to the final binary.

Where possible to use I generally (not always) prefer `cfg!` over `#[cfg]` for the above reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4944)
<!-- Reviewable:end -->
