### PR TITLE
Reset port when chaning transport protocol

### DIFF
--- a/gui/src/renderer/components/OpenVpnSettings.tsx
+++ b/gui/src/renderer/components/OpenVpnSettings.tsx
@@ -138,6 +138,7 @@ function TransportProtocolSelector() {
     async (protocol: RelayProtocol | null) => {
       await relaySettingsUpdater((settings) => {
         settings.openvpnConstraints.protocol = wrapConstraint(protocol);
+        settings.openvpnConstraints.port = wrapConstraint<number>(undefined);
         return settings;
       });
     },


### PR DESCRIPTION
Issue introduced in https://github.com/mullvad/mullvadvpn-app/pull/5376. When changing the OpenVPN transport protocol the port isn't reset resulting in the blocked state if connected. This is fixed by resetting the port when changing transport protocol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5445)
<!-- Reviewable:end -->
