### PR TITLE
Bump Linux build container to one with Rust 1.73 and newer protoc

### DIFF
--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:cf1a3c951
+ghcr.io/mullvad/mullvadvpn-app-build:4986f0398


### PR DESCRIPTION
Getting with the times. Most importantly having access to the newer protoc that will allow significant Rust code cleanups.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5268)
<!-- Reviewable:end -->
