### PR TITLE
Fix missing test runner binary in CI

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -15,6 +15,7 @@ if [[ $TARGET == x86_64-unknown-linux-gnu ]]; then
         -v "${SCRIPT_DIR}/.container/cargo-registry":/root/.cargo/registry \
         -v "${APP_DIR}":/src:Z \
         -e CARGO_HOME=/root/.cargo/registry \
+        -e CARGO_TARGET_DIR=/src/test/target \
         mullvadvpn-app-tests \
         /bin/bash -c "cd /src/test/; cargo build --bin test-runner --release --target ${TARGET}"
 else

--- a/test/test-runner/src/sys.rs
+++ b/test/test-runner/src/sys.rs
@@ -301,7 +301,7 @@ pub async fn stop_app() -> Result<(), test_rpc::Error> {
 /// This function waits for the app to successfully start again.
 #[cfg(target_os = "macos")]
 pub async fn start_app() -> Result<(), test_rpc::Error> {
-    set_launch_daemon_state(false).await?;
+    set_launch_daemon_state(true).await?;
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
     Ok(())
 }


### PR DESCRIPTION
The new image used for building the test framework (since #5569) overrode `CARGO_TARGET_DIR`, which lead to the `test-runner` artifact being output in an unexpected target directory. This PR sets the expected `CARGO_TARGET_DIR` explicitly.

This PR also drive-by fixes an issue with the macOS test-runner not being able to start the mullvad-daemon after it has been stopped by a test case, causing the test suite to halt.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5585)
<!-- Reviewable:end -->
