### PR TITLE
Support running under build variant app ids

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -89,4 +89,4 @@ val uiModule = module {
 }
 
 const val SELF_PACKAGE_NAME = "SELF_PACKAGE_NAME"
-const val APP_PREFERENCES_NAME = "net.mullvad.mullvadvpn.app_preferences"
+const val APP_PREFERENCES_NAME = "${BuildConfig.APPLICATION_ID}.app_preferences"

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/Actions.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/Actions.kt
@@ -1,5 +1,0 @@
-package net.mullvad.mullvadvpn.lib.common.constant
-
-const val KEY_CONNECT_ACTION = "$MULLVAD_PACKAGE_NAME.connect_action"
-const val KEY_DISCONNECT_ACTION = "$MULLVAD_PACKAGE_NAME.disconnect_action"
-const val KEY_QUIT_ACTION = "$MULLVAD_PACKAGE_NAME.quit_action"

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/Classes.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/Classes.kt
@@ -1,5 +1,0 @@
-package net.mullvad.mullvadvpn.lib.common.constant
-
-const val MULLVAD_PACKAGE_NAME = "net.mullvad.mullvadvpn"
-const val MAIN_ACTIVITY_CLASS = "$MULLVAD_PACKAGE_NAME.ui.MainActivity"
-const val VPN_SERVICE_CLASS = "$MULLVAD_PACKAGE_NAME.service.MullvadVpnService"

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/ClassesAndActions.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/ClassesAndActions.kt
@@ -1,0 +1,14 @@
+package net.mullvad.mullvadvpn.lib.common.constant
+
+// Do not use in cases where the application id is expected since the application id will differ
+// between different builds.
+private const val MULLVAD_PACKAGE_NAME = "net.mullvad.mullvadvpn"
+
+// Classes
+const val MAIN_ACTIVITY_CLASS = "$MULLVAD_PACKAGE_NAME.ui.MainActivity"
+const val VPN_SERVICE_CLASS = "$MULLVAD_PACKAGE_NAME.service.MullvadVpnService"
+
+// Actions
+const val KEY_CONNECT_ACTION = "$MULLVAD_PACKAGE_NAME.connect_action"
+const val KEY_DISCONNECT_ACTION = "$MULLVAD_PACKAGE_NAME.disconnect_action"
+const val KEY_QUIT_ACTION = "$MULLVAD_PACKAGE_NAME.quit_action"

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -16,7 +16,6 @@ import net.mullvad.mullvadvpn.lib.common.constant.KEY_CONNECT_ACTION
 import net.mullvad.mullvadvpn.lib.common.constant.KEY_DISCONNECT_ACTION
 import net.mullvad.mullvadvpn.lib.common.constant.KEY_QUIT_ACTION
 import net.mullvad.mullvadvpn.lib.common.constant.MAIN_ACTIVITY_CLASS
-import net.mullvad.mullvadvpn.lib.common.constant.MULLVAD_PACKAGE_NAME
 import net.mullvad.mullvadvpn.lib.endpoint.ApiEndpointConfiguration
 import net.mullvad.mullvadvpn.lib.endpoint.DefaultApiEndpointConfiguration
 import net.mullvad.mullvadvpn.lib.endpoint.getApiEndpointConfigurationExtras
