### PR TITLE
Update cc 1.0.83 to fix breakage on Xcode 17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cesu8"


### PR DESCRIPTION
The old `cc` crate broke compilation for the emulator in the latest XCode beta, a newer version of it works as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5146)
<!-- Reviewable:end -->
