### PR TITLE
Rename MULLVAD_INTERFACE_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for setting per-app language in system settings.
 - Add support for in app purchases for versions that are released on Google Play.
 
+#### Linux
+- Rename interface name from `wg-mullvad` to `wg0-mullvad`.
+
 
 ## [2023.6-beta1] - 2023-11-23
 ### Added

--- a/talpid-wireguard/src/wireguard_kernel/mod.rs
+++ b/talpid-wireguard/src/wireguard_kernel/mod.rs
@@ -85,7 +85,7 @@ pub enum Error {
     NetworkManager(#[error(source)] nm_tunnel::Error),
 }
 
-pub(crate) const MULLVAD_INTERFACE_NAME: &str = "wg-mullvad";
+pub(crate) const MULLVAD_INTERFACE_NAME: &str = "wg0-mullvad";
 
 #[derive(Debug)]
 pub struct Handle {


### PR DESCRIPTION
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
This PR changes the wireguard interface name on Linux from `wg-mullvad` to `wg0-mullvad`. This helps resolvconf implementations properly order the interfaces. Fixes #5499.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5522)
<!-- Reviewable:end -->
