### PR TITLE
Add missing macros feature to tokio

### DIFF
--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -27,7 +27,7 @@ mullvad-version = { path = "../mullvad-version" }
 talpid-types = { path = "../talpid-types" }
 
 mullvad-management-interface = { path = "../mullvad-management-interface" }
-tokio = { workspace = true, features =  [ "rt-multi-thread" ] }
+tokio = { workspace = true, features =  ["macros", "rt-multi-thread"] }
 
 [target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 clap_complete = { version = "4.2.1" }


### PR DESCRIPTION
I accidentally stumbled upon `cd mullvad-cli; cargo check` failing. It did not have all the required features on its dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5352)
<!-- Reviewable:end -->
