### PR TITLE
Move access method testing logic to `mullvad-daemon`

### DIFF
--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -620,4 +620,24 @@ impl ApiProxy {
         let response = self.handle.service.request(request).await?;
         response.deserialize().await
     }
+
+    /// Check the availablility of `{APP_URL_PREFIX}/api-addrs`.
+    pub async fn api_addrs_available(&self) -> Result<(), rest::Error> {
+        let service = self.handle.service.clone();
+
+        rest::send_request(
+            &self.handle.factory,
+            service,
+            &format!("{APP_URL_PREFIX}/api-addrs"),
+            Method::HEAD,
+            None,
+            &[StatusCode::OK],
+        )
+        .await?;
+
+        // NOTE: A HEAD request should *not* have a body:
+        // https://developer.mozilla.org/en-US/docs/web/http/methods/head
+        // I.e., no need to deserialize the result.
+        Ok(())
+    }
 }

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -622,22 +622,14 @@ impl ApiProxy {
     }
 
     /// Check the availablility of `{APP_URL_PREFIX}/api-addrs`.
-    pub async fn api_addrs_available(&self) -> Result<(), rest::Error> {
-        let service = self.handle.service.clone();
+    pub async fn api_addrs_available(&self) -> Result<bool, rest::Error> {
+        let request = self
+            .handle
+            .factory
+            .head(&format!("{APP_URL_PREFIX}/api-addrs"))?
+            .expected_status(&[StatusCode::OK]);
 
-        rest::send_request(
-            &self.handle.factory,
-            service,
-            &format!("{APP_URL_PREFIX}/api-addrs"),
-            Method::HEAD,
-            None,
-            &[StatusCode::OK],
-        )
-        .await?;
-
-        // NOTE: A HEAD request should *not* have a body:
-        // https://developer.mozilla.org/en-US/docs/web/http/methods/head
-        // I.e., no need to deserialize the result.
-        Ok(())
+        let response = self.handle.service.request(request).await?;
+        Ok(response.status().is_success())
     }
 }

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -524,6 +524,10 @@ impl RequestFactory {
         self.request(path, Method::DELETE)
     }
 
+    pub fn head(&self, path: &str) -> Result<Request> {
+        self.request(path, Method::HEAD)
+    }
+
     pub fn post_json<S: serde::Serialize>(&self, path: &str, body: &S) -> Result<Request> {
         self.json_request(Method::POST, path, body)
     }

