### PR TITLE
Promote changelog to modal route IOS-277

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -172,8 +172,11 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
                 endHorizontalFlow(animated: context.isAnimated, completion: completion)
                 context.dismissedRoutes.forEach { $0.coordinator.removeFromParent() }
 
-            case .selectLocation, .account, .settings:
-                let coordinator = dismissedRoute.coordinator as! Presentable
+            case .selectLocation, .account, .settings, .changelog:
+                guard let coordinator = dismissedRoute.coordinator as? Presentable else {
+                    completion()
+                    return assertionFailure("Expected presentable coordinator for \(dismissedRoute.route)")
+                }
 
                 coordinator.dismiss(animated: context.isAnimated, completion: completion)
             }
@@ -278,39 +281,59 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
      Continues application flow by evaluating what route to present next.
      */
     private func continueFlow(animated: Bool) {
-        let next = evaluateNextRoute()
+        var nextRoutes = evaluateNextRoutes()
 
-        /*
-         On iPad the main route is always visible as it's a part of root controller hence we never
-         ask router to navigate to it. Instead this is when we hide the primary horizontal
-         navigation.
-         */
-        if isPad, next == .main {
-            router.dismissAll(.primary, animated: animated)
-        } else {
-            router.present(next, animated: animated)
+        if isPad {
+            /*
+             On iPad the main route is always visible as it's a part of root controller hence we never
+             ask router to navigate to it. Instead this is when we hide the primary horizontal
+             navigation.
+             */
+            if nextRoutes.contains(.main) {
+                router.dismissAll(.primary, animated: animated)
+            }
+
+            nextRoutes.removeAll { $0 == .main }
+        }
+
+        for nextRoute in nextRoutes {
+            router.present(nextRoute, animated: animated)
         }
     }
 
-    private func evaluateNextRoute() -> AppRoute {
+    /**
+     Evaluates conditions and returns the routes that need to be presented next.
+     */
+    private func evaluateNextRoutes() -> [AppRoute] {
+        // Show TOS alone blocking all other routes.
         guard TermsOfService.isAgreed else {
-            return .tos
+            return [.tos]
         }
 
-        guard ChangeLog.isSeen else {
-            return .changelog
-        }
+        var routes = [AppRoute]()
 
+        // Pick the primary route to present
         switch tunnelManager.deviceState {
         case .revoked:
-            return .revoked
+            routes.append(.revoked)
 
         case .loggedOut:
-            return .login
+            routes.append(.login)
 
         case let .loggedIn(accountData, _):
-            return accountData.isExpired ? (accountData.isNew ? .welcome : .outOfTime) : .main
+            if accountData.isExpired {
+                routes.append(accountData.isNew ? .welcome : .outOfTime)
+            } else {
+                routes.append(.main)
+            }
         }
+
+        // Changelog can be presented simultaneously with other routes.
+        if !ChangeLog.isSeen {
+            routes.append(.changelog)
+        }
+
+        return routes
     }
 
     private func logoutRevokedDevice() {
@@ -493,13 +516,19 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     }
 
     private func presentChangeLog(completion: @escaping (Coordinator) -> Void) {
-        let coordinator = ChangeLogCoordinator(navigationController: primaryNavigationContainer)
+        let coordinator = ChangeLogCoordinator()
 
-        addChild(coordinator)
-        coordinator.start(animated: false)
+        coordinator.didFinish = { [weak self] in
+            ChangeLog.markAsSeen()
 
-        continueFlow(animated: false)
-        completion(coordinator)
+            self?.router.dismiss(.changelog, animated: true)
+        }
+
+        coordinator.start()
+
+        presentChild(coordinator, animated: false) {
+            completion(coordinator)
+        }
     }
 
     private func presentMain(animated: Bool, completion: @escaping (Coordinator) -> Void) {

--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -143,7 +143,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             presentLogin(animated: animated, completion: completion)
 
         case .changelog:
-            presentChangeLog(completion: completion)
+            presentChangeLog(animated: animated, completion: completion)
 
         case .tos:
             presentTOS(animated: animated, completion: completion)
@@ -515,7 +515,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         }
     }
 
-    private func presentChangeLog(completion: @escaping (Coordinator) -> Void) {
+    private func presentChangeLog(animated: Bool, completion: @escaping (Coordinator) -> Void) {
         let coordinator = ChangeLogCoordinator()
 
         coordinator.didFinish = { [weak self] in
@@ -526,7 +526,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
 
         coordinator.start()
 
-        presentChild(coordinator, animated: false) {
+        presentChild(coordinator, animated: animated) {
             completion(coordinator)
         }
     }

--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -88,11 +88,6 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         self.apiProxy = apiProxy
         self.devicesProxy = devicesProxy
 
-        /*
-         Uncomment if you'd like to test TOS again
-         TermsOfService.unsetAgreed()
-         */
-
         super.init()
 
         primaryNavigationContainer.delegate = self

--- a/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
@@ -36,6 +36,11 @@ enum AppRouteGroup: Comparable, Equatable, Hashable {
     case settings
 
     /**
+     Changelog group.
+     */
+    case changelog
+
+    /**
      Returns `true` if group is presented modally, otherwise `false` if group is a part of root view
      controller.
      */
@@ -44,7 +49,7 @@ enum AppRouteGroup: Comparable, Equatable, Hashable {
         case .primary:
             return UIDevice.current.userInterfaceIdiom == .pad
 
-        case .selectLocation, .account, .settings:
+        case .selectLocation, .account, .settings, .changelog:
             return true
         }
     }
@@ -53,7 +58,7 @@ enum AppRouteGroup: Comparable, Equatable, Hashable {
         switch self {
         case .primary:
             return 0
-        case .settings, .account, .selectLocation:
+        case .settings, .account, .selectLocation, .changelog:
             return 1
         }
     }
@@ -83,16 +88,21 @@ enum AppRoute: Equatable, Hashable {
     case selectLocation
 
     /**
+     Changelog route.
+     */
+    case changelog
+
+    /**
      Routes that are part of primary horizontal navigation group.
      */
-    case tos, changelog, login, main, revoked, outOfTime, welcome, setupAccountCompleted
+    case tos, login, main, revoked, outOfTime, welcome, setupAccountCompleted
 
     /**
      Returns `true` when only one route of a kind can be displayed.
      */
     var isExclusive: Bool {
         switch self {
-        case .selectLocation, .account, .settings:
+        case .selectLocation, .account, .settings, .changelog:
             return true
         default:
             return false
@@ -115,8 +125,10 @@ enum AppRoute: Equatable, Hashable {
      */
     var routeGroup: AppRouteGroup {
         switch self {
-        case .tos, .changelog, .login, .main, .revoked, .outOfTime, .welcome, .setupAccountCompleted:
+        case .tos, .login, .main, .revoked, .outOfTime, .welcome, .setupAccountCompleted:
             return .primary
+        case .changelog:
+            return .changelog
         case .selectLocation:
             return .selectLocation
         case .account:

--- a/ios/MullvadVPN/Coordinators/Base/ModalPresentationConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Base/ModalPresentationConfiguration.swift
@@ -14,6 +14,7 @@ import UIKit
 struct ModalPresentationConfiguration {
     var preferredContentSize: CGSize?
     var modalPresentationStyle: UIModalPresentationStyle?
+    var modalTransitionStyle: UIModalTransitionStyle?
     var isModalInPresentation: Bool?
     var transitioningDelegate: UIViewControllerTransitioningDelegate?
     var presentationControllerDelegate: UIAdaptivePresentationControllerDelegate?
@@ -23,6 +24,10 @@ struct ModalPresentationConfiguration {
 
         if let modalPresentationStyle {
             vc.modalPresentationStyle = modalPresentationStyle
+        }
+
+        if let modalTransitionStyle {
+            vc.modalTransitionStyle = modalTransitionStyle
         }
 
         if let preferredContentSize {


### PR DESCRIPTION
- This PR promotes changelog to modal route and updates `evaluateRoute() -> AppRoute` to return multiple routes that can be presented simultaneously.
- `ChangeLogCoordinator` is promoted to `Presentable`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5012)
<!-- Reviewable:end -->
