### PR TITLE
Return RESTTransport from TransportProvider IOS-284

### DIFF
--- a/ios/MullvadREST/RESTNetworkOperation.swift
+++ b/ios/MullvadREST/RESTNetworkOperation.swift
@@ -17,7 +17,7 @@ extension REST {
         private let responseHandler: AnyResponseHandler<Success>
 
         private let logger: Logger
-        private let transportProvider: () -> RESTTransport?
+        private let transportProvider: RESTTransportProvider
         private let addressCacheStore: AddressCache
 
         private var networkTask: Cancellable?
@@ -137,8 +137,7 @@ extension REST {
         private func didReceiveURLRequest(_ restRequest: REST.Request, endpoint: AnyIPEndpoint) {
             dispatchPrecondition(condition: .onQueue(dispatchQueue))
 
-            let transport = transportProvider()
-            guard let transport else {
+            guard let transport = transportProvider.makeTransport() else {
                 logger.error("Failed to obtain transport.")
                 finish(result: .failure(REST.Error.transport(InternalTransportError.noTransport)))
                 return

--- a/ios/MullvadREST/RESTProxy.swift
+++ b/ios/MullvadREST/RESTProxy.swift
@@ -67,11 +67,11 @@ extension REST {
     }
 
     public class ProxyConfiguration {
-        public let transportProvider: () -> RESTTransport?
+        public let transportProvider: RESTTransportProvider
         public let addressCacheStore: AddressCache
 
         public init(
-            transportProvider: @escaping () -> RESTTransport?,
+            transportProvider: RESTTransportProvider,
             addressCacheStore: AddressCache
         ) {
             self.transportProvider = transportProvider

--- a/ios/MullvadREST/RESTProxyFactory.swift
+++ b/ios/MullvadREST/RESTProxyFactory.swift
@@ -13,7 +13,7 @@ extension REST {
         public let configuration: AuthProxyConfiguration
 
         public class func makeProxyFactory(
-            transportProvider: @escaping () -> RESTTransport?,
+            transportProvider: RESTTransportProvider,
             addressCache: AddressCache
         ) -> ProxyFactory {
             let basicConfiguration = REST.ProxyConfiguration(

--- a/ios/MullvadREST/RESTTransport.swift
+++ b/ios/MullvadREST/RESTTransport.swift
@@ -11,8 +11,6 @@ import MullvadTypes
 
 public protocol RESTTransport {
     var name: String { get }
-    func sendRequest(
-        _ request: URLRequest,
-        completion: @escaping (Data?, URLResponse?, Error?) -> Void
-    ) -> Cancellable
+
+    func sendRequest(_ request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> Cancellable
 }

--- a/ios/MullvadREST/RESTTransportProvider.swift
+++ b/ios/MullvadREST/RESTTransportProvider.swift
@@ -1,0 +1,25 @@
+//
+//  RESTTransportProvider.swift
+//  MullvadREST
+//
+//  Created by pronebird on 24/08/2023.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+public protocol RESTTransportProvider {
+    func makeTransport() -> RESTTransport?
+}
+
+public struct AnyTransportProvider: RESTTransportProvider {
+    private let block: () -> RESTTransport?
+
+    public init(_ block: @escaping () -> RESTTransport?) {
+        self.block = block
+    }
+
+    public func makeTransport() -> RESTTransport? {
+        return block()
+    }
+}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 		58E45A5729F12C5100281ECF /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F1311427E0B2AB007AC5BC /* Result+Extensions.swift */; };
 		58E511E628DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E511E528DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift */; };
 		58E511E828DDDF2400B0BCDE /* CodingErrors+CustomErrorDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E511E528DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift */; };
+		58E7BA192A975DF70068EC3A /* RESTTransportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E7BA182A975DF70068EC3A /* RESTTransportProvider.swift */; };
 		58EC067A2A8D208D00BEB973 /* MockTunnelDeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EC06792A8D208D00BEB973 /* MockTunnelDeviceInfo.swift */; };
 		58EC067C2A8D2A0B00BEB973 /* NetworkCounters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EC067B2A8D2A0B00BEB973 /* NetworkCounters.swift */; };
 		58ED3A142A7C199C0085CE65 /* StartOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58ED3A132A7C199C0085CE65 /* StartOptions.swift */; };
@@ -1259,6 +1260,7 @@
 		58E511E328DDDE8900B0BCDE /* CustomErrorDescriptionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomErrorDescriptionProtocol.swift; sourceTree = "<group>"; };
 		58E511E528DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CodingErrors+CustomErrorDescription.swift"; sourceTree = "<group>"; };
 		58E511EA28DDE18400B0BCDE /* Error+Chain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Chain.swift"; sourceTree = "<group>"; };
+		58E7BA182A975DF70068EC3A /* RESTTransportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTTransportProvider.swift; sourceTree = "<group>"; };
 		58E973DD24850EB600096F90 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
 		58EC06792A8D208D00BEB973 /* MockTunnelDeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTunnelDeviceInfo.swift; sourceTree = "<group>"; };
 		58EC067B2A8D2A0B00BEB973 /* NetworkCounters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCounters.swift; sourceTree = "<group>"; };
@@ -1627,6 +1629,7 @@
 				06FAE66528F83CA30033DD93 /* RESTURLSession.swift */,
 				06FAE67728F83CA40033DD93 /* ServerRelaysResponse.swift */,
 				06FAE66B28F83CA30033DD93 /* SSLPinningURLSessionDelegate.swift */,
+				58E7BA182A975DF70068EC3A /* RESTTransportProvider.swift */,
 			);
 			path = MullvadREST;
 			sourceTree = "<group>";
@@ -3495,6 +3498,7 @@
 				06799AF428F98E4800ACD94E /* RESTAuthorization.swift in Sources */,
 				06799AE228F98E4800ACD94E /* RESTRequestFactory.swift in Sources */,
 				06799AEC28F98E4800ACD94E /* RESTTaskIdentifier.swift in Sources */,
+				58E7BA192A975DF70068EC3A /* RESTTransportProvider.swift in Sources */,
 				06799ADE28F98E4800ACD94E /* RESTRequestHandler.swift in Sources */,
 				06799AEF28F98E4800ACD94E /* RESTRetryStrategy.swift in Sources */,
 				06799AE128F98E4800ACD94E /* SSLPinningURLSessionDelegate.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -59,7 +59,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         addressCache.loadFromFile()
 
         proxyFactory = REST.ProxyFactory.makeProxyFactory(
-            transportProvider: { [weak self] in self?.transportMonitor },
+            transportProvider: AnyTransportProvider { [weak self] in
+                return self?.transportMonitor.makeTransport()
+            },
             addressCache: addressCache
         )
 

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -155,13 +155,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         )
 
         let proxyFactory = REST.ProxyFactory.makeProxyFactory(
-            transportProvider: { transportProvider },
+            transportProvider: transportProvider,
             addressCache: addressCache
         )
 
         urlRequestProxy = URLRequestProxy(
             dispatchQueue: dispatchQueue,
-            transportProvider: { transportProvider }
+            transportProvider: transportProvider
         )
         accountsProxy = proxyFactory.createAccountsProxy()
         devicesProxy = proxyFactory.createDevicesProxy()


### PR DESCRIPTION
Ensures that RESTTransport returns consistent values throughout execution and solves the following issues:

- Dynamic implementation of RESTTransport implemented by TransportProvider may yield different values (i.e RESTTransport.name) when accessed at different times during network operation execution
- Current implementation of RESTTransport on TransportProvider yields "TransportProvider" before the first call to sendRequest() which is not correct behavior becuase we always log the name of transport that's being used before sending request.
- When starting the app with network link conditioner blocking traffic, TransportProvider seems to print "TransportProvider" indefinitely even after the first call to sendRequest().