### PR TITLE
Remedy connection check timeouts in `test_bridge`

### DIFF
--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -449,25 +449,6 @@ pub fn unreachable_wireguard_tunnel() -> talpid_types::net::wireguard::Connectio
     }
 }
 
-/// Find a relay from the daemon's relay list that matches `critera`.
-///
-/// * `mullvad_client` - An interface to the Mullvad daemon.
-/// * `critera` - A function used to determine which relays to include in random selection.
-pub async fn relay<Filter>(
-    mullvad_client: &mut ManagementServiceClient,
-    criteria: Filter,
-) -> Result<Relay, Error>
-where
-    Filter: Fn(&Relay) -> bool,
-{
-    filter_relays(mullvad_client, criteria)
-        .await?
-        .pop()
-        .ok_or(Error::Other(
-            "No mathing bridge was found in the relay list".to_string(),
-        ))
-}
-
 /// Randomly select an entry and exit node from the daemon's relay list.
 /// The exit node is distinct from the entry node.
 ///

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -3,11 +3,13 @@ use crate::network_monitor::{start_packet_monitor, MonitorOptions};
 use futures::StreamExt;
 use mullvad_management_interface::{types, ManagementServiceClient};
 use mullvad_types::{
+    location::Location,
     relay_constraints::{
-        BridgeState, Constraint, GeographicLocationConstraint, LocationConstraint,
+        BridgeSettings, BridgeState, Constraint, GeographicLocationConstraint, LocationConstraint,
         ObfuscationSettings, OpenVpnConstraints, RelayConstraints, RelaySettings,
         WireguardConstraints,
     },
+    relay_list::{Relay, RelayList},
     states::TunnelState,
 };
 use pnet_packet::ip::IpNextHeaderProtocols;
@@ -378,6 +380,19 @@ pub async fn set_relay_settings(
     Ok(())
 }
 
+pub async fn set_bridge_settings(
+    mullvad_client: &mut ManagementServiceClient,
+    bridge_settings: BridgeSettings,
+) -> Result<(), Error> {
+    let new_settings = types::BridgeSettings::from(bridge_settings);
+
+    mullvad_client
+        .set_bridge_settings(new_settings)
+        .await
+        .map_err(|error| Error::DaemonError(format!("Failed to set bridge settings: {}", error)))?;
+    Ok(())
+}
+
 pub async fn get_tunnel_state(mullvad_client: &mut ManagementServiceClient) -> TunnelState {
     let state = mullvad_client
         .get_tunnel_state(())
@@ -434,6 +449,25 @@ pub fn unreachable_wireguard_tunnel() -> talpid_types::net::wireguard::Connectio
     }
 }
 
+/// Find a relay from the daemon's relay list that matches `critera`.
+///
+/// * `mullvad_client` - An interface to the Mullvad daemon.
+/// * `critera` - A function used to determine which relays to include in random selection.
+pub async fn relay<Filter>(
+    mullvad_client: &mut ManagementServiceClient,
+    criteria: Filter,
+) -> Result<Relay, Error>
+where
+    Filter: Fn(&Relay) -> bool,
+{
+    filter_relays(mullvad_client, criteria)
+        .await?
+        .pop()
+        .ok_or(Error::Other(
+            "No mathing bridge was found in the relay list".to_string(),
+        ))
+}
+
 /// Randomly select an entry and exit node from the daemon's relay list.
 /// The exit node is distinct from the entry node.
 ///
@@ -442,9 +476,9 @@ pub fn unreachable_wireguard_tunnel() -> talpid_types::net::wireguard::Connectio
 pub async fn random_entry_and_exit<Filter>(
     mullvad_client: &mut ManagementServiceClient,
     criteria: Filter,
-) -> Result<(types::Relay, types::Relay), Error>
+) -> Result<(Relay, Relay), Error>
 where
-    Filter: Fn(&types::Relay) -> bool,
+    Filter: Fn(&Relay) -> bool,
 {
     use itertools::Itertools;
     // Pluck the first 2 relays and return them as a tuple.
@@ -465,30 +499,22 @@ where
 pub async fn filter_relays<Filter>(
     mullvad_client: &mut ManagementServiceClient,
     criteria: Filter,
-) -> Result<Vec<types::Relay>, Error>
+) -> Result<Vec<Relay>, Error>
 where
