### PR TITLE
Add burst guard to macOS route monitor

### DIFF
--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -12,9 +12,6 @@ use std::sync::{
 };
 use talpid_routing::{DefaultRouteEvent, RouteManagerHandle};
 
-/// How long to wait before announcing changes to the offline state
-//const DEBOUNCE_INTERVAL: Duration = Duration::from_secs(2);
-
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "Failed to initialize route monitor")]
@@ -119,11 +116,6 @@ pub async fn spawn_monitor(
                         Some(tx) => tx,
                         None => return,
                     };
-
-                    // Debounce event updates
-                    // FIXME: Debounce is disabled because the DNS config can get messed up
-                    //        when switching between networks otherwise.
-                    //tokio::time::sleep(DEBOUNCE_INTERVAL).await;
 
                     if prev_notified.swap(new_connectivity, Ordering::AcqRel) == new_connectivity {
                         // We don't care about network changes here

--- a/talpid-routing/src/debounce.rs
+++ b/talpid-routing/src/debounce.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::{
     sync::mpsc::{channel, RecvTimeoutError, Sender},
     time::{Duration, Instant},
@@ -70,7 +72,7 @@ impl BurstGuard {
 
     /// When `stop` returns an then the `BurstGuard` thread is guaranteed to not make any further
     /// calls to `callback`.
-    pub fn stop(&self) {
+    pub fn stop(self) {
         let (sender, listener) = channel();
         // If we could not send then it means the thread has already shut down and we can return
         if self.sender.send(BurstGuardEvent::Shutdown(sender)).is_ok() {
@@ -78,6 +80,12 @@ impl BurstGuard {
             // it is Err it also means it shut down.
             let _ = listener.recv();
         }
+    }
+
+    /// Stop without waiting for in-flight events to complete.
+    pub fn stop_nonblocking(self) {
+        let (sender, _listener) = channel();
+        let _ = self.sender.send(BurstGuardEvent::Shutdown(sender));
     }
 
     /// Asynchronously trigger burst

--- a/talpid-routing/src/debounce.rs
+++ b/talpid-routing/src/debounce.rs
@@ -1,0 +1,87 @@
+use std::{
+    sync::mpsc::{channel, RecvTimeoutError, Sender},
+    time::{Duration, Instant},
+};
+
+/// BurstGuard is a wrapper for a function that protects that function from being called too many
+/// times in a short amount of time. To call the function use `burst_guard.trigger()`, at that point
+/// `BurstGuard` will wait for `buffer_period` and if no more calls to `trigger` are made then it
+/// will call the wrapped function. If another call to `trigger` is made during this wait then it
+/// will wait another `buffer_period`, this happens over and over until either
+/// `longest_buffer_period` time has elapsed or until no call to `trigger` has been made in
+/// `buffer_period`. At which point the wrapped function will be called.
+pub struct BurstGuard {
+    sender: Sender<BurstGuardEvent>,
+}
+
+enum BurstGuardEvent {
+    Trigger,
+    Shutdown(Sender<()>),
+}
+
+impl BurstGuard {
+    pub fn new<F: Fn() + Send + 'static>(callback: F) -> Self {
+        /// This is the period of time the `BurstGuard` will wait for a new trigger to be sent
+        /// before it calls the callback.
+        const BURST_BUFFER_PERIOD: Duration = Duration::from_millis(200);
+        /// This is the longest period that the `BurstGuard` will wait from the first trigger till
+        /// it calls the callback.
+        const BURST_LONGEST_BUFFER_PERIOD: Duration = Duration::from_secs(2);
+
+        let (sender, listener) = channel();
+        std::thread::spawn(move || {
+            // The `stop` implementation assumes that this thread will not call `callback` again
+            // if the listener has been dropped.
+            while let Ok(message) = listener.recv() {
+                match message {
+                    BurstGuardEvent::Trigger => {
+                        let start = Instant::now();
+                        loop {
+                            match listener.recv_timeout(BURST_BUFFER_PERIOD) {
+                                Ok(BurstGuardEvent::Trigger) => {
+                                    if start.elapsed() >= BURST_LONGEST_BUFFER_PERIOD {
+                                        callback();
+                                        break;
+                                    }
+                                }
+                                Ok(BurstGuardEvent::Shutdown(tx)) => {
+                                    let _ = tx.send(());
+                                    return;
+                                }
+                                Err(RecvTimeoutError::Timeout) => {
+                                    callback();
+                                    break;
+                                }
+                                Err(RecvTimeoutError::Disconnected) => {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    BurstGuardEvent::Shutdown(tx) => {
+                        let _ = tx.send(());
+                        return;
+                    }
+                }
+            }
+        });
+        Self { sender }
+    }
+
+    /// When `stop` returns an then the `BurstGuard` thread is guaranteed to not make any further
+    /// calls to `callback`.
+    pub fn stop(&self) {
+        let (sender, listener) = channel();
+        // If we could not send then it means the thread has already shut down and we can return
+        if self.sender.send(BurstGuardEvent::Shutdown(sender)).is_ok() {
+            // We do not care what the result is, if it is OK it means the thread shut down, if
+            // it is Err it also means it shut down.
+            let _ = listener.recv();
+        }
+    }
+
+    /// Asynchronously trigger burst
+    pub fn trigger(&self) {
+        self.sender.send(BurstGuardEvent::Trigger).unwrap();
+    }
+}

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -6,7 +6,7 @@
 use ipnetwork::IpNetwork;
 use std::{fmt, net::IpAddr};
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 mod debounce;
 
 #[cfg(target_os = "windows")]

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -7,6 +7,9 @@ use ipnetwork::IpNetwork;
 use std::{fmt, net::IpAddr};
 
 #[cfg(target_os = "windows")]
+mod debounce;
+
+#[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
 mod imp;
 

--- a/talpid-routing/src/windows/default_route_monitor.rs
+++ b/talpid-routing/src/windows/default_route_monitor.rs
@@ -122,10 +122,8 @@ impl Drop for DefaultRouteMonitor {
         let context = unsafe { Box::from_raw(self.context as *mut ContextAndBurstGuard) };
 
         // Stop the burst guard
-        context.burst_guard.lock().unwrap().stop();
-
-        // Drop the context now that we are guaranteed nothing might try to access the context
-        drop(context);
+        let context = context.burst_guard.into_inner().unwrap();
+        context.stop();
     }
 }
 

--- a/talpid-routing/src/windows/default_route_monitor.rs
+++ b/talpid-routing/src/windows/default_route_monitor.rs
@@ -2,14 +2,11 @@ use super::{
     get_best_default_route, get_best_default_route::route_has_gateway, Error, InterfaceAndGateway,
     Result,
 };
+use crate::debounce::BurstGuard;
 
 use std::{
     ffi::c_void,
-    sync::{
-        mpsc::{channel, RecvTimeoutError, Sender},
-        Arc, Mutex,
-    },
-    time::{Duration, Instant},
+    sync::{Arc, Mutex},
 };
 use talpid_types::win32_err;
 use windows_sys::Win32::{
@@ -349,87 +346,4 @@ unsafe extern "system" fn ip_address_change_callback(
 
     context.update_refresh_flag(&row.InterfaceLuid, row.InterfaceIndex);
     context_and_burst.burst_guard.lock().unwrap().trigger();
-}
-
-/// BurstGuard is a wrapper for a function that protects that function from being called too many
-/// times in a short amount of time. To call the function use `burst_guard.trigger()`, at that point
-/// `BurstGuard` will wait for `buffer_period` and if no more calls to `trigger` are made then it
-/// will call the wrapped function. If another call to `trigger` is made during this wait then it
-/// will wait another `buffer_period`, this happens over and over until either
-/// `longest_buffer_period` time has elapsed or until no call to `trigger` has been made in
-/// `buffer_period`. At which point the wrapped function will be called.
-struct BurstGuard {
-    sender: Sender<BurstGuardEvent>,
-}
-
-enum BurstGuardEvent {
-    Trigger,
-    Shutdown(Sender<()>),
-}
-
-impl BurstGuard {
-    fn new<F: Fn() + Send + 'static>(callback: F) -> Self {
-        /// This is the period of time the `BurstGuard` will wait for a new trigger to be sent
-        /// before it calls the callback.
-        const BURST_BUFFER_PERIOD: Duration = Duration::from_millis(200);
-        /// This is the longest period that the `BurstGuard` will wait from the first trigger till
-        /// it calls the callback.
-        const BURST_LONGEST_BUFFER_PERIOD: Duration = Duration::from_secs(2);
-
-        let (sender, listener) = channel();
-        std::thread::spawn(move || {
-            // The `stop` implementation assumes that this thread will not call `callback` again
-            // if the listener has been dropped.
-            while let Ok(message) = listener.recv() {
-                match message {
-                    BurstGuardEvent::Trigger => {
-                        let start = Instant::now();
-                        loop {
-                            match listener.recv_timeout(BURST_BUFFER_PERIOD) {
-                                Ok(BurstGuardEvent::Trigger) => {
-                                    if start.elapsed() >= BURST_LONGEST_BUFFER_PERIOD {
-                                        callback();
-                                        break;
-                                    }
-                                }
-                                Ok(BurstGuardEvent::Shutdown(tx)) => {
-                                    let _ = tx.send(());
-                                    return;
-                                }
-                                Err(RecvTimeoutError::Timeout) => {
-                                    callback();
-                                    break;
-                                }
-                                Err(RecvTimeoutError::Disconnected) => {
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    BurstGuardEvent::Shutdown(tx) => {
-                        let _ = tx.send(());
-                        return;
-                    }
-                }
-            }
-        });
-        Self { sender }
-    }
-
-    /// When `stop` returns an then the `BurstGuard` thread is guaranteed to not make any further
-    /// calls to `callback`.
-    fn stop(&self) {
-        let (sender, listener) = channel();
-        // If we could not send then it means the thread has already shut down and we can return
-        if self.sender.send(BurstGuardEvent::Shutdown(sender)).is_ok() {
-            // We do not care what the result is, if it is OK it means the thread shut down, if
-            // it is Err it also means it shut down.
-            let _ = listener.recv();
-        }
-    }
-
-    /// Non-blocking
-    fn trigger(&self) {
-        self.sender.send(BurstGuardEvent::Trigger).unwrap();
-    }
 }


### PR DESCRIPTION
The route monitor currently *immediately* reacts to any route change. What happens is somewhat unpredictable because we're likely changing the routing table at the same time as the OS. We're also making many unnecessary changes to the routing table, and we might potentially end up constantly updating routes in a tight loop.

The PR fixes these issues by triggering route changes only after a minimum interval of time has elapsed.

Close DES-384.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5225)
<!-- Reviewable:end -->
