### PR TITLE
Fix black screen bug if redeem voucher view if canceled to early

### DIFF
--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
@@ -30,6 +30,8 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
     ) {
         self.contentView = RedeemVoucherContentView(configuration: configuration)
         self.interactor = interactor
+        self.contentView.isUserInteractionEnabled = false
+
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -67,6 +69,8 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
+        contentView.isUserInteractionEnabled = true
         contentView.isEditing = true
     }
 


### PR DESCRIPTION
If redeem voucher view is canceled before its presentation transition is done, the view will be removed prematurely and we end up with a black screen.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5187)
<!-- Reviewable:end -->
