### PR TITLE
Limit firebase test execution

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -29,6 +29,10 @@ on:
         description: Override container image
         type: string
         required: false
+      run_firebase_tests:
+        description: Run firebase tests
+        type: boolean
+        required: false
   # Build if main is updated to ensure up-to-date caches are available
   push:
     branches: [main]
@@ -300,7 +304,7 @@ jobs:
 
   instrumented-firebase-tests:
     name: Run instrumented firebase tests
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'schedule' || github.event.inputs.run_firebase_tests == true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [build-app]


### PR DESCRIPTION
Only run firebase tests nightly and when explicitly enabled while manually triggering a workflow.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5424)
<!-- Reviewable:end -->
