### PR TITLE
Upgrade uuid from 0.8 to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4363,9 +4363,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.3",
  "serde",

--- a/mullvad-fs/Cargo.toml
+++ b/mullvad-fs/Cargo.toml
@@ -11,6 +11,6 @@ publish.workspace = true
 [dependencies]
 log = "0.4"
 tokio = { workspace = true, features = ["fs"] }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.4.1", features = ["v4"] }
 
 talpid-types = { path = "../talpid-types" }

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -14,7 +14,7 @@ err-derive = "0.3.1"
 once_cell = "1.13"
 log = "0.4"
 regex = "1.0"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.4.1", features = ["v4"] }
 tokio = { workspace = true, features = ["rt"] }
 
 mullvad-paths = { path = "../mullvad-paths" }

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 rand = "0.8"
-uuid = { version = "0.8", features = ["v4", "serde"] }
+uuid = { version = "1.4.1", features = ["v4", "serde" ] }
 
 talpid-types = { path = "../talpid-types" }
 

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -23,7 +23,7 @@ shell-escape = "0.1"
 talpid-routing = { path = "../talpid-routing" }
 talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-types = { path = "../talpid-types" }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.4.1", features = ["v4"] }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 shadowsocks-service = { git = "https://github.com/mullvad/shadowsocks-rust", rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36",  features = [ "local", "stream-cipher" ] }
 


### PR DESCRIPTION
No issues with version 0.8 as far as I know. But nice to use the latest version. Since it's "stable" in the sense of being >=1.0 it's also a bit more future proof.

Upgrade was trivial. The *only* thing we use from this crate is `uuid::Uuid::new_v4()` (and the to_string + serialization support)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4977)
<!-- Reviewable:end -->
