### PR TITLE
Fix daemon ending up in irrecoverable error state due to missing access methods

### DIFF
--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -51,21 +51,22 @@ impl Settings {
     pub fn cloned(&self) -> Vec<AccessMethodSetting> {
         self.access_method_settings.clone()
     }
+
+    pub fn direct() -> AccessMethodSetting {
+        let method = BuiltInAccessMethod::Direct;
+        AccessMethodSetting::new(method.canonical_name(), true, AccessMethod::from(method))
+    }
+
+    pub fn mullvad_bridges() -> AccessMethodSetting {
+        let method = BuiltInAccessMethod::Bridge;
+        AccessMethodSetting::new(method.canonical_name(), true, AccessMethod::from(method))
+    }
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            access_method_settings: vec![BuiltInAccessMethod::Direct, BuiltInAccessMethod::Bridge]
-                .into_iter()
-                .map(|built_in| {
-                    AccessMethodSetting::new(
-                        built_in.canonical_name(),
-                        true,
-                        AccessMethod::from(built_in),
-                    )
-                })
-                .collect(),
+            access_method_settings: vec![Settings::direct(), Settings::mullvad_bridges()],
         }
     }
 }


### PR DESCRIPTION
This PR solves a bug where the daemon could end up in an irrecoverable error state due to missing access methods.
If the user disable all of their configured access methods, the daemon would suddenly crash and be unable to start up again due to it expecting there to always be at least one enabled access method.

Fixes DES-475

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5482)
<!-- Reviewable:end -->
