### PR TITLE
fix-font-weights-in-the-device-revoked-view-ios-377

### DIFF
--- a/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
+++ b/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
@@ -27,20 +27,19 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
             value: "Device is inactive",
             comment: ""
         )
-        titleLabel.font = UIFont.systemFont(ofSize: 32)
         return titleLabel
     }()
 
     private lazy var bodyLabel: UILabel = {
         let bodyLabel = UILabel()
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
-        bodyLabel.font = UIFont.systemFont(ofSize: 17)
+        bodyLabel.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         bodyLabel.numberOfLines = 0
         bodyLabel.textColor = .white
         bodyLabel.text = NSLocalizedString(
             "DESCRIPTION_LABEL",
             tableName: "RevokedDevice",
-            value: "You have revoked this device. To connect again, you will need to log back in.",
+            value: "You have removed this device. To connect again, you will need to log back in.",
             comment: ""
         )
         return bodyLabel


### PR DESCRIPTION
This pull request updates the font weights in the `Revoked Device View` to match the design.
<table style="height: 568px; width: 600px; border-collapse: collapse; margin-left: auto; margin-right: auto;" cellspacing="20" cellpadding="28">
<tbody>
<tr>
    <th>Before</th>
    <th colspan="5">After</th>
</tr>
<tr>
<td style="width: 50%;"><img src="https://github.com/mullvad/mullvadvpn-app/assets/129863230/fc31494d-9bfe-4216-a0dc-1b76258a2968"  width="160" height="284" /></td>
<td style="width: 50%;"><img src="https://github.com/mullvad/mullvadvpn-app/assets/129863230/9f834764-9130-415c-97a8-3d14a8c15f61"  width="160" height="284" /></td>
</tr>
</tbody>
</table>



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5407)
<!-- Reviewable:end -->
