### PR TITLE
Migrate translation-converter to err_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,12 +566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,7 +662,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "fiat-crypto",
  "platforms",
- "rustc_version 0.4.0",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -834,19 +828,6 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.100",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version 0.3.3",
  "syn 1.0.100",
 ]
 
@@ -3081,20 +3062,11 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver",
 ]
 
 [[package]]
@@ -3200,27 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "sendfd"
@@ -4165,7 +4119,7 @@ dependencies = [
 name = "translations-converter"
 version = "0.0.0"
 dependencies = [
- "derive_more",
+ "err-derive",
  "htmlize",
  "lazy_static",
  "quick-xml",

--- a/android/translations-converter/Cargo.toml
+++ b/android/translations-converter/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
-derive_more = "0.99"
+err-derive = "0.3.1"
 htmlize = { version = "1.0.2", features = ["unescape"] }
 lazy_static = "1"
 regex = "1"

--- a/android/translations-converter/src/gettext/messages.rs
+++ b/android/translations-converter/src/gettext/messages.rs
@@ -1,5 +1,4 @@
 use super::{msg_string::MsgString, parser::Parser, plural_form::PluralForm};
-use derive_more::{Display, Error, From};
 use std::{
     fs::File,
     io::{BufRead, BufReader},
@@ -104,13 +103,13 @@ impl From<MsgString> for MsgValue {
     }
 }
 
-#[derive(Debug, Display, Error, From)]
+#[derive(Debug, err_derive::Error)]
 pub enum Error {
     /// Parser error while parsing file
-    #[display(fmt = "Failed to parse input file")]
-    Parse(super::parser::Error),
+    #[error(display = "Failed to parse input file")]
+    Parse(#[error(source)] super::parser::Error),
 
     /// IO error while reading input file.
-    #[display(fmt = "Failed to read from the input file")]
-    Io(std::io::Error),
+    #[error(display = "Failed to read from the input file")]
+    Io(#[error(source)] std::io::Error),
 }

--- a/android/translations-converter/src/gettext/parser.rs
+++ b/android/translations-converter/src/gettext/parser.rs
@@ -1,5 +1,4 @@
 use super::{Messages, MsgString, PluralForm};
-use derive_more::{Display, Error};
 use std::{collections::BTreeMap, mem};
 
 /// A gettext messages file parser.
@@ -527,29 +526,35 @@ fn collect_variants(
 }
 
 /// Parsing errors.
-#[derive(Clone, Debug, Display, Error, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, err_derive::Error)]
 pub enum Error {
     /// An unexpected line was read while parsing.
-    #[display(fmt = "Unexpected line parsing gettext messages: {_0}")]
-    UnexpectedLine(#[error(not(source))] String),
+    #[error(display = "Unexpected line parsing gettext messages: {}", _0)]
+    UnexpectedLine(String),
 
     /// Input uses an unrecognized plural forumal.
-    #[display(fmt = "Input uses an unrecognized formula for the plural form: {_0}")]
-    UnrecognizedPluralFormula(#[error(not(source))] String),
+    #[error(
+        display = "Input uses an unrecognized formula for the plural form: {}",
+        _0
+    )]
+    UnrecognizedPluralFormula(String),
 
     /// Input ended with an incomplete entry.
-    #[display(fmt = "Input ended with an incomplete gettext entry with ID: {_0}")]
-    IncompleteEntry(#[error(not(source))] MsgString),
+    #[error(
+        display = "Input ended with an incomplete gettext entry with ID: {}",
+        _0
+    )]
+    IncompleteEntry(MsgString),
 
     /// Plural entry definition is missing a plural variant.
-    #[display(fmt = "Plural entry is missing a plural variant: {_0}")]
-    IncompletePluralEntry(#[error(not(source))] MsgString),
+    #[error(display = "Plural entry is missing a plural variant: {}", _0)]
+    IncompletePluralEntry(MsgString),
 
     /// Plural variant is invalid.
-    #[display(fmt = "Plural variant line is invalid: {_0}")]
-    InvalidPluralVariant(#[error(not(source))] String),
+    #[error(display = "Plural variant line is invalid: {}", _0)]
+    InvalidPluralVariant(String),
 
     /// Plural variant index was not parsable.
-    #[display(fmt = "Plural variant line contains an invalid index: {_0}")]
-    InvalidPluralIndex(#[error(not(source))] String),
+    #[error(display = "Plural variant line contains an invalid index: {}", _0)]
+    InvalidPluralIndex(String),
 }

--- a/android/translations-converter/src/gettext/plural_form.rs
+++ b/android/translations-converter/src/gettext/plural_form.rs
@@ -1,4 +1,3 @@
-use derive_more::{Display, Error};
 use std::str::FromStr;
 
 /// Known plural forms.
@@ -45,6 +44,6 @@ impl FromStr for PluralForm {
 /// Failed to create [`PluralForm`] from specified plural formula.
 ///
 /// The formula could be an invalid formula, or support for it hasn't been added yet.
-#[derive(Clone, Debug, Display, Error)]
-#[display(fmt = "Unsupported plural formula: {_0}")]
-pub struct UnsupportedPluralFormulaError(#[error(not(source))] String);
+#[derive(Clone, Debug, err_derive::Error)]
+#[error(display = "Unsupported plural formula: {}", _0)]
+pub struct UnsupportedPluralFormulaError(String);


### PR DESCRIPTION
On my dependency excursion lately I found out that we use `derive_more` in `translations-converter` to derive the standard `Error` macro for us. We do the same but with the `err_derive` crate everywhere else. So I figured if I migrate this tool to also use that things would be more uniform and we would drop a few dependencies along the way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4954)
<!-- Reviewable:end -->
