### PR TITLE
tls-pinning-via-infoplist-if-thats-easier-to-do-for-ios-386

### DIFF
--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -85,14 +85,6 @@
 						<key>SPKI-SHA256-BASE64</key>
 						<string>C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=</string>
 					</dict>
-					<dict>
-						<key>SPKI-SHA256-BASE64</key>
-						<string>jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=</string>
-					</dict>
-					<dict>
-						<key>SPKI-SHA256-BASE64</key>
-						<string>j6WQit687Hx++4Sz4yOu+CFWvxx6Vvo+42oVvDHmJF8=</string>
-					</dict>
 				</array>
 			</dict>
 		</dict>

--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -73,6 +73,29 @@
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
+		<key>NSPinnedDomains</key>
+		<dict>
+			<key>am.i.mullvad.net</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSPinnedCAIdentities</key>
+				<array>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=</string>
+					</dict>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=</string>
+					</dict>
+					<dict>
+						<key>SPKI-SHA256-BASE64</key>
+						<string>j6WQit687Hx++4Sz4yOu+CFWvxx6Vvo+42oVvDHmJF8=</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>127.0.0.1</key>


### PR DESCRIPTION
After iOS 14 Apple have added a new Property List Key called `NSPinnedDomains` in `NSAppTransportSecurity` that holds a collection of certificate that `App Transport Security` expects when connecting to named domains.

This pull request leverages the newly introduced capability to pin the public keys of certificates associated with exit IP addresses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5443)
<!-- Reviewable:end -->