--- a/mullvad-cli/src/cmds/api_access.rs
+++ b/mullvad-cli/src/cmds/api_access.rs
@@ -186,11 +186,11 @@ impl ApiAccess {
 
         println!("Testing access method \"{}\"", access_method.name);
         match rpc.test_api_access_method(access_method.get_id()).await {
-            Ok(_) => {
+            Ok(true) => {
                 println!("Success!");
                 Ok(())
             }
-            Err(_) => Err(anyhow!("Could not reach the Mullvad API.")),
+            Ok(false) | Err(_) => Err(anyhow!("Could not reach the Mullvad API.")),
         }
     }
 

--- a/mullvad-daemon/src/access_method.rs
+++ b/mullvad-daemon/src/access_method.rs
@@ -1,8 +1,9 @@
 use crate::{
-    api,
+    api::{self, AccessModeSelectorHandle},
     settings::{self, MadeChanges},
     Daemon, EventListener,
 };
+use mullvad_api::rest::{self, MullvadRestHandle};
 use mullvad_types::{
     access_method::{self, AccessMethod, AccessMethodSetting},
     settings::Settings,
@@ -26,6 +27,8 @@ pub enum Error {
     /// [`AccessMethodSetting`]s & [`ApiConnectionMode`]s.
     #[error(display = "Error occured when handling connection settings & details")]
     ConnectionMode(#[error(source)] api::Error),
+    #[error(display = "API endpoint rotation failed")]
+    RestError(#[error(source)] rest::Error),
     /// Access methods settings error
     #[error(display = "Settings error")]
     Settings(#[error(source)] settings::Error),
@@ -202,7 +205,7 @@ where
             tokio::spawn(async move {
                 match handle.update_access_methods(new_access_methods).await {
                     Ok(_) => (),
-                    Err(crate::api::Error::NoAccessMethods) => {
+                    Err(api::Error::NoAccessMethods) | Err(_) => {
                         // `access_methods` was empty! This implies that the user
                         // disabled all access methods. If we ever get into this
                         // state, we should default to using the direct access
@@ -224,4 +227,93 @@ where
             Command::Set(id) => self.set_api_access_method(id).await,
         }
     }
+}
+
+/// Try to reach the Mullvad API using a specific access method, returning
+/// an [`Error`] in the case where the test fails to reach the API.
+///
+/// Ephemerally sets a new access method (associated with `access_method`)
+/// to be used for subsequent API calls, before performing an API call and
+/// switching back to the previously active access method. The previous
+/// access method is *always* reset.
+pub async fn test_access_method(
+    new_access_method: AccessMethodSetting,
+    access_mode_selector: AccessModeSelectorHandle,
+    rest_handle: MullvadRestHandle,
+) -> Result<bool, Error> {
+    // Setup test
+    let previous_access_method = access_mode_selector
+        .get_access_method()
+        .await
+        .map_err(Error::ConnectionMode)?;
+
+    let method_under_test = new_access_method.clone();
+    access_mode_selector
+        .set_access_method(new_access_method)
+        .await
+        .map_err(Error::ConnectionMode)?;
+
+    // We need to perform a rotation of API endpoint after a set action
+    let rotation_handle = rest_handle.clone();
+    rotation_handle
+        .service()
+        .next_api_endpoint()
+        .await
+        .map_err(|err| {
+            log::error!("Failed to rotate API endpoint: {err}");
+            Error::RestError(err)
+        })?;
+
+    // Set up the reset
+    //
+    // In case the API call fails, the next API endpoint will
+    // automatically be selected, which means that we need to set up
+    // with the previous API endpoint beforehand.
+    access_mode_selector
+        .set_access_method(previous_access_method)
+        .await
+        .map_err(|err| {
+            log::error!(
+                "Could not reset to previous access
+            method after API reachability test was carried out. This should only
+            happen if the previous access method was removed in the meantime."
+            );
+            Error::ConnectionMode(err)
+        })?;
+
+    // Perform test
+    //
+    // Send a HEAD request to some Mullvad API endpoint. We issue a HEAD
+    // request because we are *only* concerned with if we get a reply from
+    // the API, and not with the actual data that the endpoint returns.
+    let result = mullvad_api::ApiProxy::new(rest_handle)
+        .api_addrs_available()
+        .await
+        .map_err(Error::RestError)?;
+
+    // We need to perform a rotation of API endpoint after a set action
+    // Note that this will be done automatically if the API call fails,
+    // so it only has to be done if the call succeeded ..
+    if result {
+        rotation_handle
+            .service()
+            .next_api_endpoint()
+            .await
+            .map_err(|err| {
+                log::error!("Failed to rotate API endpoint: {err}");
+                Error::RestError(err)
+            })?;
+    }
+
+    log::info!(
+        "The result of testing {method:?} is {result}",
+        method = method_under_test.access_method,
+        result = if result {
+            "success".to_string()
+        } else {
+            "failed".to_string()
+        }
+    );
+
+    Ok(result)
 }

--- a/mullvad-daemon/src/access_method.rs
+++ b/mullvad-daemon/src/access_method.rs
@@ -198,15 +198,7 @@ where
                 .notify_settings(self.settings.to_settings());
 
             let handle = self.connection_modes_handler.clone();
-            let new_access_methods = self
-                .settings
-                .api_access_methods
-                .access_method_settings
-                .iter()
-                .filter(|api_access_method| api_access_method.enabled())
-                .cloned()
-                .collect();
-
+            let new_access_methods = self.settings.api_access_methods.collect_enabled();
             tokio::spawn(async move {
                 match handle.update_access_methods(new_access_methods).await {
                     Ok(_) => (),

--- a/mullvad-daemon/src/access_method.rs
+++ b/mullvad-daemon/src/access_method.rs
@@ -19,16 +19,13 @@ pub enum Error {
     /// Can not find access method
     #[error(display = "Cannot find custom access method {}", _0)]
     NoSuchMethod(access_method::Id),
-    /// Can not find *any* access method. This should never happen. If it does,
-    /// the user should do a factory reset.
-    #[error(display = "No access methods are configured")]
-    NoMethodsExist,
     /// Access method could not be rotate
     #[error(display = "Access method could not be rotated")]
     RotationError,
-    /// Daemon API error
-    #[error(display = "Daemon API handling error")]
-    Api(#[error(source)] api::Error),
+    /// Some error occured in the daemon's state of handling
+    /// [`AccessMethodSetting`]s & [`ApiConnectionMode`]s.
+    #[error(display = "Error occured when handling connection settings & details")]
+    ConnectionMode(#[error(source)] api::Error),
     /// Access methods settings error
     #[error(display = "Settings error")]
     Settings(#[error(source)] settings::Error),

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -46,21 +46,6 @@ pub struct AccessModeSelectorHandle {
 }
 
 impl AccessModeSelectorHandle {
-    pub fn new(
-        cache_dir: PathBuf,
-        relay_selector: RelaySelector,
-        connection_modes: Vec<AccessMethodSetting>,
-    ) -> Self {
-        let (cmd_tx, cmd_rx) = mpsc::unbounded();
-
-        let mut actor = AccessModeSelector {
-            cmd_rx,
-            state: ApiConnectionModeProvider::new(cache_dir, relay_selector, connection_modes),
-        };
-        tokio::spawn(async move { actor.run().await });
-        Self { cmd_tx }
-    }
-
     async fn send_command<T>(&self, make_cmd: impl FnOnce(ResponseTx<T>) -> Message) -> Result<T> {
         let (tx, rx) = oneshot::channel();
         // TODO(markus): Error handling
@@ -120,7 +105,36 @@ pub struct AccessModeSelector {
 }
 
 impl AccessModeSelector {
-    async fn run(&mut self) {
+    pub fn spawn(
+        cache_dir: PathBuf,
+        relay_selector: RelaySelector,
+        connection_modes: Vec<AccessMethodSetting>,
+    ) -> AccessModeSelectorHandle {
+        let (cmd_tx, cmd_rx) = mpsc::unbounded();
+
+        let state =
+            match ApiConnectionModeProvider::new(cache_dir, relay_selector, connection_modes) {
+                Ok(provider) => provider,
+                Err(api::Error::NoAccessMethods) => {
+                    // No settings seem to have been found. Default to using the the
+                    // direct access method.
+                    let default = mullvad_types::access_method::Settings::direct();
+                    api::ApiConnectionModeProvider::new(
+                    cache_dir.clone(),
+                    relay_selector.clone(),
+                    vec![default],
+                )
+                .expect(
+                    "Failed to create the data structure responsible for managing access methods",
+                )
+                }
+            };
+        let selector = AccessModeSelector { cmd_rx, state };
+        tokio::spawn(selector.into_future());
+        AccessModeSelectorHandle { cmd_tx }
+    }
+
+    async fn into_future(mut self) {
         while let Some(cmd) = self.cmd_rx.next().await {
             let _ = match cmd {
                 Message::Get(tx) => self.on_get_access_method(tx),

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -2,7 +2,8 @@
 use crate::{DaemonCommand, DaemonEventSender};
 use futures::{
     channel::{mpsc, oneshot},
-    Future, Stream, StreamExt,
+    stream::unfold,
+    Stream, StreamExt,
 };
 use mullvad_api::{
     availability::ApiAvailabilityHandle,
@@ -13,17 +14,205 @@ use mullvad_relay_selector::RelaySelector;
 use mullvad_types::access_method::{self, AccessMethod, AccessMethodSetting, BuiltInAccessMethod};
 use std::{
     path::PathBuf,
-    pin::Pin,
     sync::{Arc, Mutex, Weak},
-    task::Poll,
 };
 #[cfg(target_os = "android")]
 use talpid_core::mpsc::Sender;
 use talpid_core::tunnel_state_machine::TunnelCommand;
-use talpid_types::{
-    net::{openvpn::ProxySettings, AllowedEndpoint, Endpoint},
-    ErrorExt,
-};
+use talpid_types::net::{openvpn::ProxySettings, AllowedEndpoint, Endpoint};
+
+// TODO(markus): Remove text
+/// Here, a new agent was born.
+
+pub enum Message {
+    Get(ResponseTx<AccessMethodSetting>),
+    Set(ResponseTx<()>, AccessMethodSetting),
+    Next(ResponseTx<ApiConnectionMode>),
+    Update(ResponseTx<()>, Vec<AccessMethodSetting>),
+}
+
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// Oddly specific.
+    #[error(display = "Very Generic error.")]
+    Generic,
+}
+
+#[derive(Clone)]
+pub struct Ehandle {
+    cmd_tx: mpsc::UnboundedSender<Message>,
+}
+
+impl Ehandle {
+    pub fn new(
+        cache_dir: PathBuf,
+        relay_selector: RelaySelector,
+        connection_modes: Vec<AccessMethodSetting>,
+    ) -> Self {
+        let (cmd_tx, cmd_rx) = mpsc::unbounded();
+
+        let mut actor = EActor {
+            cmd_rx,
+            state: ApiConnectionModeProvider::new(cache_dir, relay_selector, connection_modes),
+        };
+        tokio::spawn(async move { actor.run().await });
+        Self { cmd_tx }
+    }
+
+    async fn send_command<T>(&self, make_cmd: impl FnOnce(ResponseTx<T>) -> Message) -> Result<T> {
+        let (tx, rx) = oneshot::channel();
+        // TODO(markus): Error handling
+        self.cmd_tx.unbounded_send(make_cmd(tx)).unwrap();
+        // TODO(markus): Error handling
+        rx.await.unwrap()
+    }
+
+    pub async fn get_access_method(&self) -> Result<AccessMethodSetting> {
+        self.send_command(Message::Get).await.map_err(|err| {
+            log::error!("Failed to get current access method!");
+            err
+        })
+    }
+
+    pub async fn set_access_method(&self, value: AccessMethodSetting) -> Result<()> {
+        self.send_command(|tx| Message::Set(tx, value))
+            .await
+            .map_err(|err| {
+                log::error!("Failed to set new access method!");
+                err
+            })
+    }
+
+    pub async fn update_access_methods(&self, values: Vec<AccessMethodSetting>) -> Result<()> {
+        self.send_command(|tx| Message::Update(tx, values))
+            .await
+            .map_err(|err| {
+                log::error!("Failed to update new access methods!");
+                err
+            })
+    }
+
+    pub async fn next(&self) -> Result<ApiConnectionMode> {
+        self.send_command(Message::Next).await.map_err(|err| {
+            log::error!("Failed to update new access methods!");
+            err
+        })
+    }
+
+    /// Stream the connection modes of this actor.
+    pub fn as_stream(&self) -> impl Stream<Item = ApiConnectionMode> {
+        let handle = self.clone();
+        unfold(handle, |handle| async move {
+            let connection_mode = handle
+                .next()
+                .await
+                .expect("It should always be safe to `unwrap` a new API connection mode");
+            Some((connection_mode, handle))
+        })
+    }
+}
+
+pub struct EActor {
+    cmd_rx: mpsc::UnboundedReceiver<Message>,
+    state: ApiConnectionModeProvider,
+}
+
+impl EActor {
+    async fn run(&mut self) {
+        while let Some(cmd) = self.cmd_rx.next().await {
+            let _ = match cmd {
+                Message::Get(tx) => self.on_get_access_method(tx),
+                Message::Set(tx, value) => self.on_set_access_method(tx, value),
+                Message::Next(tx) => self.on_next_connection_mode(tx),
+                Message::Update(tx, values) => self.on_update_access_methods(tx, values),
+            }
+            .map_err(|err| {
+                log::error!("todo(markus): Some error occured {err}");
+                err
+            });
+        }
+    }
+
+    fn reply<T>(&self, tx: ResponseTx<T>, value: T) -> Result<()> {
+        // TODO(markus): The error probably should come from the value/tx
+        tx.send(Ok(value)).map_err(|_| Error::Generic)
+    }
+
+    fn on_get_access_method(&mut self, tx: ResponseTx<AccessMethodSetting>) -> Result<()> {
+        let value = self.get_access_method()?;
+        self.reply(tx, value)
+    }
+
+    fn get_access_method(&mut self) -> Result<AccessMethodSetting> {
+        let connections_modes = self.state.connection_modes.lock().unwrap();
+        Ok(connections_modes.peek())
+    }
+
+    fn on_set_access_method(
+        &mut self,
+        tx: ResponseTx<()>,
+        value: AccessMethodSetting,
+    ) -> Result<()> {
+        self.set_access_method(value)?;
+        self.reply(tx, ())
+    }
+
+    fn set_access_method(&mut self, value: AccessMethodSetting) -> Result<()> {
+        let mut connections_modes = self.state.connection_modes.lock().unwrap();
+        connections_modes.set_access_method(value);
+        Ok(())
+    }
+
+    fn on_next_connection_mode(&mut self, tx: ResponseTx<ApiConnectionMode>) -> Result<()> {
+        let next = self.next_connection_mode();
+        // Save the new connection mode to cache!
+        {
+            let cache_dir = self.state.cache_dir.clone();
+            let next = next.clone();
+            tokio::spawn(async move {
+                if next.save(&cache_dir).await.is_err() {
+                    log::warn!(
+                        "Failed to save {connection_mode} to cache",
+                        connection_mode = next
+                    )
+                }
+            });
+        }
+        self.reply(tx, next)
+    }
+
+    fn next_connection_mode(&mut self) -> ApiConnectionMode {
+        let access_method = {
+            let mut connection_modes = self.state.connection_modes.lock().unwrap();
+            connection_modes
+                .next()
+                .map(|access_method_setting| access_method_setting.access_method)
+                .unwrap_or(AccessMethod::from(BuiltInAccessMethod::Direct))
+        };
+
+        let connection_mode = self.state.from(access_method);
+        log::info!("New API connection mode selected: {}", connection_mode);
+        connection_mode
+    }
+
+    fn on_update_access_methods(
+        &mut self,
+        tx: ResponseTx<()>,
+        values: Vec<AccessMethodSetting>,
+    ) -> Result<()> {
+        self.update_access_methods(values)?;
+        self.reply(tx, ())
+    }
+
+    fn update_access_methods(&mut self, values: Vec<AccessMethodSetting>) -> Result<()> {
+        let mut connection_modes = self.state.connection_modes.lock().unwrap();
+        connection_modes.update_access_methods(values);
+        Ok(())
+    }
+}
+
+type ResponseTx<T> = oneshot::Sender<Result<T>>;
+type Result<T> = std::result::Result<T, Error>;
 
 /// A stream that returns the next API connection mode to use for reaching the API.
 ///
@@ -38,43 +227,7 @@ pub struct ApiConnectionModeProvider {
     cache_dir: PathBuf,
     /// Used for selecting a Bridge when the `Mullvad Bridges` access method is used.
     relay_selector: RelaySelector,
-    current_task: Option<Pin<Box<dyn Future<Output = ApiConnectionMode> + Send>>>,
     connection_modes: Arc<Mutex<ConnectionModesIterator>>,
-}
-
-impl Stream for ApiConnectionModeProvider {
-    type Item = ApiConnectionMode;
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        // Poll the current task
-        if let Some(task) = self.current_task.as_mut() {
-            return match task.as_mut().poll(cx) {
-                Poll::Ready(mode) => {
-                    self.current_task = None;
-                    Poll::Ready(Some(mode))
-                }
-                Poll::Pending => Poll::Pending,
-            };
-        }
-
-        let connection_mode = self.new_connection_mode();
-
-        let cache_dir = self.cache_dir.clone();
-        self.current_task = Some(Box::pin(async move {
-            if let Err(error) = connection_mode.save(&cache_dir).await {
-                log::debug!(
-                    "{}",
-                    error.display_chain_with_msg("Failed to save API endpoint")
-                );
-            }
-            connection_mode
-        }));
-
-        self.poll_next(cx)
-    }
 }
 
 impl ApiConnectionModeProvider {
@@ -87,33 +240,8 @@ impl ApiConnectionModeProvider {
         Ok(Self {
             cache_dir,
             relay_selector,
-            current_task: None,
             connection_modes: Arc::new(Mutex::new(connection_modes_iterator)),
         })
-    }
-
-    /// Return a pointer to the underlying iterator over [`AccessMethod`].
-    /// Having access to this iterator allow you to influence , e.g. by calling
-    /// [`ConnectionModesIterator::set_access_method()`] or
-    /// [`ConnectionModesIterator::update_access_methods()`].
-    pub(crate) fn handle(&self) -> Arc<Mutex<ConnectionModesIterator>> {
-        self.connection_modes.clone()
-    }
-
-    /// Return a new connection mode to be used for the API connection.
-    fn new_connection_mode(&mut self) -> ApiConnectionMode {
-        log::debug!("Rotating Access mode!");
-        let access_method = {
-            let mut access_methods_picker = self.connection_modes.lock().unwrap();
-            access_methods_picker
-                .next()
-                .map(|access_method_setting| access_method_setting.access_method)
-                .unwrap_or(AccessMethod::from(BuiltInAccessMethod::Direct))
-        };
-
-        let connection_mode = self.from(access_method);
-        log::info!("New API connection mode selected: {}", connection_mode);
-        connection_mode
     }
 
     /// Ad-hoc version of [`std::convert::From::from`], but since some

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -50,6 +50,8 @@ pub enum ActorError {
     NotRunning(#[error(source)] oneshot::Canceled),
 }
 
+/// A channel for sending [`Message`] commands to a running
+/// [`AccessModeSelector`].
 #[derive(Clone)]
 pub struct AccessModeSelectorHandle {
     cmd_tx: mpsc::UnboundedSender<Message>,
@@ -96,10 +98,13 @@ impl AccessModeSelectorHandle {
         })
     }
 
-    /// Stream the connection modes of this actor.
-    pub fn as_stream(&self) -> impl Stream<Item = ApiConnectionMode> {
-        let handle = self.clone();
-        unfold(handle, |handle| async move {
+    /// Convert this handle to a [`Stream`] of [`ApiConnectionMode`] from the
+    /// associated [`AccessModeSelector`].
+    ///
+    /// Practically converts the handle to a listener for when the
+    /// currently valid connection modes changes.
+    pub fn as_stream(self) -> impl Stream<Item = ApiConnectionMode> {
+        unfold(self, |handle| async move {
             match handle.next().await {
                 Ok(connection_mode) => Some((connection_mode, handle)),
                 // End this stream in case of failure in `next`. `next` should
@@ -110,9 +115,11 @@ impl AccessModeSelectorHandle {
     }
 }
 
+/// A small actor which takes care of handling the logic around rotating
+/// connection modes to be used for Mullvad API request.
 pub struct AccessModeSelector {
     cmd_rx: mpsc::UnboundedReceiver<Message>,
-    state: ApiConnectionModeProvider,
+    connection_mode_provider: ApiConnectionModeProvider,
 }
 
 impl AccessModeSelector {
@@ -140,7 +147,7 @@ impl AccessModeSelector {
                 )
                 }
             };
-        let selector = AccessModeSelector { cmd_rx, state };
+        let selector = AccessModeSelector { cmd_rx, connection_mode_provider: state };
         tokio::spawn(selector.into_future());
         AccessModeSelectorHandle { cmd_tx }
     }
@@ -171,7 +178,7 @@ impl AccessModeSelector {
     }
 
     fn get_access_method(&mut self) -> AccessMethodSetting {
-        self.state.connection_modes.peek()
+        self.connection_mode_provider.connection_modes.peek()
     }
 
     fn on_set_access_method(
@@ -184,14 +191,16 @@ impl AccessModeSelector {
     }
 
     fn set_access_method(&mut self, value: AccessMethodSetting) {
-        self.state.connection_modes.set_access_method(value);
+        self.connection_mode_provider
+            .connection_modes
+            .set_access_method(value);
     }
 
     fn on_next_connection_mode(&mut self, tx: ResponseTx<ApiConnectionMode>) -> Result<()> {
         let next = self.next_connection_mode();
         // Save the new connection mode to cache!
         {
-            let cache_dir = self.state.cache_dir.clone();
+            let cache_dir = self.connection_mode_provider.cache_dir.clone();
             let next = next.clone();
             tokio::spawn(async move {
                 if next.save(&cache_dir).await.is_err() {
@@ -207,13 +216,13 @@ impl AccessModeSelector {
 
     fn next_connection_mode(&mut self) -> ApiConnectionMode {
         let access_method = self
-            .state
+            .connection_mode_provider
             .connection_modes
             .next()
             .map(|access_method_setting| access_method_setting.access_method)
             .unwrap_or(AccessMethod::from(BuiltInAccessMethod::Direct));
 
-        let connection_mode = self.state.from(access_method);
+        let connection_mode = self.connection_mode_provider.from(access_method);
         log::info!(
             "New API connection mode selected: {connection_mode}",
             connection_mode = connection_mode
@@ -231,7 +240,9 @@ impl AccessModeSelector {
     }
 
     fn update_access_methods(&mut self, values: Vec<AccessMethodSetting>) {
-        self.state.connection_modes.update_access_methods(values);
+        self.connection_mode_provider
+            .connection_modes
+            .update_access_methods(values);
     }
 }
 

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -166,13 +166,12 @@ impl AccessModeSelector {
     }
 
     fn on_get_access_method(&mut self, tx: ResponseTx<AccessMethodSetting>) -> Result<()> {
-        let value = self.get_access_method()?;
+        let value = self.get_access_method();
         self.reply(tx, value)
     }
 
-    fn get_access_method(&mut self) -> Result<AccessMethodSetting> {
-        let connections_modes = self.state.connection_modes.lock().unwrap();
-        Ok(connections_modes.peek())
+    fn get_access_method(&mut self) -> AccessMethodSetting {
+        self.state.connection_modes.peek()
     }
 
     fn on_set_access_method(
@@ -180,14 +179,12 @@ impl AccessModeSelector {
         tx: ResponseTx<()>,
         value: AccessMethodSetting,
     ) -> Result<()> {
-        self.set_access_method(value)?;
+        self.set_access_method(value);
         self.reply(tx, ())
     }
 
-    fn set_access_method(&mut self, value: AccessMethodSetting) -> Result<()> {
-        let mut connections_modes = self.state.connection_modes.lock().unwrap();
-        connections_modes.set_access_method(value);
-        Ok(())
+    fn set_access_method(&mut self, value: AccessMethodSetting) {
+        self.state.connection_modes.set_access_method(value);
     }
 
     fn on_next_connection_mode(&mut self, tx: ResponseTx<ApiConnectionMode>) -> Result<()> {
@@ -209,16 +206,18 @@ impl AccessModeSelector {
     }
 
     fn next_connection_mode(&mut self) -> ApiConnectionMode {
-        let access_method = {
-            let mut connection_modes = self.state.connection_modes.lock().unwrap();
-            connection_modes
-                .next()
-                .map(|access_method_setting| access_method_setting.access_method)
-                .unwrap_or(AccessMethod::from(BuiltInAccessMethod::Direct))
-        };
+        let access_method = self
+            .state
+            .connection_modes
+            .next()
+            .map(|access_method_setting| access_method_setting.access_method)
+            .unwrap_or(AccessMethod::from(BuiltInAccessMethod::Direct));
 
         let connection_mode = self.state.from(access_method);
-        log::info!("New API connection mode selected: {}", connection_mode);
+        log::info!(
+            "New API connection mode selected: {connection_mode}",
+            connection_mode = connection_mode
+        );
         connection_mode
     }
 
@@ -227,14 +226,12 @@ impl AccessModeSelector {
         tx: ResponseTx<()>,
         values: Vec<AccessMethodSetting>,
     ) -> Result<()> {
-        self.update_access_methods(values)?;
+        self.update_access_methods(values);
         self.reply(tx, ())
     }
 
-    fn update_access_methods(&mut self, values: Vec<AccessMethodSetting>) -> Result<()> {
-        let mut connection_modes = self.state.connection_modes.lock().unwrap();
-        connection_modes.update_access_methods(values);
-        Ok(())
+    fn update_access_methods(&mut self, values: Vec<AccessMethodSetting>) {
+        self.state.connection_modes.update_access_methods(values);
     }
 }
 
@@ -254,7 +251,7 @@ pub struct ApiConnectionModeProvider {
     cache_dir: PathBuf,
     /// Used for selecting a Bridge when the `Mullvad Bridges` access method is used.
     relay_selector: RelaySelector,
-    connection_modes: Arc<Mutex<ConnectionModesIterator>>,
+    connection_modes: ConnectionModesIterator,
 }
 
 impl ApiConnectionModeProvider {
@@ -267,8 +264,8 @@ impl ApiConnectionModeProvider {
         Ok(Self {
             cache_dir,
             relay_selector,
-            connection_modes: Arc::new(Mutex::new(connection_modes_iterator)),
-        })
+            connection_modes: connection_modes_iterator,
+        }
     }
 
     /// Ad-hoc version of [`std::convert::From::from`], but since some

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -35,15 +35,8 @@ pub enum Message {
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
-    /// Oddly specific.
-    #[error(display = "Very Generic error.")]
-    Generic,
-    #[error(display = "{}", _0)]
-    Actor(#[error(source)] ActorError),
-}
-
-#[derive(err_derive::Error, Debug)]
-pub enum ActorError {
+    #[error(display = "No access methods were provided.")]
+    NoAccessMethods,
     #[error(display = "AccessModeSelector is not receiving any messages.")]
     SendFailed(#[error(source)] mpsc::TrySendError<Message>),
     #[error(display = "AccessModeSelector is not receiving any messages.")]
@@ -51,6 +44,9 @@ pub enum ActorError {
     #[error(display = "AccessModeSelector is not responding.")]
     NotRunning(#[error(source)] oneshot::Canceled),
 }
+
+type ResponseTx<T> = oneshot::Sender<Result<T>>;
+type Result<T> = std::result::Result<T, Error>;
 
 /// A channel for sending [`Message`] commands to a running
 /// [`AccessModeSelector`].
@@ -64,8 +60,8 @@ impl AccessModeSelectorHandle {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .unbounded_send(make_cmd(tx))
-            .map_err(ActorError::SendFailed)?;
-        rx.await.map_err(ActorError::NotRunning)?
+            .map_err(Error::SendFailed)?;
+        rx.await.map_err(Error::NotRunning)?
     }
 
     pub async fn get_access_method(&self) -> Result<AccessMethodSetting> {
@@ -105,7 +101,7 @@ impl AccessModeSelectorHandle {
     ///
     /// Practically converts the handle to a listener for when the
     /// currently valid connection modes changes.
-    pub fn as_stream(self) -> impl Stream<Item = ApiConnectionMode> {
+    pub fn into_stream(self) -> impl Stream<Item = ApiConnectionMode> {
         unfold(self, |handle| async move {
             match handle.next().await {
                 Ok(connection_mode) => Some((connection_mode, handle)),
@@ -146,7 +142,7 @@ impl AccessModeSelector {
 
         let connection_modes = match ConnectionModesIterator::new(connection_modes) {
             Ok(provider) => provider,
-            Err(Error::NoAccessMethods) => {
+            Err(Error::NoAccessMethods) | Err(_) => {
                 // No settings seem to have been found. Default to using the the
                 // direct access method.
                 let default = mullvad_types::access_method::Settings::direct();
@@ -187,9 +183,8 @@ impl AccessModeSelector {
     }
 
     fn reply<T>(&self, tx: ResponseTx<T>, value: T) -> Result<()> {
-        Ok(tx
-            .send(Ok(value))
-            .map_err(|_| ActorError::OneshotSendFailed)?)
+        tx.send(Ok(value)).map_err(|_| Error::OneshotSendFailed)?;
+        Ok(())
     }
 
     fn on_get_access_method(&mut self, tx: ResponseTx<AccessMethodSetting>) -> Result<()> {
@@ -240,10 +235,7 @@ impl AccessModeSelector {
             .unwrap_or(AccessMethod::from(BuiltInAccessMethod::Direct));
 
         let connection_mode = self.from(access_method);
-        log::info!(
-            "New API connection mode selected: {connection_mode}",
-            connection_mode = connection_mode
-        );
+        log::info!("New API connection mode selected: {connection_mode}");
         connection_mode
     }
 
@@ -252,12 +244,12 @@ impl AccessModeSelector {
         tx: ResponseTx<()>,
         values: Vec<AccessMethodSetting>,
     ) -> Result<()> {
-        self.update_access_methods(values);
+        self.update_access_methods(values)?;
         self.reply(tx, ())
     }
 
-    fn update_access_methods(&mut self, values: Vec<AccessMethodSetting>) {
-        self.connection_modes.update_access_methods(values);
+    fn update_access_methods(&mut self, values: Vec<AccessMethodSetting>) -> Result<()> {
+        self.connection_modes.update_access_methods(values)
     }
 
     /// Ad-hoc version of [`std::convert::From::from`], but since some
@@ -302,9 +294,6 @@ impl AccessModeSelector {
     }
 }
 
-type ResponseTx<T> = oneshot::Sender<Result<T>>;
-type Result<T> = std::result::Result<T, Error>;
-
 /// An iterator which will always produce an [`AccessMethod`].
 ///
 /// Safety: It is always safe to [`unwrap`] after calling [`next`] on a
@@ -319,14 +308,10 @@ pub struct ConnectionModesIterator {
     current: AccessMethodSetting,
 }
 
-#[derive(err_derive::Error, Debug)]
-pub enum Error {
-    #[error(display = "No access methods were provided.")]
-    NoAccessMethods,
-}
-
 impl ConnectionModesIterator {
-    pub fn new(access_methods: Vec<AccessMethodSetting>) -> Result<ConnectionModesIterator, Error> {
+    pub fn new(
+        access_methods: Vec<AccessMethodSetting>,
+    ) -> std::result::Result<ConnectionModesIterator, Error> {
         let mut iterator = Self::new_iterator(access_methods)?;
         Ok(Self {
             next: None,
@@ -344,7 +329,7 @@ impl ConnectionModesIterator {
     pub fn update_access_methods(
         &mut self,
         access_methods: Vec<AccessMethodSetting>,
-    ) -> Result<(), Error> {
+    ) -> std::result::Result<(), Error> {
         self.available_modes = Self::new_iterator(access_methods)?;
         Ok(())
     }
@@ -355,7 +340,7 @@ impl ConnectionModesIterator {
     /// returned.
     fn new_iterator(
         access_methods: Vec<AccessMethodSetting>,
-    ) -> Result<Box<dyn Iterator<Item = AccessMethodSetting> + Send>, Error> {
+    ) -> std::result::Result<Box<dyn Iterator<Item = AccessMethodSetting> + Send>, Error> {
         if access_methods.is_empty() {
             Err(Error::NoAccessMethods)
         } else {

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -46,6 +46,8 @@ pub enum Error {
 pub enum ActorError {
     #[error(display = "AccessModeSelector is not receiving any messages.")]
     SendFailed(#[error(source)] mpsc::TrySendError<Message>),
+    #[error(display = "AccessModeSelector is not receiving any messages.")]
+    OneshotSendFailed,
     #[error(display = "AccessModeSelector is not responding.")]
     NotRunning(#[error(source)] oneshot::Canceled),
 }
@@ -154,22 +156,29 @@ impl AccessModeSelector {
 
     async fn into_future(mut self) {
         while let Some(cmd) = self.cmd_rx.next().await {
-            let _ = match cmd {
+            let execution = match cmd {
                 Message::Get(tx) => self.on_get_access_method(tx),
                 Message::Set(tx, value) => self.on_set_access_method(tx, value),
                 Message::Next(tx) => self.on_next_connection_mode(tx),
                 Message::Update(tx, values) => self.on_update_access_methods(tx, values),
+            };
+            match execution {
+                Ok(_) => (),
+                Err(err) => {
+                    log::trace!(
+                        "AccessModeSelector is going down due to {error}",
+                        error = err
+                    );
+                    break;
+                }
             }
-            .map_err(|err| {
-                log::error!("todo(markus): Some error occured {err}");
-                err
-            });
         }
     }
 
     fn reply<T>(&self, tx: ResponseTx<T>, value: T) -> Result<()> {
-        // TODO(markus): The error probably should come from the value/tx
-        tx.send(Ok(value)).map_err(|_| Error::Generic)
+        Ok(tx
+            .send(Ok(value))
+            .map_err(|_| ActorError::OneshotSendFailed)?)
     }
 
     fn on_get_access_method(&mut self, tx: ResponseTx<AccessMethodSetting>) -> Result<()> {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -693,7 +693,7 @@ where
 
         let api_handle = api_runtime
             .mullvad_rest_handle(
-                Box::pin(connection_modes_handler.clone().as_stream()),
+                Box::pin(connection_modes_handler.clone().into_stream()),
                 endpoint_updater.callback(),
             )
             .await;
@@ -1135,7 +1135,7 @@ where
             UpdateApiAccessMethod(tx, method) => self.on_update_api_access_method(tx, method).await,
             GetCurrentAccessMethod(tx) => self.on_get_current_api_access_method(tx),
             SetApiAccessMethod(tx, method) => self.on_set_api_access_method(tx, method).await,
-            TestApiAccessMethod(tx, method) => self.on_test_api_access_method(tx, method).await,
+            TestApiAccessMethod(tx, method) => self.on_test_api_access_method(tx, method),
             IsPerformingPostUpgrade(tx) => self.on_is_performing_post_upgrade(tx),
             GetCurrentVersion(tx) => self.on_get_current_version(tx),
             #[cfg(not(target_os = "android"))]
@@ -2369,14 +2369,7 @@ where
         });
     }
 
-    /// Try to reach the Mullvad API using a specific access method, returning
-    /// an [`Error`] in the case where the test fails to reach the API.
-    ///
-    /// Ephemerally sets a new access method (associated with `access_method`)
-    /// to be used for subsequent API calls, before performing an API call and
-    /// switching back to the previously active access method. The previous
-    /// access method is *always* reset.
-    async fn on_test_api_access_method(
+    fn on_test_api_access_method(
         &mut self,
         tx: ResponseTx<bool, Error>,
         access_method: mullvad_types::access_method::Id,
@@ -2387,105 +2380,24 @@ where
         // access method.
         let api_handle = self.api_handle.clone();
         let handle = self.connection_modes_handler.clone();
-        let access_method = self.get_api_access_method(access_method);
-        // TODO(markus): Clean up this error handling
-        let new_access_method = if let Ok(access_method) = access_method {
-            access_method
-        } else {
-            Self::oneshot_send(
-                tx,
-                access_method
-                    .map(|_| false)
-                    .map_err(Error::AccessMethodError),
-                "on_test_api_access_method response",
-            );
-            return;
-        };
+        let access_method_lookup = self
+            .get_api_access_method(access_method)
+            .map_err(Error::AccessMethodError);
 
-        let fut = async move {
-            // Setup test
-            let previous_access_method = handle
-                .get_access_method()
-                .await
-                .map_err(Error::ApiConnectionModeError)
-                // TODO(markus): Do not unwrap!
-                .unwrap();
-
-            let x = new_access_method.clone();
-            handle.set_access_method(new_access_method)
-                .await
-                .map_err(Error::ApiConnectionModeError)
-                // TODO(markus): Do not unwrap!
-                .unwrap();
-
-            // We need to perform a rotation of API endpoint after a set action
-            let rotation_handle = api_handle.clone();
-            rotation_handle
-                .service()
-                .next_api_endpoint()
-                .await
-                .map_err(|err| {
-                    log::error!("Failed to rotate API endpoint: {err}");
-                    err
-                })
-                // TODO(markus): Error handling
-                .unwrap();
-
-            // Set up the reset
-            //
-            // In case the API call fails, the next API endpoint will
-            // automatically be selected, which means that we need to set up
-            // with the previous API endpoint beforehand.
-            handle
-                .set_access_method(previous_access_method)
-                .await
-                .map_err(|err| {
-                    log::error!(
-                        "Could not reset to previous access
-            method after API reachability test was carried out. This should only
-            happen if the previous access method was removed in the meantime."
-                    );
-                    err
-                })
-                // TODO(markus): Do not unwrap!
-                .unwrap();
-
-            // Perform test
-            //
-            // Send a HEAD request to some Mullvad API endpoint. We issue a HEAD
-            // request because we are *only* concerned with if we get a reply from
-            // the API, and not with the actual data that the endpoint returns.
-            let result = mullvad_api::ApiProxy::new(api_handle)
-                .api_addrs_available()
-                .await
-                .map_err(Error::RestError);
-
-            // We need to perform a rotation of API endpoint after a set action
-            // Note that this will be done automatically if the API call fails,
-            // so it only has to be done if the call succeeded ..
-            if result.as_ref().is_ok_and(|&succeeded| succeeded) {
-                rotation_handle
-                .service()
-                .next_api_endpoint()
-                .await
-                .map_err(|err| {
-                    log::error!("Failed to rotate API endpoint: {err}");
-                    err
-                })
-                // TODO(markus): Error handling
-                .unwrap();
+        match access_method_lookup {
+            Ok(access_method) => {
+                tokio::spawn(async move {
+                    let result =
+                        access_method::test_access_method(access_method, handle, api_handle)
+                            .await
+                            .map_err(Error::AccessMethodError);
+                    Self::oneshot_send(tx, result, "on_test_api_access_method response");
+                });
             }
-
-            log::info!(
-                "The result of testing {method:?} is {result:?}",
-                method = x.access_method,
-                result = result
-            );
-
-            Self::oneshot_send(tx, result, "on_test_api_access_method response");
-        };
-
-        tokio::spawn(fut);
+            Err(err) => {
+                Self::oneshot_send(tx, Err(err), "on_test_api_access_method response");
+            }
+        }
     }
 
     fn on_get_settings(&self, tx: oneshot::Sender<Settings>) {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -683,36 +683,9 @@ where
                 .set_config(new_selector_config(settings));
         });
 
-        let connection_modes: Vec<_> = settings
-                .api_access_methods
-                .access_method_settings
-                .iter()
-                // We only care about the access methods which are set to 'enabled' by the user.
-                .filter(|api_access_method| api_access_method.enabled())
-                .cloned()
-                .collect();
-        let proxy_provider = match api::ApiConnectionModeProvider::new(
-            cache_dir.clone(),
-            relay_selector.clone(),
-            connection_modes,
-        ) {
-            Ok(provider) => provider,
-            Err(api::Error::NoAccessMethods) => {
-                // No settings seem to have been found. Default to using the the
-                // direct access method.
-                let default = mullvad_types::access_method::Settings::direct();
-                api::ApiConnectionModeProvider::new(
-                    cache_dir.clone(),
-                    relay_selector.clone(),
-                    vec![default],
-                )
-                .expect(
-                    "Failed to create the data structure responsible for managing access methods",
-                )
-            }
-        };
+        let connection_modes = settings.api_access_methods.collect_enabled();
 
-        let connection_modes_handler = api::AccessModeSelectorHandle::new(
+        let connection_modes_handler = api::AccessModeSelector::spawn(
             cache_dir.clone(),
             relay_selector.clone(),
             connection_modes,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -293,8 +293,8 @@ pub enum DaemonCommand {
     UpdateApiAccessMethod(ResponseTx<(), Error>, AccessMethodSetting),
     /// Get the currently used API access method
     GetCurrentAccessMethod(ResponseTx<AccessMethodSetting, Error>),
-    /// Get the addresses of all known API endpoints
-    GetApiAddresses(ResponseTx<Vec<std::net::SocketAddr>, Error>),
+    /// Test an API access method
+    TestApiAccessMethod(ResponseTx<(), Error>, mullvad_types::access_method::Id),
     /// Get information about the currently running and latest app versions
     GetVersionInfo(oneshot::Sender<Option<AppVersionInfo>>),
     /// Return whether the daemon is performing post-upgrade tasks
@@ -1151,7 +1151,7 @@ where
             UpdateApiAccessMethod(tx, method) => self.on_update_api_access_method(tx, method).await,
             GetCurrentAccessMethod(tx) => self.on_get_current_api_access_method(tx),
             SetApiAccessMethod(tx, method) => self.on_set_api_access_method(tx, method).await,
-            GetApiAddresses(tx) => self.on_get_api_addresses(tx).await,
+            TestApiAccessMethod(tx, method) => self.on_test_api_access_method(tx, method).await,
             IsPerformingPostUpgrade(tx) => self.on_is_performing_post_upgrade(tx),
             GetCurrentVersion(tx) => self.on_get_current_version(tx),
             #[cfg(not(target_os = "android"))]
@@ -2381,11 +2381,57 @@ where
         Self::oneshot_send(tx, result, "get_current_api_access_method response");
     }
 
-    async fn on_get_api_addresses(&mut self, tx: ResponseTx<Vec<std::net::SocketAddr>, Error>) {
-        let api_proxy = mullvad_api::ApiProxy::new(self.api_handle.clone());
-        let result = api_proxy.get_api_addrs().await.map_err(Error::RestError);
+    /// Try to reach the Mullvad API using a specific access method, returning
+    /// an [`Error`] in the case where the test fails to reach the API.
+    ///
+    /// Ephemerally sets a new access method (associated with `access_method`)
+    /// to be used for subsequent API calls, before performing an API call and
+    /// switching back to the previously active access method. The previous
+    /// access method is *always* reset.
+    async fn on_test_api_access_method(
+        &mut self,
+        tx: ResponseTx<(), Error>,
+        access_method: mullvad_types::access_method::Id,
+    ) {
+        // NOTE: Preferably we would block all new API calls until the test is
+        // done and the previous access method is reset. Otherwise we run the
+        // risk of errounously triggering a rotation of the currently in-use
+        // access method.
+        let result = async {
+            // Setup test
+            let previous_access_method = self
+                .get_current_access_method()
+                .map_err(Error::AccessMethodError)?;
 
-        Self::oneshot_send(tx, result, "on_get_api_adressess response");
+            self.set_api_access_method(access_method)
+                .await
+                .map_err(Error::AccessMethodError)?;
+            // Perform test
+            //
+            // Send a HEAD request to some Mullvad API endpoint. We issue a HEAD
+            // request because we are *only* concerned with if we get a reply from
+            // the API, and not with the actual data that the endpoint returns.
+            let result = mullvad_api::ApiProxy::new(self.api_handle.clone())
+                .api_addrs_available()
+                .await
+                .map_err(Error::RestError);
+
+            // Reset test
+            self.set_api_access_method(previous_access_method.get_id())
+                .await
+                .map_err(|err| {
+                    log::error!(
+                        "Could not reset to previous access
+            method after API reachability test was carried out. This should only
+            happen if the previous access method was removed in the meantime."
+                    );
+                    Error::AccessMethodError(err)
+                })?;
+
+            result
+        };
+
+        Self::oneshot_send(tx, result.await, "on_test_api_access_method response");
     }
 
     fn on_get_settings(&self, tx: oneshot::Sender<Settings>) {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -605,7 +605,7 @@ pub struct Daemon<L: EventListener> {
     account_history: account_history::AccountHistory,
     device_checker: device::TunnelStateChangeHandler,
     account_manager: device::AccountManagerHandle,
-    connection_modes_handler: api::Ehandle,
+    connection_modes_handler: api::AccessModeSelectorHandle,
     api_runtime: mullvad_api::Runtime,
     api_handle: mullvad_api::rest::MullvadRestHandle,
     version_updater_handle: version_check::VersionUpdaterHandle,
@@ -712,8 +712,11 @@ where
             }
         };
 
-        let connection_modes_handler =
-            api::Ehandle::new(cache_dir.clone(), relay_selector.clone(), connection_modes);
+        let connection_modes_handler = api::AccessModeSelectorHandle::new(
+            cache_dir.clone(),
+            relay_selector.clone(),
+            connection_modes,
+        );
 
         let api_handle = api_runtime
             .mullvad_rest_handle(

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -693,7 +693,7 @@ where
 
         let api_handle = api_runtime
             .mullvad_rest_handle(
-                Box::pin(connection_modes_handler.as_stream()),
+                Box::pin(connection_modes_handler.clone().as_stream()),
                 endpoint_updater.callback(),
             )
             .await;

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -66,7 +66,7 @@ use std::{
     mem,
     path::PathBuf,
     pin::Pin,
-    sync::{Arc, Mutex, Weak},
+    sync::{Arc, Weak},
     time::Duration,
 };
 #[cfg(any(target_os = "linux", windows))]
@@ -178,6 +178,9 @@ pub enum Error {
 
     #[error(display = "Access method error")]
     AccessMethodError(#[error(source)] access_method::Error),
+
+    #[error(display = "API connection mode error")]
+    ApiConnectionModeError(#[error(source)] api::Error),
 
     #[cfg(target_os = "macos")]
     #[error(display = "Failed to set exclusion group")]
@@ -294,7 +297,7 @@ pub enum DaemonCommand {
     /// Get the currently used API access method
     GetCurrentAccessMethod(ResponseTx<AccessMethodSetting, Error>),
     /// Test an API access method
-    TestApiAccessMethod(ResponseTx<(), Error>, mullvad_types::access_method::Id),
+    TestApiAccessMethod(ResponseTx<bool, Error>, mullvad_types::access_method::Id),
     /// Get information about the currently running and latest app versions
     GetVersionInfo(oneshot::Sender<Option<AppVersionInfo>>),
     /// Return whether the daemon is performing post-upgrade tasks
@@ -602,7 +605,7 @@ pub struct Daemon<L: EventListener> {
     account_history: account_history::AccountHistory,
     device_checker: device::TunnelStateChangeHandler,
     account_manager: device::AccountManagerHandle,
-    connection_modes: Arc<Mutex<api::ConnectionModesIterator>>,
+    connection_modes_handler: api::Ehandle,
     api_runtime: mullvad_api::Runtime,
     api_handle: mullvad_api::rest::MullvadRestHandle,
     version_updater_handle: version_check::VersionUpdaterHandle,
@@ -680,17 +683,18 @@ where
                 .set_config(new_selector_config(settings));
         });
 
-        let proxy_provider = match api::ApiConnectionModeProvider::new(
-            cache_dir.clone(),
-            relay_selector.clone(),
-            settings
+        let connection_modes: Vec<_> = settings
                 .api_access_methods
                 .access_method_settings
                 .iter()
                 // We only care about the access methods which are set to 'enabled' by the user.
                 .filter(|api_access_method| api_access_method.enabled())
                 .cloned()
-                .collect(),
+                .collect();
+        let proxy_provider = match api::ApiConnectionModeProvider::new(
+            cache_dir.clone(),
+            relay_selector.clone(),
+            connection_modes,
         ) {
             Ok(provider) => provider,
             Err(api::Error::NoAccessMethods) => {
@@ -708,10 +712,14 @@ where
             }
         };
 
-        let connection_modes = proxy_provider.handle();
+        let connection_modes_handler =
+            api::Ehandle::new(cache_dir.clone(), relay_selector.clone(), connection_modes);
 
         let api_handle = api_runtime
-            .mullvad_rest_handle(proxy_provider, endpoint_updater.callback())
+            .mullvad_rest_handle(
+                Box::pin(connection_modes_handler.as_stream()),
+                endpoint_updater.callback(),
+            )
             .await;
 
         let migration_complete = if let Some(migration_data) = migration_data {
@@ -861,7 +869,7 @@ where
             account_history,
             device_checker: device::TunnelStateChangeHandler::new(account_manager.clone()),
             account_manager,
-            connection_modes,
+            connection_modes_handler,
             api_runtime,
             api_handle,
             version_updater_handle,
@@ -2375,10 +2383,14 @@ where
     }
 
     fn on_get_current_api_access_method(&mut self, tx: ResponseTx<AccessMethodSetting, Error>) {
-        let result = self
-            .get_current_access_method()
-            .map_err(Error::AccessMethodError);
-        Self::oneshot_send(tx, result, "get_current_api_access_method response");
+        let handle = self.connection_modes_handler.clone();
+        tokio::spawn(async move {
+            let result = handle
+                .get_access_method()
+                .await
+                .map_err(Error::ApiConnectionModeError);
+            Self::oneshot_send(tx, result, "get_current_api_access_method response");
+        });
     }
 
     /// Try to reach the Mullvad API using a specific access method, returning
@@ -2390,34 +2402,66 @@ where
     /// access method is *always* reset.
     async fn on_test_api_access_method(
         &mut self,
-        tx: ResponseTx<(), Error>,
+        tx: ResponseTx<bool, Error>,
         access_method: mullvad_types::access_method::Id,
     ) {
         // NOTE: Preferably we would block all new API calls until the test is
         // done and the previous access method is reset. Otherwise we run the
         // risk of errounously triggering a rotation of the currently in-use
         // access method.
-        let result = async {
+        let api_handle = self.api_handle.clone();
+        let handle = self.connection_modes_handler.clone();
+        let access_method = self.get_api_access_method(access_method);
+        // TODO(markus): Clean up this error handling
+        let new_access_method = if let Ok(access_method) = access_method {
+            access_method
+        } else {
+            Self::oneshot_send(
+                tx,
+                access_method
+                    .map(|_| false)
+                    .map_err(Error::AccessMethodError),
+                "on_test_api_access_method response",
+            );
+            return;
+        };
+
+        let fut = async move {
             // Setup test
-            let previous_access_method = self
-                .get_current_access_method()
-                .map_err(Error::AccessMethodError)?;
-
-            self.set_api_access_method(access_method)
+            let previous_access_method = handle
+                .get_access_method()
                 .await
-                .map_err(Error::AccessMethodError)?;
-            // Perform test
+                .map_err(Error::ApiConnectionModeError)
+                // TODO(markus): Do not unwrap!
+                .unwrap();
+
+            let x = new_access_method.clone();
+            handle.set_access_method(new_access_method)
+                .await
+                .map_err(Error::ApiConnectionModeError)
+                // TODO(markus): Do not unwrap!
+                .unwrap();
+
+            // We need to perform a rotation of API endpoint after a set action
+            let rotation_handle = api_handle.clone();
+            rotation_handle
+                .service()
+                .next_api_endpoint()
+                .await
+                .map_err(|err| {
+                    log::error!("Failed to rotate API endpoint: {err}");
+                    err
+                })
+                // TODO(markus): Error handling
+                .unwrap();
+
+            // Set up the reset
             //
-            // Send a HEAD request to some Mullvad API endpoint. We issue a HEAD
-            // request because we are *only* concerned with if we get a reply from
-            // the API, and not with the actual data that the endpoint returns.
-            let result = mullvad_api::ApiProxy::new(self.api_handle.clone())
-                .api_addrs_available()
-                .await
-                .map_err(Error::RestError);
-
-            // Reset test
-            self.set_api_access_method(previous_access_method.get_id())
+            // In case the API call fails, the next API endpoint will
+            // automatically be selected, which means that we need to set up
+            // with the previous API endpoint beforehand.
+            handle
+                .set_access_method(previous_access_method)
                 .await
                 .map_err(|err| {
                     log::error!(
@@ -2425,13 +2469,47 @@ where
             method after API reachability test was carried out. This should only
             happen if the previous access method was removed in the meantime."
                     );
-                    Error::AccessMethodError(err)
-                })?;
+                    err
+                })
+                // TODO(markus): Do not unwrap!
+                .unwrap();
 
-            result
+            // Perform test
+            //
+            // Send a HEAD request to some Mullvad API endpoint. We issue a HEAD
+            // request because we are *only* concerned with if we get a reply from
+            // the API, and not with the actual data that the endpoint returns.
+            let result = mullvad_api::ApiProxy::new(api_handle)
+                .api_addrs_available()
+                .await
+                .map_err(Error::RestError);
+
+            // We need to perform a rotation of API endpoint after a set action
+            // Note that this will be done automatically if the API call fails,
+            // so it only has to be done if the call succeeded ..
+            if result.as_ref().is_ok_and(|&succeeded| succeeded) {
+                rotation_handle
+                .service()
+                .next_api_endpoint()
+                .await
+                .map_err(|err| {
+                    log::error!("Failed to rotate API endpoint: {err}");
+                    err
+                })
+                // TODO(markus): Error handling
+                .unwrap();
+            }
+
+            log::info!(
+                "The result of testing {method:?} is {result:?}",
+                method = x.access_method,
+                result = result
+            );
+
+            Self::oneshot_send(tx, result, "on_test_api_access_method response");
         };
 
-        Self::oneshot_send(tx, result.await, "on_test_api_access_method response");
+        tokio::spawn(fut);
     }
 
     fn on_get_settings(&self, tx: oneshot::Sender<Settings>) {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -693,13 +693,13 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
     }
 
-    async fn get_api_addresses(&self, _: Request<()>) -> ServiceResult<types::ApiAddresses> {
-        log::debug!("get_api_addresses");
+    async fn test_api_access_method(&self, request: Request<types::Uuid>) -> ServiceResult<()> {
+        log::debug!("test_api_access_method");
         let (tx, rx) = oneshot::channel();
-        self.send_command_to_daemon(DaemonCommand::GetApiAddresses(tx))?;
+        let api_access_method = mullvad_types::access_method::Id::try_from(request.into_inner())?;
+        self.send_command_to_daemon(DaemonCommand::TestApiAccessMethod(tx, api_access_method))?;
         self.wait_for_result(rx)
             .await?
-            .map(types::ApiAddresses::from)
             .map(Response::new)
             .map_err(map_daemon_error)
     }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -693,7 +693,7 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
     }
 
-    async fn test_api_access_method(&self, request: Request<types::Uuid>) -> ServiceResult<()> {
+    async fn test_api_access_method(&self, request: Request<types::Uuid>) -> ServiceResult<bool> {
         log::debug!("test_api_access_method");
         let (tx, rx) = oneshot::channel();
         let api_access_method = mullvad_types::access_method::Id::try_from(request.into_inner())?;

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -22,7 +22,6 @@ service ManagementService {
 
   rpc GetCurrentVersion(google.protobuf.Empty) returns (google.protobuf.StringValue) {}
   rpc GetVersionInfo(google.protobuf.Empty) returns (AppVersionInfo) {}
-  rpc GetApiAddresses(google.protobuf.Empty) returns (ApiAddresses) {}
 
   rpc IsPerformingPostUpgrade(google.protobuf.Empty) returns (google.protobuf.BoolValue) {}
 
@@ -82,6 +81,7 @@ service ManagementService {
   rpc SetApiAccessMethod(UUID) returns (google.protobuf.Empty) {}
   rpc UpdateApiAccessMethod(AccessMethodSetting) returns (google.protobuf.Empty) {}
   rpc GetCurrentApiAccessMethod(google.protobuf.Empty) returns (AccessMethodSetting) {}
+  rpc TestApiAccessMethod(UUID) returns (google.protobuf.Empty) {}
 
   // Split tunneling (Linux)
   rpc GetSplitTunnelProcesses(google.protobuf.Empty) returns (stream google.protobuf.Int32Value) {}
@@ -109,8 +109,6 @@ message UUID { string value = 1; }
 message AccountData { google.protobuf.Timestamp expiry = 1; }
 
 message AccountHistory { google.protobuf.StringValue token = 1; }
-
-message ApiAddresses { repeated google.protobuf.StringValue api_addresses = 1; }
 
 message VoucherSubmission {
   uint64 seconds_added = 1;

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -81,7 +81,7 @@ service ManagementService {
   rpc SetApiAccessMethod(UUID) returns (google.protobuf.Empty) {}
   rpc UpdateApiAccessMethod(AccessMethodSetting) returns (google.protobuf.Empty) {}
   rpc GetCurrentApiAccessMethod(google.protobuf.Empty) returns (AccessMethodSetting) {}
-  rpc TestApiAccessMethod(UUID) returns (google.protobuf.Empty) {}
+  rpc TestApiAccessMethod(UUID) returns (google.protobuf.BoolValue) {}
 
   // Split tunneling (Linux)
   rpc GetSplitTunnelProcesses(google.protobuf.Empty) returns (stream google.protobuf.Int32Value) {}

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -208,12 +208,13 @@ impl MullvadProxyClient {
             })
     }
 
-    pub async fn test_api_access_method(&mut self, id: access_method::Id) -> Result<()> {
-        self.0
+    pub async fn test_api_access_method(&mut self, id: access_method::Id) -> Result<bool> {
+        let result = self
+            .0
             .test_api_access_method(types::Uuid::from(id))
             .await
             .map_err(Error::Rpc)?;
-        Ok(())
+        Ok(result.into_inner())
     }
 
     pub async fn update_relay_locations(&mut self) -> Result<()> {

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -208,15 +208,12 @@ impl MullvadProxyClient {
             })
     }
 
-    pub async fn get_api_addresses(&mut self) -> Result<Vec<std::net::SocketAddr>> {
+    pub async fn test_api_access_method(&mut self, id: access_method::Id) -> Result<()> {
         self.0
-            .get_api_addresses(())
+            .test_api_access_method(types::Uuid::from(id))
             .await
-            .map_err(Error::Rpc)
-            .map(tonic::Response::into_inner)
-            .and_then(|api_addresses| {
-                Vec::<std::net::SocketAddr>::try_from(api_addresses).map_err(Error::InvalidResponse)
-            })
+            .map_err(Error::Rpc)?;
+        Ok(())
     }
 
     pub async fn update_relay_locations(&mut self) -> Result<()> {

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -163,27 +163,6 @@ impl From<proto::IpVersion> for talpid_types::net::IpVersion {
     }
 }
 
-impl TryFrom<proto::ApiAddresses> for Vec<SocketAddr> {
-    type Error = FromProtobufTypeError;
-
-    fn try_from(value: proto::ApiAddresses) -> Result<Self, Self::Error> {
-        value
-            .api_addresses
-            .iter()
-            .map(|api_address| api_address.parse::<SocketAddr>())
-            .collect::<Result<_, _>>()
-            .map_err(|_| FromProtobufTypeError::InvalidArgument("Invalid socket address"))
-    }
-}
-
-impl From<Vec<SocketAddr>> for proto::ApiAddresses {
-    fn from(value: Vec<SocketAddr>) -> Self {
-        Self {
-            api_addresses: value.iter().map(SocketAddr::to_string).collect(),
-        }
-    }
-}
-
 pub fn try_tunnel_type_from_i32(
     tunnel_type: i32,
 ) -> Result<talpid_types::net::TunnelType, FromProtobufTypeError> {

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -61,6 +61,14 @@ impl Settings {
         let method = BuiltInAccessMethod::Bridge;
         AccessMethodSetting::new(method.canonical_name(), true, AccessMethod::from(method))
     }
+
+    /// Retrieve all [`AccessMethodSetting`]s which are enabled.
+    pub fn collect_enabled(&self) -> Vec<AccessMethodSetting> {
+        self.cloned()
+            .into_iter()
+            .filter(|access_method| access_method.enabled)
+            .collect()
+    }
 }
 
 impl Default for Settings {


### PR DESCRIPTION
Move access method testing logic to `mullvad-daemon`, which means that the implementation details of how the test works is opaque to whatever frontend which wants to issue a test of some (configured) access method.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5370)
<!-- Reviewable:end -->
