### PR TITLE
Remove extern crate

### DIFF
--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -78,7 +78,7 @@ pub enum Error {
 }
 
 /// Contains the current device state.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PrivateDeviceState {
     LoggedIn(PrivateAccountAndDevice),
@@ -139,7 +139,7 @@ impl From<PrivateDeviceState> for DeviceState {
 }
 
 /// Same as [PrivateDevice] but also contains the associated account token.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 pub struct PrivateAccountAndDevice {
     pub account_token: AccountToken,
     pub device: PrivateDevice,
@@ -155,7 +155,7 @@ impl From<PrivateAccountAndDevice> for AccountAndDevice {
 }
 
 /// Device type that contains private data.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 pub struct PrivateDevice {
     pub id: DeviceId,
     pub name: DeviceName,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1,9 +1,6 @@
 #![deny(rust_2018_idioms)]
 #![recursion_limit = "512"]
 
-#[macro_use]
-extern crate serde;
-
 pub mod account_history;
 mod api;
 #[cfg(not(target_os = "android"))]

--- a/mullvad-daemon/src/migrations/v1.rs
+++ b/mullvad-daemon/src/migrations/v1.rs
@@ -1,5 +1,6 @@
 use super::Result;
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
+use serde::{Deserialize, Serialize};
 
 // ======================================================
 // Section for vendoring types and values that

--- a/mullvad-daemon/src/migrations/v3.rs
+++ b/mullvad-daemon/src/migrations/v3.rs
@@ -1,5 +1,6 @@
 use super::{Error, Result};
 use mullvad_types::settings::SettingsVersion;
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
 // ======================================================

--- a/mullvad-daemon/src/migrations/v4.rs
+++ b/mullvad-daemon/src/migrations/v4.rs
@@ -1,5 +1,6 @@
 use super::{Error, Result};
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
+use serde::{Deserialize, Serialize};
 
 // ======================================================
 // Section for vendoring types and values that

--- a/mullvad-daemon/src/migrations/v5.rs
+++ b/mullvad-daemon/src/migrations/v5.rs
@@ -1,5 +1,6 @@
 use super::{Error, Result};
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
+use serde::{Deserialize, Serialize};
 
 // ======================================================
 // Section for vendoring types and values that

--- a/mullvad-daemon/src/migrations/v6.rs
+++ b/mullvad-daemon/src/migrations/v6.rs
@@ -1,5 +1,6 @@
 use super::{Error, Result};
 use mullvad_types::{relay_constraints::Constraint, settings::SettingsVersion};
+use serde::{Deserialize, Serialize};
 
 // ======================================================
 // Section for vendoring types and values that

--- a/mullvad-nsis/build.rs
+++ b/mullvad-nsis/build.rs
@@ -1,7 +1,6 @@
 fn main() {
     #[cfg(all(target_arch = "x86", target_os = "windows"))]
     {
-        extern crate cbindgen;
         use std::env;
 
         let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();


### PR DESCRIPTION
I found these "extern crate .." statements laying around. They should no longer be needed. Those are from a prehistoric Rust era. Let's remove them! That means the macros are not globally available and we need to import them explicitly. But this is cleaner anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4978)
<!-- Reviewable:end -->
