### PR TITLE
Fix tests that fail on macOS 14

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -70,11 +70,10 @@ jobs:
           path: ~/.cache/mullvad-test/packages
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
+          git fetch --tags --force
           ./test/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
         if: '!cancelled()'
@@ -140,11 +139,10 @@ jobs:
           path: ~/.cache/mullvad-test/packages
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
+          git fetch --tags --force
           ./test/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
         if: '!cancelled()'
@@ -210,11 +208,10 @@ jobs:
           path: ~/Library/Caches/mullvad-test/packages
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
+          git fetch --tags --force
           ./test/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
         if: '!cancelled()'

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -152,36 +152,30 @@ jobs:
 
   build-macos:
     if: ${{ !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' }}
-    runs-on: macos-latest
+    runs-on: [self-hosted, desktop-test, macOS] # app-test-macos-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Checkout submodules
         run: git submodule update --init --depth=1
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.5
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           node-version: 18
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
-          target: aarch64-apple-darwin
-          default: true
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18.5
+          cache: 'npm'
+          cache-dependency-path: gui/package-lock.json
       - name: Build app
-        run: ./build.sh --universal
+        run: ./build.sh
       - name: Build test executable
-        run: ./gui/scripts/build-test-executable.sh aarch64-apple-darwin
-        # FIXME: This fails for some reason, but the artifact is built
-        continue-on-error: true
+        run: ./gui/scripts/build-test-executable.sh
       - uses: actions/upload-artifact@v3
         if: '!cancelled()'
         with:

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1899,9 +1899,15 @@ where
             .await
         {
             Ok(settings_changed) => {
-                Self::oneshot_send(tx, Ok(()), "set_allow_lan response");
                 if settings_changed {
-                    self.send_tunnel_command(TunnelCommand::AllowLan(allow_lan));
+                    self.send_tunnel_command(TunnelCommand::AllowLan(
+                        allow_lan,
+                        oneshot_map(tx, |tx, ()| {
+                            Self::oneshot_send(tx, Ok(()), "set_allow_lan response");
+                        }),
+                    ));
+                } else {
+                    Self::oneshot_send(tx, Ok(()), "set_allow_lan response");
                 }
             }
             Err(e) => {
@@ -1946,11 +1952,15 @@ where
             .await
         {
             Ok(settings_changed) => {
-                Self::oneshot_send(tx, Ok(()), "set_block_when_disconnected response");
                 if settings_changed {
                     self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(
                         block_when_disconnected,
+                        oneshot_map(tx, |tx, ()| {
+                            Self::oneshot_send(tx, Ok(()), "set_block_when_disconnected response");
+                        }),
                     ));
+                } else {
+                    Self::oneshot_send(tx, Ok(()), "set_block_when_disconnected response");
                 }
             }
             Err(e) => {
@@ -2148,12 +2158,18 @@ where
             .await
         {
             Ok(settings_changed) => {
-                Self::oneshot_send(tx, Ok(()), "set_dns_options response");
                 if settings_changed {
                     let settings = self.settings.to_settings();
                     let resolvers =
                         dns::addresses_from_options(&settings.tunnel_options.dns_options);
-                    self.send_tunnel_command(TunnelCommand::Dns(resolvers));
+                    self.send_tunnel_command(TunnelCommand::Dns(
+                        resolvers,
+                        oneshot_map(tx, |tx, ()| {
+                            Self::oneshot_send(tx, Ok(()), "set_dns_options response");
+                        }),
+                    ));
+                } else {
+                    Self::oneshot_send(tx, Ok(()), "set_dns_options response");
                 }
             }
             Err(e) => {
@@ -2396,7 +2412,8 @@ where
             && (*self.target_state == TargetState::Secured || self.settings.auto_connect)
         {
             log::debug!("Blocking firewall during shutdown since system is going down");
-            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
+            let (tx, _rx) = oneshot::channel();
+            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true, tx));
         }
 
         self.state.shutdown(&self.tunnel_state);
@@ -2408,7 +2425,8 @@ where
         //       without causing the service to be restarted.
 
         if *self.target_state == TargetState::Secured {
-            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true));
+            let (tx, _rx) = oneshot::channel();
+            self.send_tunnel_command(TunnelCommand::BlockWhenDisconnected(true, tx));
         }
         self.target_state.lock();
     }
@@ -2568,4 +2586,20 @@ fn new_selector_config(settings: &Settings) -> SelectorConfig {
         custom_lists: settings.custom_lists.clone(),
         relay_overrides: settings.relay_overrides.clone(),
     }
+}
+
+/// Consume a oneshot sender of `T1` and return a sender that takes a different type `T2`. `forwarder` should map `T1` back to `T2` and
+/// send the result back to the original receiver.
+fn oneshot_map<T1: Send + 'static, T2: Send + 'static>(
+    tx: oneshot::Sender<T1>,
+    forwarder: impl Fn(oneshot::Sender<T1>, T2) + Send + 'static,
+) -> oneshot::Sender<T2> {
+    let (new_tx, new_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        match new_rx.await {
+            Ok(result) => forwarder(tx, result),
+            Err(oneshot::Canceled) => (),
+        }
+    });
+    new_tx
 }

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -73,6 +73,10 @@ impl MullvadProxyClient {
         super::new_rpc_client().await.map(Self)
     }
 
