### PR TITLE
Detect changes to interfaces in the dynamic store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Correctly detect whether OS is Windows Server (primarily for logging in daemon.log).
 
+#### macOS
+- Fix connectivity issues when switching between networks or disconnecting.
+
 
 ## [android/2023.6] - 2023-09-25
 ### Fixed

--- a/talpid-core/src/resolver.rs
+++ b/talpid-core/src/resolver.rs
@@ -30,7 +30,7 @@ use trust_dns_server::{
     ServerFuture,
 };
 
-const ALLOWED_RECORD_TYPES: &[RecordType] = &[RecordType::A, RecordType::AAAA, RecordType::CNAME];
+const ALLOWED_RECORD_TYPES: &[RecordType] = &[RecordType::A, RecordType::CNAME];
 const CAPTIVE_PORTAL_DOMAINS: &[&str] = &["captive.apple.com", "netcts.cdn-apple.com"];
 
 static ALLOWED_DOMAINS: Lazy<Vec<LowerName>> = Lazy::new(|| {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -539,6 +539,12 @@ impl TunnelState for ConnectingState {
         retry_attempt: u32,
     ) -> (TunnelStateWrapper, TunnelStateTransition) {
         if shared_values.is_offline {
+            // FIXME: Temporary: Nudge route manager to update the default interface
+            #[cfg(target_os = "macos")]
+            if let Ok(handle) = shared_values.route_manager.handle() {
+                log::debug!("Poking route manager to update default routes");
+                let _ = handle.refresh_routes();
+            }
             return ErrorState::enter(shared_values, ErrorStateCause::IsOffline);
         }
         match shared_values.runtime.block_on(

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -56,6 +56,7 @@ impl Family {
     }
 }
 
+#[derive(Debug)]
 struct NetworkServiceDetails {
     name: String,
     router_ip: IpAddr,
@@ -251,6 +252,19 @@ impl PrimaryInterfaceMonitor {
                 Some(NetworkServiceDetails { name, router_ip })
             })
             .collect::<Vec<_>>()
+    }
+
+    pub fn debug(&self) {
+        for family in [Family::V4, Family::V6] {
+            log::debug!(
+                "Primary interface ({family}): {:?}",
+                self.get_primary_interface(family)
+            );
+            log::debug!(
+                "Network services ({family}): {:?}",
+                self.network_services(family)
+            );
+        }
     }
 }
 

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -15,7 +15,7 @@ use system_configuration::{
         dictionary::CFDictionary,
         string::CFString,
     },
-    dynamic_store::SCDynamicStoreBuilder,
+    dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder},
     network_configuration::SCNetworkSet,
     preferences::SCPreferences,
     sys::schema_definitions::{
@@ -41,42 +41,165 @@ impl std::fmt::Display for Family {
     }
 }
 
