### PR TITLE
Fix failing macOS DNS tests, and truncate log files in tests

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
@@ -30,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
@@ -45,6 +49,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |

--- a/test/ci-runtests.sh
+++ b/test/ci-runtests.sh
@@ -211,7 +211,7 @@ echo "* Building test runner"
 echo "**********************************"
 
 # Clean up packages. Try to keep ones that match the versions we're testing
-find "$PACKAGES_DIR/" -type f ! \( -name "*${OLD_APP_VERSION}_*" -o -name "*${OLD_APP_VERSION}.*" -o -name "*${NEW_APP_VERSION}*" \) -delete || true
+find "$PACKAGES_DIR/" -type f ! \( -name "*${OLD_APP_VERSION}*" -o -name "*${commit}*" \) -delete || true
 
 function build_test_runner {
     local target=""

--- a/test/test-runner/src/logging.rs
+++ b/test/test-runner/src/logging.rs
@@ -1,10 +1,12 @@
 use log::{Level, LevelFilter, Metadata, Record, SetLoggerError};
 use once_cell::sync::Lazy;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use test_rpc::logging::Error;
 use test_rpc::logging::{LogFile, LogOutput, Output};
 use tokio::{
-    fs::read_to_string,
+    fs::File,
+    io::{self, AsyncBufReadExt, BufReader},
     sync::{
         broadcast::{channel, Receiver, Sender},
         Mutex,
@@ -12,6 +14,12 @@ use tokio::{
 };
 
 const MAX_OUTPUT_BUFFER: usize = 10_000;
+/// Only consider files that end with ".log"
+const INCLUDE_LOG_FILE_EXT: &str = "log";
+/// Ignore log files that contain ".old"
+const EXCLUDE_LOG_FILE_CONTAIN: &str = ".old";
+/// Maximum number of lines that each log file may contain
+const TRUNCATE_LOG_FILE_LINES: usize = 100;
 
 pub static LOGGER: Lazy<StdOutBuffer> = Lazy::new(|| {
     let (sender, listener) = channel(MAX_OUTPUT_BUFFER);
@@ -69,7 +77,7 @@ async fn read_settings_file() -> Result<String, Error> {
     let mut settings_path = mullvad_paths::get_default_settings_dir()
         .map_err(|error| Error::Logs(format!("{}", error)))?;
     settings_path.push("settings.json");
-    read_to_string(&settings_path)
+    read_truncated(&settings_path)
         .await
         .map_err(|error| Error::Logs(format!("{}: {}", settings_path.display(), error)))
 }
@@ -82,7 +90,7 @@ async fn read_log_files() -> Result<Vec<Result<LogFile, Error>>, Error> {
         .map_err(|error| Error::Logs(format!("{}", error)))?;
     let mut log_files = Vec::new();
     for path in paths {
-        let log_file = read_to_string(&path)
+        let log_file = read_truncated(&path)
             .await
             .map_err(|error| Error::Logs(format!("{}: {}", path.display(), error)))
             .map(|content| LogFile {
@@ -98,14 +106,33 @@ async fn list_logs<T: AsRef<Path>>(log_dir: T) -> Result<Vec<PathBuf>, Error> {
     let mut dir_entries = tokio::fs::read_dir(&log_dir)
         .await
         .map_err(|e| Error::Logs(format!("{}: {}", log_dir.as_ref().display(), e)))?;
-    let log_extension = Some(std::ffi::OsStr::new("log"));
 
     let mut paths = Vec::new();
     while let Ok(Some(entry)) = dir_entries.next_entry().await {
         let path = entry.path();
-        if path.extension() == log_extension {
+        if let Some(u8_path) = path.to_str() {
+            if u8_path.contains(EXCLUDE_LOG_FILE_CONTAIN) {
+                continue;
+            }
+        }
+        if path.extension() == Some(OsStr::new(INCLUDE_LOG_FILE_EXT)) {
             paths.push(path);
         }
     }
     Ok(paths)
+}
+
+async fn read_truncated<T: AsRef<Path>>(path: T) -> io::Result<String> {
+    let mut output = vec![];
+    let reader = BufReader::new(File::open(path).await?);
+    let mut lines = reader.lines();
+    while let Some(line) = lines.next_line().await? {
+        output.push(line);
+    }
+    if output.len() > TRUNCATE_LOG_FILE_LINES {
+        let drop_count = output.len() - TRUNCATE_LOG_FILE_LINES;
+        // not the most efficient
+        output.drain(0..drop_count);
+    }
+    Ok(output.join("\n"))
 }


### PR DESCRIPTION
Changes:
* Fetch tags when checking out code in GH Actions (so that `ci-runtests.sh` can recognize tags).
* Make sure tests don't leave any lingering tokio tasks that were spawned.
* Cache UI runners.
* Truncate log files before transferring them and ignore `.old.log` files.
* Fix failing DNS leak tests on macOS

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5346)
<!-- Reviewable:end -->
