### PR TITLE
the-buttons-for-deleting-the-account-and-redeeming-a-voucher-ios-294

### DIFF
--- a/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
@@ -192,6 +192,8 @@ class AccountViewController: UIViewController {
         purchaseButton.isEnabled = productState.isReceived && isInteractionEnabled
         contentView.restorePurchasesButton.isEnabled = isInteractionEnabled
         contentView.logoutButton.isEnabled = isInteractionEnabled
+        contentView.redeemVoucherButton.isEnabled = isInteractionEnabled
+        contentView.deleteButton.isEnabled = isInteractionEnabled
 
         view.isUserInteractionEnabled = isInteractionEnabled
         isModalInPresentation = !isInteractionEnabled
@@ -265,7 +267,6 @@ class AccountViewController: UIViewController {
         }
 
         setPaymentState(.restoringPurchases, animated: true)
-
         _ = interactor.restorePurchases(for: accountData.number) { [weak self] completion in
             guard let self else { return }
 


### PR DESCRIPTION
This PR disables the buttons for deleting the account and redeeming a voucher on the account page when the app is restoring purchases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5095)
<!-- Reviewable:end -->
