### PR TITLE
Add social media blocklists to daemon+CLI

### DIFF
--- a/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/model/DefaultDnsOptions.kt
+++ b/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/model/DefaultDnsOptions.kt
@@ -10,8 +10,14 @@ data class DefaultDnsOptions(
     val blockMalware: Boolean = false,
     val blockAdultContent: Boolean = false,
     val blockGambling: Boolean = false,
+    val blockSocialMedia: Boolean = false,
 ) : Parcelable {
     fun isAnyBlockerEnabled(): Boolean {
-        return blockAds || blockTrackers || blockMalware || blockAdultContent || blockGambling
+        return blockAds ||
+            blockTrackers ||
+            blockMalware ||
+            blockAdultContent ||
+            blockGambling ||
+            blockSocialMedia
     }
 }

--- a/mullvad-cli/src/cmds/dns.rs
+++ b/mullvad-cli/src/cmds/dns.rs
@@ -40,6 +40,10 @@ pub enum DnsSet {
         /// Block domains known to be used for gambling
         #[arg(long)]
         block_gambling: bool,
+
+        /// Block domains related to social media
+        #[arg(long)]
+        block_social_media: bool,
     },
 
     /// Set a list of custom DNS servers
@@ -62,6 +66,7 @@ impl Dns {
                         block_malware,
                         block_adult_content,
                         block_gambling,
+                        block_social_media,
                     },
             } => {
                 Self::set_default(
@@ -70,6 +75,7 @@ impl Dns {
                     block_malware,
                     block_adult_content,
                     block_gambling,
+                    block_social_media,
                 )
                 .await
             }
@@ -94,6 +100,10 @@ impl Dns {
                     options.default_options.block_adult_content
                 );
                 println!("Block gambling: {}", options.default_options.block_gambling);
+                println!(
+                    "Block social media: {}",
+                    options.default_options.block_social_media
+                );
             }
             DnsState::Custom => {
                 println!("Custom DNS: yes\nServers:");
@@ -112,6 +122,7 @@ impl Dns {
         block_malware: bool,
         block_adult_content: bool,
         block_gambling: bool,
+        block_social_media: bool,
     ) -> Result<()> {
         let mut rpc = MullvadProxyClient::new().await?;
         let settings = rpc.get_settings().await?;
@@ -123,6 +134,7 @@ impl Dns {
                 block_malware,
                 block_adult_content,
                 block_gambling,
+                block_social_media,
             },
             ..settings.tunnel_options.dns_options
         })

--- a/mullvad-daemon/src/dns.rs
+++ b/mullvad-daemon/src/dns.rs
@@ -10,6 +10,7 @@ const DNS_TRACKER_BLOCKING_IP_BIT: u8 = 1 << 1; // 0b00000010
 const DNS_MALWARE_BLOCKING_IP_BIT: u8 = 1 << 2; // 0b00000100
 const DNS_ADULT_BLOCKING_IP_BIT: u8 = 1 << 3; // 0b00001000
 const DNS_GAMBLING_BLOCKING_IP_BIT: u8 = 1 << 4; // 0b00010000
+const DNS_SOCIAL_MEDIA_BLOCKING_IP_BIT: u8 = 1 << 5; // 0b00100000
 
 /// Return the resolvers as a vector of `IpAddr`s. Returns `None` when no special resolvers
 /// are requested and the tunnel default gateway should be used.
@@ -34,6 +35,9 @@ pub fn addresses_from_options(options: &DnsOptions) -> Option<Vec<IpAddr>> {
             }
             if options.default_options.block_gambling {
                 last_byte |= DNS_GAMBLING_BLOCKING_IP_BIT;
+            }
+            if options.default_options.block_social_media {
+                last_byte |= DNS_SOCIAL_MEDIA_BLOCKING_IP_BIT;
             }
 
             if last_byte != 0 {

--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -281,6 +281,9 @@ impl<'a> Display for SettingsSummary<'a> {
                 if default_options.block_gambling {
                     content.push("gambling");
                 }
+                if default_options.block_social_media {
+                    content.push("social media");
+                }
                 if content.is_empty() {
                     content.push("default");
                 }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -483,6 +483,7 @@ message DefaultDnsOptions {
   bool block_malware = 3;
   bool block_adult_content = 4;
   bool block_gambling = 5;
+  bool block_social_media = 6;
 }
 
 message CustomDnsOptions { repeated string addresses = 1; }

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -59,6 +59,7 @@ impl From<&mullvad_types::settings::DnsOptions> for proto::DnsOptions {
                 block_malware: options.default_options.block_malware,
                 block_adult_content: options.default_options.block_adult_content,
                 block_gambling: options.default_options.block_gambling,
+                block_social_media: options.default_options.block_social_media,
             }),
             custom_options: Some(proto::CustomDnsOptions {
                 addresses: options
@@ -315,6 +316,7 @@ impl TryFrom<proto::DnsOptions> for mullvad_types::settings::DnsOptions {
                 block_malware: default_options.block_malware,
                 block_adult_content: default_options.block_adult_content,
                 block_gambling: default_options.block_gambling,
+                block_social_media: default_options.block_social_media,
             },
             custom_options: MullvadCustomDnsOptions {
                 addresses: custom_options

--- a/mullvad-types/src/settings/dns.rs
+++ b/mullvad-types/src/settings/dns.rs
@@ -35,6 +35,7 @@ pub struct DefaultDnsOptions {
     pub block_malware: bool,
     pub block_adult_content: bool,
     pub block_gambling: bool,
+    pub block_social_media: bool,
 }
 
 /// Custom DNS config


### PR DESCRIPTION
When infra has deployed these block lists to the relays, this setting will allow blocking social media domains directly with the app.

I intentionally left it out of the changelog for now. This should not go into production before it's added to the UI anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5163)
<!-- Reviewable:end -->