-    Filter: Fn(&types::Relay) -> bool,
+    Filter: Fn(&Relay) -> bool,
 {
-    let relaylist = mullvad_client
+    let relay_list: RelayList = mullvad_client
         .get_relay_locations(())
         .await
         .map_err(|error| Error::DaemonError(format!("Failed to obtain relay list: {}", error)))?
-        .into_inner();
+        .into_inner()
+        .try_into()?;
 
-    Ok(flatten_relaylist(relaylist)
-        .into_iter()
-        .filter(criteria)
+    Ok(relay_list
+        .relays()
+        .filter(|relay| criteria(relay))
+        .cloned()
         .collect())
-}
-
-/// Dig out the [`Relay`]s contained in a [`RelayList`].
-pub fn flatten_relaylist(relays: types::RelayList) -> Vec<types::Relay> {
-    relays
-        .countries
-        .iter()
-        .flat_map(|country| country.cities.clone())
-        .flat_map(|city| city.relays)
-        .collect()
 }
 
 /// Convenience function for constructing a constraint from a given [`Relay`].
@@ -496,12 +522,12 @@ pub fn flatten_relaylist(relays: types::RelayList) -> Vec<types::Relay> {
 /// # Panics
 ///
 /// The relay must have a location set.
-pub fn into_constraint(relay: &types::Relay) -> Constraint<LocationConstraint> {
+pub fn into_constraint(relay: &Relay) -> Constraint<LocationConstraint> {
     relay
         .location
         .as_ref()
         .map(
-            |types::Location {
+            |Location {
                  country_code,
                  city_code,
                  ..

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -17,7 +17,10 @@ use test_rpc::ServiceClient;
 
 use futures::future::BoxFuture;
 
-use mullvad_management_interface::{types::Settings, ManagementServiceClient};
+use mullvad_management_interface::{
+    types::{self, Settings},
+    ManagementServiceClient,
+};
 use once_cell::sync::OnceCell;
 use std::time::Duration;
 
@@ -37,7 +40,7 @@ pub type TestWrapperFunction = Box<
     ) -> BoxFuture<'static, Result<(), Error>>,
 >;
 
-#[derive(err_derive::Error, Debug, PartialEq, Eq)]
+#[derive(err_derive::Error, Debug)]
 pub enum Error {
     #[error(display = "RPC call failed")]
     Rpc(#[source] test_rpc::Error),
@@ -56,6 +59,9 @@ pub enum Error {
 
     #[error(display = "The daemon returned an error: {}", _0)]
     DaemonError(String),
+
+    #[error(display = "Failed to parse gRPC response")]
+    InvalidGrpcResponse(#[error(source)] types::FromProtobufTypeError),
 
     #[error(display = "An error occurred: {}", _0)]
     Other(String),

--- a/test/test-manager/src/tests/tunnel.rs
+++ b/test/test-manager/src/tests/tunnel.rs
@@ -202,27 +202,9 @@ pub async fn test_bridge(
     rpc: ServiceClient,
     mut mullvad_client: ManagementServiceClient,
 ) -> Result<(), Error> {
-    let entry = helpers::relay(&mut mullvad_client, |bridge| {
-        bridge.active && matches!(bridge.endpoint_data, RelayEndpointData::Bridge)
-    })
-    .await?;
-    let exit = helpers::relay(&mut mullvad_client, |relay| {
-        relay.active && matches!(relay.endpoint_data, RelayEndpointData::Openvpn)
-    })
-    .await?;
-
-    log::info!(
-        "Selected entry bridge {entry}:{entry_ip} & exit relay {exit}:{exit_ip}",
-        entry = entry.hostname,
-        entry_ip = entry.ipv4_addr_in.to_string(),
-        exit = exit.hostname,
-        exit_ip = exit.ipv4_addr_in.to_string()
-    );
-
     //
     // Enable bridge mode
     //
-
     log::info!("Updating bridge settings");
 
     mullvad_client
@@ -230,24 +212,22 @@ pub async fn test_bridge(
         .await
         .expect("failed to enable bridge mode");
 
-    let bridge_settings = BridgeSettings::Normal(BridgeConstraints {
-        location: helpers::into_constraint(&entry),
-        ..Default::default()
-    });
+    set_bridge_settings(
+        &mut mullvad_client,
+        BridgeSettings::Normal(BridgeConstraints::default()),
+    )
+    .await
+    .expect("failed to update bridge settings");
 
-    set_bridge_settings(&mut mullvad_client, bridge_settings)
-        .await
-        .expect("failed to update bridge settings");
-
-    let relay_settings = RelaySettings::Normal(RelayConstraints {
-        location: helpers::into_constraint(&exit),
-        tunnel_protocol: Constraint::Only(TunnelType::OpenVpn),
-        ..Default::default()
-    });
-
-    set_relay_settings(&mut mullvad_client, relay_settings)
-        .await
-        .expect("failed to update relay settings");
+    set_relay_settings(
+        &mut mullvad_client,
+        RelaySettings::Normal(RelayConstraints {
+            tunnel_protocol: Constraint::Only(TunnelType::OpenVpn),
+            ..Default::default()
+        }),
+    )
+    .await
+    .expect("failed to update relay settings");
 
     //
     // Connect to VPN
@@ -255,15 +235,42 @@ pub async fn test_bridge(
 
     log::info!("Connect to OpenVPN relay via bridge");
 
+    connect_and_wait(&mut mullvad_client)
+        .await
+        .expect("connect_and_wait");
+
+    let tunnel = helpers::get_tunnel_state(&mut mullvad_client).await;
+    let (entry, exit) = match tunnel {
+        mullvad_types::states::TunnelState::Connected { endpoint, .. } => {
+            (endpoint.proxy.unwrap().endpoint, endpoint.endpoint)
+        }
+        _ => return Err(Error::DaemonError("daemon entered error state".to_string())),
+    };
+
+    log::info!(
+        "Selected entry bridge {entry_ip} & exit relay {exit_ip}",
+        entry_ip = entry.address.ip().to_string(),
+        exit_ip = exit.address.ip().to_string()
+    );
+
+    // Start recording outgoing packets. Their destination will be verified
+    // against the bridge's IP address later.
     let monitor = start_packet_monitor(
-        move |packet| packet.destination.ip() == entry.ipv4_addr_in,
+        move |packet| packet.destination.ip() == entry.address.ip(),
         MonitorOptions::default(),
     )
     .await;
 
-    connect_and_wait(&mut mullvad_client)
-        .await
-        .expect("connect_and_wait");
+    //
+    // Verify exit IP
+    //
+
+    log::info!("Verifying exit server");
+
+    assert!(
+        helpers::using_mullvad_exit(&rpc).await,
+        "expected Mullvad exit IP"
+    );
 
     //
     // Verify entry IP
@@ -275,17 +282,6 @@ pub async fn test_bridge(
     assert!(
         !monitor_result.packets.is_empty(),
         "detected no traffic to entry server",
-    );
-
-    //
-    // Verify exit IP
-    //
-
-    log::info!("Verifying exit server");
-
-    assert!(
-        helpers::using_mullvad_exit(&rpc).await,
-        "expected Mullvad exit IP"
     );
 
     disconnect_and_wait(&mut mullvad_client).await?;

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -1,8 +1,9 @@
 use super::config::TEST_CONFIG;
 use super::helpers;
 use super::{Error, TestContext};
-use mullvad_management_interface::{types, ManagementServiceClient};
+use mullvad_management_interface::ManagementServiceClient;
 use mullvad_types::relay_constraints::{RelayConstraints, RelaySettings};
+use mullvad_types::relay_list::{Relay, RelayEndpointData};
 use std::{
     collections::BTreeMap,
     fmt::Debug,
@@ -87,8 +88,8 @@ pub async fn test_ui_tunnel_settings(
 ) -> Result<(), Error> {
     // tunnel-state.spec precondition: a single WireGuard relay should be selected
     log::info!("Select WireGuard relay");
-    let entry = helpers::filter_relays(&mut mullvad_client, |relay: &types::Relay| {
-        relay.active && relay.endpoint_type == i32::from(types::relay::RelayType::Wireguard)
+    let entry = helpers::filter_relays(&mut mullvad_client, |relay: &Relay| {
+        relay.active && matches!(relay.endpoint_data, RelayEndpointData::Wireguard(_))
     })
     .await?
     .pop()
@@ -109,7 +110,7 @@ pub async fn test_ui_tunnel_settings(
         &["tunnel-state.spec"],
         [
             ("HOSTNAME", entry.hostname.as_str()),
-            ("IN_IP", entry.ipv4_addr_in.as_str()),
+            ("IN_IP", &entry.ipv4_addr_in.to_string()),
             (
                 "CONNECTION_CHECK_URL",
                 &format!("https://am.i.{}", TEST_CONFIG.mullvad_host),


### PR DESCRIPTION
Delegate the task of picking entry & exit nodes to the relay selector in `test_bridge` because of latency concerns. 

We have seen `test_bridge` fail due to high latency if slow + far-away servers were
selected, even with a generous timeout of 10 seconds.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5442)
<!-- Reviewable:end -->
