### PR TITLE
Change address cache schema IOS-282

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -27,6 +27,11 @@ Line wrap the file at 100 chars.                                              Th
 - Allow deleting account in account view.
 - Add new account flow
 
+### Fixed
+- Invalidate API IP address cache to fix connectivity issues for some of devices updating from 
+  2023.2 or earlier.
+
+
 ## [2023.3 - 2023-07-15]
 ### Added
 - Add search functionality to location selection view.


### PR DESCRIPTION
Recently we received a number of reports in regards of persistent communication errors with the API, namely SSL errors and timeouts. 

In <= 2023.2 we used to shuffle a list of IPs and manage them as a stack, first IP in array of endpoints was used to talk to the API. If it didn't work, we picked next by moving the first IP to the end of the list. From >= 2023.3 we always use the first IP in the list.

It's quite likely that the app that ended up using the broken API IP would remain stuck using it after update 2023.3 which always relies on the first IP in the list. I also confirmed that one of API IPs hasn't been working for a while.

I think the most logical and simplest would be to modify the cache schema to store a single endpoint IP instead of array of them, which should then fail to decode after update from 2023.2 to 2023.3 and invalidate cache as address cache would fallback to default hardcoded IP in that case.

Additionally this PR adds a mutex guard to `AddressCache.loadFromFile()` since this call mutates internal cache data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5041)
<!-- Reviewable:end -->
