### PR TITLE
Add console.log error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Show correct endpoint in CLI for custom relays.
 - Lower risk of being rate limited.
+- Fix error dialog when failing to write to console by handling the thrown error.
 
 #### Windows
 - Correctly detect whether OS is Windows Server (primarily for logging in daemon.log).


### PR DESCRIPTION
This PR adds error handling around console output. If `console.log` throws an error we now disable the console logger and writes the error to the file logger.

Fixes https://github.com/mullvad/mullvadvpn-app/issues/4188
Fixes DES-89

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5330)
<!-- Reviewable:end -->
