### PR TITLE
Relax relay location constraints in some end-to-end tests

### DIFF
--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -4,8 +4,8 @@ use futures::StreamExt;
 use mullvad_management_interface::{types, ManagementServiceClient};
 use mullvad_types::{
     relay_constraints::{
-        Constraint, GeographicLocationConstraint, LocationConstraint, OpenVpnConstraints,
-        RelayConstraintsUpdate, RelaySettingsUpdate, WireguardConstraints,
+        BridgeState, Constraint, GeographicLocationConstraint, LocationConstraint,
+        ObfuscationSettings, RelayConstraintsUpdate, RelaySettingsUpdate,
     },
     states::TunnelState,
 };

--- a/test/test-manager/src/tests/tunnel.rs
+++ b/test/test-manager/src/tests/tunnel.rs
@@ -48,9 +48,6 @@ pub async fn test_openvpn_tunnel(
         log::info!("Connect to {protocol} OpenVPN endpoint");
 
         let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-            location: Some(Constraint::Only(LocationConstraint::Location(
-                GeographicLocationConstraint::Country("se".to_string()),
-            ))),
             tunnel_protocol: Some(Constraint::Only(TunnelType::OpenVpn)),
             openvpn_constraints: Some(OpenVpnConstraints { port: constraint }),
             ..Default::default()
@@ -91,9 +88,6 @@ pub async fn test_wireguard_tunnel(
         log::info!("Connect to WireGuard endpoint on port {port}");
 
         let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-            location: Some(Constraint::Only(LocationConstraint::Location(
-                GeographicLocationConstraint::Country("se".to_string()),
-            ))),
             tunnel_protocol: Some(Constraint::Only(TunnelType::Wireguard)),
             wireguard_constraints: Some(WireguardConstraints {
                 port: Constraint::Only(port),
@@ -149,11 +143,7 @@ pub async fn test_udp2tcp_tunnel(
         .expect("failed to enable udp2tcp");
 
     let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-        location: Some(Constraint::Only(LocationConstraint::Location(
-            GeographicLocationConstraint::Country("se".to_string()),
-        ))),
         tunnel_protocol: Some(Constraint::Only(TunnelType::Wireguard)),
-        wireguard_constraints: Some(WireguardConstraints::default()),
         ..Default::default()
     });
 
@@ -394,9 +384,6 @@ pub async fn test_wireguard_autoconnect(
     log::info!("Setting tunnel protocol to WireGuard");
 
     let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-        location: Some(Constraint::Only(LocationConstraint::Location(
-            GeographicLocationConstraint::Country("se".to_string()),
-        ))),
         tunnel_protocol: Some(Constraint::Only(TunnelType::Wireguard)),
         ..Default::default()
     });
@@ -439,9 +426,6 @@ pub async fn test_openvpn_autoconnect(
     log::info!("Setting tunnel protocol to OpenVPN");
 
     let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-        location: Some(Constraint::Only(LocationConstraint::Location(
-            GeographicLocationConstraint::Country("se".to_string()),
-        ))),
         tunnel_protocol: Some(Constraint::Only(TunnelType::OpenVpn)),
         ..Default::default()
     });
@@ -513,9 +497,6 @@ pub async fn test_quantum_resistant_tunnel(
     log::info!("Setting tunnel protocol to WireGuard");
 
     let relay_settings = RelaySettingsUpdate::Normal(RelayConstraintsUpdate {
-        location: Some(Constraint::Only(LocationConstraint::Location(
-            GeographicLocationConstraint::Country("se".to_string()),
-        ))),
         tunnel_protocol: Some(Constraint::Only(TunnelType::Wireguard)),
         ..Default::default()
     });


### PR DESCRIPTION
Clean up some older test cases: 
* relax (too restrictive) relay location constraints
* Use types from `mullvad_types` instead of the auto-generated gRPC types. These are generally easier to work with, and reflects how code in the rest of the app is written.
* Add some docs à la boy scout rule

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5351)
<!-- Reviewable:end -->
