### PR TITLE
Upgrade socket2 from 0.4 to 0.5 in our own crates (removes one winapi dependency)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,7 +3649,7 @@ dependencies = [
  "prost",
  "shadowsocks-service",
  "shell-escape",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "talpid-routing",
  "talpid-tunnel",
  "talpid-types",
@@ -3782,9 +3782,8 @@ version = "0.0.0"
 dependencies = [
  "err-derive",
  "futures",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "talpid-types",
- "winapi",
  "windows-sys 0.48.0",
 ]
 
@@ -3812,7 +3811,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rtnetlink",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "talpid-dbus",
  "talpid-routing",
  "talpid-tunnel",

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 shadowsocks-service = { git = "https://github.com/mullvad/shadowsocks-rust", rev = "c45980bb22d0d50ac888813c59a1edf0cff14a36",  features = [ "local", "stream-cipher" ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-socket2 = { version = "0.4.2", features = ["all"] }
+socket2 = { version = "0.5.3" }
 parity-tokio-ipc = "0.9"
 triggered = "0.1.1"
 tonic = { workspace = true }

--- a/talpid-windows-net/Cargo.toml
+++ b/talpid-windows-net/Cargo.toml
@@ -10,9 +10,8 @@ publish.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 err-derive = "0.3.1"
-socket2 = { version = "0.4.2", features = ["all"] }
+socket2 = { version = "0.5.3" }
 futures = "0.3.15"
-winapi = { version = "0.3.6", features = ["ws2def"] }
 
 talpid-types = { path = "../talpid-types" }
 

--- a/talpid-windows-net/src/net.rs
+++ b/talpid-windows-net/src/net.rs
@@ -9,9 +9,9 @@ use std::{
     time::{Duration, Instant},
 };
 use talpid_types::win32_err;
-use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
 use windows_sys::{
     core::GUID,
+    Win32::Networking::WinSock::SOCKADDR_STORAGE as sockaddr_storage,
     Win32::{
         Foundation::{ERROR_NOT_FOUND, HANDLE},
         NetworkManagement::{
@@ -438,7 +438,6 @@ pub fn try_socketaddr_from_inet_sockaddr(addr: SOCKADDR_INET) -> Result<SocketAd
     unsafe {
         let mut storage: sockaddr_storage = mem::zeroed();
         *(&mut storage as *mut _ as *mut SOCKADDR_INET) = addr;
-        // TODO: Switch to windows-sys struct once socket2 is updated
         SockAddr::new(storage, mem::size_of_val(&addr) as i32)
     }
     .as_socket()

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -34,7 +34,7 @@ duct = "0.13"
 [target.'cfg(not(target_os="android"))'.dependencies]
 byteorder = "1"
 internet-checksum = "0.2"
-socket2 = { version = "0.4.2", features = ["all"] }
+socket2 = { version = "0.5.3", features = ["all"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"


### PR DESCRIPTION
I just realized I had this cleanup PR laying around since last week. This had to be done after the `windows-sys 0.48` upgrade, #4966, so that's why it was left behind.

This upgrades all our direct dependencies to `socket2` to the latest version. This in turn allows us to drop one direct dependency to `winapi`. None of this has any practical difference. It's mostly a dependency tree maintenance task.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5006)
<!-- Reviewable:end -->
