### PR TITLE
Set default route MTU when using multihop on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Rename interface name from `wg-mullvad` to `wg0-mullvad`.
 
+### Fixed
+#### Linux
+- Prevent fragmentation when multihop is enabled by setting a default route MTU.
+
 
 ## [2023.6-beta1] - 2023-11-23
 ### Added

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -23,7 +23,7 @@ talpid-types = { path = "../talpid-types" }
 libc = "0.2"
 once_cell = { workspace = true }
 rtnetlink = "0.11"
-netlink-packet-route = "0.13"
+netlink-packet-route = { version = "0.13", features = ["rich_nlas"] }
 netlink-sys = "0.8.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -38,6 +38,8 @@ pub struct Route {
     metric: Option<u32>,
     #[cfg(target_os = "linux")]
     table_id: u32,
+    #[cfg(target_os = "linux")]
+    mtu: Option<u32>,
 }
 
 impl Route {
@@ -49,6 +51,8 @@ impl Route {
             metric: None,
             #[cfg(target_os = "linux")]
             table_id: u32::from(RT_TABLE_MAIN),
+            #[cfg(target_os = "linux")]
+            mtu: None,
         }
     }
 
@@ -72,6 +76,10 @@ impl fmt::Display for Route {
         }
         #[cfg(target_os = "linux")]
         write!(f, " table {}", self.table_id)?;
+        #[cfg(target_os = "linux")]
+        if let Some(mtu) = self.mtu {
+            write!(f, " mtu {mtu}")?;
+        }
         Ok(())
     }
 }
@@ -87,6 +95,9 @@ pub struct RequiredRoute {
     /// Specifies whether the route should be added to the main routing table or not.
     #[cfg(target_os = "linux")]
     main_table: bool,
+    /// Specifies route MTU
+    #[cfg(target_os = "linux")]
+    mtu: Option<u16>,
 }
 
 impl RequiredRoute {
@@ -97,6 +108,8 @@ impl RequiredRoute {
             prefix,
             #[cfg(target_os = "linux")]
             main_table: true,
+            #[cfg(target_os = "linux")]
+            mtu: None,
         }
     }
 
@@ -104,6 +117,13 @@ impl RequiredRoute {
     #[cfg(target_os = "linux")]
     pub fn use_main_table(mut self, main_table: bool) -> Self {
         self.main_table = main_table;
+        self
+    }
+
+    /// Set route MTU to the given value.
+    #[cfg(target_os = "linux")]
+    pub fn mtu(mut self, mtu: u16) -> Self {
+        self.mtu = Some(mtu);
         self
     }
 }

--- a/talpid-wireguard/src/wireguard_kernel/nm_tunnel.rs
+++ b/talpid-wireguard/src/wireguard_kernel/nm_tunnel.rs
@@ -130,7 +130,7 @@ fn convert_config_to_dbus(config: &Config) -> DeviceConfig {
     );
     wireguard_config.insert("private-key-flags".into(), Variant(Box::new(0x0u32)));
 
-    for peer in config.peers.iter() {
+    for peer in config.peers() {
         let mut peer_config: VariantMap = HashMap::new();
         let allowed_ips = peer
             .allowed_ips

--- a/talpid-wireguard/src/wireguard_kernel/wg_message.rs
+++ b/talpid-wireguard/src/wireguard_kernel/wg_message.rs
@@ -78,7 +78,7 @@ impl DeviceMessage {
     pub fn reset_config(message_type: u16, interface_index: u32, config: &Config) -> DeviceMessage {
         let mut peers = vec![];
 
-        for peer in config.peers.iter() {
+        for peer in config.peers() {
             let peer_endpoint = InetAddr::from_std(&peer.endpoint);
             let allowed_ips = peer.allowed_ips.iter().map(From::from).collect();
             let mut peer_nlas = vec![

--- a/talpid-wireguard/src/wireguard_nt.rs
+++ b/talpid-wireguard/src/wireguard_nt.rs
@@ -811,12 +811,12 @@ fn serialize_config(config: &Config) -> Result<Vec<MaybeUninit<u8>>> {
         listen_port: 0,
         private_key: config.tunnel.private_key.to_bytes(),
         public_key: [0u8; WIREGUARD_KEY_LENGTH],
-        peers_count: u32::try_from(config.peers.len()).unwrap(),
+        peers_count: u32::try_from(config.peers().count()).unwrap(),
     };
 
     buffer.extend(as_uninit_byte_slice(&header));
 
-    for peer in &config.peers {
+    for peer in config.peers() {
         let flags = if peer.psk.is_some() {
             WgPeerFlag::HAS_PRESHARED_KEY | WgPeerFlag::HAS_PUBLIC_KEY | WgPeerFlag::HAS_ENDPOINT
         } else {
@@ -1005,12 +1005,13 @@ mod tests {
             private_key: WG_PRIVATE_KEY.clone(),
             addresses: vec![],
         },
-        peers: vec![wireguard::PeerConfig {
+        entry_peer: wireguard::PeerConfig {
             public_key: WG_PUBLIC_KEY.clone(),
             allowed_ips: vec!["1.3.3.0/24".parse().unwrap()],
             endpoint: "1.2.3.4:1234".parse().unwrap(),
             psk: None,
-        }],
+        },
+        exit_peer: None,
         ipv4_gateway: "0.0.0.0".parse().unwrap(),
         ipv6_gateway: None,
         mtu: 0,


### PR DESCRIPTION
This prevents fragmentation when multihop is enabled.

Fix DES-483.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5501)
<!-- Reviewable:end -->
