### PR TITLE
Fix tunnel default route being missing after waking from hibernation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Correctly detect whether OS is Windows Server (primarily for logging in daemon.log).
 
+#### macOS
+- Ensure that the default tunnel route is added back after waking from hibernation. Previously, the
+  tunnel became unusable despite the app appearing to be connected.
+
 
 ## [android/2023.6-beta1] - 2023-08-29
 

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -43,8 +43,7 @@ pub async fn get_best_default_route(
         // Get interface ID
         let index = match if_nametoindex(iface_bytes.as_c_str()) {
             Ok(index) => index,
-            Err(error) => {
-                log::error!("Failed to get index of network interface: {error}");
+            Err(_error) => {
                 continue;
             }
         };

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -273,11 +273,23 @@ impl RouteManagerImpl {
         }
     }
 
-    /// Update routes that use the non-tunnel default interface
+    /// Handle changes to the routing table. Specifically, when a default route is added, modified,
+    /// or deleted:
+    ///
+    /// * Replace the default route with a default route for the tunnel interface (i.e., one whose
+    ///   gateway is set to the link address of the tunnel interface).
+    /// * At the same time, update the route used by non-tunnel interfaces to reach the relay/VPN
+    ///   server. The gateway of the relay route is set to the first interface in the network
+    ///   service order that has a working ifscoped default route.
+    ///
+    /// # Arguments
+    ///
+    /// * `route_is_being_deleted` - A boolean that should be set to `true` if `route` is being
+    ///   deleted. This should be `false` if the route is being modified or added.
     async fn handle_route_change(
         &mut self,
         route: data::RouteMessage,
-        is_deletion: bool,
+        route_is_being_deleted: bool,
     ) -> Result<()> {
         // Ignore routes that aren't default routes
         if !route.is_default().map_err(Error::InvalidData)? {
@@ -292,7 +304,7 @@ impl RouteManagerImpl {
                 let tun_gateway_link_addr =
                     tunnel_route.gateway().and_then(|addr| addr.as_link_addr());
 
-                if new_gateway_link_addr == tun_gateway_link_addr && !is_deletion {
+                if new_gateway_link_addr == tun_gateway_link_addr && !route_is_being_deleted {
                     return Ok(());
                 }
             }

--- a/talpid-routing/src/unix/macos/watch.rs
+++ b/talpid-routing/src/unix/macos/watch.rs
@@ -8,7 +8,7 @@ type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, err_derive::Error)]
 pub enum Error {
-    #[error(display = "Failed to open routing socket")]
+    #[error(display = "Routing socket error: {}", _0)]
     RoutingSocket(routing_socket::Error),
     #[error(display = "Invalid message")]
     InvalidMessage(data::Error),


### PR DESCRIPTION
The fix is simply to not ignore the tunnel route if it's being deleted. The PR also adds a timeout for waiting for responses to messages sent on the socket, since we have observed that they occasionally never arrive. Without the timeout, the route monitor becomes completely unresponsive in that case.

Fixes DES-313.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5096)
<!-- Reviewable:end -->
