### PR TITLE
Enable swiftlint ios 182

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -28,16 +28,12 @@ jobs:
 
   swiftlint:
     name: Run swiftlint
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/realm/swiftlint:0.52.4
-
+    runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-      - name: SwiftLint
+      - name: Run swiftlint
         run: |
           swiftlint --reporter github-actions-logging
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -26,6 +26,21 @@ jobs:
           swiftformat --version
           swiftformat --lint .
 
+  swiftlint:
+    name: Run swiftlint
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/realm/swiftlint:0.52.4
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: SwiftLint
+        run: |
+          swiftlint --reporter github-actions-logging
+
   test:
     name: Unit tests
     runs-on: macos-13

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,0 +1,49 @@
+---
+disabled_rules:
+  - colon
+  - comma
+  - control_statement
+  - identifier_name
+  - type_body_length
+  - opening_brace  # Differs from Google swift guidelines enforced by swiftformat
+  - trailing_comma
+opt_in_rules:
+  - empty_count
+
+analyzer_rules:  # rules run by `swiftlint analyze`
+  - explicit_self
+
+included:  # case-sensitive paths to include during linting. `--path` is ignored if present
+  - .
+excluded:  # case-sensitive paths to ignore during linting. Takes precedence over `included`
+  - AdditionalAssets
+  - Assets
+  - Configurations
+  - MullvadVPNScreenshots
+
+allow_zero_lintable_files: false
+
+force_cast: warning
+force_try:
+  severity: warning
+line_length:
+  ignores_comments: true
+  ignores_interpolated_strings: true
+  warning: 120
+  error: 300
+
+type_name:
+  min_length: 4
+  max_length:
+    error: 50
+  excluded: iPhone  # excluded via string
+  allowed_symbols: ["_"]  # these are allowed in type names
+identifier_name:
+  allowed_symbols: ["_"]  # these are allowed in type names
+  min_length:
+    error: 3
+  excluded:
+    - id
+    - URL
+    - GlobalAPIKey
+reporter: "xcode"

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -449,6 +449,7 @@ class RootContainerViewController: UIViewController {
         showSettings(animated: true)
     }
 
+    // swiftlint:disable:next function_body_length
     private func setViewControllersInternal(
         _ newViewControllers: [UIViewController],
         isUnwinding: Bool,

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -1325,3 +1325,5 @@ private struct TunnelInteractorProxy: TunnelInteractor {
         tunnelManager.handleRestError(error)
     }
 }
+
+// swiftlint:disable:this file_length

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
@@ -36,6 +36,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
         return cell
     }
 
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     func configureCell(_ cell: UITableViewCell, item: PreferencesDataSource.Item, indexPath: IndexPath) {
         switch item {
         case .blockAdvertising:

--- a/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceContentView.swift
+++ b/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceContentView.swift
@@ -36,7 +36,13 @@ class TermsOfServiceContentView: UIView {
         bodyLabel.text = NSLocalizedString(
             "PRIVACY_NOTICE_BODY",
             tableName: "TermsOfService",
-            value: "You have a right to privacy. That’s why we never store activity logs, don’t ask for personal information, and encourage anonymous payments.\n\nIn some situations, as outlined in our privacy policy, we might process personal data that you choose to send, for example if you email us.\n\nWe strongly believe in retaining as little data as possible because we want you to remain anonymous.",
+            value: """
+            You have a right to privacy. That’s why we never store activity logs, don’t ask for personal information, and encourage anonymous payments.
+
+            In some situations, as outlined in our privacy policy, we might process personal data that you choose to send, for example if you email us.
+
+            We strongly believe in retaining as little data as possible because we want you to remain anonymous.
+            """,
             comment: ""
         )
         return bodyLabel


### PR DESCRIPTION
This PR adds a  `swiftlint` configuration file, a github action file to run `swiftlint` automatically on new pull requests, and silences some errors, for now, in order to keep having green builds on pull requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5005)
<!-- Reviewable:end -->
