### PR TITLE
Fix duration logging

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -1077,9 +1077,7 @@ final class TunnelManager: StorePaymentObserver {
 
         isPolling = true
 
-        logger.debug(
-            "Start polling tunnel status every \(interval) second(s)."
-        )
+        logger.debug("Start polling tunnel status every \(interval.logFormat()).")
 
         let timer = DispatchSource.makeTimerSource(queue: .main)
         timer.setEventHandler { [weak self] in


### PR DESCRIPTION
This PR fixes a regression introduced after switch to `Duration`. Just noticed today that logs state:

```
Start polling tunnel status every Duration(components: (seconds: 3, attoseconds: 0)) second(s).
```

Since `Duration` supports `logFormat()` we should use that function to output durations in log file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5229)
<!-- Reviewable:end -->
