### PR TITLE
remove user token after account is deleted

### DIFF
--- a/ios/MullvadREST/RESTAccessTokenManager.swift
+++ b/ios/MullvadREST/RESTAccessTokenManager.swift
@@ -62,5 +62,14 @@ extension REST {
 
             return operation
         }
+
+        func invalidateToken(for accountNumber: String) {
+            operationQueue.addOperation(AsyncBlockOperation(dispatchQueue: dispatchQueue) { [weak self] in
+                guard let self else {
+                    return
+                }
+                self.tokens.removeValue(forKey: accountNumber)
+            })
+        }
     }
 }

--- a/ios/MullvadREST/RESTAccountsProxy.swift
+++ b/ios/MullvadREST/RESTAccountsProxy.swift
@@ -94,6 +94,7 @@ extension REST {
             retryStrategy: RetryStrategy,
             completion: @escaping CompletionHandler<Void>
         ) -> Cancellable {
+            let accessTokenProvider = createAuthorizationProvider(accountNumber: accountNumber)
             let requestHandler = AnyRequestHandler(createURLRequest: { endpoint, authorization in
                 var requestBuilder = try self.requestFactory.createRequestBuilder(
                     endpoint: endpoint,
@@ -104,13 +105,14 @@ extension REST {
                 requestBuilder.addValue(accountNumber, forHTTPHeaderField: "Mullvad-Account-Number")
 
                 return requestBuilder.getRequest()
-            }, authorizationProvider: createAuthorizationProvider(accountNumber: accountNumber))
+            }, authorizationProvider: accessTokenProvider)
 
             let responseHandler = AnyResponseHandler { response, data -> ResponseHandlerResult<Void> in
                 let statusCode = HTTPStatus(rawValue: response.statusCode)
 
                 switch statusCode {
                 case let statusCode where statusCode.isSuccess:
+                    accessTokenProvider.invalidateToken(for: accountNumber)
                     return .success(())
                 default:
                     return .unhandledResponse(

--- a/ios/MullvadREST/RESTAuthorization.swift
+++ b/ios/MullvadREST/RESTAuthorization.swift
@@ -13,6 +13,7 @@ import Operations
 protocol RESTAuthorizationProvider {
     func getAuthorization(completion: @escaping (Result<REST.Authorization, Swift.Error>) -> Void)
         -> Cancellable
+    func invalidateToken(for accountNumber: String)
 }
 
 extension REST {
@@ -36,6 +37,10 @@ extension REST {
                     tokenData.accessToken
                 })
             }
+        }
+
+        func invalidateToken(for accountNumber: String) {
+            accessTokenManager.invalidateToken(for: accountNumber)
         }
     }
 }


### PR DESCRIPTION
This PR introduces a crucial improvement to our system. After an account is deleted, it is essential to remove the associated user token from memory. This enhancement ensures that user data remains secure and reduces the risk of unauthorized access.