### PR TITLE
Update x25519-dalek to get stable version instead of rc3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.3"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4746,9 +4746,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0-rc.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7fae07da688e17059d5886712c933bb0520f15eff2e09cfa18e30968f4e63a"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -12,7 +12,7 @@ publish.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 ipnetwork = "0.16"
 base64 = "0.13"
-x25519-dalek = { version = "2.0.0-rc.3", features = ["static_secrets", "zeroize", "getrandom"] }
+x25519-dalek = { version = "2.0.0", features = ["static_secrets", "zeroize", "getrandom"] }
 err-derive = "0.3.1"
 zeroize = "1.5.7"
 


### PR DESCRIPTION
I just saw that `x25519-dalek` was recently published as stable. As far as I can tell there is no notable difference. Just nicer to get onto stable and off of release candidates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5057)
<!-- Reviewable:end -->
