### PR TITLE
Fix LocationRow and search input line height

### DIFF
--- a/gui/src/renderer/components/SearchBar.tsx
+++ b/gui/src/renderer/components/SearchBar.tsx
@@ -18,6 +18,7 @@ export const StyledSearchInput = styled.input.attrs({ type: 'text' })({
   borderRadius: '4px',
   padding: '9px 38px',
   margin: 0,
+  lineHeight: '24px',
   color: colors.white60,
   backgroundColor: colors.white10,
   '::placeholder': {

--- a/gui/src/renderer/components/select-location/LocationRow.tsx
+++ b/gui/src/renderer/components/select-location/LocationRow.tsx
@@ -87,6 +87,7 @@ export const StyledLocationRowLabel = styled(Cell.Label)(normalText, {
   flex: 1,
   minWidth: 0,
   fontWeight: 400,
+  lineHeight: '24px',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',


### PR DESCRIPTION
Both the search input and location row didn't fit descenders on Linux. This PR fixes that by increasing the line height.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5306)
<!-- Reviewable:end -->
