### PR TITLE
Add missing text about unblocking Internet on device revoked view

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -99,7 +99,8 @@ enum TunnelState: Equatable, CustomStringConvertible {
 
     var isSecured: Bool {
         switch self {
-        case .reconnecting, .connecting, .connected, .waitingForConnectivity(.noConnection), .error(.accountExpired):
+        case .reconnecting, .connecting, .connected, .waitingForConnectivity(.noConnection), .error(.accountExpired),
+             .error(.deviceRevoked):
             return true
         case .pendingReconnect, .disconnecting, .disconnected, .waitingForConnectivity(.noNetwork), .error:
             return false

--- a/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
+++ b/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
@@ -48,7 +48,7 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
     private lazy var footerLabel: UILabel = {
         let bodyLabel = UILabel()
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
-        bodyLabel.font = UIFont.systemFont(ofSize: 17)
+        bodyLabel.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         bodyLabel.numberOfLines = 0
         bodyLabel.textColor = .white
         bodyLabel.text = NSLocalizedString(


### PR DESCRIPTION
[The designs](https://app.zeplin.io/project/5f928a32fdc9962af9018d70/screen/619ccb73de7defaada71e553) specify that if the device enters the revoked state when connected to a VPN, we should also display the following text:

"Going to login will unblock the internet on this device"

After adding blocked state this doesn't happen anymore since that isn't supported.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5430)
<!-- Reviewable:end -->
