### PR TITLE
Partially revert "Remove android file migration"

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: relay-list
-          path: build/relays.json
+          path: build
 
       - name: Build Android app
         uses: burrunan/gradle-cache-action@v1

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/FileResourceExtractor.kt
@@ -1,0 +1,23 @@
+package net.mullvad.mullvadvpn.service
+
+import android.content.Context
+import java.io.File
+import java.io.FileOutputStream
+
+class FileResourceExtractor(val context: Context) {
+    fun extract(asset: String, force: Boolean = false) {
+        val destination = File(context.filesDir, asset)
+
+        if (!destination.exists() || force) {
+            extractFile(asset, destination)
+        }
+    }
+
+    private fun extractFile(asset: String, destination: File) {
+        val destinationStream = FileOutputStream(destination)
+
+        context.assets.open(asset).copyTo(destinationStream)
+
+        destinationStream.close()
+    }
+}


### PR DESCRIPTION
This PR aims to restore the `relays.json` asset->file extraction that was removed by accident in #4449. The remaining file migration logic will not be re-introduced.

This partially reverts commit e64abbb94ae641d05ee3cf8dc0f4340b17cdc033.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5194)
<!-- Reviewable:end -->
