### PR TITLE
Add missing call to completion handler in sleep()

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -373,9 +373,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, TunnelMonitorDelegate {
     }
 
     override func sleep(completionHandler: @escaping () -> Void) {
-        tunnelMonitor.onSleep {
-            completionHandler()
-        }
+        tunnelMonitor.onSleep()
+        completionHandler()
     }
 
     override func wake() {

--- a/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnel/TunnelMonitor/TunnelMonitor.swift
@@ -312,7 +312,7 @@ final class TunnelMonitor: PingerDelegate {
         }
     }
 
-    func onSleep(completion: @escaping () -> Void) {
+    func onSleep() {
         nslock.lock()
         defer { nslock.unlock() }
 


### PR DESCRIPTION
Regression was introduced 6 months ago in https://github.com/mullvad/mullvadvpn-app/commit/faece927955044c84bee84208c5cd95ddc22944c#diff-c503a02421ff9c96816ad57be865788af955bd8f706ef4ab177eda75158c6745L277-L281. This PR fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4994)
<!-- Reviewable:end -->
