### PR TITLE
Add unit test for device validity check

### DIFF
--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -49,15 +49,9 @@ Endpoints may be filtered by:
 Whilst all user selected constraints are always honored, when the user hasn't selected any specific
 constraints, following default ones will take effect:
 
-- If no tunnel protocol is specified for tunnel endpoints, then the behavior is different on Windows
-  and other platforms.
-  - On MacOS and Linux, first two connection attempts will use WireGuard, over a random port at
-    first and then port 53. From the third attempt onwards, OpenVPN will be used, alternating
-    between UDP on any port and TCP on port 443.
-  - On Windows, a migration to WireGuard is ongoing and a percentage value provided by the API tells
-    clients to randomly decide if they will use WireGuard as a default or OpenVPN as a default.
-    The client's decision will persist over time.
-    If the client decides to use WireGuard it will have the same behavior as MacOS and Linux.
+- If no tunnel protocol is specified, the first two connection attempts will use WireGuard, over a
+  random port at first and then port 53. From the third attempt onwards, OpenVPN will be used,
+  alternating between UDP on any port and TCP on port 443.
 
 - If the tunnel protocol is specified as WireGuard and obfuscation mode is set to _Auto_:
   - First two attempts will be used without _udp2tcp_, using a random port on first attempt, and

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2580,14 +2580,11 @@ impl DaemonShutdownHandle {
 }
 
 fn new_selector_config(settings: &Settings) -> SelectorConfig {
-    let default_tunnel_type = TunnelType::Wireguard;
-
     SelectorConfig {
         relay_settings: settings.relay_settings.clone(),
         bridge_state: settings.bridge_state,
         bridge_settings: settings.bridge_settings.clone(),
         obfuscation_settings: settings.obfuscation_settings.clone(),
-        default_tunnel_type,
         custom_lists: settings.custom_lists.clone(),
         relay_overrides: settings.relay_overrides.clone(),
     }

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -762,11 +762,11 @@ impl RelaySelector {
             custom_lists,
         );
         let (preferred_port, preferred_protocol, preferred_tunnel) = self
-            .preferred_tunnel_constraints(
+            .preferred_tunnel_constraints_for_location(
                 retry_attempt,
                 &location,
                 &original_constraints.providers,
-                &original_constraints.ownership,
+                original_constraints.ownership,
             );
 
         let mut relay_constraints = original_constraints.clone();
@@ -1108,31 +1108,43 @@ impl RelaySelector {
             })
     }
 
