### PR TITLE
Fix macOS route monitor bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Ensure that the default tunnel route is added back after waking from hibernation. Previously, the
   tunnel became unusable despite the app appearing to be connected.
+- Work around issue where the default route was lost after disconnecting after switching between
+  networks.
+- Fix slow offline detection.
+- Fix inability to switch from a network to a higher-priority network without the tunnel timing out.
 
 
 ## [android/2023.6-beta1] - 2023-08-29

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -6,17 +6,14 @@
 //! in [`RouteManager`] using a `PF_ROUTE` socket. If there is no default route for neither IPv4 nor
 //! IPv6, the host is considered to be offline.
 use futures::{channel::mpsc::UnboundedSender, StreamExt};
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
-    },
-    time::Duration,
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
 };
 use talpid_routing::{DefaultRouteEvent, RouteManagerHandle};
 
 /// How long to wait before announcing changes to the offline state
-const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(2);
+//const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(2);
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
@@ -124,7 +121,9 @@ pub async fn spawn_monitor(
                     };
 
                     // Debounce event updates
-                    tokio::time::sleep(DEBOUNCE_INTERVAL).await;
+                    // FIXME: Debounce is disabled because the DNS config can get messed up
+                    //        when switching between networks otherwise.
+                    //tokio::time::sleep(DEBOUNCE_INTERVAL).await;
 
                     if prev_notified.swap(new_connectivity, Ordering::AcqRel) == new_connectivity {
                         // We don't care about network changes here

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -23,6 +23,15 @@ pub enum Family {
     V6,
 }
 
+impl std::fmt::Display for Family {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Family::V4 => f.write_str("V4"),
+            Family::V6 => f.write_str("V6"),
+        }
+    }
+}
+
 impl From<Family> for IpNetwork {
     fn from(fam: Family) -> Self {
         match fam {

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -1,6 +1,8 @@
+use ipnetwork::IpNetwork;
+use libc::{if_indextoname, IFNAMSIZ};
 use nix::net::if_::{if_nametoindex, InterfaceFlags};
 use std::{
-    ffi::CString,
+    ffi::{CStr, CString},
     io,
     net::{Ipv4Addr, Ipv6Addr},
 };
@@ -21,18 +23,69 @@ pub enum Family {
     V6,
 }
 
-/// Attempt to retrieve the best current default route.
-/// Note: The tunnel interface is not even listed in the service order, so it will be skipped.
+impl From<Family> for IpNetwork {
+    fn from(fam: Family) -> Self {
+        match fam {
+            Family::V4 => IpNetwork::new(Ipv4Addr::UNSPECIFIED.into(), 0).unwrap(),
+            Family::V6 => IpNetwork::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap(),
+        }
+    }
+}
+
+/// Retrieve the current unscoped default route. That is the only default route that does not have
+/// the IF_SCOPE flag set, if such a route exists.
+///
+/// # Note
+///
+/// For some reason, the socket sometimes returns a route with the IF_SCOPE flag set, if there also
+/// exists a scoped route for the same interface. This does not occur if there is no unscoped route,
+/// so we can still rely on it.
+pub async fn get_unscoped_default_route(
+    routing_table: &mut RoutingTable,
+    family: Family,
+) -> Option<RouteMessage> {
+    let mut msg = RouteMessage::new_route(Destination::Network(IpNetwork::from(family)));
+    msg = msg.set_gateway_route(true);
+
+    let route = routing_table
+        .get_route(&msg)
+        .await
+        .unwrap_or_else(|error| {
+            log::error!("Failed to retrieve unscoped default route: {error}");
+            None
+        })?;
+
+    let idx = u32::from(route.interface_index());
+    if idx != 0 {
+        let mut ifname = [0u8; IFNAMSIZ];
+
+        // SAFETY: The buffer is large to contain any interface name.
+        if !unsafe { if_indextoname(idx, ifname.as_mut_ptr() as _) }.is_null() {
+            let ifname = CStr::from_bytes_until_nul(&ifname).unwrap();
+            let name = ifname.to_str().expect("expected ascii");
+
+            // Ignore the unscoped route if its interface is not "active"
+            if !is_active_interface(name, family).unwrap_or(true) {
+                return None;
+            }
+        }
+    }
+
+    Some(route)
+}
+
+/// Retrieve the best current default route. That is the first scoped default route, ordered by
+/// network service order, and with interfaces filtered out if they do not have valid IP addresses
+/// assigned.
+///
+/// # Note
+///
+/// The tunnel interface is not even listed in the service order, so it will be skipped.
 pub async fn get_best_default_route(
     routing_table: &mut RoutingTable,
     family: Family,
 ) -> Option<RouteMessage> {
-    let destination = match family {
-        Family::V4 => super::v4_default(),
-        Family::V6 => super::v6_default(),
-    };
-
-    let mut msg = RouteMessage::new_route(Destination::Network(destination));
+    let mut msg = RouteMessage::new_route(Destination::Network(IpNetwork::from(family)));
     msg = msg.set_gateway_route(true);
 
     for iface in network_service_order() {

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -54,6 +54,17 @@ pub enum Error {
     RestoringUnscopedRoutes,
 }
 
+/// Convenience macro to get the current default route. Macro because I don't want to borrow `self`
+/// mutably.
+macro_rules! get_current_best_default_route {
+    ($self:expr, $family:expr) => {{
+        match $family {
+            interface::Family::V4 => &mut $self.v4_default_route,
+            interface::Family::V6 => &mut $self.v6_default_route,
+        }
+    }};
+}
+
 /// Route manager can be in 1 of 4 states -
 ///  - waiting for a route to be added or removed from the route table
 ///  - obtaining default routes
@@ -353,10 +364,7 @@ impl RouteManagerImpl {
         };
         log::trace!("Best route ({family:?}): {best_route:?}");
 
-        let default_route = match family {
-            interface::Family::V4 => &mut self.v4_default_route,
-            interface::Family::V6 => &mut self.v6_default_route,
-        };
+        let default_route = get_current_best_default_route!(self, family);
 
         if default_route == &best_route {
             log::trace!("Default route ({family:?}) is unchanged");
@@ -420,20 +428,17 @@ impl RouteManagerImpl {
                 Some(route) => route,
                 None => continue,
             };
+            let family = if tunnel_route.is_ipv4() {
+                interface::Family::V4
+            } else {
+                interface::Family::V6
+            };
 
             // Replace the default route with an ifscope route
-            self.set_default_route_ifscope(tunnel_route.is_ipv4(), true)
-                .await?;
+            self.set_default_route_ifscope(family, true).await?;
 
             // Make sure there is really no other unscoped default route
-            let mut msg = RouteMessage::new_route(
-                if tunnel_route.is_ipv4() {
-                    v4_default()
-                } else {
-                    v6_default()
-                }
-                .into(),
-            );
+            let mut msg = RouteMessage::new_route(IpNetwork::from(family).into());
             msg = msg.set_gateway_route(true);
             let old_route = self.routing_table.get_route(&msg).await;
             if let Ok(Some(old_route)) = old_route {
@@ -508,14 +513,11 @@ impl RouteManagerImpl {
     /// instead.
     async fn set_default_route_ifscope(
         &mut self,
-        ipv4: bool,
+        family: interface::Family,
         should_be_ifscoped: bool,
     ) -> Result<()> {
-        let default_route = match (ipv4, &mut self.v4_default_route, &mut self.v6_default_route) {
-            (true, Some(default_route), _) | (false, _, Some(default_route)) => default_route,
-            _ => {
-                return Ok(());
-            }
+        let Some(default_route) = get_current_best_default_route!(self, family) else {
+            return Ok(());
         };
 
         if default_route.is_ifscope() == should_be_ifscoped {
@@ -609,31 +611,39 @@ impl RouteManagerImpl {
     /// Add back unscoped default routes, if they are still missing. This function returns
     /// true when no routes had to be added.
     async fn try_restore_default_routes(&mut self) -> bool {
-        let restore_route = |family, current_route: &mut RouteMessage| {
-            let message = RouteMessage::new_route(IpNetwork::from(family).into());
-            if matches!(self.routing_table.get_route(&message).await, Ok(Some(_))) {
-                true
-            } else {
-                let new_route =
-                    interface::get_best_default_route(&mut self.routing_table, family).await;
-                let old_route = std::mem::replace(current_route, new_route);
-                if old_route != current_route {
-                    self.notify_default_route_listeners(family, current_route.is_some());
-                }
-                if let Some(route) = current_route {
-                    let _ = std::mem::replace(route, route.clone().set_ifscope(0));
-                    if let Err(error) = self.routing_table.add_route(route).await {
-                        log::trace!("Failed to add non-ifscope {family} route: {error}");
-                    }
-                    false
-                } else {
-                    true
-                }
+        self.restore_default_route(interface::Family::V4).await
+            && self.restore_default_route(interface::Family::V6).await
+    }
+
+    /// Add back unscoped default route for the given `family`, if it is still missing. This
+    /// function returns true when no route had to be added.
+    async fn restore_default_route(&mut self, family: interface::Family) -> bool {
+        let current_route = get_current_best_default_route!(self, family);
+        let message = RouteMessage::new_route(IpNetwork::from(family).into());
+        if matches!(self.routing_table.get_route(&message).await, Ok(Some(_))) {
+            return true;
+        }
+
+        let new_route = interface::get_best_default_route(&mut self.routing_table, family).await;
+        let old_route = std::mem::replace(current_route, new_route);
+        let notify = &old_route != current_route;
+
+        let done = if let Some(route) = current_route {
+            *route = route.clone().set_ifscope(0);
+            if let Err(error) = self.routing_table.add_route(route).await {
+                log::trace!("Failed to add non-ifscope {family} route: {error}");
             }
+            false
+        } else {
+            true
         };
 
-        restore_route(interface::Family::V4, &mut self.v4_default_route)
-            && restore_route(interface::Family::V6, &mut self.v6_default_route)
+        if notify {
+            let changed = current_route.is_some();
+            self.notify_default_route_listeners(family, changed);
+        }
+
+        done
     }
 }
 


### PR DESCRIPTION
Fix issues:

* Unscoped default routes were not restored after disconnecting after a switching to a different network.
* We now filter out default routes with "inactive" interfaces. Fixes timeouts when switching from a network lower to one higher in the network service order, and other strange behavior.
* Fix nearly useless offline monitor.

Closes DES-344, DES-343.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5122)
<!-- Reviewable:end -->
