### PR TITLE
Prep iOS for same ip

### DIFF
--- a/ios/MullvadREST/HTTP.swift
+++ b/ios/MullvadREST/HTTP.swift
@@ -47,4 +47,5 @@ enum HTTPHeader {
     static let contentType = "Content-Type"
     static let etag = "ETag"
     static let ifNoneMatch = "If-None-Match"
+    static let userAgent = "User-Agent"
 }

--- a/ios/MullvadREST/RESTRequestFactory.swift
+++ b/ios/MullvadREST/RESTRequestFactory.swift
@@ -62,6 +62,7 @@ extension REST {
             request.httpShouldHandleCookies = false
             request.addValue(hostname, forHTTPHeaderField: HTTPHeader.host)
             request.addValue("application/json", forHTTPHeaderField: HTTPHeader.contentType)
+            request.addValue("mullvad-app", forHTTPHeaderField: HTTPHeader.userAgent)
             request.httpMethod = method.rawValue
 
             let prefixedPathTemplate = URLPathTemplate(stringLiteral: pathPrefix) + pathTemplate

--- a/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -208,7 +208,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             let selectorResult = tunnelConfiguration.selectorResult
             self.selectorResult = selectorResult
             self.providerLogger.debug("Set tunnel relay to \(selectorResult.relay.hostname).")
-            self.logIfDeviceHasSameIP(than: tunnelConfiguration.wgTunnelConfig.interface.addresses)
+            self.logIfDeviceHasSameIP(as: tunnelConfiguration.wgTunnelConfig.interface.addresses)
 
             // Start tunnel.
             self.adapter.start(tunnelConfiguration: tunnelConfiguration.wgTunnelConfig) { error in
@@ -239,7 +239,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
     }
 
-    private func logIfDeviceHasSameIP(than addresses: [IPAddressRange]) {
+    private func logIfDeviceHasSameIP(as addresses: [IPAddressRange]) {
         let hasIPv4SameAddress = addresses.compactMap { $0.address as? IPv4Address }
             .contains { $0 == ApplicationConfiguration.sameIPv4 }
         let hasIPv6SameAddress = addresses.compactMap { $0.address as? IPv6Address }
@@ -664,6 +664,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         providerLogger.debug("Set tunnel relay to \(newTunnelRelay.hostname).")
         setReconnecting(true)
 
+        logIfDeviceHasSameIP(as: tunnelConfiguration.wgTunnelConfig.interface.addresses)
         adapter.update(tunnelConfiguration: tunnelConfiguration.wgTunnelConfig) { error in
             self.dispatchQueue.async {
                 if let error {


### PR DESCRIPTION
Our app won't be receiving the _same IP_ address unless we set the user agent string. And, in case the packet tunnel lives forever, it's best to log about using the _same IP_ every time a new config is generated. So I've added these changes with hopes of merging them into the release branch. Once that is done, I'll rebase these changes for the `main` as well :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5269)
<!-- Reviewable:end -->
