### PR TITLE
Disable enumNamespace in swfitlint

### DIFF
--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -32,7 +32,9 @@ organizeDeclarations,             \
 # Do not reorder switch case statements
 sortedSwitchCases,                \
 # Do not add // MARK: ClassName before every type
-markTypes
+markTypes,                        \
+# disable enum imports since it seems borken
+enumNamespaces
 
 
 --rules                           \


### PR DESCRIPTION
Disable `enumNamespaces` since it seems to be broken right now and we're not sure we want to use this feature of `swiftformat`. 

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5426)
<!-- Reviewable:end -->
