### PR TITLE
Add mark based accept rule for forward chain as well

### DIFF
--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -331,7 +331,7 @@ impl<'a> PolicyBatch<'a> {
         rule.add_expr(&nft_expr!(meta mark set));
         self.batch.add(&rule, nftnl::MsgType::Add);
 
-        for chain in &[&self.in_chain, &self.out_chain] {
+        for chain in &[&self.in_chain, &self.out_chain, &self.forward_chain] {
             let mut rule = Rule::new(chain);
             rule.add_expr(&nft_expr!(ct mark));
             rule.add_expr(&nft_expr!(cmp == split_tunnel::MARK));


### PR DESCRIPTION
I'm using mullvad and tailscale together on the same server. Using [Split tunneling with Linux (advanced)](https://mullvad.net/en/help/split-tunneling-with-linux-advanced/), I'm able to add ip-based exceptions to the input and output chains to exclude tailscale traffic and they both work.

What does _not_ work is incoming tailscale connections to exposed docker ports, because the current firewall table does not have a similar ability to mark exceptions in the forward chain. This PR adds that ability.

With this PR applied, the following tailscale nft table allows all tailscale connections, docker or otherwise:
```
table inet mullvad-ts {
        chain prerouting {
                type filter hook prerouting priority -100; policy accept;
                ip saddr 100.64.0.0/10 ct mark set 0x00000f41 meta mark set 0x6d6f6c65
        }

        chain outgoing {
                type route hook output priority -100; policy accept;
                meta mark 0x00080000 ct mark set 0x00000f41 meta mark set 0x6d6f6c65
                ip daddr 100.64.0.0/10 ct mark set 0x00000f41 meta mark set 0x6d6f6c65
        }
}
```

Hoping this simple change does not have any other security implications.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5011)
<!-- Reviewable:end -->
