### PR TITLE
Introduce MigrationManager

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -421,6 +421,8 @@
 		A9A8A8EB2A262AB30086D569 /* FileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A8A8EA2A262AB30086D569 /* FileCache.swift */; };
 		A9AD31D72A6AB68B00141BE8 /* InputTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582AE30F2440A6CA00E6733A /* InputTextFormatter.swift */; };
 		A9B2CF722A1F64CD0013CC6C /* MullvadREST.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06799ABC28F98E1D00ACD94E /* MullvadREST.framework */; };
+		A9D96B1A2A8247C100A5C673 /* MigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D96B192A8247C100A5C673 /* MigrationManager.swift */; };
+		A9D96B1B2A8248F200A5C673 /* MigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D96B192A8247C100A5C673 /* MigrationManager.swift */; };
 		A9D99B9A2A1F7C3200DE27D3 /* RESTTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FAE67D28F83CA50033DD93 /* RESTTransport.swift */; };
 		A9D99BA02A1F7F3A00DE27D3 /* TransportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D99B9F2A1F7F3A00DE27D3 /* TransportProvider.swift */; };
 		A9D99BA52A1F808900DE27D3 /* RelayCache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 063F02732902B63F001FA09F /* RelayCache.framework */; };
@@ -1210,6 +1212,7 @@
 		A97FF54F2A0D2FFC00900996 /* NSFileCoordinator+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFileCoordinator+Extensions.swift"; sourceTree = "<group>"; };
 		A9A8A8EA2A262AB30086D569 /* FileCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCache.swift; sourceTree = "<group>"; };
 		A9CF11FC2A0518E7001D9565 /* AddressCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressCacheTests.swift; sourceTree = "<group>"; };
+		A9D96B192A8247C100A5C673 /* MigrationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationManager.swift; sourceTree = "<group>"; };
 		A9D99B9F2A1F7F3A00DE27D3 /* TransportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportProvider.swift; sourceTree = "<group>"; };
 		A9EC20E52A5C488D0040D56E /* Haversine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Haversine.swift; sourceTree = "<group>"; };
 		A9EC20E72A5D3A8C0040D56E /* CoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatesTests.swift; sourceTree = "<group>"; };
@@ -2154,6 +2157,7 @@
 				58C774C929AB543C003A1A56 /* Containers */,
 				58CAF9F22983D32200BE19F7 /* Coordinators */,
 				583FE02329C1AC9F006E85F9 /* Extensions */,
+				A9D96B182A82479700A5C673 /* MigrationManager */,
 				58B26E1F2943516500D5980C /* Notifications */,
 				586A950B2901250A007BAF2B /* Operations */,
 				5864859729A0D012006C5743 /* Presentation controllers */,
@@ -2324,6 +2328,14 @@
 				A9467E8A2A2E0317000DC21F /* ShadowsocksConfigurationCache.swift */,
 			);
 			path = MullvadTransport;
