### PR TITLE
Do not set default password for custom `shadowsocks` access method

### DIFF
--- a/mullvad-cli/src/cmds/api_access.rs
+++ b/mullvad-cli/src/cmds/api_access.rs
@@ -272,12 +272,11 @@ pub enum AddCustomCommands {
         name: String,
         /// The IP of the remote Shadowsocks-proxy
         remote_ip: IpAddr,
+        /// Password for authentication
+        password: String,
         /// Port on which the remote Shadowsocks-proxy listens for traffic
         #[arg(default_value = "443")]
         remote_port: u16,
-        /// Password for authentication
-        #[arg(default_value = "mullvad")]
-        password: String,
         /// Cipher to use
         #[arg(value_parser = SHADOWSOCKS_CIPHERS, default_value = "aes-256-gcm")]
         cipher: String,


### PR DESCRIPTION
Do not try to set default password for custom `shadowsocks` access method.
The previously provided default is the password for Mullvad's own bridge severs.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
