### PR TITLE
Update settings schema to V4 to fix a migration bug in obfuscation settings

### DIFF
--- a/ios/MullvadSettings/WireGuardObfuscationSettings.swift
+++ b/ios/MullvadSettings/WireGuardObfuscationSettings.swift
@@ -20,7 +20,7 @@ public enum WireGuardObfuscationState: Codable {
 /// The port to select when using UDP-over-TCP obfuscation
 ///
 /// `.automatic` means an algorith will decide between using `port80` or `port5001`
-public enum WireGuardObfuscationPort: UInt16, Codable {
+public enum WireGuardObfuscationPort: UInt16, Codable, CaseIterable {
     case automatic = 0
     case port80 = 80
     case port5001 = 5001
@@ -39,6 +39,14 @@ public enum WireGuardObfuscationPort: UInt16, Codable {
             self = .port5001
         default: self = .automatic
         }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let decodedValue = try? container.decode(UInt16.self)
+
+        let port = WireGuardObfuscationPort.allCases.first(where: { $0.rawValue == decodedValue })
+        self = port ?? .automatic
     }
 }
 


### PR DESCRIPTION
We've introduced breaking changes in the current main that necessitate a new settings schema version. We should add a migration and bump the schema version for this. This can currently be verified by installing a main version over 2023.7.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5543)
<!-- Reviewable:end -->