-impl From<Family> for IpNetwork {
-    fn from(fam: Family) -> Self {
-        match fam {
+impl Family {
+    pub fn default_network(self) -> IpNetwork {
+        match self {
             Family::V4 => IpNetwork::new(Ipv4Addr::UNSPECIFIED.into(), 0).unwrap(),
             Family::V6 => IpNetwork::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap(),
         }
     }
 }
 
-/// Retrieve the best current default route. That is the first scoped default route, ordered by
-/// network service order, and with interfaces filtered out if they do not have valid IP addresses
-/// assigned.
-///
-/// # Note
-///
-/// The tunnel interface is not even listed in the service order, so it will be skipped.
-pub fn get_best_default_route(family: Family) -> Option<RouteMessage> {
-    for iface in network_service_order(family) {
-        let Ok(index) = if_nametoindex(iface.name.as_str()) else {
-            continue;
-        };
+struct NetworkServiceDetails {
+    name: String,
+    router_ip: IpAddr,
+}
 
-        // Request ifscoped default route for this interface
-        let msg = RouteMessage::new_route(Destination::Network(IpNetwork::from(family)))
-            .set_gateway_addr(iface.router_ip)
-            .set_interface_index(u16::try_from(index).unwrap());
-        let active = is_active_interface(&iface.name, family).unwrap_or_else(|error| {
-            log::error!("is_active_interface() returned an error for interface \"{}\", assuming active. Error: {error}", iface.name);
-            true
-        });
-        if active {
-            return Some(msg);
-        }
+pub struct PrimaryInterfaceMonitor {
+    store: SCDynamicStore,
+    set: SCNetworkSet,
+}
+
+// FIXME: Implement Send on SCDynamicStore, if it's safe
+unsafe impl Send for PrimaryInterfaceMonitor {}
+
+impl PrimaryInterfaceMonitor {
+    pub fn new() -> Self {
+        let store = SCDynamicStoreBuilder::new("talpid-routing").build();
+        let prefs = SCPreferences::default(&CFString::new("talpid-routing"));
+        let set = SCNetworkSet::new(&prefs);
+        Self { store, set }
     }
 
-    None
+    /// Retrieve the best current default route. This is based on the primary interface, or else
+    /// the first active interface in the network service order.
+    pub fn get_route(&self, family: Family) -> Option<RouteMessage> {
+        let ifaces = self
+            .get_primary_interface(family)
+            .map(|iface| {
+                log::debug!("Found primary interface for {family}");
+                vec![iface]
+            })
+            .unwrap_or_else(|| {
+                log::debug!("No primary interface for {family}. Checking service order");
+                self.network_services(family)
+            });
+
+        let (iface, index) = ifaces
+            .into_iter()
+            .filter_map(|iface| {
+                let index = if_nametoindex(iface.name.as_str()).map_err(|error| {
+                    log::error!("Failed to retrieve interface index for \"{}\": {error}", iface.name);
+                    error
+                }).ok()?;
+
+                let active = is_active_interface(&iface.name, family).unwrap_or_else(|error| {
+                    log::error!("is_active_interface() returned an error for interface \"{}\", assuming active. Error: {error}", iface.name);
+                    true
+                });
+                if !active {
+                    log::debug!("Skipping inactive interface {}, router IP {}", iface.name, iface.router_ip);
+                    return None;
+                }
+                Some((iface, index))
+            })
+            .next()?;
+
+        // Synthesize a scoped route for the interface
+        let msg = RouteMessage::new_route(Destination::Network(family.default_network()))
+            .set_gateway_addr(iface.router_ip)
+            .set_interface_index(u16::try_from(index).unwrap());
+        Some(msg)
+    }
+
+    fn get_primary_interface(&self, family: Family) -> Option<NetworkServiceDetails> {
+        let global_name = if family == Family::V4 {
+            "State:/Network/Global/IPv4"
+        } else {
+            "State:/Network/Global/IPv6"
+        };
+        let global_dict = self
+            .store
+            .get(CFString::new(global_name))
+            .and_then(|v| v.downcast_into::<CFDictionary>())?;
+        let name = global_dict
+            .find(unsafe { kSCDynamicStorePropNetPrimaryInterface }.to_void())
+            .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
+            .and_then(|s| s.downcast::<CFString>())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                log::debug!("Missing name for primary interface ({family})");
+                None
+            })?;
+
+        let router_key = if family == Family::V4 {
+            unsafe { kSCPropNetIPv4Router.to_void() }
+        } else {
+            unsafe { kSCPropNetIPv6Router.to_void() }
+        };
+
+        let router_ip = global_dict
+            .find(router_key)
+            .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
+            .and_then(|s| s.downcast::<CFString>())
+            .and_then(|ip| ip.to_string().parse().ok())
+            .or_else(|| {
+                log::debug!("Missing router IP for primary interface \"{name}\"");
+                None
+            })?;
+
+        Some(NetworkServiceDetails { name, router_ip })
+    }
+
+    fn network_services(&self, family: Family) -> Vec<NetworkServiceDetails> {
+        let router_key = if family == Family::V4 {
+            unsafe { kSCPropNetIPv4Router.to_void() }
+        } else {
+            unsafe { kSCPropNetIPv6Router.to_void() }
+        };
+
+        self.set
+            .service_order()
+            .iter()
+            .filter_map(|service_id| {
+                let service_id_s = service_id.to_string();
+                let key = if family == Family::V4 {
+                    format!("State:/Network/Service/{service_id_s}/IPv4")
+                } else {
+                    format!("State:/Network/Service/{service_id_s}/IPv6")
+                };
+
+                let ip_dict = self
+                    .store
+                    .get(CFString::new(&key))
+                    .and_then(|v| v.downcast_into::<CFDictionary>())
+                    .or_else(|| {
+                        log::debug!("No {family} dict for {service_id_s}");
+                        None
+                    })?;
+                let name = ip_dict
+                    .find(unsafe { kSCPropInterfaceName }.to_void())
+                    .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
+                    .and_then(|s| s.downcast::<CFString>())
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        log::debug!("Missing name for service {service_id_s} ({family})");
+                        None
+                    })?;
+                let router_ip = ip_dict
+                    .find(router_key)
+                    .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
+                    .and_then(|s| s.downcast::<CFString>())
+                    .and_then(|ip| ip.to_string().parse().ok())
+                    .or_else(|| {
+                        log::debug!("Missing router IP for {service_id_s} ({name}, {family})");
+                        None
+                    })?;
+
+                Some(NetworkServiceDetails { name, router_ip })
+            })
+            .collect::<Vec<_>>()
+    }
 }
 
 /// Return a map from interface name to link addresses (AF_LINK)
@@ -90,82 +213,6 @@ pub fn get_interface_link_addresses() -> io::Result<BTreeMap<String, SockaddrSto
         gateway_link_addrs.insert(addr.interface_name, addr.address.unwrap());
     }
     Ok(gateway_link_addrs)
