### PR TITLE
Update privacy strings

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/PrivacyDisclaimerScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/PrivacyDisclaimerScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -30,6 +31,7 @@ import androidx.constraintlayout.compose.Dimension
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.button.PrimaryButton
 import net.mullvad.mullvadvpn.compose.component.ScaffoldWithTopBar
+import net.mullvad.mullvadvpn.compose.util.toDp
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 
@@ -73,22 +75,31 @@ fun PrivacyDisclaimerScreen(
             ) {
                 Text(
                     text = stringResource(id = R.string.privacy_disclaimer_title),
-                    fontSize = 24.sp,
-                    color = Color.White,
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onBackground,
                     fontWeight = FontWeight.Bold
                 )
 
+                val fontSize = 14.sp
                 Text(
-                    text = stringResource(id = R.string.privacy_disclaimer_body),
-                    fontSize = 14.sp,
-                    color = Color.White,
+                    text = stringResource(id = R.string.privacy_disclaimer_body_first_paragraph),
+                    fontSize = fontSize,
+                    color = MaterialTheme.colorScheme.onBackground,
                     modifier = Modifier.padding(top = 10.dp)
+                )
+
+                Spacer(modifier = Modifier.height(fontSize.toDp() + Dimens.smallPadding))
+
+                Text(
+                    text = stringResource(id = R.string.privacy_disclaimer_body_second_paragraph),
+                    fontSize = fontSize,
+                    color = MaterialTheme.colorScheme.onBackground,
                 )
 
                 Row(modifier = Modifier.padding(top = 10.dp)) {
                     ClickableText(
                         text = AnnotatedString(stringResource(id = R.string.privacy_policy_label)),
-                        onClick = { onPrivacyPolicyLinkClicked.invoke() },
+                        onClick = { onPrivacyPolicyLinkClicked() },
                         style =
                             TextStyle(
                                 fontSize = 12.sp,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/UnitConversion.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/UnitConversion.kt
@@ -1,0 +1,8 @@
+package net.mullvad.mullvadvpn.compose.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+
+@Composable fun TextUnit.toDp(): Dp = with(LocalDensity.current) { this@toDp.toDp() }

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -162,7 +162,8 @@
     <string name="new_device_notification_message"><![CDATA[Welcome, this device is now called <b>%s</b>. For more details see the info button in Account.]]></string>
     <string name="agree_and_continue">Agree and continue</string>
     <string name="privacy_disclaimer_title">Privacy</string>
-    <string name="privacy_disclaimer_body">To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you.\n\nIf the split tunneling feature is used, then the app queries your system for a list of all installed applications. This list is only retrieved in the split tunneling view. The list of installed applications is never sent from the device.</string>
+    <string name="privacy_disclaimer_body_first_paragraph">To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you.</string>
+    <string name="privacy_disclaimer_body_second_paragraph">If the split tunneling feature is used, then the app queries your system for a list of all installed applications. This list is only retrieved in the split tunneling view. The list of installed applications is never sent from the device.</string>
     <string name="submit_button">Submit</string>
     <string name="remove_button">Remove</string>
     <string name="enter_value_placeholder">Enter MTU</string>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1729,6 +1729,9 @@ msgstr ""
 msgid "Going to login will unblock the internet on this device."
 msgstr ""
 
+msgid "If the split tunneling feature is used, then the app queries your system for a list of all installed applications. This list is only retrieved in the split tunneling view. The list of installed applications is never sent from the device."
+msgstr ""
+
 msgid "Install Mullvad VPN (%s) to stay up to date"
 msgstr ""
 
@@ -1789,7 +1792,7 @@ msgstr ""
 msgid "This might cause issues on certain websites, services, and apps."
 msgstr ""
 
-msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you.\\n\\nIf the split tunneling feature is used, then the app queries your system for a list of all installed applications. This list is only retrieved in the split tunneling view. The list of installed applications is never sent from the device."
+msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr ""
 
 msgid "Toggle VPN"


### PR DESCRIPTION
We had an invalid privacy policy string that contained `\n` our translations-converter tool does not support this. This PR fixes this string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5356)
<!-- Reviewable:end -->
