### PR TITLE
Add missing changelog entries about custom lists and electron update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,14 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add customizable relay lists to the CLI on desktop. Custom lists can be managed through
   `mullvad custom-lists` and can be selected through `mullvad relay set` and `mullvad bridge set`.
+- Add custom lists to location selector in desktop app.
 
 #### Linux
 - Start signing the deb and rpm files (GPG)
 
 ### Changed
+- Update Electron from 25.2.0 to 26.3.0.
+
 #### Android
 - Migrate welcome view to compose.
 - Migrate in app notifications to compose.


### PR DESCRIPTION
When adding custom lists and updating Electron I forgot to add the changes to the changelog. This PR corrects that by adding them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5267)
<!-- Reviewable:end -->
