### PR TITLE
Add platform to download urls

### DIFF
--- a/gui/src/config.json
+++ b/gui/src/config.json
@@ -4,8 +4,7 @@
     "purchase": "https://mullvad.net/account/",
     "faq": "https://mullvad.net/help/tag/mullvad-app/",
     "privacyGuide": "https://mullvad.net/help/first-steps-towards-online-privacy/",
-    "download": "https://mullvad.net/download/",
-    "betaDownload": "https://mullvad.net/download/beta"
+    "download": "https://mullvad.net/download/vpn/"
   },
   "colors": {
     "darkBlue": "rgb(25, 46, 69)",

--- a/gui/src/renderer/components/ProblemReport.tsx
+++ b/gui/src/renderer/components/ProblemReport.tsx
@@ -12,8 +12,8 @@ import {
   useState,
 } from 'react';
 
-import { links } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { getDownloadUrl } from '../../shared/version';
 import { useAppContext } from '../context';
 import useActions from '../lib/actionsHook';
 import { useHistory } from '../lib/history';
@@ -326,7 +326,7 @@ function OutdatedVersionWarningDialog() {
   }, []);
 
   const openDownloadLink = useCallback(async () => {
-    await openUrl(suggestedIsBeta ? links.betaDownload : links.download);
+    await openUrl(getDownloadUrl(suggestedIsBeta));
   }, [suggestedIsBeta]);
 
   const onClose = useCallback(() => history.pop(), [history.pop]);

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
 
-import { colors, links } from '../../config.json';
+import { colors } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { getDownloadUrl } from '../../shared/version';
 import { useAppContext } from '../context';
 import { useHistory } from '../lib/history';
 import { RoutePath } from '../lib/routes';
@@ -148,10 +149,10 @@ function AppVersionButton() {
   const isOffline = useSelector((state) => state.connection.isBlocked);
 
   const { openUrl } = useAppContext();
-  const openDownloadLink = useCallback(
-    () => openUrl(suggestedIsBeta ? links.betaDownload : links.download),
-    [openUrl, suggestedIsBeta],
-  );
+  const openDownloadLink = useCallback(() => openUrl(getDownloadUrl(suggestedIsBeta)), [
+    openUrl,
+    suggestedIsBeta,
+  ]);
 
   let icon;
   let footer;

--- a/gui/src/shared/notifications/unsupported-version.ts
+++ b/gui/src/shared/notifications/unsupported-version.ts
@@ -1,5 +1,5 @@
-import { links } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { getDownloadUrl } from '../version';
 import {
   InAppNotification,
   InAppNotificationProvider,
@@ -31,7 +31,7 @@ export class UnsupportedVersionNotificationProvider
       severity: SystemNotificationSeverityType.high,
       action: {
         type: 'open-url',
-        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
+        url: getDownloadUrl(this.context.suggestedIsBeta ?? false),
         text: messages.pgettext('notifications', 'Upgrade'),
       },
       presentOnce: { value: true, name: this.constructor.name },
@@ -46,7 +46,7 @@ export class UnsupportedVersionNotificationProvider
       subtitle: this.getMessage(),
       action: {
         type: 'open-url',
-        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
+        url: getDownloadUrl(this.context.suggestedIsBeta ?? false),
       },
     };
   }

--- a/gui/src/shared/notifications/update-available.ts
+++ b/gui/src/shared/notifications/update-available.ts
@@ -1,7 +1,7 @@
 import { sprintf } from 'sprintf-js';
 
-import { links } from '../../config.json';
 import { messages } from '../../shared/gettext';
+import { getDownloadUrl } from '../version';
 import {
   InAppNotification,
   InAppNotificationProvider,
@@ -33,7 +33,7 @@ export class UpdateAvailableNotificationProvider
       subtitle: this.inAppMessage(),
       action: {
         type: 'open-url',
-        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
+        url: getDownloadUrl(this.context.suggestedIsBeta ?? false),
       },
     };
   }
@@ -45,7 +45,7 @@ export class UpdateAvailableNotificationProvider
       severity: SystemNotificationSeverityType.medium,
       action: {
         type: 'open-url',
-        url: this.context.suggestedIsBeta ? links.betaDownload : links.download,
+        url: getDownloadUrl(this.context.suggestedIsBeta ?? false),
         text: messages.pgettext('notifications', 'Upgrade'),
       },
       presentOnce: { value: true, name: this.constructor.name },

--- a/gui/src/shared/version.ts
+++ b/gui/src/shared/version.ts
@@ -1,0 +1,22 @@
+import { links } from '../config.json';
+
+export function getDownloadUrl(suggestedIsBeta: boolean): string {
+  let url = links.download;
+  switch (process.platform ?? window.env.platform) {
+    case 'win32':
+      url += 'windows/';
+      break;
+    case 'linux':
+      url += 'linux/';
+      break;
+    case 'darwin':
+      url += 'macos/';
+      break;
+  }
+
+  if (suggestedIsBeta) {
+    url += 'beta/';
+  }
+
+  return url;
+}


### PR DESCRIPTION
This PR adds support for including the platform in the download url to make it work with spoofed user agents.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5197)
<!-- Reviewable:end -->
