### PR TITLE
Fix signature verification path extraction

### DIFF
--- a/ci/verify-locked-down-signatures.sh
+++ b/ci/verify-locked-down-signatures.sh
@@ -52,7 +52,7 @@ fi
 readonly SEPARATOR=';'
 locked_down_paths=$(\
     < "$REPO_DIR/.github/workflows/verify-locked-down-signatures.yml" tr '\n' $SEPARATOR \
-    | sed "s/.*paths:$SEPARATOR\(\(\s*-\s[a-zA-Z\/\.-]*$SEPARATOR\)*\).*/\1/" \
+    | sed "s/.*paths:$SEPARATOR\(\(\s*-\s[a-zA-Z\/.*-]*$SEPARATOR\)*\).*/\1/" \
     | tr $SEPARATOR '\n' \
     | awk '{print $2}')
 


### PR DESCRIPTION
This PR aims to fix a problem with the path extraction logic in the signature verification script where it would only extract paths up until any path containing a `*` character, resulting in a subset of all paths being verified.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5241)
<!-- Reviewable:end -->
