### PR TITLE
Include platform in Android download URL

### DIFF
--- a/android/lib/resource/src/main/res/values/strings_non_translatable.xml
+++ b/android/lib/resource/src/main/res/values/strings_non_translatable.xml
@@ -3,7 +3,7 @@
     <string name="login_hint" translatable="false">0000 0000 0000 0000</string>
     <string name="voucher_hint" translatable="false">XXXX-XXXX-XXXX-XXXX</string>
     <string name="account_url" translatable="false">https://mullvad.net/account</string>
-    <string name="download_url" translatable="false">https://mullvad.net/download</string>
+    <string name="download_url" translatable="false">https://mullvad.net/download/vpn/android</string>
     <string name="faqs_and_guides_url" translatable="false">https://mullvad.net/help/tag/mullvad-app/</string>
     <string name="privacy_policy_url" translatable="false">https://mullvad.net/help/privacy-policy/</string>
     <string name="split_tunneling" translatable="false">Split tunneling</string>


### PR DESCRIPTION
This PR changes the Android download URL to include the platform to avoid showing the wrong download page if the user-agent is spoofed. It will now lead to: https://mullvad.net/download/vpn/android

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5205)
<!-- Reviewable:end -->
