### PR TITLE
Use app build container for building test runner

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,2 @@
-FROM debian:stable
-
-RUN apt-get update && apt-get install -y \
-    gcc curl libdbus-1-dev protobuf-compiler
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+ARG IMAGE=ghcr.io/mullvad/mullvadvpn-app-build:latest
+FROM $IMAGE

--- a/test/build.sh
+++ b/test/build.sh
@@ -3,15 +3,17 @@
 set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+APP_DIR="$SCRIPT_DIR/.."
 cd "$SCRIPT_DIR"
 
 if [[ $TARGET == x86_64-unknown-linux-gnu ]]; then
     mkdir -p .container/cargo-registry
-    podman build -t mullvadvpn-app-tests .
+    container_image=$(cat "$APP_DIR/building/linux-container-image.txt")
+    podman build -t mullvadvpn-app-tests --build-arg IMAGE="${container_image}" .
 
     podman run --rm -it \
         -v "${SCRIPT_DIR}/.container/cargo-registry":/root/.cargo/registry \
-        -v "${SCRIPT_DIR}/..":/src:Z \
+        -v "${APP_DIR}":/src:Z \
         -e CARGO_HOME=/root/.cargo/registry \
         mullvadvpn-app-tests \
         /bin/bash -c "cd /src/test/; cargo build --bin test-runner --release --target ${TARGET}"


### PR DESCRIPTION
Since 96d2e3a9c709b3757a62e8bfe0b559413b125c94 was merged a few days ago, the end-to-end test runner has failed to compile on Linux in Github Actions due to the container image having a too old version of `rustc` to make use of the `is_some_and` feature stabilized in Rust `1.70`.

This PR updates the container image for building the test runner to use the container image for building the Mullvad App.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5569)
<!-- Reviewable:end -->
