### PR TITLE
Enable more safety around calling into the Objective-C runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,6 +2388,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -55,7 +55,7 @@ simple-signal = "1.1"
 talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(target_os="macos")'.dependencies]
-objc = "0.2.7"
+objc = { version = "0.2.7", features = ["exception"] }
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -55,7 +55,7 @@ simple-signal = "1.1"
 talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(target_os="macos")'.dependencies]
-objc = "0.2.3"
+objc = "0.2.7"
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"


### PR DESCRIPTION
Little follow up to the last commit in #4957. This enables the exception safety of `objc`. I'm not sure if any of the calls we make into the Objective-C runtime actually can throw exceptions. But since the result of them doing so is UB we should definitely be cautious. Performance is not a concern at all here. This code is not performance critical in any way. Stability is way more important.

I wish I could also enable the `verify_message` feature of `objc`. But sadly that makes `msg_send!` enforce message verification on all messages, with no easy way of opting out of a few that does not adhere to the `: Encode` bound. Sadly `NSOperatingSystemVersion` does not implement `Encode` here. It would be possible to manually verify messages or the other way around. But that would be combersome and I ignored it since we have very little code calling into Objective-C anyway. But I created an issue upstream for it. https://github.com/SSheldon/rust-objc/issues/121

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4990)
<!-- Reviewable:end -->
