### PR TITLE
Add user agent header for all requests on iOS

### DIFF
--- a/ios/MullvadREST/HTTP.swift
+++ b/ios/MullvadREST/HTTP.swift
@@ -47,4 +47,5 @@ enum HTTPHeader {
     static let contentType = "Content-Type"
     static let etag = "ETag"
     static let ifNoneMatch = "If-None-Match"
+    static let userAgent = "User-Agent"
 }

--- a/ios/MullvadREST/RESTRequestFactory.swift
+++ b/ios/MullvadREST/RESTRequestFactory.swift
@@ -62,6 +62,7 @@ extension REST {
             request.httpShouldHandleCookies = false
             request.addValue(hostname, forHTTPHeaderField: HTTPHeader.host)
             request.addValue("application/json", forHTTPHeaderField: HTTPHeader.contentType)
+            request.addValue("mullvad-app", forHTTPHeaderField: HTTPHeader.userAgent)
             request.httpMethod = method.rawValue
 
             let prefixedPathTemplate = URLPathTemplate(stringLiteral: pathPrefix) + pathTemplate


### PR DESCRIPTION
Backporting a fix from the release branch - without the user agent, our client won't be receiving a _same-ip_ IP from the API when rotating keys/creating devices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5280)
<!-- Reviewable:end -->
