### PR TITLE
Upgrade `windows-sys` to 0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,7 +1968,7 @@ dependencies = [
  "natord",
  "talpid-types",
  "tokio",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "winres",
 ]
 
@@ -2012,7 +2012,7 @@ dependencies = [
  "tokio-stream",
  "winapi",
  "windows-service",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "winres",
 ]
 
@@ -2093,7 +2093,7 @@ dependencies = [
  "log",
  "once_cell",
  "widestring",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ dependencies = [
  "talpid-types",
  "tokio",
  "uuid",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "winres",
 ]
 
@@ -3606,7 +3606,7 @@ dependencies = [
  "which",
  "widestring",
  "windows-service",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "winreg 0.7.0",
 ]
 
@@ -3650,7 +3650,7 @@ dependencies = [
  "triggered",
  "uuid",
  "widestring",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "winreg 0.7.0",
 ]
 
@@ -3670,7 +3670,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "winres",
 ]
 
@@ -3680,7 +3680,7 @@ version = "0.0.0"
 dependencies = [
  "rs-release",
  "talpid-dbus",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3703,7 +3703,7 @@ dependencies = [
  "talpid-windows-net",
  "tokio",
  "widestring",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3731,7 +3731,7 @@ dependencies = [
  "talpid-windows-net",
  "tokio",
  "tun",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3749,7 +3749,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "zeroize",
 ]
 
@@ -3775,7 +3775,7 @@ dependencies = [
  "libc",
  "socket2 0.4.9",
  "winapi",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3813,7 +3813,7 @@ dependencies = [
  "tokio-stream",
  "tunnel-obfuscation",
  "widestring",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "futures",
  "libc",
  "socket2 0.4.9",
+ "talpid-types",
  "winapi",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tower = "0.4"
 prost = "0.11"
 prost-types = "0.11"
 
-windows-sys = "0.45.0"
+windows-sys = "0.48.0"
 
 chrono = { version = "0.4.26", default-features = false}
 clap = { version = "4.2.7", features = ["cargo", "derive"] }

--- a/mullvad-paths/src/windows.rs
+++ b/mullvad-paths/src/windows.rs
@@ -5,8 +5,8 @@ use windows_sys::{
     core::{GUID, PWSTR},
     Win32::{
         Foundation::{
-            CloseHandle, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS, HANDLE, INVALID_HANDLE_VALUE,
-            LUID, S_OK,
+            CloseHandle, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS, GENERIC_READ, HANDLE,
+            INVALID_HANDLE_VALUE, LUID, S_OK,
         },
         Security::{
             AdjustTokenPrivileges, CreateWellKnownSid, EqualSid, GetTokenInformation,
@@ -17,8 +17,7 @@ use windows_sys::{
         Storage::FileSystem::MAX_SID_SIZE,
         System::{
             Com::CoTaskMemFree,
-            ProcessStatus::K32EnumProcesses,
-            SystemServices::GENERIC_READ,
+            ProcessStatus::EnumProcesses,
             Threading::{
                 GetCurrentThread, OpenProcess, OpenProcessToken, OpenThreadToken,
                 PROCESS_QUERY_INFORMATION,
@@ -209,9 +208,7 @@ fn find_process<T>(handle_process: impl Fn(HANDLE) -> Option<T>) -> io::Result<T
 
     let bytes_available = num_procs * (mem::size_of::<u32>() as u32);
     let mut bytes_written = 0;
-    if unsafe { K32EnumProcesses(pid_buffer.as_mut_ptr(), bytes_available, &mut bytes_written) }
-        == 0
-    {
+    if unsafe { EnumProcesses(pid_buffer.as_mut_ptr(), bytes_available, &mut bytes_written) } == 0 {
         return Err(io::Error::last_os_error());
     }
 

--- a/talpid-core/src/dns/windows/auto.rs
+++ b/talpid-core/src/dns/windows/auto.rs
@@ -82,7 +82,7 @@ impl DnsMonitor {
     fn fallback_due_to_dnscache(&mut self, result: &Result<(), super::Error>) -> bool {
         let is_dnscache_error = match result {
             Err(super::Error::Iphlpapi(iphlpapi::Error::SetInterfaceDnsSettings(error))) => {
-                *error == RPC_S_SERVER_UNAVAILABLE
+                error.raw_os_error() == Some(RPC_S_SERVER_UNAVAILABLE)
             }
             Err(super::Error::Netsh(netsh::Error::Netsh(Some(1)))) => true,
             _ => false,

--- a/talpid-core/src/dns/windows/iphlpapi.rs
+++ b/talpid-core/src/dns/windows/iphlpapi.rs
@@ -7,12 +7,13 @@ use std::{
     os::windows::ffi::OsStrExt,
     ptr,
 };
+use talpid_types::win32_err;
 use talpid_windows_net::{guid_from_luid, luid_from_alias};
 use windows_sys::{
     core::GUID,
     s, w,
     Win32::{
-        Foundation::{ERROR_PROC_NOT_FOUND, NO_ERROR, NTSTATUS},
+        Foundation::{ERROR_PROC_NOT_FOUND, WIN32_ERROR},
         NetworkManagement::IpHelper::{
             DNS_INTERFACE_SETTINGS, DNS_INTERFACE_SETTINGS_VERSION1, DNS_SETTING_IPV6,
             DNS_SETTING_NAMESERVER,
@@ -36,8 +37,8 @@ pub enum Error {
     ObtainInterfaceGuid(#[error(source)] io::Error),
 
     /// Failed to set DNS settings on interface.
-    #[error(display = "Failed to set DNS settings on interface: {}", _0)]
-    SetInterfaceDnsSettings(i32),
+    #[error(display = "Failed to set DNS settings on interface")]
+    SetInterfaceDnsSettings(#[error(source)] io::Error),
 
     /// Failure to flush DNS cache.
     #[error(display = "Failed to flush DNS resolver cache")]
@@ -55,7 +56,7 @@ pub enum Error {
 type SetInterfaceDnsSettingsFn = unsafe extern "stdcall" fn(
     interface: GUID,
     settings: *const DNS_INTERFACE_SETTINGS,
-) -> NTSTATUS;
+) -> WIN32_ERROR;
 
 struct IphlpApi {
     set_interface_dns_settings: SetInterfaceDnsSettingsFn,
@@ -199,12 +200,10 @@ fn set_interface_dns_servers<T: ToString>(
         ProfileNameServer: ptr::null_mut(),
     };
 
-    let result =
-        unsafe { (iphlpapi.set_interface_dns_settings)(guid.to_owned(), &dns_interface_settings) };
-    if result != (NO_ERROR as i32) {
-        return Err(Error::SetInterfaceDnsSettings(result));
-    }
-    Ok(())
+    win32_err!(unsafe {
+        (iphlpapi.set_interface_dns_settings)(guid.to_owned(), &dns_interface_settings)
+    })
+    .map_err(Error::SetInterfaceDnsSettings)
 }
 
 fn flush_dns_cache() -> Result<(), Error> {

--- a/talpid-core/src/dns/windows/netsh.rs
+++ b/talpid-core/src/dns/windows/netsh.rs
@@ -13,8 +13,8 @@ use talpid_windows_net::{index_from_luid, luid_from_alias};
 use windows_sys::Win32::{
     Foundation::{MAX_PATH, WAIT_OBJECT_0, WAIT_TIMEOUT},
     System::{
-        SystemInformation::GetSystemDirectoryW, Threading::WaitForSingleObject,
-        WindowsProgramming::INFINITE,
+        SystemInformation::GetSystemDirectoryW,
+        Threading::{WaitForSingleObject, INFINITE},
     },
 };
 

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -32,8 +32,7 @@ use windows_sys::Win32::{
     System::{
         Diagnostics::ToolHelp::TH32CS_SNAPPROCESS,
         Ioctl::{FILE_ANY_ACCESS, METHOD_BUFFERED, METHOD_NEITHER},
-        Threading::{WaitForMultipleObjects, WaitForSingleObject},
-        WindowsProgramming::INFINITE,
+        Threading::{WaitForMultipleObjects, WaitForSingleObject, INFINITE},
         IO::{DeviceIoControl, GetOverlappedResult, OVERLAPPED},
     },
 };

--- a/talpid-core/src/split_tunnel/windows/path_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/path_monitor.rs
@@ -28,7 +28,7 @@ use windows_sys::Win32::{
     System::{
         Ioctl::FSCTL_GET_REPARSE_POINT,
         SystemServices::{IO_REPARSE_TAG_MOUNT_POINT, IO_REPARSE_TAG_SYMLINK},
-        WindowsProgramming::INFINITE,
+        Threading::INFINITE,
         IO::{
             CancelIoEx, CreateIoCompletionPort, DeviceIoControl, GetQueuedCompletionStatus,
             PostQueuedCompletionStatus, OVERLAPPED,

--- a/talpid-core/src/split_tunnel/windows/volume_monitor.rs
+++ b/talpid-core/src/split_tunnel/windows/volume_monitor.rs
@@ -12,11 +12,10 @@ use std::{
 use talpid_types::ErrorExt;
 use windows_sys::Win32::{
     Storage::FileSystem::GetLogicalDrives,
-    System::SystemServices::{
-        DBTF_NET, DBT_DEVICEARRIVAL, DBT_DEVICEREMOVECOMPLETE, DBT_DEVTYP_VOLUME,
-        DEV_BROADCAST_HDR, DEV_BROADCAST_VOLUME,
+    UI::WindowsAndMessaging::{
+        DefWindowProcW, DBTF_NET, DBT_DEVICEARRIVAL, DBT_DEVICEREMOVECOMPLETE, DBT_DEVTYP_VOLUME,
+        DEV_BROADCAST_HDR, DEV_BROADCAST_VOLUME, WM_DEVICECHANGE,
     },
-    UI::WindowsAndMessaging::{DefWindowProcW, WM_DEVICECHANGE},
 };
 
 pub(super) struct VolumeMonitor(());

--- a/talpid-core/src/split_tunnel/windows/windows.rs
+++ b/talpid-core/src/split_tunnel/windows/windows.rs
@@ -21,7 +21,7 @@ use windows_sys::Win32::{
         Diagnostics::ToolHelp::{
             CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
         },
-        ProcessStatus::K32GetProcessImageFileNameW,
+        ProcessStatus::GetProcessImageFileNameW,
         Threading::{
             CreateEventW, GetProcessTimes, OpenProcess, SetEvent, PROCESS_QUERY_LIMITED_INFORMATION,
         },
@@ -285,7 +285,7 @@ fn get_process_device_path_inner(
     buffer.reserve_exact(buffer_capacity);
 
     let written = unsafe {
-        K32GetProcessImageFileNameW(
+        GetProcessImageFileNameW(
             handle,
             buffer.as_mut_ptr() as *mut _,
             buffer.capacity() as u32,

--- a/talpid-openvpn/src/wintun.rs
+++ b/talpid-openvpn/src/wintun.rs
@@ -12,7 +12,7 @@ use widestring::{U16CStr, U16CString};
 use windows_sys::{
     core::GUID,
     Win32::{
-        Foundation::{HINSTANCE, NO_ERROR},
+        Foundation::{HMODULE, NO_ERROR},
         NetworkManagement::{IpHelper::ConvertInterfaceLuidToGuid, Ndis::NET_LUID_LH},
         System::{
             Com::StringFromGUID2,
@@ -55,7 +55,7 @@ enum WintunLoggerLevel {
 }
 
 pub struct WintunDll {
-    handle: HINSTANCE,
+    handle: HMODULE,
     func_create: WintunCreateAdapterFn,
     func_close: WintunCloseAdapterFn,
     func_get_adapter_luid: WintunGetAdapterLuidFn,
@@ -204,9 +204,9 @@ impl WintunDll {
     }
 
     fn new_inner(
-        handle: HINSTANCE,
+        handle: HMODULE,
         get_proc_fn: unsafe fn(
-            HINSTANCE,
+            HMODULE,
             &CStr,
         ) -> io::Result<unsafe extern "system" fn() -> isize>,
     ) -> io::Result<Self> {
@@ -240,7 +240,7 @@ impl WintunDll {
     }
 
     unsafe fn get_proc_address(
-        handle: HINSTANCE,
+        handle: HMODULE,
         name: &CStr,
     ) -> io::Result<unsafe extern "system" fn() -> isize> {
         let handle = GetProcAddress(handle, name.as_ptr() as *const u8);
@@ -371,7 +371,7 @@ mod tests {
     use super::*;
 
     fn get_proc_fn(
-        _handle: HINSTANCE,
+        _handle: HMODULE,
         _symbol: &CStr,
     ) -> io::Result<unsafe extern "system" fn() -> isize> {
         Ok(null_fn)

--- a/talpid-routing/src/windows/route_manager.rs
+++ b/talpid-routing/src/windows/route_manager.rs
@@ -10,6 +10,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::{Arc, Mutex},
 };
+use talpid_types::win32_err;
 use talpid_windows_net::{
     inet_sockaddr_from_socketaddr, try_socketaddr_from_inet_sockaddr, AddressFamily,
 };
@@ -17,7 +18,7 @@ use widestring::{WideCStr, WideCString};
 use windows_sys::Win32::{
     Foundation::{
         ERROR_BUFFER_OVERFLOW, ERROR_NOT_FOUND, ERROR_NO_DATA, ERROR_OBJECT_ALREADY_EXISTS,
-        ERROR_SUCCESS, NO_ERROR,
+        ERROR_SUCCESS,
     },
     NetworkManagement::{
         IpHelper::{
@@ -215,18 +216,17 @@ impl RouteManagerInternal {
         //
         // The simplest thing in this case is to just overwrite the route.
         //
-
-        if ERROR_OBJECT_ALREADY_EXISTS as i32 == status {
+        if ERROR_OBJECT_ALREADY_EXISTS == status {
             // SAFETY: DestinationPrefix must be initialized to a valid prefix. NextHop must have
             // a valid IP address and family. At least one of InterfaceLuid and InterfaceIndex must
             // be set to the interface.
             status = unsafe { SetIpForwardEntry2(&spec) };
         }
 
-        if NO_ERROR as i32 != status {
+        win32_err!(status).map_err(|e| {
             log::error!("Could not register route in routing table");
-            return Err(Error::AddToRouteTable(io::Error::from_raw_os_error(status)));
-        }
+            Error::AddToRouteTable(e)
+        })?;
 
         Ok(RegisteredRoute {
             network: route.network,
@@ -263,15 +263,10 @@ impl RouteManagerInternal {
                         None => {
                             let mut luid = NET_LUID_LH { Value: 0 };
                             // SAFETY: No specific safety requirement
-                            if NO_ERROR as i32
-                                != unsafe {
-                                    ConvertInterfaceAliasToLuid(device_name.as_ptr(), &mut luid)
-                                }
-                            {
-                                log::error!(
-                                    "Unable to derive interface LUID from interface alias: {:?}",
-                                    device_name
-                                );
+                            if let Err(e) = win32_err!(unsafe {
+                                ConvertInterfaceAliasToLuid(device_name.as_ptr(), &mut luid)
+                            }) {
+                                log::error!("Unable to get interface LUID for interface \"{device_name:?}\": {e}");
                                 return Err(Error::DeviceNameNotFound);
                             } else {
                                 luid
@@ -355,26 +350,17 @@ impl RouteManagerInternal {
         // SAFETY: DestinationPrefix must be initialized to a valid prefix. NextHop must have
         // a valid IP address and family. At least one of InterfaceLuid and InterfaceIndex must be
         // set to the interface.
-        let status = unsafe { DeleteIpForwardEntry2(&r) };
-
-        match u32::try_from(status) {
-            Ok(ERROR_NOT_FOUND) => {
-                log::warn!("Attempting to delete route which was not present in routing table, ignoring and proceeding. Route: {}", route);
+        match win32_err!(unsafe { DeleteIpForwardEntry2(&r) }) {
+            Ok(()) => Ok(()),
+            Err(e) if e.raw_os_error() == Some(ERROR_NOT_FOUND as i32) => {
+                log::warn!("Attempting to delete route which was not present in routing table, ignoring and proceeding. Route: {route}");
+                Ok(())
             }
-            Ok(NO_ERROR) => (),
-            _ => {
-                log::error!(
-                    "Failed to delete route in routing table. Route: {}, Status: {}",
-                    route,
-                    status
-                );
-                return Err(Error::DeleteFromRouteTable(io::Error::from_raw_os_error(
-                    status,
-                )));
+            Err(e) => {
+                log::error!("Failed to delete route in routing table. Route: {route}, Error: {e}");
+                Err(Error::DeleteFromRouteTable(e))
             }
         }
-
-        Ok(())
     }
 
     fn restore_into_routing_table(route: &RegisteredRoute) -> Result<()> {
@@ -396,16 +382,10 @@ impl RouteManagerInternal {
         // SAFETY: DestinationPrefix must be initialized to a valid prefix. NextHop must have a
         // valid IP address and family. At least one of InterfaceLuid and InterfaceIndex must be set
         // to the interface.
-        let status = unsafe { CreateIpForwardEntry2(&spec) };
-
-        if NO_ERROR as i32 != status {
-            log::error!(
-                "Could not register route in routing table. Route: {}, Status: {}",
-                route,
-                status
-            );
-            return Err(Error::AddToRouteTable(io::Error::from_raw_os_error(status)));
-        }
+        win32_err!(unsafe { CreateIpForwardEntry2(&spec) }).map_err(|e| {
+            log::error!("Could not register route in routing table. Route: {route}");
+            Error::AddToRouteTable(e)
+        })?;
         Ok(())
     }
 

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -200,8 +200,8 @@ fn try_set_tcp_sock_mtu(sock: RawSocket, mtu: u16) {
     let result = unsafe {
         setsockopt(
             raw_sock,
-            IPPROTO_IP as i32,
-            IP_USER_MTU as i32,
+            IPPROTO_IP,
+            IP_USER_MTU,
             &mtu as *const _ as _,
             std::ffi::c_int::try_from(std::mem::size_of_val(&mtu)).unwrap(),
         )

--- a/talpid-types/src/error.rs
+++ b/talpid-types/src/error.rs
@@ -1,0 +1,70 @@
+use std::{error::Error, fmt, fmt::Write};
+
+/// Used to generate string representations of error chains.
+pub trait ErrorExt {
+    /// Creates a string representation of the entire error chain.
+    fn display_chain(&self) -> String;
+
+    /// Like [Self::display_chain] but with an extra message at the start of the chain
+    fn display_chain_with_msg(&self, msg: &str) -> String;
+}
+
+impl<E: Error> ErrorExt for E {
+    fn display_chain(&self) -> String {
+        let mut s = format!("Error: {self}");
+        let mut source = self.source();
+        while let Some(error) = source {
+            write!(&mut s, "\nCaused by: {error}").expect("formatting failed");
+            source = error.source();
+        }
+        s
+    }
+
+    fn display_chain_with_msg(&self, msg: &str) -> String {
+        let mut s = format!("Error: {msg}\nCaused by: {self}");
+        let mut source = self.source();
+        while let Some(error) = source {
+            write!(&mut s, "\nCaused by: {error}").expect("formatting failed");
+            source = error.source();
+        }
+        s
+    }
+}
+
+#[derive(Debug)]
+pub struct BoxedError(Box<dyn Error + 'static + Send>);
+
+impl fmt::Display for BoxedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for BoxedError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl BoxedError {
+    pub fn new(error: impl Error + 'static + Send) -> Self {
+        BoxedError(Box::new(error))
+    }
+}
+
+/// Helper macro allowing simpler handling of Windows FFI returning `WIN32_ERROR`
+/// status codes. Converts a `WIN32_ERROR` into an `io::Result<()>`.
+///
+/// The caller of this macro must have `windows_sys` as a dependency.
+#[cfg(windows)]
+#[macro_export]
+macro_rules! win32_err {
+    ($expr:expr) => {{
+        let status = $expr;
+        if status == ::windows_sys::Win32::Foundation::NO_ERROR {
+            Ok(())
+        } else {
+            Err(::std::io::Error::from_raw_os_error(status as i32))
+        }
+    }};
+}

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(rust_2018_idioms)]
 
-use std::{error::Error, fmt, fmt::Write};
-
 #[cfg(target_os = "android")]
 pub mod android;
 pub mod net;
@@ -13,54 +11,5 @@ pub mod cgroup;
 #[cfg(target_os = "windows")]
 pub mod split_tunnel;
 
-/// Used to generate string representations of error chains.
-pub trait ErrorExt {
-    /// Creates a string representation of the entire error chain.
-    fn display_chain(&self) -> String;
-
-    /// Like [Self::display_chain] but with an extra message at the start of the chain
-    fn display_chain_with_msg(&self, msg: &str) -> String;
-}
-
-impl<E: Error> ErrorExt for E {
-    fn display_chain(&self) -> String {
-        let mut s = format!("Error: {self}");
-        let mut source = self.source();
-        while let Some(error) = source {
-            write!(&mut s, "\nCaused by: {error}").expect("formatting failed");
-            source = error.source();
-        }
-        s
-    }
-
-    fn display_chain_with_msg(&self, msg: &str) -> String {
-        let mut s = format!("Error: {msg}\nCaused by: {self}");
-        let mut source = self.source();
-        while let Some(error) = source {
-            write!(&mut s, "\nCaused by: {error}").expect("formatting failed");
-            source = error.source();
-        }
-        s
-    }
-}
-
-#[derive(Debug)]
-pub struct BoxedError(Box<dyn Error + 'static + Send>);
-
-impl fmt::Display for BoxedError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Error for BoxedError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.0.source()
-    }
-}
-
-impl BoxedError {
-    pub fn new(error: impl Error + 'static + Send) -> Self {
-        BoxedError(Box::new(error))
-    }
-}
+mod error;
+pub use error::*;

--- a/talpid-windows-net/Cargo.toml
+++ b/talpid-windows-net/Cargo.toml
@@ -15,6 +15,8 @@ socket2 = { version = "0.4.2", features = ["all"] }
 futures = "0.3.15"
 winapi = { version = "0.3.6", features = ["ws2def"] }
 
+talpid-types = { path = "../talpid-types" }
+
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true
 features = [

--- a/talpid-windows-net/src/net.rs
+++ b/talpid-windows-net/src/net.rs
@@ -9,11 +9,12 @@ use std::{
     sync::Mutex,
     time::{Duration, Instant},
 };
+use talpid_types::win32_err;
 use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
 use windows_sys::{
     core::GUID,
     Win32::{
-        Foundation::{ERROR_NOT_FOUND, HANDLE, NO_ERROR},
+        Foundation::{ERROR_NOT_FOUND, HANDLE},
         NetworkManagement::{
             IpHelper::{
                 CancelMibChangeNotify2, ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToAlias,
@@ -174,7 +175,7 @@ pub fn notify_ip_interface_change<'a, T: FnMut(&MIB_IPINTERFACE_ROW, i32) + Send
         handle: 0,
     });
 
-    let status = unsafe {
+    win32_err!(unsafe {
         NotifyIpInterfaceChange(
             af_family_from_family(family),
             Some(inner_callback),
@@ -182,13 +183,8 @@ pub fn notify_ip_interface_change<'a, T: FnMut(&MIB_IPINTERFACE_ROW, i32) + Send
             0,
             (&mut context.handle) as *mut _,
         )
-    };
-
-    if status == NO_ERROR as i32 {
-        Ok(context)
-    } else {
-        Err(io::Error::from_raw_os_error(status))
-    }
+    })?;
+    Ok(context)
 }
 
 /// Returns information about a network IP interface.
@@ -200,22 +196,13 @@ pub fn get_ip_interface_entry(
     row.Family = family as u16;
     row.InterfaceLuid = *luid;
 
-    let result = unsafe { GetIpInterfaceEntry(&mut row) };
-    if result == NO_ERROR as i32 {
-        Ok(row)
-    } else {
-        Err(io::Error::from_raw_os_error(result))
-    }
+    win32_err!(unsafe { GetIpInterfaceEntry(&mut row) })?;
+    Ok(row)
 }
 
 /// Set the properties of an IP interface.
 pub fn set_ip_interface_entry(row: &mut MIB_IPINTERFACE_ROW) -> io::Result<()> {
-    let result = unsafe { SetIpInterfaceEntry(row as *mut _) };
-    if result == NO_ERROR as i32 {
-        Ok(())
-    } else {
-        Err(io::Error::from_raw_os_error(result))
-    }
+    win32_err!(unsafe { SetIpInterfaceEntry(row as *mut _) })
 }
 
 fn ip_interface_entry_exists(family: AddressFamily, luid: &NET_LUID_LH) -> io::Result<bool> {
@@ -293,12 +280,8 @@ pub async fn wait_for_addresses(luid: NET_LUID_LH) -> Result<()> {
             let mut ready = true;
 
             for row in &mut unicast_rows {
-                let status = unsafe { GetUnicastIpAddressEntry(row) };
-                if status != NO_ERROR as i32 {
-                    return Err(Error::ObtainUnicastAddress(io::Error::from_raw_os_error(
-                        status,
-                    )));
-                }
+                win32_err!(unsafe { GetUnicastIpAddressEntry(row) })
+                    .map_err(Error::ObtainUnicastAddress)?;
                 if row.DadState == IpDadStateTentative {
                     ready = false;
                     break;
@@ -347,13 +330,7 @@ pub fn add_ip_address_for_interface(luid: NET_LUID_LH, address: IpAddr) -> Resul
     row.DadState = IpDadStatePreferred;
     row.OnLinkPrefixLength = 255;
 
-    let status = unsafe { CreateUnicastIpAddressEntry(&row) };
-    if status != NO_ERROR as i32 {
-        return Err(Error::CreateUnicastEntry(io::Error::from_raw_os_error(
-            status,
-        )));
-    }
-    Ok(())
+    win32_err!(unsafe { CreateUnicastIpAddressEntry(&row) }).map_err(Error::CreateUnicastEntry)
 }
 
 /// Returns the unicast IP address table. If `family` is `None`, then addresses for all families are
@@ -364,11 +341,9 @@ pub fn get_unicast_table(
     let mut unicast_rows = vec![];
     let mut unicast_table: *mut MIB_UNICASTIPADDRESS_TABLE = std::ptr::null_mut();
 
-    let status =
-        unsafe { GetUnicastIpAddressTable(af_family_from_family(family), &mut unicast_table) };
-    if status != NO_ERROR as i32 {
-        return Err(io::Error::from_raw_os_error(status));
-    }
+    win32_err!(unsafe {
+        GetUnicastIpAddressTable(af_family_from_family(family), &mut unicast_table)
+    })?;
     let first_row = unsafe { &(*unicast_table).Table[0] } as *const MIB_UNICASTIPADDRESS_ROW;
     for i in 0..unsafe { *unicast_table }.NumEntries {
         unicast_rows.push(unsafe { *(first_row.offset(i as isize)) });
@@ -381,20 +356,14 @@ pub fn get_unicast_table(
 /// Returns the index of a network interface given its LUID.
 pub fn index_from_luid(luid: &NET_LUID_LH) -> io::Result<u32> {
     let mut index = 0u32;
-    let status = unsafe { ConvertInterfaceLuidToIndex(luid, &mut index) };
-    if status != NO_ERROR as i32 {
-        return Err(io::Error::from_raw_os_error(status));
-    }
+    win32_err!(unsafe { ConvertInterfaceLuidToIndex(luid, &mut index) })?;
     Ok(index)
 }
 
 /// Returns the GUID of a network interface given its LUID.
 pub fn guid_from_luid(luid: &NET_LUID_LH) -> io::Result<GUID> {
     let mut guid = MaybeUninit::zeroed();
-    let status = unsafe { ConvertInterfaceLuidToGuid(luid, guid.as_mut_ptr()) };
-    if status != NO_ERROR as i32 {
-        return Err(io::Error::from_raw_os_error(status));
-    }
+    win32_err!(unsafe { ConvertInterfaceLuidToGuid(luid, guid.as_mut_ptr()) })?;
     Ok(unsafe { guid.assume_init() })
 }
 
@@ -406,21 +375,16 @@ pub fn luid_from_alias<T: AsRef<OsStr>>(alias: T) -> io::Result<NET_LUID_LH> {
         .chain(std::iter::once(0u16))
         .collect();
     let mut luid: NET_LUID_LH = unsafe { std::mem::zeroed() };
-    let status = unsafe { ConvertInterfaceAliasToLuid(alias_wide.as_ptr(), &mut luid) };
-    if status != NO_ERROR as i32 {
-        return Err(io::Error::from_raw_os_error(status));
-    }
+    win32_err!(unsafe { ConvertInterfaceAliasToLuid(alias_wide.as_ptr(), &mut luid) })?;
     Ok(luid)
 }
 
 /// Returns the alias of an interface given its LUID.
 pub fn alias_from_luid(luid: &NET_LUID_LH) -> io::Result<OsString> {
     let mut buffer = [0u16; IF_MAX_STRING_SIZE as usize + 1];
-    let status =
-        unsafe { ConvertInterfaceLuidToAlias(luid, &mut buffer[0] as *mut _, buffer.len()) };
-    if status != NO_ERROR as i32 {
-        return Err(io::Error::from_raw_os_error(status));
-    }
+    win32_err!(unsafe {
+        ConvertInterfaceLuidToAlias(luid, &mut buffer[0] as *mut _, buffer.len())
+    })?;
     let nul = buffer.iter().position(|&c| c == 0u16).unwrap();
     Ok(OsString::from_wide(&buffer[0..nul]))
 }

--- a/talpid-windows-net/src/net.rs
+++ b/talpid-windows-net/src/net.rs
@@ -348,7 +348,7 @@ pub fn get_unicast_table(
     for i in 0..unsafe { *unicast_table }.NumEntries {
         unicast_rows.push(unsafe { *(first_row.offset(i as isize)) });
     }
-    unsafe { FreeMibTable(unicast_table as *mut _) };
+    unsafe { FreeMibTable(unicast_table as *const _) };
 
     Ok(unicast_rows)
 }

--- a/windows/nsis-plugins/src/cleanup/cleanup.vcxproj
+++ b/windows/nsis-plugins/src/cleanup/cleanup.vcxproj
@@ -70,7 +70,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <AdditionalLibraryDirectories>$(ProjectDir)../../../../target/i686-pc-windows-msvc/release;$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>mullvad_nsis.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mullvad_nsis.lib;psapi.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>cleanup.def</ModuleDefinitionFile>
     </Link>
@@ -100,7 +100,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <AdditionalLibraryDirectories>$(ProjectDir)../../../../target/i686-pc-windows-msvc/release;$(ProjectDir)../../../../dist-assets/binaries/x86_64-pc-windows-msvc/nsis/;$(SolutionDir)bin\$(Platform)-$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>mullvad_nsis.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mullvad_nsis.lib;psapi.lib;libcommon.lib;pluginapi-x86-unicode.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libc.lib</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>cleanup.def</ModuleDefinitionFile>
     </Link>


### PR DESCRIPTION
The `windows-sys` ecosystem moves along. A lot of our dependencies already use version 0.48. It was about time to upgrade. I'm not the most familiar with the win32 APIs, but I did my best.

This is mostly constants changing which module they are defined in.

But then it's also the fact that a lot of fallible functions now return `WIN32_ERROR` (== `u32`) instead of the previous `NTSTATUS` (== `i32`). We used this return code to instantiate `io::Error`s. But the constructor `io::Error::from_raw_os_error` takes a `i32` and we now have a `u32`. The simplest thing would just be to cast it. But I don't know if any of these Windows functions could return an error code `> i32::MAX`. If they ever do we will cast it to an invalid value and get a bogus error. That's fine maybe. But I thought it was also easily fixable.

First I just implemented an extension trait on `io::Error` with a constructor method `from_raw_win32_error(u32) -> Self`. But I then also thought we did quite a lot of boilerplate of the sort:
```rust
let result = unsafe {SomeWindowsFunctionW(...)};
if result != NO_ERROR {
    return Err(...);
}
```
Since all of them just want to early return on the same constant I thought I could remove a lot of code by wrapping this up in a handy macro (`win32_err!`). Tell me what you think about this. I personally think this provides more ergonomics than it introduces magic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4966)
<!-- Reviewable:end -->
