### PR TITLE
Make social media block setting conflict with custom DNS

### DIFF
--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
@@ -139,7 +139,8 @@ struct PreferencesViewModel: Equatable {
 
     /// Precondition for enabling Custom DNS.
     var customDNSPrecondition: CustomDNSPrecondition {
-        if blockAdvertising || blockTracking || blockMalware || blockAdultContent || blockGambling {
+        if blockAdvertising || blockTracking || blockMalware ||
+            blockAdultContent || blockGambling || blockSocialMedia {
             return .conflictsWithOtherSettings
         } else {
             let hasValidDNSDomains = customDNSDomains.contains { entry in


### PR DESCRIPTION
When adding the social media blocking option, we missed a check to verify that turning it on correctly disables custom DNS. This PR fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5235)
<!-- Reviewable:end -->
