### PR TITLE
Move out of time behaviour to view model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Migrate welcome view to compose.
 - Migrate in app notifications to compose.
+- Move out of time evaluation to connect view model.
 
 #### Linux
 - Don't block forwarding of traffic when the split tunnel mark (ct mark) is set.

--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreenTest.kt
@@ -820,4 +820,20 @@ class ConnectScreenTest {
         // Assert
         composeTestRule.apply { onNodeWithTag(SCROLLABLE_COLUMN_TEST_TAG).assertDoesNotExist() }
     }
+
+    @Test
+    fun testOpenOutOfTimeScreen() {
+        // Arrange
+        val mockedOpenScreenHandler: () -> Unit = mockk(relaxed = true)
+        composeTestRule.setContent {
+            ConnectScreen(
+                uiState = ConnectUiState.INITIAL,
+                viewActions = MutableStateFlow(ConnectViewModel.ViewAction.OpenOutOfTimeView),
+                onOpenOutOfTimeScreen = mockedOpenScreenHandler
+            )
+        }
+
+        // Assert
+        verify { mockedOpenScreenHandler.invoke() }
+    }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
@@ -74,13 +74,19 @@ fun ConnectScreen(
     onSwitchLocationClick: () -> Unit = {},
     onToggleTunnelInfo: () -> Unit = {},
     onUpdateVersionClick: () -> Unit = {},
-    onManageAccountClick: () -> Unit = {}
+    onManageAccountClick: () -> Unit = {},
+    onOpenOutOfTimeScreen: () -> Unit = {}
 ) {
     val context = LocalContext.current
     LaunchedEffect(key1 = Unit) {
         viewActions.collect { viewAction ->
-            if (viewAction is ConnectViewModel.ViewAction.OpenAccountManagementPageInBrowser) {
-                context.openAccountPageInBrowser(viewAction.token)
+            when (viewAction) {
+                is ConnectViewModel.ViewAction.OpenAccountManagementPageInBrowser -> {
+                    context.openAccountPageInBrowser(viewAction.token)
+                }
+                is ConnectViewModel.ViewAction.OpenOutOfTimeView -> {
+                    onOpenOutOfTimeScreen()
+                }
             }
         }
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/ConnectFragment.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/fragment/ConnectFragment.kt
@@ -24,7 +24,6 @@ import net.mullvad.mullvadvpn.ui.NavigationBarPainter
 import net.mullvad.mullvadvpn.ui.paintNavigationBar
 import net.mullvad.mullvadvpn.ui.widget.HeaderBar
 import net.mullvad.mullvadvpn.viewmodel.ConnectViewModel
-import net.mullvad.talpid.tunnel.ErrorStateCause
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class ConnectFragment : BaseFragment(), NavigationBarPainter {
@@ -66,7 +65,8 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
                     onSwitchLocationClick = { openSwitchLocationScreen() },
                     onToggleTunnelInfo = connectViewModel::toggleTunnelInfoExpansion,
                     onUpdateVersionClick = { openDownloadUrl() },
-                    onManageAccountClick = connectViewModel::onManageAccountClick
+                    onManageAccountClick = connectViewModel::onManageAccountClick,
+                    onOpenOutOfTimeScreen = ::openOutOfTimeScreen
                 )
             }
         }
@@ -103,10 +103,6 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
 
     private fun updateTunnelState(realState: TunnelState) {
         headerBar.tunnelState = realState
-
-        if (realState.isTunnelErrorStateDueToExpiredAccount()) {
-            openOutOfTimeScreen()
-        }
     }
 
     private fun openSwitchLocationScreen() {
@@ -124,17 +120,9 @@ class ConnectFragment : BaseFragment(), NavigationBarPainter {
     }
 
     private fun openOutOfTimeScreen() {
-        jobTracker.newUiJob("openOutOfTimeScreen") {
-            parentFragmentManager.beginTransaction().apply {
-                replace(R.id.main_fragment, OutOfTimeFragment())
-                commitAllowingStateLoss()
-            }
+        parentFragmentManager.beginTransaction().apply {
+            replace(R.id.main_fragment, OutOfTimeFragment())
+            commitAllowingStateLoss()
         }
-    }
-
-    private fun TunnelState.isTunnelErrorStateDueToExpiredAccount(): Boolean {
-        return ((this as? TunnelState.Error)?.errorState?.cause as? ErrorStateCause.AuthFailed)
-            ?.isCausedByExpiredAccount()
-            ?: false
     }
 }


### PR DESCRIPTION
Current behaviour is in the fragment, since we want to remove fragments I have moved it to the viewModel.

This replicate the view action pattern that is used elsewhere and in the other connect PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5049)
<!-- Reviewable:end -->
