### PR TITLE
Fix list animations for split tunneling

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
@@ -65,17 +65,12 @@ internal fun BaseCell(
     minHeight: Dp = Dimens.cellHeight,
     testTag: String = ""
 ) {
-    val rowModifier =
-        Modifier.let {
-            if (isRowEnabled) {
-                it.clickable { onCellClicked() }
-            } else it
-        }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Start,
         modifier =
-            rowModifier
+            modifier
+                .clickable(isRowEnabled, onClick = onCellClicked)
                 .wrapContentHeight()
                 .defaultMinSize(minHeight = minHeight)
                 .fillMaxWidth()
@@ -89,7 +84,7 @@ internal fun BaseCell(
 
         Spacer(modifier = Modifier.weight(1.0f))
 
-        Column(modifier = modifier.wrapContentWidth().wrapContentHeight()) { bodyView() }
+        Column(modifier = Modifier.wrapContentWidth().wrapContentHeight()) { bodyView() }
     }
 }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SplitTunnelingCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SplitTunnelingCell.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
@@ -33,7 +35,10 @@ import org.koin.androidx.compose.get
 @Composable
 private fun PreviewTunnelingCell() {
     AppTheme {
-        Column(modifier = Modifier.background(color = MaterialTheme.colorScheme.background)) {
+        Column(
+            modifier =
+                Modifier.background(color = MaterialTheme.colorScheme.background).padding(20.dp)
+        ) {
             SplitTunnelingCell(title = "Mullvad VPN", packageName = "", isSelected = false)
             SplitTunnelingCell(title = "Mullvad VPN", packageName = "", isSelected = true)
         }
@@ -63,7 +68,11 @@ fun SplitTunnelingCell(
                 .defaultMinSize(minHeight = Dimens.listItemHeightExtra)
                 .fillMaxWidth()
                 .padding(vertical = Dimens.listItemDivider)
-                .background(MaterialTheme.colorScheme.primaryContainer)
+                .background(
+                    MaterialTheme.colorScheme.primaryContainer.compositeOver(
+                        MaterialTheme.colorScheme.background
+                    )
+                )
                 .clickable(onClick = onCellClicked)
     ) {
         Image(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SwitchComposeCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SwitchComposeCell.kt
@@ -75,11 +75,12 @@ fun NormalSwitchComposeCell(
 fun HeaderSwitchComposeCell(
     title: String,
     isToggled: Boolean,
+    modifier: Modifier = Modifier,
     startPadding: Dp = Dimens.cellStartPadding,
     isEnabled: Boolean = true,
     background: Color = MaterialTheme.colorScheme.primary,
     onCellClicked: (Boolean) -> Unit = {},
-    onInfoClicked: (() -> Unit)? = null
+    onInfoClicked: (() -> Unit)? = null,
 ) {
     SwitchComposeCell(
         titleView = { BaseCellTitle(title = title, style = MaterialTheme.typography.titleMedium) },
@@ -88,7 +89,8 @@ fun HeaderSwitchComposeCell(
         isEnabled = isEnabled,
         background = background,
         onCellClicked = onCellClicked,
-        onInfoClicked = onInfoClicked
+        onInfoClicked = onInfoClicked,
+        modifier,
     )
 }
 
@@ -100,9 +102,11 @@ private fun SwitchComposeCell(
     isEnabled: Boolean,
     background: Color,
     onCellClicked: (Boolean) -> Unit,
-    onInfoClicked: (() -> Unit)?
+    onInfoClicked: (() -> Unit)?,
+    modifier: Modifier = Modifier,
 ) {
     BaseCell(
+        modifier = modifier,
         title = titleView,
         isRowEnabled = isEnabled,
         bodyView = {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SplitTunnelingScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SplitTunnelingScreen.kt
@@ -183,7 +183,10 @@ fun SplitTunnelingScreen(
                             }
                         }
                         item(key = CommonContentKey.SPACER, contentType = ContentType.SPACER) {
-                            Spacer(modifier = Modifier.height(Dimens.mediumPadding))
+                            Spacer(
+                                modifier =
+                                    Modifier.animateItemPlacement().height(Dimens.mediumPadding)
+                            )
                         }
                     }
 
@@ -194,7 +197,8 @@ fun SplitTunnelingScreen(
                         HeaderSwitchComposeCell(
                             title = stringResource(id = R.string.show_system_apps),
                             isToggled = uiState.showSystemApps,
-                            onCellClicked = { newValue -> onShowSystemAppsClick(newValue) }
+                            onCellClicked = { newValue -> onShowSystemAppsClick(newValue) },
+                            modifier = Modifier.animateItemPlacement()
                         )
                     }
                     itemWithDivider(
@@ -202,6 +206,7 @@ fun SplitTunnelingScreen(
                         contentType = ContentType.HEADER
                     ) {
                         BaseCell(
+                            modifier = Modifier.animateItemPlacement(),
                             title = {
                                 Text(
                                     text = stringResource(id = R.string.all_applications),


### PR DESCRIPTION
This pull requests fixes the animations on the Split tunneling view in 3 ways:

- Removes alpha on list items causing them to overlap and look weird.
- Adds animateItemPlacement on missing items
- Fixes modifier on BaseCell so it is applied on top most item

Note: Animations only fully work in release mode and thus might look a bit choppy or incorrect when using emulator and/or debug mode.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5145)
<!-- Reviewable:end -->
