### PR TITLE
Only build devmole and stagemole builds when api-override supported

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -13,8 +13,8 @@ echo ""
 
 BUILD_TYPE="release"
 GRADLE_BUILD_TYPE="release"
-GRADLE_TASKS=(createOssProdReleaseDistApk createPlayProdReleaseDistApk createPlayDevmoleReleaseDistApk createPlayStagemoleReleaseDistApk)
-BUNDLE_TASKS=(createPlayProdReleaseDistBundle createPlayDevmoleReleaseDistBundle createPlayStagemoleReleaseDistBundle)
+GRADLE_TASKS=(createOssProdReleaseDistApk createPlayProdReleaseDistApk)
+BUNDLE_TASKS=(createPlayProdReleaseDistBundle)
 CARGO_ARGS="--release"
 EXTRA_WGGO_ARGS=""
 BUILD_BUNDLE="no"
@@ -58,6 +58,8 @@ if [[ "$BUILD_TYPE" == "release" && "$PRODUCT_VERSION" != *"-dev-"* ]]; then
     CARGO_ARGS+=" --locked"
 else
     CARGO_ARGS+=" --features api-override"
+    GRADLE_TASKS+=(createPlayDevmoleReleaseDistApk createPlayStagemoleReleaseDistApk)
+    BUNDLE_TASKS+=(createPlayDevmoleReleaseDistBundle createPlayStagemoleReleaseDistBundle)
 fi
 
 pushd "$SCRIPT_DIR/android"


### PR DESCRIPTION
This PR aims to make sure that devmole and stagemole builds are enabled when the daemon api-override flag is set to enable overriding the api endpoint.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5504)
<!-- Reviewable:end -->
