### PR TITLE
Make username+password authentication optional for SOCKS5 access method

### DIFF
--- a/mullvad-cli/src/cmds/api_access.rs
+++ b/mullvad-cli/src/cmds/api_access.rs
@@ -321,12 +321,13 @@ pub enum AddSocks5Commands {
 }
 
 #[derive(Args, Debug, Clone)]
+#[group(requires_all = ["username", "password"])] // https://github.com/clap-rs/clap/issues/5092
 pub struct SocksAuthentication {
     /// Username for authentication against a remote SOCKS5 proxy
-    #[arg(short, long)]
+    #[arg(short, long, required = false)]
     username: String,
     /// Password for authentication against a remote SOCKS5 proxy
-    #[arg(short, long)]
+    #[arg(short, long, required = false)]
     password: String,
 }
 


### PR DESCRIPTION
SOCKS5 optionally supports username+password authentication, which has been implemented since https://github.com/mullvad/mullvadvpn-app/commit/bb2caa8fa93b9272817d22c08ed6f4e5371a35ac. This commit addresses a bug in the argument parsing, which made username+password required arguments when adding a remote SOCKS5 api access method using `mullvad api-access add socks5 remote`.

Apparently, this is a known pitfall with `clap`: https://github.com/clap-rs/clap/issues/5092

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5366)
<!-- Reviewable:end -->
