### PR TITLE
Quote paths in upload script

### DIFF
--- a/ci/ios/upload-app.sh
+++ b/ci/ios/upload-app.sh
@@ -5,4 +5,4 @@ VM_UPLOAD_IPA_PATH="/Volumes/My Shared Files/build-output/MullvadVPN.ipa"
 API_KEY_PATH="$HOME/ci/app-store-connect-key.json"
 cd ci/
 source ~/.bash_profile
-bundle exec fastlane pilot upload --api-key-path ${API_KEY_PATH} --ipa ${VM_UPLOAD_IPA_PATH}
+bundle exec fastlane pilot upload --api-key-path "${API_KEY_PATH}" --ipa "${VM_UPLOAD_IPA_PATH}"


### PR DESCRIPTION
One last fix - when testing this script out, I passed a `--dry-run` argument to fastlane. This clearly didn't have the effect I wanted as it didn't fail when testing :see_no_evil:. The _production_ copy of this script already has the quotes paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5097)
<!-- Reviewable:end -->
