### PR TITLE
Add blocked state due to account expiration

### DIFF
--- a/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
@@ -231,6 +231,8 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
             errorString = "No servers match your settings, try changing server or other settings."
         case .invalidAccount:
             errorString = "You are logged in with an invalid account number. Please log out and try another one."
+        case .accountExpired:
+            errorString = "Account is out of time."
         case .deviceRevoked, .deviceLoggedOut:
             errorString = "Unable to authenticate account. Please log out and log back in."
         default:

--- a/ios/PacketTunnel/PacketTunnelProvider/DeviceCheck+BlockedStateReason.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/DeviceCheck+BlockedStateReason.swift
@@ -20,6 +20,10 @@ extension DeviceCheck {
             return .deviceRevoked
         }
 
+        if case .expired = accountVerdict {
+            return .accountExpired
+        }
+
         return nil
     }
 }

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -105,8 +105,8 @@ extension BlockedStateReason {
         case .deviceLocked:
             return true
 
-        case .noRelaysSatisfyingConstraints, .readSettings, .invalidAccount, .deviceRevoked, .tunnelAdapter, .unknown,
-             .deviceLoggedOut, .outdatedSchema, .invalidRelayPublicKey:
+        case .noRelaysSatisfyingConstraints, .readSettings, .invalidAccount, .accountExpired, .deviceRevoked,
+             .tunnelAdapter, .unknown, .deviceLoggedOut, .outdatedSchema, .invalidRelayPublicKey:
             return false
         }
     }

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -177,6 +177,9 @@ public enum BlockedStateReason: String, Codable, Equatable {
     /// Invalid account.
     case invalidAccount
 
+    /// Account is expired.
+    case accountExpired
+
     /// Device revoked.
     case deviceRevoked
 


### PR DESCRIPTION
Currently tunnel actor enters endless reconnection loop when configured with expired account number. Instead it should recognize why connection is broken during the device check and enter blocked state immediately.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5301)
<!-- Reviewable:end -->
