### PR TITLE
Suggest reboot if upgrade fails on Windows

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -874,7 +874,7 @@
 	${ExtractMullvadSetup}
 	${ClearFirewallRules}
 
-	MessageBox MB_OK "Failed to uninstall a previous version. Contact support or review the logs for more information."
+	MessageBox MB_OK "Failed to uninstall a previous version. Please try restarting your computer and try again. If you still have this issue, please contact support."
 	SetErrorLevel 5
 	Abort
 


### PR DESCRIPTION
Rebooting is always suggested when upgrading fails, which typically occurs because there's some inexplicable file handle preventing it. This PR adds that suggestion to the installer.

Fixes DES-400.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5312)
<!-- Reviewable:end -->
