### PR TITLE
Update CVE suppression

### DIFF
--- a/android/config/dependency-check-suppression.xml
+++ b/android/config/dependency-check-suppression.xml
@@ -41,7 +41,7 @@
         <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib.*@.*$</packageUrl>
         <cve>CVE-2022-24329</cve>
     </suppress>
-    <suppress until="2023-12-01Z">
+    <suppress until="2024-06-01Z">
         <notes><![CDATA[
         This CVE only affect the leakCanary build type which is limited to memory leak testing etc.
         This will most likely be solved by bumping to a future version of the leakcanary dependency

--- a/android/test/test-suppression.xml
+++ b/android/test/test-suppression.xml
@@ -92,7 +92,7 @@
         <packageUrl regex="true">^pkg:maven/com\.android\.tools/common@.*$</packageUrl>
         <cve>CVE-2021-4277</cve>
     </suppress>
-    <suppress until="2023-12-01Z">
+    <suppress until="2024-06-01Z">
         <notes><![CDATA[
         This CVE only affect the leakCanary build type which is limited to memory leak testing etc.
         This will most likely be solved by bumping to a future version of the leakcanary dependency


### PR DESCRIPTION
There are still no new release for leak canary, that removed the dependency on `okio` version `2.2.2`, so this PR extends the timeperiod for this CVE warning. This CVE doesn't affect any users since it is only the tests that are affected.

Dependency declaration:
https://github.com/square/leakcanary/blob/8e4c80212dd11571d965a3d1b7b474303f5087a6/gradle/libs.versions.toml#L68
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5553)
<!-- Reviewable:end -->
