### PR TITLE
Put app in blocked state on tunnel start if relay constraints cannot be satisfied

### DIFF
--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -50,14 +50,8 @@ class StartTunnelOperation: ResultOperation<Void> {
             finish(result: .success(()))
 
         case .disconnected, .pendingReconnect:
-            do {
-                let selectedRelay = try interactor.selectRelay()
-
-                makeTunnelProviderAndStartTunnel(selectedRelay: selectedRelay) { error in
-                    self.finish(result: error.map { .failure($0) } ?? .success(()))
-                }
-            } catch {
-                finish(result: .failure(error))
+            makeTunnelProviderAndStartTunnel { error in
+                self.finish(result: error.map { .failure($0) } ?? .success(()))
             }
 
         default:
@@ -65,18 +59,11 @@ class StartTunnelOperation: ResultOperation<Void> {
         }
     }
 
-    private func makeTunnelProviderAndStartTunnel(
-        selectedRelay: SelectedRelay,
-        completionHandler: @escaping (Error?) -> Void
-    ) {
+    private func makeTunnelProviderAndStartTunnel(completionHandler: @escaping (Error?) -> Void) {
         makeTunnelProvider { result in
             self.dispatchQueue.async {
                 do {
-                    try self.startTunnel(
-                        tunnel: try result.get(),
-                        selectedRelay: selectedRelay
-                    )
-
+                    try self.startTunnel(tunnel: result.get())
                     completionHandler(nil)
                 } catch {
                     completionHandler(error)
@@ -85,11 +72,14 @@ class StartTunnelOperation: ResultOperation<Void> {
         }
     }
 
-    private func startTunnel(tunnel: Tunnel, selectedRelay: SelectedRelay) throws {
+    private func startTunnel(tunnel: Tunnel) throws {
+        let selectedRelay = try? interactor.selectRelay()
         var tunnelOptions = PacketTunnelOptions()
 
         do {
-            try tunnelOptions.setSelectedRelay(selectedRelay)
+            if let selectedRelay {
+                try tunnelOptions.setSelectedRelay(selectedRelay)
+            }
         } catch {
             logger.error(
                 error: error,
@@ -101,8 +91,8 @@ class StartTunnelOperation: ResultOperation<Void> {
 
         interactor.updateTunnelStatus { tunnelStatus in
             tunnelStatus = TunnelStatus()
-            tunnelStatus.packetTunnelStatus.tunnelRelay = selectedRelay.packetTunnelRelay
-            tunnelStatus.state = .connecting(selectedRelay.packetTunnelRelay)
+            tunnelStatus.packetTunnelStatus.tunnelRelay = selectedRelay?.packetTunnelRelay
+            tunnelStatus.state = .connecting(selectedRelay?.packetTunnelRelay)
         }
 
         try tunnel.start(options: tunnelOptions.rawOptions())

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -284,18 +284,10 @@ final class TunnelManager: StorePaymentObserver {
                     throw UnsetTunnelError()
                 }
 
-                let nextRelay: NextRelay = selectNewRelay ? .preSelected(try self.selectRelay()) : .current
-
-                return tunnel.reconnectTunnel(to: nextRelay) { result in
+                return tunnel.reconnectTunnel(to: selectNewRelay ? .random : .current) { result in
                     finish(result.error)
                 }
             } catch {
-                if let error = error as? NoRelaysSatisfyingConstraintsError {
-                    _ = self.setTunnelStatus { tunnelStatus in
-                        tunnelStatus.state = .error(.noRelaysSatisfyingConstraints)
-                    }
-                }
-
                 finish(error)
 
                 return AnyCancellable()


### PR DESCRIPTION
On tunnel start, if no valid relay can be selected app-side we let the packet tunnel take care of it instead. This will put the app in blocked state.

This PR takes care of issue the following issue as well:
https://linear.app/mullvad/issue/IOS-351/removing-relay-filters-does-not-exit-blocked-state

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5300)
<!-- Reviewable:end -->
