### PR TITLE
Prevent logging error when settings are not found in Keychain

### DIFF
--- a/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
@@ -61,7 +61,8 @@ class LoadTunnelConfigurationOperation: ResultOperation<Void> {
     private func readSettings() -> Result<LatestTunnelSettings?, Error> {
         Result { try SettingsManager.readSettings() }
             .flatMapError { error in
-                if let error = error as? KeychainError, error == .itemNotFound {
+                if let error = error as? ReadSettingsVersionError,
+                   let keychainError = error.underlyingError as? KeychainError, keychainError == .itemNotFound {
                     logger.debug("Settings not found in keychain.")
 
                     return .success(nil)


### PR DESCRIPTION
`SettingsManager.readSettings()` throws `ReadSettingsVersionError` which should not be logged when the underlying error points at item not being found in Keychain.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5284)
<!-- Reviewable:end -->
