### PR TITLE
Add regression test: Default to connecting state on corrupt state cache

### DIFF
--- a/mullvad-daemon/src/target_state.rs
+++ b/mullvad-daemon/src/target_state.rs
@@ -1,5 +1,6 @@
 use mullvad_types::states::TargetState;
 use std::{
+    future::Future,
     ops::Deref,
     path::{Path, PathBuf},
 };
@@ -21,39 +22,10 @@ impl PersistentTargetState {
     /// Initialize using the current target state (if there is one)
     pub async fn new(cache_dir: &Path) -> Self {
         let cache_path = cache_dir.join(TARGET_START_STATE_FILE);
-        let mut update_cache = false;
-        let state = match fs::read_to_string(&cache_path).await {
-            Ok(content) => serde_json::from_str(&content)
-                .map(|state| {
-                    log::info!(
-                        "Loaded cached target state \"{}\" from {}",
-                        state,
-                        cache_path.display()
-                    );
-                    state
-                })
-                .unwrap_or_else(|error| {
-                    log::error!(
-                        "{}",
-                        error.display_chain_with_msg("Failed to parse cached target tunnel state")
-                    );
-                    update_cache = true;
-                    TargetState::Secured
-                }),
-            Err(error) => {
-                if error.kind() == io::ErrorKind::NotFound {
-                    log::debug!("No cached target state to load");
-                    DEFAULT_TARGET_STATE
-                } else {
-                    log::error!(
-                        "{}",
-                        error.display_chain_with_msg("Failed to read cached target tunnel state")
-                    );
-                    update_cache = true;
-                    TargetState::Secured
-                }
-            }
-        };
+        let TargetStateInner {
+            state,
+            update_cache,
+        } = Self::read_target_state(&cache_path, fs::read_to_string).await;
         let state = PersistentTargetState {
             state,
             cache_path,
@@ -63,6 +35,63 @@ impl PersistentTargetState {
             state.save().await;
         }
         state
+    }
+
+    /// Construct a [`TargetState`] from cache.
+    ///
+    /// `read_cache` allows the caller to decide how to read from a cache of
+    /// [`TargetState`].
+    ///
+    /// This function will always succeed, even in the presence of IO
+    /// operations. Errors are handled gracefully by defaulting to safe target
+    /// states if necessary.
+    async fn read_target_state<F, R>(cache: &Path, read_cache: F) -> TargetStateInner
+    where
+        F: FnOnce(PathBuf) -> R,
+        R: Future<Output = io::Result<String>>,
+    {
+        match read_cache(cache.to_path_buf()).await {
+            Ok(content) => serde_json::from_str(&content)
+                .map(|state| {
+                    log::info!(
+                        "Loaded cached target state \"{}\" from {}",
+                        state,
+                        cache.display()
+                    );
+                    TargetStateInner {
+                        state,
+                        update_cache: false,
+                    }
+                })
+                .unwrap_or_else(|error| {
+                    log::error!(
+                        "{}",
+                        error.display_chain_with_msg("Failed to parse cached target tunnel state")
+                    );
+                    TargetStateInner {
+                        state: TargetState::Secured,
+                        update_cache: true,
+                    }
+                }),
+
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                log::debug!("No cached target state to load");
+                TargetStateInner {
+                    state: DEFAULT_TARGET_STATE,
+                    update_cache: false,
+                }
+            }
+            Err(error) => {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Failed to read cached target tunnel state")
+                );
+                TargetStateInner {
+                    state: TargetState::Secured,
+                    update_cache: true,
+                }
+            }
+        }
     }
 
     /// Override the current target state, if there is one
