### PR TITLE
Update tunnel manager to not return error for configuration loading

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -434,12 +434,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }
 
     private func getInitTunnelManagerOperation() -> AsyncBlockOperation {
+        // This operation is always treated as successful no matter what the configuration load yields.
+        // If the tunnel settings or device state can't be read, we simply pretend they are not there
+        // and leave user in logged out state. VPN config will be removed as well.
         AsyncBlockOperation(dispatchQueue: .main) { finish in
-            self.tunnelManager.loadConfiguration { error in
-                if let error {
-                    fatalError(error.localizedDescription)
-                }
-
+            self.tunnelManager.loadConfiguration {
                 self.logger.debug("Finished initialization.")
 
                 NotificationManager.shared.updateNotifications()

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -168,7 +168,7 @@ final class TunnelManager: StorePaymentObserver {
 
     // MARK: - Public methods
 
-    func loadConfiguration(completionHandler: @escaping (Error?) -> Void) {
+    func loadConfiguration(completionHandler: @escaping () -> Void) {
         let loadTunnelOperation = LoadTunnelConfigurationOperation(
             dispatchQueue: internalQueue,
             interactor: TunnelInteractorProxy(self)
@@ -187,7 +187,7 @@ final class TunnelManager: StorePaymentObserver {
             self.updatePrivateKeyRotationTimer()
             self.startNetworkMonitor()
 
-            completionHandler(completion.error)
+            completionHandler()
         }
 
         loadTunnelOperation.addObserver(


### PR DESCRIPTION
It seems we have sufficient handling of cases where we cannot load the config we need. The current path does not allow the load config operation to return a failure/error, so we cannot end up with a thrown fatalError unless there's an implementation error.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5188)
<!-- Reviewable:end -->
