### PR TITLE
Use std::ffi::c_void in Rust<->iOS code instead of libc::c_void

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,7 +3366,6 @@ name = "shadowsocks-proxy"
 version = "0.0.0"
 dependencies = [
  "cbindgen",
- "libc",
  "log",
  "oslog",
  "shadowsocks-service",
@@ -4301,7 +4300,6 @@ name = "tunnel-obfuscator-proxy"
 version = "0.0.0"
 dependencies = [
  "cbindgen",
- "libc",
  "log",
  "oslog",
  "tokio",

--- a/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
+++ b/ios/MullvadTransport/shadowsocks-proxy/Cargo.toml
@@ -17,7 +17,6 @@ shadowsocks-service.rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36"
 shadowsocks-service.features = [ "local", "stream-cipher", "local-http", "local-tunnel" ]
 
 tokio = { workspace = true }
-libc = "0.2"
 log = "0.4"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/ios/MullvadTransport/shadowsocks-proxy/src/ffi.rs
+++ b/ios/MullvadTransport/shadowsocks-proxy/src/ffi.rs
@@ -9,7 +9,7 @@ static INIT_LOGGING: Once = Once::new();
 
 #[repr(C)]
 pub struct ProxyHandle {
-    pub context: *mut libc::c_void,
+    pub context: *mut std::ffi::c_void,
     pub port: u16,
 }
 

--- a/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
+++ b/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
@@ -14,7 +14,6 @@ bench = false
 [target.'cfg(target_os = "ios")'.dependencies]
 tunnel-obfuscation = { path = "../../../tunnel-obfuscation" }
 tokio = { workspace = true, features = ["sync"] }
-libc = "0.2"
 log = "0.4"
 oslog = "0.2"
 

--- a/ios/TunnelObfuscation/tunnel-obfuscator-proxy/src/ffi.rs
+++ b/ios/TunnelObfuscation/tunnel-obfuscator-proxy/src/ffi.rs
@@ -8,7 +8,7 @@ static INIT_LOGGING: Once = Once::new();
 
 #[repr(C)]
 pub struct ProxyHandle {
-    pub context: *mut libc::c_void,
+    pub context: *mut std::ffi::c_void,
     pub port: u16,
 }
 


### PR DESCRIPTION
On my recent excursion hunting down unused Rust dependencies (https://github.com/mullvad/mullvadvpn-app/pull/4953 & https://github.com/mullvad/mullvadvpn-app/pull/4947) I realized that both these iOS Rust packages depend on `libc` solely for the `c_void` definition. This type is available in the standard library since a long time now. So I figured we could use those and make things just a tad bit simpler/cleaner.

I have not tested this change. But these types should be equivalent. On Rust >=1.30 libc just re-exports the standard library version of it, so they are the same. https://github.com/rust-lang/libc/blob/main/build.rs#L109-L114 + https://github.com/rust-lang/libc/blob/main/src/unix/mod.rs#L1603-L1604