### PR TITLE
Fix device banner not showing after logging in

### DIFF
--- a/gui/src/renderer/redux/account/reducers.ts
+++ b/gui/src/renderer/redux/account/reducers.ts
@@ -43,7 +43,11 @@ export default function (
     case 'LOGGED_IN':
       return {
         ...state,
-        status: { type: 'ok', method: 'existing_account', newDeviceBanner: false },
+        status: {
+          type: 'ok',
+          method: 'existing_account',
+          newDeviceBanner: state.status.type === 'logging in',
+        },
         accountToken: action.accountToken,
         deviceName: action.deviceName,
       };


### PR DESCRIPTION
When implementing https://github.com/mullvad/mullvadvpn-app/pull/4790 I mistakenly made the new device banner only show after creating a new account. This PR makes sure that the banner is always shown after logging in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5299)
<!-- Reviewable:end -->
