### PR TITLE
Fix getDevice method signature

### DIFF
--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/ForegroundNotificationManager.kt
@@ -60,7 +60,7 @@ class ForegroundNotificationManager(
             jobTracker.newBackgroundJob("notificationLoggedInJob") {
                 daemon
                     ?.deviceStateUpdates
-                    ?.onStart { emit(daemon.getAndEmitDeviceState()) }
+                    ?.onStart { daemon.getAndEmitDeviceState()?.let { emit(it) } }
                     ?.collect { deviceState -> loggedIn = deviceState is DeviceState.LoggedIn }
             }
         }

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadDaemon.kt
@@ -135,8 +135,8 @@ class MullvadDaemon(
         }
     }
 
-    fun getAndEmitDeviceState(): DeviceState {
-        return getDevice(daemonInterfaceAddress).also { deviceState ->
+    fun getAndEmitDeviceState(): DeviceState? {
+        return getDevice(daemonInterfaceAddress)?.also { deviceState ->
             _deviceStateUpdates.tryEmit(deviceState)
         }
     }
@@ -257,7 +257,9 @@ class MullvadDaemon(
         accountToken: String?
     ): List<Device>?
 
-    private external fun getDevice(daemonInterfaceAddress: Long): DeviceState
+    // TODO: Review this method when redoing Daemon communication, it can be null which was not
+    // considered when this method was initially added.
+    private external fun getDevice(daemonInterfaceAddress: Long): DeviceState?
 
     private external fun updateDevice(daemonInterfaceAddress: Long)
 


### PR DESCRIPTION
As part of a timeboxed issue I looked through Play Store crashes and found that we have the wrong signature on this JNI calling function.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5365)
<!-- Reviewable:end -->
