### PR TITLE
Add signatures in all deb and rpm artifacts produced by build server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add customizable relay lists to the CLI on desktop. Custom lists can be managed through
   `mullvad custom-lists` and can be selected through `mullvad relay set` and `mullvad bridge set`.
 
+#### Linux
+- Start signing the deb and rpm files (GPG)
+
 ### Changed
 #### Android
 - Migrate welcome view to compose.


### PR DESCRIPTION
In preparation for providing deb and yum repositories we should start signing the corresponding Linux artifacts. This PR adds the signing. This is a prerequisite for providing the repositories, but is also good even without the repositories. Just adds more integrity to all produced artifacts.

At first, I wanted to do the signing in `build.sh` where we do other signing. But since that runs in a container on Linux, we can't. The keys are not available there.

So I moved it up one level and instead sign in the buildserver specific script, running outside the container.

The dependencies/changed build server setup requirements include:
* Installing RPM signing tools: `dnf install rpm rpmsign`
* Configure RPM to use the correct GPG key:
  ```
  echo "%_signature gpg
  %_gpg_name A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF" > ~/.rpmmacros
  ```
* Getting hold of `dpkg-sig`. Since it's not available in Fedora I did this to vendor it:
  * Steal the `dpkg-sig` Perl script from a Debian container:
    ```
    $ podman run --rm -it -v $HOME/.local/bin:/the_outside:Z debian:latest
    root # apt update && apt install dpkg-sig
    root # cp $(which dpkg-sig) /the_outside/
    ```
  * Install the required Perl dependencies:
    ```
    $ sudo dnf install cpan
    $ sudo cpan Config::File
    ```
* Configure the signing key as the default key in GnuPG, so `dpkg-sig` will pick the correct one. `~/.gnupg/gpg.conf`:
  ```
  default-key A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF
  ```

I will add the above buildserver setup instructions to the documentation once this has been approved/merged.

I have tested this out, and the artifacts are here: https://releases.mullvad.net/builds/2023.5-beta2-dev-382d72+test-dpkg-sig/

To verify signatures issue these commands:
* Deb: `dpkg-sig --verify $the_deb`
* Rpm: `sudo rpm --import /path/to/mullvad-code-signing.asc` + `rpm -K $the_rpm`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5208)
<!-- Reviewable:end -->
