### PR TITLE
Make every crate compile on its own

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ prost-types = "0.11"
 windows-sys = "0.45.0"
 
 chrono = { version = "0.4.26", default-features = false}
+clap = { version = "4.2.7", features = ["cargo", "derive"] }
 
 
 [profile.release]

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 chrono = { workspace = true }
-clap = { version = "4.2.7", features = ["cargo", "derive"] }
+clap = { workspace = true }
 env_logger = "0.10.0"
 futures = "0.3"
 natord = "1.0.9"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -39,7 +39,7 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 talpid-time = { path = "../talpid-time" }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-clap = { version = "4.2.7", features = ["cargo", "derive"] }
+clap = { workspace = true }
 log-panics = "2.0.0"
 mullvad-management-interface = { path = "../mullvad-management-interface" }
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-fs/Cargo.toml
+++ b/mullvad-fs/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 
 [dependencies]
 log = "0.4"
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "rt"] }
 uuid = { version = "0.8", features = ["v4"] }
 
 talpid-types = { path = "../talpid-types" }

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -24,7 +24,7 @@ talpid-types = { path = "../talpid-types" }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-clap = { version = "4.2.7", features = ["cargo"] }
+clap = { workspace = true }
 env_logger = "0.10.0"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -13,7 +13,7 @@ name = "mullvad-setup"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.2.7", features = ["cargo"] }
+clap = { workspace = true }
 env_logger = "0.10.0"
 err-derive = "0.3.1"
 once_cell = "1.13"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "0.8", features = ["v4", "serde"] }
 
 talpid-types = { path = "../talpid-types" }
 
-clap = { version = "4.2.7", features = ["derive"], optional = true }
+clap = { workspace = true , optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.5", features = ["derive"] }

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -23,7 +23,7 @@ talpid-types = { path = "../talpid-types" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 zeroize = "1"
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 rand = "0.8.5"


### PR DESCRIPTION
With this handly little "oneliner" I was able to automatically check every crate independently if it would build or not:
```
time for package in $(cargo metadata --format-version 1 | jq '.workspace_members[]' | grep -P -o '(?<=path\+file://).*(?=\)\")'); do (cd $package; echo "Building $package"; cargo build); done
```
This allowed me to find three crates that did not currently build. All of them because of missing features in dependency specifications.

Building every crate independently takes much longer than just `cargo build` directly in the workspace. So I'm not going to make the CI do this on every PR. This is mostly good hygiene, and not strictly necessary.