### PR TITLE
Fix missing account history on new start

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/AccountRepository.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/AccountRepository.kt
@@ -52,7 +52,7 @@ class AccountRepository(
             .events<Event.AccountHistoryEvent>()
             .map { it.history }
             .onStart { fetchAccountHistory() }
-            .stateIn(CoroutineScope(dispatcher), SharingStarted.Eagerly, AccountHistory.Missing)
+            .stateIn(CoroutineScope(dispatcher), SharingStarted.Lazily, AccountHistory.Missing)
 
     private val loginEvents: SharedFlow<LoginResult> =
         messageHandler


### PR DESCRIPTION
Fixes a regression from previous bugfix where we set flowables to be eagerly started, however, this specific flow uses a `onStart` that would execute before the Daemon connection is setup and ready thus not getting a reply. I've now changed it to be lazily loaded.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5440)
<!-- Reviewable:end -->
