### PR TITLE
Add Ubuntu 23.10 (Mantic) to DEB repository

### DIFF
--- a/ci/buildserver-config.sh
+++ b/ci/buildserver-config.sh
@@ -8,8 +8,12 @@ export CODE_SIGNING_KEY_FINGERPRINT="A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF"
 
 # Debian codenames we support.
 SUPPORTED_DEB_CODENAMES=("sid" "testing" "bookworm" "bullseye")
-# Ubuntu codenames we support (latest two LTS + latest non-LTS)
-SUPPORTED_DEB_CODENAMES+=("jammy" "focal" "lunar")
+# Ubuntu codenames we support (latest two LTS) ...
+SUPPORTED_DEB_CODENAMES+=("jammy" "focal")
+# ... + latest non-LTS Ubuntu. We officially only support the latest non-LTS.
+# But to not cause too much disturbance just when Ubuntu is released, we keep
+# the last two codenames working in the repository.
+SUPPORTED_DEB_CODENAMES+=("lunar" "mantic")
 export SUPPORTED_DEB_CODENAMES
 
 export SUPPORTED_RPM_ARCHITECTURES=("x86_64" "aarch64")


### PR DESCRIPTION
Mantic has been out since ~2 months. We really should have it in our DEB repository. Requested here: https://github.com/mullvad/mullvadvpn-app/issues/3049#issuecomment-1840264691

We officially only support the latest non-LTS release, not further back. But I feel like it would cause a lot of issues for users if we immediately on an Ubuntu release unsupport one version when we switch to the new one. So I propose we have a ~6 month overlap. Meaning we technically support the two latest non-LTS releases in the DEB repository.

We could remove "lunar" (release N-1) earlier than when the next version comes out. But then we would need to change this file more often. Easier to just change it once on every Ubuntu release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5550)
<!-- Reviewable:end -->
