### PR TITLE
Prevent user from navigation while requesting in-app purchase

### DIFF
--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -352,6 +352,11 @@ class RootContainerViewController: UIViewController {
         }
     }
 
+    func enableHeaderBarButtons(_ enabled: Bool) {
+        headerBarView.accountButton.isEnabled = enabled
+        headerBarView.settingsButton.isEnabled = enabled
+    }
+
     // MARK: - Accessibility
 
     override func accessibilityPerformMagicTap() -> Bool {

--- a/ios/MullvadVPN/Coordinators/WelcomeCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/WelcomeCoordinator.swift
@@ -122,6 +122,8 @@ extension WelcomeCoordinator: WelcomeViewControllerDelegate {
     }
 
     func didRequestToPurchaseCredit(controller: WelcomeViewController, accountNumber: String, product: SKProduct) {
+        navigationController.enableHeaderBarButtons(false)
+
         let coordinator = InAppPurchaseCoordinator(
             navigationController: navigationController,
             interactor: inAppPurchaseInteractor
@@ -131,11 +133,13 @@ extension WelcomeCoordinator: WelcomeViewControllerDelegate {
 
         coordinator.didFinish = { [weak self] coordinator in
             guard let self else { return }
+            navigationController.enableHeaderBarButtons(true)
             coordinator.removeFromParent()
             didFinish?()
         }
 
-        coordinator.didCancel = { coordinator in
+        coordinator.didCancel = { [weak self] coordinator in
+            self?.navigationController.enableHeaderBarButtons(true)
             coordinator.removeFromParent()
         }
 

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
@@ -178,6 +178,7 @@ final class WelcomeContentView: UIView {
         didSet {
             let alpha = isPurchasing ? 0.7 : 1.0
             purchaseButton.isLoading = isPurchasing
+            purchaseButton.isEnabled = !isPurchasing
             purchaseButton.alpha = alpha
             redeemVoucherButton.isEnabled = !isPurchasing
             redeemVoucherButton.alpha = alpha


### PR DESCRIPTION
When starting a payment flow from the new account view, the user can navigate away. Instead, we should block the view and show a spinner, not unlike how we currently handle the voucher redemption in the account view.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5328)
<!-- Reviewable:end -->
