### PR TITLE
Remove forwarded ports on iOS

### DIFF
--- a/ios/MullvadTypes/RESTTypes.swift
+++ b/ios/MullvadTypes/RESTTypes.swift
@@ -13,16 +13,12 @@ import class WireGuardKitTypes.PublicKey
 public struct Account: Codable, Equatable {
     public let id: String
     public let expiry: Date
-    public let maxPorts: Int
-    public let canAddPorts: Bool
     public let maxDevices: Int
     public let canAddDevices: Bool
 
-    public init(id: String, expiry: Date, maxPorts: Int, canAddPorts: Bool, maxDevices: Int, canAddDevices: Bool) {
+    public init(id: String, expiry: Date, maxDevices: Int, canAddDevices: Bool) {
         self.id = id
         self.expiry = expiry
-        self.maxPorts = maxPorts
-        self.canAddPorts = canAddPorts
         self.maxDevices = maxDevices
         self.canAddDevices = canAddDevices
     }
@@ -36,11 +32,10 @@ public struct Device: Codable, Equatable {
     public let created: Date
     public let ipv4Address: IPAddressRange
     public let ipv6Address: IPAddressRange
-    public let ports: [Port]
 
     private enum CodingKeys: String, CodingKey {
         case hijackDNS = "hijackDns"
-        case id, name, pubkey, created, ipv4Address, ipv6Address, ports
+        case id, name, pubkey, created, ipv4Address, ipv6Address
     }
 
     public init(
@@ -50,8 +45,7 @@ public struct Device: Codable, Equatable {
         hijackDNS: Bool,
         created: Date,
         ipv4Address: IPAddressRange,
-        ipv6Address: IPAddressRange,
-        ports: [Port]
+        ipv6Address: IPAddressRange
     ) {
         self.id = id
         self.name = name
@@ -60,14 +54,5 @@ public struct Device: Codable, Equatable {
         self.created = created
         self.ipv4Address = ipv4Address
         self.ipv6Address = ipv6Address
-        self.ports = ports
-    }
-}
-
-public struct Port: Codable, Equatable {
-    public let id: String
-
-    public init(id: String) {
-        self.id = id
     }
 }

--- a/ios/MullvadVPNTests/DeviceCheckOperationTests.swift
+++ b/ios/MullvadVPNTests/DeviceCheckOperationTests.swift
@@ -533,8 +533,7 @@ private extension Device {
             hijackDNS: false,
             created: Date(),
             ipv4Address: IPAddressRange(from: "127.0.0.1/32")!,
-            ipv6Address: IPAddressRange(from: "::ff/64")!,
-            ports: []
+            ipv6Address: IPAddressRange(from: "::ff/64")!
         )
     }
 }
@@ -544,8 +543,6 @@ private extension Account {
         Account(
             id: "account-id",
             expiry: expiry,
-            maxPorts: 5,
-            canAddPorts: true,
             maxDevices: 5,
             canAddDevices: true
         )

--- a/ios/MullvadVPNTests/WgKeyRotationTests.swift
+++ b/ios/MullvadVPNTests/WgKeyRotationTests.swift
@@ -110,8 +110,7 @@ private extension Device {
             hijackDNS: false,
             created: Date(),
             ipv4Address: IPAddressRange(from: "127.0.0.1/32")!,
-            ipv6Address: IPAddressRange(from: "::ff/64")!,
-            ports: []
+            ipv6Address: IPAddressRange(from: "::ff/64")!
         )
     }
 }


### PR DESCRIPTION
In sympathy with https://github.com/mullvad/mullvadvpn-app/pull/5074, it's time to drop forwarded ports as those were decommissioned anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5078)
<!-- Reviewable:end -->
