### PR TITLE
Introduce RESTRequestExecutor to support async flows

### DIFF
--- a/ios/MullvadREST/RESTAPIProxy.swift
+++ b/ios/MullvadREST/RESTAPIProxy.swift
@@ -110,10 +110,8 @@ extension REST {
 
         public func createApplePayment(
             accountNumber: String,
-            receiptString: Data,
-            retryStrategy: REST.RetryStrategy,
-            completionHandler: @escaping CompletionHandler<CreateApplePaymentResponse>
-        ) -> Cancellable {
+            receiptString: Data
+        ) -> any RESTRequestExecutor<CreateApplePaymentResponse> {
             let requestHandler = AnyRequestHandler(
                 createURLRequest: { endpoint, authorization in
                     var requestBuilder = try self.requestFactory.createRequestBuilder(
@@ -160,11 +158,22 @@ extension REST {
                     }
                 }
 
-            return addOperation(
+            return makeRequestExecutor(
                 name: "create-apple-payment",
-                retryStrategy: retryStrategy,
                 requestHandler: requestHandler,
-                responseHandler: responseHandler,
+                responseHandler: responseHandler
+            )
+        }
+
+        @available(*, deprecated, message: "Use createApplePayment(accountNumber:, receiptString:) instead")
+        public func createApplePayment(
+            accountNumber: String,
+            receiptString: Data,
+            retryStrategy: REST.RetryStrategy,
+            completionHandler: @escaping CompletionHandler<CreateApplePaymentResponse>
+        ) -> Cancellable {
+            return createApplePayment(accountNumber: accountNumber, receiptString: receiptString).execute(
+                retryStrategy: retryStrategy,
                 completionHandler: completionHandler
             )
         }

--- a/ios/MullvadREST/RESTAccountsProxy.swift
+++ b/ios/MullvadREST/RESTAccountsProxy.swift
@@ -49,11 +49,7 @@ extension REST {
             )
         }
 
-        public func getAccountData(
-            accountNumber: String,
-            retryStrategy: REST.RetryStrategy,
-            completion: @escaping CompletionHandler<Account>
-        ) -> Cancellable {
+        public func getAccountData(accountNumber: String) -> any RESTRequestExecutor<Account> {
             let requestHandler = AnyRequestHandler(
                 createURLRequest: { endpoint, authorization in
                     var requestBuilder = try self.requestFactory.createRequestBuilder(
@@ -74,11 +70,21 @@ extension REST {
                 with: responseDecoder
             )
 
-            return addOperation(
+            return makeRequestExecutor(
                 name: "get-my-account",
-                retryStrategy: retryStrategy,
                 requestHandler: requestHandler,
-                responseHandler: responseHandler,
+                responseHandler: responseHandler
+            )
+        }
+
+        @available(*, deprecated, message: "Use getAccountData(accountNumber:) instead")
+        public func getAccountData(
+            accountNumber: String,
+            retryStrategy: REST.RetryStrategy,
+            completion: @escaping CompletionHandler<Account>
+        ) -> Cancellable {
+            return getAccountData(accountNumber: accountNumber).execute(
+                retryStrategy: retryStrategy,
                 completionHandler: completion
             )
         }

--- a/ios/MullvadREST/RESTNetworkOperation.swift
+++ b/ios/MullvadREST/RESTNetworkOperation.swift
@@ -14,7 +14,7 @@ import Operations
 extension REST {
     class NetworkOperation<Success>: ResultOperation<Success> {
         private let requestHandler: RESTRequestHandler
-        private let responseHandler: AnyResponseHandler<Success>
+        private let responseHandler: any RESTResponseHandler<Success>
 
         private let logger: Logger
         private let transportProvider: () -> RESTTransport?
@@ -37,8 +37,8 @@ extension REST {
             configuration: ProxyConfiguration,
             retryStrategy: RetryStrategy,
             requestHandler: RESTRequestHandler,
-            responseHandler: AnyResponseHandler<Success>,
-            completionHandler: @escaping CompletionHandler
+            responseHandler: some RESTResponseHandler<Success>,
+            completionHandler: CompletionHandler?
         ) {
             addressCacheStore = configuration.addressCacheStore
             transportProvider = configuration.transportProvider

--- a/ios/MullvadREST/RESTRequestExecutor.swift
+++ b/ios/MullvadREST/RESTRequestExecutor.swift
@@ -1,0 +1,29 @@
+//
+//  RESTRequestExecutor.swift
+//  MullvadREST
+//
+//  Created by pronebird on 21/08/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import protocol MullvadTypes.Cancellable
+
+public protocol RESTRequestExecutor<Success> {
+    associatedtype Success
+
+    /// Execute new network request with `.noRetry` strategy and receive the result in a completion handler on main queue.
+    func execute(completionHandler: @escaping (Result<Success, Swift.Error>) -> Void) -> Cancellable
+
+    /// Execute new network request and receive the result in a completion handler on main queue.
+    func execute(
+        retryStrategy: REST.RetryStrategy,
+        completionHandler: @escaping (Result<Success, Swift.Error>) -> Void
+    ) -> Cancellable
+
+    /// Execute new network request with `.noRetry` strategy and receive the result back via async flow.
+    func execute() async throws -> Success
+
+    /// Execute new network request and receive the result back via async flow.
+    func execute(retryStrategy: REST.RetryStrategy) async throws -> Success
+}

--- a/ios/MullvadREST/RESTResponseHandler.swift
+++ b/ios/MullvadREST/RESTResponseHandler.swift
@@ -9,11 +9,10 @@
 import Foundation
 import MullvadTypes
 
-protocol RESTResponseHandler {
+protocol RESTResponseHandler<Success> {
     associatedtype Success
 
-    func handleURLResponse(_ response: HTTPURLResponse, data: Data) -> REST
-        .ResponseHandlerResult<Success>
+    func handleURLResponse(_ response: HTTPURLResponse, data: Data) -> REST.ResponseHandlerResult<Success>
 }
 
 extension REST {

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		589C6A782A45AAB700DAD3EF /* tunnel_obfuscator_proxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 584023272A407679007B27AC /* tunnel_obfuscator_proxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		589C6A7C2A45AE0100DAD3EF /* TunnelObfuscation.h in Headers */ = {isa = PBXBuildFile; fileRef = 589C6A7B2A45AE0100DAD3EF /* TunnelObfuscation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		589C6A7D2A45B06800DAD3EF /* TunnelObfuscation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5840231F2A406BF5007B27AC /* TunnelObfuscation.framework */; };
+		589E76C02A9378F100E502F3 /* RESTRequestExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589E76BF2A9378F100E502F3 /* RESTRequestExecutor.swift */; };
 		58A1AA8C23F5584C009F7EA6 /* ConnectionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A1AA8B23F5584B009F7EA6 /* ConnectionPanelView.swift */; };
 		58A8EE5A2976BFBB009C0F8D /* SKError+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A8EE592976BFBB009C0F8D /* SKError+Localized.swift */; };
 		58A8EE5E2976DB00009C0F8D /* StorePaymentManagerError+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A8EE5D2976DB00009C0F8D /* StorePaymentManagerError+Display.swift */; };
@@ -1130,6 +1131,7 @@
 		589D28792846250500F9A7B3 /* OperationObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationObserver.swift; sourceTree = "<group>"; };
 		589D287F28462CB000F9A7B3 /* BackgroundObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundObserver.swift; sourceTree = "<group>"; };
 		589D28812846306C00F9A7B3 /* GroupOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupOperation.swift; sourceTree = "<group>"; };
+		589E76BF2A9378F100E502F3 /* RESTRequestExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequestExecutor.swift; sourceTree = "<group>"; };
 		58A1AA8623F43901009F7EA6 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		58A1AA8B23F5584B009F7EA6 /* ConnectionPanelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionPanelView.swift; sourceTree = "<group>"; };
 		58A3BDAF28A1821A00C8C2C6 /* WgStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WgStats.swift; sourceTree = "<group>"; };
@@ -1536,6 +1538,7 @@
 				06FAE66928F83CA30033DD93 /* RESTError.swift */,
 				06FAE66F28F83CA40033DD93 /* RESTNetworkOperation.swift */,
 				06FAE66E28F83CA40033DD93 /* RESTProxy.swift */,
+				589E76BF2A9378F100E502F3 /* RESTRequestExecutor.swift */,
 				06FAE66728F83CA30033DD93 /* RESTProxyFactory.swift */,
 				06FAE66A28F83CA30033DD93 /* RESTRequestFactory.swift */,
 				06FAE67428F83CA40033DD93 /* RESTRequestHandler.swift */,
@@ -3330,6 +3333,7 @@
 				06799AF328F98E4800ACD94E /* RESTAuthenticationProxy.swift in Sources */,
 				06799AE628F98E4800ACD94E /* ServerRelaysResponse.swift in Sources */,
 				06799AF128F98E4800ACD94E /* RESTAPIProxy.swift in Sources */,
+				589E76C02A9378F100E502F3 /* RESTRequestExecutor.swift in Sources */,
 				06799AE528F98E4800ACD94E /* HTTP.swift in Sources */,
 				A9D99B9A2A1F7C3200DE27D3 /* RESTTransport.swift in Sources */,
 				06799AE028F98E4800ACD94E /* RESTCoding.swift in Sources */,


### PR DESCRIPTION
This PR is a stepping stone to having async flows support in MullvadREST.

Changes:

- Introduce `RESTRequestExecutor` protocol which should be returned from API proxies and is basically used as adaptor that supports callback or async based flows and doesn't schedule request until explicitly requested via a call to `execute()` optionally providing `REST.RetryStrategy` with default fallback to `.noRetry`.
  
  Interaction with this object in a callback based fashion is not very different from what we had before except retry strategy and completion handler aren't passed directly to API proxy but to `RESTRequestExecutor`:

    ```swift
    let accountsProxy: REST.AccountsProxy = ...
    
    let executor = accountsProxy.getAccountData(accountNumber: "1234")
    
    // With .noRetry strategy
    let cancellable = executor.execute { result in
      // handle result
    }
    
    // Providing .default retry strategy
    let cancellable = executor.execute(retryStrategy: .default) {
      // handle result
    }
    ```

  Slightly simpler in async flow:
  
    ```swift
    let accountsProxy: REST.AccountsProxy = ...
    
    let executor = accountsProxy.getAccountData(accountNumber: "1234")
    
    // With .noRetry strategy
    let response = try await executor.execute { result in
      // handle result
    }
    
    // Providing .default retry strategy
    let response = try await executor.execute(retryStrategy: .default)
    ```
  
  Cancellation should work in structured concurrency too:
    
    ```swift
    let task = Task {
        do {
            let accountsProxy: REST.AccountsProxy = ...
    
            let executor = accountsProxy.getAccountData(accountNumber: "1234")
            let response = try await executor.execute()
            // hande response
        } catch {
           // handle error
        }
    }

    // cancel network task
    task.cancel()
    ```

- Deprecate `RESTProxy.addOperation()` in favor of `makeRequestExecutor()`
- Since this PR would turn into a huge change across the entire codebase, I have deprecated two endpoints only `getAccountData()` and `createApplePayment()` and introduced variants that return return `RESTRequestExecutor`.