### PR TITLE
Replace volta-cli/action with actions/setup-node

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,21 +19,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup volta
-        uses: volta-cli/action@v4
-
-      - name: Get npm cache directory path
-        id: npm-cache-dir-path
-        shell: bash  # To ensure that Windows correctly ouputs the cache path
-        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-
-      - name: Cache npm dependencies
-        uses: actions/cache@v3
+      - name: Read volta info
+        id: volta
+        uses: zoexx/github-action-json-file-properties@release
         with:
-          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
+          file_path: 'gui/package.json'
+          prop_path: 'volta'
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.volta.outputs.node }}
+          cache: 'npm'
+          cache-dependency-path: gui/package-lock.json
+
+      - name: Update NPM
+        run: npm i -g npm@${{ steps.volta.outputs.npm }}
 
       - name: Install dependencies
         working-directory: gui

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -16,20 +16,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup volta
-        uses: volta-cli/action@v4
-
-      - name: Get npm cache directory path
-        id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm config get cache)"
-
-      - name: Cache npm dependencies
-        uses: actions/cache@v3
+      - name: Read volta info
+        id: volta
+        uses: zoexx/github-action-json-file-properties@release
         with:
-          path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
+          file_path: 'gui/package.json'
+          prop_path: 'volta'
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ steps.volta.outputs.node }}
+          cache: 'npm'
+          cache-dependency-path: gui/package-lock.json
+
+      - name: Update NPM
+        run: npm i -g npm@${{ steps.volta.outputs.npm }}
 
       - name: Install JS dependencies
         working-directory: gui


### PR DESCRIPTION
The volta action has been failing a lot and from what I can find there is no good solution. I'm replacing the volta action with the `setup-node` one and specify the node version from `package.json`. This also means we get dependency caching automatically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5305)
<!-- Reviewable:end -->
