### PR TITLE
Prevent OpenVPN servers from showing in relay list when protocol is automatic

### DIFF
--- a/gui/src/renderer/lib/filter-locations.ts
+++ b/gui/src/renderer/lib/filter-locations.ts
@@ -44,9 +44,6 @@ function getTunnelProtocolFilter(
     endpointTypes.push('bridge');
   } else if (tunnelProtocol === 'any') {
     endpointTypes.push('wireguard');
-    if (!relaySettings?.wireguard.useMultihop) {
-      endpointTypes.push('openvpn');
-    }
   } else {
     endpointTypes.push(tunnelProtocol);
   }


### PR DESCRIPTION
This PR prevents OpenVPN relays from showing in the select location view when protocol is set to automatic. This is the last part of the process to make WireGuard the default protocol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5059)
<!-- Reviewable:end -->