-    /// Returns preferred constraints
-    #[allow(unused_variables)]
-    fn preferred_tunnel_constraints(
+    /// Return the preferred constraints, on attempt `retry_attempt`, for matching locations
+    fn preferred_tunnel_constraints_for_location(
         &self,
         retry_attempt: u32,
-        location_constraint: &Constraint<ResolvedLocationConstraint>,
-        providers_constraint: &Constraint<Providers>,
-        ownership_constraint: &Constraint<Ownership>,
+        location: &Constraint<ResolvedLocationConstraint>,
+        providers: &Constraint<Providers>,
+        ownership: Constraint<Ownership>,
     ) -> (Constraint<u16>, TransportProtocol, TunnelType) {
-        let location_supports_wireguard = self.parsed_relays.lock().relays().any(|relay| {
+        let parsed_relays = self.parsed_relays.lock();
+        let mut active_location_relays = parsed_relays.relays().filter(|relay| {
             relay.active
-                && matches!(relay.endpoint_data, RelayEndpointData::Wireguard(_))
-                && location_constraint.matches_with_opts(relay, true)
-                && providers_constraint.matches(relay)
-                && ownership_constraint.matches(relay)
+                && location.matches_with_opts(relay, true)
+                && providers.matches(relay)
+                && ownership.matches(relay)
         });
-
-        // If location does not support WireGuard, defer to preferred OpenVPN tunnel
-        // constraints
-        if !location_supports_wireguard {
-            let (preferred_port, preferred_protocol) =
-                Self::preferred_openvpn_constraints(retry_attempt);
-            return (preferred_port, preferred_protocol, TunnelType::OpenVpn);
+        let location_supports_wg = active_location_relays
+            .clone()
+            .any(|relay| matches!(relay.endpoint_data, RelayEndpointData::Wireguard(_)));
+        let location_supports_openvpn = active_location_relays
+            .any(|relay| matches!(relay.endpoint_data, RelayEndpointData::Openvpn));
+        match (location_supports_wg, location_supports_openvpn) {
+            (true, true) | (false, false) => Self::preferred_tunnel_constraints(retry_attempt),
+            (true, false) => {
+                let port = Self::preferred_wireguard_port(retry_attempt);
+                (port, TransportProtocol::Udp, TunnelType::Wireguard)
+            }
+            (false, true) => {
+                let (port, transport) = Self::preferred_openvpn_constraints(retry_attempt);
+                (port, transport, TunnelType::OpenVpn)
+            }
         }
+    }
 
+    /// Return the preferred constraints, on attempt `retry_attempt`, given no other constraints
+    pub const fn preferred_tunnel_constraints(
+        retry_attempt: u32,
+    ) -> (Constraint<u16>, TransportProtocol, TunnelType) {
         // Try out WireGuard in the first two connection attempts, first with any port,
         // afterwards on port 53. Afterwards, connect through OpenVPN alternating between UDP
         // on any port twice and TCP on port 443 once.
@@ -1155,7 +1167,7 @@ impl RelaySelector {
         }
     }
 
-    fn preferred_wireguard_port(retry_attempt: u32) -> Constraint<u16> {
+    const fn preferred_wireguard_port(retry_attempt: u32) -> Constraint<u16> {
         // This ensures that if after the first 2 failed attempts the daemon does not
         // connect, then afterwards 2 of each 4 successive attempts will try to connect
         // on port 53.
@@ -1165,7 +1177,9 @@ impl RelaySelector {
         }
     }
 
-    fn preferred_openvpn_constraints(retry_attempt: u32) -> (Constraint<u16>, TransportProtocol) {
+    const fn preferred_openvpn_constraints(
+        retry_attempt: u32,
+    ) -> (Constraint<u16>, TransportProtocol) {
         // Prefer UDP by default. But if that has failed a couple of times, then try TCP port
         // 443, which works for many with UDP problems. After that, just alternate
         // between protocols.

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -14,6 +14,7 @@ use mullvad_types::{
         SelectedObfuscation, Set, TransportPort, Udp2TcpObfuscationSettings,
     },
     relay_list::{BridgeEndpointData, Relay, RelayEndpointData, RelayList},
+    settings::Settings,
     CustomTunnelEndpoint,
 };
 use parking_lot::{Mutex, MutexGuard};
@@ -223,9 +224,22 @@ pub struct SelectorConfig {
     pub bridge_state: BridgeState,
     pub bridge_settings: BridgeSettings,
     pub obfuscation_settings: ObfuscationSettings,
-    pub default_tunnel_type: TunnelType,
     pub custom_lists: CustomListsSettings,
     pub relay_overrides: Vec<RelayOverride>,
+}
+
+impl Default for SelectorConfig {
+    fn default() -> Self {
+        let default_settings = Settings::default();
+        SelectorConfig {
+            relay_settings: default_settings.relay_settings,
+            bridge_settings: default_settings.bridge_settings,
+            obfuscation_settings: default_settings.obfuscation_settings,
+            bridge_state: default_settings.bridge_state,
+            custom_lists: default_settings.custom_lists,
+            relay_overrides: default_settings.relay_overrides,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -258,6 +272,17 @@ impl RelaySelector {
         RelaySelector {
             config: Arc::new(Mutex::new(config)),
             parsed_relays: Arc::new(Mutex::new(unsynchronized_parsed_relays)),
+        }
+    }
+
+    pub fn from_list(config: SelectorConfig, relay_list: RelayList) -> Self {
+        RelaySelector {
+            parsed_relays: Arc::new(Mutex::new(ParsedRelays::from_relay_list(
+                relay_list,
+                SystemTime::now(),
+                &config.relay_overrides,
+            ))),
+            config: Arc::new(Mutex::new(config)),
         }
     }
 
@@ -295,7 +320,6 @@ impl RelaySelector {
                     constraints,
                     config.bridge_state,
                     retry_attempt,
-                    config.default_tunnel_type,
                     &config.custom_lists,
                 )?;
                 let bridge = match relay.endpoint {
@@ -337,7 +361,6 @@ impl RelaySelector {
         relay_constraints: &RelayConstraints,
         bridge_state: BridgeState,
         retry_attempt: u32,
-        default_tunnel_type: TunnelType,
         custom_lists: &CustomListsSettings,
     ) -> Result<NormalSelectedRelay, Error> {
         #[cfg(target_os = "android")]
@@ -361,7 +384,6 @@ impl RelaySelector {
                 relay_constraints,
                 bridge_state,
                 retry_attempt,
-                default_tunnel_type,
                 custom_lists,
             ),
         }
@@ -689,14 +711,12 @@ impl RelaySelector {
         relay_constraints: &RelayConstraints,
         bridge_state: BridgeState,
         retry_attempt: u32,
-        default_tunnel_type: TunnelType,
         custom_lists: &CustomListsSettings,
     ) -> Result<NormalSelectedRelay, Error> {
         let preferred_constraints = self.preferred_constraints(
             relay_constraints,
             bridge_state,
             retry_attempt,
-            default_tunnel_type,
             custom_lists,
         );
 
@@ -735,7 +755,6 @@ impl RelaySelector {
         original_constraints: &RelayConstraints,
         bridge_state: BridgeState,
         retry_attempt: u32,
-        default_tunnel_type: TunnelType,
         custom_lists: &CustomListsSettings,
     ) -> RelayConstraints {
         let location = ResolvedLocationConstraint::from_constraint(
@@ -745,7 +764,6 @@ impl RelaySelector {
         let (preferred_port, preferred_protocol, preferred_tunnel) = self
             .preferred_tunnel_constraints(
                 retry_attempt,
-                default_tunnel_type,
                 &location,
                 &original_constraints.providers,
                 &original_constraints.ownership,
@@ -1095,44 +1113,24 @@ impl RelaySelector {
     fn preferred_tunnel_constraints(
         &self,
         retry_attempt: u32,
-        default_tunnel_type: TunnelType,
         location_constraint: &Constraint<ResolvedLocationConstraint>,
         providers_constraint: &Constraint<Providers>,
         ownership_constraint: &Constraint<Ownership>,
     ) -> (Constraint<u16>, TransportProtocol, TunnelType) {
-        match default_tunnel_type {
-            TunnelType::OpenVpn => {
-                let location_supports_openvpn = self.parsed_relays.lock().relays().any(|relay| {
-                    relay.active
-                        && relay.endpoint_data == RelayEndpointData::Openvpn
-                        && location_constraint.matches_with_opts(relay, true)
-                        && providers_constraint.matches(relay)
-                        && ownership_constraint.matches(relay)
-                });
+        let location_supports_wireguard = self.parsed_relays.lock().relays().any(|relay| {
+            relay.active
+                && matches!(relay.endpoint_data, RelayEndpointData::Wireguard(_))
+                && location_constraint.matches_with_opts(relay, true)
+                && providers_constraint.matches(relay)
+                && ownership_constraint.matches(relay)
+        });
 
-                if location_supports_openvpn {
-                    let (preferred_port, preferred_protocol) =
-                        Self::preferred_openvpn_constraints(retry_attempt);
-                    return (preferred_port, preferred_protocol, TunnelType::OpenVpn);
-                }
-            }
-            TunnelType::Wireguard => {
-                let location_supports_wireguard = self.parsed_relays.lock().relays().any(|relay| {
-                    relay.active
-                        && matches!(relay.endpoint_data, RelayEndpointData::Wireguard(_))
-                        && location_constraint.matches_with_opts(relay, true)
-                        && providers_constraint.matches(relay)
-                        && ownership_constraint.matches(relay)
-                });
-
-                // If location does not support WireGuard, defer to preferred OpenVPN tunnel
-                // constraints
-                if !location_supports_wireguard {
-                    let (preferred_port, preferred_protocol) =
-                        Self::preferred_openvpn_constraints(retry_attempt);
-                    return (preferred_port, preferred_protocol, TunnelType::OpenVpn);
-                }
-            }
+        // If location does not support WireGuard, defer to preferred OpenVPN tunnel
+        // constraints
+        if !location_supports_wireguard {
+            let (preferred_port, preferred_protocol) =
+                Self::preferred_openvpn_constraints(retry_attempt);
+            return (preferred_port, preferred_protocol, TunnelType::OpenVpn);
         }
 
         // Try out WireGuard in the first two connection attempts, first with any port,
@@ -1339,8 +1337,7 @@ mod test {
     use mullvad_types::{
         custom_list::CustomListsSettings,
         relay_constraints::{
-            BridgeConstraints, GeographicLocationConstraint, RelayConstraints, RelaySettings,
-            WireguardConstraints,
+            GeographicLocationConstraint, RelayConstraints, RelaySettings, WireguardConstraints,
         },
         relay_list::{
             OpenVpnEndpoint, OpenVpnEndpointData, Relay, RelayListCity, RelayListCountry,
@@ -1492,48 +1489,9 @@ mod test {
         },
     });
 
-    fn default_tunnel_type() -> TunnelType {
-        if cfg!(target_os = "windows") {
-            TunnelType::OpenVpn
-        } else {
-            TunnelType::Wireguard
-        }
-    }
-
-    fn new_relay_selector_with_relays(relay_list: RelayList) -> RelaySelector {
-        RelaySelector {
-            parsed_relays: Arc::new(Mutex::new(ParsedRelays::from_relay_list(
-                relay_list,
-                SystemTime::now(),
-                &[],
-            ))),
-            config: Arc::new(Mutex::new(SelectorConfig {
-                relay_settings: RelaySettings::Normal(RelayConstraints {
-                    location: Constraint::Only(LocationConstraint::from(
-                        GeographicLocationConstraint::Country("se".to_owned()),
-                    )),
-                    ..Default::default()
-                }),
-                bridge_settings: BridgeSettings::Normal(BridgeConstraints::default()),
-                obfuscation_settings: ObfuscationSettings {
-                    selected_obfuscation: SelectedObfuscation::Off,
-                    ..Default::default()
-                },
-                bridge_state: BridgeState::Auto,
-                default_tunnel_type: default_tunnel_type(),
-                custom_lists: CustomListsSettings::default(),
-                relay_overrides: vec![],
-            })),
-        }
-    }
-
-    fn new_relay_selector() -> RelaySelector {
-        new_relay_selector_with_relays(RELAYS.clone())
-    }
-
     #[test]
     fn test_preferred_tunnel_protocol() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         // Prefer WG if the location only supports it
         let location = GeographicLocationConstraint::Hostname(
@@ -1551,7 +1509,6 @@ mod test {
             &relay_constraints,
             BridgeState::Off,
             0,
-            TunnelType::Wireguard,
             &CustomListsSettings::default(),
         );
         assert_eq!(
@@ -1565,7 +1522,6 @@ mod test {
                     &relay_constraints,
                     BridgeState::Off,
                     attempt,
-                    TunnelType::Wireguard,
                     &CustomListsSettings::default()
                 )
                 .is_ok());
@@ -1587,7 +1543,6 @@ mod test {
             &relay_constraints,
             BridgeState::Off,
             0,
-            TunnelType::Wireguard,
             &CustomListsSettings::default(),
         );
         assert_eq!(
@@ -1601,7 +1556,6 @@ mod test {
                     &relay_constraints,
                     BridgeState::Off,
                     attempt,
-                    TunnelType::Wireguard,
                     &CustomListsSettings::default()
                 )
                 .is_ok());
@@ -1639,7 +1593,7 @@ mod test {
 
     #[test]
     fn test_wg_entry_hostname_collision() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         let location1 = GeographicLocationConstraint::Hostname(
             "se".to_string(),
@@ -1668,7 +1622,6 @@ mod test {
                 &relay_constraints,
                 BridgeState::Off,
                 0,
-                TunnelType::Wireguard,
                 &CustomListsSettings::default()
             )
             .is_err());
@@ -1682,7 +1635,6 @@ mod test {
                 &relay_constraints,
                 BridgeState::Off,
                 0,
-                TunnelType::Wireguard,
                 &CustomListsSettings::default()
             )
             .is_ok());
@@ -1690,7 +1642,7 @@ mod test {
 
     #[test]
     fn test_wg_entry_filter() -> Result<(), String> {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         let specific_hostname = "se10-wireguard";
 
@@ -1720,7 +1672,6 @@ mod test {
                 &relay_constraints,
                 BridgeState::Off,
                 0,
-                TunnelType::OpenVpn,
                 &CustomListsSettings::default(),
             )
             .map_err(|error| error.to_string())?
@@ -1741,7 +1692,6 @@ mod test {
                 &relay_constraints,
                 BridgeState::Off,
                 0,
-                TunnelType::Wireguard,
                 &CustomListsSettings::default(),
             )
             .map_err(|error| error.to_string())?;
@@ -1760,7 +1710,7 @@ mod test {
 
     #[test]
     fn test_openvpn_constraints() -> Result<(), String> {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         const ACTUAL_TCP_PORT: u16 = 443;
         const ACTUAL_UDP_PORT: u16 = 1194;
@@ -1858,7 +1808,6 @@ mod test {
                     &relay_constraints,
                     BridgeState::Auto,
                     retry_attempt,
-                    default_tunnel_type(),
                     &CustomListsSettings::default(),
                 );
 
@@ -1886,7 +1835,7 @@ mod test {
 
     #[test]
     fn test_bridge_constraints() -> Result<(), String> {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         let location = LocationConstraint::from(GeographicLocationConstraint::Hostname(
             "se".to_string(),
@@ -1907,7 +1856,6 @@ mod test {
             &relay_constraints,
             BridgeState::On,
             0,
-            TunnelType::Wireguard,
             &CustomListsSettings::default(),
         );
         assert_eq!(
@@ -1938,7 +1886,6 @@ mod test {
             &relay_constraints,
             BridgeState::On,
             0,
-            TunnelType::Wireguard,
             &CustomListsSettings::default(),
         );
         assert_eq!(
@@ -1962,7 +1909,6 @@ mod test {
                 &relay_constraints,
                 BridgeState::On,
                 0,
-                TunnelType::Wireguard,
                 &CustomListsSettings::default(),
             );
             assert_eq!(
@@ -1974,7 +1920,6 @@ mod test {
             &relay_constraints,
             BridgeState::On,
             2,
-            TunnelType::Wireguard,
             &CustomListsSettings::default(),
         );
         assert_eq!(
@@ -2005,18 +1950,11 @@ mod test {
             ..RelayConstraints::default()
         };
 
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
-        let result = relay_selector.get_tunnel_endpoint(&relay_constraints, BridgeState::Off, 0, default_tunnel_type(), &CustomListsSettings::default())
+        let result = relay_selector.get_tunnel_endpoint(&relay_constraints, BridgeState::Off, 0, &CustomListsSettings::default())
             .expect("Failed to get relay when tunnel constraints are set to Any and retrying the selection");
-        // Windows will ignore WireGuard until WireGuard is supported well enough
-        // TODO: Remove this caveat once Windows defaults to using WireGuard
-        #[cfg(target_os = "windows")]
-        assert!(
-            matches!(result.endpoint, MullvadEndpoint::OpenVpn(_)) && result.entry_relay.is_none()
-        );
 
-        #[cfg(not(target_os = "windows"))]
         assert!(
             matches!(result.endpoint, MullvadEndpoint::Wireguard(_))
                 && result.entry_relay.is_some()
@@ -2057,9 +1995,9 @@ mod test {
 
     #[test]
     fn test_selecting_wireguard_location_will_consider_multihop() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
-        let result = relay_selector.get_tunnel_endpoint(&WIREGUARD_MULTIHOP_CONSTRAINTS, BridgeState::Off, 0, default_tunnel_type(), &CustomListsSettings::default())
+        let result = relay_selector.get_tunnel_endpoint(&WIREGUARD_MULTIHOP_CONSTRAINTS, BridgeState::Off, 0, &CustomListsSettings::default())
             .expect("Failed to get relay when tunnel constraints are set to default WireGuard multihop constraints");
 
         assert!(result.entry_relay.is_some());
@@ -2068,9 +2006,9 @@ mod test {
 
     #[test]
     fn test_selecting_wg_endpoint_with_udp2tcp_obfuscation() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
-        let result = relay_selector.get_tunnel_endpoint(&WIREGUARD_SINGLEHOP_CONSTRAINTS, BridgeState::Off, 0, default_tunnel_type(), &CustomListsSettings::default())
+        let result = relay_selector.get_tunnel_endpoint(&WIREGUARD_SINGLEHOP_CONSTRAINTS, BridgeState::Off, 0, &CustomListsSettings::default())
             .expect("Failed to get relay when tunnel constraints are set to default WireGuard constraints");
 
         assert!(result.entry_relay.is_none());
@@ -2097,9 +2035,9 @@ mod test {
 
     #[test]
     fn test_selecting_wg_endpoint_with_auto_obfuscation() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
-        let result = relay_selector.get_tunnel_endpoint(&WIREGUARD_SINGLEHOP_CONSTRAINTS, BridgeState::Off, 0, default_tunnel_type(), &CustomListsSettings::default())
+        let result = relay_selector.get_tunnel_endpoint(&WIREGUARD_SINGLEHOP_CONSTRAINTS, BridgeState::Off, 0, &CustomListsSettings::default())
             .expect("Failed to get relay when tunnel constraints are set to default WireGuard constraints");
 
         assert!(result.entry_relay.is_none());
@@ -2128,7 +2066,7 @@ mod test {
 
     #[test]
     fn test_selected_endpoints_use_correct_port_ranges() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         const TCP2UDP_PORTS: [u16; 3] = [80, 443, 5001];
 
@@ -2143,7 +2081,6 @@ mod test {
                     &WIREGUARD_SINGLEHOP_CONSTRAINTS,
                     BridgeState::Off,
                     attempt,
-                    TunnelType::Wireguard,
                     &CustomListsSettings::default(),
                 )
                 .expect("Failed to select a WireGuard relay");
@@ -2176,7 +2113,7 @@ mod test {
 
     #[test]
     fn test_ownership() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
         let mut constraints = RelayConstraints::default();
         for i in 0..10 {
             constraints.ownership = Constraint::Only(Ownership::MullvadOwned);
@@ -2185,7 +2122,6 @@ mod test {
                     &constraints,
                     BridgeState::Auto,
                     i,
-                    TunnelType::Wireguard,
                     &CustomListsSettings::default(),
                 )
                 .unwrap();
@@ -2203,7 +2139,6 @@ mod test {
                     &constraints,
                     BridgeState::Auto,
                     i,
-                    TunnelType::Wireguard,
                     &CustomListsSettings::default(),
                 )
                 .unwrap();
@@ -2220,7 +2155,7 @@ mod test {
     // Make sure server and port selection varies between retry attempts.
     #[test]
     fn test_load_balancing() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         for tunnel_protocol in [
             Constraint::Any,
@@ -2268,7 +2203,7 @@ mod test {
     fn test_providers() {
         const EXPECTED_PROVIDERS: [&str; 2] = ["provider0", "provider2"];
 
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
         let mut constraints = RelayConstraints::default();
 
         for i in 0..10 {
@@ -2280,7 +2215,6 @@ mod test {
                     &constraints,
                     BridgeState::Auto,
                     i,
-                    TunnelType::Wireguard,
                     &CustomListsSettings::default(),
                 )
                 .unwrap();
@@ -2297,7 +2231,7 @@ mod test {
     /// to automatic.
     #[test]
     fn test_auto_bridge() {
-        let relay_selector = new_relay_selector();
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         {
             let mut config = relay_selector.config.lock();
@@ -2412,27 +2346,31 @@ mod test {
         // If include_in_country is false for all relays, a relay must be selected anyway.
         //
 
-        let relay_selector = new_relay_selector_with_relays(relay_list.clone());
+        let relay_selector =
+            RelaySelector::from_list(SelectorConfig::default(), relay_list.clone());
         assert!(relay_selector.get_relay(0).is_ok());
 
         // If include_in_country is true for some relay, it must always be selected.
         //
 
         relay_list.countries[0].cities[0].relays[0].include_in_country = true;
-        let expected_relay = relay_list.countries[0].cities[0].relays[0].clone();
+        let expected_hostname = relay_list.countries[0].cities[0].relays[0].hostname.clone();
 
-        let relay_selector = new_relay_selector_with_relays(relay_list);
+        let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relay_list);
         let (relay, ..) = relay_selector.get_relay(0).expect("expected match");
 
-        assert!(matches!(
-            relay,
-            SelectedRelay::Normal(NormalSelectedRelay {
-                exit_relay: Relay {
-                    hostname,
+        assert!(
+            matches!(
+                relay,
+                SelectedRelay::Normal(NormalSelectedRelay {
+                    exit_relay: Relay {
+                        ref hostname,
+                        ..
+                    },
                     ..
-                },
-                ..
-            }) if hostname == expected_relay.hostname
-        ))
+                }) if hostname == &expected_hostname,
+            ),
+            "found {relay:?}, expected {expected_hostname:?}",
+        )
     }
 }


### PR DESCRIPTION
This PR adds a unit tests for device validity checks. It also removes some outdated or incorrect documentation for the relay selector.

Fix DES-500.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5557)
<!-- Reviewable:end -->
