### PR TITLE
Make sure filter count is correct when using multiple filters

### DIFF
--- a/gui/src/renderer/components/Filter.tsx
+++ b/gui/src/renderer/components/Filter.tsx
@@ -264,15 +264,17 @@ function FilterByProvider(props: IFilterByProviderProps) {
 
   const onToggle = useCallback(
     (provider: string) =>
-      props.setProviders((providers) => ({ ...providers, [provider]: !providers[provider] })),
-    [props.setProviders],
+      props.setProviders((providers) => {
+        const newProviders = { ...providers, [provider]: !providers[provider] };
+        return props.availableOptions.every((provider) => newProviders[provider])
+          ? toggleAllProviders(providers, true)
+          : newProviders;
+      }),
+    [props.availableOptions, props.setProviders],
   );
 
   const toggleAll = useCallback(() => {
-    props.setProviders((providers) => {
-      const shouldSelect = !Object.values(providers).every((value) => value);
-      return Object.fromEntries(Object.keys(providers).map((provider) => [provider, shouldSelect]));
-    });
+    props.setProviders((providers) => toggleAllProviders(providers));
   }, []);
 
   return (
@@ -300,6 +302,11 @@ function FilterByProvider(props: IFilterByProviderProps) {
       </Accordion>
     </>
   );
+}
+
+function toggleAllProviders(providers: Record<string, boolean>, value?: boolean) {
+  const shouldSelect = value ?? !Object.values(providers).every((value) => value);
+  return Object.fromEntries(Object.keys(providers).map((provider) => [provider, shouldSelect]));
 }
 
 interface IStyledRowTitleProps {

--- a/gui/src/renderer/components/select-location/SelectLocation.tsx
+++ b/gui/src/renderer/components/select-location/SelectLocation.tsx
@@ -12,6 +12,7 @@ import { RoutePath } from '../../lib/routes';
 import { useNormalBridgeSettings, useNormalRelaySettings } from '../../lib/utilityHooks';
 import { useSelector } from '../../redux/store';
 import * as Cell from '../cell';
+import { useFilteredProviders } from '../Filter';
 import ImageView from '../ImageView';
 import { BackAction } from '../KeyboardNavigation';
 import { Layout, SettingsContainer } from '../Layout';
@@ -69,6 +70,7 @@ export default function SelectLocation() {
   const relaySettings = useNormalRelaySettings();
   const ownership = relaySettings?.ownership ?? Ownership.any;
   const providers = relaySettings?.providers ?? [];
+  const filteredProviders = useFilteredProviders(providers, ownership);
 
   const [searchValue, setSearchValue] = useState('');
 
@@ -201,7 +203,7 @@ export default function SelectLocation() {
                           'select-location-view',
                           'Providers: %(numberOfProviders)d',
                         ),
-                        { numberOfProviders: providers.length },
+                        { numberOfProviders: filteredProviders.length },
                       )}
                       <StyledClearFilterButton
                         aria-label={messages.gettext('Clear')}


### PR DESCRIPTION
This PR solves a bug where the provider filter count in the select location view included providers which wasn't compatible with the selected ownership filter. This resulted in an higher than expected number. This is now solved by using a provider list filtered by the selected ownership option when calculating the number of selected filters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5304)
<!-- Reviewable:end -->
