### PR TITLE
Fix leak in blocked state

### DIFF
--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import MullvadTypes
+import Network
 import WireGuardKitTypes
 
 extension PacketTunnelActor {
@@ -114,7 +116,15 @@ extension PacketTunnelActor {
                 privateKey: PrivateKey(),
                 interfaceAddresses: []
             )
-            try await tunnelAdapter.start(configuration: configurationBuilder.makeConfiguration())
+            var config = try configurationBuilder.makeConfiguration()
+            config.dns = [IPv4Address.loopback]
+            config.interfaceAddresses = [IPAddressRange(from: "10.64.0.1/8")!]
+            config.peer = TunnelPeer(
+                endpoint: .ipv4(IPv4Endpoint(string: "127.0.0.1:9090")!),
+                publicKey: PrivateKey().publicKey
+            )
+            try? await tunnelAdapter.stop()
+            try await tunnelAdapter.start(configuration: config)
         } catch {
             logger.error(error: error, message: "Unable to configure the tunnel for error state.")
         }


### PR DESCRIPTION
For the packet tunnel to receive traffic, it needs to have a peer configured so that the system configures routes for it. Otherwise, no routes are applied and all traffic leaks.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5477)
<!-- Reviewable:end -->
