### PR TITLE
Use optional modifier for scalars in protobuf

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -306,9 +306,9 @@ export class DaemonRpc {
 
       if (settingsUpdate.tunnelProtocol) {
         const tunnelTypeUpdate = new grpcTypes.TunnelTypeUpdate();
-        tunnelTypeUpdate.setTunnelType(
-          convertToTunnelTypeConstraint(settingsUpdate.tunnelProtocol),
-        );
+        if (settingsUpdate.tunnelProtocol !== 'any') {
+          tunnelTypeUpdate.setTunnelType(convertToTunnelType(settingsUpdate.tunnelProtocol.only));
+        }
         normalUpdate.setTunnelType(tunnelTypeUpdate);
       }
 
@@ -416,11 +416,9 @@ export class DaemonRpc {
 
     if (obfuscationSettings.udp2tcpSettings) {
       const grpcUdp2tcpSettings = new grpcTypes.Udp2TcpObfuscationSettings();
-      grpcUdp2tcpSettings.setPort(
-        obfuscationSettings.udp2tcpSettings.port === 'any'
-          ? 0
-          : obfuscationSettings.udp2tcpSettings.port.only,
-      );
+      if (obfuscationSettings.udp2tcpSettings.port !== 'any') {
+        grpcUdp2tcpSettings.setPort(obfuscationSettings.udp2tcpSettings.port.only);
+      }
       grpcObfuscationSettings.setUdp2tcp(grpcUdp2tcpSettings);
     }
 
@@ -995,7 +993,7 @@ function convertFromBlockingError(
       return { type: FirewallPolicyErrorType.generic };
     case grpcTypes.ErrorState.FirewallPolicyError.ErrorType.LOCKED: {
       const pid = error.lockPid;
-      const name = error.lockName;
+      const name = error.lockName!;
       return { type: FirewallPolicyErrorType.locked, pid, name };
     }
   }
@@ -1151,7 +1149,10 @@ function convertFromRelaySettings(
         const normal = relaySettings.getNormal()!;
         const locationConstraint = convertFromLocationConstraint(normal.getLocation());
         const location = locationConstraint ? { only: locationConstraint } : 'any';
-        const tunnelProtocol = convertFromTunnelTypeConstraint(normal.getTunnelType()!);
+        // `getTunnelType()` is not falsy if type is 'any'
+        const tunnelProtocol = convertFromTunnelTypeConstraint(
+          normal.hasTunnelType() ? normal.getTunnelType() : undefined,
+        );
         const providers = normal.getProvidersList();
         const ownership = convertFromOwnership(normal.getOwnership());
         const openvpnConstraints = convertFromOpenVpnConstraints(normal.getOpenvpnConstraints()!);
@@ -1276,11 +1277,13 @@ function convertFromLocationConstraint(
     return { customList: location.getCustomList() };
   } else {
     const innerLocation = location.getLocation()?.toObject();
-    return innerLocation && convertFromRelayLocation(innerLocation);
+    return innerLocation && convertFromGeographicConstraint(innerLocation);
   }
 }
 
-function convertFromRelayLocation(location: grpcTypes.RelayLocation.AsObject): RelayLocation {
+function convertFromGeographicConstraint(
+  location: grpcTypes.GeographicLocationConstraint.AsObject,
+): RelayLocation {
   if (location.hostname) {
     return location;
   } else if (location.city) {
@@ -1356,10 +1359,9 @@ function convertFromObfuscationSettings(
 
   return {
     selectedObfuscation: selectedObfuscationType,
-    udp2tcpSettings:
-      obfuscationSettings?.udp2tcp && obfuscationSettings.udp2tcp.port !== 0
-        ? { port: { only: obfuscationSettings.udp2tcp.port } }
-        : { port: 'any' },
+    udp2tcpSettings: obfuscationSettings?.udp2tcp
+      ? { port: convertFromConstraint(obfuscationSettings.udp2tcp.port) }
+      : { port: 'any' },
   };
 }
 
@@ -1458,14 +1460,16 @@ function convertFromWireguardConstraints(
     result.port = { only: port };
   }
 
-  const ipVersion = constraints.getIpVersion()?.getProtocol();
-  switch (ipVersion) {
-    case grpcTypes.IpVersion.V4:
-      result.ipVersion = { only: 'ipv4' };
-      break;
-    case grpcTypes.IpVersion.V6:
-      result.ipVersion = { only: 'ipv6' };
-      break;
+  // `getIpVersion()` is not falsy if type is 'any'
+  if (constraints.hasIpVersion()) {
+    switch (constraints.getIpVersion()) {
+      case grpcTypes.IpVersion.V4:
+        result.ipVersion = { only: 'ipv4' };
+        break;
+      case grpcTypes.IpVersion.V6:
+        result.ipVersion = { only: 'ipv6' };
+        break;
+    }
   }
 
   const entryLocation = constraints.getEntryLocation();
@@ -1478,9 +1482,9 @@ function convertFromWireguardConstraints(
 }
 
 function convertFromTunnelTypeConstraint(
-  constraint: grpcTypes.TunnelTypeConstraint | undefined,
+  constraint: grpcTypes.TunnelType | undefined,
 ): Constraint<TunnelProtocol> {
-  switch (constraint?.getTunnelType()) {
+  switch (constraint) {
     case grpcTypes.TunnelType.WIREGUARD: {
       return { only: 'wireguard' };
     }
@@ -1518,15 +1522,17 @@ function convertToLocation(
   if (constraint && 'customList' in constraint && constraint.customList) {
     locationConstraint.setCustomList(constraint.customList);
   } else {
-    const location = constraint && convertToRelayLocation(constraint);
+    const location = constraint && convertToGeographicConstraint(constraint);
     locationConstraint.setLocation(location);
   }
 
   return locationConstraint;
 }
 
-function convertToRelayLocation(location: RelayLocation): grpcTypes.RelayLocation {
-  const relayLocation = new grpcTypes.RelayLocation();
+function convertToGeographicConstraint(
+  location: RelayLocation,
+): grpcTypes.GeographicLocationConstraint {
+  const relayLocation = new grpcTypes.GeographicLocationConstraint();
   if ('hostname' in location) {
     relayLocation.setCountry(location.country);
     relayLocation.setCity(location.city);
@@ -1541,22 +1547,13 @@ function convertToRelayLocation(location: RelayLocation): grpcTypes.RelayLocatio
   return relayLocation;
 }
 
-function convertToTunnelTypeConstraint(
-  constraint: Constraint<TunnelType>,
-): grpcTypes.TunnelTypeConstraint | undefined {
-  const grpcConstraint = new grpcTypes.TunnelTypeConstraint();
-
-  if (constraint !== undefined && constraint !== 'any' && 'only' in constraint) {
-    switch (constraint.only) {
-      case 'wireguard':
-        grpcConstraint.setTunnelType(grpcTypes.TunnelType.WIREGUARD);
-        return grpcConstraint;
-      case 'openvpn':
-        grpcConstraint.setTunnelType(grpcTypes.TunnelType.OPENVPN);
-        return grpcConstraint;
-    }
+function convertToTunnelType(tunnelProtocol: TunnelProtocol): grpcTypes.TunnelType {
+  switch (tunnelProtocol) {
+    case 'wireguard':
+      return grpcTypes.TunnelType.WIREGUARD;
+    case 'openvpn':
+      return grpcTypes.TunnelType.OPENVPN;
   }
-  return undefined;
 }
 
 function convertToOpenVpnConstraints(
@@ -1595,9 +1592,7 @@ function convertToWireguardConstraints(
     if (ipVersion) {
       const ipVersionProtocol =
         ipVersion === 'ipv4' ? grpcTypes.IpVersion.V4 : grpcTypes.IpVersion.V6;
-      const ipVersionConstraints = new grpcTypes.IpVersionConstraint();
-      ipVersionConstraints.setProtocol(ipVersionProtocol);
-      wireguardConstraints.setIpVersion(ipVersionConstraints);
+      wireguardConstraints.setIpVersion(ipVersionProtocol);
     }
 
     if (constraint.useMultihop) {
@@ -1687,7 +1682,7 @@ function convertFromCustomLists(customLists: Array<grpcTypes.CustomList>): Custo
     locations: list
       .getLocationsList()
       .map((location) =>
-        convertFromRelayLocation(location.toObject()),
+        convertFromGeographicConstraint(location.toObject()),
       ) as Array<RelayLocationGeographical>,
   }));
 }
@@ -1697,7 +1692,7 @@ function convertToCustomList(customList: ICustomList): grpcTypes.CustomList {
   grpcCustomList.setId(customList.id);
   grpcCustomList.setName(customList.name);
 
-  const locations = customList.locations.map(convertToRelayLocation);
+  const locations = customList.locations.map(convertToGeographicConstraint);
   grpcCustomList.setLocationsList(locations);
 
   return grpcCustomList;

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -161,7 +161,7 @@ message ErrorState {
 
     // LOCKED
     uint32 lock_pid = 2;
-    string lock_name = 3;
+    optional string lock_name = 3;
   }
 
   Cause cause = 1;
@@ -240,17 +240,17 @@ message ProxyEndpoint {
 }
 
 message GeoIpLocation {
-  string ipv4 = 1;
-  string ipv6 = 2;
+  optional string ipv4 = 1;
+  optional string ipv6 = 2;
   string country = 3;
-  string city = 4;
+  optional string city = 4;
   double latitude = 5;
   double longitude = 6;
   bool mullvad_exit_ip = 7;
-  string hostname = 8;
-  string bridge_hostname = 9;
-  string entry_hostname = 10;
-  string obfuscator_hostname = 11;
+  optional string hostname = 8;
+  optional string bridge_hostname = 9;
+  optional string entry_hostname = 10;
+  optional string obfuscator_hostname = 11;
 }
 
 message TunnelMetadata { string tunnel_interface = 1; }
@@ -297,14 +297,14 @@ message BridgeSettings {
 message LocationConstraint {
   oneof type {
     string custom_list = 1;
-    RelayLocation location = 2;
+    GeographicLocationConstraint location = 2;
   }
 }
 
-message RelayLocation {
+message GeographicLocationConstraint {
   string country = 1;
-  string city = 2;
-  string hostname = 3;
+  optional string city = 2;
+  optional string hostname = 3;
 }
 
 message BridgeState {
@@ -316,7 +316,7 @@ message BridgeState {
   State state = 1;
 }
 
-message Udp2TcpObfuscationSettings { uint32 port = 1; }
+message Udp2TcpObfuscationSettings { optional uint32 port = 1; }
 
 message ObfuscationSettings {
   enum SelectedObfuscation {
@@ -331,7 +331,7 @@ message ObfuscationSettings {
 message CustomList {
   string id = 1;
   string name = 2;
-  repeated RelayLocation locations = 3;
+  repeated GeographicLocationConstraint locations = 3;
 }
 
 message CustomListSettings { repeated CustomList custom_lists = 1; }
@@ -410,12 +410,10 @@ message RelaySettings {
   }
 }
 
-message TunnelTypeConstraint { TunnelType tunnel_type = 1; }
-
 message NormalRelaySettings {
   LocationConstraint location = 1;
   repeated string providers = 2;
-  TunnelTypeConstraint tunnel_type = 3;
+  optional TunnelType tunnel_type = 3;
   WireguardConstraints wireguard_constraints = 4;
   OpenvpnConstraints openvpn_constraints = 5;
   Ownership ownership = 6;
@@ -433,11 +431,11 @@ message NormalRelaySettingsUpdate {
 
 message ProviderUpdate { repeated string providers = 1; }
 
-message TunnelTypeUpdate { TunnelTypeConstraint tunnel_type = 2; }
+message TunnelTypeUpdate { optional TunnelType tunnel_type = 2; }
 
 message TransportPort {
   TransportProtocol protocol = 1;
-  uint32 port = 2;
+  optional uint32 port = 2;
 }
 
 message OpenvpnConstraints { TransportPort port = 1; }
@@ -449,11 +447,9 @@ enum IpVersion {
   V6 = 1;
 }
 
-message IpVersionConstraint { IpVersion protocol = 1; }
-
 message WireguardConstraints {
-  uint32 port = 1;
-  IpVersionConstraint ip_version = 2;
+  optional uint32 port = 1;
+  optional IpVersion ip_version = 2;
   bool use_multihop = 3;
   LocationConstraint entry_location = 4;
 }
@@ -484,7 +480,7 @@ message ConnectionConfig {
     TunnelConfig tunnel = 1;
     PeerConfig peer = 2;
     string ipv4_gateway = 3;
-    string ipv6_gateway = 4;
+    optional string ipv6_gateway = 4;
   }
 
   oneof config {
@@ -503,9 +499,9 @@ message QuantumResistantState {
 }
 
 message TunnelOptions {
-  message OpenvpnOptions { uint32 mssfix = 1; }
+  message OpenvpnOptions { optional uint32 mssfix = 1; }
   message WireguardOptions {
-    uint32 mtu = 1;
+    optional uint32 mtu = 1;
     google.protobuf.Duration rotation_interval = 2;
     QuantumResistantState quantum_resistant = 4;
   }
@@ -555,7 +551,7 @@ message AppVersionInfo {
   bool supported = 1;
   string latest_stable = 2;
   string latest_beta = 3;
-  string suggested_upgrade = 4;
+  optional string suggested_upgrade = 4;
 }
 
 message RelayListCountry {
@@ -581,7 +577,7 @@ message Relay {
 
   string hostname = 1;
   string ipv4_addr_in = 2;
-  string ipv6_addr_in = 3;
+  optional string ipv6_addr_in = 3;
   bool include_in_country = 4;
   bool active = 5;
   bool owned = 6;

--- a/mullvad-management-interface/src/types/conversions/custom_list.rs
+++ b/mullvad-management-interface/src/types/conversions/custom_list.rs
@@ -33,7 +33,7 @@ impl From<mullvad_types::custom_list::CustomList> for proto::CustomList {
         let locations = custom_list
             .locations
             .into_iter()
-            .map(proto::RelayLocation::from)
+            .map(proto::GeographicLocationConstraint::from)
             .collect();
         Self {
             id: custom_list.id.to_string(),
@@ -58,41 +58,5 @@ impl TryFrom<proto::CustomList> for mullvad_types::custom_list::CustomList {
             name: custom_list.name,
             locations,
         })
-    }
-}
-
-impl TryFrom<proto::RelayLocation> for GeographicLocationConstraint {
-    type Error = FromProtobufTypeError;
-
-    fn try_from(relay_location: proto::RelayLocation) -> Result<Self, Self::Error> {
-        match (
-            relay_location.country.as_ref(),
-            relay_location.city.as_ref(),
-            relay_location.hostname.as_ref(),
-        ) {
-            ("", ..) => Err(FromProtobufTypeError::InvalidArgument(
-                "Invalid geographic relay location",
-            )),
-            (_country, "", "") => Ok(GeographicLocationConstraint::Country(
-                relay_location.country,
-            )),
-            (_country, _city, "") => Ok(GeographicLocationConstraint::City(
-                relay_location.country,
-                relay_location.city,
-            )),
-            (_country, city, _hostname) => {
-                if city.is_empty() {
-                    Err(FromProtobufTypeError::InvalidArgument(
-                        "Relay location must contain a city if hostname is included",
-                    ))
-                } else {
-                    Ok(GeographicLocationConstraint::Hostname(
-                        relay_location.country,
-                        relay_location.city,
-                        relay_location.hostname,
-                    ))
-                }
-            }
-        }
     }
 }

--- a/mullvad-management-interface/src/types/conversions/custom_tunnel.rs
+++ b/mullvad-management-interface/src/types/conversions/custom_tunnel.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    conversions::{bytes_to_privkey, bytes_to_pubkey, option_from_proto_string},
+    conversions::{bytes_to_privkey, bytes_to_pubkey},
     proto, FromProtobufTypeError,
 };
 use talpid_types::net::wireguard;
@@ -51,7 +51,8 @@ impl TryFrom<proto::ConnectionConfig> for mullvad_types::ConnectionConfig {
                 let ipv4_gateway = config.ipv4_gateway.parse().map_err(|_err| {
                     FromProtobufTypeError::InvalidArgument("invalid IPv4 gateway")
                 })?;
-                let ipv6_gateway = option_from_proto_string(config.ipv6_gateway)
+                let ipv6_gateway = config
+                    .ipv6_gateway
                     .map(|addr| {
                         addr.parse().map_err(|_err| {
                             FromProtobufTypeError::InvalidArgument("invalid IPv6 gateway")
@@ -144,8 +145,7 @@ impl From<mullvad_types::ConnectionConfig> for proto::ConnectionConfig {
                         ipv6_gateway: config
                             .ipv6_gateway
                             .as_ref()
-                            .map(|address| address.to_string())
-                            .unwrap_or_default(),
+                            .map(|address| address.to_string()),
                     })
                 }
             }),

--- a/mullvad-management-interface/src/types/conversions/location.rs
+++ b/mullvad-management-interface/src/types/conversions/location.rs
@@ -1,22 +1,19 @@
-use crate::types::{
-    conversions::{arg_from_str, option_from_proto_string},
-    proto, FromProtobufTypeError,
-};
+use crate::types::{conversions::arg_from_str, proto, FromProtobufTypeError};
 
 impl From<mullvad_types::location::GeoIpLocation> for proto::GeoIpLocation {
     fn from(geoip: mullvad_types::location::GeoIpLocation) -> proto::GeoIpLocation {
         proto::GeoIpLocation {
-            ipv4: geoip.ipv4.map(|ip| ip.to_string()).unwrap_or_default(),
-            ipv6: geoip.ipv6.map(|ip| ip.to_string()).unwrap_or_default(),
+            ipv4: geoip.ipv4.map(|ip| ip.to_string()),
+            ipv6: geoip.ipv6.map(|ip| ip.to_string()),
             country: geoip.country,
-            city: geoip.city.unwrap_or_default(),
+            city: geoip.city,
             latitude: geoip.latitude,
             longitude: geoip.longitude,
             mullvad_exit_ip: geoip.mullvad_exit_ip,
-            hostname: geoip.hostname.unwrap_or_default(),
-            bridge_hostname: geoip.bridge_hostname.unwrap_or_default(),
-            entry_hostname: geoip.entry_hostname.unwrap_or_default(),
-            obfuscator_hostname: geoip.obfuscator_hostname.unwrap_or_default(),
+            hostname: geoip.hostname,
+            bridge_hostname: geoip.bridge_hostname,
+            entry_hostname: geoip.entry_hostname,
+            obfuscator_hostname: geoip.obfuscator_hostname,
         }
     }
 }
@@ -26,21 +23,23 @@ impl TryFrom<proto::GeoIpLocation> for mullvad_types::location::GeoIpLocation {
 
     fn try_from(geoip: proto::GeoIpLocation) -> Result<Self, Self::Error> {
         Ok(mullvad_types::location::GeoIpLocation {
-            ipv4: option_from_proto_string(geoip.ipv4)
+            ipv4: geoip
+                .ipv4
                 .map(|addr| arg_from_str(&addr, "invalid IPv4 address"))
                 .transpose()?,
-            ipv6: option_from_proto_string(geoip.ipv6)
+            ipv6: geoip
+                .ipv6
                 .map(|addr| arg_from_str(&addr, "invalid IPv6 address"))
                 .transpose()?,
             country: geoip.country,
-            city: option_from_proto_string(geoip.city),
+            city: geoip.city,
             latitude: geoip.latitude,
             longitude: geoip.longitude,
             mullvad_exit_ip: geoip.mullvad_exit_ip,
-            hostname: option_from_proto_string(geoip.hostname),
-            bridge_hostname: option_from_proto_string(geoip.bridge_hostname),
-            entry_hostname: option_from_proto_string(geoip.entry_hostname),
-            obfuscator_hostname: option_from_proto_string(geoip.obfuscator_hostname),
+            hostname: geoip.hostname,
+            bridge_hostname: geoip.bridge_hostname,
+            entry_hostname: geoip.entry_hostname,
+            obfuscator_hostname: geoip.obfuscator_hostname,
         })
     }
 }

--- a/mullvad-management-interface/src/types/conversions/mod.rs
+++ b/mullvad-management-interface/src/types/conversions/mod.rs
@@ -45,14 +45,6 @@ fn bytes_to_wg_key<'a>(
     <&[u8; 32]>::try_from(bytes).map_err(|_| FromProtobufTypeError::InvalidArgument(error_msg))
 }
 
-/// Returns `Option<String>`, where an empty string represents `None`.
-fn option_from_proto_string(s: String) -> Option<String> {
-    match s {
-        s if s.is_empty() => None,
-        s => Some(s),
-    }
-}
-
 fn arg_from_str<T: FromStr<Err = E>, E>(
     s: &str,
     invalid_arg_msg: &'static str,

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -1,5 +1,4 @@
 use crate::types::{conversions::arg_from_str, proto, FromProtobufTypeError};
-use mullvad_types::relay_constraints::Constraint;
 use std::net::SocketAddr;
 
 impl From<talpid_types::net::TunnelEndpoint> for proto::TunnelEndpoint {
@@ -155,21 +154,11 @@ impl From<proto::TransportProtocol> for talpid_types::net::TransportProtocol {
     }
 }
 
-impl TryFrom<proto::TunnelTypeConstraint> for Constraint<talpid_types::net::TunnelType> {
-    type Error = FromProtobufTypeError;
-
-    fn try_from(
-        tunnel_type: proto::TunnelTypeConstraint,
-    ) -> Result<Constraint<talpid_types::net::TunnelType>, Self::Error> {
-        let tunnel_type = try_tunnel_type_from_i32(tunnel_type.tunnel_type)?;
-        Ok(Constraint::Only(tunnel_type))
-    }
-}
-
-impl From<proto::IpVersion> for proto::IpVersionConstraint {
+impl From<proto::IpVersion> for talpid_types::net::IpVersion {
     fn from(version: proto::IpVersion) -> Self {
-        Self {
-            protocol: i32::from(version),
+        match version {
+            proto::IpVersion::V4 => talpid_types::net::IpVersion::V4,
+            proto::IpVersion::V6 => talpid_types::net::IpVersion::V6,
         }
     }
 }

--- a/mullvad-management-interface/src/types/conversions/relay_list.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_list.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::types::{
-    conversions::{bytes_to_pubkey, option_from_proto_string, to_proto_any, try_from_proto_any},
+    conversions::{bytes_to_pubkey, to_proto_any, try_from_proto_any},
     proto, FromProtobufTypeError,
 };
 
@@ -106,10 +106,7 @@ impl From<mullvad_types::relay_list::Relay> for proto::Relay {
         Self {
             hostname: relay.hostname,
             ipv4_addr_in: relay.ipv4_addr_in.to_string(),
-            ipv6_addr_in: relay
-                .ipv6_addr_in
-                .map(|addr| addr.to_string())
-                .unwrap_or_default(),
+            ipv6_addr_in: relay.ipv6_addr_in.map(|addr| addr.to_string()),
             include_in_country: relay.include_in_country,
             active: relay.active,
             owned: relay.owned,
@@ -249,7 +246,8 @@ impl TryFrom<proto::Relay> for mullvad_types::relay_list::Relay {
             }
         };
 
-        let ipv6_addr_in = option_from_proto_string(relay.ipv6_addr_in)
+        let ipv6_addr_in = relay
+            .ipv6_addr_in
             .map(|addr| {
                 addr.parse().map_err(|_err| {
                     FromProtobufTypeError::InvalidArgument("invalid relay IPv6 address")

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -82,10 +82,10 @@ impl From<&mullvad_types::settings::TunnelOptions> for proto::TunnelOptions {
     fn from(options: &mullvad_types::settings::TunnelOptions) -> Self {
         Self {
             openvpn: Some(proto::tunnel_options::OpenvpnOptions {
-                mssfix: u32::from(options.openvpn.mssfix.unwrap_or_default()),
+                mssfix: options.openvpn.mssfix.map(u32::from),
             }),
             wireguard: Some(proto::tunnel_options::WireguardOptions {
-                mtu: u32::from(options.wireguard.mtu.unwrap_or_default()),
+                mtu: options.wireguard.mtu.map(u32::from),
                 rotation_interval: options.wireguard.rotation_interval.map(|ivl| {
                     prost_types::Duration::try_from(std::time::Duration::from(ivl))
                         .expect("Failed to convert std::time::Duration to prost_types::Duration for tunnel_options.wireguard.rotation_interval")
@@ -247,18 +247,10 @@ impl TryFrom<proto::TunnelOptions> for mullvad_types::settings::TunnelOptions {
 
         Ok(Self {
             openvpn: net::openvpn::TunnelOptions {
-                mssfix: if openvpn_options.mssfix != 0 {
-                    Some(openvpn_options.mssfix as u16)
-                } else {
-                    None
-                },
+                mssfix: openvpn_options.mssfix.map(|mssfix| mssfix as u16),
             },
             wireguard: mullvad_types::wireguard::TunnelOptions {
-                mtu: if wireguard_options.mtu != 0 {
-                    Some(wireguard_options.mtu as u16)
-                } else {
-                    None
-                },
+                mtu: wireguard_options.mtu.map(|mtu| mtu as u16),
                 rotation_interval: wireguard_options
                     .rotation_interval
                     .map(std::time::Duration::try_from)

--- a/mullvad-management-interface/src/types/conversions/version.rs
+++ b/mullvad-management-interface/src/types/conversions/version.rs
@@ -6,7 +6,7 @@ impl From<mullvad_types::version::AppVersionInfo> for proto::AppVersionInfo {
             supported: version_info.supported,
             latest_stable: version_info.latest_stable,
             latest_beta: version_info.latest_beta,
-            suggested_upgrade: version_info.suggested_upgrade.unwrap_or_default(),
+            suggested_upgrade: version_info.suggested_upgrade,
         }
     }
 }
@@ -17,11 +17,7 @@ impl From<proto::AppVersionInfo> for mullvad_types::version::AppVersionInfo {
             supported: version_info.supported,
             latest_stable: version_info.latest_stable,
             latest_beta: version_info.latest_beta,
-            suggested_upgrade: if version_info.suggested_upgrade.is_empty() {
-                None
-            } else {
-                Some(version_info.suggested_upgrade)
-            },
+            suggested_upgrade: version_info.suggested_upgrade,
         }
     }
 }


### PR DESCRIPTION
Instead of mapping default values of strings and integers to 0/"", we can just set them to optional. `optional` was reintroduced in protobuf 3.15.

Closes DES-367.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5191)
<!-- Reviewable:end -->