@@ -151,5 +180,72 @@ impl Deref for PersistentTargetState {
 
     fn deref(&self) -> &Self::Target {
         &self.state
+    }
+}
+
+/// The result of calling `read_target_state`.
+struct TargetStateInner {
+    state: TargetState,
+    /// In some circumstances, the target state cache should be updated on disk
+    /// upon initialization a [`PersistentTargetState`]. This is signaled to the
+    /// constructor of [`PersistentTargetState`] by setting this value to
+    /// `true`.
+    update_cache: bool,
+}
+
+impl Deref for TargetStateInner {
+    type Target = TargetState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    static DUMMY_CACHE_DIR: &str = "target-state-test";
+
+    /// If no target state cache exist, the default target state is used. This
+    /// is the most basic check.
+    #[tokio::test]
+    async fn test_target_state_initialization_empty() {
+        let target_state =
+            PersistentTargetState::read_target_state(Path::new(DUMMY_CACHE_DIR), |_| async {
+                // A completely blank slate. No target state cache file has been created yet.
+                Err(io::ErrorKind::NotFound.into())
+            })
+            .await;
+        assert_eq!(*target_state, DEFAULT_TARGET_STATE);
+    }
+
+    /// If a target state cache exist with some target state, the state can be
+    /// read-back successfully.
+    #[tokio::test]
+    async fn test_target_state_initialization_existing() {
+        for cached_state in [TargetState::Secured, TargetState::Unsecured] {
+            let target_state =
+                PersistentTargetState::read_target_state(Path::new(DUMMY_CACHE_DIR), |_| async {
+                    Ok(serde_json::to_string(&cached_state).unwrap())
+                })
+                .await;
+            assert_eq!(*target_state, cached_state);
+        }
+    }
+
+    /// The state can not be read-back successfully if the state file has become
+    /// corrupt. In such cases, initializing a [`PersistentTargetState`] should
+    /// yield a "better safe than sorry"-target state of `Secured`.
+    #[tokio::test]
+    async fn test_target_corrupt_state_cache() {
+        let target_state =
+            PersistentTargetState::read_target_state(Path::new(DUMMY_CACHE_DIR), |_| async {
+                // Intentionally corrupt the target state cache.
+                Ok("Not a valid target state".to_string())
+            })
+            .await;
+        // Reading back a corrupt target state cache should yield `TargetState::Secured`.
+        assert_eq!(*target_state, TargetState::Secured);
     }
 }

