### PR TITLE
Improve notification banner transitions

### DIFF
--- a/ios/MullvadVPN/Notifications/UI/NotificationController.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationController.swift
@@ -12,7 +12,6 @@ final class NotificationController: UIViewController {
     let bannerView: NotificationBannerView = {
         let bannerView = NotificationBannerView()
         bannerView.translatesAutoresizingMaskIntoConstraints = false
-        bannerView.isHidden = true
         bannerView.isAccessibilityElement = true
         return bannerView
     }()
@@ -63,19 +62,11 @@ final class NotificationController: UIViewController {
             // avoid undesired horizontal expansion animation.
             view.layoutIfNeeded()
 
-            bannerView.isHidden = false
             hideBannerConstraint?.isActive = false
             showBannerConstraint?.isActive = true
         } else {
             showBannerConstraint?.isActive = false
             hideBannerConstraint?.isActive = true
-        }
-
-        let finish = { [weak self] in
-            if self?.lastNotification == nil {
-                self?.bannerView.isHidden = true
-            }
-            completion?()
         }
 
         if animated {
@@ -89,12 +80,12 @@ final class NotificationController: UIViewController {
                 self.view.layoutIfNeeded()
             }
             animator.addCompletion { _ in
-                finish()
+                completion?()
             }
             animator.startAnimation()
         } else {
             view.layoutIfNeeded()
-            finish()
+            completion?()
         }
     }
 


### PR DESCRIPTION
Notification banner animations might get choppy if many notifications are fired quickly after each other.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5170)
<!-- Reviewable:end -->
