### PR TITLE
Enable forced direct connection for devmole and stagemole builds

### DIFF
--- a/android/lib/endpoint/src/main/kotlin/net/mullvad/mullvadvpn/lib/endpoint/CustomApiEndpointConfiguration.kt
+++ b/android/lib/endpoint/src/main/kotlin/net/mullvad/mullvadvpn/lib/endpoint/CustomApiEndpointConfiguration.kt
@@ -9,9 +9,9 @@ const val CUSTOM_ENDPOINT_HTTPS_PORT = 443
 data class CustomApiEndpointConfiguration(
     val hostname: String,
     val port: Int,
-    val disableAddressCache: Boolean = false,
+    val disableAddressCache: Boolean = true,
     val disableTls: Boolean = false,
-    val forceDirectConnection: Boolean = false
+    val forceDirectConnection: Boolean = true
 ) : ApiEndpointConfiguration {
     override fun apiEndpoint() =
         ApiEndpoint(


### PR DESCRIPTION
This PR enables forced API direct connection as well as disables API address caching to improve testing against the devmole and stagemole environments.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5509)
<!-- Reviewable:end -->
