### PR TITLE
Detect whether OS is Windows Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Remove wireguard-go (userspace WireGuard) support.
 
+### Fixed
+#### Windows
+- Correctly detect whether OS is Windows Server (primarily for logging in daemon.log).
+
 
 ## [android/2023.6-beta1] - 2023-08-29
 

--- a/talpid-platform-metadata/src/lib.rs
+++ b/talpid-platform-metadata/src/lib.rs
@@ -15,6 +15,3 @@ mod imp;
 mod imp;
 
 pub use self::imp::{extra_metadata, short_version, version};
-
-#[cfg(target_os = "windows")]
-pub use self::imp::WindowsVersion;

--- a/talpid-platform-metadata/src/windows.rs
+++ b/talpid-platform-metadata/src/windows.rs
@@ -37,7 +37,7 @@ pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
     std::iter::empty()
 }
 
-pub struct WindowsVersion {
+struct WindowsVersion {
     inner: RTL_OSVERSIONINFOEXW,
 }
 

--- a/talpid-platform-metadata/src/windows.rs
+++ b/talpid-platform-metadata/src/windows.rs
@@ -6,11 +6,12 @@ use std::{
 };
 use windows_sys::Win32::System::{
     LibraryLoader::{GetModuleHandleW, GetProcAddress},
-    SystemInformation::OSVERSIONINFOW,
+    SystemInformation::OSVERSIONINFOEXW,
+    SystemServices::VER_NT_WORKSTATION,
 };
 
 #[allow(non_camel_case_types)]
-type RTL_OSVERSIONINFOW = OSVERSIONINFOW;
+type RTL_OSVERSIONINFOEXW = OSVERSIONINFOEXW;
 
 pub fn version() -> String {
     let (major, build) = WindowsVersion::new()
@@ -20,7 +21,7 @@ pub fn version() -> String {
                 version_info.build_number().to_string(),
             )
         })
-        .unwrap_or_else(|_| ("N/A".to_string(), "N/A".to_string()));
+        .unwrap_or_else(|_| ("N/A".to_owned(), "N/A".to_owned()));
 
     format!("Windows {} Build {}", major, build)
 }
@@ -37,7 +38,7 @@ pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
 }
 
 pub struct WindowsVersion {
-    inner: RTL_OSVERSIONINFOW,
+    inner: RTL_OSVERSIONINFOEXW,
 }
 
 impl WindowsVersion {
@@ -56,10 +57,10 @@ impl WindowsVersion {
         let function_address = unsafe { GetProcAddress(ntdll, b"RtlGetVersion\0" as *const u8) }
             .ok_or_else(io::Error::last_os_error)?;
 
-        let rtl_get_version: extern "stdcall" fn(*mut RTL_OSVERSIONINFOW) =
+        let rtl_get_version: extern "stdcall" fn(*mut RTL_OSVERSIONINFOEXW) =
             unsafe { *(&function_address as *const _ as *const _) };
 
-        let mut version_info: MaybeUninit<RTL_OSVERSIONINFOW> = mem::MaybeUninit::zeroed();
+        let mut version_info: MaybeUninit<RTL_OSVERSIONINFOEXW> = mem::MaybeUninit::zeroed();
         unsafe {
             (*version_info.as_mut_ptr()).dwOSVersionInfoSize =
                 mem::size_of_val(&version_info) as u32;
@@ -72,6 +73,13 @@ impl WindowsVersion {
     }
 
     pub fn windows_version_string(&self) -> String {
+        // `wProductType != VER_NT_WORKSTATION` implies that OS is Windows Server
+        // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_osversioninfoexw
+        // NOTE: This does not deduce which Windows Server version is running.
+        if u32::from(self.inner.wProductType) != VER_NT_WORKSTATION {
+            return "Server".to_owned();
+        }
+
         // Check https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions#Personal_computer_versions 'Release version' column
         // for the correct NT versions for specific windows releases.
         match (self.major_version(), self.minor_version()) {


### PR DESCRIPTION
We do not officially support Windows Server, but we could still distinguish between it and the desktop OSes. Currently, we incorrectly assume that the user is necessarily on the desktop version.

This code simply returns "Windows Server" and does not bother to detect the specific version/year. This is fine because we log the build number as well, and the main point is to distinguish between desktop and server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5089)
<!-- Reviewable:end -->
