### PR TITLE
Align copy with design for content blockers

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -22,7 +22,8 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
-
+### Changed
+- The DNS content blockers option do not include the word "block" anymore
 
 ## [2023.4 - 2023-09-12]
 ### Added

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
@@ -63,7 +63,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             let localizedString = NSLocalizedString(
                 "BLOCK_ADS_CELL_LABEL",
                 tableName: "Preferences",
-                value: "Block ads",
+                value: "Ads",
                 comment: ""
             )
 
@@ -78,7 +78,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             let localizedString = NSLocalizedString(
                 "BLOCK_TRACKERS_CELL_LABEL",
                 tableName: "Preferences",
-                value: "Block trackers",
+                value: "Trackers",
                 comment: ""
             )
             configure(
@@ -94,7 +94,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             let localizedString = NSLocalizedString(
                 "BLOCK_MALWARE_CELL_LABEL",
                 tableName: "Preferences",
-                value: "Block malware",
+                value: "Malware",
                 comment: ""
             )
             configure(
@@ -112,7 +112,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             let localizedString = NSLocalizedString(
                 "BLOCK_ADULT_CELL_LABEL",
                 tableName: "Preferences",
-                value: "Block adult content",
+                value: "Adult content",
                 comment: ""
             )
             configure(
@@ -126,7 +126,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             let localizedString = NSLocalizedString(
                 "BLOCK_GAMBLING_CELL_LABEL",
                 tableName: "Preferences",
-                value: "Block gambling",
+                value: "Gambling",
                 comment: ""
             )
             configure(
@@ -140,7 +140,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             let localizedString = NSLocalizedString(
                 "BLOCK_SOCIAL_MEDIA_CELL_LABEL",
                 tableName: "Preferences",
-                value: "Block social media",
+                value: "Social media",
                 comment: ""
             )
             configure(


### PR DESCRIPTION
As the title says, we remove the "block" word from the content blockers to align with other platforms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5182)
<!-- Reviewable:end -->
