### PR TITLE
Add missing macros feature to tokio in talpid-tunnel-config-client

### DIFF
--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -15,7 +15,7 @@ talpid-types = { path = "../talpid-types" }
 tonic = { workspace = true }
 tower = { workspace = true }
 prost = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 classic-mceliece-rust = { version = "2.0.0", features = ["mceliece460896f", "zeroize"] }
 pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024", "zeroize"] }
 zeroize = "1.5.7"


### PR DESCRIPTION
Fixes #5503.

A feature was missing from the `tokio` dependency, making it impossible to build just that crate alone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5517)
<!-- Reviewable:end -->
