### PR TITLE
Remove 'ResponseFailure' error variant

### DIFF
--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -729,20 +729,16 @@ fn flatten_result<T, E>(
     }
 }
 
-impl From<hyper::Error> for Error {
-    fn from(value: hyper::Error) -> Self {
-        Error::HyperError(Arc::new(value))
-    }
+macro_rules! impl_into_arc_err {
+    ($ty:ty) => {
+        impl From<$ty> for Error {
+            fn from(error: $ty) -> Self {
+                Error::from(Arc::from(error))
+            }
+        }
+    };
 }
 
-impl From<serde_json::Error> for Error {
-    fn from(value: serde_json::Error) -> Self {
-        Error::DeserializeError(Arc::new(value))
-    }
-}
-
-impl From<http::Error> for Error {
-    fn from(value: http::Error) -> Self {
-        Error::HttpError(Arc::new(value))
-    }
-}
+impl_into_arc_err!(hyper::Error);
+impl_into_arc_err!(serde_json::Error);
+impl_into_arc_err!(http::Error);

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1122,7 +1122,6 @@ fn map_device_error(error: &device::Error) -> Status {
             Status::new(Code::Unavailable, error.to_string())
         }
         device::Error::OtherRestError(error) => map_rest_error(error),
-        device::Error::ResponseFailure(error) => map_device_error(error.unpack()),
         _ => Status::new(Code::Unknown, error.to_string()),
     }
 }


### PR DESCRIPTION
Minor cleanup that removes `Error::ResponseFailure` from `device`. It was easy to forget about it while matching, as you had to remember to "unwrap" it, so removing it makes it harder to introduce bugs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5349)
<!-- Reviewable:end -->
