### PR TITLE
Fix UIKit nagging regarding to present alert top of keyboard

### DIFF
--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
@@ -187,9 +187,17 @@ class AccountDeletionContentView: UIView {
         }
     }
 
-    var isEditing = false {
-        didSet {
-            _ = isEditing ? accountTextField.becomeFirstResponder() : accountTextField.resignFirstResponder()
+    var isEditing: Bool {
+        get {
+            accountTextField.isEditing
+        }
+        set {
+            guard accountTextField.isFirstResponder != newValue else { return }
+            if newValue {
+                accountTextField.becomeFirstResponder()
+            } else {
+                accountTextField.resignFirstResponder()
+            }
         }
     }
 

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewController.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewController.swift
@@ -42,27 +42,17 @@ class AccountDeletionViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        enableEditing()
+        contentView.isEditing = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        disableEditing()
+        contentView.isEditing = false
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         contentView.isEditing = false
         super.viewWillTransition(to: size, with: coordinator)
-    }
-
-    private func enableEditing() {
-        guard !contentView.isEditing else { return }
-        contentView.isEditing = true
-    }
-
-    private func disableEditing() {
-        guard contentView.isEditing else { return }
-        contentView.isEditing = false
     }
 
     private func configureUI() {
@@ -95,6 +85,7 @@ extension AccountDeletionViewController: AccountDeletionContentViewDelegate {
     func didTapDeleteButton(contentView: AccountDeletionContentView, button: AppButton) {
         switch interactor.validate(input: contentView.lastPartOfAccountNumber) {
         case let .success(accountNumber):
+            contentView.isEditing = false
             submit(accountNumber: accountNumber)
         case let .failure(error):
             contentView.state = .failure(error)

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherContentView.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherContentView.swift
@@ -192,9 +192,13 @@ final class RedeemVoucherContentView: UIView {
         }
     }
 
-    var isEditing = false {
-        didSet {
-            if isEditing {
+    var isEditing: Bool {
+        get {
+            textField.isEditing
+        }
+        set {
+            guard textField.isFirstResponder != newValue else { return }
+            if newValue {
                 textField.becomeFirstResponder()
             } else {
                 textField.resignFirstResponder()

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
@@ -64,30 +64,20 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        enableEditing()
+        contentView.isEditing = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        disableEditing()
+        contentView.isEditing = false
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        self.contentView.isEditing = false
+        contentView.isEditing = false
         super.viewWillTransition(to: size, with: coordinator)
     }
 
     // MARK: - private functions
-
-    private func enableEditing() {
-        guard !self.contentView.isEditing else { return }
-        self.contentView.isEditing = true
-    }
-
-    private func disableEditing() {
-        guard contentView.isEditing else { return }
-        self.contentView.isEditing = false
-    }
 
     private func addActions() {
         contentView.redeemAction = { [weak self] code in


### PR DESCRIPTION
When the app attempts to display an alert on top of the keyboard, `UIKit` may trigger `[UIKeyboardTaskQueue waitUntilAllTasksAreFinished]`. To prevent interference with keyboard notifications, I set `isEditing` to `false` before making an API call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5092)
<!-- Reviewable:end -->
