### PR TITLE
Remove debug code in logging function

### DIFF
--- a/gui/src/shared/logging.ts
+++ b/gui/src/shared/logging.ts
@@ -87,7 +87,6 @@ export class ConsoleOutput implements ILogOutput {
           break;
         case LogLevel.info:
           console.info(message);
-          throw new Error('Log failed');
           break;
         case LogLevel.verbose:
           console.log(message);


### PR DESCRIPTION
This PR removes a line of code that was used for debugging failures in the console logger, that was forgotten about before merging. It was added in this PR: https://github.com/mullvad/mullvadvpn-app/pull/5330.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5461)
<!-- Reviewable:end -->
