### PR TITLE
Add change listener to SettingsPersister

### DIFF
--- a/mullvad-daemon/src/settings.rs
+++ b/mullvad-daemon/src/settings.rs
@@ -38,10 +38,11 @@ pub enum Error {
     WriteError(String, #[error(source)] io::Error),
 }
 
-#[derive(Debug)]
 pub struct SettingsPersister {
     settings: Settings,
     path: PathBuf,
+    #[allow(clippy::type_complexity)]
+    on_change_listeners: Vec<Box<dyn Fn(&Settings)>>,
 }
 
 pub type MadeChanges = bool;
@@ -77,7 +78,11 @@ impl SettingsPersister {
             settings.show_beta_releases = true;
         }
 
-        let mut persister = SettingsPersister { settings, path };
+        let mut persister = SettingsPersister {
+            settings,
+            path,
+            on_change_listeners: vec![],
+        };
 
         if should_save {
             if let Err(error) = persister.save().await {
@@ -89,6 +94,16 @@ impl SettingsPersister {
         }
 
         persister
+    }
+
+    pub fn register_change_listener(&mut self, change_listener: impl Fn(&Settings) + 'static) {
+        self.on_change_listeners.push(Box::new(change_listener));
+    }
+
+    fn notify_listeners(&self) {
+        for listener in &self.on_change_listeners {
+            listener(&self.settings);
+        }
     }
 
     async fn load_from_file(path: &Path) -> Result<(Settings, bool), Error> {
@@ -150,7 +165,11 @@ impl SettingsPersister {
                     .map_err(|e| Error::DeleteError(path.display().to_string(), e))
                     .await
             })
-            .await
+            .await?;
+
+        self.notify_listeners();
+
+        Ok(())
     }
 
     pub fn to_settings(&self) -> Settings {
@@ -187,6 +206,9 @@ impl SettingsPersister {
 
         Self::save_inner(&self.path, &new_settings).await?;
         self.settings = new_settings;
+
+        self.notify_listeners();
+
         Ok(true)
     }
 


### PR DESCRIPTION
Currently, we manually notify the management interface, relay selector, and parameters generator of changes to (some subset of) the settings. This is easy to forget about, so I've replaced it with a simple change event in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5411)
<!-- Reviewable:end -->