-}
-
-struct NetworkServiceDetails {
-    name: String,
-    router_ip: IpAddr,
-}
-
-fn network_service_order(family: Family) -> Vec<NetworkServiceDetails> {
-    let prefs = SCPreferences::default(&CFString::new("talpid-routing"));
-    let set = SCNetworkSet::new(&prefs);
-    let service_order = set.service_order();
-    let store = SCDynamicStoreBuilder::new("talpid-routing").build();
-
-    let global_dict = if family == Family::V4 {
-        "State:/Network/Global/IPv4"
-    } else {
-        "State:/Network/Global/IPv6"
-    };
-    let global_dict = store
-        .get(CFString::new(global_dict))
-        .and_then(|v| v.downcast_into::<CFDictionary>());
-    let primary_interface = if let Some(ref dict) = global_dict {
-        dict.find(unsafe { kSCDynamicStorePropNetPrimaryInterface }.to_void())
-            .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
-            .and_then(|s| s.downcast::<CFString>())
-            .map(|s| s.to_string())
-    } else {
-        None
-    };
-
-    let router_key = if family == Family::V4 {
-        unsafe { kSCPropNetIPv4Router.to_void() }
-    } else {
-        unsafe { kSCPropNetIPv6Router.to_void() }
-    };
-
-    service_order
-        .iter()
-        .filter_map(|service_id| {
-            let service_id_s = service_id.to_string();
-            let key = if family == Family::V4 {
-                format!("State:/Network/Service/{service_id_s}/IPv4")
-            } else {
-                format!("State:/Network/Service/{service_id_s}/IPv6")
-            };
-
-            let ip_dict = store
-                .get(CFString::new(&key))
-                .and_then(|v| v.downcast_into::<CFDictionary>())?;
-            let name = ip_dict
-                .find(unsafe { kSCPropInterfaceName }.to_void())
-                .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
-                .and_then(|s| s.downcast::<CFString>())
-                .map(|s| s.to_string())?;
-            let router_ip = ip_dict
-                .find(router_key)
-                .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
-                .and_then(|s| s.downcast::<CFString>())
-                .and_then(|ip| ip.to_string().parse().ok())
-                .or_else(|| {
-                    if Some(&name) != primary_interface.as_ref() {
-                        return None;
-                    }
-                    let Some(ref dict) = global_dict else {
-                        return None;
-                    };
-                    // Sometimes only the primary interface contains the router IPv6 addr
-                    dict.find(router_key)
-                        .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })
-                        .and_then(|s| s.downcast::<CFString>())
-                        .and_then(|ip| ip.to_string().parse().ok())
-                })?;
-
-            Some(NetworkServiceDetails { name, router_ip })
-        })
-        .collect::<Vec<_>>()
 }
 
 /// Return whether the given interface has an assigned (unicast) IP address.

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -152,6 +152,8 @@ impl RouteManagerImpl {
                 false
             });
 
