### PR TITLE
Ensure atomicity between (re)connection attempts

### DIFF
--- a/ios/PacketTunnelCore/Actor/Actor.swift
+++ b/ios/PacketTunnelCore/Actor/Actor.swift
@@ -87,8 +87,8 @@ public actor PacketTunnelActor {
                 case .stop:
                     await stop()
 
-                case let .reconnect(nextRelay, stopTunnelMonitor):
-                    await reconnect(to: nextRelay, shouldStopTunnelMonitor: stopTunnelMonitor)
+                case let .reconnect(nextRelay, reason):
+                    await reconnect(to: nextRelay, reason: reason)
 
                 case let .error(reason):
                     await setErrorStateInternal(with: reason)
@@ -173,16 +173,22 @@ extension PacketTunnelActor {
 
      - Parameters:
          - nextRelay: next relay to connect to
-         - shouldStopTunnelMonitor: whether tunnel monitor should be stopped
+         - reason: reason for reconnect
      */
-    private func reconnect(to nextRelay: NextRelay, shouldStopTunnelMonitor: Bool) async {
+    private func reconnect(to nextRelay: NextRelay, reason: ReconnectReason) async {
         do {
             switch state {
             case .connecting, .connected, .reconnecting, .error:
-                if shouldStopTunnelMonitor {
+                switch reason {
+                case .connectionLoss:
+                    // Tunnel monitor is already paused at this point. Avoid calling stop() to prevent the reset of
+                    // internal state
+                    break
+                case .userInitiated:
                     tunnelMonitor.stop()
                 }
-                try await tryStart(nextRelay: nextRelay)
+
+                try await tryStart(nextRelay: nextRelay, reason: reason)
 
             case .disconnected, .disconnecting, .initial:
                 break
@@ -205,12 +211,14 @@ extension PacketTunnelActor {
      - Start tunnel monitor.
      - Reactivate default path observation (disabled when configuring tunnel adapter)
 
-     - Parameter nextRelay: which relay should be selected next.
+     - Parameters:
+         - nextRelay: which relay should be selected next.
+         - reason: reason for reconnect
      */
-    private func tryStart(nextRelay: NextRelay = .random) async throws {
+    private func tryStart(nextRelay: NextRelay = .random, reason: ReconnectReason = .userInitiated) async throws {
         let settings: Settings = try settingsReader.read()
 
-        guard let connectionState = try makeConnectionState(nextRelay: nextRelay, settings: settings),
+        guard let connectionState = try makeConnectionState(nextRelay: nextRelay, settings: settings, reason: reason),
               let targetState = state.targetStateForReconnect else { return }
 
         let activeKey: PrivateKey
@@ -261,10 +269,15 @@ extension PacketTunnelActor {
      - Parameters:
          - nextRelay: relay preference that should be used when selecting next relay.
          - settings: current settings
+         - reason: reason for reconnect
 
      - Returns: New connection state or `nil` if current state is at or past `.disconnecting` phase.
      */
-    private func makeConnectionState(nextRelay: NextRelay, settings: Settings) throws -> ConnectionState? {
+    private func makeConnectionState(
+        nextRelay: NextRelay,
+        settings: Settings,
+        reason: ReconnectReason
+    ) throws -> ConnectionState? {
         let relayConstraints = settings.relayConstraints
         let privateKey = settings.privateKey
 
@@ -284,7 +297,18 @@ extension PacketTunnelActor {
                 connectionAttemptCount: 0
             )
 
-        case var .connecting(connState), var .connected(connState), var .reconnecting(connState):
+        case var .connecting(connState), var .reconnecting(connState):
+            switch reason {
+            case .connectionLoss:
+                // Increment attempt counter when reconnection is requested due to connectivity loss.
+                connState.incrementAttemptCount()
+            case .userInitiated:
+                break
+            }
+            // Explicit fallthrough
+            fallthrough
+
+        case var .connected(connState):
             connState.selectedRelay = try selectRelay(
                 nextRelay: nextRelay,
                 relayConstraints: relayConstraints,

--- a/ios/PacketTunnelCore/Actor/Command.swift
+++ b/ios/PacketTunnelCore/Actor/Command.swift
@@ -17,9 +17,7 @@ enum Command {
     case stop
 
     /// Reconnect tunnel.
-    /// `stopTunnelMonitor = false` is only used when tunnel monitor is paused in response to connectivity loss and shouldn't be stopped explicitly,
-    /// as this would reset its internal counters.
-    case reconnect(NextRelay, stopTunnelMonitor: Bool = true)
+    case reconnect(NextRelay, reason: ReconnectReason = .userInitiated)
 
     /// Enter blocked state.
     case error(BlockedStateReason)

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -212,3 +212,13 @@ public enum NextRelay: Equatable, Codable {
     /// Use pre-selected relay.
     case preSelected(SelectedRelay)
 }
+
+/// Describes the reason for reconnection request.
+public enum ReconnectReason {
+    /// Initiated by user.
+    case userInitiated
+
+    /// Initiated by tunnel monitor due to loss of connectivity.
+    /// Actor will increment the connection attempt counter before picking next relay.
+    case connectionLoss
+}

--- a/ios/PacketTunnelCoreTests/Mocks/TunnelMonitorStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/TunnelMonitorStub.swift
@@ -64,7 +64,7 @@ class TunnelMonitorStub: TunnelMonitorProtocol {
 
     func onSleep() {}
 
-    private func dispatch(_ event: TunnelMonitorEvent, after delay: DispatchTimeInterval = .never) {
+    func dispatch(_ event: TunnelMonitorEvent, after delay: DispatchTimeInterval = .never) {
         if case .never = delay {
             onEvent?(event)
         } else {


### PR DESCRIPTION
Currently reconnection is a two fold operation:
- First we increment attempt counter
- Then schedule command for reconnect to leverage coalescing system.

This approach produces two individual changes to `state` which can be misleading when observed from the outside. For instance:

-  If the tunnel is currently in `.connected` state, the first mutation increments attempt counter updating it to `1`.
- The observer then receives a `.connected` state with attempt counter updated to `1`. 
- The second mutation changes `state` to `.reconnecting` with attempt counter set to `1`.
- The observer then receives a `.reconnecting` state with attempt counter set to `1`.

Because `connected`, `reconnecting`, `connecting` were handled the same way, the tunnel losing connectivity also starts connection attempt counter at `1` which is suboptimal.

This PR aims to fix the aforementioned issues by introducing `ReconnectReason` which is passed along with `reconnect()` command in place of `shouldStopTunnelMonitor` parameter. `tryStart()` then is responsible for incrementing the attempt counter following these rules:

- The counter is not incremented If current state is `.connected`. That's because the tunnel is going to transition to `.reconnecting` phase and attempt counter should start at zero during the first attempt, then increment with each subsequent attempt.
- The counter is incremented if current state is either `.connecting` or `.reconnecting` as normal.

Two tests added to ensure that state transitions for (re)connection attempts happen as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5273)
<!-- Reviewable:end -->
