### PR TITLE
Fix deprecation warning

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -964,6 +964,6 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
 
 extension DeviceState {
     var splitViewMode: UISplitViewController.DisplayMode {
-        isLoggedIn ? .allVisible : .secondaryOnly
+        isLoggedIn ? UISplitViewController.DisplayMode.oneBesideSecondary : .secondaryOnly
     }
 }


### PR DESCRIPTION
We forgot a warning when deprecating iOS 13. This PR fixes the warning by using the Xcode suggested setting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4970)
<!-- Reviewable:end -->
