### PR TITLE
Add CI workflows for `test` workspace

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -13,6 +13,7 @@ on:
       - '!graphics/**'
       - '!gui/**'
       - '!ios/**'
+      - '!test/**'
       - '!scripts/**'
       - '!windows/**'
       - '!**/**.md'

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -1,0 +1,73 @@
+# Run `clippy` on the `test` workspace
+---
+name: DES Testframework - Clippy
+on:
+  pull_request:
+    paths:
+      - 'test/**/*.rs'
+      - .github/workflows/clippy-test.yml
+      - clippy.toml
+  workflow_dispatch:
+jobs:
+  clippy-check-test:
+    name: Clippy linting of test workspace
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Install build dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdbus-1-dev
+
+      - name: Clippy check
+        working-directory: test
+        shell: bash
+        env:
+          RUSTFLAGS: --deny warnings
+        run: |
+          time cargo clippy --locked -- -W clippy::unused_async
+
+  clippy-check-test-windows:
+    name: Clippy linting of test workspace (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Clippy check
+        working-directory: test
+        shell: bash
+        env:
+          RUSTFLAGS: --deny warnings
+        run: |
+          # Exclude checking test-manager on Windows, since it is not a supported compilation target.
+          time cargo clippy --workspace --exclude test-manager --locked -- -W clippy::unused_async

--- a/.github/workflows/testframework-rustfmt.yml
+++ b/.github/workflows/testframework-rustfmt.yml
@@ -1,0 +1,29 @@
+# Run `cargo fmt --check` on the `test` workspace
+---
+name: DES Testframework - Check formatting
+on:
+  pull_request:
+    paths:
+      - 'test/**/*.rs'
+      - .github/workflows/rustfmt-test.yml
+      - rustfmt.toml
+  workflow_dispatch:
+jobs:
+  check-formatting-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          components: rustfmt
+          default: true
+
+      - name: Check formatting
+        working-directory: test
+        run: |-
+          rustfmt --version
+          cargo fmt -- --check

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -1,0 +1,111 @@
+# Compile the test framework
+---
+name: DES Testframework - Build
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!**/**.md'
+      - '!.github/workflows/**'
+      - '.github/workflows/daemon.yml'
+      - '!android/**'
+      - '!audits/**'
+      - '!build-apk.sh'
+      - '!build.sh'
+      - '!clippy.toml'
+      - '!deny.toml'
+      - '!docs/**'
+      - '!graphics/**'
+      - '!gui/**'
+      - '!ios/**'
+      - '!scripts/**'
+      - '!.*ignore'
+      - '!prepare-release.sh'
+      - '!rustfmt.toml'
+      - '!.yamllint'
+  workflow_dispatch:
+jobs:
+  prepare-build-test-framework-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Use custom container image if specified
+        if: ${{ github.event.inputs.override_container_image != '' }}
+        run: echo "inner_container_image=${{ github.event.inputs.override_container_image }}"
+          >> $GITHUB_ENV
+
+      - name: Use default container image and resolve digest
+        if: ${{ github.event.inputs.override_container_image == '' }}
+        run: |
+          echo "inner_container_image=$(cat ./building/linux-container-image.txt)" >> $GITHUB_ENV
+
+    outputs:
+      container_image: ${{ env.inner_container_image }}
+
+  # Build the test runner + test manager at once.
+  build-test-framework-linux:
+    needs: prepare-build-test-framework-linux
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.prepare-build-test-framework-linux.outputs.container_image }}
+
+    steps:
+      # Fix for HOME path overridden by GH runners when building in containers, see:
+      # https://github.com/actions/runner/issues/863
+      - name: Fix HOME path
+        run: echo "HOME=/root" >> $GITHUB_ENV
+
+      - name: Install system dependencies # Needed to build test-manager, and is not included in the app container.
+        run: apt update && apt install -y pkg-config libssl-dev libpcap-dev
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build test framework
+        working-directory: test
+        run: cargo build --release
+
+  # Build the test runner + test manager at once.
+  build-test-framework-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          default: true
+
+      - name: Build test runner
+        working-directory: test
+        run: cargo build
+
+  # Build only the test-runner binary on Windows. Windows is not a supported host for test-manager.
+  build-test-runner-windows:
+    # Cross-compile the test runner for Windows from Linux.
+    needs: prepare-build-test-framework-linux
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.prepare-build-test-framework-linux.outputs.container_image }}
+    continue-on-error: true
+    steps:
+      # Fix for HOME path overridden by GH runners when building in containers, see:
+      # https://github.com/actions/runner/issues/863
+      - name: Fix HOME path
+        run: echo "HOME=/root" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build test runner
+        working-directory: test
+        run: cargo build --release -p test-runner --target x86_64-pc-windows-gnu

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,2 +1,5 @@
 ARG IMAGE=ghcr.io/mullvad/mullvadvpn-app-build:latest
 FROM $IMAGE
+
+RUN apt-get update && apt-get install -y \
+    pkg-config libssl-dev libpcap-dev

--- a/test/test-manager/src/mullvad_daemon.rs
+++ b/test/test-manager/src/mullvad_daemon.rs
@@ -76,7 +76,7 @@ impl RpcClientProvider {
     }
 }
 
-pub async fn new_rpc_client(
+pub fn new_rpc_client(
     connection_handle: ConnectionHandle,
     mullvad_daemon_transport: GrpcForwarder,
 ) -> RpcClientProvider {

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -35,7 +35,7 @@ pub async fn run(
     let serial_stream =
         tokio_serial::SerialStream::open(&tokio_serial::new(pty_path, BAUD)).unwrap();
     let (runner_transport, mullvad_daemon_transport, mut connection_handle, completion_handle) =
-        test_rpc::transport::create_client_transports(serial_stream).await?;
+        test_rpc::transport::create_client_transports(serial_stream)?;
 
     if !skip_wait {
         connection_handle.wait_for_server().await?;
@@ -45,7 +45,7 @@ pub async fn run(
 
     let client = ServiceClient::new(connection_handle.clone(), runner_transport);
     let mullvad_client =
-        mullvad_daemon::new_rpc_client(connection_handle, mullvad_daemon_transport).await;
+        mullvad_daemon::new_rpc_client(connection_handle, mullvad_daemon_transport);
 
     let mut tests: Vec<_> = inventory::iter::<tests::TestMetadata>().collect();
     tests.sort_by_key(|test| test.priority.unwrap_or(0));

--- a/test/test-rpc/src/transport.rs
+++ b/test/test-rpc/src/transport.rs
@@ -162,7 +162,7 @@ pub fn create_server_transports(
     (runner_forwarder_1, daemon_rx, completion_handle)
 }
 
-pub async fn create_client_transports(
+pub fn create_client_transports(
     serial_stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
 ) -> Result<
     (

--- a/test/test-rpc/src/transport.rs
+++ b/test/test-rpc/src/transport.rs
@@ -120,16 +120,18 @@ impl ConnectionHandle {
     }
 }
 
-pub fn create_server_transports(
-    serial_stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
-) -> (
+type ServerTransports = (
     tarpc::transport::channel::UnboundedChannel<
         ClientMessage<ServiceRequest>,
         Response<ServiceResponse>,
     >,
     GrpcForwarder,
     CompletionHandle,
-) {
+);
+
+pub fn create_server_transports(
+    serial_stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+) -> ServerTransports {
     let (runner_forwarder_1, runner_forwarder_2) = tarpc::transport::channel::unbounded();
 
     let (daemon_rx, mullvad_daemon_forwarder) = tokio::io::duplex(DAEMON_CHANNEL_BUF_SIZE);
@@ -164,18 +166,7 @@ pub fn create_server_transports(
 
 pub fn create_client_transports(
     serial_stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
-) -> Result<
-    (
-        tarpc::transport::channel::UnboundedChannel<
-            Response<ServiceResponse>,
-            ClientMessage<ServiceRequest>,
-        >,
-        GrpcForwarder,
-        ConnectionHandle,
-        CompletionHandle,
-    ),
-    Error,
-> {
+) -> Result<ClientTransports, Error> {
     let (runner_forwarder_1, runner_forwarder_2) = tarpc::transport::channel::unbounded();
 
     let (daemon_rx, mullvad_daemon_forwarder) = tokio::io::duplex(DAEMON_CHANNEL_BUF_SIZE);
@@ -215,6 +206,16 @@ pub fn create_client_transports(
         completion_handle,
     ))
 }
+
+type ClientTransports = (
+    tarpc::transport::channel::UnboundedChannel<
+        Response<ServiceResponse>,
+        ClientMessage<ServiceRequest>,
+    >,
+    GrpcForwarder,
+    ConnectionHandle,
+    CompletionHandle,
+);
 
 #[derive(err_derive::Error, Debug)]
 #[error(no_from)]

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -177,7 +177,7 @@ impl Service for TestServer {
         _: context::Context,
         interface: String,
     ) -> Result<IpAddr, test_rpc::Error> {
-        net::get_interface_ip(&interface).await
+        net::get_interface_ip(&interface)
     }
 
     async fn get_default_interface(self, _: context::Context) -> Result<String, test_rpc::Error> {

--- a/test/test-runner/src/net.rs
+++ b/test/test-runner/src/net.rs
@@ -202,7 +202,7 @@ pub async fn send_ping(
 }
 
 #[cfg(unix)]
-pub async fn get_interface_ip(interface: &str) -> Result<IpAddr, test_rpc::Error> {
+pub fn get_interface_ip(interface: &str) -> Result<IpAddr, test_rpc::Error> {
     // TODO: IPv6
     use std::net::Ipv4Addr;
 
@@ -225,7 +225,7 @@ pub async fn get_interface_ip(interface: &str) -> Result<IpAddr, test_rpc::Error
 }
 
 #[cfg(target_os = "windows")]
-pub async fn get_interface_ip(interface: &str) -> Result<IpAddr, test_rpc::Error> {
+pub fn get_interface_ip(interface: &str) -> Result<IpAddr, test_rpc::Error> {
     // TODO: IPv6
 
     get_interface_ip_for_family(interface, talpid_windows::net::AddressFamily::Ipv4)

--- a/test/test-runner/src/sys.rs
+++ b/test/test-runner/src/sys.rs
@@ -379,6 +379,7 @@ pub async fn set_daemon_log_level(verbosity_level: Verbosity) -> Result<(), test
 }
 
 #[cfg(target_os = "macos")]
+#[allow(clippy::unused_async)]
 pub async fn set_daemon_log_level(_verbosity_level: Verbosity) -> Result<(), test_rpc::Error> {
     // TODO: Not implemented
     log::warn!("Setting log level is not implemented on macOS");


### PR DESCRIPTION
The testing framework living in `test/` historically had no CI checks. It didn't use to have it while it was developed in a separate repository, nor did it get any during its adoption into the app repository.

This PR introduces some basic CI checks when application logic is touched in the `test` workspace:
- `rustfmt --check` is run on all Rust source files
- `clippy` is run with the same configuration as the main app
- `test-runner` is compiled for all supported platforms (Linux, Windows & macOS)
- `test-manager` is compiled for all supported host platforms (Linux & macOS)

This should hopefully stabilize the development done to the testing framework. There is still more to be done on the CI front in the testing framework, but this is a good start.

Fixes DES-502

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5575)
<!-- Reviewable:end -->
