### PR TITLE
Bump container jdk to 17

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -76,13 +76,14 @@ RUN apt-get update -y && apt-get install -y \
     python \
     software-properties-common \
     unzip \
-    openjdk-11-jdk \
+    ca-certificates-java \
+    openjdk-17-jdk \
     tidy \
     && rm -rf /var/lib/apt/lists/*
 
 # Set default java version
-RUN update-alternatives --set java  /usr/lib/jvm/java-11-openjdk-amd64/bin/java
-RUN update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+RUN update-alternatives --set java  /usr/lib/jvm/java-17-openjdk-amd64/bin/java
+RUN update-alternatives --set javac /usr/lib/jvm/java-17-openjdk-amd64/bin/javac
 
 # Install Android command line tools
 RUN curl -sfLo /tmp/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-${COMMAND_LINE_TOOLS_VERSION}_latest.zip && \


### PR DESCRIPTION
Bumping the container JDK is the first step of migrating to newer versions of the Android Gradle Plugin including Gradle and Kotlin.

Also updates `ca-certificates-java` since the jdk installation would fail otherwise.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4948)
<!-- Reviewable:end -->
