### PR TITLE
Add ability to override in-IPs to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
   `mullvad api-access`, and the initially supported network protocols are `Shadowsocks` and
   `SOCKS5`.
 - Add social media content blocker.
+- Add ability to override server IPs to the CLI.
 
 ### Changed
 - Update Electron from 25.2.0 to 26.3.0.

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -1,4 +1,5 @@
 use clap::builder::{PossibleValuesParser, TypedValueParser, ValueParser};
+use std::io::stdin;
 use std::ops::Deref;
 
 pub mod account;
@@ -79,4 +80,24 @@ impl std::fmt::Display for BooleanOption {
             self.off_label.fmt(f)
         }
     }
+}
+
+async fn receive_confirmation(msg: &'static str, default: bool) -> bool {
+    println!("{}", msg);
+
+    tokio::task::spawn_blocking(move || loop {
+        let mut buf = String::new();
+        if let Err(e) = stdin().read_line(&mut buf) {
+            eprintln!("Couldn't read from STDIN: {e}");
+            return false;
+        }
+        match buf.trim().to_ascii_lowercase().as_str() {
+            "" => return default,
+            "y" | "ye" | "yes" => return true,
+            "n" | "no" => return false,
+            _ => eprintln!("Unexpected response. Please enter \"y\" or \"n\""),
+        }
+    })
+    .await
+    .unwrap()
 }

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -83,7 +83,12 @@ impl std::fmt::Display for BooleanOption {
 }
 
 async fn receive_confirmation(msg: &'static str, default: bool) -> bool {
-    println!("{}", msg);
+    let helper_str = match default {
+        true => "[Y/n]",
+        false => "[y/N]",
+    };
+
+    println!("{msg} {helper_str}");
 
     tokio::task::spawn_blocking(move || loop {
         let mut buf = String::new();

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -3,16 +3,17 @@ use clap::Subcommand;
 use itertools::Itertools;
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::{
-    location::Location,
+    location::{CountryCode, Location},
     relay_constraints::{
         Constraint, GeographicLocationConstraint, LocationConstraint, LocationConstraintFormatter,
-        Match, OpenVpnConstraints, Ownership, Provider, Providers, RelayConstraints, RelaySettings,
-        TransportPort, WireguardConstraints,
+        Match, OpenVpnConstraints, Ownership, Provider, Providers, RelayConstraints, RelayOverride,
+        RelaySettings, TransportPort, WireguardConstraints,
     },
     relay_list::{RelayEndpointData, RelayListCountry},
     ConnectionConfig, CustomTunnelEndpoint,
 };
 use std::{
+    collections::HashMap,
     io::BufRead,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
@@ -21,7 +22,7 @@ use talpid_types::net::{
 };
 
 use super::{relay_constraints::LocationArgs, BooleanOption};
-use crate::print_option;
+use crate::{cmds::receive_confirmation, print_option};
 
 #[derive(Subcommand, Debug)]
 pub enum Relay {
@@ -37,6 +38,10 @@ pub enum Relay {
 
     /// Update the relay list
     Update,
+
+    /// Override options for individual relays/servers
+    #[clap(subcommand)]
+    Override(OverrideCommands),
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -201,6 +206,50 @@ pub enum SetCustomCommands {
     },
 }
 
+#[derive(Subcommand, Debug, Clone)]
+pub enum OverrideCommands {
+    /// Show current custom fields for servers
+    Get,
+    /// Set a custom field for a server
+    #[clap(subcommand)]
+    Set(OverrideSetCommands),
+    /// Unset a custom field for a server
+    #[clap(subcommand)]
+    Unset(OverrideUnsetCommands),
+    /// Unset custom IPs for all servers
+    ClearAll {
+        /// Clear overrides without asking for confirmation
+        #[arg(long, short = 'y', default_value_t = false)]
+        confirm: bool,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum OverrideSetCommands {
+    /// Override entry IPv4 address for a given relay
+    Ipv4 {
+        /// The unique hostname for the server to set the override on
+        hostname: String,
+        /// The IPv4 address to use to connect to this server
+        address: Ipv4Addr,
+    },
+    /// Override entry IPv6 address for a given relay
+    Ipv6 {
+        /// The unique hostname for the server to set the override on
+        hostname: String,
+        /// The IPv6 address to use to connect to this server
+        address: Ipv6Addr,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum OverrideUnsetCommands {
+    /// Remove overridden entry IPv4 address for the given server
+    Ipv4 { hostname: String },
+    /// Remove overridden entry IPv6 address for the given server
+    Ipv6 { hostname: String },
+}
+
 impl Relay {
     pub async fn handle(self) -> Result<()> {
         match self {
@@ -208,6 +257,7 @@ impl Relay {
             Relay::List => Self::list().await,
             Relay::Update => Self::update().await,
             Relay::Set(subcmd) => Self::set(subcmd).await,
+            Relay::Override(subcmd) => Self::r#override(subcmd).await,
         }
     }
 
@@ -661,6 +711,151 @@ impl Relay {
             constraints.tunnel_protocol = protocol;
         })
         .await
+    }
+
+    async fn update_override(
+        hostname: &str,
+        update_fn: impl FnOnce(&mut RelayOverride),
+    ) -> Result<()> {
+        let mut rpc = MullvadProxyClient::new().await?;
+        let settings = rpc.get_settings().await?;
+
+        let mut relay_overrides = settings.relay_overrides;
+        let mut element = relay_overrides
+            .iter()
+            .position(|elem| elem.hostname == hostname)
+            .map(|index| relay_overrides.swap_remove(index))
+            .unwrap_or_else(|| RelayOverride::empty(hostname.to_owned()));
+        update_fn(&mut element);
+
+        rpc.set_relay_override(element).await?;
+        println!("Updated override options for {hostname}");
+        Ok(())
+    }
+
+    async fn r#override(subcmd: OverrideCommands) -> Result<()> {
+        match subcmd {
+            OverrideCommands::Get => {
+                let mut rpc = MullvadProxyClient::new().await?;
+                let settings = rpc.get_settings().await?;
+
+                let mut overrides = HashMap::new();
+                for relay_override in settings.relay_overrides {
+                    overrides.insert(relay_override.hostname.clone(), relay_override);
+                }
+
+                struct Country {
+                    name: String,
+                    code: CountryCode,
+                    cities: Vec<City>,
+                }
+                struct City {
+                    name: String,
+                    code: CountryCode,
+                    overrides: Vec<RelayOverride>,
+                }
+
+                let mut countries_with_overrides = vec![];
+                for country in get_filtered_relays().await? {
+                    let mut country_with_overrides = Country {
+                        name: country.name,
+                        code: country.code,
+                        cities: vec![],
+                    };
+
+                    for city in country.cities {
+                        let mut city_with_overrides = City {
+                            name: city.name,
+                            code: city.code,
+                            overrides: vec![],
+                        };
+
+                        for relay in city.relays {
+                            if let Some(relay_override) = overrides.remove(&relay.hostname) {
+                                city_with_overrides.overrides.push(relay_override);
+                            }
+                        }
+
+                        if !city_with_overrides.overrides.is_empty() {
+                            country_with_overrides.cities.push(city_with_overrides);
+                        }
+                    }
+
+                    if !country_with_overrides.cities.is_empty() {
+                        countries_with_overrides.push(country_with_overrides);
+                    }
+                }
+
+                let print_relay_override = |relay_override: RelayOverride| {
+                    println!("{:<8}{}:", " ", relay_override.hostname);
+                    if let Some(ipv4) = relay_override.ipv4_addr_in {
+                        println!("{:<12}ipv4: {ipv4}", " ");
+                    }
+                    if let Some(ipv6) = relay_override.ipv6_addr_in {
+                        println!("{:<12}ipv6: {ipv6}", " ");
+                    }
+                };
+
+                for country in countries_with_overrides {
+                    println!("{} ({})", country.name, country.code);
+                    for city in country.cities {
+                        println!("{:<4}{} ({})", " ", city.name, city.code);
+                        for relay_override in city.overrides {
+                            print_relay_override(relay_override);
+                        }
+                    }
+                }
+
+                if !overrides.is_empty() {
+                    println!("Overrides for unrecognized servers. Consider removing these!");
+                    for relay_override in overrides.into_values() {
+                        print_relay_override(relay_override);
+                    }
+                }
+            }
+            OverrideCommands::Set(set_cmds) => match set_cmds {
+                OverrideSetCommands::Ipv4 { hostname, address } => {
+                    Self::update_override(&hostname, |relay_override| {
+                        relay_override.ipv4_addr_in = Some(address)
+                    })
+                    .await?;
+                }
+                OverrideSetCommands::Ipv6 { hostname, address } => {
+                    Self::update_override(&hostname, |relay_override| {
+                        relay_override.ipv6_addr_in = Some(address)
+                    })
+                    .await?;
+                }
+            },
+            OverrideCommands::Unset(cmds) => match cmds {
+                OverrideUnsetCommands::Ipv4 { hostname } => {
+                    Self::update_override(&hostname, |relay_override| {
+                        let _ = relay_override.ipv4_addr_in.take();
+                    })
+                    .await?;
+                }
+                OverrideUnsetCommands::Ipv6 { hostname } => {
+                    Self::update_override(&hostname, |relay_override| {
+                        let _ = relay_override.ipv6_addr_in.take();
+                    })
+                    .await?;
+                }
+            },
+            OverrideCommands::ClearAll { confirm } => {
+                if confirm
+                    || receive_confirmation(
+                        "Are you sure you want to clear all overrides? [Y/n]",
+                        true,
+                    )
+                    .await
+                {
+                    let mut rpc = MullvadProxyClient::new().await?;
+                    rpc.clear_all_relay_overrides().await?;
+                    println!("All overrides unset");
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -716,9 +716,17 @@ impl Relay {
     async fn update_override(
         hostname: &str,
         update_fn: impl FnOnce(&mut RelayOverride),
+        warn_non_existent_hostname: bool,
     ) -> Result<()> {
         let mut rpc = MullvadProxyClient::new().await?;
         let settings = rpc.get_settings().await?;
+
+        if warn_non_existent_hostname {
+            let countries = get_filtered_relays_with_client(&mut rpc).await?;
+            if find_relay_by_hostname(&countries, hostname).is_none() {
+                eprintln!("Warning: Setting overrides for an unrecognized server");
+            }
+        }
 
         let mut relay_overrides = settings.relay_overrides;
         let mut element = relay_overrides
@@ -815,39 +823,44 @@ impl Relay {
             }
             OverrideCommands::Set(set_cmds) => match set_cmds {
                 OverrideSetCommands::Ipv4 { hostname, address } => {
-                    Self::update_override(&hostname, |relay_override| {
-                        relay_override.ipv4_addr_in = Some(address)
-                    })
+                    Self::update_override(
+                        &hostname,
+                        |relay_override| relay_override.ipv4_addr_in = Some(address),
+                        true,
+                    )
                     .await?;
                 }
                 OverrideSetCommands::Ipv6 { hostname, address } => {
-                    Self::update_override(&hostname, |relay_override| {
-                        relay_override.ipv6_addr_in = Some(address)
-                    })
+                    Self::update_override(
+                        &hostname,
+                        |relay_override| relay_override.ipv6_addr_in = Some(address),
+                        true,
+                    )
                     .await?;
                 }
             },
             OverrideCommands::Unset(cmds) => match cmds {
                 OverrideUnsetCommands::Ipv4 { hostname } => {
-                    Self::update_override(&hostname, |relay_override| {
-                        let _ = relay_override.ipv4_addr_in.take();
-                    })
+                    Self::update_override(
+                        &hostname,
+                        |relay_override| relay_override.ipv4_addr_in = None,
+                        false,
+                    )
                     .await?;
                 }
                 OverrideUnsetCommands::Ipv6 { hostname } => {
-                    Self::update_override(&hostname, |relay_override| {
-                        let _ = relay_override.ipv6_addr_in.take();
-                    })
+                    Self::update_override(
+                        &hostname,
+                        |relay_override| relay_override.ipv6_addr_in = None,
+                        false,
+                    )
                     .await?;
                 }
             },
             OverrideCommands::ClearAll { confirm } => {
                 if confirm
-                    || receive_confirmation(
-                        "Are you sure you want to clear all overrides? [Y/n]",
-                        true,
-                    )
-                    .await
+                    || receive_confirmation("Are you sure you want to clear all overrides?", true)
+                        .await
                 {
                     let mut rpc = MullvadProxyClient::new().await?;
                     rpc.clear_all_relay_overrides().await?;
@@ -909,8 +922,16 @@ pub fn find_relay_by_hostname(
         })
 }
 
+/// Return a list of all active non-bridge relays
 pub async fn get_filtered_relays() -> Result<Vec<RelayListCountry>> {
     let mut rpc = MullvadProxyClient::new().await?;
+    get_filtered_relays_with_client(&mut rpc).await
+}
+
+/// Return a list of all active non-bridge relays
+async fn get_filtered_relays_with_client(
+    rpc: &mut MullvadProxyClient,
+) -> Result<Vec<RelayListCountry>> {
     let relay_list = rpc.get_relay_locations().await?;
 
     let mut countries = vec![];

--- a/mullvad-cli/src/cmds/reset.rs
+++ b/mullvad-cli/src/cmds/reset.rs
@@ -1,32 +1,14 @@
+use super::receive_confirmation;
 use anyhow::Result;
 use mullvad_management_interface::MullvadProxyClient;
-use std::io::stdin;
 
 pub async fn handle() -> Result<()> {
-    if receive_confirmation().await {
-        let mut rpc = MullvadProxyClient::new().await?;
-        rpc.factory_reset().await?;
-        #[cfg(target_os = "linux")]
-        println!("If you're running systemd, to remove all logs, you must use journalctl");
+    if !receive_confirmation("Are you sure you want to disconnect, log out, delete all settings, logs and cache files for the Mullvad VPN system service? [y/N]", false).await {
+        return Ok(());
     }
+    let mut rpc = MullvadProxyClient::new().await?;
+    rpc.factory_reset().await?;
+    #[cfg(target_os = "linux")]
+    println!("If you're running systemd, to remove all logs, you must use journalctl");
     Ok(())
-}
-
-async fn receive_confirmation() -> bool {
-    println!("Are you sure you want to disconnect, log out, delete all settings, logs and cache files for the Mullvad VPN system service? [Yes/No (default)]");
-
-    tokio::task::spawn_blocking(|| loop {
-        let mut buf = String::new();
-        if let Err(e) = stdin().read_line(&mut buf) {
-            eprintln!("Couldn't read from STDIN: {e}");
-            return false;
-        }
-        match buf.trim() {
-            "Yes" => return true,
-            "No" | "no" | "" => return false,
-            _ => eprintln!("Unexpected response. Please enter \"Yes\" or \"No\""),
-        }
-    })
-    .await
-    .unwrap()
 }

--- a/mullvad-cli/src/cmds/reset.rs
+++ b/mullvad-cli/src/cmds/reset.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use mullvad_management_interface::MullvadProxyClient;
 
 pub async fn handle() -> Result<()> {
-    if !receive_confirmation("Are you sure you want to disconnect, log out, delete all settings, logs and cache files for the Mullvad VPN system service? [y/N]", false).await {
+    if !receive_confirmation("Are you sure you want to disconnect, log out, delete all settings, logs and cache files for the Mullvad VPN system service?", false).await {
         return Ok(());
     }
     let mut rpc = MullvadProxyClient::new().await?;

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2522,5 +2522,6 @@ fn new_selector_config(settings: &Settings) -> SelectorConfig {
         obfuscation_settings: settings.obfuscation_settings.clone(),
         default_tunnel_type,
         custom_lists: settings.custom_lists.clone(),
+        relay_overrides: settings.relay_overrides.clone(),
     }
 }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -46,6 +46,8 @@ service ManagementService {
   rpc SetEnableIpv6(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
   rpc SetQuantumResistantTunnel(QuantumResistantState) returns (google.protobuf.Empty) {}
   rpc SetDnsOptions(DnsOptions) returns (google.protobuf.Empty) {}
+  rpc SetRelayOverride(RelayOverride) returns (google.protobuf.Empty) {}
+  rpc ClearAllRelayOverrides(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
   // Account management
   rpc CreateNewAccount(google.protobuf.Empty) returns (google.protobuf.StringValue) {}

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -390,6 +390,13 @@ message Settings {
   ObfuscationSettings obfuscation_settings = 10;
   CustomListSettings custom_lists = 11;
   ApiAccessMethodSettings api_access_methods = 12;
+  repeated RelayOverride relay_overrides = 13;
+}
+
+message RelayOverride {
+  string hostname = 1;
+  optional string ipv4_addr_in = 2;
+  optional string ipv6_addr_in = 3;
 }
 
 message SplitTunnelSettings {

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -8,7 +8,9 @@ use mullvad_types::{
     custom_list::{CustomList, Id},
     device::{Device, DeviceEvent, DeviceId, DeviceState, RemoveDeviceEvent},
     location::GeoIpLocation,
-    relay_constraints::{BridgeSettings, BridgeState, ObfuscationSettings, RelaySettings},
+    relay_constraints::{
+        BridgeSettings, BridgeState, ObfuscationSettings, RelayOverride, RelaySettings,
+    },
     relay_list::RelayList,
     settings::{DnsOptions, Settings},
     states::TunnelState,
@@ -336,6 +338,23 @@ impl MullvadProxyClient {
     pub async fn set_dns_options(&mut self, options: DnsOptions) -> Result<()> {
         let options = types::DnsOptions::from(&options);
         self.0.set_dns_options(options).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn set_relay_override(&mut self, relay_override: RelayOverride) -> Result<()> {
+        let r#override = types::RelayOverride::from(relay_override);
+        self.0
+            .set_relay_override(r#override)
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    pub async fn clear_all_relay_overrides(&mut self) -> Result<()> {
+        self.0
+            .clear_all_relay_overrides(())
+            .await
+            .map_err(Error::Rpc)?;
         Ok(())
     }
 

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -45,6 +45,12 @@ impl From<&mullvad_types::settings::Settings> for proto::Settings {
             api_access_methods: Some(proto::ApiAccessMethodSettings::from(
                 &settings.api_access_methods,
             )),
+            relay_overrides: settings
+                .relay_overrides
+                .iter()
+                .cloned()
+                .map(proto::RelayOverride::from)
+                .collect(),
         }
     }
 }
@@ -168,6 +174,11 @@ impl TryFrom<proto::Settings> for mullvad_types::settings::Settings {
             block_when_disconnected: settings.block_when_disconnected,
             auto_connect: settings.auto_connect,
             tunnel_options: mullvad_types::settings::TunnelOptions::try_from(tunnel_options)?,
+            relay_overrides: settings
+                .relay_overrides
+                .into_iter()
+                .map(mullvad_types::relay_constraints::RelayOverride::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             show_beta_releases: settings.show_beta_releases,
             #[cfg(windows)]
             split_tunnel: mullvad_types::settings::SplitTunnelSettings::from(split_tunnel),

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -172,8 +172,10 @@ impl ParsedRelays {
                 .insert(r#override.hostname.to_owned(), r#override);
         }
 
+        let mut remaining_overrides = self.overrides.clone();
+
         for relay in &mut self.relays {
-            if let Some(overrides) = self.overrides.get(&relay.hostname) {
+            if let Some(overrides) = remaining_overrides.remove(&relay.hostname) {
                 if let Some(ipv4_addr_in) = overrides.ipv4_addr_in {
                     log::debug!(
                         "Overriding ipv4_addr_in for {}: {ipv4_addr_in}",
@@ -189,6 +191,13 @@ impl ParsedRelays {
                     relay.ipv6_addr_in = Some(ipv6_addr_in);
                 }
             }
+        }
+
+        for relay_override in remaining_overrides.into_values() {
+            log::warn!(
+                "No overrides were applied for hostname \"{}\": not found",
+                relay_override.hostname
+            );
         }
     }
 

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -6,12 +6,12 @@ use ipnetwork::IpNetwork;
 use mullvad_types::{
     custom_list::CustomListsSettings,
     endpoint::{MullvadEndpoint, MullvadWireguardEndpoint},
-    location::{Coordinates, Location},
+    location::{Coordinates, Hostname, Location},
     relay_constraints::{
         BridgeSettings, BridgeState, Constraint, InternalBridgeConstraints, LocationConstraint,
         Match, ObfuscationSettings, OpenVpnConstraints, Ownership, Providers, RelayConstraints,
-        RelayConstraintsFormatter, RelaySettings, ResolvedLocationConstraint, SelectedObfuscation,
-        Set, TransportPort, Udp2TcpObfuscationSettings,
+        RelayConstraintsFormatter, RelayOverride, RelaySettings, ResolvedLocationConstraint,
+        SelectedObfuscation, Set, TransportPort, Udp2TcpObfuscationSettings,
     },
     relay_list::{BridgeEndpointData, Relay, RelayEndpointData, RelayList},
     CustomTunnelEndpoint,
@@ -19,6 +19,7 @@ use mullvad_types::{
 use parking_lot::{Mutex, MutexGuard};
 use rand::{seq::SliceRandom, Rng};
 use std::{
+    collections::HashMap,
     io,
     net::{IpAddr, SocketAddr},
     path::Path,
@@ -81,6 +82,7 @@ struct ParsedRelays {
     last_updated: SystemTime,
     locations: RelayList,
     relays: Vec<Relay>,
+    overrides: HashMap<Hostname, RelayOverride>,
 }
 
 impl ParsedRelays {
@@ -89,6 +91,7 @@ impl ParsedRelays {
             last_updated: time::UNIX_EPOCH,
             locations: RelayList::empty(),
             relays: Vec::new(),
+            overrides: HashMap::new(),
         }
     }
 
@@ -97,36 +100,33 @@ impl ParsedRelays {
         if relay_list.wireguard.udp2tcp_ports.is_empty() {
             relay_list.wireguard.udp2tcp_ports.extend(UDP2TCP_PORTS);
         }
+        ParsedRelays {
+            last_updated,
+            relays: Self::relays_with_location(&relay_list),
+            locations: relay_list,
+            overrides: HashMap::new(),
+        }
+    }
 
-        let mut relays = Vec::new();
+    fn relays_with_location(relay_list: &RelayList) -> Vec<Relay> {
+        let mut relays = vec![];
         for country in &relay_list.countries {
-            let country_name = country.name.clone();
-            let country_code = country.code.clone();
             for city in &country.cities {
-                let city_name = city.name.clone();
-                let city_code = city.code.clone();
-                let latitude = city.latitude;
-                let longitude = city.longitude;
                 for relay in &city.relays {
                     let mut relay_with_location = relay.clone();
                     relay_with_location.location = Some(Location {
-                        country: country_name.clone(),
-                        country_code: country_code.clone(),
-                        city: city_name.clone(),
-                        city_code: city_code.clone(),
-                        latitude,
-                        longitude,
+                        country: country.name.clone(),
+                        country_code: country.code.clone(),
+                        city: city.name.clone(),
+                        city_code: city.code.clone(),
+                        latitude: city.latitude,
+                        longitude: city.longitude,
                     });
                     relays.push(relay_with_location);
                 }
             }
         }
-
-        ParsedRelays {
-            last_updated,
-            locations: relay_list,
-            relays,
-        }
+        relays
     }
 
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self, Error> {
@@ -160,6 +160,43 @@ impl ParsedRelays {
     pub fn tag(&self) -> Option<&str> {
         self.locations.etag.as_deref()
     }
+
+    fn reset_overrides(&mut self) {
+        self.relays = Self::relays_with_location(&self.locations);
+    }
+
+    fn append_overrides(&mut self, overrides: Vec<RelayOverride>) {
+        self.overrides.clear();
+        for r#override in overrides {
+            self.overrides
+                .insert(r#override.hostname.to_owned(), r#override);
+        }
+
+        for relay in &mut self.relays {
+            if let Some(overrides) = self.overrides.get(&relay.hostname) {
+                if let Some(ipv4_addr_in) = overrides.ipv4_addr_in {
+                    log::debug!(
+                        "Overriding ipv4_addr_in for {}: {ipv4_addr_in}",
+                        relay.hostname
+                    );
+                    relay.ipv4_addr_in = ipv4_addr_in;
+                }
+                if let Some(ipv6_addr_in) = overrides.ipv6_addr_in {
+                    log::debug!(
+                        "Overriding ipv6_addr_in for {}: {ipv6_addr_in}",
+                        relay.hostname
+                    );
+                    relay.ipv6_addr_in = Some(ipv6_addr_in);
+                }
+            }
+        }
+    }
+
+    /// Update list while keeping overrides
+    pub fn update(&mut self, update: ParsedRelays) {
+        let old = std::mem::replace(self, update);
+        self.append_overrides(old.overrides.into_values().collect());
+    }
 }
 
 #[derive(Clone)]
@@ -170,6 +207,7 @@ pub struct SelectorConfig {
     pub obfuscation_settings: ObfuscationSettings,
     pub default_tunnel_type: TunnelType,
     pub custom_lists: CustomListsSettings,
+    pub relay_overrides: Vec<RelayOverride>,
 }
 
 #[derive(Clone)]
@@ -183,8 +221,8 @@ impl RelaySelector {
     pub fn new(config: SelectorConfig, resource_dir: &Path, cache_dir: &Path) -> Self {
         let cache_path = cache_dir.join(RELAYS_FILENAME);
         let resource_path = resource_dir.join(RELAYS_FILENAME);
-        let unsynchronized_parsed_relays = Self::read_relays_from_disk(&cache_path, &resource_path)
-            .unwrap_or_else(|error| {
+        let mut unsynchronized_parsed_relays =
+            Self::read_relays_from_disk(&cache_path, &resource_path).unwrap_or_else(|error| {
                 log::error!(
                     "{}",
                     error.display_chain_with_msg("Unable to load cached relays")
@@ -198,6 +236,8 @@ impl RelaySelector {
                 .format(DATE_TIME_FORMAT_STR)
         );
 
+        unsynchronized_parsed_relays.append_overrides(config.relay_overrides.clone());
+
         RelaySelector {
             config: Arc::new(Mutex::new(config)),
             parsed_relays: Arc::new(Mutex::new(unsynchronized_parsed_relays)),
@@ -205,6 +245,9 @@ impl RelaySelector {
     }
 
     pub fn set_config(&mut self, config: SelectorConfig) {
+        let mut parsed_relays = self.parsed_relays.lock();
+        parsed_relays.reset_overrides();
+        parsed_relays.append_overrides(config.relay_overrides.clone());
         *self.config.lock() = config;
     }
 
@@ -1474,6 +1517,7 @@ mod test {
                 bridge_state: BridgeState::Auto,
                 default_tunnel_type: default_tunnel_type(),
                 custom_lists: CustomListsSettings::default(),
+                relay_overrides: vec![],
             })),
         }
     }

--- a/mullvad-relay-selector/src/matcher.rs
+++ b/mullvad-relay-selector/src/matcher.rs
@@ -67,13 +67,12 @@ impl RelayMatcher<WireguardMatcher> {
 impl<T: EndpointMatcher> RelayMatcher<T> {
     /// Filter a list of relays and their endpoints based on constraints.
     /// Only relays with (and including) matching endpoints are returned.
-    pub fn filter_matching_relay_list(&self, relays: &[Relay]) -> Vec<Relay> {
-        let matches = relays
-            .iter()
-            .filter(|relay| self.pre_filter_matching_relay(relay));
-
+    pub fn filter_matching_relay_list<'a, R: Iterator<Item = &'a Relay> + Clone>(
+        &self,
+        relays: R,
+    ) -> Vec<Relay> {
+        let matches = relays.filter(|relay| self.pre_filter_matching_relay(relay));
         let ignore_include_in_country = !matches.clone().any(|relay| relay.include_in_country);
-
         matches
             .filter(|relay| self.post_filter_matching_relay(relay, ignore_include_in_country))
             .cloned()

--- a/mullvad-relay-selector/src/updater.rs
+++ b/mullvad-relay-selector/src/updater.rs
@@ -185,7 +185,7 @@ impl RelayListUpdater {
         );
 
         let mut parsed_relays = self.parsed_relays.lock();
-        *parsed_relays = new_parsed_relays;
+        parsed_relays.update(new_parsed_relays);
         (self.on_update)(parsed_relays.locations());
         Ok(())
     }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -10,7 +10,12 @@ use crate::{
 #[cfg(target_os = "android")]
 use jnix::{jni::objects::JObject, FromJava, IntoJava, JnixEnv};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, fmt, str::FromStr};
+use std::{
+    collections::HashSet,
+    fmt,
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
 use talpid_types::net::{openvpn::ProxySettings, IpVersion, TransportProtocol, TunnelType};
 
 pub trait Match<T> {
@@ -990,4 +995,16 @@ pub struct InternalBridgeConstraints {
     pub providers: Constraint<Providers>,
     pub ownership: Constraint<Ownership>,
     pub transport_protocol: Constraint<TransportProtocol>,
+}
+
+/// Options to override for a particular relay to use instead of the ones specified in the relay
+/// list
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct RelayOverride {
+    /// Hostname for which to override the given options
+    pub hostname: Hostname,
+    /// IPv4 address to use instead of the default
+    pub ipv4_addr_in: Option<Ipv4Addr>,
+    /// IPv6 address to use instead of the default
+    pub ipv6_addr_in: Option<Ipv6Addr>,
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -1021,4 +1021,21 @@ impl RelayOverride {
     pub fn is_empty(&self) -> bool {
         self == &Self::empty(self.hostname.clone())
     }
+
+    pub fn apply_to_relay(&self, relay: &mut Relay) {
+        if let Some(ipv4_addr_in) = self.ipv4_addr_in {
+            log::debug!(
+                "Overriding ipv4_addr_in for {}: {ipv4_addr_in}",
+                relay.hostname
+            );
+            relay.ipv4_addr_in = ipv4_addr_in;
+        }
+        if let Some(ipv6_addr_in) = self.ipv6_addr_in {
+            log::debug!(
+                "Overriding ipv6_addr_in for {}: {ipv6_addr_in}",
+                relay.hostname
+            );
+            relay.ipv6_addr_in = Some(ipv6_addr_in);
+        }
+    }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -1008,3 +1008,17 @@ pub struct RelayOverride {
     /// IPv6 address to use instead of the default
     pub ipv6_addr_in: Option<Ipv6Addr>,
 }
+
+impl RelayOverride {
+    pub fn empty(hostname: Hostname) -> RelayOverride {
+        RelayOverride {
+            hostname,
+            ipv4_addr_in: None,
+            ipv6_addr_in: None,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self == &Self::empty(self.hostname.clone())
+    }
+}

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -35,6 +35,14 @@ impl RelayList {
             .iter()
             .find(|country| country.code == country_code)
     }
+
+    /// Return a flat iterator with all relays
+    pub fn relays(&self) -> impl Iterator<Item = &Relay> + Clone + '_ {
+        self.countries
+            .iter()
+            .flat_map(|country| country.cities.iter())
+            .flat_map(|city| city.relays.iter())
+    }
 }
 
 /// A list of [`RelayListCity`]s within a country. Used by [`RelayList`].

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -175,6 +175,24 @@ impl Settings {
             self.relay_settings = new_settings;
         }
     }
+
+    pub fn set_relay_override(&mut self, relay_override: RelayOverride) {
+        let existing_override = self
+            .relay_overrides
+            .iter_mut()
+            .enumerate()
+            .find(|(_, elem)| elem.hostname == relay_override.hostname);
+        match existing_override {
+            None => self.relay_overrides.push(relay_override),
+            Some((index, elem)) => {
+                if relay_override.is_empty() {
+                    self.relay_overrides.swap_remove(index);
+                } else {
+                    *elem = relay_override;
+                }
+            }
+        }
+    }
 }
 
 /// TunnelOptions holds configuration data that applies to all kinds of tunnels.

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     custom_list::CustomListsSettings,
     relay_constraints::{
         BridgeConstraints, BridgeSettings, BridgeState, Constraint, GeographicLocationConstraint,
-        LocationConstraint, ObfuscationSettings, RelayConstraints, RelaySettings,
+        LocationConstraint, ObfuscationSettings, RelayConstraints, RelayOverride, RelaySettings,
         RelaySettingsFormatter, SelectedObfuscation, WireguardConstraints,
     },
     wireguard,
@@ -91,6 +91,9 @@ pub struct Settings {
     /// Options that should be applied to tunnels of a specific type regardless of where the relays
     /// might be located.
     pub tunnel_options: TunnelOptions,
+    /// Overrides for relays
+    #[cfg_attr(target_os = "android", jnix(skip))]
+    pub relay_overrides: Vec<RelayOverride>,
     /// Whether to notify users of beta updates.
     pub show_beta_releases: bool,
     /// Split tunneling settings
@@ -131,16 +134,17 @@ impl Default for Settings {
                 ..Default::default()
             },
             bridge_state: BridgeState::Auto,
+            custom_lists: CustomListsSettings::default(),
+            api_access_methods: access_method::Settings::default(),
             allow_lan: false,
             block_when_disconnected: false,
             auto_connect: false,
             tunnel_options: TunnelOptions::default(),
+            relay_overrides: vec![],
             show_beta_releases: false,
             #[cfg(windows)]
             split_tunnel: SplitTunnelSettings::default(),
             settings_version: CURRENT_SETTINGS_VERSION,
-            custom_lists: CustomListsSettings::default(),
-            api_access_methods: access_method::Settings::default(),
         }
     }
 }


### PR DESCRIPTION
This adds a new subcommand `mullvad relay override` that can be used to override values in the relay list. The fields that can be overridden (as of this PR) are `ipv4_addr_in` and `ipv6_addr_in`.

Fix DES-421.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5410)
<!-- Reviewable:end -->
