### PR TITLE
Save WireGuard obfuscation settings choice and move DNS settings to a custom view

### DIFF
--- a/ios/MullvadSettings/WireGuardObfuscationSettings.swift
+++ b/ios/MullvadSettings/WireGuardObfuscationSettings.swift
@@ -14,15 +14,29 @@ public enum WireGuardObfuscationState: Codable {
     case off
 }
 
-public enum WireGuardObfuscationPort: Codable {
-    case automatic
-    case port80
-    case port5001
+public enum WireGuardObfuscationPort: UInt16, Codable {
+    case automatic = 0
+    case port80 = 80
+    case port5001 = 5001
+
+    public var portValue: UInt16 {
+        rawValue
+    }
+
+    public init?(rawValue: UInt16) {
+        switch rawValue {
+        case 80:
+            self = .port80
+        case 5001:
+            self = .port5001
+        default: self = .automatic
+        }
+    }
 }
 
 public struct WireGuardObfuscationSettings: Codable, Equatable {
-    let state: WireGuardObfuscationState
-    let port: WireGuardObfuscationPort
+    public let state: WireGuardObfuscationState
+    public let port: WireGuardObfuscationPort
 
     public init(state: WireGuardObfuscationState = .automatic, port: WireGuardObfuscationPort = .automatic) {
         self.state = state

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -442,6 +442,10 @@
 		7A6B4F592AB8412E00123853 /* TunnelMonitorTimings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */; };
 		7A6F2FA52AFA3CB2006D0856 /* AccountExpiryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FA42AFA3CB2006D0856 /* AccountExpiryTests.swift */; };
 		7A6F2FA72AFBB9AE006D0856 /* AccountExpiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FA62AFBB9AE006D0856 /* AccountExpiry.swift */; };
+		7A6F2FA92AFD0842006D0856 /* CustomDNSDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FA82AFD0842006D0856 /* CustomDNSDataSource.swift */; };
+		7A6F2FAB2AFD3097006D0856 /* CustomDNSCellFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FAA2AFD3097006D0856 /* CustomDNSCellFactory.swift */; };
+		7A6F2FAD2AFD3DA7006D0856 /* CustomDNSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FAC2AFD3DA7006D0856 /* CustomDNSViewController.swift */; };
+		7A6F2FAF2AFE36E7006D0856 /* PreferencesInfoButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FAE2AFE36E7006D0856 /* PreferencesInfoButtonItem.swift */; };
 		7A7AD28D29DC677800480EF1 /* FirstTimeLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7AD28C29DC677800480EF1 /* FirstTimeLaunch.swift */; };
 		7A818F1F29F0305800C7F0F4 /* RootConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A818F1E29F0305800C7F0F4 /* RootConfiguration.swift */; };
 		7A83C3FF2A55B72E00DFB83A /* MullvadVPNApp.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 7A83C3FE2A55B72E00DFB83A /* MullvadVPNApp.xctestplan */; };
@@ -515,7 +519,6 @@
 		A988A3E22AFE54AC0008D2C7 /* AccountExpiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FA62AFBB9AE006D0856 /* AccountExpiry.swift */; };
 		A988DF212ADD293D00D807EF /* RESTTransportStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A1DE782AD5708E0073F689 /* RESTTransportStrategy.swift */; };
 		A988DF242ADD307200D807EF /* libRelaySelector.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5898D29829017DAC00EB5EBA /* libRelaySelector.a */; };
-		A988DF262ADE86ED00D807EF /* WireGuardObfuscationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A988DF252ADE86ED00D807EF /* WireGuardObfuscationSettings.swift */; };
 		A988DF272ADE86ED00D807EF /* WireGuardObfuscationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A988DF252ADE86ED00D807EF /* WireGuardObfuscationSettings.swift */; };
 		A988DF2A2ADE880300D807EF /* TunnelSettingsV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A988DF282ADE880300D807EF /* TunnelSettingsV3.swift */; };
 		A9A1DE792AD5708E0073F689 /* RESTTransportStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A1DE782AD5708E0073F689 /* RESTTransportStrategy.swift */; };