+        self.debug_offline();
+
         let mut completion_tx = None;
 
         loop {
@@ -365,6 +367,8 @@ impl RouteManagerImpl {
         self.update_best_default_route(interface::Family::V4)?;
         self.update_best_default_route(interface::Family::V6)?;
 
+        self.debug_offline();
+
         if !self.unhandled_default_route_changes {
             return Ok(());
         }
@@ -384,6 +388,12 @@ impl RouteManagerImpl {
         self.unhandled_default_route_changes = false;
 
         Ok(())
+    }
+
+    fn debug_offline(&self) {
+        if self.v4_default_route.is_none() && self.v6_default_route.is_none() {
+            self.primary_interface_monitor.debug();
+        }
     }
 
     /// Figure out what the best default routes to use are, and send updates to default route change

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -25,6 +25,9 @@ mod watch;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+const BURST_BUFFER_PERIOD: Duration = Duration::from_millis(200);
+const BURST_LONGEST_BUFFER_PERIOD: Duration = Duration::from_secs(2);
+
 /// Errors that can happen in the macOS routing integration.
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]
@@ -93,12 +96,18 @@ impl RouteManagerImpl {
         manage_tx: Weak<mpsc::UnboundedSender<RouteManagerCommand>>,
     ) -> Result<Self> {
         let routing_table = RoutingTable::new().map_err(Error::RoutingTable)?;
-        let update_trigger = BurstGuard::new(move || {
-            let Some(manage_tx) = manage_tx.upgrade() else {
-                return;
-            };
-            let _ = manage_tx.unbounded_send(RouteManagerCommand::RefreshRoutes);
-        });
+
+        let update_trigger = BurstGuard::new(
+            BURST_BUFFER_PERIOD,
+            BURST_LONGEST_BUFFER_PERIOD,
+            move || {
+                let Some(manage_tx) = manage_tx.upgrade() else {
+                    return;
+                };
+                let _ = manage_tx.unbounded_send(RouteManagerCommand::RefreshRoutes);
+            },
+        );
+
         Ok(Self {
             routing_table,
             non_tunnel_routes: HashSet::new(),

--- a/talpid-routing/src/unix/mod.rs
+++ b/talpid-routing/src/unix/mod.rs
@@ -93,6 +93,14 @@ impl RouteManagerHandle {
         response_rx.await.map_err(|_| Error::ManagerChannelDown)
     }
 
+    /// Get current non-tunnel default routes.
+    #[cfg(target_os = "macos")]
+    pub fn refresh_routes(&self) -> Result<(), Error> {
+        self.tx
+            .unbounded_send(RouteManagerCommand::RefreshRoutes)
+            .map_err(|_| Error::RouteManagerDown)
+    }
+
     /// Ensure that packets are routed using the correct tables.
     #[cfg(target_os = "linux")]
     pub async fn create_routing_rules(&self, enable_ipv6: bool) -> Result<(), Error> {

--- a/talpid-routing/src/windows/default_route_monitor.rs
+++ b/talpid-routing/src/windows/default_route_monitor.rs
@@ -7,6 +7,7 @@ use crate::debounce::BurstGuard;
 use std::{
     ffi::c_void,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 use talpid_types::win32_err;
 use windows_sys::Win32::{
@@ -173,10 +174,17 @@ impl DefaultRouteMonitor {
             family,
         )));
 
+        const BURST_BUFFER_PERIOD: Duration = Duration::from_millis(200);
+        const BURST_LONGEST_BUFFER_PERIOD: Duration = Duration::from_secs(2);
+
         let moved_context = context.clone();
-        let burst_guard = Mutex::new(BurstGuard::new(move || {
-            moved_context.lock().unwrap().evaluate_routes();
-        }));
+        let burst_guard = Mutex::new(BurstGuard::new(
+            BURST_BUFFER_PERIOD,
+            BURST_LONGEST_BUFFER_PERIOD,
+            move || {
+                moved_context.lock().unwrap().evaluate_routes();
+            },
+        ));
 
         // SAFETY: We need to send the ContextAndBurstGuard to the windows notification functions as
         // a raw pointer. This imposes the requirement it is not mutated or dropped until


### PR DESCRIPTION
This PR makes a few changes:
* Use the primary interface as the "best (scoped) default route", or else the first active interface in the network service order. (Same as before, but the flow is much easier to understand.)
* Check whether the "best default route" has changed in response to any changes to network services in the dynamic store.
* Check whether the "best default route" has changed when the user tries to connect in the offline state.
* Log all the things.

Fix DES-398
Fix DES-396

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5254)
<!-- Reviewable:end -->
