### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           swiftformat --version
           swiftformat --lint .
+        working-directory: ios
 
   swiftlint:
     name: Run swiftlint
@@ -36,6 +37,7 @@ jobs:
       - name: Run swiftlint
         run: |
           swiftlint --reporter github-actions-logging
+        working-directory: ios
 
   test:
     name: Unit tests

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -84,11 +84,11 @@ jobs:
 
       - name: Run tests
         run: |
-          NSUnbufferedIO=YES set -o pipefail && \
-            xcodebuild -project MullvadVPN.xcodeproj \
-              -scheme MullvadVPN \
-              -testPlan MullvadVPNCI \
-              -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14" \
-              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
-              test 2>&1 | xcbeautify
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
+            -project MullvadVPN.xcodeproj \
+            -scheme MullvadVPN \
+            -testPlan MullvadVPNCI \
+            -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            test 2>&1 | xcbeautify
         working-directory: ios/

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Run swiftlint
         run: |
+          swiftlint --version
           swiftlint --reporter github-actions-logging
         working-directory: ios
 


### PR DESCRIPTION
1. Set working directory for both `swiftformat` and `swiftlint` to prevent scanning the whole file tree from the root.
2. Use `env` to pass `NSUnbufferedIO` to `xcodebuild` because the way it was wired up was wrong.
3. Print SwiftLint version before linting so that we know which version is installed on CI. Should help with troubleshooting if something breaks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5047)
<!-- Reviewable:end -->
