### PR TITLE
Block all traffic when device is connecting or reconnecting

### DIFF
--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
@@ -48,6 +48,9 @@ extension PacketTunnelActor {
         case var .connecting(connState):
             if mutateConnectionState(&connState) {
                 state = .connecting(connState)
+                Task {
+                    await blockAllTrafficUntilDeviceIsConnected()
+                }
             }
 
         case var .connected(connState):
@@ -58,6 +61,9 @@ extension PacketTunnelActor {
         case var .reconnecting(connState):
             if mutateConnectionState(&connState) {
                 state = .reconnecting(connState)
+                Task {
+                    await blockAllTrafficUntilDeviceIsConnected()
+                }
             }
 
         case var .error(blockedState):
@@ -127,6 +133,9 @@ extension PacketTunnelActor {
         case var .connecting(connState):
             if setCurrentKeyPolicy(&connState.keyPolicy) {
                 state = .connecting(connState)
+                Task {
+                    await blockAllTrafficUntilDeviceIsConnected()
+                }
                 return true
             }
 
@@ -139,6 +148,9 @@ extension PacketTunnelActor {
         case var .reconnecting(connState):
             if setCurrentKeyPolicy(&connState.keyPolicy) {
                 state = .reconnecting(connState)
+                Task {
+                    await blockAllTrafficUntilDeviceIsConnected()
+                }
                 return true
             }
 

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -65,6 +65,9 @@ extension PacketTunnelActor {
         case var .reconnecting(connState):
             if mutateConnectionState(&connState) {
                 state = .reconnecting(connState)
+                Task {
+                    await blockAllTrafficUntilDeviceIsConnected()
+                }
             }
 
         case var .disconnecting(connState):


### PR DESCRIPTION
This PR extend's @pinkisemils's fix for blocking traffic when in error state to the `connecting` and `reconnecting` states too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5547)
<!-- Reviewable:end -->