@@ -267,7 +266,7 @@ class MullvadVpnService : TalpidVpnService() {
     private fun openUi() {
         val intent =
             Intent().apply {
-                setClassName(MULLVAD_PACKAGE_NAME, MAIN_ACTIVITY_CLASS)
+                setClassName(applicationContext.packageName, MAIN_ACTIVITY_CLASS)
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/endpoint/VpnPermission.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.VpnService
 import net.mullvad.mullvadvpn.lib.common.constant.MAIN_ACTIVITY_CLASS
-import net.mullvad.mullvadvpn.lib.common.constant.MULLVAD_PACKAGE_NAME
 import net.mullvad.mullvadvpn.lib.common.util.Intermittent
 import net.mullvad.mullvadvpn.lib.ipc.Event
 import net.mullvad.mullvadvpn.lib.ipc.Request
@@ -30,7 +29,7 @@ class VpnPermission(private val context: Context, private val endpoint: ServiceE
         } else {
             val activityIntent =
                 Intent().apply {
-                    setClassName(MULLVAD_PACKAGE_NAME, MAIN_ACTIVITY_CLASS)
+                    setClassName(context.packageName, MAIN_ACTIVITY_CLASS)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 }

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/AccountExpiryNotification.kt
@@ -11,7 +11,6 @@ import androidx.core.app.NotificationCompat
 import kotlin.properties.Delegates.observable
 import kotlinx.coroutines.delay
 import net.mullvad.mullvadvpn.lib.common.constant.MAIN_ACTIVITY_CLASS
-import net.mullvad.mullvadvpn.lib.common.constant.MULLVAD_PACKAGE_NAME
 import net.mullvad.mullvadvpn.lib.common.util.Intermittent
 import net.mullvad.mullvadvpn.lib.common.util.JobTracker
 import net.mullvad.mullvadvpn.lib.common.util.SdkUtils
@@ -106,7 +105,7 @@ class AccountExpiryNotification(
         val intent =
             if (IS_PLAY_BUILD) {
                 Intent().apply {
-                    setClassName(MULLVAD_PACKAGE_NAME, MAIN_ACTIVITY_CLASS)
+                    setClassName(context.packageName, MAIN_ACTIVITY_CLASS)
                     flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                     action = Intent.ACTION_MAIN
                 }

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/TunnelStateNotification.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import kotlin.properties.Delegates.observable
 import net.mullvad.mullvadvpn.lib.common.constant.MAIN_ACTIVITY_CLASS
-import net.mullvad.mullvadvpn.lib.common.constant.MULLVAD_PACKAGE_NAME
 import net.mullvad.mullvadvpn.lib.common.util.SdkUtils
 import net.mullvad.mullvadvpn.lib.common.util.SdkUtils.isNotificationPermissionGranted
 import net.mullvad.mullvadvpn.lib.common.util.getErrorNotificationResources
@@ -115,7 +114,7 @@ class TunnelStateNotification(val context: Context) {
     fun build(): Notification {
         val intent =
             Intent().apply {
-                setClassName(MULLVAD_PACKAGE_NAME, MAIN_ACTIVITY_CLASS)
+                setClassName(context.packageName, MAIN_ACTIVITY_CLASS)
                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                 action = Intent.ACTION_MAIN
             }
@@ -139,7 +138,7 @@ class TunnelStateNotification(val context: Context) {
     private fun buildAction(): NotificationCompat.Action {
         val action = TunnelStateNotificationAction.from(tunnelState)
         val label = context.getString(action.text)
-        val intent = Intent(action.key).setPackage(MULLVAD_PACKAGE_NAME)
+        val intent = Intent(action.key).setPackage(context.packageName)
         val pendingIntent =
             PendingIntent.getForegroundService(
                 context,

--- a/android/tile/src/main/kotlin/net/mullvad/mullvadvpn/tile/MullvadTileService.kt
+++ b/android/tile/src/main/kotlin/net/mullvad/mullvadvpn/tile/MullvadTileService.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import net.mullvad.mullvadvpn.lib.common.constant.KEY_CONNECT_ACTION
 import net.mullvad.mullvadvpn.lib.common.constant.KEY_DISCONNECT_ACTION
-import net.mullvad.mullvadvpn.lib.common.constant.MULLVAD_PACKAGE_NAME
 import net.mullvad.mullvadvpn.lib.common.constant.VPN_SERVICE_CLASS
 import net.mullvad.mullvadvpn.lib.common.util.SdkUtils.setSubtitleIfSupported
 import net.mullvad.mullvadvpn.model.ServiceResult
@@ -78,7 +77,7 @@ class MullvadTileService : TileService() {
     private fun toggleTunnel() {
         val intent =
             Intent().apply {
-                setClassName(MULLVAD_PACKAGE_NAME, VPN_SERVICE_CLASS)
+                setClassName(applicationContext.packageName, VPN_SERVICE_CLASS)
                 action =
                     if (qsTile.state == Tile.STATE_INACTIVE) {
                         KEY_CONNECT_ACTION

--- a/android/tile/src/main/kotlin/net/mullvad/mullvadvpn/tile/ServiceConnection.kt
+++ b/android/tile/src/main/kotlin/net/mullvad/mullvadvpn/tile/ServiceConnection.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import net.mullvad.mullvadvpn.lib.common.constant.MULLVAD_PACKAGE_NAME
 import net.mullvad.mullvadvpn.lib.common.constant.VPN_SERVICE_CLASS
 import net.mullvad.mullvadvpn.lib.common.util.DispatchingFlow
 import net.mullvad.mullvadvpn.lib.common.util.bindServiceFlow
@@ -81,7 +80,7 @@ class ServiceConnection(context: Context, scope: CoroutineScope) {
     }
 
     private suspend fun connect(context: Context) {
-        val intent = Intent().apply { setClassName(MULLVAD_PACKAGE_NAME, VPN_SERVICE_CLASS) }
+        val intent = Intent().apply { setClassName(context.packageName, VPN_SERVICE_CLASS) }
 
         context
             .bindServiceFlow(intent)


### PR DESCRIPTION
This PR aims to make sure the android app can run under build variant specific app ids, such as `net.mullvad.mullvadvpn.devmole`.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5184)
<!-- Reviewable:end -->
