### PR TITLE
Eliminate force cast for HTTP response

### DIFF
--- a/ios/MullvadREST/RESTError.swift
+++ b/ios/MullvadREST/RESTError.swift
@@ -122,9 +122,21 @@ extension REST {
         }
     }
 
-    public struct NoTransportError: LocalizedError {
+    public enum InternalTransportError: LocalizedError {
+        /// Programmer error. Indicates that REST framework is not configured with any transport.
+        case noTransport
+
+        /// Indicates that the transport returned something else but `HTTPURLResponse` upon success.
+        /// Likely a programmer error.
+        case invalidResponse(URLResponse?)
+
         public var errorDescription: String? {
-            "Transport is not configured."
+            switch self {
+            case .noTransport:
+                return "Transport is not configured."
+            case let .invalidResponse(response):
+                return "Received invalid response. Expected HTTPURLResponse, got \(response.map { "\($0.self)" } ?? "(nil)")."
+            }
         }
     }
 }

--- a/ios/MullvadREST/RESTResponseHandler.swift
+++ b/ios/MullvadREST/RESTResponseHandler.swift
@@ -12,8 +12,7 @@ import MullvadTypes
 protocol RESTResponseHandler {
     associatedtype Success
 
-    func handleURLResponse(_ response: HTTPURLResponse, data: Data) -> REST
-        .ResponseHandlerResult<Success>
+    func handleURLResponse(_ response: HTTPURLResponse, data: Data) -> REST.ResponseHandlerResult<Success>
 }
 
 extension REST {


### PR DESCRIPTION
Changes:

- Eliminate force cast from `URLResponse` to `HTTPURLResponse` and report a `.transport` error in that case.
- Introduce `InternalTransportError`, move `REST.NoTransportError` into internal one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5035)
<!-- Reviewable:end -->