--- a/test/test-manager/src/tests/account.rs
+++ b/test/test-manager/src/tests/account.rs
@@ -324,7 +324,7 @@ pub async fn test_automatic_wireguard_rotation(
         .pubkey;
 
     // Stop daemon
-    rpc.set_mullvad_daemon_service_state(false)
+    rpc.stop_mullvad_daemon()
         .await
         .expect("Could not stop system service");
 
@@ -334,7 +334,7 @@ pub async fn test_automatic_wireguard_rotation(
         .expect("Could not change device.json to have an old created timestamp");
 
     // Start daemon
-    rpc.set_mullvad_daemon_service_state(true)
+    rpc.start_mullvad_daemon()
         .await
         .expect("Could not start system service");
 

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -221,8 +221,19 @@ impl ServiceClient {
             .await?
     }
 
-    pub async fn restart_app(&self) -> Result<(), Error> {
-        let _ = self.client.restart_app(tarpc::context::current()).await?;
+    /// Restarts the app.
+    ///
+    /// Shuts down a running app, making it disconnect from any current tunnel
+    /// connection before starting the app again.
+    ///
+    /// # Note
+    /// This function will return *after* the app is running again, thus
+    /// blocking execution until then.
+    pub async fn restart_mullvad_daemon(&self) -> Result<(), Error> {
+        let _ = self
+            .client
+            .restart_mullvad_daemon(tarpc::context::current())
+            .await?;
         Ok(())
     }
 
@@ -234,18 +245,24 @@ impl ServiceClient {
     /// # Note
     /// This function will return *after* the app has been stopped, thus
     /// blocking execution until then.
-    pub async fn stop_app(&self) -> Result<(), Error> {
-        let _ = self.client.stop_app(tarpc::context::current()).await?;
+    pub async fn stop_mullvad_daemon(&self) -> Result<(), Error> {
+        let _ = self
+            .client
+            .stop_mullvad_daemon(tarpc::context::current())
+            .await?;
         Ok(())
     }
 
     /// Start the app.
     ///
     /// # Note
-    /// This function will return *after* the app has been start, thus
+    /// This function will return *after* the app has been started, thus
     /// blocking execution until then.
-    pub async fn start_app(&self) -> Result<(), Error> {
-        let _ = self.client.start_app(tarpc::context::current()).await?;
+    pub async fn start_mullvad_daemon(&self) -> Result<(), Error> {
+        let _ = self
+            .client
+            .start_mullvad_daemon(tarpc::context::current())
+            .await?;
         Ok(())
     }
 
@@ -309,23 +326,6 @@ impl ServiceClient {
         self.connection_handle.wait_for_server().await?;
 
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
-        Ok(())
-    }
-
-    pub async fn set_mullvad_daemon_service_state(&self, on: bool) -> Result<(), Error> {
-        self.client
-            .set_mullvad_daemon_service_state(tarpc::context::current(), on)
-            .await??;
-
-        self.mullvad_daemon_wait_for_state(|state| {
-            if on {
-                state == ServiceStatus::Running
-            } else {
-                state == ServiceStatus::NotRunning
-            }
-        })
-        .await?;
 
         Ok(())
     }

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -151,6 +151,13 @@ impl ServiceClient {
             .await?
     }
 
+    /// Returns path of Mullvad app cache directorie on the test runner.
+    pub async fn find_mullvad_app_cache_dir(&self) -> Result<PathBuf, Error> {
+        self.client
+            .get_mullvad_app_cache_dir(tarpc::context::current())
+            .await?
+    }
+
     /// Send TCP packet
     pub async fn send_tcp(
         &self,
@@ -213,6 +220,34 @@ impl ServiceClient {
             .await?
     }
 
+    pub async fn restart_app(&self) -> Result<(), Error> {
+        let _ = self.client.restart_app(tarpc::context::current()).await?;
+        Ok(())
+    }
+
+    /// Stop the app.
+    ///
+    /// Shuts down a running app, making it disconnect from any current tunnel
+    /// connection and making it write to caches.
+    ///
+    /// # Note
+    /// This function will return *after* the app has been stopped, thus
+    /// blocking execution until then.
+    pub async fn stop_app(&self) -> Result<(), Error> {
+        let _ = self.client.stop_app(tarpc::context::current()).await?;
+        Ok(())
+    }
+
+    /// Start the app.
+    ///
+    /// # Note
+    /// This function will return *after* the app has been start, thus
+    /// blocking execution until then.
+    pub async fn start_app(&self) -> Result<(), Error> {
+        let _ = self.client.start_app(tarpc::context::current()).await?;
+        Ok(())
+    }
+
     pub async fn set_daemon_log_level(
         &self,
         verbosity_level: mullvad_daemon::Verbosity,
@@ -244,6 +279,17 @@ impl ServiceClient {
         log::debug!("Copying \"{src}\" to \"{dest}\"");
         self.client
             .copy_file(tarpc::context::current(), src, dest)
+            .await?
+    }
+
+    pub async fn write_file(&self, dest: String, bytes: Vec<u8>) -> Result<(), Error> {
+        log::debug!(
+            "Writing {bytes} bytes to \"{file}\"",
+            bytes = bytes.len(),
+            file = dest
+        );
+        self.client
+            .write_file(tarpc::context::current(), dest, bytes)
             .await?
     }
 

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    path::Path,
     time::{Duration, SystemTime},
 };
 
@@ -51,7 +52,7 @@ impl ServiceClient {
         self.client.uninstall_app(ctx, env).await?
     }
 
-    /// Execute a program.
+    /// Execute a program with additional environment-variables set.
     pub async fn exec_env<
         I: IntoIterator<Item = T>,
         M: IntoIterator<Item = (K, T)>,
@@ -282,14 +283,18 @@ impl ServiceClient {
             .await?
     }
 
-    pub async fn write_file(&self, dest: String, bytes: Vec<u8>) -> Result<(), Error> {
+    pub async fn write_file(&self, dest: impl AsRef<Path>, bytes: Vec<u8>) -> Result<(), Error> {
         log::debug!(
             "Writing {bytes} bytes to \"{file}\"",
             bytes = bytes.len(),
-            file = dest
+            file = dest.as_ref().display()
         );
         self.client
-            .write_file(tarpc::context::current(), dest, bytes)
+            .write_file(
+                tarpc::context::current(),
+                dest.as_ref().to_path_buf(),
+                bytes,
+            )
             .await?
     }
 

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -152,13 +152,13 @@ mod service {
         async fn resolve_hostname(hostname: String) -> Result<Vec<SocketAddr>, Error>;
 
         /// Restart the Mullvad VPN application.
-        async fn restart_app() -> Result<(), Error>;
+        async fn restart_mullvad_daemon() -> Result<(), Error>;
 
         /// Stop the Mullvad VPN application.
-        async fn stop_app() -> Result<(), Error>;
+        async fn stop_mullvad_daemon() -> Result<(), Error>;
 
         /// Start the Mullvad VPN application.
-        async fn start_app() -> Result<(), Error>;
+        async fn start_mullvad_daemon() -> Result<(), Error>;
 
         /// Sets the log level of the daemon service, the verbosity level represents the number of
         /// `-v`s passed on the command line. This will restart the daemon system service.
@@ -176,8 +176,6 @@ mod service {
         async fn write_file(dest: PathBuf, bytes: Vec<u8>) -> Result<(), Error>;
 
         async fn reboot() -> Result<(), Error>;
-
-        async fn set_mullvad_daemon_service_state(on: bool) -> Result<(), Error>;
 
         async fn make_device_json_old() -> Result<(), Error>;
     }

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -173,7 +173,7 @@ mod service {
         async fn copy_file(src: String, dest: String) -> Result<(), Error>;
 
         /// Write arbitrary bytes to some file `dest` on the test runner.
-        async fn write_file(dest: String, bytes: Vec<u8>) -> Result<(), Error>;
+        async fn write_file(dest: PathBuf, bytes: Vec<u8>) -> Result<(), Error>;
 
         async fn reboot() -> Result<(), Error>;
 

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -120,6 +120,8 @@ mod service {
         /// Returns all Mullvad app files, directories, and other data found on the system.
         async fn find_mullvad_app_traces() -> Result<Vec<AppTrace>, Error>;
 
+        async fn get_mullvad_app_cache_dir() -> Result<PathBuf, Error>;
+
         /// Send TCP packet
         async fn send_tcp(
             interface: Option<String>,
@@ -149,6 +151,15 @@ mod service {
         /// Perform DNS resolution.
         async fn resolve_hostname(hostname: String) -> Result<Vec<SocketAddr>, Error>;
 
+        /// Restart the Mullvad VPN application.
+        async fn restart_app() -> Result<(), Error>;
+
+        /// Stop the Mullvad VPN application.
+        async fn stop_app() -> Result<(), Error>;
+
+        /// Start the Mullvad VPN application.
+        async fn start_app() -> Result<(), Error>;
+
         /// Sets the log level of the daemon service, the verbosity level represents the number of
         /// `-v`s passed on the command line. This will restart the daemon system service.
         async fn set_daemon_log_level(
@@ -160,6 +171,9 @@ mod service {
 
         /// Copy a file from `src` to `dest` on the test runner.
         async fn copy_file(src: String, dest: String) -> Result<(), Error>;
+
+        /// Write arbitrary bytes to some file `dest` on the test runner.
+        async fn write_file(dest: String, bytes: Vec<u8>) -> Result<(), Error>;
 
         async fn reboot() -> Result<(), Error>;
 

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { workspace = true }
 tokio-serde = { workspace = true }
 
 libc = "0.2"
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
 
 test-rpc = { path = "../test-rpc" }
 mullvad-paths = { path = "../../mullvad-paths" }

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -226,17 +226,17 @@ impl Service for TestServer {
         logging::get_mullvad_app_logs().await
     }
 
-    async fn restart_app(self, _: context::Context) -> Result<(), test_rpc::Error> {
+    async fn restart_mullvad_daemon(self, _: context::Context) -> Result<(), test_rpc::Error> {
         sys::restart_app().await
     }
 
     /// Stop the Mullvad VPN application.
-    async fn stop_app(self, _: context::Context) -> Result<(), test_rpc::Error> {
+    async fn stop_mullvad_daemon(self, _: context::Context) -> Result<(), test_rpc::Error> {
         sys::stop_app().await
     }
 
     /// Start the Mullvad VPN application.
-    async fn start_app(self, _: context::Context) -> Result<(), test_rpc::Error> {
+    async fn start_mullvad_daemon(self, _: context::Context) -> Result<(), test_rpc::Error> {
         sys::start_app().await
     }
 
@@ -290,14 +290,6 @@ impl Service for TestServer {
 
     async fn reboot(self, _: context::Context) -> Result<(), test_rpc::Error> {
         sys::reboot()
-    }
-
-    async fn set_mullvad_daemon_service_state(
-        self,
-        _: context::Context,
-        on: bool,
-    ) -> Result<(), test_rpc::Error> {
-        sys::set_mullvad_daemon_service_state(on).await
     }
 
     async fn make_device_json_old(self, _: context::Context) -> Result<(), test_rpc::Error> {

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -3,7 +3,7 @@ use logging::LOGGER;
 use std::{
     collections::{BTreeMap, HashMap},
     net::{IpAddr, SocketAddr},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use tarpc::context;
@@ -114,6 +114,13 @@ impl Service for TestServer {
         app::find_traces()
     }
 
+    async fn get_mullvad_app_cache_dir(
+        self,
+        _: context::Context,
+    ) -> Result<PathBuf, test_rpc::Error> {
+        app::find_cache_traces()
+    }
+
     async fn send_tcp(
         self,
         _: context::Context,
@@ -140,7 +147,7 @@ impl Service for TestServer {
         interface: Option<String>,
         destination: IpAddr,
     ) -> Result<(), test_rpc::Error> {
-        net::send_ping(interface.as_ref().map(String::as_str), destination).await
+        net::send_ping(interface.as_deref(), destination).await
     }
 
     async fn geoip_lookup(
@@ -219,6 +226,20 @@ impl Service for TestServer {
         logging::get_mullvad_app_logs().await
     }
 
+    async fn restart_app(self, _: context::Context) -> Result<(), test_rpc::Error> {
+        sys::restart_app().await
+    }
+
+    /// Stop the Mullvad VPN application.
+    async fn stop_app(self, _: context::Context) -> Result<(), test_rpc::Error> {
+        sys::stop_app().await
+    }
+
+    /// Start the Mullvad VPN application.
+    async fn start_app(self, _: context::Context) -> Result<(), test_rpc::Error> {
+        sys::start_app().await
+    }
+
     async fn set_daemon_log_level(
         self,
         _: context::Context,
@@ -243,6 +264,25 @@ impl Service for TestServer {
     ) -> Result<(), test_rpc::Error> {
         tokio::fs::copy(&src, &dest).await.map_err(|error| {
             log::error!("Failed to copy \"{src}\" to \"{dest}\": {error}");
+            test_rpc::Error::Syscall
+        })?;
+        Ok(())
+    }
+
+    /// Write a slice as the entire contents of a file.
+    ///
+    /// See the documention of [`tokio::fs::write`] for details of the behavior.
+    async fn write_file(
+        self,
+        _: context::Context,
+        dest: PathBuf,
+        bytes: Vec<u8>,
+    ) -> Result<(), test_rpc::Error> {
+        tokio::fs::write(&dest, bytes).await.map_err(|error| {
+            log::error!(
+                "Failed to write to \"{dest}\": {error}",
+                dest = dest.display()
+            );
             test_rpc::Error::Syscall
         })?;
         Ok(())

--- a/test/test-runner/src/net.rs
+++ b/test/test-runner/src/net.rs
@@ -35,7 +35,7 @@ pub async fn send_tcp(
         };
 
         #[cfg(target_os = "macos")]
-        sock.bind_device_by_index(Some(interface_index))
+        sock.bind_device_by_index_v4(Some(interface_index))
             .map_err(|error| {
                 log::error!("Failed to set IP_BOUND_IF on socket: {error}");
                 test_rpc::Error::SendTcp
@@ -102,7 +102,7 @@ pub async fn send_udp(
         };
 
         #[cfg(target_os = "macos")]
-        sock.bind_device_by_index(Some(interface_index))
+        sock.bind_device_by_index_v4(Some(interface_index))
             .map_err(|error| {
                 log::error!("Failed to set IP_BOUND_IF on socket: {error}");
                 test_rpc::Error::SendUdp

--- a/test/test-runner/src/sys.rs
+++ b/test/test-runner/src/sys.rs
@@ -216,7 +216,14 @@ pub async fn restart_app() -> Result<(), test_rpc::Error> {
 /// This function waits for the app to successfully shut down.
 #[cfg(target_os = "linux")]
 pub async fn stop_app() -> Result<(), test_rpc::Error> {
-    set_mullvad_daemon_service_state(false).await
+    tokio::process::Command::new("systemctl")
+        .args(["stop", "mullvad-daemon"])
+        .status()
+        .await
+        .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
+    wait_for_service_state(ServiceState::Inactive).await?;
+
+    Ok(())
 }
 
 /// Start the Mullvad VPN application.
@@ -224,7 +231,13 @@ pub async fn stop_app() -> Result<(), test_rpc::Error> {
 /// This function waits for the app to successfully start again.
 #[cfg(target_os = "linux")]
 pub async fn start_app() -> Result<(), test_rpc::Error> {
-    set_mullvad_daemon_service_state(true).await
+    tokio::process::Command::new("systemctl")
+        .args(["start", "mullvad-daemon"])
+        .status()
+        .await
+        .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
+    wait_for_service_state(ServiceState::Running).await?;
+    Ok(())
 }
 
 /// Restart the Mullvad VPN application.
@@ -278,7 +291,9 @@ pub async fn restart_app() -> Result<(), test_rpc::Error> {
 /// This function waits for the app to successfully shut down.
 #[cfg(target_os = "macos")]
 pub async fn stop_app() -> Result<(), test_rpc::Error> {
-    set_mullvad_daemon_service_state(false).await
+    set_launch_daemon_state(false).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    Ok(())
 }
 
 /// Start the Mullvad VPN application.
@@ -286,7 +301,9 @@ pub async fn stop_app() -> Result<(), test_rpc::Error> {
 /// This function waits for the app to successfully start again.
 #[cfg(target_os = "macos")]
 pub async fn start_app() -> Result<(), test_rpc::Error> {
-    set_mullvad_daemon_service_state(true).await
+    set_launch_daemon_state(false).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]
@@ -502,51 +519,6 @@ pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), 
     set_launch_daemon_state(false).await?;
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
     set_launch_daemon_state(true).await?;
-    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-pub async fn set_mullvad_daemon_service_state(on: bool) -> Result<(), test_rpc::Error> {
-    if on {
-        tokio::process::Command::new("systemctl")
-            .args(["start", "mullvad-daemon"])
-            .status()
-            .await
-            .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
-        wait_for_service_state(ServiceState::Running).await?;
-    } else {
-        tokio::process::Command::new("systemctl")
-            .args(["stop", "mullvad-daemon"])
-            .status()
-            .await
-            .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
-        wait_for_service_state(ServiceState::Inactive).await?;
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "windows")]
-pub async fn set_mullvad_daemon_service_state(on: bool) -> Result<(), test_rpc::Error> {
-    if on {
-        tokio::process::Command::new("net")
-            .args(["start", "mullvadvpn"])
-            .status()
-            .await
-            .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
-    } else {
-        tokio::process::Command::new("net")
-            .args(["stop", "mullvadvpn"])
-            .status()
-            .await
-            .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-pub async fn set_mullvad_daemon_service_state(on: bool) -> Result<(), test_rpc::Error> {
-    set_launch_daemon_state(on).await?;
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
     Ok(())
 }


### PR DESCRIPTION
Add regression test which checks that the daemon successfully recovers from a corrupt target state cache. 
If the target state cache is corrupt, the daemon should default to the `Connecting` target state on startup.

Fixes DES-460

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5513)
<!-- Reviewable:end -->
