### PR TITLE
Fix custom port input crash

### DIFF
--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreenTest.kt
@@ -17,6 +17,7 @@ import io.mockk.verifyAll
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import net.mullvad.mullvadvpn.compose.state.VpnSettingsUiState
+import net.mullvad.mullvadvpn.compose.test.CUSTOM_PORT_DIALOG_INPUT_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_LAST_ITEM_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_QUANTUM_ITEM_ON_TEST_TAG
@@ -811,6 +812,33 @@ class VpnSettingsScreenTest {
 
         // Assert
         verify { onWireguardPortSelected.invoke(Constraint.Only(Port(4000))) }
+    }
+
+    @Test
+    fun testShowWireguardCustomPortDialogInvalidInt() {
+        // Input a number to make sure that a too long number does not show and it does not crash
+        // the app
+
+        // Arrange
+        composeTestRule.setContent {
+            VpnSettingsScreen(
+                uiState =
+                    VpnSettingsUiState.CustomPortDialogUiState(
+                        availablePortRanges = listOf(PortRange(53, 53), PortRange(120, 121))
+                    ),
+                toastMessagesSharedFlow = MutableSharedFlow<String>().asSharedFlow()
+            )
+        }
+
+        // Act
+        composeTestRule
+            .onNodeWithTag(CUSTOM_PORT_DIALOG_INPUT_TEST_TAG)
+            .performTextInput("21474836471")
+
+        // Assert
+        composeTestRule
+            .onNodeWithTagAndText(CUSTOM_PORT_DIALOG_INPUT_TEST_TAG, "21474836471")
+            .assertDoesNotExist()
     }
 
     companion object {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CustomPortDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CustomPortDialog.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.button.ActionButton
-import net.mullvad.mullvadvpn.compose.test.CUSTOM_PORT_DIALOG_INPUT_TEST_TAG
 import net.mullvad.mullvadvpn.compose.textfield.CustomPortTextField
 import net.mullvad.mullvadvpn.lib.theme.AlphaDescription
 import net.mullvad.mullvadvpn.lib.theme.AlphaDisabled
@@ -119,7 +118,7 @@ fun CustomPortDialog(
                     isValidValue =
                         port.value.isNotEmpty() &&
                             allowedPortRanges.isPortInValidRanges(port.value.toIntOrNull() ?: 0),
-                    modifier = Modifier.testTag(CUSTOM_PORT_DIALOG_INPUT_TEST_TAG)
+                    maxCharLength = 5
                 )
                 Spacer(modifier = Modifier.height(Dimens.smallPadding))
                 Text(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CustomPortDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CustomPortDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.button.ActionButton
+import net.mullvad.mullvadvpn.compose.test.CUSTOM_PORT_DIALOG_INPUT_TEST_TAG
 import net.mullvad.mullvadvpn.compose.textfield.CustomPortTextField
 import net.mullvad.mullvadvpn.lib.theme.AlphaDescription
 import net.mullvad.mullvadvpn.lib.theme.AlphaDisabled
@@ -118,7 +119,8 @@ fun CustomPortDialog(
                     isValidValue =
                         port.value.isNotEmpty() &&
                             allowedPortRanges.isPortInValidRanges(port.value.toIntOrNull() ?: 0),
-                    maxCharLength = 5
+                    maxCharLength = 5,
+                    modifier = Modifier.testTag(CUSTOM_PORT_DIALOG_INPUT_TEST_TAG)
                 )
                 Spacer(modifier = Modifier.height(Dimens.smallPadding))
                 Text(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CustomPortDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CustomPortDialog.kt
@@ -12,10 +12,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.button.ActionButton
+import net.mullvad.mullvadvpn.compose.test.CUSTOM_PORT_DIALOG_INPUT_TEST_TAG
 import net.mullvad.mullvadvpn.compose.textfield.CustomPortTextField
 import net.mullvad.mullvadvpn.lib.theme.AlphaDescription
 import net.mullvad.mullvadvpn.lib.theme.AlphaDisabled
@@ -75,7 +77,7 @@ fun CustomPortDialog(
                         ),
                     isEnabled =
                         port.value.isNotEmpty() &&
-                            allowedPortRanges.isPortInValidRanges(port.value.toInt())
+                            allowedPortRanges.isPortInValidRanges(port.value.toIntOrNull() ?: 0)
                 )
                 if (showReset) {
                     ActionButton(
@@ -108,7 +110,7 @@ fun CustomPortDialog(
                     onSubmit = { input ->
                         if (
                             input.isNotEmpty() &&
-                                allowedPortRanges.isPortInValidRanges(input.toInt())
+                                allowedPortRanges.isPortInValidRanges(input.toIntOrNull() ?: 0)
                         ) {
                             onSave(input)
                         }
@@ -116,7 +118,8 @@ fun CustomPortDialog(
                     onValueChanged = { input -> port.value = input },
                     isValidValue =
                         port.value.isNotEmpty() &&
-                            allowedPortRanges.isPortInValidRanges(port.value.toInt())
+                            allowedPortRanges.isPortInValidRanges(port.value.toIntOrNull() ?: 0),
+                    modifier = Modifier.testTag(CUSTOM_PORT_DIALOG_INPUT_TEST_TAG)
                 )
                 Spacer(modifier = Modifier.height(Dimens.smallPadding))
                 Text(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/test/ComposeTestTagConstants.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/test/ComposeTestTagConstants.kt
@@ -10,6 +10,7 @@ const val LAZY_LIST_WIREGUARD_CUSTOM_PORT_TEXT_TEST_TAG =
     "lazy_list_wireguard_custom_port_text_test_tag"
 const val LAZY_LIST_WIREGUARD_CUSTOM_PORT_NUMBER_TEST_TAG =
     "lazy_list_wireguard_custom_port_number_test_tag"
+const val CUSTOM_PORT_DIALOG_INPUT_TEST_TAG = "custom_port_dialog_input_test_tag"
 
 // SelectLocationScreen, ConnectScreen
 const val CIRCULAR_PROGRESS_INDICATOR = "circular_progress_indicator"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomPortTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomPortTextField.kt
@@ -12,7 +12,8 @@ fun CustomPortTextField(
     modifier: Modifier = Modifier,
     onSubmit: (String) -> Unit,
     onValueChanged: (String) -> Unit,
-    isValidValue: Boolean
+    isValidValue: Boolean,
+    maxCharLength: Int
 ) {
     CustomTextField(
         value = value,
@@ -24,6 +25,7 @@ fun CustomPortTextField(
         onSubmit = onSubmit,
         isDigitsOnlyAllowed = true,
         isEnabled = true,
-        isValidValue = isValidValue
+        isValidValue = isValidValue,
+        maxCharLength = maxCharLength
     )
 }


### PR DESCRIPTION
1. Use `toIntOrNull` instead of `toInt` to avoid NumberFormatException.
2. Limit the number of characters in the custom port dialogue input to 5 since numbers that large are not valid port numbers anyway.
3. Add a test that checks for this crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5079)
<!-- Reviewable:end -->
