### PR TITLE
Decrease risk of app freezing due to race conditions in transition animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Line wrap the file at 100 chars.                                              Th
 - Lower risk of being rate limited.
 - Fix error dialog when failing to write to console by handling the thrown error.
 - Fix error dialog displayed when the daemon was killed.
+- Fix desktop app freezing when navigations occur in very quick succession.
 
 #### Windows
 - Correctly detect whether OS is Windows Server (primarily for logging in daemon.log).

--- a/gui/src/renderer/components/TransitionContainer.tsx
+++ b/gui/src/renderer/components/TransitionContainer.tsx
@@ -179,7 +179,7 @@ export default class TransitionContainer extends React.Component<IProps, IState>
     if (candidate && this.state.currentItem) {
       // Update currentItem, nextItem, queuedItem depending on which the candidate matches.
       if (
-        !this.isTransitioning &&
+        !this.isCycling &&
         this.state.currentItem.view.props.routePath === candidate.props.routePath
       ) {
         // There's no transition in progress and the newest candidate has the same path as the
@@ -196,7 +196,7 @@ export default class TransitionContainer extends React.Component<IProps, IState>
           },
           () => (this.isCycling = false),
         );
-      } else if (!this.isTransitioning && this.state.nextItem) {
+      } else if (!this.isCycling && this.state.nextItem) {
         // There's no transition in progress but there is a next item. Abort the transition and add
         // the candidate to the queue. The app shouldn't start a transition if there is another view
         // to queue.


### PR DESCRIPTION
This PR decreases the risk of the app freezing due to race conditions in `TransitionContainer` by using `isCycling` instead of `isTransitioning` to know weather a navigation is in progress. `isTransitioning` is set to true when the actual transition starts and `isCycling` is set to true when the navigation is being acted on, i.e. a lot earlier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5458)
<!-- Reviewable:end -->
