### PR TITLE
Update to Electron 26

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -37,7 +37,7 @@
         "@types/google-protobuf": "^3.15.6",
         "@types/history": "^4.7.11",
         "@types/mocha": "^10.0.0",
-        "@types/node": "^18.15.0",
+        "@types/node": "^18.16.1",
         "@types/node-gettext": "^3.0.3",
         "@types/rbush": "^3.0.0",
         "@types/react": "^18.0.21",
@@ -55,7 +55,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
         "cross-env": "^7.0.3",
-        "electron": "^25.2.0",
+        "electron": "^26.3.0",
         "electron-builder": "^23.6.0",
         "electron-devtools-installer": "^3.2.0",
         "electron-mocha": "^11.0.2",
@@ -1564,9 +1564,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
-      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
+      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
     },
     "node_modules/@types/node-gettext": {
       "version": "3.0.3",
@@ -4811,9 +4811,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
-      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.3.0.tgz",
+      "integrity": "sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -15721,9 +15721,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
-      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
+      "version": "18.16.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
+      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
     },
     "@types/node-gettext": {
       "version": "3.0.3",
@@ -18385,9 +18385,9 @@
       }
     },
     "electron": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-25.2.0.tgz",
-      "integrity": "sha512-I/rhcW2sV2fyiveVSBr2N7v5ZiCtdGY0UiNCDZgk2fpSC+irQjbeh7JT2b4vWmJ2ogOXBjqesrN9XszTIG6DHg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.3.0.tgz",
+      "integrity": "sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/gui/package.json
+++ b/gui/package.json
@@ -43,7 +43,7 @@
     "@types/google-protobuf": "^3.15.6",
     "@types/history": "^4.7.11",
     "@types/mocha": "^10.0.0",
-    "@types/node": "^18.15.0",
+    "@types/node": "^18.16.1",
     "@types/node-gettext": "^3.0.3",
     "@types/rbush": "^3.0.0",
     "@types/react": "^18.0.21",
@@ -61,7 +61,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "cross-env": "^7.0.3",
-    "electron": "^25.2.0",
+    "electron": "^26.3.0",
     "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "electron-mocha": "^11.0.2",
@@ -112,7 +112,7 @@
     "npm": ">=8.3"
   },
   "volta": {
-    "node": "18.15.0",
-    "npm": "9.7.2"
+    "node": "18.16.1",
+    "npm": "10.2.0"
   }
 }

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -183,7 +183,6 @@ class ApplicationMain
       );
     });
 
-    app.on('activate', this.onActivate);
     app.on('ready', this.onReady);
 
     app.on('before-quit', this.onBeforeQuit);
@@ -195,9 +194,6 @@ class ApplicationMain
       log.info('quit received');
       this.onQuit();
     });
-
-    powerMonitor.on('suspend', this.onSuspend);
-    powerMonitor.on('resume', this.onResume);
   }
 
   public async performPostUpgradeCheck(): Promise<void> {
@@ -368,6 +364,10 @@ class ApplicationMain
   }
 
   private onReady = async () => {
+    app.on('activate', this.onActivate);
+    powerMonitor.on('suspend', this.onSuspend);
+    powerMonitor.on('resume', this.onResume);
+
     // Disable built-in DNS resolver.
     app.configureHostResolver({
       enableBuiltInResolver: false,


### PR DESCRIPTION
This PR updates electron from 25.2.0 to 26.3.0, as well as NodeJS to 18.16.1 and npm to 10.2.0.

For some reason registering the `powerMonitor` listeners before the `ready` event now restults in a crash on Linux so those have been moved to the `onReady` function.

Changelog for Electron 26:
https://github.com/electron/electron/releases/tag/v26.0.0

Fixes DES-397

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5255)
<!-- Reviewable:end -->
