### PR TITLE
Remove deadcode from mullvad-api

### DIFF
--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -479,22 +479,6 @@ impl RequestFactory {
     }
 }
 
-pub fn get_request<T: serde::de::DeserializeOwned>(
-    factory: &RequestFactory,
-    service: RequestServiceHandle,
-    uri: &str,
-    auth: Option<String>,
-    expected_statuses: &'static [hyper::StatusCode],
-) -> impl Future<Output = Result<Response>> + 'static {
-    let request = factory.get(uri);
-    async move {
-        let mut request = request?;
-        request.set_auth(auth)?;
-        let response = service.request(request).await?;
-        parse_rest_response(response, expected_statuses).await
-    }
-}
-
 pub fn send_request(
     factory: &RequestFactory,
     service: RequestServiceHandle,


### PR DESCRIPTION
This function has been superfluous for ages - I wonder what other dead code we could remove.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5167)
<!-- Reviewable:end -->
