### PR TITLE
Use appTarget in address cache

### DIFF
--- a/ios/MullvadTypes/ApplicationTarget.swift
+++ b/ios/MullvadTypes/ApplicationTarget.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-enum ApplicationTarget: CaseIterable {
+public enum ApplicationTarget: CaseIterable {
     case mainApp, packetTunnel
 
     /// Returns target bundle identifier.
-    var bundleIdentifier: String {
+    public var bundleIdentifier: String {
         let mainBundleIdentifier = Bundle.main.object(forInfoDictionaryKey: "MainApplicationIdentifier") as! String
         switch self {
         case .mainApp:

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -240,14 +240,13 @@
 		58B993B12608A34500BA7811 /* LoginContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B993B02608A34500BA7811 /* LoginContentView.swift */; };
 		58B9EB152489139B00095626 /* RESTError+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B9EB142489139B00095626 /* RESTError+Display.swift */; };
 		58BA693123EADA6A009DC256 /* SimulatorTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA693023EADA6A009DC256 /* SimulatorTunnelProvider.swift */; };
+		58BDEB9F2A99068300F578F2 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
 		58BFA5C622A7C97F00A6173D /* RelayCacheTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5C522A7C97F00A6173D /* RelayCacheTracker.swift */; };
 		58BFA5CC22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
 		58C3A4B222456F1B00340BDB /* AccountInputGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3A4B122456F1A00340BDB /* AccountInputGroupView.swift */; };
 		58C3F4F92964B08300D72515 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3F4F82964B08300D72515 /* MapViewController.swift */; };
 		58C3FA662A38549D006A450A /* MockFileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3FA652A38549D006A450A /* MockFileCache.swift */; };
 		58C3FA682A385C89006A450A /* FileCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C3FA672A385C89006A450A /* FileCacheTests.swift */; };
-		58C76A082A33850E00100D75 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
-		58C76A092A33850E00100D75 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
 		58C76A0B2A338E4300100D75 /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A0A2A338E4300100D75 /* BackgroundTask.swift */; };
 		58C774BE29A7A249003A1A56 /* CustomNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C774BD29A7A249003A1A56 /* CustomNavigationController.swift */; };
 		58C7A43E2A863F470060C66F /* PacketTunnelCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58C7A4362A863F440060C66F /* PacketTunnelCore.framework */; platformFilter = ios; };
