### PR TITLE
Make app router more abstract 

### DIFF
--- a/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationCoordinator.swift
@@ -17,10 +17,12 @@ import UIKit
 final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewControllerDelegate,
     UISplitViewControllerDelegate, ApplicationRouterDelegate,
     NotificationManagerDelegate {
+    typealias RouteType = AppRoute
+
     /**
      Application router.
      */
-    private var router: ApplicationRouter!
+    private var router: ApplicationRouter<AppRoute>!
 
     /**
      Primary navigation container.
@@ -113,7 +115,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     // MARK: - ApplicationRouterDelegate
 
     func applicationRouter(
-        _ router: ApplicationRouter,
+        _ router: ApplicationRouter<RouteType>,
         route: AppRoute,
         animated: Bool,
         completion: @escaping (Coordinator) -> Void
@@ -155,8 +157,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     }
 
     func applicationRouter(
-        _ router: ApplicationRouter,
-        dismissWithContext context: RouteDismissalContext,
+        _ router: ApplicationRouter<RouteType>,
+        dismissWithContext context: RouteDismissalContext<RouteType>,
         completion: @escaping () -> Void
     ) {
         if context.isClosing {
@@ -210,7 +212,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         }
     }
 
-    func applicationRouter(_ router: ApplicationRouter, shouldPresent route: AppRoute) -> Bool {
+    func applicationRouter(_ router: ApplicationRouter<RouteType>, shouldPresent route: RouteType) -> Bool {
         switch route {
         case .revoked:
             // Check if device is still revoked.
@@ -226,8 +228,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     }
 
     func applicationRouter(
-        _ router: ApplicationRouter,
-        shouldDismissWithContext context: RouteDismissalContext
+        _ router: ApplicationRouter<RouteType>,
+        shouldDismissWithContext context: RouteDismissalContext<RouteType>
     ) -> Bool {
         context.dismissedRoutes.allSatisfy { dismissedRoute in
             /*
@@ -245,8 +247,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     }
 
     func applicationRouter(
-        _ router: ApplicationRouter,
-        handleSubNavigationWithContext context: RouteSubnavigationContext,
+        _ router: ApplicationRouter<RouteType>,
+        handleSubNavigationWithContext context: RouteSubnavigationContext<RouteType>,
         completion: @escaping () -> Void
     ) {
         switch context.route {

--- a/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
@@ -65,7 +65,7 @@ protocol AppRouteProtocol: Equatable, Hashable {
  Enum type describing groups of routes. Each group is a modal layer with horizontal navigation
  inside with exception where primary navigation is a part of root controller on iPhone.
  */
-enum AppRouteGroup: Comparable, Equatable, Hashable {
+enum AppRouteGroup: AppRouteGroupProtocol {
     /**
      Primary horizontal navigation group.
      */
@@ -114,7 +114,7 @@ enum AppRouteGroup: Comparable, Equatable, Hashable {
 /**
  Enum type describing primary application routes.
  */
-enum AppRoute: Equatable, Hashable {
+enum AppRoute: AppRouteProtocol {
     /**
      Account route.
      */
@@ -172,9 +172,6 @@ enum AppRoute: Equatable, Hashable {
         }
     }
 }
-
-extension AppRoute: AppRouteProtocol {}
-extension AppRouteGroup: AppRouteGroupProtocol {}
 
 /**
  Struct describing a routing request for presentation or dismissal.

--- a/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
+++ b/ios/MullvadVPN/Coordinators/App/ApplicationRouter.swift
@@ -19,6 +19,24 @@ protocol AppRouteGroupProtocol: Comparable, Equatable, Hashable {
      controller.
      */
     var isModal: Bool { get }
+
+    /**
+     Defines a modal level that's used for restricting modal presentation.
+
+     A group with higher modal level can be presented above a group with lower level but not the other way around. For example, if a modal group is represented by
+     `UIAlertController`, it should have the highest level (i.e `Int.max`) to prevent other modals from being presented above it, however it enables alert
+     controller to be presented above any other modal.
+     */
+    var modalLevel: Int { get }
+}
+
+/**
+ Default implementation of `Comparable` for `AppRouteGroupProtocol` which compares `modalLevel` of both sides.
+ */
+extension AppRouteGroupProtocol {
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.modalLevel < rhs.modalLevel
+    }
 }
 
 /**
@@ -83,17 +101,13 @@ enum AppRouteGroup: Comparable, Equatable, Hashable {
         }
     }
 
-    private var order: Int {
+    var modalLevel: Int {
         switch self {
         case .primary:
             return 0
         case .settings, .account, .selectLocation, .changelog:
             return 1
         }
-    }
-
-    static func < (lhs: AppRouteGroup, rhs: AppRouteGroup) -> Bool {
-        lhs.order < rhs.order
     }
 }
 


### PR DESCRIPTION
This PR makes app router more abstract. 

Changes:

- Add abstractions for describing routes and groups of routes via `AppRouteProtocol` and `AppRouteGroupProtocol` protocols.
- Add generic constraint `<RouteType: AppRouteProtocol>` for `ApplicationRouter` and all related types.
- Add `var modalLevel: Int` requirement for groups (enforced via `AppRouteGroupProtocol`), which is used to restrict modal presentation. Previously it was implemented exclusively via `Comparable`, however Swift provides default imp of that protocol so to avoid confusion, the new requirement was introduced. In addition to that the default impl of `Comparable` is provided and it calls `modalLevel` internally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5013)
<!-- Reviewable:end -->
