### PR TITLE
Replace text share with file share

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -90,5 +90,15 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
+
+        <provider
+            android:name="net.mullvad.mullvadvpn.provider.MullvadFileProvider"
+            android:authorities="net.mullvad.mullvadvpn.FileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -90,15 +90,12 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
-
-        <provider
-            android:name="net.mullvad.mullvadvpn.provider.MullvadFileProvider"
-            android:authorities="net.mullvad.mullvadvpn.FileProvider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths" />
+        <provider android:name="net.mullvad.mullvadvpn.provider.MullvadFileProvider"
+                  android:authorities="net.mullvad.mullvadvpn.FileProvider"
+                  android:exported="false"
+                  android:grantUriPermissions="true">
+            <meta-data android:name="android.support.FILE_PROVIDER_PATHS"
+                       android:resource="@xml/provider_paths" />
         </provider>
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ViewLogsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ViewLogsScreen.kt
@@ -1,9 +1,6 @@
 package net.mullvad.mullvadvpn.compose.screen
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -17,20 +14,26 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.component.MullvadCircularProgressIndicatorMedium
 import net.mullvad.mullvadvpn.compose.component.MullvadMediumTopBar
+import net.mullvad.mullvadvpn.compose.component.MullvadSnackbar
 import net.mullvad.mullvadvpn.compose.component.NavigateBackIconButton
 import net.mullvad.mullvadvpn.compose.component.drawVerticalScrollbar
+import net.mullvad.mullvadvpn.compose.util.createCopyToClipboardHandle
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaScrollbar
@@ -57,13 +60,30 @@ fun ViewLogsScreen(
 ) {
     val context = LocalContext.current
 
+    val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val clipboardHandle = createCopyToClipboardHandle(snackbarHostState = snackbarHostState)
     Scaffold(
+        snackbarHost = {
+            SnackbarHost(
+                snackbarHostState,
+                snackbar = { snackbarData -> MullvadSnackbar(snackbarData = snackbarData) }
+            )
+        },
         topBar = {
             MullvadMediumTopBar(
                 title = stringResource(id = R.string.view_logs),
                 navigationIcon = { NavigateBackIconButton(onBackClick) },
                 actions = {
+                    val clipboardToastMessage = stringResource(R.string.copied_logs_to_clipboard)
+                    IconButton(
+                        onClick = { clipboardHandle(uiState.text(), clipboardToastMessage) }
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.icon_copy),
+                            contentDescription = null
+                        )
+                    }
                     IconButton(onClick = { scope.launch { shareText(context, uiState.text()) } }) {
                         Icon(imageVector = Icons.Default.Share, contentDescription = null)
                     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ViewLogsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ViewLogsScreen.kt
@@ -2,6 +2,8 @@ package net.mullvad.mullvadvpn.compose.screen
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -17,11 +19,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.component.MullvadCircularProgressIndicatorMedium
 import net.mullvad.mullvadvpn.compose.component.MullvadMediumTopBar
@@ -30,6 +34,7 @@ import net.mullvad.mullvadvpn.compose.component.drawVerticalScrollbar
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaScrollbar
+import net.mullvad.mullvadvpn.provider.getLogsShareIntent
 import net.mullvad.mullvadvpn.viewmodel.ViewLogsUiState
 
 @Preview
@@ -52,13 +57,14 @@ fun ViewLogsScreen(
 ) {
     val context = LocalContext.current
 
+    val scope = rememberCoroutineScope()
     Scaffold(
         topBar = {
             MullvadMediumTopBar(
                 title = stringResource(id = R.string.view_logs),
                 navigationIcon = { NavigateBackIconButton(onBackClick) },
                 actions = {
-                    IconButton(onClick = { shareText(context, uiState.text()) }) {
+                    IconButton(onClick = { scope.launch { shareText(context, uiState.text()) } }) {
                         Icon(imageVector = Icons.Default.Share, contentDescription = null)
                     }
                 }
@@ -101,14 +107,7 @@ fun ViewLogsScreen(
     }
 }
 
-private fun shareText(context: Context, text: String) {
-    val sendIntent: Intent =
-        Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, text)
-            type = "text/plain"
-        }
-    val shareIntent = Intent.createChooser(sendIntent, null)
-
+private fun shareText(context: Context, logContent: String) {
+    val shareIntent = context.getLogsShareIntent("Share logs", logContent)
     context.startActivity(shareIntent)
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/provider/MullvadFileProvider.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/provider/MullvadFileProvider.kt
@@ -1,0 +1,59 @@
+package net.mullvad.mullvadvpn.provider
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+import net.mullvad.mullvadvpn.R
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+
+// https://developer.android.com/reference/androidx/core/content/FileProvider
+// From link: It is possible to use FileProvider directly instead of extending it. However, this is
+// not reliable and will causes crashes on some devices.
+class MullvadFileProvider : FileProvider(R.xml.provider_paths) {
+    companion object {
+        fun uriForFile(context: Context, file: File): Uri {
+            return getUriForFile(context, "net.mullvad.mullvadvpn.FileProvider", file)
+        }
+    }
+}
+
+enum class ProviderCacheDirectory(val directoryName: String) {
+    LOGS("logs")
+}
+
+fun Context.getLogsShareIntent(shareTitle: String, logContent: String): Intent {
+    val fileName = createShareLogFileName()
+    val cacheFile = createCacheFile(ProviderCacheDirectory.LOGS, fileName)
+    cacheFile.writeText(logContent)
+    val logsUri = MullvadFileProvider.uriForFile(this, cacheFile)
+
+    val sendIntent: Intent =
+        Intent().apply {
+            action = Intent.ACTION_SEND
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, logsUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    return Intent.createChooser(sendIntent, null)
+}
+
+fun Context.createCacheFile(
+    directory: ProviderCacheDirectory,
+    fileName: String,
+): File {
+    // Path to log file
+    val logsPath = File(cacheDir, directory.directoryName)
+
+    // Ensure path is created
+    logsPath.mkdirs()
+
+    return File(logsPath, fileName)
+}
+
+fun createShareLogFileName(): String {
+    val datetime = ISODateTimeFormat.basicOrdinalDateTimeNoMillis().print(DateTime.now())
+    return "mullvad_log-${datetime}.txt"
+}

--- a/android/app/src/main/res/xml/provider_paths.xml
+++ b/android/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="logs"
+        path="logs/" />
+</paths>
+
+

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -243,4 +243,5 @@
     <string name="payment_pending_dialog_message">We are currently verifying your purchase, this might take some time. Your time will be added if the verification is successful.</string>
     <string name="loading_connecting">Connecting...</string>
     <string name="loading_verifying">Verifying purchase...</string>
+    <string name="copied_logs_to_clipboard">Copied logs to clipboard</string>
 </resources>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1711,6 +1711,9 @@ msgstr ""
 msgid "Copied Mullvad account number to clipboard"
 msgstr ""
 
+msgid "Copied logs to clipboard"
+msgstr ""
+
 msgid "Copied to clipboard"
 msgstr ""
 


### PR DESCRIPTION
Attempt of sharing text through share intent don't work due to the text being too long, this PR replaces it by sharing it as a file instead. This PR also offers the option to directly copy the logs into clipboard.

It is possible to crash system UI with this PR since the new Copy dialog from system also offers a "share" functionality which will share the logs in a similar fashion as we did before, thus causing `intentChooser` to fail due to the text being too long.. To reproduce this add, `repeat(5)` in `ViewLogsUiState` to the `text()` function

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5485)
<!-- Reviewable:end -->
