### PR TITLE
Fix expired account UI showing blocked state instead of out of time view

### DIFF
--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -781,9 +781,17 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
 
     private func addTunnelObserver() {
         let tunnelObserver =
-            TunnelBlockObserver(didUpdateDeviceState: { [weak self] _, deviceState, previousDeviceState in
-                self?.deviceStateDidChange(deviceState, previousDeviceState: previousDeviceState)
-            })
+            TunnelBlockObserver(
+                didUpdateTunnelStatus: { [weak self] _, tunnelStatus in
+                    if case let .error(observedState) = tunnelStatus.observedState,
+                       observedState.reason == .accountExpired {
+                        self?.router.present(.outOfTime)
+                    }
+                },
+                didUpdateDeviceState: { [weak self] _, deviceState, previousDeviceState in
+                    self?.deviceStateDidChange(deviceState, previousDeviceState: previousDeviceState)
+                }
+            )
 
         tunnelManager.addObserver(tunnelObserver)
 

--- a/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
@@ -57,7 +57,7 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
 
     private func handleTunnelStatus(_ tunnelStatus: TunnelStatus) {
         let invalidateForTunnelError: Bool
-        if case let .error(blockStateReason) = tunnelStatus.state {
+        if case let .error(blockStateReason) = tunnelStatus.state, blockStateReason != .accountExpired {
             invalidateForTunnelError = updateLastTunnelError(blockStateReason)
         } else {
             invalidateForTunnelError = updateLastTunnelError(nil)
@@ -231,8 +231,6 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
             errorString = "No servers match your settings, try changing server or other settings."
         case .invalidAccount:
             errorString = "You are logged in with an invalid account number. Please log out and try another one."
-        case .accountExpired:
-            errorString = "Account is out of time."
         case .deviceRevoked, .deviceLoggedOut:
             errorString = "Unable to authenticate account. Please log out and log back in."
         default:

--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -99,7 +99,7 @@ enum TunnelState: Equatable, CustomStringConvertible {
 
     var isSecured: Bool {
         switch self {
-        case .reconnecting, .connecting, .connected, .waitingForConnectivity(.noConnection):
+        case .reconnecting, .connecting, .connected, .waitingForConnectivity(.noConnection), .error(.accountExpired):
             return true
         case .pendingReconnect, .disconnecting, .disconnected, .waitingForConnectivity(.noNetwork), .error:
             return false


### PR DESCRIPTION
When an account expires the app sometimes go into blocked state (with banner) instead of routing to the "out of time" view. This typically happens when the tunnel is connected, but not when eg. entering app without time left on the account.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5403)
<!-- Reviewable:end -->
