### PR TITLE
On delete account screen, add account number validation during input

### DIFF
--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
@@ -253,9 +253,18 @@ class AccountDeletionContentView: UIView {
         }
     }
 
-    private var isAccountNumberLengthSatisfied: Bool {
-        let length = accountTextField.text?.count ?? 0
-        return length == 4
+    private var isInputValid: Bool {
+        guard let input = accountTextField.text,
+              let accountNumber = viewModel?.accountNumber,
+              !accountNumber.isEmpty
+        else {
+            return false
+        }
+
+        let inputLengthIsValid = input.count == 4
+        let inputMatchesAccountNumber = accountNumber.suffix(4) == input
+
+        return inputLengthIsValid && inputMatchesAccountNumber
     }
 
     weak var delegate: AccountDeletionContentViewDelegate?
@@ -334,7 +343,7 @@ class AccountDeletionContentView: UIView {
         } else {
             activityIndicator.stopAnimating()
         }
-        deleteButton.isEnabled = isDeleteButtonEnabled && isAccountNumberLengthSatisfied
+        deleteButton.isEnabled = isDeleteButtonEnabled && isInputValid
         statusLabel.text = text
         statusLabel.textColor = textColor
     }


### PR DESCRIPTION
When entering the last 4 digits of the account number on the account deletion screen, the OK button lights up even if the number is incorrect. When pressing the OK button an error message is displayed, saying that the number is indeed incorrect. The process has now been simplified by having the OK button itself function as validation instead and only enabling it if input is valid.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5069)
<!-- Reviewable:end -->
