### PR TITLE
Change - to ~ before beta in rpm version to make dnf treat it as upgrade

### DIFF
--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -179,7 +179,7 @@ const config = {
     fpm: [
       '--no-depends',
       '--version',
-      getDebVersion(),
+      getLinuxVersion(),
       '--before-install',
       distAssets('linux/before-install.sh'),
       '--before-remove',
@@ -202,6 +202,8 @@ const config = {
 
   rpm: {
     fpm: [
+      '--version',
+      getLinuxVersion(),
       // Prevents RPM from packaging build-id metadata, some of which is the
       // same across all electron-builder applications, which causes package
       // conflicts
@@ -427,9 +429,12 @@ function getMacArch() {
   }
 }
 
-// Replace '-' between components with a tilde to make the version comparison understand that
-// YYYY.NN-dev-HHHHHH > YYYY.NN > YYYY.NN-betaN-dev-HHHHHH > YYYY.NN-betaN.
-function getDebVersion() {
+// Replace '-' with `~` (tilde) before the beta component, to make the version comparison
+// understand that stable `YYYY.NN` is newer than beta `YYYY.NN-betaN`. Both Debian and
+// Fedora do this where a tilde denotes a version component that must be sorted as earlier
+// than a non-tilde version component
+// https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning
+function getLinuxVersion() {
   const [version, ...prereleaseParts] = productVersion([]).split('-');
   const [major, minor] = version.split('.');
   const prerelease = prereleaseParts.join('-');


### PR DESCRIPTION
Same fix as #2266 but for RPM instead of DEB.

Basically the Linux package managers compares versions in such a way that `YYYY.NN-betaX` is regarded as a later version than `YYYY.NN`. But in our case it's the other way around. A beta is a pre-release to the corresponding stable. And for both deb and rpm this is denoted with a tilde:

> The tilde symbol ('\~') is used before a version component which must sort earlier than any non-tilde component. It is used for any pre-release versions which wouldn't otherwise sort appropriately.
For example, with upstream releases 0.4.0, 0.4.1, 0.5.0-rc1, 0.5.0-rc2, 0.5.0, the two "release candidates" should use 0.5.0\~rc1 and 0.5.0\~rc2 in the Version: field.

https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5434)
<!-- Reviewable:end -->