@@ -1551,6 +1554,10 @@
 		7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitorTimings.swift; sourceTree = "<group>"; };
 		7A6F2FA42AFA3CB2006D0856 /* AccountExpiryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExpiryTests.swift; sourceTree = "<group>"; };
 		7A6F2FA62AFBB9AE006D0856 /* AccountExpiry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExpiry.swift; sourceTree = "<group>"; };
+		7A6F2FA82AFD0842006D0856 /* CustomDNSDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDNSDataSource.swift; sourceTree = "<group>"; };
+		7A6F2FAA2AFD3097006D0856 /* CustomDNSCellFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDNSCellFactory.swift; sourceTree = "<group>"; };
+		7A6F2FAC2AFD3DA7006D0856 /* CustomDNSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDNSViewController.swift; sourceTree = "<group>"; };
+		7A6F2FAE2AFE36E7006D0856 /* PreferencesInfoButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesInfoButtonItem.swift; sourceTree = "<group>"; };
 		7A7AD28C29DC677800480EF1 /* FirstTimeLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstTimeLaunch.swift; sourceTree = "<group>"; };
 		7A818F1E29F0305800C7F0F4 /* RootConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootConfiguration.swift; sourceTree = "<group>"; };
 		7A83C3FE2A55B72E00DFB83A /* MullvadVPNApp.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MullvadVPNApp.xctestplan; sourceTree = "<group>"; };
@@ -2107,9 +2114,13 @@
 		583FE01A29C19777006E85F9 /* Preferences */ = {
 			isa = PBXGroup;
 			children = (
+				7A6F2FAA2AFD3097006D0856 /* CustomDNSCellFactory.swift */,
+				7A6F2FA82AFD0842006D0856 /* CustomDNSDataSource.swift */,
+				7A6F2FAC2AFD3DA7006D0856 /* CustomDNSViewController.swift */,
 				5864AF0229C7879B005B0CD9 /* PreferencesCellFactory.swift */,
 				584D26C3270C855A004EA533 /* PreferencesDataSource.swift */,
 				587EB6732714520600123C75 /* PreferencesDataSourceDelegate.swift */,
+				7A6F2FAE2AFE36E7006D0856 /* PreferencesInfoButtonItem.swift */,
 				5871167E2910035700D41AAC /* PreferencesInteractor.swift */,
 				58ACF6482655365700ACE4B7 /* PreferencesViewController.swift */,
 				587EB671271451E300123C75 /* PreferencesViewModel.swift */,
@@ -2423,10 +2434,10 @@
 		587B75422669034500DEF7E9 /* Notification Providers */ = {
 			isa = PBXGroup;
 			children = (
-				58C8191729FAA2C400DEB1B4 /* NotificationConfiguration.swift */,
 				7A6F2FA62AFBB9AE006D0856 /* AccountExpiry.swift */,
-				587B75402668FD7700DEF7E9 /* AccountExpirySystemNotificationProvider.swift */,
 				58607A4C2947287800BC467D /* AccountExpiryInAppNotificationProvider.swift */,
+				587B75402668FD7700DEF7E9 /* AccountExpirySystemNotificationProvider.swift */,
+				58C8191729FAA2C400DEB1B4 /* NotificationConfiguration.swift */,
 				F07CFF1F29F2720E008C0343 /* RegisteredDeviceInAppNotificationProvider.swift */,
 				58A94AE326CFD945001CB97C /* TunnelStatusNotificationProvider.swift */,
 			);
@@ -4351,7 +4362,6 @@
 				5896CEF226972DEB00B0FAE8 /* AccountContentView.swift in Sources */,
 				7A3353932AAA089000F0A71C /* SimulatorTunnelInfo.swift in Sources */,
 				5867771429097BCD006F721F /* PaymentState.swift in Sources */,
-				A988DF262ADE86ED00D807EF /* WireGuardObfuscationSettings.swift in Sources */,
 				F0EF50D32A8FA47E0031E8DF /* ChangeLogInteractor.swift in Sources */,
 				7AC8A3AF2ABC71D600DC4939 /* TermsOfServiceCoordinator.swift in Sources */,
 				F0C2AEFD2A0BB5CC00986207 /* NotificationProviderIdentifier.swift in Sources */,
@@ -4429,6 +4439,7 @@
 				58F70FE52AEA707800E6890E /* StoreTransactionLog.swift in Sources */,
 				582AE3102440A6CA00E6733A /* InputTextFormatter.swift in Sources */,
 				7A9CCCBA2A96302800DD6A34 /* CreateAccountVoucherCoordinator.swift in Sources */,
+				7A6F2FAD2AFD3DA7006D0856 /* CustomDNSViewController.swift in Sources */,
 				5820EDAB288FF0D2006BF4E4 /* DeviceRowView.swift in Sources */,
 				F0E8CC0C2A4EE672007ED3B4 /* SetupAccountCompletedController.swift in Sources */,
 				5846227726E22A7C0035F7C2 /* StorePaymentManagerDelegate.swift in Sources */,
@@ -4444,6 +4455,7 @@
 				5864859929A0D028006C5743 /* FormsheetPresentationController.swift in Sources */,
 				7A9CCCB52A96302800DD6A34 /* AddCreditSucceededCoordinator.swift in Sources */,
 				7A0C0F632A979C4A0058EFCE /* Coordinator+Router.swift in Sources */,
+				7A6F2FAB2AFD3097006D0856 /* CustomDNSCellFactory.swift in Sources */,
 				58A99ED3240014A0006599E9 /* TermsOfServiceViewController.swift in Sources */,
 				58CCA0162242560B004F3011 /* UIColor+Palette.swift in Sources */,
 				587CBFE322807F530028DED3 /* UIColor+Helpers.swift in Sources */,
@@ -4502,6 +4514,7 @@
 				F0C6FA852A6A733700F521F0 /* InAppPurchaseInteractor.swift in Sources */,
 				5878F50029CDA742003D4BE2 /* UIView+AutoLayoutBuilder.swift in Sources */,
 				583FE01029C0F532006E85F9 /* CustomSplitViewController.swift in Sources */,
+				7A6F2FA92AFD0842006D0856 /* CustomDNSDataSource.swift in Sources */,
 				58EF580B25D69D7A00AEBA94 /* ProblemReportSubmissionOverlayView.swift in Sources */,
 				5892A45E265FABFF00890742 /* EmptyTableViewHeaderFooterView.swift in Sources */,
 				580909D32876D09A0078138D /* RevokedDeviceViewController.swift in Sources */,
@@ -4560,6 +4573,7 @@
 				F0E8CC032A4C753B007ED3B4 /* WelcomeViewController.swift in Sources */,
 				584D26C4270C855B004EA533 /* PreferencesDataSource.swift in Sources */,
 				F0D8825B2B04F53600D3EF9A /* OutgoingConnectionData.swift in Sources */,
+				7A6F2FAF2AFE36E7006D0856 /* PreferencesInfoButtonItem.swift in Sources */,
 				7A9CCCB62A96302800DD6A34 /* OutOfTimeCoordinator.swift in Sources */,
 				58FD5BF024238EB300112C88 /* SKProduct+Formatting.swift in Sources */,
 				58B43C1925F77DB60002C8C3 /* TunnelControlView.swift in Sources */,

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -564,6 +564,16 @@ final class TunnelManager: StorePaymentObserver {
         )
     }
 
+    func setObfuscationSettings(_ newSettings: WireGuardObfuscationSettings) {
+        scheduleSettingsUpdate(
+            taskName: "Set obfuscation settings",
+            modificationBlock: { settings in
+                settings.wireGuardObfuscation = newSettings
+            },
+            completionHandler: nil
+        )
+    }
+
     // MARK: - Tunnel observeration
 
     /// Add tunnel observer.
@@ -982,6 +992,7 @@ final class TunnelManager: StorePaymentObserver {
             let updatedConstraints = updatedSettings.relayConstraints
             let selectNewRelay = currentConstraints != updatedConstraints
 
+            // TODO: Handle using an obfuscator here
             self.setSettings(updatedSettings, persist: true)
             self.reconnectTunnel(selectNewRelay: selectNewRelay, completionHandler: nil)
         }

--- a/ios/MullvadVPN/View controllers/Preferences/CustomDNSCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/CustomDNSCellFactory.swift
@@ -1,0 +1,214 @@
+//
+//  CustomDNSCellFactory.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2023-11-09.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadSettings
+import UIKit
+
+protocol CustomDNSCellEventHandler {
+    func addDNSEntry()
+    func didChangeDNSEntry(with identifier: UUID, inputString: String) -> Bool
+    func didChangeState(for preference: CustomDNSDataSource.Item, isOn: Bool)
+    func showInfo(for button: PreferencesInfoButtonItem)
+}
+
+final class CustomDNSCellFactory: CellFactoryProtocol {
+    let tableView: UITableView
+    var viewModel: PreferencesViewModel
+    var delegate: CustomDNSCellEventHandler?
+    var isEditing = false
+
+    init(tableView: UITableView, viewModel: PreferencesViewModel) {
+        self.tableView = tableView
+        self.viewModel = viewModel
+    }
+
+    func makeCell(for item: CustomDNSDataSource.Item, indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: item.reuseIdentifier.rawValue, for: indexPath)
+
+        configureCell(cell, item: item, indexPath: indexPath)
+
+        return cell
+    }
+
+    func configure(
+        _ cell: UITableViewCell,
+        toggleSetting: Bool,
+        title: String,
+        for preference: CustomDNSDataSource.Item
+    ) {
+        guard let cell = cell as? SettingsSwitchCell else { return }
+
+        cell.titleLabel.text = title
+        cell.accessibilityHint = nil
+        cell.applySubCellStyling()
+        cell.setOn(toggleSetting, animated: false)
+        cell.action = { [weak self] isOn in
+            self?.delegate?.didChangeState(
+                for: preference,
+                isOn: isOn
+            )
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func configureCell(_ cell: UITableViewCell, item: CustomDNSDataSource.Item, indexPath: IndexPath) {
+        switch item {
+        case .blockAdvertising:
+            let localizedString = NSLocalizedString(
+                "BLOCK_ADS_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Ads",
+                comment: ""
+            )
+
+            configure(
+                cell,
+                toggleSetting: viewModel.blockAdvertising,
+                title: localizedString,
+                for: .blockAdvertising
+            )
+
+        case .blockTracking:
+            let localizedString = NSLocalizedString(
+                "BLOCK_TRACKERS_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Trackers",
+                comment: ""
+            )
+            configure(
+                cell,
+                toggleSetting: viewModel.blockTracking,
+                title: localizedString,
+                for: .blockTracking
+            )
+
+        case .blockMalware:
+            guard let cell = cell as? SettingsSwitchCell else { return }
+
+            let localizedString = NSLocalizedString(
+                "BLOCK_MALWARE_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Malware",
+                comment: ""
+            )
+            configure(
+                cell,
+                toggleSetting: viewModel.blockMalware,
+                title: localizedString,
+                for: .blockMalware
+            )
+            cell.infoButtonHandler = { [weak self] in
+                self?.delegate?.showInfo(for: .blockMalware)
+            }
+
+        case .blockAdultContent:
+            let localizedString = NSLocalizedString(
+                "BLOCK_ADULT_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Adult content",
+                comment: ""
+            )
+            configure(
+                cell,
+                toggleSetting: viewModel.blockAdultContent,
+                title: localizedString,
+                for: .blockAdultContent
+            )
+
+        case .blockGambling:
+            let localizedString = NSLocalizedString(
+                "BLOCK_GAMBLING_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Gambling",
+                comment: ""
+            )
+            configure(
+                cell,
+                toggleSetting: viewModel.blockGambling,
+                title: localizedString,
+                for: .blockGambling
+            )
+
+        case .blockSocialMedia:
+            let localizedString = NSLocalizedString(
+                "BLOCK_SOCIAL_MEDIA_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Social media",
+                comment: ""
+            )
+            configure(
+                cell,
+                toggleSetting: viewModel.blockSocialMedia,
+                title: localizedString,
+                for: .blockSocialMedia
+            )
+
+        case .useCustomDNS:
+            guard let cell = cell as? SettingsSwitchCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "CUSTOM_DNS_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Use custom DNS",
+                comment: ""
+            )
+            cell.setEnabled(viewModel.customDNSPrecondition == .satisfied)
+            cell.setOn(viewModel.effectiveEnableCustomDNS, animated: false)
+            cell.accessibilityHint = viewModel.customDNSPrecondition
+                .localizedDescription(isEditing: isEditing)
+            cell.action = { [weak self] isOn in
+                self?.delegate?.didChangeState(for: .useCustomDNS, isOn: isOn)
+            }
+
+        case .addDNSServer:
+            guard let cell = cell as? SettingsAddDNSEntryCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "ADD_CUSTOM_DNS_SERVER_CELL_LABEL",
+                tableName: "Preferences",
+                value: "Add a server",
+                comment: ""
+            )
+            cell.action = { [weak self] in
+                self?.delegate?.addDNSEntry()
+            }
+
+        case let .dnsServer(entryIdentifier):
+            guard let cell = cell as? SettingsDNSTextCell else { return }
+
+            let dnsServerEntry = viewModel.dnsEntry(entryIdentifier: entryIdentifier)!
+
+            cell.textField.text = dnsServerEntry.address
+            cell.isValidInput = dnsEntryIsValid(identifier: entryIdentifier, cell: cell)
+
+            cell.onTextChange = { [weak self] cell in
+                cell.isValidInput = self?
+                    .dnsEntryIsValid(identifier: entryIdentifier, cell: cell) ?? false
+            }
+
+            cell.onReturnKey = { cell in
+                cell.endEditing(false)
+            }
+
+        case .dnsServerInfo:
+            guard let cell = cell as? SettingsDNSInfoCell else { return }
+
+            cell.titleLabel.attributedText = viewModel.customDNSPrecondition.attributedLocalizedDescription(
+                isEditing: isEditing,
+                preferredFont: .systemFont(ofSize: 14)
+            )
+        }
+    }
+
+    private func dnsEntryIsValid(identifier: UUID, cell: SettingsDNSTextCell) -> Bool {
+        delegate?.didChangeDNSEntry(
+            with: identifier,
+            inputString: cell.textField.text ?? ""
+        ) ?? false
+    }
+}

--- a/ios/MullvadVPN/View controllers/Preferences/CustomDNSDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/CustomDNSDataSource.swift
@@ -1,0 +1,659 @@
+//
+//  CustomDNSDataSource.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2023-11-09.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadSettings
+import UIKit
+
+final class CustomDNSDataSource: UITableViewDiffableDataSource<
+    CustomDNSDataSource.Section,
+    CustomDNSDataSource.Item
+>, UITableViewDelegate {
+    typealias InfoButtonHandler = (Item) -> Void
+
+    enum CellReuseIdentifiers: String, CaseIterable {
+        case settingSwitch
+        case dnsServer
+        case dnsServerInfo
+        case addDNSServer
+
+        var reusableViewClass: AnyClass {
+            switch self {
+            case .settingSwitch:
+                return SettingsSwitchCell.self
+            case .dnsServer:
+                return SettingsDNSTextCell.self
+            case .dnsServerInfo:
+                return SettingsDNSInfoCell.self
+            case .addDNSServer:
+                return SettingsAddDNSEntryCell.self
+            }
+        }
+    }
+
+    private enum HeaderFooterReuseIdentifiers: String, CaseIterable {
+        case contentBlockerHeader
+
+        var reusableViewClass: AnyClass {
+            return SettingsHeaderView.self
+        }
+    }
+
+    enum Section: String, Hashable, CaseIterable {
+        case contentBlockers
+        case customDNS
+    }
+
+    enum Item: Hashable {
+        case blockAdvertising
+        case blockTracking
+        case blockMalware
+        case blockAdultContent
+        case blockGambling
+        case blockSocialMedia
+        case useCustomDNS
+        case addDNSServer
+        case dnsServer(_ uniqueID: UUID)
+        case dnsServerInfo
+
+        static var contentBlockers: [Item] {
+            [.blockAdvertising, .blockTracking, .blockMalware, .blockAdultContent, .blockGambling, .blockSocialMedia]
+        }
+
+        var accessibilityIdentifier: String {
+            switch self {
+            case .blockAdvertising:
+                return "blockAdvertising"
+            case .blockTracking:
+                return "blockTracking"
+            case .blockMalware:
+                return "blockMalware"
+            case .blockGambling:
+                return "blockGambling"
+            case .blockAdultContent:
+                return "blockAdultContent"
+            case .blockSocialMedia:
+                return "blockSocialMedia"
+            case .useCustomDNS:
+                return "useCustomDNS"
+            case .addDNSServer:
+                return "addDNSServer"
+            case let .dnsServer(uuid):
+                return "dnsServer(\(uuid.uuidString))"
+            case .dnsServerInfo:
+                return "dnsServerInfo"
+            }
+        }
+
+        static func isDNSServerItem(_ item: Item) -> Bool {
+            if case .dnsServer = item {
+                return true
+            } else {
+                return false
+            }
+        }
+
+        var reuseIdentifier: CellReuseIdentifiers {
+            switch self {
+            case .addDNSServer:
+                return .addDNSServer
+            case .dnsServer:
+                return .dnsServer
+            case .dnsServerInfo:
+                return .dnsServerInfo
+            default:
+                return .settingSwitch
+            }
+        }
+    }
+
+    private var isEditing = false
+
+    private(set) var viewModel = PreferencesViewModel() { didSet {
+        cellFactory.viewModel = viewModel
+    }}
+    private(set) var viewModelBeforeEditing = PreferencesViewModel()
+    private let cellFactory: CustomDNSCellFactory
+    private weak var tableView: UITableView?
+
+    weak var delegate: PreferencesDataSourceDelegate?
+
+    init(tableView: UITableView) {
+        self.tableView = tableView
+
+        let cellFactory = CustomDNSCellFactory(
+            tableView: tableView,
+            viewModel: viewModel
+        )
+        self.cellFactory = cellFactory
+
+        super.init(tableView: tableView) { _, indexPath, item in
+            cellFactory.makeCell(for: item, indexPath: indexPath)
+        }
+
+        tableView.delegate = self
+        cellFactory.delegate = self
+
+        registerClasses()
+    }
+
+    func setAvailablePortRanges(_ ranges: [[UInt16]]) {
+        viewModel.availableWireGuardPortRanges = ranges
+    }
+
+    func setEditing(_ editing: Bool, animated: Bool) {
+        guard isEditing != editing else { return }
+
+        isEditing = editing
+        cellFactory.isEditing = isEditing
+
+        if editing {
+            viewModelBeforeEditing = viewModel
+        } else {
+            viewModel.sanitizeCustomDNSEntries()
+        }
+
+        updateSnapshot(animated: true)
+
+        viewModel.customDNSDomains.forEach { entry in
+            reload(item: .dnsServer(entry.identifier))
+        }
+
+        if !editing, viewModelBeforeEditing != viewModel {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    func update(from tunnelSettings: LatestTunnelSettings) {
+        let newViewModel = PreferencesViewModel(from: tunnelSettings)
+        let mergedViewModel = viewModel.merged(newViewModel)
+
+        if viewModel != mergedViewModel {
+            viewModel = mergedViewModel
+        }
+
+        updateSnapshot()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Disable swipe to delete when not editing the table view
+        guard isEditing else { return false }
+
+        let item = itemIdentifier(for: indexPath)
+
+        switch item {
+        case .dnsServer, .addDNSServer:
+            return true
+        default:
+            return false
+        }
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        commit editingStyle: UITableViewCell.EditingStyle,
+        forRowAt indexPath: IndexPath
+    ) {
+        let item = itemIdentifier(for: indexPath)
+
+        if case .addDNSServer = item, editingStyle == .insert {
+            addDNSServerEntry()
+        }
+
+        if case let .dnsServer(entryIdentifier) = item, editingStyle == .delete {
+            deleteDNSServerEntry(entryIdentifier: entryIdentifier)
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        let item = itemIdentifier(for: indexPath)
+
+        switch item {
+        case .dnsServer:
+            return true
+        default:
+            return false
+        }
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        moveRowAt sourceIndexPath: IndexPath,
+        to destinationIndexPath: IndexPath
+    ) {
+        let sourceItem = itemIdentifier(for: sourceIndexPath)!
+        let destinationItem = itemIdentifier(for: destinationIndexPath)!
+
+        guard case let .dnsServer(sourceIdentifier) = sourceItem,
+              case let .dnsServer(targetIdentifier) = destinationItem,
+              let sourceIndex = viewModel.indexOfDNSEntry(entryIdentifier: sourceIdentifier),
+              let destinationIndex = viewModel.indexOfDNSEntry(entryIdentifier: targetIdentifier)
+        else { return }
+
+        let removedEntry = viewModel.customDNSDomains.remove(at: sourceIndex)
+        viewModel.customDNSDomains.insert(removedEntry, at: destinationIndex)
+
+        updateSnapshot()
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        false
+    }
+
+    // Disallow selection for tapping on a selected setting
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let sectionIdentifier = snapshot().sectionIdentifiers[section]
+
+        guard let view = tableView
+            .dequeueReusableHeaderFooterView(
+                withIdentifier: HeaderFooterReuseIdentifiers.contentBlockerHeader
+                    .rawValue
+            ) as? SettingsHeaderView else { return nil }
+
+        switch sectionIdentifier {
+        case .contentBlockers:
+            configureContentBlockersHeader(view)
+            return view
+        default:
+            return nil
+        }
+    }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        nil
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        let sectionIdentifier = snapshot().sectionIdentifiers[section]
+
+        switch sectionIdentifier {
+        case .customDNS:
+            return 0
+
+        default:
+            return UITableView.automaticDimension
+        }
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        0
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        editingStyleForRowAt indexPath: IndexPath
+    ) -> UITableViewCell.EditingStyle {
+        let item = itemIdentifier(for: indexPath)
+
+        switch item {
+        case .dnsServer:
+            return .delete
+        case .addDNSServer:
+            return .insert
+        default:
+            return .none
+        }
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
+        toProposedIndexPath proposedDestinationIndexPath: IndexPath
+    ) -> IndexPath {
+        let sectionIdentifier = snapshot().sectionIdentifiers[sourceIndexPath.section]
+        guard case .customDNS = sectionIdentifier else { return sourceIndexPath }
+
+        let items = snapshot().itemIdentifiers(inSection: sectionIdentifier)
+
+        let indexPathForFirstRow = items.first(where: Item.isDNSServerItem).flatMap { item in
+            indexPath(for: item)
+        }
+
+        let indexPathForLastRow = items.last(where: Item.isDNSServerItem).flatMap { item in
+            indexPath(for: item)
+        }
+
+        guard let indexPathForFirstRow,
+              let indexPathForLastRow else { return sourceIndexPath }
+
+        if proposedDestinationIndexPath.section == sourceIndexPath.section {
+            return min(max(proposedDestinationIndexPath, indexPathForFirstRow), indexPathForLastRow)
+        } else {
+            if proposedDestinationIndexPath.section > sourceIndexPath.section {
+                return indexPathForLastRow
+            } else {
+                return indexPathForFirstRow
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func registerClasses() {
+        CellReuseIdentifiers.allCases.forEach { enumCase in
+            tableView?.register(
+                enumCase.reusableViewClass,
+                forCellReuseIdentifier: enumCase.rawValue
+            )
+        }
+
+        HeaderFooterReuseIdentifiers.allCases.forEach { enumCase in
+            tableView?.register(
+                enumCase.reusableViewClass,
+                forHeaderFooterViewReuseIdentifier: enumCase.rawValue
+            )
+        }
+    }
+
+    private func updateSnapshot(animated: Bool = false, completion: (() -> Void)? = nil) {
+        var newSnapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+        let oldSnapshot = snapshot()
+
+        newSnapshot.appendSections(Section.allCases)
+
+        // Append sections
+
+        if oldSnapshot.sectionIdentifiers.contains(.contentBlockers) {
+            newSnapshot.appendItems(
+                oldSnapshot.itemIdentifiers(inSection: .contentBlockers),
+                toSection: .contentBlockers
+            )
+        }
+
+        // Append DNS settings
+
+        newSnapshot.appendItems([.useCustomDNS], toSection: .customDNS)
+
+        let dnsServerItems = viewModel.customDNSDomains.map { entry in
+            Item.dnsServer(entry.identifier)
+        }
+        newSnapshot.appendItems(dnsServerItems, toSection: .customDNS)
+
+        if isEditing, viewModel.customDNSDomains.count < DNSSettings.maxAllowedCustomDNSDomains {
+            newSnapshot.appendItems([.addDNSServer], toSection: .customDNS)
+        }
+
+        // Append/update DNS server info.
+
+        if viewModel.customDNSPrecondition == .satisfied {
+            newSnapshot.deleteItems([.dnsServerInfo])
+        } else {
+            if newSnapshot.itemIdentifiers(inSection: .customDNS).contains(.dnsServerInfo) {
+                newSnapshot.reloadItems([.dnsServerInfo])
+            } else {
+                newSnapshot.appendItems([.dnsServerInfo], toSection: .customDNS)
+            }
+        }
+
+        applySnapshot(newSnapshot, animated: animated, completion: completion)
+    }
+
+    private func applySnapshot(
+        _ snapshot: NSDiffableDataSourceSnapshot<Section, Item>,
+        animated: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        apply(snapshot, animatingDifferences: animated) {
+            completion?()
+        }
+    }
+
+    private func reload(item: Item) {
+        if let indexPath = indexPath(for: item),
+           let cell = tableView?.cellForRow(at: indexPath) {
+            cellFactory.configureCell(cell, item: item, indexPath: indexPath)
+        }
+    }
+
+    private func setBlockAdvertising(_ isEnabled: Bool) {
+        let oldViewModel = viewModel
+
+        viewModel.setBlockAdvertising(isEnabled)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        if !isEditing {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    private func setBlockTracking(_ isEnabled: Bool) {
+        let oldViewModel = viewModel
+
+        viewModel.setBlockTracking(isEnabled)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        if !isEditing {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    private func setBlockMalware(_ isEnabled: Bool) {
+        let oldViewModel = viewModel
+
+        viewModel.setBlockMalware(isEnabled)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        if !isEditing {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    private func setBlockAdultContent(_ isEnabled: Bool) {
+        let oldViewModel = viewModel
+
+        viewModel.setBlockAdultContent(isEnabled)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        if !isEditing {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    private func setBlockGambling(_ isEnabled: Bool) {
+        let oldViewModel = viewModel
+
+        viewModel.setBlockGambling(isEnabled)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        if !isEditing {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    private func setBlockSocialMedia(_ isEnabled: Bool) {
+        let oldViewModel = viewModel
+
+        viewModel.setBlockSocialMedia(isEnabled)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        if !isEditing {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    private func setEnableCustomDNS(_ isEnabled: Bool) {
+        let oldViewModel = viewModel
+
+        viewModel.setEnableCustomDNS(isEnabled)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        if !isEditing {
+            delegate?.didChangeViewModel(viewModel)
+        }
+    }
+
+    private func handleDNSEntryChange(with identifier: UUID, inputString: String) -> Bool {
+        let oldViewModel = viewModel
+
+        viewModel.updateDNSEntry(entryIdentifier: identifier, newAddress: inputString)
+
+        if oldViewModel.customDNSPrecondition != viewModel.customDNSPrecondition {
+            reloadDnsServerInfo()
+        }
+
+        return viewModel.isDNSDomainUserInputValid(inputString)
+    }
+
+    private func addDNSServerEntry() {
+        let newDNSEntry = DNSServerEntry(address: "")
+        viewModel.customDNSDomains.append(newDNSEntry)
+
+        updateSnapshot(animated: true) { [weak self] in
+            // Focus on the new entry text field.
+            let lastDNSEntry = self?.snapshot().itemIdentifiers(inSection: .customDNS)
+                .last { item in
+                    if case let .dnsServer(entryIdentifier) = item {
+                        return entryIdentifier == newDNSEntry.identifier
+                    } else {
+                        return false
+                    }
+                }
+
+            if let lastDNSEntry,
+               let indexPath = self?.indexPath(for: lastDNSEntry) {
+                let cell = self?.tableView?.cellForRow(at: indexPath) as? SettingsDNSTextCell
+
+                self?.tableView?.scrollToRow(at: indexPath, at: .bottom, animated: true)
+                cell?.textField.becomeFirstResponder()
+            }
+        }
+    }
+
+    private func deleteDNSServerEntry(entryIdentifier: UUID) {
+        let entryIndex = viewModel.customDNSDomains.firstIndex { entry in
+            entry.identifier == entryIdentifier
+        }
+
+        guard let entryIndex else { return }
+
+        viewModel.customDNSDomains.remove(at: entryIndex)
+
+        reload(item: .useCustomDNS)
+        updateSnapshot(animated: true)
+    }
+
+    private func reloadDnsServerInfo() {
+        var snapshot = snapshot()
+
+        reload(item: .useCustomDNS)
+
+        if viewModel.customDNSPrecondition == .satisfied {
+            snapshot.deleteItems([.dnsServerInfo])
+        } else {
+            if snapshot.itemIdentifiers(inSection: .customDNS).contains(.dnsServerInfo) {
+                snapshot.reloadItems([.dnsServerInfo])
+            } else {
+                snapshot.appendItems([.dnsServerInfo], toSection: .customDNS)
+            }
+        }
+
+        apply(snapshot, animatingDifferences: true)
+    }
+
+    private func configureContentBlockersHeader(_ header: SettingsHeaderView) {
+        let title = NSLocalizedString(
+            "CONTENT_BLOCKERS_HEADER_LABEL",
+            tableName: "Preferences",
+            value: "DNS content blockers",
+            comment: ""
+        )
+
+        header.titleLabel.text = title
+        header.accessibilityCustomActionName = title
+
+        header.infoButtonHandler = { [weak self] in
+            self?.delegate?.showInfo(for: .contentBlockers)
+        }
+
+        header.didCollapseHandler = { [weak self] headerView in
+            guard let self else { return }
+
+            var snapshot = self.snapshot()
+
+            if headerView.isExpanded {
+                snapshot.deleteItems(Item.contentBlockers)
+            } else {
+                snapshot.appendItems(Item.contentBlockers, toSection: .contentBlockers)
+            }
+
+            headerView.isExpanded.toggle()
+            self.apply(snapshot, animatingDifferences: true)
+        }
+    }
+}
+
+extension CustomDNSDataSource: CustomDNSCellEventHandler {
+    func didChangeState(for preference: Item, isOn: Bool) {
+        switch preference {
+        case .blockAdvertising:
+            setBlockAdvertising(isOn)
+
+        case .blockTracking:
+            setBlockTracking(isOn)
+
+        case .blockMalware:
+            setBlockMalware(isOn)
+
+        case .blockAdultContent:
+            setBlockAdultContent(isOn)
+
+        case .blockGambling:
+            setBlockGambling(isOn)
+
+        case .blockSocialMedia:
+            setBlockSocialMedia(isOn)
+
+        case .useCustomDNS:
+            setEnableCustomDNS(isOn)
+
+        default:
+            break
+        }
+    }
+
+    func addDNSEntry() {
+        addDNSServerEntry()
+    }
+
+    func didChangeDNSEntry(
+        with identifier: UUID,
+        inputString: String
+    ) -> Bool {
+        handleDNSEntryChange(with: identifier, inputString: inputString)
+    }
+
+    func showInfo(for button: PreferencesInfoButtonItem) {
+        delegate?.showInfo(for: button)
+    }
+}
+
+// swiftlint:disable:this file_length

--- a/ios/MullvadVPN/View controllers/Preferences/CustomDNSViewController.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/CustomDNSViewController.swift
@@ -1,0 +1,142 @@
+//
+//  CustomDNSViewController.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2023-11-09.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadSettings
+import UIKit
+
+class CustomDNSViewController: UITableViewController, PreferencesDataSourceDelegate {
+    private let interactor: PreferencesInteractor
+    private var dataSource: CustomDNSDataSource?
+    private let alertPresenter: AlertPresenter
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        .lightContent
+    }
+
+    init(interactor: PreferencesInteractor, alertPresenter: AlertPresenter) {
+        self.interactor = interactor
+        self.alertPresenter = alertPresenter
+
+        super.init(style: .grouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.backgroundColor = .secondaryColor
+        tableView.separatorColor = .secondaryColor
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 60
+        tableView.estimatedSectionHeaderHeight = tableView.estimatedRowHeight
+
+        dataSource = CustomDNSDataSource(tableView: tableView)
+        dataSource?.delegate = self
+
+        navigationItem.title = NSLocalizedString(
+            "NAVIGATION_TITLE",
+            tableName: "Preferences",
+            value: "DNS settings",
+            comment: ""
+        )
+        navigationItem.rightBarButtonItem = editButtonItem
+
+        interactor.tunnelSettingsDidChange = { [weak self] newSettings in
+            self?.dataSource?.update(from: newSettings)
+        }
+        dataSource?.update(from: interactor.tunnelSettings)
+
+        tableView.tableHeaderView = UIView(frame: CGRect(
+            origin: .zero,
+            size: CGSize(width: 0, height: UIMetrics.TableView.sectionSpacing)
+        ))
+    }
+
+    override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: animated)
+
+        dataSource?.setEditing(editing, animated: animated)
+
+        navigationItem.setHidesBackButton(editing, animated: animated)
+
+        // Disable swipe to dismiss when editing
+        isModalInPresentation = editing
+    }
+
+    private func showInfo(with message: String) {
+        let presentation = AlertPresentation(
+            id: "preferences-content-blockers-alert",
+            icon: .info,
+            message: message,
+            buttons: [
+                AlertAction(
+                    title: NSLocalizedString(
+                        "PREFERENCES_DNS_SETTINGS_OK_ACTION",
+                        tableName: "ContentBlockers",
+                        value: "Got it!",
+                        comment: ""
+                    ),
+                    style: .default
+                ),
+            ]
+        )
+
+        alertPresenter.showAlert(presentation: presentation, animated: true)
+    }
+
+    // MARK: - PreferencesDataSourceDelegate
+
+    func didChangeViewModel(_ viewModel: PreferencesViewModel) {
+        interactor.setDNSSettings(viewModel.asDNSSettings())
+    }
+
+    func showInfo(for item: PreferencesInfoButtonItem) {
+        var message = ""
+
+        switch item {
+        case .contentBlockers:
+            message = NSLocalizedString(
+                "PREFERENCES_CONTENT_BLOCKERS_GENERAL",
+                tableName: "ContentBlockers",
+                value: """
+                When this feature is enabled it stops the device from contacting certain \
+                domains or websites known for distributing ads, malware, trackers and more. \
+                This might cause issues on certain websites, services, and programs.
+                """,
+                comment: ""
+            )
+
+        case .blockMalware:
+            message = NSLocalizedString(
+                "PREFERENCES_CONTENT_BLOCKERS_MALWARE",
+                tableName: "ContentBlockers",
+                value: """
+                Warning: The malware blocker is not an anti-virus and should not \
+                be treated as such, this is just an extra layer of protection.
+                """,
+                comment: ""
+            )
+
+        default:
+            assertionFailure("No matching InfoButtonItem")
+        }
+
+        showInfo(with: message)
+    }
+
+    func showDNSSettings() {
+        // No op.
+    }
+
+    func didSelectWireGuardPort(_ port: UInt16?) {
+        // No op.
+    }
+}

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
@@ -108,6 +108,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
                 }
             }
 
+        #if DEBUG
         case .wireGuardObfuscationAutomatic:
             guard let cell = cell as? SelectableSettingsCell else { return }
 
@@ -156,6 +157,7 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             )
             cell.accessibilityHint = nil
             cell.applySubCellStyling()
+        #endif
         }
     }
 }

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
@@ -19,8 +19,10 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case dnsSettings
         case wireGuardPort
         case wireGuardCustomPort
+        #if DEBUG
         case wireGuardObfuscation
         case wireGuardObfuscationPort
+        #endif
         var reusableViewClass: AnyClass {
             switch self {
             case .dnsSettings:
@@ -29,10 +31,12 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                 return SelectableSettingsCell.self
             case .wireGuardCustomPort:
                 return SettingsInputCell.self
+            #if DEBUG
             case .wireGuardObfuscation:
                 return SelectableSettingsCell.self
             case .wireGuardObfuscationPort:
                 return SelectableSettingsCell.self
+            #endif
             }
         }
     }
@@ -48,18 +52,22 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
     enum Section: String, Hashable, CaseIterable {
         case dnsSettings
         case wireGuardPorts
+        #if DEBUG
         case wireGuardObfuscation
         case wireGuardObfuscationPort
+        #endif
     }
 
     enum Item: Hashable {
         case dnsSettings
         case wireGuardPort(_ port: UInt16?)
         case wireGuardCustomPort
+        #if DEBUG
         case wireGuardObfuscationAutomatic
         case wireGuardObfuscationOn
         case wireGuardObfuscationOff
         case wireGuardObfuscationPort(_ port: UInt16)
+        #endif
 
         static var wireGuardPorts: [Item] {
             let defaultPorts = PreferencesViewModel.defaultWireGuardPorts.map {
@@ -68,6 +76,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             return [.wireGuardPort(nil)] + defaultPorts + [.wireGuardCustomPort]
         }
 
+        #if DEBUG
         static var wireGuardObfuscation: [Item] {
             [.wireGuardObfuscationAutomatic, .wireGuardObfuscationOn, wireGuardObfuscationOff]
         }
@@ -75,7 +84,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         static var wireGuardObfuscationPort: [Item] {
             [.wireGuardObfuscationPort(0), wireGuardObfuscationPort(80), wireGuardObfuscationPort(5001)]
         }
-
+        #endif
         var accessibilityIdentifier: String {
             switch self {
             case .dnsSettings:
@@ -88,6 +97,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                 }
             case .wireGuardCustomPort:
                 return "wireGuardCustomPort"
+            #if DEBUG
             case .wireGuardObfuscationAutomatic:
                 return "Automatic"
             case .wireGuardObfuscationOn:
@@ -99,6 +109,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                     return "Automatic"
                 }
                 return "\(port)"
+            #endif
             }
         }
 
@@ -110,10 +121,12 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                 return .wireGuardPort
             case .wireGuardCustomPort:
                 return .wireGuardCustomPort
+            #if DEBUG
             case .wireGuardObfuscationAutomatic, .wireGuardObfuscationOn, .wireGuardObfuscationOff:
                 return .wireGuardObfuscation
             case .wireGuardObfuscationPort:
                 return .wireGuardObfuscationPort
+            #endif
             }
         }
     }
@@ -131,6 +144,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             ? .wireGuardPort(viewModel.wireGuardPort)
             : .wireGuardCustomPort
 
+        #if DEBUG
         let obfuscationStateItem: Item = switch viewModel.obfuscationState {
         case .automatic: .wireGuardObfuscationAutomatic
         case .off: .wireGuardObfuscationOff
@@ -144,6 +158,11 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             indexPath(for: obfuscationStateItem),
             indexPath(for: obfuscationPortItem),
         ].compactMap { $0 }
+        #else
+        return [
+            indexPath(for: wireGuardPortItem),
+        ].compactMap { $0 }
+        #endif
     }
 
     init(tableView: UITableView) {
@@ -235,6 +254,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case .wireGuardCustomPort:
             getCustomPortCell()?.textField.becomeFirstResponder()
 
+        #if DEBUG
         case .wireGuardObfuscationAutomatic:
             selectObfuscationState(.automatic)
             delegate?.didChangeViewModel(viewModel)
@@ -247,7 +267,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case let .wireGuardObfuscationPort(port):
             selectObfuscationPort(port)
             delegate?.didChangeViewModel(viewModel)
-
+        #endif
         default:
             break
         }
@@ -279,13 +299,14 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             configureWireguardPortsHeader(view)
             return view
 
+        #if DEBUG
         case .wireGuardObfuscation:
             configureObfuscationHeader(view)
             return view
         case .wireGuardObfuscationPort:
             configureObfuscationPortHeader(view)
             return view
-
+        #endif
         default:
             return nil
         }
@@ -412,6 +433,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         }
     }
 
+    #if DEBUG
     private func configureObfuscationHeader(_ header: SettingsHeaderView) {
         let title = NSLocalizedString(
             "OBFUSCATION_HEADER_LABEL",
@@ -467,6 +489,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             self.map { $0.delegate?.showInfo(for: .wireGuardObfuscationPort) }
         }
     }
+    #endif
 
     private func selectRow(at indexPath: IndexPath?, animated: Bool = false) {
         tableView?.selectRow(at: indexPath, animated: animated, scrollPosition: .none)

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSourceDelegate.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSourceDelegate.swift
@@ -9,18 +9,8 @@
 import Foundation
 
 protocol PreferencesDataSourceDelegate: AnyObject {
-    func preferencesDataSource(
-        _ dataSource: PreferencesDataSource,
-        didChangeViewModel viewModel: PreferencesViewModel
-    )
-
-    func preferencesDataSource(
-        _ dataSource: PreferencesDataSource,
-        showInfo for: PreferencesDataSource.InfoButtonItem?
-    )
-
-    func preferencesDataSource(
-        _ dataSource: PreferencesDataSource,
-        didSelectPort port: UInt16?
-    )
+    func didChangeViewModel(_ viewModel: PreferencesViewModel)
+    func showInfo(for: PreferencesInfoButtonItem)
+    func showDNSSettings()
+    func didSelectWireGuardPort(_ port: UInt16?)
 }

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesInfoButtonItem.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesInfoButtonItem.swift
@@ -1,0 +1,15 @@
+//
+//  PreferencesInfoButtonItem.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2023-11-10.
+//  Copyright © 2023 Mullvad VPN AB. All rights reserved.
+//
+
+enum PreferencesInfoButtonItem {
+    case contentBlockers
+    case blockMalware
+    case wireGuardPorts
+    case wireGuardObfuscation
+    case wireGuardObfuscationPort
+}

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesInteractor.swift
@@ -40,6 +40,10 @@ final class PreferencesInteractor {
         tunnelManager.setDNSSettings(newDNSSettings, completionHandler: completion)
     }
 
+    func setObfuscationSettings(_ newSettings: WireGuardObfuscationSettings) {
+        tunnelManager.setObfuscationSettings(newSettings)
+    }
+
     func setPort(_ port: UInt16?, completion: (() -> Void)? = nil) {
         var relayConstraints = tunnelManager.settings.relayConstraints
 

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
@@ -95,6 +95,9 @@ struct PreferencesViewModel: Equatable {
     var customDNSDomains: [DNSServerEntry]
     var availableWireGuardPortRanges: [[UInt16]] = []
 
+    private(set) var obfuscationState: WireGuardObfuscationState
+    private(set) var obfuscationPort: WireGuardObfuscationPort
+
     static let defaultWireGuardPorts: [UInt16] = [51820, 53]
 
     mutating func setBlockAdvertising(_ newValue: Bool) {
@@ -135,6 +138,14 @@ struct PreferencesViewModel: Equatable {
 
     mutating func setWireGuardPort(_ newValue: UInt16?) {
         wireGuardPort = newValue
+    }
+
+    mutating func setWireGuardObfuscationState(_ newState: WireGuardObfuscationState) {
+        obfuscationState = newState
+    }
+
+    mutating func setWireGuardObfuscationPort(_ newPort: WireGuardObfuscationPort) {
+        obfuscationPort = newPort
     }
 
     /// Precondition for enabling Custom DNS.
@@ -179,6 +190,9 @@ struct PreferencesViewModel: Equatable {
             DNSServerEntry(identifier: UUID(), address: "\(ipAddress)")
         }
         wireGuardPort = tunnelSettings.relayConstraints.port.value
+
+        obfuscationState = tunnelSettings.wireGuardObfuscation.state
+        obfuscationPort = tunnelSettings.wireGuardObfuscation.port
     }
 
     /// Produce merged view model keeping entry `identifier` for matching DNS entries.


### PR DESCRIPTION
This PR is mostly accomplishing 2 goals:
- Wiring up the WireGuard obfuscation settings to be saved in the tunnel settings
- Separating the WireGuard settings and the DNS settings into 2 different screens

The PR looks big, but most of the code is just being moved around.
The aim was to declutter `PreferencesDataSource`, parts of it were moved to `CustomDNSDataSource`

### Open Questions
- We are thinking of adding a "WireGuard settings" title below the cell that goes to the DNS settings for better visual separation of sections

Here's what it looked like before the changes
![Screenshot 2023-11-14 at 11 25 04](https://github.com/mullvad/mullvadvpn-app/assets/129761703/f777e75d-1705-4476-9657-c0e1e19be3c9)

Here's what it looks like after the changes

![Screenshot 2023-11-14 at 11 25 36](https://github.com/mullvad/mullvadvpn-app/assets/129761703/ae2f1749-44b6-4315-aea0-a973a4205e9c)

![Screenshot 2023-11-14 at 11 25 49](https://github.com/mullvad/mullvadvpn-app/assets/129761703/8ca0211b-b4f3-43fa-a70e-b9a9dcb85b02)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5433)
<!-- Reviewable:end -->
