### PR TITLE
Print same-ip message on each connect

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -24,7 +24,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var appMessageHandler: AppMessageHandler!
     private var stateObserverTask: AnyTask?
     private var deviceChecker: DeviceChecker!
-    private var isLoggedSameIP = false
 
     override init() {
         Self.configureLogging()
@@ -124,36 +123,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     override func wake() {
         actor.onWake()
-    }
-}
-
-extension PacketTunnelProvider {
-    override func setTunnelNetworkSettings(
-        _ tunnelNetworkSettings: NETunnelNetworkSettings?,
-        completionHandler: ((Error?) -> Void)? = nil
-    ) {
-        if let networkSettings = tunnelNetworkSettings as? NEPacketTunnelNetworkSettings {
-            let ipv4Addresses = networkSettings.ipv4Settings?.addresses.compactMap { IPv4Address($0) } ?? []
-            let ipv6Addresses = networkSettings.ipv6Settings?.addresses.compactMap { IPv6Address($0) } ?? []
-            let allIPAddresses: [IPAddress] = ipv4Addresses + ipv6Addresses
-
-            if !allIPAddresses.isEmpty, !isLoggedSameIP {
-                isLoggedSameIP = true
-                logIfDeviceHasSameIP(than: allIPAddresses)
-            }
-        }
-
-        super.setTunnelNetworkSettings(tunnelNetworkSettings, completionHandler: completionHandler)
-    }
-
-    private func logIfDeviceHasSameIP(than addresses: [IPAddress]) {
-        let hasIPv4SameAddress = addresses.compactMap { $0 as? IPv4Address }
-            .contains { $0 == ApplicationConfiguration.sameIPv4 }
-        let hasIPv6SameAddress = addresses.compactMap { $0 as? IPv6Address }
-            .contains { $0 == ApplicationConfiguration.sameIPv6 }
-
-        let isUsingSameIP = (hasIPv4SameAddress || hasIPv6SameAddress) ? "" : "NOT "
-        providerLogger.debug("Same IP is \(isUsingSameIP)being used")
     }
 }
 


### PR DESCRIPTION
This PR ensures that same-ip message is printed on each connect by exposing tun addresses over `ConnectionState`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5277)
<!-- Reviewable:end -->
