### PR TITLE
Make chrono a workspace dependency and fix features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ prost-types = "0.11"
 
 windows-sys = "0.45.0"
 
+chrono = { version = "0.4.26", default-features = false}
+
 
 [profile.release]
 opt-level = 3

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -13,7 +13,7 @@ publish.workspace = true
 api-override = []
 
 [dependencies]
-chrono = { version = "0.4.26", default-features = false }
+chrono = { workspace = true }
 err-derive = "0.3.1"
 futures = "0.3"
 http = "0.2"

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13"
-chrono = { version = "0.4.26", default-features = false }
+chrono = { workspace = true }
 clap = { version = "4.2.7", features = ["cargo", "derive"] }
 env_logger = "0.10.0"
 futures = "0.3"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -14,7 +14,7 @@ api-override = ["mullvad-api/api-override"]
 
 [dependencies]
 cfg-if = "1.0"
-chrono = { version = "0.4.26", default-features = false }
+chrono = { workspace = true }
 err-derive = "0.3.1"
 fern = { version = "0.6", features = ["colored"] }
 futures = "0.3"

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-chrono = { version = "0.4.26", default-features = false }
+chrono = { workspace = true }
 err-derive = "0.3.1"
 mullvad-types = { path = "../mullvad-types" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-chrono = { version = "0.4.26", default-features = false }
+chrono = { workspace = true }
 err-derive = "0.3.1"
 futures = "0.3"
 ipnetwork = "0.16"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-chrono = { version = "0.4.26", default-features = false, features = ["clock", "serde"] }
+chrono = { workspace = true, features = ["clock", "serde"] }
 err-derive = "0.3.1"
 ipnetwork = "0.16"
 lazy_static = "1.1.0"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -24,7 +24,7 @@ talpid-time = { path = "../talpid-time" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-wireguard = { path = "../talpid-wireguard" }
-chrono = { version = "0.4.26", default-features = false }
+chrono = { workspace = true, features = ["clock"] }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 rand = "0.8.5"
 

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -23,7 +23,7 @@ talpid-types = { path = "../talpid-types" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 zeroize = "1"
-chrono = { version = "0.4.26", default-features = false }
+chrono = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 rand = "0.8.5"


### PR DESCRIPTION
I noticed today that if I do `cd talpid-core; cargo build` it would fail. Because there is a difference between building the entire workspace and building one crate. `talpid-core` depend on the `clock` feature of `chrono` but did not specify it. This is a regression due to #4938.

This PR moves `chrono` to a workspace dependency. This eliminates the need to repeat `default-features = false` way too many times. We probably only ever want one version of `chrono` in this workspace anyway. And the PR also of course adds the `clock` feature to `talpid-core`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4950)
<!-- Reviewable:end -->
