### PR TITLE
Synchronise presentations for settings and account modals

### DIFF
--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -728,11 +728,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
             animated: animated,
             configuration: ModalPresentationConfiguration(
                 preferredContentSize: UIMetrics.preferredFormSheetContentSize,
-                modalPresentationStyle: .custom,
-                transitioningDelegate: FormSheetTransitioningDelegate(options: FormSheetPresentationOptions(
-                    useFullScreenPresentationInCompactWidth: true,
-                    adjustViewWhenKeyboardAppears: false
-                ))
+                modalPresentationStyle: .formSheet
             )
         ) { [weak self] in
             completion(coordinator)


### PR DESCRIPTION
We should synchronise presentations for the settings and account modals. Using the style of settings modal also ensures conformance to the "Reduce Motion" accessibility setting.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5248)
<!-- Reviewable:end -->
