### PR TITLE
Ensure the app fetches account data whenever it enters the new account flow view

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/WelcomeCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/WelcomeCoordinator.swift
@@ -38,7 +38,8 @@ final class WelcomeCoordinator: Coordinator, Presentable {
         }
         let interactor = WelcomeInteractor(
             deviceData: storedDeviceData,
-            accountData: storedAccountData
+            accountData: storedAccountData,
+            tunnelManager: tunnelManager
         )
 
         let controller = WelcomeViewController(interactor: interactor)
@@ -123,5 +124,11 @@ extension WelcomeCoordinator: WelcomeViewControllerDelegate {
         addChild(coordinator)
 
         coordinator.start()
+    }
+
+    func didUpdateDeviceState(deviceState: DeviceState) {
+        if deviceState.accountData?.isExpired == false {
+            didFinishPayment?(self)
+        }
     }
 }

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeInteractor.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeInteractor.swift
@@ -7,9 +7,21 @@
 //
 
 import Foundation
+import MullvadLogging
+
 class WelcomeInteractor {
+    private let logger = Logger(label: "WelcomeInteractor")
+
+    private let accountUpdateTimerInterval: TimeInterval = 60
+    private var accountUpdateTimer: DispatchSourceTimer?
+
     private let deviceData: StoredDeviceData
     private let accountData: StoredAccountData
+
+    private let tunnelManager: TunnelManager
+    private var tunnelObserver: TunnelObserver?
+
+    var didUpdateDeviceState: ((DeviceState) -> Void)?
 
     var viewModel: WelcomeViewModel {
         WelcomeViewModel(
@@ -18,8 +30,43 @@ class WelcomeInteractor {
         )
     }
 
-    init(deviceData: StoredDeviceData, accountData: StoredAccountData) {
+    init(deviceData: StoredDeviceData, accountData: StoredAccountData, tunnelManager: TunnelManager) {
         self.deviceData = deviceData
         self.accountData = accountData
+        self.tunnelManager = tunnelManager
+
+        let tunnelObserver =
+            TunnelBlockObserver(didUpdateDeviceState: { [weak self] tunnelManager, deviceState, previousDeviceState in
+                self?.didUpdateDeviceState?(deviceState)
+            })
+
+        tunnelManager.addObserver(tunnelObserver)
+        self.tunnelObserver = tunnelObserver
+    }
+
+    func startAccountUpdateTimer() {
+        logger.debug(
+            "Start polling account updates every \(accountUpdateTimerInterval) second(s)."
+        )
+
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.setEventHandler { [weak self] in
+            self?.tunnelManager.updateAccountData()
+        }
+
+        accountUpdateTimer?.cancel()
+        accountUpdateTimer = timer
+
+        timer.schedule(wallDeadline: .now() + accountUpdateTimerInterval, repeating: accountUpdateTimerInterval)
+        timer.activate()
+    }
+
+    func stopAccountUpdateTimer() {
+        logger.debug(
+            "Stop polling account updates."
+        )
+
+        accountUpdateTimer?.cancel()
+        accountUpdateTimer = nil
     }
 }

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeViewController.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeViewController.swift
@@ -11,6 +11,7 @@ protocol WelcomeViewControllerDelegate: AnyObject {
     func didRequestToPurchaseCredit(controller: WelcomeViewController)
     func didRequestToRedeemVoucher(controller: WelcomeViewController)
     func didRequestToShowInfo(controller: WelcomeViewController)
+    func didUpdateDeviceState(deviceState: DeviceState)
 }
 
 class WelcomeViewController: UIViewController, RootContainment {
@@ -55,8 +56,23 @@ class WelcomeViewController: UIViewController, RootContainment {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         configureUI()
         contentView.viewModel = interactor.viewModel
+
+        interactor.didUpdateDeviceState = { [weak self] deviceState in
+            self?.delegate?.didUpdateDeviceState(deviceState: deviceState)
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        interactor.startAccountUpdateTimer()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        interactor.stopAccountUpdateTimer()
     }
 
     private func configureUI() {

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeInteractor.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeInteractor.swift
@@ -13,9 +13,6 @@ import MullvadTypes
 import Operations
 import StoreKit
 
-/// Interval used for periodic polling account updates.
-private let accountUpdateTimerInterval: TimeInterval = 60
-
 final class OutOfTimeInteractor {
     private let storePaymentManager: StorePaymentManager
     private let tunnelManager: TunnelManager
@@ -24,6 +21,8 @@ final class OutOfTimeInteractor {
     private var paymentObserver: StorePaymentObserver?
 
     private let logger = Logger(label: "OutOfTimeInteractor")
+
+    private let accountUpdateTimerInterval: TimeInterval = 60
     private var accountUpdateTimer: DispatchSourceTimer?
 
     var didReceivePaymentEvent: ((StorePaymentEvent) -> Void)?
@@ -93,7 +92,6 @@ final class OutOfTimeInteractor {
         logger.debug(
             "Start polling account updates every \(accountUpdateTimerInterval) second(s)."
         )
-
         let timer = DispatchSource.makeTimerSource(queue: .main)
         timer.setEventHandler { [weak self] in
             self?.tunnelManager.updateAccountData()
@@ -104,5 +102,14 @@ final class OutOfTimeInteractor {
 
         timer.schedule(wallDeadline: .now() + accountUpdateTimerInterval, repeating: accountUpdateTimerInterval)
         timer.activate()
+    }
+
+    func stopAccountUpdateTimer() {
+        logger.debug(
+            "Stop polling account updates."
+        )
+
+        accountUpdateTimer?.cancel()
+        accountUpdateTimer = nil
     }
 }

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
@@ -108,8 +108,16 @@ class OutOfTimeViewController: UIViewController, RootContainment {
         } else {
             productState = .cannotMakePurchases
         }
+    }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         interactor.startAccountUpdateTimer()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        interactor.stopAccountUpdateTimer()
     }
 
     // MARK: - Private


### PR DESCRIPTION
Since it's possible to pay for account time in many ways in the app, and it's possible to do it on a completely different device, when in the new account flow, the app should try to pro-actively deduce if time has been added. So, whenever it enters a new account flow view, it should fetch new account data from the API.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/4998)
<!-- Reviewable:end -->
