### PR TITLE
Configure upload dir and container cache volumes in buildserver-config

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -17,7 +17,6 @@ shopt -s nullglob
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$SCRIPT_DIR/mullvadvpn-app"
 LAST_BUILT_DIR="$SCRIPT_DIR/last-built"
-UPLOAD_DIR="$SCRIPT_DIR/upload"
 
 BRANCHES_TO_BUILD=("origin/main")
 

--- a/ci/buildserver-config.sh
+++ b/ci/buildserver-config.sh
@@ -16,3 +16,13 @@ export SUPPORTED_DEB_CODENAMES
 export DEV_LINUX_REPOSITORY_SERVERS=("se-got-cdn-001.devmole.eu" "se-got-cdn-002.devmole.eu")
 export STAGING_LINUX_REPOSITORY_SERVERS=("se-got-cdn-001.stagemole.eu" "se-got-cdn-002.stagemole.eu")
 export PRODUCTION_LINUX_REPOSITORY_SERVERS=("se-got-cdn-111.mullvad.net" "se-mma-cdn-101.mullvad.net")
+
+# What container volumes cargo should put caches in.
+# Specify differently if running multiple builds in parallel on one machine,
+# so they don't use the same cache.
+export CARGO_TARGET_VOLUME_NAME="cargo-target"
+export CARGO_REGISTRY_VOLUME_NAME="cargo-registry"
+
+# Where buildserver-build.sh should move artifacts (on Linux) and where
+# buildserver-upload.sh should pick artifacts to upload
+export UPLOAD_DIR="PLEASE CONFIGURE ME"

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -6,7 +6,8 @@ shopt -s nullglob
 CODE_SIGNING_KEY_FINGERPRINT="A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-UPLOAD_DIR="$SCRIPT_DIR/upload"
+
+source "$SCRIPT_DIR/buildserver-config.sh"
 
 cd "$UPLOAD_DIR"
 


### PR DESCRIPTION
Move a few variables that were previously hardcoded in `buildserver-build.sh` on some build machines to the config file. This allows easier upgrading the build script without manually copying over bespoke config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5436)
<!-- Reviewable:end -->