@@ -1667,6 +1666,7 @@
 		581943F228F8014500B0CB5E /* MullvadTypes */ = {
 			isa = PBXGroup;
 			children = (
+				58C76A072A33850E00100D75 /* ApplicationTarget.swift */,
 				584D26BE270C550B004EA533 /* AnyIPAddress.swift */,
 				586A951329013235007BAF2B /* AnyIPEndpoint.swift */,
 				06AC113628F83FD70037AF9A /* Cancellable.swift */,
@@ -2137,7 +2137,6 @@
 			isa = PBXGroup;
 			children = (
 				58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */,
-				58C76A072A33850E00100D75 /* ApplicationTarget.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -3761,7 +3760,6 @@
 				58E25F812837BBBB002CFB2C /* SceneDelegate.swift in Sources */,
 				7A9CCCB42A96302800DD6A34 /* TermsOfServiceCoordinator.swift in Sources */,
 				5867771629097C5B006F721F /* ProductState.swift in Sources */,
-				58C76A082A33850E00100D75 /* ApplicationTarget.swift in Sources */,
 				F07BF2622A26279100042943 /* RedeemVoucherOperation.swift in Sources */,
 				585E820327F3285E00939F0E /* SendStoreReceiptOperation.swift in Sources */,
 				5820676426E771DB00655B05 /* TunnelManagerErrors.swift in Sources */,
@@ -3889,7 +3887,6 @@
 				580F8B8428197884002E0998 /* TunnelSettingsV2.swift in Sources */,
 				06410E08292D117800AFC18C /* SettingsStore.swift in Sources */,
 				A92ECC222A77FFAF0052F1B1 /* TunnelSettings.swift in Sources */,
-				58C76A092A33850E00100D75 /* ApplicationTarget.swift in Sources */,
 				583D86482A2678DC0060D63B /* DeviceStateAccessor.swift in Sources */,
 				58906DE02445C7A5002F0673 /* NEProviderStopReason+Debug.swift in Sources */,
 				06410DFF292CF16C00AFC18C /* KeychainSettingsStore.swift in Sources */,
@@ -3967,6 +3964,7 @@
 				58D22416294C90210029F5F8 /* PacketTunnelRelay.swift in Sources */,
 				58D22417294C90210029F5F8 /* FixedWidthInteger+Arithmetics.swift in Sources */,
 				58D22418294C90210029F5F8 /* PacketTunnelErrorWrapper.swift in Sources */,
+				58BDEB9F2A99068300F578F2 /* ApplicationTarget.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         let containerURL = ApplicationConfiguration.containerURL
 
-        addressCache = REST.AddressCache(canWriteToCache: true, cacheDirectory: containerURL)
+        addressCache = REST.AddressCache(appTarget: .mainApp, cacheDirectory: containerURL)
         addressCache.loadFromFile()
 
         proxyFactory = REST.ProxyFactory.makeProxyFactory(

--- a/ios/MullvadVPN/BackgroundTask.swift
+++ b/ios/MullvadVPN/BackgroundTask.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MullvadTypes
 
 /**
  Background tasks defined by the app.

--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MullvadLogging
+import MullvadTypes
 import NetworkExtension
 import Operations
 import RelayCache

--- a/ios/MullvadVPNTests/AddressCacheTests.swift
+++ b/ios/MullvadVPNTests/AddressCacheTests.swift
@@ -18,7 +18,7 @@ final class AddressCacheTests: XCTestCase {
 
     func testAddressCacheHasDefaultEndpoint() {
         let addressCache = REST.AddressCache(
-            canWriteToCache: false,
+            appTarget: .packetTunnel,
             fileCache: MockFileCache(initialState: .fileNotFound)
         )
         XCTAssertEqual(addressCache.getCurrentEndpoint(), REST.defaultAPIEndpoint)
@@ -26,7 +26,7 @@ final class AddressCacheTests: XCTestCase {
 
     func testSetEndpoints() throws {
         let addressCache = REST.AddressCache(
-            canWriteToCache: false,
+            appTarget: .packetTunnel,
             fileCache: MockFileCache(initialState: .fileNotFound)
         )
 
@@ -36,7 +36,7 @@ final class AddressCacheTests: XCTestCase {
 
     func testSetEndpointsUpdatesDateWhenSettingSameAddress() throws {
         let addressCache = REST.AddressCache(
-            canWriteToCache: false,
+            appTarget: .packetTunnel,
             fileCache: MockFileCache(initialState: .fileNotFound)
         )
         addressCache.setEndpoints([apiEndpoint])
@@ -50,7 +50,7 @@ final class AddressCacheTests: XCTestCase {
 
     func testSetEndpointsDoesNotDoAnythingIfSettingEmptyEndpoints() throws {
         let addressCache = REST.AddressCache(
-            canWriteToCache: false,
+            appTarget: .packetTunnel,
             fileCache: MockFileCache(initialState: .fileNotFound)
         )
         addressCache.loadFromFile()
@@ -69,7 +69,7 @@ final class AddressCacheTests: XCTestCase {
         let firstIPEndpoint = try XCTUnwrap(ipAddresses.first)
 
         let fileCache = MockFileCache<REST.StoredAddressCache>()
-        let addressCache = REST.AddressCache(canWriteToCache: true, fileCache: fileCache)
+        let addressCache = REST.AddressCache(appTarget: .mainApp, fileCache: fileCache)
         addressCache.setEndpoints(ipAddresses)
 
         let fileState = fileCache.getState()
@@ -85,7 +85,7 @@ final class AddressCacheTests: XCTestCase {
     func testCacheReadsFromFile() throws {
         let fixedDate = Date()
         let addressCache = REST.AddressCache(
-            canWriteToCache: true,
+            appTarget: .mainApp,
             fileCache: MockFileCache(initialState: .exists(
                 REST.StoredAddressCache(updatedAt: fixedDate, endpoint: apiEndpoint)
             ))
@@ -98,7 +98,7 @@ final class AddressCacheTests: XCTestCase {
 
     func testCacheWritesToDiskWhenSettingNewEndpoints() throws {
         let fileCache = MockFileCache<REST.StoredAddressCache>()
-        let addressCache = REST.AddressCache(canWriteToCache: true, fileCache: fileCache)
+        let addressCache = REST.AddressCache(appTarget: .mainApp, fileCache: fileCache)
 
         XCTAssertEqual(fileCache.getState(), .fileNotFound)
         addressCache.setEndpoints([apiEndpoint])
@@ -117,7 +117,7 @@ final class AddressCacheTests: XCTestCase {
 
     func testGetCurrentEndpointReadsFromCacheWhenReadOnly() throws {
         let addressCache = REST.AddressCache(
-            canWriteToCache: false,
+            appTarget: .packetTunnel,
             fileCache: MockFileCache(initialState: .exists(
                 REST.StoredAddressCache(updatedAt: Date(), endpoint: apiEndpoint)
             ))

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -138,7 +138,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         tunnelLogger = Logger(label: "WireGuard")
 
         let containerURL = ApplicationConfiguration.containerURL
-        let addressCache = REST.AddressCache(canWriteToCache: false, cacheDirectory: containerURL)
+        let addressCache = REST.AddressCache(appTarget: .packetTunnel, cacheDirectory: containerURL)
         addressCache.loadFromFile()
 
         relayCache = RelayCache(cacheDirectory: containerURL)

--- a/ios/Shared/ApplicationConfiguration.swift
+++ b/ios/Shared/ApplicationConfiguration.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import enum MullvadTypes.ApplicationTarget
 import struct Network.IPv4Address
 
 enum ApplicationConfiguration {


### PR DESCRIPTION
As @rablador pointed out it's probably better to use app target where we want to achieve a specific behavior such as in AddressCache.

This is a draft PR to gather feedback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5053)
<!-- Reviewable:end -->
