### PR TITLE
Prevent gRPC channel from entering the idle state

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -699,6 +699,7 @@ export class DaemonRpc {
       'grpc.initial_reconnect_backoff_ms': 3000,
       'grpc.keepalive_time_ms': Math.pow(2, 30),
       'grpc.keepalive_timeout_ms': Math.pow(2, 30),
+      'grpc.client_idle_timeout_ms': Math.pow(2, 30),
     };
     /* eslint-enable @typescript-eslint/naming-convention */
   }


### PR DESCRIPTION
This PR adds the `grpc.client_idle_timeout_ms` option and sets a high value to prevent the connection from going into the idle state. This option was introduce in `@grpc/grpc-js@1.9.0` which we upgraded to in https://github.com/mullvad/mullvadvpn-app/pull/5331.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5460)
<!-- Reviewable:end -->
