### PR TITLE
Replace all instances of Calendar.current with Calendar.autoupdatingCurrent

### DIFF
--- a/ios/MullvadVPN/Classes/AccountDataThrottling.swift
+++ b/ios/MullvadVPN/Classes/AccountDataThrottling.swift
@@ -47,7 +47,7 @@ struct AccountDataThrottling {
             break
 
         case .whenCloseToExpiryAndBeyond:
-            guard let closeToExpiry = Calendar.current.date(
+            guard let closeToExpiry = Calendar.autoupdatingCurrent.date(
                 byAdding: .day,
                 value: Self.closeToExpiryDays * -1,
                 to: accountData.expiry

--- a/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
+++ b/ios/MullvadVPN/Classes/CustomDateComponentsFormatting.swift
@@ -22,7 +22,7 @@ extension CustomDateComponentsFormatting {
     static func localizedString(
         from start: Date,
         to end: Date,
-        calendar: Calendar = Calendar.current,
+        calendar: Calendar = Calendar.autoupdatingCurrent,
         unitsStyle: DateComponentsFormatter.UnitsStyle
     ) -> String? {
         let dateComponents = calendar.dateComponents([.year, .day], from: start, to: max(start, end))

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiry.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiry.swift
@@ -14,7 +14,7 @@ struct AccountExpiry {
     var triggerDate: Date? {
         guard let expiryDate else { return nil }
 
-        return Calendar.current.date(
+        return Calendar.autoupdatingCurrent.date(
             byAdding: .day,
             value: -NotificationConfiguration.closeToExpiryTriggerInterval,
             to: expiryDate

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
@@ -82,7 +82,7 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
     private var trigger: UNNotificationTrigger? {
         guard let accountExpiry else { return nil }
 
-        guard let triggerDate = Calendar.current.date(
+        guard let triggerDate = Calendar.autoupdatingCurrent.date(
             byAdding: .day,
             value: -NotificationConfiguration.closeToExpiryTriggerInterval,
             to: accountExpiry
@@ -92,7 +92,7 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
         guard triggerDate > Date() else { return nil }
 
         // Create date components for calendar trigger
-        let dateComponents = Calendar.current.dateComponents(
+        let dateComponents = Calendar.autoupdatingCurrent.dateComponents(
             [.second, .minute, .hour, .day, .month, .year],
             from: triggerDate
         )

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -1175,7 +1175,7 @@ extension TunnelManager {
         case active
 
         fileprivate var date: Date? {
-            let calendar = Calendar.current
+            let calendar = Calendar.autoupdatingCurrent
             let now = Date()
 
             switch self {

--- a/ios/MullvadVPNTests/AccountExpiryTests.swift
+++ b/ios/MullvadVPNTests/AccountExpiryTests.swift
@@ -25,7 +25,7 @@ class AccountExpiryTests: XCTestCase {
     }
 
     func testDateWithinTriggerIntervalReturnsDuration() {
-        let date = Calendar.current.date(
+        let date = Calendar.autoupdatingCurrent.date(
             byAdding: .day,
             value: NotificationConfiguration.closeToExpiryTriggerInterval - 1,
             to: Date()
@@ -36,7 +36,7 @@ class AccountExpiryTests: XCTestCase {
     }
 
     func testDateNotWithinTriggerIntervalReturnsNoDuration() {
-        let date = Calendar.current.date(
+        let date = Calendar.autoupdatingCurrent.date(
             byAdding: .day,
             value: NotificationConfiguration.closeToExpiryTriggerInterval + 1,
             to: Date()


### PR DESCRIPTION
`Calendar.current` does not observe any user made changes to the calendar.

This will not affect caching problems, or calendar values that were cached, but if the user is frequently travelling time zones, this should make a nicer experience for them.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5529)
<!-- Reviewable:end -->
