### PR TITLE
Remove unused link from config.json

### DIFF
--- a/gui/src/config.json
+++ b/gui/src/config.json
@@ -2,7 +2,6 @@
   "supportEmail": "support@mullvad.net",
   "links": {
     "purchase": "https://mullvad.net/account/",
-    "manageKeys": "https://mullvad.net/account/ports/",
     "faq": "https://mullvad.net/help/tag/mullvad-app/",
     "privacyGuide": "https://mullvad.net/help/first-steps-towards-online-privacy/",
     "download": "https://mullvad.net/download/",


### PR DESCRIPTION
This `manageKeys` url in `config.json` was forgotten about when the code that used it was removed. This PR removes the url.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5067)
<!-- Reviewable:end -->
