### PR TITLE
Do not use global dispatch queue in tests

### DIFF
--- a/ios/OperationsTests/OperationSmokeTests.swift
+++ b/ios/OperationsTests/OperationSmokeTests.swift
@@ -28,7 +28,8 @@ class OperationSmokeTests: XCTestCase {
             return [parent, child]
         }
 
-        DispatchQueue.global().async {
+        let dispatchQueue = DispatchQueue(label: "com.OperationSmokeTests.testBatch")
+        dispatchQueue.async {
             operationQueue.addOperations(operations, waitUntilFinished: true)
             expect.fulfill()
         }


### PR DESCRIPTION
This test is flaky when the system is under a lot of pressure due to the usage of the global dispatch queue.
Use a local queue instead to avoid that problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5448)
<!-- Reviewable:end -->
