### PR TITLE
Detect platform when uploading builds from buildserver

### DIFF
--- a/ci/buildserver-build-android.sh
+++ b/ci/buildserver-build-android.sh
@@ -22,7 +22,7 @@ function upload {
     version=$1
 
     files=( * )
-    checksums_path="$version+$(hostname).sha256"
+    checksums_path="android+$(hostname)+$version.sha256"
     sha256sum "${files[@]}" > "$checksums_path"
 
     mv "${files[@]}" "$checksums_path" "$UPLOAD_DIR/"

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -56,7 +56,7 @@ function upload {
     version=$1
 
     files=( * )
-    checksums_path="$version+$(hostname).sha256"
+    checksums_path="desktop+$(hostname)+$version.sha256"
     sha256sum "${files[@]}" > "$checksums_path"
 
     case "$(uname -s)" in

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -21,18 +21,18 @@ while true; do
     for checksums_path in *.sha256; do
         sleep 1
 
-        # Strip everything from the last "+" in the file name to only keep the version and tag (if
-        # present).
-        version="${checksums_path%+*}"
+        # Parse the platform name and version out of the filename of the checksums file.
+        platform="$(echo "$checksums_path" | cut -d + -f 1)"
+        version="$(echo "$checksums_path" | cut -d + -f 3,4 | sed 's/\.sha256//')"
         if ! sha256sum --quiet -c "$checksums_path"; then
             echo "Failed to verify checksums for $version"
             continue
         fi
 
         if [[ $version == *"-dev-"* ]]; then
-            upload_path="builds"
+            upload_path="$platform/builds"
         else
-            upload_path="releases"
+            upload_path="$platform/releases"
         fi
 
         files=$(awk '{print $2}' < "$checksums_path")


### PR DESCRIPTION
Since we're now uploading files into platform specific directories we need to know which platform a build is for in the upload script. This also allows for running just one instance of the upload script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5287)
<!-- Reviewable:end -->