+			sourceTree = "<group>";
+		};
+		A9D96B182A82479700A5C673 /* MigrationManager */ = {
+			isa = PBXGroup;
+			children = (
+				A9D96B192A8247C100A5C673 /* MigrationManager.swift */,
+			);
+			path = MigrationManager;
 			sourceTree = "<group>";
 		};
 		F028A5472A336E1900C0CAA3 /* RedeemVoucher */ = {
@@ -3272,6 +3284,7 @@
 				E158B360285381C60002F069 /* String+AccountFormatting.swift in Sources */,
 				582BB1B1229569620055B6EF /* UINavigationBar+Appearance.swift in Sources */,
 				58ACF6492655365700ACE4B7 /* PreferencesViewController.swift in Sources */,
+				A9D96B1A2A8247C100A5C673 /* MigrationManager.swift in Sources */,
 				7ABE318D2A1CDD4500DF4963 /* UIFont+Weight.swift in Sources */,
 				58C774BE29A7A249003A1A56 /* CustomNavigationController.swift in Sources */,
 				E1FD0DF528AA7CE400299DB4 /* StatusActivityView.swift in Sources */,
@@ -3461,6 +3474,7 @@
 				5838318B27C40A3900000571 /* Pinger.swift in Sources */,
 				06410E05292D0FC000AFC18C /* SettingsParser.swift in Sources */,
 				A92ECC292A7802AB0052F1B1 /* StoredDeviceData.swift in Sources */,
+				A9D96B1B2A8248F200A5C673 /* MigrationManager.swift in Sources */,
 				58E0729D28814AAE008902F8 /* PacketTunnelConfiguration.swift in Sources */,
 				58E0729F28814ACC008902F8 /* WireGuardLogLevel+Logging.swift in Sources */,
 				580F8B8428197884002E0998 /* TunnelSettingsV2.swift in Sources */,

--- a/ios/MullvadVPN/MigrationManager/MigrationManager.swift
+++ b/ios/MullvadVPN/MigrationManager/MigrationManager.swift
@@ -1,0 +1,98 @@
+//
+//  MigrationManager.swift
+//  MullvadVPN
+//
+//  Created by Marco Nikic on 2023-08-08.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+import MullvadREST
+import MullvadTypes
+
+enum SettingsMigrationResult {
+    /// Nothing to migrate.
+    case nothing
+
+    /// Successfully performed migration.
+    case success
+
+    /// Failure when migrating store.
+    case failure(Error)
+}
+
+struct MigrationManager {
+    private let logger = Logger(label: "MigrationManager")
+
+    /// Migrate settings store if needed.
+    ///
+    /// The following types of error are expected to be returned by this method:
+    /// `SettingsMigrationError`, `UnsupportedSettingsVersionError`, `ReadSettingsVersionError`.
+    func migrateSettings(
+        store: SettingsStore,
+        proxyFactory: REST.ProxyFactory,
+        migrationCompleted: @escaping (SettingsMigrationResult) -> Void
+    ) {
+        let handleCompletion = { (result: SettingsMigrationResult) in
+            // Reset store upon failure to migrate settings.
+            if case .failure = result {
+                SettingsManager.resetStore()
+            }
+            migrationCompleted(result)
+        }
+
+        do {
+            try checkLatestSettingsVersion(in: store)
+            handleCompletion(.nothing)
+        } catch {
+            handleCompletion(.failure(error))
+        }
+    }
+
+    private func checkLatestSettingsVersion(in store: SettingsStore) throws {
+        let settingsVersion: Int
+        do {
+            let parser = SettingsParser(decoder: JSONDecoder(), encoder: JSONEncoder())
+            let settingsData = try store.read(key: SettingsKey.settings)
+            settingsVersion = try parser.parseVersion(data: settingsData)
+        } catch .itemNotFound as KeychainError {
+            return
+        } catch {
+            throw ReadSettingsVersionError(underlyingError: error)
+        }
+
+        guard settingsVersion != SchemaVersion.current.rawValue else {
+            return
+        }
+
+        let error = UnsupportedSettingsVersionError(
+            storedVersion: settingsVersion,
+            currentVersion: SchemaVersion.current
+        )
+
+        logger.error(error: error, message: "Encountered an unknown version.")
+
+        throw error
+    }
+}
+
+/// A wrapper type for errors returned by concrete migrations.
+struct SettingsMigrationError: LocalizedError, WrappingError {
+    private let inner: Error
+    let sourceVersion, targetVersion: SchemaVersion
+
+    var underlyingError: Error? {
+        inner
+    }
+
+    var errorDescription: String? {
+        "Failed to migrate settings from \(sourceVersion) to \(targetVersion)."
+    }
+
+    init(sourceVersion: SchemaVersion, targetVersion: SchemaVersion, underlyingError: Error) {
+        self.sourceVersion = sourceVersion
+        self.targetVersion = targetVersion
+        inner = underlyingError
+    }
+}

--- a/ios/MullvadVPN/SettingsManager/SettingsStore.swift
+++ b/ios/MullvadVPN/SettingsManager/SettingsStore.swift
@@ -8,6 +8,13 @@
 
 import Foundation
 
+enum SettingsKey: String, CaseIterable {
+    case settings = "Settings"
+    case deviceState = "DeviceState"
+    case lastUsedAccount = "LastUsedAccount"
+    case shouldWipeSettings = "ShouldWipeSettings"
+}
+
 protocol SettingsStore {
     func read(key: SettingsKey) throws -> Data
     func write(_ data: Data, for key: SettingsKey) throws

--- a/ios/MullvadVPN/SettingsManager/TunnelSettings.swift
+++ b/ios/MullvadVPN/SettingsManager/TunnelSettings.swift
@@ -10,3 +10,15 @@ import Foundation
 
 /// Alias to the latest version of the `TunnelSettings`.
 typealias LatestTunnelSettings = TunnelSettingsV2
+
+/// Settings and device state schema versions.
+enum SchemaVersion: Int, Equatable {
+    /// Legacy settings format, stored as `TunnelSettingsV1`.
+    case v1 = 1
+
+    /// New settings format, stored as `TunnelSettingsV2`.
+    case v2 = 2
+
+    /// Current schema version.
+    static let current = SchemaVersion.v2
+}

--- a/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
+++ b/ios/MullvadVPN/SettingsManager/TunnelSettingsV2.swift
@@ -13,18 +13,6 @@ import struct WireGuardKitTypes.IPAddressRange
 import class WireGuardKitTypes.PrivateKey
 import class WireGuardKitTypes.PublicKey
 
-/// Settings and device state schema versions.
-enum SchemaVersion: Int, Equatable {
-    /// Legacy settings format, stored as `TunnelSettingsV1`.
-    case v1 = 1
-
-    /// New settings format, stored as `TunnelSettingsV2`.
-    case v2 = 2
-
-    /// Current schema version.
-    static let current = SchemaVersion.v2
-}
-
 struct TunnelSettingsV2: Codable, Equatable {
     /// Relay constraints.
     var relayConstraints = RelayConstraints()


### PR DESCRIPTION
Refactoring settings part 3, introducing a `MigrationManager` object.

This PR does very little. It takes away the `SettingsManager.migrateStore` function and places it in `MigrationManager.migrateSettings` instead. 

No actual code has been changed, however `SettingsKey` have been moved to `SettingsStore.swift`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4992)
<!-- Reviewable:end -->
