### PR TITLE
Fix CLI output for custom relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Line wrap the file at 100 chars.                                              Th
 - Remove wireguard-go (userspace WireGuard) support.
 
 ### Fixed
+- Show correct endpoint in CLI for custom relays.
+
 #### Windows
 - Correctly detect whether OS is Windows Server (primarily for logging in daemon.log).
 

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -82,8 +82,10 @@ impl fmt::Display for CustomTunnelEndpoint {
             ),
             ConnectionConfig::Wireguard(connection) => write!(
                 f,
-                "WireGuard relay - {} with public key {}",
-                connection.peer.endpoint, connection.peer.public_key
+                "WireGuard relay - {}:{} with public key {}",
+                self.host,
+                connection.peer.endpoint.port(),
+                connection.peer.public_key
             ),
         }
     }


### PR DESCRIPTION
Show the actual IP address when running `mullvad relay get` instead of `0.0.0.0`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5315)
<!-- Reviewable:end -->
