### PR TITLE
Use C FFI types from `std::ffi` instead of `libc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3772,7 +3772,6 @@ version = "0.0.0"
 dependencies = [
  "err-derive",
  "futures",
- "libc",
  "socket2 0.4.9",
  "talpid-types",
  "winapi",

--- a/mullvad-daemon/src/exception_logging/unix.rs
+++ b/mullvad-daemon/src/exception_logging/unix.rs
@@ -1,8 +1,9 @@
 //! Installs signal handlers to catch critical program faults and logs them.
 
-use libc::{c_int, c_void, siginfo_t};
+use libc::{c_int, siginfo_t};
 use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
 
+use std::ffi::c_void;
 use std::{convert::TryFrom, sync::Once};
 
 static INIT_ONCE: Once = Once::new();

--- a/mullvad-daemon/src/exception_logging/unix.rs
+++ b/mullvad-daemon/src/exception_logging/unix.rs
@@ -1,9 +1,9 @@
 //! Installs signal handlers to catch critical program faults and logs them.
 
-use libc::{c_int, siginfo_t};
+use libc::siginfo_t;
 use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
 
-use std::ffi::c_void;
+use std::ffi::{c_int, c_void};
 use std::{convert::TryFrom, sync::Once};
 
 static INIT_ONCE: Once = Once::new();

--- a/mullvad-daemon/src/exception_logging/win.rs
+++ b/mullvad-daemon/src/exception_logging/win.rs
@@ -1,8 +1,7 @@
-use libc::c_void;
 use mullvad_paths::log_dir;
 use std::{
     borrow::Cow,
-    ffi::CStr,
+    ffi::{c_void, CStr},
     fmt::Write,
     fs, io, mem,
     os::{raw::c_char, windows::io::AsRawHandle},

--- a/mullvad-daemon/src/exception_logging/win.rs
+++ b/mullvad-daemon/src/exception_logging/win.rs
@@ -1,10 +1,10 @@
 use mullvad_paths::log_dir;
 use std::{
     borrow::Cow,
-    ffi::{c_void, CStr},
+    ffi::{c_char, c_void, CStr},
     fmt::Write,
     fs, io, mem,
-    os::{raw::c_char, windows::io::AsRawHandle},
+    os::windows::io::AsRawHandle,
     path::{Path, PathBuf},
     ptr,
 };

--- a/mullvad-daemon/src/macos_launch_daemon.rs
+++ b/mullvad-daemon/src/macos_launch_daemon.rs
@@ -6,7 +6,7 @@
 //! daemon in the system settings.
 
 use objc::{class, msg_send, sel, sel_impl};
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
 
 type Id = *mut objc::runtime::Object;
 
@@ -80,7 +80,7 @@ fn daemon_plist_url() -> Object {
     let nsurl_inst: Id = unsafe { msg_send![class!(NSURL), alloc] };
     let nsurl_inst: Id = unsafe { msg_send![nsurl_inst, initWithString: nsstr_inst] };
 
-    let _: libc::c_void = unsafe { msg_send![nsstr_inst, release] };
+    let _: c_void = unsafe { msg_send![nsstr_inst, release] };
 
     assert!(!nsurl_inst.is_null());
 
@@ -92,6 +92,6 @@ struct Object(Id);
 
 impl Drop for Object {
     fn drop(&mut self) {
-        let _: libc::c_void = unsafe { msg_send![self.0, release] };
+        let _: c_void = unsafe { msg_send![self.0, release] };
     }
 }

--- a/mullvad-daemon/src/macos_launch_daemon.rs
+++ b/mullvad-daemon/src/macos_launch_daemon.rs
@@ -6,7 +6,7 @@
 //! daemon in the system settings.
 
 use objc::{class, msg_send, sel, sel_impl};
-use std::ffi::{c_void, CStr};
+use std::ffi::CStr;
 
 type Id = *mut objc::runtime::Object;
 
@@ -80,7 +80,7 @@ fn daemon_plist_url() -> Object {
     let nsurl_inst: Id = unsafe { msg_send![class!(NSURL), alloc] };
     let nsurl_inst: Id = unsafe { msg_send![nsurl_inst, initWithString: nsstr_inst] };
 
-    let _: c_void = unsafe { msg_send![nsstr_inst, release] };
+    let _: () = unsafe { msg_send![nsstr_inst, release] };
 
     assert!(!nsurl_inst.is_null());
 
@@ -92,6 +92,6 @@ struct Object(Id);
 
 impl Drop for Object {
     fn drop(&mut self) {
-        let _: c_void = unsafe { msg_send![self.0, release] };
+        let _: () = unsafe { msg_send![self.0, release] };
     }
 }

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -1,10 +1,9 @@
 use crate::cli;
-use libc::c_void;
 use mullvad_daemon::{runtime::new_runtime_builder, DaemonShutdownHandle};
 use once_cell::sync::Lazy;
 use std::{
     env,
-    ffi::OsString,
+    ffi::{c_void, OsString},
     ptr, slice,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -335,7 +335,7 @@ fn widestring_ip(ip: IpAddr) -> WideCString {
 pub extern "system" fn log_sink(
     level: log::Level,
     msg: *const libc::c_char,
-    context: *mut libc::c_void,
+    context: *mut std::ffi::c_void,
 ) {
     if msg.is_null() {
         log::error!("Log message from FFI boundary is NULL");
@@ -409,11 +409,11 @@ fn multibyte_to_wide(mb_string: &CStr, codepage: u32) -> Result<Vec<u16>, io::Er
 #[allow(non_snake_case)]
 mod winfw {
     use super::{widestring_ip, AllowedEndpoint, AllowedTunnelTraffic, Error, WideCString};
-    use libc;
+    use std::ffi::c_void;
     use talpid_types::net::TransportProtocol;
 
     type LogSink =
-        extern "system" fn(level: log::Level, msg: *const libc::c_char, context: *mut libc::c_void);
+        extern "system" fn(level: log::Level, msg: *const libc::c_char, context: *mut c_void);
 
     pub struct WinFwAllowedEndpointContainer {
         _clients: Box<[WideCString]>,

--- a/talpid-core/src/firewall/windows.rs
+++ b/talpid-core/src/firewall/windows.rs
@@ -334,7 +334,7 @@ fn widestring_ip(ip: IpAddr) -> WideCString {
 /// Logging callback implementation.
 pub extern "system" fn log_sink(
     level: log::Level,
-    msg: *const libc::c_char,
+    msg: *const std::ffi::c_char,
     context: *mut std::ffi::c_void,
 ) {
     if msg.is_null() {
@@ -409,11 +409,10 @@ fn multibyte_to_wide(mb_string: &CStr, codepage: u32) -> Result<Vec<u16>, io::Er
 #[allow(non_snake_case)]
 mod winfw {
     use super::{widestring_ip, AllowedEndpoint, AllowedTunnelTraffic, Error, WideCString};
-    use std::ffi::c_void;
+    use std::ffi::{c_char, c_void};
     use talpid_types::net::TransportProtocol;
 
-    type LogSink =
-        extern "system" fn(level: log::Level, msg: *const libc::c_char, context: *mut c_void);
+    type LogSink = extern "system" fn(level: log::Level, msg: *const c_char, context: *mut c_void);
 
     pub struct WinFwAllowedEndpointContainer {
         _clients: Box<[WideCString]>,

--- a/talpid-routing/src/unix/macos/data.rs
+++ b/talpid-routing/src/unix/macos/data.rs
@@ -5,6 +5,7 @@ use nix::{
 };
 use std::{
     collections::BTreeMap,
+    ffi::{c_int, c_uchar, c_ushort},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
 
@@ -385,13 +386,13 @@ impl RouteMessage {
 #[derive(Debug)]
 #[repr(C)]
 struct ifa_msghdr {
-    ifam_msglen: libc::c_ushort,
-    ifam_version: libc::c_uchar,
-    ifam_type: libc::c_uchar,
-    ifam_addrs: libc::c_int,
-    ifam_flags: libc::c_int,
-    ifam_index: libc::c_ushort,
-    ifam_metric: libc::c_int,
+    ifam_msglen: c_ushort,
+    ifam_version: c_uchar,
+    ifam_type: c_uchar,
+    ifam_addrs: c_int,
+    ifam_flags: c_int,
+    ifam_index: c_ushort,
+    ifam_metric: c_int,
 }
 
 #[derive(Debug)]
@@ -529,7 +530,7 @@ pub enum Error {
     /// Unrecognized message
     UnknownMessageType(u8),
     /// Unrecognized address flag
-    UnknownAddressFlag(libc::c_int),
+    UnknownAddressFlag(c_int),
     /// Mismatched socket address type
     MismatchedSocketAddress(AddressFlag, Box<SockaddrStorage>),
     /// Link socket address contains no identifier
@@ -1003,16 +1004,16 @@ impl<'a> Iterator for RouteSockAddrIterator<'a> {
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct rt_msghdr {
-    pub rtm_msglen: libc::c_ushort,
-    pub rtm_version: libc::c_uchar,
-    pub rtm_type: libc::c_uchar,
-    pub rtm_index: libc::c_ushort,
-    pub rtm_flags: libc::c_int,
-    pub rtm_addrs: libc::c_int,
+    pub rtm_msglen: c_ushort,
+    pub rtm_version: c_uchar,
+    pub rtm_type: c_uchar,
+    pub rtm_index: c_ushort,
+    pub rtm_flags: c_int,
+    pub rtm_addrs: c_int,
     pub rtm_pid: libc::pid_t,
-    pub rtm_seq: libc::c_int,
-    pub rtm_errno: libc::c_int,
-    pub rtm_use: libc::c_int,
+    pub rtm_seq: c_int,
+    pub rtm_errno: c_int,
+    pub rtm_use: c_int,
     pub rtm_inits: u32,
     pub rtm_rmx: rt_metrics,
 }
@@ -1049,15 +1050,15 @@ impl rt_msghdr {
 #[derive(Debug)]
 #[repr(C)]
 pub struct rt_msghdr_short {
-    pub rtm_msglen: libc::c_ushort,
-    pub rtm_version: libc::c_uchar,
-    pub rtm_type: libc::c_uchar,
-    pub rtm_index: libc::c_ushort,
-    pub rtm_flags: libc::c_int,
-    pub rtm_addrs: libc::c_int,
+    pub rtm_msglen: c_ushort,
+    pub rtm_version: c_uchar,
+    pub rtm_type: c_uchar,
+    pub rtm_index: c_ushort,
+    pub rtm_flags: c_int,
+    pub rtm_addrs: c_int,
     pub rtm_pid: libc::pid_t,
-    pub rtm_seq: libc::c_int,
-    pub rtm_errno: libc::c_int,
+    pub rtm_seq: c_int,
+    pub rtm_errno: c_int,
 }
 const ROUTE_MESSAGE_HEADER_SHORT_SIZE: usize = std::mem::size_of::<rt_msghdr_short>();
 

--- a/talpid-windows-net/Cargo.toml
+++ b/talpid-windows-net/Cargo.toml
@@ -10,7 +10,6 @@ publish.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 err-derive = "0.3.1"
-libc = "0.2"
 socket2 = { version = "0.4.2", features = ["all"] }
 futures = "0.3.15"
 winapi = { version = "0.3.6", features = ["ws2def"] }

--- a/talpid-windows-net/src/net.rs
+++ b/talpid-windows-net/src/net.rs
@@ -1,4 +1,3 @@
-use libc::c_void;
 use socket2::SockAddr;
 use std::{
     ffi::{OsStr, OsString},
@@ -153,7 +152,7 @@ impl<'a> Drop for IpNotifierHandle<'a> {
 }
 
 unsafe extern "system" fn inner_callback(
-    context: *const c_void,
+    context: *const std::ffi::c_void,
     row: *const MIB_IPINTERFACE_ROW,
     notify_type: i32,
 ) {

--- a/talpid-wireguard/src/logging.rs
+++ b/talpid-wireguard/src/logging.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
+use std::ffi::c_void;
 use std::{collections::HashMap, fmt, fs, io::Write, path::Path};
 
 static LOG_MUTEX: Lazy<Mutex<HashMap<u32, fs::File>>> = Lazy::new(|| Mutex::new(HashMap::new()));
@@ -92,7 +93,7 @@ fn log_inner(logfile: &mut fs::File, level: LogLevel, tag: &str, msg: &str) {
 pub unsafe extern "system" fn wg_go_logging_callback(
     level: WgLogLevel,
     msg: *const libc::c_char,
-    context: *mut libc::c_void,
+    context: *mut c_void,
 ) {
     let mut map = LOG_MUTEX.lock();
     if let Some(logfile) = map.get_mut(&(context as u32)) {

--- a/talpid-wireguard/src/logging.rs
+++ b/talpid-wireguard/src/logging.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 use std::{collections::HashMap, fmt, fs, io::Write, path::Path};
 
 static LOG_MUTEX: Lazy<Mutex<HashMap<u32, fs::File>>> = Lazy::new(|| Mutex::new(HashMap::new()));
@@ -92,7 +92,7 @@ fn log_inner(logfile: &mut fs::File, level: LogLevel, tag: &str, msg: &str) {
 // Callback that receives messages from WireGuard
 pub unsafe extern "system" fn wg_go_logging_callback(
     level: WgLogLevel,
-    msg: *const libc::c_char,
+    msg: *const c_char,
     context: *mut c_void,
 ) {
     let mut map = LOG_MUTEX.lock();

--- a/talpid-wireguard/src/wireguard_go.rs
+++ b/talpid-wireguard/src/wireguard_go.rs
@@ -95,7 +95,7 @@ impl WgGoTunnel {
                 wg_config_str.as_ptr() as *const i8,
                 tunnel_fd,
                 Some(wg_go_logging_callback),
-                logging_context.0 as *mut libc::c_void,
+                logging_context.0 as *mut c_void,
             )
         };
         check_wg_status(handle)?;
@@ -154,7 +154,7 @@ impl WgGoTunnel {
                 &mut alias_ptr,
                 &mut interface_luid,
                 Some(wg_go_logging_callback),
-                logging_context.0 as *mut libc::c_void,
+                logging_context.0 as *mut c_void,
             )
         };
         check_wg_status(handle)?;
@@ -424,11 +424,8 @@ fn check_wg_status(wg_code: i32) -> Result<()> {
 #[cfg(unix)]
 pub type Fd = std::os::unix::io::RawFd;
 
-pub type LoggingCallback = unsafe extern "system" fn(
-    level: WgLogLevel,
-    msg: *const libc::c_char,
-    context: *mut libc::c_void,
-);
+pub type LoggingCallback =
+    unsafe extern "system" fn(level: WgLogLevel, msg: *const libc::c_char, context: *mut c_void);
 
 const ERROR_GENERAL_FAILURE: i32 = -1;
 const ERROR_INTERMITTENT_FAILURE: i32 = -2;
@@ -445,7 +442,7 @@ extern "C" {
         settings: *const i8,
         fd: Fd,
         logging_callback: Option<LoggingCallback>,
-        logging_context: *mut libc::c_void,
+        logging_context: *mut c_void,
     ) -> i32;
 
     // Android
@@ -454,7 +451,7 @@ extern "C" {
         settings: *const i8,
         fd: Fd,
         logging_callback: Option<LoggingCallback>,
-        logging_context: *mut libc::c_void,
+        logging_context: *mut c_void,
     ) -> i32;
 
     // Windows
@@ -466,7 +463,7 @@ extern "C" {
         iface_name_out: *mut *mut std::os::raw::c_char,
         iface_luid_out: *mut u64,
         logging_callback: Option<LoggingCallback>,
-        logging_context: *mut libc::c_void,
+        logging_context: *mut c_void,
     ) -> i32;
 
     // Pass a handle that was created by wgTurnOn to stop a wireguard tunnel.

--- a/talpid-wireguard/src/wireguard_go.rs
+++ b/talpid-wireguard/src/wireguard_go.rs
@@ -6,9 +6,8 @@ use crate::logging::{clean_up_logging, initialize_logging, wg_go_logging_callbac
 #[cfg(windows)]
 use futures::SinkExt;
 use std::{
-    ffi::{c_void, CStr},
+    ffi::{c_char, c_void, CStr},
     future::Future,
-    os::raw::c_char,
     path::Path,
     pin::Pin,
 };
@@ -425,7 +424,7 @@ fn check_wg_status(wg_code: i32) -> Result<()> {
 pub type Fd = std::os::unix::io::RawFd;
 
 pub type LoggingCallback =
-    unsafe extern "system" fn(level: WgLogLevel, msg: *const libc::c_char, context: *mut c_void);
+    unsafe extern "system" fn(level: WgLogLevel, msg: *const c_char, context: *mut c_void);
 
 const ERROR_GENERAL_FAILURE: i32 = -1;
 const ERROR_INTERMITTENT_FAILURE: i32 = -2;
@@ -460,7 +459,7 @@ extern "C" {
         iface_name: *const i8,
         mtu: i64,
         settings: *const i8,
-        iface_name_out: *mut *mut std::os::raw::c_char,
+        iface_name_out: *mut *mut c_char,
         iface_luid_out: *mut u64,
         logging_callback: Option<LoggingCallback>,
         logging_context: *mut c_void,
@@ -470,7 +469,7 @@ extern "C" {
     fn wgTurnOff(handle: i32) -> i32;
 
     // Returns the file descriptor of the tunnel IPv4 socket.
-    fn wgGetConfig(handle: i32) -> *mut std::os::raw::c_char;
+    fn wgGetConfig(handle: i32) -> *mut c_char;
 
     // Sets the config of the WireGuard interface.
     fn wgSetConfig(handle: i32, settings: *const i8) -> i32;


### PR DESCRIPTION
This PR is related to #4956. In that PR I managed to actually get rid of a dependency because of the migration. That's not the case in this PR. But it might be nice to be consistent with what FFI types we use. Since Rust 1.64 the `std::ffi` module was expanded with char and int type definitions.

The motivation for this PR is just a tiny cleanup. But it has no known downsides either afaict, so why not.

If you approve of this, I might add to our coding guidelines to prefer `std::ffi` where possible. Most packages will depend on `libc` in one way or another anyway. But why pollute `Cargo.toml` for no reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4957)
<!-- Reviewable:end -->
