### PR TITLE
Check if the device is valid on every third connection attempt

### DIFF
--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -63,8 +63,8 @@ constraints, following default ones will take effect:
   _udp2tcp_ all of the time.
 
   If obfuscation is turned _off_, WireGuard connections will first alternate between using
-  a random port and port 53, with 2 attempts each, e.g. first attempt using port 22151, second
-  26107, third attempt and fourth attempt using port 53, and then back to random ports.
+  a random port and port 53, e.g. first attempt using port 22151, second 53, third
+  26107, fourth attempt using port 53, and so on.
 
   If the user has specified a specific port for either _udp2tcp_ or WireGuard, it will override the
   port selection, but it will not change the connection type described above (WireGuard or WireGuard

--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -49,9 +49,13 @@ Endpoints may be filtered by:
 Whilst all user selected constraints are always honored, when the user hasn't selected any specific
 constraints, following default ones will take effect:
 
-- If no tunnel protocol is specified, the first two connection attempts will use WireGuard, over a
-  random port at first and then port 53. From the third attempt onwards, OpenVPN will be used,
-  alternating between UDP on any port and TCP on port 443.
+- If no tunnel protocol is specified, the first three connection attempts will use WireGuard. All
+  remaining attempts will use OpenVPN. If no specific constraints are set:
+  - The first two attempts will connect to a Wireguard server, first on a random port, and then port
+    53.
+  - The third attempt will connect to a Wireguard server on port 80 with _udp2tcp_.
+  - Remaining attempts will connect to OpenVPN servers, first over UDP on two random ports, and then
+    over TCP on port 443. Remaining attempts alternate between TCP and UDP on random ports.
 
 - If the tunnel protocol is specified as WireGuard and obfuscation mode is set to _Auto_:
   - First two attempts will be used without _udp2tcp_, using a random port on first attempt, and

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -46,7 +46,7 @@ const LOGOUT_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Validate the current device once for every `WG_DEVICE_CHECK_THRESHOLD` attempt to set up
 /// a WireGuard tunnel.
-const WG_DEVICE_CHECK_THRESHOLD: usize = 2;
+const WG_DEVICE_CHECK_THRESHOLD: usize = 3;
 
 #[derive(err_derive::Error, Debug, Clone)]
 pub enum Error {

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -1158,12 +1158,11 @@ impl RelaySelector {
     }
 
     const fn preferred_wireguard_port(retry_attempt: u32) -> Constraint<u16> {
-        // This ensures that if after the first 2 failed attempts the daemon does not
-        // connect, then afterwards 2 of each 4 successive attempts will try to connect
-        // on port 53.
-        match retry_attempt % 4 {
-            0 | 1 => Constraint::Any,
-            _ => Constraint::Only(53),
+        // Alternate between using a random port and port 53
+        if retry_attempt % 2 == 0 {
+            Constraint::Any
+        } else {
+            Constraint::Only(53)
         }
     }
 

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -262,7 +262,7 @@ impl Endpoint {
         }
     }
 
-    pub fn from_socket_address(address: SocketAddr, protocol: TransportProtocol) -> Self {
+    pub const fn from_socket_address(address: SocketAddr, protocol: TransportProtocol) -> Self {
         Endpoint { address, protocol }
     }
 }


### PR DESCRIPTION
This PR changes the default constraints somewhat. WireGuard is used three times instead of two: once on a random port, once on port 53, and once using udp2tcp (if obfuscation is `auto`).

In general, when the tunnel protocol is WireGuard and no port is set, the relay selector simply alternates between a random port and port 53.

The device validity check occurs on every third attempt instead of on every other attempt.

Fix DES-486.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5567)
<!-- Reviewable:end -->
