### PR TITLE
Do not show change log when it is empty

### DIFF
--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -326,7 +326,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         }
 
         // Change log can be presented simultaneously with other routes.
-        if !appPreferences.isSeenLatestChanges {
+        if !appPreferences.hasSeenLastChanges {
             routes.append(.changelog)
         }
 
@@ -995,12 +995,13 @@ extension DeviceState {
 }
 
 fileprivate extension AppPreferencesDataSource {
-    var isSeenLatestChanges: Bool {
-        self.lastSeenChangeLogVersion == Bundle.main.shortVersion
+    var hasSeenLastChanges: Bool {
+        !ChangeLogInteractor().hasNewChanges ||
+            (lastSeenChangeLogVersion == Bundle.main.shortVersion)
     }
 
     mutating func markChangeLogSeen() {
-        self.lastSeenChangeLogVersion = Bundle.main.shortVersion
+        lastSeenChangeLogVersion = Bundle.main.shortVersion
     }
 
     // swiftlint:disable:next file_length

--- a/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogInteractor.swift
@@ -12,6 +12,11 @@ import MullvadLogging
 final class ChangeLogInteractor {
     private let logger = Logger(label: "ChangeLogInteractor")
     private var items: [String] = []
+
+    var hasNewChanges: Bool {
+        !items.isEmpty
+    }
+
     var viewModel: ChangeLogViewModel {
         return ChangeLogViewModel(
             body: items


### PR DESCRIPTION
When there are no meaningful changes we do not want to advertise anything in the app.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5297)
<!-- Reviewable:end -->
