### PR TITLE
Improve error handling for API requests that failed due to being offline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,7 @@ dependencies = [
  "http",
  "hyper",
  "ipnetwork",
+ "libc",
  "log",
  "mullvad-fs",
  "mullvad-types",

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -13,6 +13,7 @@ publish.workspace = true
 api-override = []
 
 [dependencies]
+libc = "0.2"
 chrono = { workspace = true }
 err-derive = { workspace = true }
 futures = "0.3"

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -19,6 +19,7 @@ use hyper::{
 };
 use mullvad_types::account::AccountToken;
 use std::{
+    error::Error as StdError,
     future::Future,
     str::FromStr,
     sync::{Arc, Weak},
@@ -88,6 +89,21 @@ impl Error {
         matches!(self, Error::HyperError(_) | Error::TimeoutError)
     }
 
+    /// Return true if there was no route to the destination
+    pub fn is_offline(&self) -> bool {
+        match self {
+            Error::HyperError(error) if error.is_connect() => {
+                if let Some(cause) = error.source() {
+                    if let Some(err) = cause.downcast_ref::<std::io::Error>() {
+                        return err.raw_os_error() == Some(libc::ENETUNREACH);
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
     pub fn is_aborted(&self) -> bool {
         matches!(self, Error::Aborted)
     }
@@ -95,7 +111,6 @@ impl Error {
     /// Returns a new instance for which `abortable_stream::Aborted` is mapped to `Self::Aborted`.
     fn map_aborted(self) -> Self {
         if let Error::HyperError(error) = &self {
-            use std::error::Error;
             let mut source = error.source();
             while let Some(error) = source {
                 let io_error: Option<&std::io::Error> = error.downcast_ref();


### PR DESCRIPTION
This PR adds `mullvad_api::rest::Error::is_offline`, which returns `true` for (and only for) network errors that were due to `ENETUNREACH` (i.e., there's no route to the host). Unlike the previous code in `geoip`, it also works if an error is cloned.

Fix DES-413.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5339)
<!-- Reviewable:end -->
