### PR TITLE
Remove broken test and speed up iOS CI

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check-formatting:
     name: Check formatting
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - name: Install SwiftFormat
         run: |
@@ -29,20 +29,21 @@ jobs:
 
   swiftlint:
     name: Run swiftlint
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Run swiftlint
         run: |
+          brew install swiftlint
           swiftlint --version
           swiftlint --reporter github-actions-logging
         working-directory: ios
 
   test:
     name: Unit tests
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     env:
       SOURCE_PACKAGES_PATH: .spm
     steps:
@@ -62,12 +63,17 @@ jobs:
         with:
           go-version: 1.19.5
 
+      - name: Set up yeetd to workaround XCode being slow in CI
+        run: |
+          wget https://github.com/biscuitehh/yeetd/releases/download/1.0/yeetd-normal.pkg
+          sudo installer -pkg yeetd-normal.pkg -target /
+          yeetd &
       - name: Configure Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '15.0.1'
       - name: Configure Rust
-        run: rustup target add x86_64-apple-ios
+        run: rustup target add aarch64-apple-ios-sim
 
       - name: Configure Xcode project
         run: |

--- a/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
+++ b/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
@@ -302,7 +302,12 @@ final class PacketTunnelActorTests: XCTestCase {
         await fulfillment(of: [disconnectedStateExpectation, didStopObserverExpectation], timeout: 1)
     }
 
-    func testSetErrorStateGetsCancelledWhenStopping() async throws {
+    // FIXME: Reconsider if this test should exist. As it stands currently, it
+    // relies the packet tunnel process processing app message calls and a
+    // `stopTunnel()` call in a particular, deterministic order, which makes it
+    // unreliable. In reality, we cannot guarantee the order between those
+    // calls, and it fails almost reliably on low core count VMs.
+    func setErrorStateGetsCancelledWhenStopping() async throws {
         let actor = PacketTunnelActor.mock()
         let connectingStateExpectation = expectation(description: "Connecting state")
         let disconnectedStateExpectation = expectation(description: "Disconnected state")


### PR DESCRIPTION
This is me trying to fix GitHub CI issues, by _following some random dude on the internet_. https://github.com/actions/runner-images/discussions/8651#discussioncomment-7393444

In addition to that, I have switched over to M1 instances, which are significantly faster and have more cores and I have chosen to remove the faulty test as per @buggmagnet instructions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5390)
<!-- Reviewable:end -->
