### PR TITLE
Update rustls-webpki to avoid RUSTSEC-2023-0053

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",


### PR DESCRIPTION
Avoids the CVE. We were not affected by the CVE to begin with.

Fixes #5036

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5054)
<!-- Reviewable:end -->