+    pub fn from_rpc_client(client: crate::ManagementServiceClient) -> Self {
+        Self(client)
+    }
+
     pub async fn connect_tunnel(&mut self) -> Result<bool> {
         Ok(self
             .0

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -40,8 +40,9 @@ impl DisconnectingState {
 
         self.after_disconnect = match after_disconnect {
             AfterDisconnect::Nothing => match command {
-                Some(TunnelCommand::AllowLan(allow_lan)) => {
+                Some(TunnelCommand::AllowLan(allow_lan, complete_tx)) => {
                     let _ = shared_values.set_allow_lan(allow_lan);
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
@@ -49,12 +50,17 @@ impl DisconnectingState {
                     let _ = tx.send(());
                     AfterDisconnect::Nothing
                 }
-                Some(TunnelCommand::Dns(servers)) => {
+                Some(TunnelCommand::Dns(servers, complete_tx)) => {
                     let _ = shared_values.set_dns_servers(servers);
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Nothing
                 }
-                Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                Some(TunnelCommand::BlockWhenDisconnected(
+                    block_when_disconnected,
+                    complete_tx,
+                )) => {
                     shared_values.block_when_disconnected = block_when_disconnected;
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::IsOffline(is_offline)) => {
@@ -76,8 +82,9 @@ impl DisconnectingState {
                 }
             },
             AfterDisconnect::Block(reason) => match command {
-                Some(TunnelCommand::AllowLan(allow_lan)) => {
+                Some(TunnelCommand::AllowLan(allow_lan, complete_tx)) => {
                     let _ = shared_values.set_allow_lan(allow_lan);
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
@@ -85,12 +92,17 @@ impl DisconnectingState {
                     let _ = tx.send(());
                     AfterDisconnect::Block(reason)
                 }
-                Some(TunnelCommand::Dns(servers)) => {
+                Some(TunnelCommand::Dns(servers, complete_tx)) => {
                     let _ = shared_values.set_dns_servers(servers);
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Block(reason)
                 }
-                Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                Some(TunnelCommand::BlockWhenDisconnected(
+                    block_when_disconnected,
+                    complete_tx,
+                )) => {
                     shared_values.block_when_disconnected = block_when_disconnected;
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Block(reason)
                 }
                 Some(TunnelCommand::IsOffline(is_offline)) => {
@@ -117,8 +129,9 @@ impl DisconnectingState {
                 None => AfterDisconnect::Block(reason),
             },
             AfterDisconnect::Reconnect(retry_attempt) => match command {
-                Some(TunnelCommand::AllowLan(allow_lan)) => {
+                Some(TunnelCommand::AllowLan(allow_lan, complete_tx)) => {
                     let _ = shared_values.set_allow_lan(allow_lan);
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::AllowEndpoint(endpoint, tx)) => {
@@ -126,12 +139,17 @@ impl DisconnectingState {
                     let _ = tx.send(());
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
-                Some(TunnelCommand::Dns(servers)) => {
+                Some(TunnelCommand::Dns(servers, complete_tx)) => {
                     let _ = shared_values.set_dns_servers(servers);
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
-                Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected)) => {
+                Some(TunnelCommand::BlockWhenDisconnected(
+                    block_when_disconnected,
+                    complete_tx,
+                )) => {
                     shared_values.block_when_disconnected = block_when_disconnected;
+                    let _ = complete_tx.send(());
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 Some(TunnelCommand::IsOffline(is_offline)) => {

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -189,15 +189,15 @@ pub async fn spawn(
 /// Representation of external commands for the tunnel state machine.
 pub enum TunnelCommand {
     /// Enable or disable LAN access in the firewall.
-    AllowLan(bool),
+    AllowLan(bool, oneshot::Sender<()>),
     /// Endpoint that should never be blocked. `()` is sent to the
     /// channel after attempting to set the firewall policy, regardless
     /// of whether it succeeded.
     AllowEndpoint(AllowedEndpoint, oneshot::Sender<()>),
     /// Set DNS servers to use.
-    Dns(Option<Vec<IpAddr>>),
+    Dns(Option<Vec<IpAddr>>, oneshot::Sender<()>),
     /// Enable or disable the block_when_disconnected feature.
-    BlockWhenDisconnected(bool),
+    BlockWhenDisconnected(bool, oneshot::Sender<()>),
     /// Notify the state machine of the connectivity of the device.
     IsOffline(bool),
     /// Open tunnel connection.

--- a/test/test-manager/src/tests/account.rs
+++ b/test/test-manager/src/tests/account.rs
@@ -107,11 +107,12 @@ pub async fn test_too_many_devices(
     )
     .await
     .unwrap();
-    assert!(ui_result.success());
 
     if let Err(error) = clear_devices(&device_client).await {
         log::error!("Failed to clear devices: {error}");
     }
+
+    assert!(ui_result.success());
 
     Ok(())
 }

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -1,7 +1,7 @@
 use super::{config::TEST_CONFIG, Error, PING_TIMEOUT, WAIT_FOR_TUNNEL_STATE_TIMEOUT};
 use crate::network_monitor::{start_packet_monitor, MonitorOptions};
 use futures::StreamExt;
-use mullvad_management_interface::{types, ManagementServiceClient};
+use mullvad_management_interface::{types, ManagementServiceClient, MullvadProxyClient};
 use mullvad_types::{
     location::Location,
     relay_constraints::{
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 use talpid_types::net::wireguard::{PeerConfig, PrivateKey, TunnelConfig};
-use test_rpc::{package::Package, AmIMullvad, Interface, ServiceClient};
+use test_rpc::{package::Package, AmIMullvad, ServiceClient};
 use tokio::time::timeout;
 
 #[macro_export]
@@ -82,17 +82,30 @@ pub async fn using_mullvad_exit(rpc: &ServiceClient) -> bool {
         .mullvad_exit_ip
 }
 
+/// Get VPN tunnel interface name
+pub async fn get_tunnel_interface(rpc: ManagementServiceClient) -> Option<String> {
+    let mut client = MullvadProxyClient::from_rpc_client(rpc);
+    match client.get_tunnel_state().await.ok()? {
+        TunnelState::Connecting { endpoint, .. } | TunnelState::Connected { endpoint, .. } => {
+            endpoint.tunnel_interface
+        }
+        _ => None,
+    }
+}
+
 /// Sends a number of probes and returns the number of observed packets (UDP, TCP, or ICMP)
 pub async fn send_guest_probes(
     rpc: ServiceClient,
-    interface: Option<Interface>,
+    interface: String,
     destination: SocketAddr,
 ) -> Result<ProbeResult, Error> {
+    const MONITOR_DURATION: Duration = Duration::from_secs(8);
+
     let pktmon = start_packet_monitor(
         move |packet| packet.destination.ip() == destination.ip(),
         MonitorOptions {
             direction: Some(crate::network_monitor::Direction::In),
-            timeout: Some(Duration::from_secs(3)),
+            timeout: Some(MONITOR_DURATION),
             ..Default::default()
         },
     )
@@ -100,7 +113,7 @@ pub async fn send_guest_probes(
 
     let send_handle = tokio::spawn(send_guest_probes_without_monitor(
         rpc,
-        interface,
+        Some(interface),
         destination,
     ));
 
@@ -132,12 +145,12 @@ pub async fn send_guest_probes(
 /// Send one probe per transport protocol to `destination` without running a packet monitor
 pub async fn send_guest_probes_without_monitor(
     rpc: ServiceClient,
-    interface: Option<Interface>,
+    interface: Option<String>,
     destination: SocketAddr,
 ) {
-    let bind_addr = if let Some(interface) = interface {
+    let bind_addr = if let Some(ref interface) = interface {
         SocketAddr::new(
-            rpc.get_interface_ip(interface)
+            rpc.get_interface_ip(interface.clone())
                 .await
                 .expect("failed to obtain interface IP"),
             0,
@@ -147,9 +160,19 @@ pub async fn send_guest_probes_without_monitor(
     };
 
     let tcp_rpc = rpc.clone();
-    let tcp_send = async move { tcp_rpc.send_tcp(interface, bind_addr, destination).await };
+    let tcp_interface = interface.clone();
+    let tcp_send = async move {
+        tcp_rpc
+            .send_tcp(tcp_interface, bind_addr, destination)
+            .await
+    };
     let udp_rpc = rpc.clone();
-    let udp_send = async move { udp_rpc.send_udp(interface, bind_addr, destination).await };
+    let udp_interface = interface.clone();
+    let udp_send = async move {
+        udp_rpc
+            .send_udp(udp_interface, bind_addr, destination)
+            .await
+    };
     let icmp = async move { ping_with_timeout(&rpc, destination.ip(), interface).await };
     let _ = tokio::join!(tcp_send, udp_send, icmp);
 }
@@ -157,7 +180,7 @@ pub async fn send_guest_probes_without_monitor(
 pub async fn ping_with_timeout(
     rpc: &ServiceClient,
     dest: IpAddr,
-    interface: Option<Interface>,
+    interface: Option<String>,
 ) -> Result<(), Error> {
     timeout(PING_TIMEOUT, rpc.send_ping(interface, dest))
         .await

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -472,30 +472,6 @@ pub fn unreachable_wireguard_tunnel() -> talpid_types::net::wireguard::Connectio
     }
 }
 
-/// Randomly select an entry and exit node from the daemon's relay list.
-/// The exit node is distinct from the entry node.
-///
-/// * `mullvad_client` - An interface to the Mullvad daemon.
-/// * `critera` - A function used to determine which relays to include in random selection.
-pub async fn random_entry_and_exit<Filter>(
-    mullvad_client: &mut ManagementServiceClient,
-    criteria: Filter,
-) -> Result<(Relay, Relay), Error>
-where
-    Filter: Fn(&Relay) -> bool,
-{
-    use itertools::Itertools;
-    // Pluck the first 2 relays and return them as a tuple.
-    // This will fail if there are less than 2 relays in the relay list.
-    filter_relays(mullvad_client, criteria)
-        .await?
-        .into_iter()
-        .next_tuple()
-        .ok_or(Error::Other(
-            "failed to randomly select two relays from daemon's relay list".to_string(),
-        ))
-}
-
 /// Return a filtered version of the daemon's relay list.
 ///
 /// * `mullvad_client` - An interface to the Mullvad daemon.

--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use test_macro::test_function;
 use test_rpc::meta::Os;
-use test_rpc::{mullvad_daemon::ServiceStatus, Interface, ServiceClient};
+use test_rpc::{mullvad_daemon::ServiceStatus, ServiceClient};
 
 /// Install the last stable version of the app and verify that it is running.
 #[test_function(priority = -200)]
@@ -102,10 +102,14 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> Result<()
     // Begin monitoring outgoing traffic and pinging
     //
 
-    let guest_ip = rpc
-        .get_interface_ip(Interface::NonTunnel)
+    let guest_iface = rpc
+        .get_default_interface()
         .await
-        .expect("failed to obtain tunnel IP");
+        .expect("failed to obtain default interface");
+    let guest_ip = rpc
+        .get_interface_ip(guest_iface)
+        .await
+        .expect("failed to obtain non-tun IP");
     log::debug!("Guest IP: {guest_ip}");
 
     log::debug!("Monitoring outgoing traffic");

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -63,6 +63,7 @@ pub enum Error {
     #[error(display = "Failed to parse gRPC response")]
     InvalidGrpcResponse(#[error(source)] types::FromProtobufTypeError),
 
+    #[cfg(target_os = "macos")]
     #[error(display = "An error occurred: {}", _0)]
     Other(String),
 }

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -17,8 +17,6 @@ pub struct ServiceClient {
     client: service::ServiceClient,
 }
 
-// TODO: implement wrapper methods using macro on Service trait
-
 impl ServiceClient {
     pub fn new(
         connection_handle: transport::ConnectionHandle,
@@ -156,7 +154,7 @@ impl ServiceClient {
     /// Send TCP packet
     pub async fn send_tcp(
         &self,
-        interface: Option<Interface>,
+        interface: Option<String>,
         bind_addr: SocketAddr,
         destination: SocketAddr,
     ) -> Result<(), Error> {
@@ -168,7 +166,7 @@ impl ServiceClient {
     /// Send UDP packet
     pub async fn send_udp(
         &self,
-        interface: Option<Interface>,
+        interface: Option<String>,
         bind_addr: SocketAddr,
         destination: SocketAddr,
     ) -> Result<(), Error> {
@@ -180,7 +178,7 @@ impl ServiceClient {
     /// Send ICMP
     pub async fn send_ping(
         &self,
-        interface: Option<Interface>,
+        interface: Option<String>,
         destination: IpAddr,
     ) -> Result<(), Error> {
         self.client
@@ -196,16 +194,16 @@ impl ServiceClient {
     }
 
     /// Returns the IP of the given interface.
-    pub async fn get_interface_name(&self, interface: Interface) -> Result<String, Error> {
+    pub async fn get_interface_ip(&self, interface: String) -> Result<IpAddr, Error> {
         self.client
-            .get_interface_name(tarpc::context::current(), interface)
+            .get_interface_ip(tarpc::context::current(), interface)
             .await?
     }
 
-    /// Returns the IP of the given interface.
-    pub async fn get_interface_ip(&self, interface: Interface) -> Result<IpAddr, Error> {
+    /// Returns the name of the default non-tunnel interface
+    pub async fn get_default_interface(&self) -> Result<String, Error> {
         self.client
-            .get_interface_ip(tarpc::context::current(), interface)
+            .get_default_interface(tarpc::context::current())
             .await?
     }
 

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -55,12 +55,6 @@ pub enum Error {
     Timeout,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
-pub enum Interface {
-    Tunnel,
-    NonTunnel,
-}
-
 /// Response from am.i.mullvad.net
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AmIMullvad {
@@ -128,29 +122,29 @@ mod service {
 
         /// Send TCP packet
         async fn send_tcp(
-            interface: Option<Interface>,
+            interface: Option<String>,
             bind_addr: SocketAddr,
             destination: SocketAddr,
         ) -> Result<(), Error>;
 
         /// Send UDP packet
         async fn send_udp(
-            interface: Option<Interface>,
+            interface: Option<String>,
             bind_addr: SocketAddr,
             destination: SocketAddr,
         ) -> Result<(), Error>;
 
         /// Send ICMP
-        async fn send_ping(interface: Option<Interface>, destination: IpAddr) -> Result<(), Error>;
+        async fn send_ping(interface: Option<String>, destination: IpAddr) -> Result<(), Error>;
 
         /// Fetch the current location.
         async fn geoip_lookup(mullvad_host: String) -> Result<AmIMullvad, Error>;
 
-        /// Returns the name of the given interface.
-        async fn get_interface_name(interface: Interface) -> Result<String, Error>;
-
         /// Returns the IP of the given interface.
-        async fn get_interface_ip(interface: Interface) -> Result<IpAddr, Error>;
+        async fn get_interface_ip(interface: String) -> Result<IpAddr, Error>;
+
+        /// Returns the name of the default interface.
+        async fn get_default_interface() -> Result<String, Error>;
 
         /// Perform DNS resolution.
         async fn resolve_hostname(hostname: String) -> Result<Vec<SocketAddr>, Error>;


### PR DESCRIPTION
Main changes:

* Fix potential races in the management interface by returning from the following commands only after the tunnel state has been updated: `set_allow_lan`, `set_dns_options`, `set_block_when_disconnected`.
* Obtain tunnel interface from management interface instead of hardcoding it. This was too fragile, particularly on macOS.
* Work around bug involving `fetch-tags` in the GHA e2e workflow. Use `git fetch --tags` directly.
* Simplify `test_multihop` and `test_udp2tcp` (analogously to #5442).

Fix DES-443.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5441)
<!-- Reviewable:end -->
