### PR TITLE
Fix nsobject_prefer_isequal swiftlint violation

### DIFF
--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProvider.swift
@@ -417,8 +417,9 @@ final class SimulatorTunnelProviderManager: NSObject, VPNTunnelProviderManagerPr
         completionHandler?(error)
     }
 
-    static func == (lhs: SimulatorTunnelProviderManager, rhs: SimulatorTunnelProviderManager) -> Bool {
-        lhs.identifier == rhs.identifier
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else { return false }
+        return self.identifier == other.identifier
     }
 }
 


### PR DESCRIPTION
Do not use `==` for equality when subclassing from `NSObject` but instead override `isEqual` 

[This article](https://noahgilmore.com/blog/nsobject-equatable/) explains why in great details