### PR TITLE
Refactor packet tunnel to use only a single network path observer

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -61,7 +61,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             eventQueue: internalQueue,
             pinger: Pinger(replyQueue: internalQueue),
             tunnelDeviceInfo: adapter,
-            defaultPathObserver: PacketTunnelPathObserver(packetTunnelProvider: self, eventQueue: internalQueue),
             timings: TunnelMonitorTimings()
         )
 

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -15,6 +15,8 @@ extension PacketTunnelActor {
      - Parameter notifyObserverWithCurrentPath: immediately notifies path observer with the current path when set to `true`.
      */
     func startDefaultPathObserver(notifyObserverWithCurrentPath: Bool = false) {
+        logger.trace("Start default path observer.")
+
         defaultPathObserver.start { [weak self] networkPath in
             self?.commandChannel.send(.networkReachability(networkPath))
         }
@@ -26,6 +28,8 @@ extension PacketTunnelActor {
 
     /// Stop observing changes to default path.
     func stopDefaultPathObserver() {
+        logger.trace("Stop default path observer.")
+
         defaultPathObserver.stop()
     }
 
@@ -35,6 +39,8 @@ extension PacketTunnelActor {
      - Parameter networkPath: new default path
      */
     func handleDefaultPathChange(_ networkPath: NetworkPath) {
+        tunnelMonitor.handleNetworkPathUpdate(networkPath)
+
         let newReachability = networkPath.networkReachability
 
         func mutateConnectionState(_ connState: inout ConnectionState) -> Bool {

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorProtocol.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorProtocol.swift
@@ -38,4 +38,7 @@ public protocol TunnelMonitorProtocol: AnyObject {
     /// Cancels internal timers and time dependent data in preparation for device sleep.
     /// Call this method when packet tunnel provider receives a sleep event.
     func onSleep()
+
+    /// Handle changes in network path, eg. update connection state and monitoring.
+    func handleNetworkPathUpdate(_ networkPath: NetworkPath)
 }

--- a/ios/PacketTunnelCoreTests/Mocks/TunnelMonitorStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/TunnelMonitorStub.swift
@@ -64,6 +64,8 @@ class TunnelMonitorStub: TunnelMonitorProtocol {
 
     func onSleep() {}
 
+    func handleNetworkPathUpdate(_ networkPath: NetworkPath) {}
+
     func dispatch(_ event: TunnelMonitorEvent, after delay: DispatchTimeInterval = .never) {
         if case .never = delay {
             onEvent?(event)

--- a/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
+++ b/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
@@ -117,7 +117,6 @@ extension TunnelMonitorTests {
             eventQueue: .main,
             pinger: pinger,
             tunnelDeviceInfo: TunnelDeviceInfoStub(networkStatsProviding: networkCounters),
-            defaultPathObserver: DefaultPathObserverFake(),
             timings: timings
         )
     }


### PR DESCRIPTION
The packet tunnel provider supplies both the actor and tunnel monitor with its own network path observer, which isn't ideal and makes the code harder to follow.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5514)
<!-- Reviewable:end -->
