### PR TITLE
Avoid showing network banners when disconnecting from an error state

### DIFF
--- a/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
@@ -95,12 +95,15 @@ class MapConnectionStatusOperation: AsyncOperation {
             break
         default:
             interactor.updateTunnelStatus { tunnelStatus in
-                let isNetworkReachable = tunnelStatus.observedState.connectionState?.isNetworkReachable ?? false
-
-                tunnelStatus = TunnelStatus()
-                tunnelStatus.state = isNetworkReachable
-                    ? .disconnecting(.nothing)
-                    : .waitingForConnectivity(.noNetwork)
+                // Avoid displaying waiting for connectivity banners if the tunnel in a blocked state when disconnecting
+                if tunnelStatus.observedState.blockedState != nil {
+                    tunnelStatus.state = .disconnecting(.nothing)
+                } else {
+                    let isNetworkReachable = tunnelStatus.observedState.connectionState?.isNetworkReachable ?? false
+                    tunnelStatus.state = isNetworkReachable
+                        ? .disconnecting(.nothing)
+                        : .waitingForConnectivity(.noNetwork)
+                }
             }
         }
     }


### PR DESCRIPTION
In this PR, we check that the tunnel is not already in an error state when pressing the disconnect button.
If it is, we keep disconnecting instead of telling the user that the device has network issues.

https://github.com/mullvad/mullvadvpn-app/assets/129761703/84d0e68e-2430-46c4-a1c0-05f32e025a2a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5437)
<!-- Reviewable:end -->
