### PR TITLE
Clear GPU cache on upgrade on Linux

### DIFF
--- a/dist-assets/linux/after-remove.sh
+++ b/dist-assets/linux/after-remove.sh
@@ -8,32 +8,36 @@ function remove_logs_and_cache {
     echo "Failed to remove mullvad-vpn cache"
 }
 
+function get_home_dirs {
+  if [[ -f "/etc/passwd" ]] && command -v cut > /dev/null; then
+      cut -d: -f6 /etc/passwd
+  fi
+}
+
 function remove_config {
   rm -r --interactive=never /etc/mullvad-vpn || \
     echo "Failed to remove mullvad-vpn config"
 
   # Remove app settings and auto-launcher for all users. This doesn't respect XDG_CONFIG_HOME due
   # to the complexity required.
-  if [[ -f "/etc/passwd" ]] && command -v cut > /dev/null; then
-      local home_dirs
-      home_dirs=$(cut -d: -f6 /etc/passwd)
-      for home_dir in $home_dirs; do
-          local mullvad_dir="$home_dir/.config/Mullvad VPN"
-          if [[ -d "$mullvad_dir" ]]; then
-              echo "Removing mullvad-vpn app settings from $mullvad_dir"
-              rm -r --interactive=never "$mullvad_dir" || \
-                  echo "Failed to remove mullvad-vpn app settings"
-          fi
+  local home_dirs
+  home_dirs=$(get_home_dirs)
+  for home_dir in $home_dirs; do
+      local mullvad_dir="$home_dir/.config/Mullvad VPN"
+      if [[ -d "$mullvad_dir" ]]; then
+          echo "Removing mullvad-vpn app settings from $mullvad_dir"
+          rm -r --interactive=never "$mullvad_dir" || \
+              echo "Failed to remove mullvad-vpn app settings"
+      fi
 
-          local autostart_path="$home_dir/.config/autostart/mullvad-vpn.desktop"
-          # mullvad-vpn.desktop can be both a file or a symlink.
-          if [[ -f "$autostart_path" || -L "$autostart_path" ]]; then
-              echo "Removing mullvad-vpn app autostart file $autostart_path"
-              rm --interactive=never "$autostart_path" || \
-                  echo "Failed to remove mullvad-vpn autostart file"
-          fi
-      done
-  fi
+      local autostart_path="$home_dir/.config/autostart/mullvad-vpn.desktop"
+      # mullvad-vpn.desktop can be both a file or a symlink.
+      if [[ -f "$autostart_path" || -L "$autostart_path" ]]; then
+          echo "Removing mullvad-vpn app autostart file $autostart_path"
+          rm --interactive=never "$autostart_path" || \
+              echo "Failed to remove mullvad-vpn autostart file"
+      fi
+  done
 }
 
 # checking what kind of an action is taking place

--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -eu
 
+function get_home_dirs {
+  if [[ -f "/etc/passwd" ]] && command -v cut > /dev/null; then
+      cut -d: -f6 /etc/passwd
+  fi
+}
+
+function clear_gpu_cache {
+  local home_dirs
+  home_dirs=$(get_home_dirs)
+
+  for home_dir in $home_dirs; do
+      local gpu_cache_dir="$home_dir/.config/Mullvad VPN/GPUCache"
+      if [[ -d "$gpu_cache_dir" ]]; then
+          echo "Clearing GPU cache in $gpu_cache_dir"
+          rm -r --interactive=never "$gpu_cache_dir" || \
+              echo "Failed to clear GPU cache"
+      fi
+  done
+}
+
 if which systemctl &> /dev/null; then
     if systemctl status mullvad-daemon &> /dev/null; then
         /opt/Mullvad\ VPN/resources/mullvad-setup prepare-restart || true
@@ -15,6 +35,9 @@ fi
 # This can be removed when 2022.4 is unsupported. That version is the last version where
 # before-remove.sh doesn't kill the GUI on upgrade.
 pkill -x "mullvad-gui" || true
+
+# We've had reports of corrumpt GPU caches. Clearing on upgrade will solve these issues.
+clear_gpu_cache
 
 rm -f /var/cache/mullvad-vpn/relays.json
 rm -f /var/cache/mullvad-vpn/api-ip-address.txt


### PR DESCRIPTION
Reported in https://github.com/mullvad/mullvadvpn-app/issues/4952 the GPU cache can be incompatible with future Electron versions. This PR removes the cache directory on upgrade by removing it after the app has been installed. The reason why we don't do it in `after-remove.sh` (where we already have code for removing app data for all users) is that it would take one more release before the change would kick into action. When upgrading `*-remove.sh` scripts are run from the old versions package while the `*-install.sh` scripts are run from the new package.
