### PR TITLE
Refer to ssh config hosts in buildserver-upload.sh

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -4,7 +4,6 @@ set -eu
 shopt -s nullglob
 
 CODE_SIGNING_KEY_FINGERPRINT="A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF"
-UPLOAD_SERVER="releases.mullvad.net"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 UPLOAD_DIR="$SCRIPT_DIR/upload"
@@ -14,7 +13,7 @@ cd "$UPLOAD_DIR"
 function rsync_upload {
     local file=$1
     local upload_dir=$2
-    rsync -av --mkpath --rsh='ssh -p 1122' "$file" "build@$UPLOAD_SERVER:$upload_dir/"
+    rsync -av --mkpath --rsh='ssh -p 1122' "$file" "upload-server-1:$upload_dir/"
 }
 
 while true; do


### PR DESCRIPTION
This PR updates the `buildserver-upload.sh` script to refer to the upload server as a ssh-config host.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5246)
<!-- Reviewable:end -->
