### PR TITLE
Implement support for custom OpenVPN socks5 bridge client in daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Remove `--location` flag from `mullvad status` CLI. Location and IP will now always
   be printed (if available). `mullvad status listen` no longer prints location info.
+- Custom socks5 bridges get a new CLI interface and now work without split tunneling or root.
+  In the CLI these can be found under `mullvad bridge set custom`.
 
 #### Android
 - Migrate to Compose Navigation which also improves screen transition animations.

--- a/gui/src/main/default-settings.ts
+++ b/gui/src/main/default-settings.ts
@@ -29,11 +29,13 @@ export function getDefaultSettings(): ISettings {
       },
     },
     bridgeSettings: {
+      type: 'normal',
       normal: {
         location: 'any',
         providers: [],
         ownership: Ownership.any,
       },
+      custom: undefined,
     },
     bridgeState: 'auto',
     tunnelOptions: {

--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -624,17 +624,13 @@ export default class AppRenderer {
   private setBridgeSettings(bridgeSettings: BridgeSettings) {
     const actions = this.reduxActions;
 
-    if ('normal' in bridgeSettings) {
-      actions.settings.updateBridgeSettings({
-        normal: {
-          location: liftConstraint(bridgeSettings.normal.location),
-        },
-      });
-    } else if ('custom' in bridgeSettings) {
-      actions.settings.updateBridgeSettings({
-        custom: bridgeSettings.custom,
-      });
-    }
+    actions.settings.updateBridgeSettings({
+      type: bridgeSettings.type,
+      normal: {
+        location: liftConstraint(bridgeSettings.normal.location),
+      },
+      custom: bridgeSettings.custom,
+    });
   }
 
   private onDaemonConnected() {

--- a/gui/src/renderer/components/select-location/select-location-hooks.ts
+++ b/gui/src/renderer/components/select-location/select-location-hooks.ts
@@ -11,6 +11,7 @@ import log from '../../../shared/logging';
 import { useAppContext } from '../../context';
 import { useRelaySettingsModifier } from '../../lib/constraint-updater';
 import { useHistory } from '../../lib/history';
+import { useSelector } from '../../redux/store';
 import { LocationType, SpecialBridgeLocationType } from './select-location-types';
 import { useSelectLocationContext } from './SelectLocationContainer';
 
@@ -88,6 +89,7 @@ function useOnSelectLocation() {
 export function useOnSelectBridgeLocation() {
   const { updateBridgeSettings } = useAppContext();
   const { setLocationType } = useSelectLocationContext();
+  const bridgeSettings = useSelector((state) => state.settings.bridgeSettings);
 
   const setLocation = useCallback(async (bridgeUpdate: BridgeSettings) => {
     if (bridgeUpdate) {
@@ -101,10 +103,14 @@ export function useOnSelectBridgeLocation() {
     }
   }, []);
 
-  const onSelectRelay = useCallback((location: RelayLocation) => {
-    const bridgeUpdate = new BridgeSettingsBuilder().location.fromRaw(location).build();
-    return setLocation(bridgeUpdate);
-  }, []);
+  const onSelectRelay = useCallback(
+    (location: RelayLocation) => {
+      const bridgeUpdate = new BridgeSettingsBuilder().location.fromRaw(location).build();
+      bridgeUpdate.custom = bridgeSettings.custom;
+      return setLocation(bridgeUpdate);
+    },
+    [bridgeSettings],
+  );
 
   const onSelectSpecial = useCallback((location: SpecialBridgeLocationType) => {
     switch (location) {

--- a/gui/src/renderer/lib/utilityHooks.ts
+++ b/gui/src/renderer/lib/utilityHooks.ts
@@ -67,5 +67,5 @@ export function useNormalRelaySettings() {
 
 export function useNormalBridgeSettings() {
   const bridgeSettings = useSelector((state) => state.settings.bridgeSettings);
-  return 'normal' in bridgeSettings ? bridgeSettings.normal : undefined;
+  return bridgeSettings.normal;
 }

--- a/gui/src/renderer/redux/settings/reducers.ts
+++ b/gui/src/renderer/redux/settings/reducers.ts
@@ -1,6 +1,7 @@
 import { IWindowsApplication } from '../../../shared/application-types';
 import {
   BridgeState,
+  BridgeType,
   CustomLists,
   IDnsOptions,
   IpVersion,
@@ -51,13 +52,11 @@ export type RelaySettingsRedux =
       };
     };
 
-export type BridgeSettingsRedux =
-  | {
-      normal: NormalBridgeSettingsRedux;
-    }
-  | {
-      custom: ProxySettings;
-    };
+export type BridgeSettingsRedux = {
+  type: BridgeType;
+  normal: NormalBridgeSettingsRedux;
+  custom?: ProxySettings;
+};
 
 export interface IRelayLocationRelayRedux {
   hostname: string;
@@ -140,9 +139,11 @@ const initialState: ISettingsReduxState = {
   allowLan: false,
   enableIpv6: true,
   bridgeSettings: {
+    type: 'normal',
     normal: {
       location: 'any',
     },
+    custom: undefined,
   },
   bridgeState: 'auto',
   blockWhenDisconnected: false,

--- a/gui/src/shared/bridge-settings-builder.ts
+++ b/gui/src/shared/bridge-settings-builder.ts
@@ -7,11 +7,13 @@ export default class BridgeSettingsBuilder {
   public build(): BridgeSettings {
     if (this.payload.location) {
       return {
+        type: 'normal',
         normal: {
           location: this.payload.location,
           providers: this.payload.providers ?? [],
           ownership: this.payload.ownership ?? Ownership.any,
         },
+        custom: undefined,
       };
     } else {
       throw new Error('Unsupported configuration');

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -345,15 +345,20 @@ export interface IDnsOptions {
   };
 }
 
-export type ProxySettings = ILocalProxySettings | IRemoteProxySettings | IShadowsocksProxySettings;
+export type ProxySettings =
+  | { local: ILocalProxySettings }
+  | { remote: IRemoteProxySettings }
+  | { shadowsocks: IShadowsocksProxySettings };
 
 export interface ILocalProxySettings {
-  port: number;
-  peer: string;
+  localPort: number;
+  remoteIp: string;
+  remotePort: number;
 }
 
 export interface IRemoteProxySettings {
-  address: string;
+  ip: string;
+  port: number;
   auth?: IRemoteProxyAuth;
 }
 
@@ -363,7 +368,8 @@ export interface IRemoteProxyAuth {
 }
 
 export interface IShadowsocksProxySettings {
-  peer: string;
+  ip: string;
+  port: number;
   password: string;
   cipher: string;
 }
@@ -451,7 +457,13 @@ export interface IBridgeConstraints {
   ownership: Ownership;
 }
 
-export type BridgeSettings = { normal: IBridgeConstraints } | { custom: ProxySettings };
+export type BridgeType = 'normal' | 'custom';
+
+export interface BridgeSettings {
+  type: BridgeType;
+  normal: IBridgeConstraints;
+  custom?: ProxySettings;
+}
 
 export interface ISocketAddress {
   host: string;

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -1,17 +1,22 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Subcommand;
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::{
     relay_constraints::{
-        BridgeConstraints, BridgeConstraintsFormatter, BridgeSettings, BridgeState, Constraint,
-        LocationConstraint, Ownership, Provider, Providers,
+        BridgeConstraintsFormatter, BridgeState, BridgeType, Constraint, LocationConstraint,
+        Ownership, Provider, Providers,
     },
     relay_list::RelayEndpointData,
 };
-use std::net::{IpAddr, SocketAddr};
-use talpid_types::net::openvpn::{self, SHADOWSOCKS_CIPHERS};
+use talpid_types::net::proxy::{CustomProxy, Shadowsocks, Socks5Local, Socks5Remote};
 
-use super::{relay::resolve_location_constraint, relay_constraints::LocationArgs};
+use crate::cmds::proxies::pp::CustomProxyFormatter;
+
+use super::{
+    proxies::{ProxyEditParams, ShadowsocksAdd, Socks5LocalAdd, Socks5RemoteAdd},
+    relay::resolve_location_constraint,
+    relay_constraints::LocationArgs,
+};
 
 #[derive(Subcommand, Debug)]
 pub enum Bridge {
@@ -73,73 +78,48 @@ pub enum SetCommands {
 
     /// Configure a SOCKS5 proxy
     #[clap(subcommand)]
-    Custom(SetCustomCommands),
+    Custom(CustomCommands),
 }
 
 #[derive(Subcommand, Debug, Clone)]
-pub enum SetCustomCommands {
+pub enum CustomCommands {
+    /// Create or update and enable the custom bridge configuration.
+    #[clap(subcommand)]
+    Set(AddCustomCommands),
+    /// Edit an existing custom bridge configuration.
+    Edit(ProxyEditParams),
+    /// Use an existing custom bridge configuration.
+    Use,
+    /// Stop using the custom bridge configuration.
+    Disable,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum AddCustomCommands {
+    #[clap(subcommand)]
+    Socks5(AddSocks5Commands),
+    /// Configure bundled Shadowsocks proxy
+    Shadowsocks {
+        #[clap(flatten)]
+        add: ShadowsocksAdd,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum AddSocks5Commands {
     /// Configure a local SOCKS5 proxy
-    #[cfg_attr(
-        target_os = "linux",
-        clap(
-            about = "Registers a local SOCKS5 proxy. The server must be excluded using \
-        'mullvad-exclude', or `SO_MARK` must be set to '0x6d6f6c65', in order \
-        to bypass firewall restrictions"
-        )
-    )]
-    #[cfg_attr(
-        target_os = "windows",
-        clap(
-            about = "Registers a local SOCKS5 proxy. The server must be excluded using \
-        split tunneling in order to bypass firewall restrictions"
-        )
-    )]
-    #[cfg_attr(
-        target_os = "macos",
-        clap(
-            about = "Registers a local SOCKS5 proxy. The server must run as root to bypass \
-        firewall restrictions"
-        )
+    #[clap(
+        about = "Registers a local SOCKS5 proxy. Will allow all local programs to leak traffic *only* to the remote endpoint."
     )]
     Local {
-        /// The port that the server on localhost is listening on
-        local_port: u16,
-        /// The IP of the remote peer
-        remote_ip: IpAddr,
-        /// The port of the remote peer
-        remote_port: u16,
+        #[clap(flatten)]
+        add: Socks5LocalAdd,
     },
 
     /// Configure a remote SOCKS5 proxy
     Remote {
-        /// The IP of the remote proxy server
-        remote_ip: IpAddr,
-        /// The port of the remote proxy server
-        remote_port: u16,
-
-        /// Username for authentication
-        #[arg(requires = "password")]
-        username: Option<String>,
-        /// Password for authentication
-        #[arg(requires = "username")]
-        password: Option<String>,
-    },
-
-    /// Configure bundled Shadowsocks proxy
-    Shadowsocks {
-        /// The IP of the remote Shadowsocks server
-        remote_ip: IpAddr,
-        /// The port of the remote Shadowsocks server
-        #[arg(default_value = "443")]
-        remote_port: u16,
-
-        /// Password for authentication
-        #[arg(default_value = "mullvad")]
-        password: String,
-
-        /// Cipher to use
-        #[arg(value_parser = SHADOWSOCKS_CIPHERS, default_value = "aes-256-gcm")]
-        cipher: String,
+        #[clap(flatten)]
+        add: Socks5RemoteAdd,
     },
 }
 
@@ -188,133 +168,35 @@ impl Bridge {
                 };
                 Self::update_bridge_settings(&mut rpc, None, Some(providers), None).await
             }
-            SetCommands::Custom(subcmd) => Self::set_custom(subcmd).await,
+            SetCommands::Custom(subcmd) => Self::handle_custom(subcmd).await,
         }
-    }
-
-    async fn set_custom(subcmd: SetCustomCommands) -> Result<()> {
-        match subcmd {
-            SetCustomCommands::Local {
-                local_port,
-                remote_ip,
-                remote_port,
-            } => {
-                let local_proxy = openvpn::LocalProxySettings {
-                    port: local_port,
-                    peer: SocketAddr::new(remote_ip, remote_port),
-                };
-                let packed_proxy = openvpn::ProxySettings::Local(local_proxy);
-                if let Err(error) = openvpn::validate_proxy_settings(&packed_proxy) {
-                    panic!("{}", error);
-                }
-
-                let mut rpc = MullvadProxyClient::new().await?;
-                rpc.set_bridge_settings(BridgeSettings::Custom(packed_proxy))
-                    .await?;
-            }
-            SetCustomCommands::Remote {
-                remote_ip,
-                remote_port,
-                username,
-                password,
-            } => {
-                let auth = match (username, password) {
-                    (Some(username), Some(password)) => {
-                        Some(openvpn::ProxyAuth { username, password })
-                    }
-                    _ => None,
-                };
-                let proxy = openvpn::RemoteProxySettings {
-                    address: SocketAddr::new(remote_ip, remote_port),
-                    auth,
-                };
-                let packed_proxy = openvpn::ProxySettings::Remote(proxy);
-                if let Err(error) = openvpn::validate_proxy_settings(&packed_proxy) {
-                    panic!("{}", error);
-                }
-
-                let mut rpc = MullvadProxyClient::new().await?;
-                rpc.set_bridge_settings(BridgeSettings::Custom(packed_proxy))
-                    .await?;
-            }
-            SetCustomCommands::Shadowsocks {
-                remote_ip,
-                remote_port,
-                password,
-                cipher,
-            } => {
-                let proxy = openvpn::ShadowsocksProxySettings {
-                    peer: SocketAddr::new(remote_ip, remote_port),
-                    password,
-                    cipher,
-                    #[cfg(target_os = "linux")]
-                    fwmark: None,
-                };
-                let packed_proxy = openvpn::ProxySettings::Shadowsocks(proxy);
-                if let Err(error) = openvpn::validate_proxy_settings(&packed_proxy) {
-                    panic!("{}", error);
-                }
-
-                let mut rpc = MullvadProxyClient::new().await?;
-                rpc.set_bridge_settings(BridgeSettings::Custom(packed_proxy))
-                    .await?;
-            }
-        }
-
-        println!("Updated bridge settings");
-        Ok(())
     }
 
     async fn get() -> Result<()> {
         let mut rpc = MullvadProxyClient::new().await?;
         let settings = rpc.get_settings().await?;
         println!("Bridge state: {}", settings.bridge_state);
-        match settings.bridge_settings {
-            BridgeSettings::Custom(proxy) => match proxy {
-                openvpn::ProxySettings::Local(local_proxy) => Self::print_local_proxy(&local_proxy),
-                openvpn::ProxySettings::Remote(remote_proxy) => {
-                    Self::print_remote_proxy(&remote_proxy)
-                }
-                openvpn::ProxySettings::Shadowsocks(shadowsocks_proxy) => {
-                    Self::print_shadowsocks_proxy(&shadowsocks_proxy)
-                }
-            },
-            BridgeSettings::Normal(ref constraints) => {
-                println!(
-                    "Bridge constraints: {}",
-                    BridgeConstraintsFormatter {
-                        constraints,
-                        custom_lists: &settings.custom_lists
-                    }
-                )
+        println!(
+            "Active bridge type: {}",
+            settings.bridge_settings.bridge_type
+        );
+
+        println!("Normal constraints");
+        println!(
+            "{:<4}{}",
+            "",
+            BridgeConstraintsFormatter {
+                constraints: &settings.bridge_settings.normal,
+                custom_lists: &settings.custom_lists
             }
-        };
-        Ok(())
-    }
+        );
 
-    fn print_local_proxy(proxy: &openvpn::LocalProxySettings) {
-        println!("proxy: local");
-        println!("  local port: {}", proxy.port);
-        println!("  peer address: {}", proxy.peer);
-    }
-
-    fn print_remote_proxy(proxy: &openvpn::RemoteProxySettings) {
-        println!("proxy: remote");
-        println!("  server address: {}", proxy.address);
-
-        if let Some(ref auth) = proxy.auth {
-            println!("  auth username: {}", auth.username);
-            println!("  auth password: {}", auth.password);
-        } else {
-            println!("  auth: none");
+        if let Some(ref custom_proxy) = settings.bridge_settings.custom {
+            println!("Custom proxy");
+            println!("{}", CustomProxyFormatter { custom_proxy });
         }
-    }
 
-    fn print_shadowsocks_proxy(proxy: &openvpn::ShadowsocksProxySettings) {
-        println!("proxy: Shadowsocks");
-        println!("  peer address: {}", proxy.peer);
-        println!("  password: {}", proxy.password);
-        println!("  cipher: {}", proxy.cipher);
+        Ok(())
     }
 
     async fn list() -> Result<()> {
@@ -379,33 +261,99 @@ impl Bridge {
         providers: Option<Constraint<Providers>>,
         ownership: Option<Constraint<Ownership>>,
     ) -> Result<()> {
-        let constraints = match rpc.get_settings().await?.bridge_settings {
-            BridgeSettings::Normal(mut constraints) => {
-                if let Some(new_location) = location {
-                    constraints.location = new_location;
-                }
-                if let Some(new_providers) = providers {
-                    constraints.providers = new_providers;
-                }
-                if let Some(new_ownership) = ownership {
-                    constraints.ownership = new_ownership;
-                }
-                constraints
-            }
-            _ => BridgeConstraints {
-                location: location
-                    .unwrap_or(Constraint::Any)
-                    .map(LocationConstraint::from),
-                providers: providers.unwrap_or(Constraint::Any),
-                ownership: ownership.unwrap_or(Constraint::Any),
-            },
-        };
+        let mut settings = rpc.get_settings().await?.bridge_settings;
+        if let Some(new_location) = location {
+            settings.normal.location = new_location;
+        }
+        if let Some(new_providers) = providers {
+            settings.normal.providers = new_providers;
+        }
+        if let Some(new_ownership) = ownership {
+            settings.normal.ownership = new_ownership;
+        }
 
-        rpc.set_bridge_settings(BridgeSettings::Normal(constraints))
-            .await?;
+        settings.bridge_type = BridgeType::Normal;
+
+        rpc.set_bridge_settings(settings).await?;
 
         println!("Updated bridge settings");
 
         Ok(())
+    }
+
+    pub async fn handle_custom(subcmd: CustomCommands) -> Result<()> {
+        match subcmd {
+            CustomCommands::Set(set_custom_commands) => {
+                Self::custom_bridge_set(set_custom_commands).await
+            }
+            CustomCommands::Edit(edit) => Self::custom_bridge_edit(edit).await,
+            CustomCommands::Use => Self::custom_bridge_use().await,
+            CustomCommands::Disable => Self::custom_bridge_disable().await,
+        }
+    }
+
+    async fn custom_bridge_edit(edit: ProxyEditParams) -> Result<()> {
+        let mut rpc = MullvadProxyClient::new().await?;
+        let mut settings = rpc.get_settings().await?;
+
+        let Some(ref mut custom_bridge) = settings.bridge_settings.custom else {
+            bail!("Can not edit as there is no currently saved custom bridge");
+        };
+
+        match custom_bridge {
+            CustomProxy::Shadowsocks(ss) => *ss = edit.merge_shadowsocks(ss),
+            CustomProxy::Socks5Local(local) => *local = edit.merge_socks_local(local),
+            CustomProxy::Socks5Remote(remote) => *remote = edit.merge_socks_remote(remote),
+        };
+
+        rpc.set_bridge_settings(settings.bridge_settings)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn custom_bridge_use() -> Result<()> {
+        let mut rpc = MullvadProxyClient::new().await?;
+
+        let mut settings = rpc.get_settings().await?;
+        if settings.bridge_settings.custom.is_none() {
+            bail!("Cannot enable custom bridge as there are no settings");
+        }
+        settings.bridge_settings.bridge_type = BridgeType::Custom;
+        rpc.set_bridge_settings(settings.bridge_settings).await?;
+
+        Ok(())
+    }
+
+    async fn custom_bridge_disable() -> Result<()> {
+        let mut rpc = MullvadProxyClient::new().await?;
+        let mut settings = rpc.get_settings().await?;
+
+        settings.bridge_settings.bridge_type = BridgeType::Normal;
+
+        rpc.set_bridge_settings(settings.bridge_settings).await?;
+        Ok(())
+    }
+
+    async fn custom_bridge_set(set_commands: AddCustomCommands) -> Result<()> {
+        let mut rpc = MullvadProxyClient::new().await?;
+        let mut settings = rpc.get_settings().await?;
+
+        settings.bridge_settings.custom = Some(match set_commands {
+            AddCustomCommands::Socks5(AddSocks5Commands::Local { add }) => {
+                CustomProxy::Socks5Local(Socks5Local::from(add))
+            }
+            AddCustomCommands::Socks5(AddSocks5Commands::Remote { add }) => {
+                CustomProxy::Socks5Remote(Socks5Remote::from(add))
+            }
+            AddCustomCommands::Shadowsocks { add } => {
+                CustomProxy::Shadowsocks(Shadowsocks::from(add))
+            }
+        });
+
+        settings.bridge_settings.bridge_type = BridgeType::Custom;
+
+        rpc.set_bridge_settings(settings.bridge_settings)
+            .await
+            .map_err(anyhow::Error::from)
     }
 }

--- a/mullvad-cli/src/cmds/mod.rs
+++ b/mullvad-cli/src/cmds/mod.rs
@@ -13,6 +13,7 @@ pub mod import_settings;
 pub mod lan;
 pub mod lockdown;
 pub mod obfuscation;
+pub mod proxies;
 pub mod relay;
 pub mod relay_constraints;
 pub mod reset;

--- a/mullvad-cli/src/cmds/proxies.rs
+++ b/mullvad-cli/src/cmds/proxies.rs
@@ -1,0 +1,214 @@
+use std::net::{IpAddr, SocketAddr};
+use talpid_types::net::{
+    proxy::{Shadowsocks, Socks5Local, Socks5Remote, SocksAuth, SHADOWSOCKS_CIPHERS},
+    Endpoint, TransportProtocol,
+};
+
+use clap::Args;
+
+#[derive(Args, Debug, Clone)]
+pub struct Socks5LocalAdd {
+    /// The port that the server on localhost is listening on
+    pub local_port: u16,
+    /// The IP of the remote peer
+    pub remote_ip: IpAddr,
+    /// The port of the remote peer
+    pub remote_port: u16,
+    /// The Mullvad App can not know which transport protocol that the
+    /// remote peer accepts, but it needs to know this in order to correctly
+    /// exempt the connection traffic in the firewall.
+    ///
+    /// By default, the transport protocol is assumed to be `TCP`, but it
+    /// can optionally be set to `UDP` as well.
+    #[arg(long, default_value_t = TransportProtocol::Tcp)]
+    pub transport_protocol: TransportProtocol,
+}
+
+impl From<Socks5LocalAdd> for Socks5Local {
+    fn from(add: Socks5LocalAdd) -> Self {
+        Self {
+            remote_endpoint: Endpoint {
+                address: SocketAddr::new(add.remote_ip, add.remote_port),
+                protocol: add.transport_protocol,
+            },
+            local_port: add.local_port,
+        }
+    }
+}
+
+// We do not support setting the protocol as anything other than tcp for remote socks5 servers
+#[derive(Args, Debug, Clone)]
+pub struct Socks5RemoteAdd {
+    /// The IP of the remote proxy server
+    pub remote_ip: IpAddr,
+    /// The port of the remote proxy server
+    pub remote_port: u16,
+
+    #[clap(flatten)]
+    pub authentication: Option<SocksAuthentication>,
+}
+
+impl From<Socks5RemoteAdd> for Socks5Remote {
+    fn from(add: Socks5RemoteAdd) -> Self {
+        Self {
+            endpoint: SocketAddr::new(add.remote_ip, add.remote_port),
+            auth: add.authentication.map(|auth| SocksAuth {
+                username: auth.username,
+                password: auth.password,
+            }),
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ShadowsocksAdd {
+    /// The IP of the remote Shadowsocks-proxy
+    pub remote_ip: IpAddr,
+    /// Port on which the remote Shadowsocks-proxy listens for traffic
+    pub remote_port: u16,
+    /// Password for authentication
+    pub password: String,
+    /// Cipher to use
+    #[arg(long, value_parser = SHADOWSOCKS_CIPHERS)]
+    pub cipher: String,
+}
+
+impl From<ShadowsocksAdd> for Shadowsocks {
+    fn from(add: ShadowsocksAdd) -> Self {
+        Self {
+            endpoint: SocketAddr::new(add.remote_ip, add.remote_port),
+            password: add.password,
+            cipher: add.cipher,
+        }
+    }
+}
+
+#[derive(Args, Debug, Clone)]
+#[group(requires_all = ["username", "password"])] // https://github.com/clap-rs/clap/issues/5092
+pub struct SocksAuthentication {
+    /// Username for authentication against a remote SOCKS5 proxy
+    #[arg(short, long, required = false)]
+    pub username: String,
+    /// Password for authentication against a remote SOCKS5 proxy
+    #[arg(short, long, required = false)]
+    pub password: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ProxyEditParams {
+    /// Username for authentication [Socks5 (Remote proxy)]
+    #[arg(long)]
+    pub username: Option<String>,
+    /// Password for authentication [Socks5 (Remote proxy), Shadowsocks]
+    #[arg(long)]
+    pub password: Option<String>,
+    /// Cipher to use [Shadowsocks]
+    #[arg(value_parser = SHADOWSOCKS_CIPHERS, long)]
+    pub cipher: Option<String>,
+    /// The IP of the remote proxy server [Socks5 (Local & Remote proxy), Shadowsocks]
+    #[arg(long)]
+    pub ip: Option<IpAddr>,
+    /// The port of the remote proxy server [Socks5 (Local & Remote proxy), Shadowsocks]
+    #[arg(long)]
+    pub port: Option<u16>,
+    /// The port that the server on localhost is listening on [Socks5 (Local proxy)]
+    #[arg(long)]
+    pub local_port: Option<u16>,
+    /// The transport protocol used by the remote proxy [Socks5 (Local proxy)]
+    #[arg(long)]
+    pub transport_protocol: Option<TransportProtocol>,
+}
+
+impl ProxyEditParams {
+    pub fn merge_socks_local(self, local: &Socks5Local) -> Socks5Local {
+        let remote_ip = self.ip.unwrap_or(local.remote_endpoint.address.ip());
+        let remote_port = self.port.unwrap_or(local.remote_endpoint.address.port());
+        let local_port = self.local_port.unwrap_or(local.local_port);
+        let remote_peer_transport_protocol = self
+            .transport_protocol
+            .unwrap_or(local.remote_endpoint.protocol);
+        Socks5Local::new_with_transport_protocol(
+            (remote_ip, remote_port),
+            local_port,
+            remote_peer_transport_protocol,
+        )
+    }
+
+    pub fn merge_socks_remote(self, remote: &Socks5Remote) -> Socks5Remote {
+        let ip = self.ip.unwrap_or(remote.endpoint.ip());
+        let port = self.port.unwrap_or(remote.endpoint.port());
+        match &remote.auth {
+            None => match (self.username, self.password) {
+                (Some(username), Some(password)) => {
+                    let auth = SocksAuth { username, password };
+                    Socks5Remote::new_with_authentication((ip, port), auth)
+                }
+                (None, None) => Socks5Remote::new((ip, port)),
+                _ => {
+                    println!("Remote SOCKS5 proxy does not have a username and password set already, so you must provide both or neither when you edit.");
+                    Socks5Remote::new((ip, port))
+                }
+            },
+            Some(SocksAuth { username, password }) => {
+                let username = self.username.unwrap_or(username.to_owned());
+                let password = self.password.unwrap_or(password.to_owned());
+                let auth = SocksAuth { username, password };
+                Socks5Remote::new_with_authentication((ip, port), auth)
+            }
+        }
+    }
+
+    pub fn merge_shadowsocks(self, shadowsocks: &Shadowsocks) -> Shadowsocks {
+        let ip = self.ip.unwrap_or(shadowsocks.endpoint.ip());
+        let port = self.port.unwrap_or(shadowsocks.endpoint.port());
+        let password = self.password.unwrap_or(shadowsocks.password.to_owned());
+        let cipher = self.cipher.unwrap_or(shadowsocks.cipher.to_owned());
+        Shadowsocks::new((ip, port), cipher, password)
+    }
+}
+
+pub mod pp {
+    use crate::print_option;
+    use talpid_types::net::proxy::{CustomProxy, SocksAuth};
+
+    pub struct CustomProxyFormatter<'a> {
+        pub custom_proxy: &'a CustomProxy,
+    }
+
+    impl<'a> std::fmt::Display for CustomProxyFormatter<'a> {
+        fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self.custom_proxy {
+                CustomProxy::Shadowsocks(shadowsocks) => {
+                    print_option!("Protocol", format!("Shadowsocks [{}]", shadowsocks.cipher));
+                    print_option!("Peer", shadowsocks.endpoint);
+                    print_option!("Password", shadowsocks.password);
+                    Ok(())
+                }
+                CustomProxy::Socks5Remote(remote) => {
+                    print_option!("Protocol", "Socks5");
+                    print_option!("Peer", remote.endpoint);
+                    match &remote.auth {
+                        Some(SocksAuth { username, password }) => {
+                            print_option!("Username", username);
+                            print_option!("Password", password);
+                        }
+                        None => (),
+                    }
+                    Ok(())
+                }
+                CustomProxy::Socks5Local(local) => {
+                    print_option!("Protocol", "Socks5 (local)");
+                    print_option!(
+                        "Peer",
+                        format!(
+                            "{}/{}",
+                            local.remote_endpoint.address, local.remote_endpoint.protocol
+                        )
+                    );
+                    print_option!("Local port", local.local_port);
+                    Ok(())
+                }
+            }
+        }
+    }
+}

--- a/mullvad-daemon/src/custom_list.rs
+++ b/mullvad-daemon/src/custom_list.rs
@@ -2,7 +2,7 @@ use crate::{new_selector_config, Daemon, Error, EventListener};
 use mullvad_types::{
     custom_list::{CustomList, Id},
     relay_constraints::{
-        BridgeSettings, BridgeState, Constraint, LocationConstraint, RelaySettings,
+        BridgeState, Constraint, LocationConstraint, RelaySettings, ResolvedBridgeSettings,
     },
 };
 use talpid_types::net::TunnelType;
@@ -157,8 +157,8 @@ where
 
                     TunnelType::OpenVpn => {
                         if !matches!(self.settings.bridge_state, BridgeState::Off) {
-                            if let BridgeSettings::Normal(bridge_settings) =
-                                &self.settings.bridge_settings
+                            if let Ok(ResolvedBridgeSettings::Normal(bridge_settings)) =
+                                self.settings.bridge_settings.resolve()
                             {
                                 if let Constraint::Only(LocationConstraint::CustomList {
                                     list_id,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -49,7 +49,7 @@ use mullvad_types::{
     device::{Device, DeviceEvent, DeviceEventCause, DeviceId, DeviceState, RemoveDeviceEvent},
     location::{GeoIpLocation, LocationEventData},
     relay_constraints::{
-        BridgeSettings, BridgeState, ObfuscationSettings, RelayOverride, RelaySettings,
+        BridgeSettings, BridgeState, BridgeType, ObfuscationSettings, RelayOverride, RelaySettings,
     },
     relay_list::RelayList,
     settings::{DnsOptions, Settings},
@@ -182,6 +182,8 @@ pub enum Error {
 
     #[error(display = "API connection mode error")]
     ApiConnectionModeError(#[error(source)] api::Error),
+    #[error(display = "No custom bridge has been specified")]
+    NoCustomProxySaved,
 
     #[cfg(target_os = "macos")]
     #[error(display = "Failed to set exclusion group")]
@@ -248,7 +250,7 @@ pub enum DaemonCommand {
     /// Set the mssfix argument for OpenVPN
     SetOpenVpnMssfix(ResponseTx<(), settings::Error>, Option<u16>),
     /// Set proxy details for OpenVPN
-    SetBridgeSettings(ResponseTx<(), settings::Error>, BridgeSettings),
+    SetBridgeSettings(ResponseTx<(), Error>, BridgeSettings),
     /// Set proxy state
     SetBridgeState(ResponseTx<(), settings::Error>, BridgeState),
     /// Set if IPv6 should be enabled in the tunnel
@@ -2027,9 +2029,19 @@ where
 
     async fn on_set_bridge_settings(
         &mut self,
-        tx: ResponseTx<(), settings::Error>,
+        tx: ResponseTx<(), Error>,
         new_settings: BridgeSettings,
     ) {
+        if new_settings.custom.is_none() && new_settings.bridge_type == BridgeType::Custom {
+            log::info!("Tried to select custom bridge but no custom bridge settings exist");
+            Self::oneshot_send(
+                tx,
+                Err(Error::NoCustomProxySaved),
+                "set_bridge_settings response",
+            );
+            return;
+        }
+
         match self
             .settings
             .update(move |settings| settings.bridge_settings = new_settings)
@@ -2050,7 +2062,7 @@ where
                     "{}",
                     e.display_chain_with_msg("Failed to set new bridge settings")
                 );
-                Self::oneshot_send(tx, Err(e), "set_bridge_settings");
+                Self::oneshot_send(tx, Err(Error::SettingsError(e)), "set_bridge_settings");
             }
         }
     }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -202,7 +202,7 @@ impl ManagementService for ManagementServiceImpl {
 
         let (tx, rx) = oneshot::channel();
         self.send_command_to_daemon(DaemonCommand::SetBridgeSettings(tx, settings))?;
-        self.wait_for_result(rx).await??;
+        self.wait_for_result(rx).await?.map_err(map_daemon_error)?;
         Ok(Response::new(()))
     }
 

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -51,6 +51,7 @@ mod v3;
 mod v4;
 mod v5;
 mod v6;
+mod v7;
 
 const SETTINGS_FILE: &str = "settings.json";
 
@@ -148,6 +149,7 @@ pub async fn migrate_all(cache_dir: &Path, settings_dir: &Path) -> Result<Option
 
     let migration_data = v5::migrate(&mut settings)?;
     v6::migrate(&mut settings)?;
+    v7::migrate(&mut settings)?;
 
     if settings == old_settings {
         // Nothing changed

--- a/mullvad-daemon/src/migrations/v7.rs
+++ b/mullvad-daemon/src/migrations/v7.rs
@@ -1,0 +1,995 @@
+use std::net::SocketAddr;
+
+use super::{Error, Result};
+use mullvad_types::{
+    relay_constraints::{BridgeConstraints, BridgeSettings as NewBridgeSettings, BridgeType},
+    settings::SettingsVersion,
+};
+use serde::{Deserialize, Serialize};
+use talpid_types::net::{
+    proxy::{CustomProxy, Shadowsocks, Socks5Local, Socks5Remote, SocksAuth},
+    Endpoint, TransportProtocol,
+};
+
+// ======================================================
+// Section for vendoring types and values that
+// this settings version depend on. See `mod.rs`.
+
+/// Specifies a specific endpoint or [`BridgeConstraints`] to use when `mullvad-daemon` selects a
+/// bridge server.
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BridgeSettings {
+    /// Let the relay selection algorithm decide on bridges, based on the relay list.
+    Normal(BridgeConstraints),
+    Custom(ProxySettings),
+}
+
+/// Proxy server options to be used by `OpenVpnMonitor` when starting a tunnel.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProxySettings {
+    Local(LocalProxySettings),
+    Remote(RemoteProxySettings),
+    Shadowsocks(ShadowsocksProxySettings),
+}
+
+/// Options for a generic proxy running on localhost.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct LocalProxySettings {
+    pub port: u16,
+    pub peer: SocketAddr,
+}
+
+/// Options for a generic proxy running on remote host.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct RemoteProxySettings {
+    pub address: SocketAddr,
+    pub auth: Option<ProxyAuth>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct ProxyAuth {
+    pub username: String,
+    pub password: String,
+}
+
+/// Options for a bundled Shadowsocks proxy.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct ShadowsocksProxySettings {
+    pub peer: SocketAddr,
+    /// Password on peer.
+    pub password: String,
+    pub cipher: String,
+    #[cfg(target_os = "linux")]
+    pub fwmark: Option<u32>,
+}
+
+// ======================================================
+/// This is a closed migration.
+
+/// We change bridge settings to no longer be an enum with custom and normal variants. It now is a
+/// struct which contains a bridge type, a normal relay constraint and optional custom constraints.
+///
+/// We also migrate api access methods to use a slightly more shallow CustomProxy implementation
+/// that instead of having a Socks5 and Shadowsocks variant instead has a Socks5Local, Socks5Remote
+/// and Shadowsocks variant.
+///
+/// We also take the oppertunity to rename a couple of fields that relate to proxy types.
+/// We rename
+/// - shadowsocks.peer to shadowsocks.endpoint
+/// - socks5_remote.authentication to socks5_remote.auth
+/// - socks5_remote.peer to socks5_remote.endpoint
+///
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to V8");
+
+    migrate_bridge_settings(settings)?;
+
+    migrate_api_access_settings(settings)?;
+
+    settings["settings_version"] = serde_json::json!(SettingsVersion::V8);
+
+    Ok(())
+}
+
+fn migrate_api_access_settings(settings: &mut serde_json::Value) -> Result<()> {
+    if let Some(access_method_settings_list) = settings
+        .get_mut("api_access_methods")
+        .and_then(|api_access_methods| api_access_methods.get_mut("access_method_settings"))
+        .and_then(|access_method_settings| access_method_settings.as_array_mut())
+    {
+        for access_method_setting in access_method_settings_list {
+            let access_method = access_method_setting
+                .get_mut("access_method")
+                .ok_or(Error::InvalidSettingsContent)?;
+            match access_method.get_mut("custom") {
+                None => continue,
+                Some(custom_access_method) => {
+                    if let Some(shadowsocks) = custom_access_method.get_mut("shadowsocks") {
+                        rename_field(shadowsocks, "peer", "endpoint")?;
+                    } else if let Some(new_socks5_local) = custom_access_method
+                        .get("socks5")
+                        .and_then(|socks5| socks5.get("local"))
+                    {
+                        custom_access_method["socks5_local"] = new_socks5_local.clone();
+                        custom_access_method
+                            .as_object_mut()
+                            .ok_or(Error::InvalidSettingsContent)?
+                            .remove("socks5");
+                    } else if let Some(socks5_remote) = custom_access_method
+                        .get("socks5")
+                        .and_then(|socks5| socks5.get("remote"))
+                    {
+                        let mut new_socks5_remote = socks5_remote.clone();
+                        rename_field(&mut new_socks5_remote, "authentication", "auth")?;
+                        rename_field(&mut new_socks5_remote, "peer", "endpoint")?;
+
+                        custom_access_method["socks5_remote"] = new_socks5_remote;
+                        custom_access_method
+                            .as_object_mut()
+                            .ok_or(Error::InvalidSettingsContent)?
+                            .remove("socks5");
+                    } else {
+                        return Err(Error::InvalidSettingsContent);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn migrate_bridge_settings(settings: &mut serde_json::Value) -> Result<()> {
+    let new = if let Some(custom_bridge_local) = settings
+        .get_mut("bridge_settings")
+        .and_then(|bridge_settings| bridge_settings.get_mut("custom"))
+        .and_then(|bridge_settings_custom| bridge_settings_custom.get_mut("local"))
+    {
+        NewBridgeSettings {
+            bridge_type: BridgeType::Custom,
+            normal: BridgeConstraints::default(),
+            custom: Some(CustomProxy::Socks5Local(Socks5Local {
+                remote_endpoint: Endpoint {
+                    address: extract_str(custom_bridge_local.get("peer"))?
+                        .parse()
+                        .map_err(|_| Error::InvalidSettingsContent)?,
+                    protocol: TransportProtocol::Tcp,
+                },
+                local_port: custom_bridge_local
+                    .get("port")
+                    .ok_or(Error::InvalidSettingsContent)?
+                    .as_u64()
+                    .ok_or(Error::InvalidSettingsContent)?
+                    .try_into()
+                    .map_err(|_| Error::InvalidSettingsContent)?,
+            })),
+        }
+    } else if let Some(custom_bridge_remote) = settings
+        .get_mut("bridge_settings")
+        .and_then(|bridge_settings| bridge_settings.get_mut("custom"))
+        .and_then(|bridge_settings_custom| bridge_settings_custom.get_mut("remote"))
+    {
+        NewBridgeSettings {
+            bridge_type: BridgeType::Custom,
+            normal: BridgeConstraints::default(),
+            custom: Some(CustomProxy::Socks5Remote(Socks5Remote {
+                endpoint: extract_str(custom_bridge_remote.get("address"))?
+                    .parse()
+                    .map_err(|_| Error::InvalidSettingsContent)?,
+                auth: custom_bridge_remote.get("auth").and_then(|auth| {
+                    Some(SocksAuth {
+                        username: auth.get("username")?.to_string(),
+                        password: auth.get("password")?.to_string(),
+                    })
+                }),
+            })),
+        }
+    } else if let Some(custom_bridge_shadowsocks) = settings
+        .get_mut("bridge_settings")
+        .and_then(|bridge_settings| bridge_settings.get_mut("custom"))
+        .and_then(|bridge_settings_custom| bridge_settings_custom.get_mut("shadowsocks"))
+    {
+        NewBridgeSettings {
+            bridge_type: BridgeType::Custom,
+            normal: BridgeConstraints::default(),
+            custom: Some(CustomProxy::Shadowsocks(Shadowsocks {
+                endpoint: extract_str(custom_bridge_shadowsocks.get("peer"))?
+                    .parse()
+                    .map_err(|_| Error::InvalidSettingsContent)?,
+                password: extract_str(custom_bridge_shadowsocks.get("password"))?.to_string(),
+                cipher: extract_str(custom_bridge_shadowsocks.get("cipher"))?.to_string(),
+            })),
+        }
+    } else if let Some(normal_bridge) = settings
+        .get_mut("bridge_settings")
+        .and_then(|bridge_settings| bridge_settings.get_mut("normal"))
+    {
+        NewBridgeSettings {
+            bridge_type: BridgeType::Normal,
+            normal: serde_json::from_value(normal_bridge.clone()).map_err(Error::Serialize)?,
+            custom: None,
+        }
+    } else {
+        return Ok(());
+    };
+
+    settings["bridge_settings"] = serde_json::json!(new);
+
+    Ok(())
+}
+
+fn extract_str(opt: Option<&serde_json::Value>) -> Result<&str> {
+    opt.ok_or(Error::InvalidSettingsContent)?
+        .as_str()
+        .ok_or(Error::InvalidSettingsContent)
+}
+
+fn rename_field(object: &mut serde_json::Value, old_name: &str, new_name: &str) -> Result<()> {
+    object[new_name] = object
+        .get(old_name)
+        .ok_or(Error::InvalidSettingsContent)?
+        .clone();
+    object
+        .as_object_mut()
+        .ok_or(Error::InvalidSettingsContent)?
+        .remove(old_name);
+    Ok(())
+}
+
+fn version_matches(settings: &mut serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V7 as u64)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::migrations::v7::{migrate_api_access_settings, migrate_bridge_settings};
+
+    use super::{migrate, version_matches};
+    use serde_json;
+
+    pub const V7_SETTINGS: &str = r#"
+{
+
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "hostname": [
+              "ch",
+              "zrh",
+              "ch-zrh-ovpn-001"
+            ]
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": {
+          "only": {
+            "protocol": "udp",
+            "port": {
+              "only": 1195
+            }
+          }
+        }
+      }
+    }
+  },
+  "bridge_settings": {
+    "custom": {
+      "local": {
+        "port": 1080,
+        "peer": "1.3.3.7:22"
+      }
+    }
+  },
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "8cbdcfc8-fa7b-41de-8d12-26fa37439f89",
+        "name": "Direct",
+        "enabled": true,
+        "access_method": {
+          "built_in": "direct"
+        }
+      },
+      {
+        "id": "1d0d8891-dbb3-4439-a8f7-0e7d742ddbe4",
+        "name": "Mullvad Bridges",
+        "enabled": true,
+        "access_method": {
+          "built_in": "bridge"
+        }
+      },
+      {
+        "id": "1aaff7ab-e09f-4c03-af02-765e41943a7b",
+        "name": "localsox",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5": {
+              "local": {
+                "remote_endpoint": {
+                  "address": "1.3.3.7:1080",
+                  "protocol": "tcp"
+                },
+                "local_port": 1079
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "1e377232-8a53-4414-8b8f-f487227aaedb",
+        "name": "remotesox",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5": {
+              "remote": {
+                "peer": "1.3.3.7:1080",
+                "authentication": null
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "74e5c659-acdd-4cad-a632-a25bf63c20e2",
+        "name": "remotess",
+        "enabled": true,
+        "access_method": {
+          "custom": {
+            "shadowsocks": {
+              "peer": "1.3.3.7:1080",
+              "password": "mypass",
+              "cipher": "aes-128-cfb"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "udp2_tcp",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "rotation_interval": {
+          "secs": 86400,
+          "nanos": 0
+      },
+      "quantum_resistant": "auto"
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false
+      },
+      "custom_options": {
+        "addresses": [
+          "1.1.1.1",
+          "1.2.3.4"
+        ]
+      }
+    }
+  },
+  "settings_version": 7
+}
+"#;
+
+    pub const V8_SETTINGS: &str = r#"
+{
+
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "hostname": [
+              "ch",
+              "zrh",
+              "ch-zrh-ovpn-001"
+            ]
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": {
+          "only": {
+            "protocol": "udp",
+            "port": {
+              "only": 1195
+            }
+          }
+        }
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "custom",
+    "normal": {
+        "location": "any",
+        "providers": "any",
+        "ownership": "any"
+    },
+    "custom": {
+      "socks5_local": {
+        "local_port": 1080,
+        "remote_endpoint": {
+            "address": "1.3.3.7:22",
+            "protocol": "tcp"
+        }
+      }
+    }
+  },
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "8cbdcfc8-fa7b-41de-8d12-26fa37439f89",
+        "name": "Direct",
+        "enabled": true,
+        "access_method": {
+          "built_in": "direct"
+        }
+      },
+      {
+        "id": "1d0d8891-dbb3-4439-a8f7-0e7d742ddbe4",
+        "name": "Mullvad Bridges",
+        "enabled": true,
+        "access_method": {
+          "built_in": "bridge"
+        }
+      },
+      {
+        "id": "1aaff7ab-e09f-4c03-af02-765e41943a7b",
+        "name": "localsox",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5_local": {
+              "remote_endpoint": {
+                "address": "1.3.3.7:1080",
+                "protocol": "tcp"
+              },
+              "local_port": 1079
+            }
+          }
+        }
+      },
+      {
+        "id": "1e377232-8a53-4414-8b8f-f487227aaedb",
+        "name": "remotesox",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5_remote": {
+              "endpoint": "1.3.3.7:1080",
+              "auth": null
+            }
+          }
+        }
+      },
+      {
+        "id": "74e5c659-acdd-4cad-a632-a25bf63c20e2",
+        "name": "remotess",
+        "enabled": true,
+        "access_method": {
+          "custom": {
+            "shadowsocks": {
+              "endpoint": "1.3.3.7:1080",
+              "password": "mypass",
+              "cipher": "aes-128-cfb"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "udp2_tcp",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "allow_lan": true,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "rotation_interval": {
+          "secs": 86400,
+          "nanos": 0
+      },
+      "quantum_resistant": "auto"
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false
+      },
+      "custom_options": {
+        "addresses": [
+          "1.1.1.1",
+          "1.2.3.4"
+        ]
+      }
+    }
+  },
+  "settings_version": 8
+}
+"#;
+
+    #[test]
+    fn test_v7_to_v8_migration() {
+        let mut old_settings = serde_json::from_str(V7_SETTINGS).unwrap();
+
+        assert!(version_matches(&mut old_settings));
+        migrate(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = serde_json::from_str(V8_SETTINGS).unwrap();
+
+        assert_eq!(&old_settings, &new_settings);
+    }
+
+    #[test]
+    fn test_bridge_settings_custom_local_proxy() {
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "custom": {
+      "local": {
+        "port": 1080,
+        "peer": "1.3.3.7:22"
+      }
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "bridge_type": "custom",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": {
+      "socks5_local": {
+        "local_port": 1080,
+        "remote_endpoint": {
+            "address": "1.3.3.7:22",
+            "protocol": "tcp"
+        }
+      }
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        migrate_bridge_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+
+    #[test]
+    fn test_bridge_settings_custom_remote_proxy() {
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "custom": {
+      "remote": {
+        "address": "1.3.3.7:1080",
+        "auth": null
+      }
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "bridge_type": "custom",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": {
+      "socks5_remote": {
+        "endpoint": "1.3.3.7:1080",
+        "auth": null
+      }
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        migrate_bridge_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+
+    #[test]
+    fn test_bridge_settings_custom_shadowsocks_proxy() {
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "custom": {
+      "shadowsocks": {
+        "peer": "1.3.3.7:1080",
+        "password": "mypass",
+        "cipher": "aes-128-cfb",
+        "fwmark": 1836018789
+      }
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "bridge_type": "custom",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": {
+      "shadowsocks": {
+        "endpoint": "1.3.3.7:1080",
+        "password": "mypass",
+        "cipher": "aes-128-cfb"
+      }
+    }
+  }
+}"#,
+        )
+        .unwrap();
+        migrate_bridge_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+
+    #[test]
+    fn test_bridge_settings_normal() {
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any"
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  }
+}"#,
+        )
+        .unwrap();
+        migrate_bridge_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+
+    #[test]
+    fn test_bridge_settings_specific_location() {
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any"
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  }
+}"#,
+        )
+        .unwrap();
+        migrate_bridge_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+
+    #[test]
+    fn test_api_access_methods_custom_socks5_local() {
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "5eb9b2ee-f764-47c8-8111-ee95910d0099",
+        "name": "mysocks",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5": {
+              "local": {
+                "remote_endpoint": {
+                  "address": "1.3.3.7:22",
+                  "protocol": "tcp"
+                },
+                "local_port": 1080
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "5eb9b2ee-f764-47c8-8111-ee95910d0099",
+        "name": "mysocks",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5_local": {
+              "remote_endpoint": {
+                "address": "1.3.3.7:22",
+                "protocol": "tcp"
+              },
+              "local_port": 1080
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#,
+        )
+        .unwrap();
+
+        migrate_api_access_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+
+    #[test]
+    fn test_api_access_methods_custom_socks5_remote() {
+        println!("wew");
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "8e377232-8a53-4414-8b8f-f487227aaedb",
+        "name": "remotesox",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5": {
+              "remote": {
+                "peer": "1.3.3.7:1080",
+                "authentication": null
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#,
+        )
+        .unwrap();
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "8e377232-8a53-4414-8b8f-f487227aaedb",
+        "name": "remotesox",
+        "enabled": false,
+        "access_method": {
+          "custom": {
+            "socks5_remote": {
+              "endpoint": "1.3.3.7:1080",
+              "auth": null
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#,
+        )
+        .unwrap();
+
+        migrate_api_access_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+
+    #[test]
+    fn test_api_access_methods_custom_socks5_shadowsocks() {
+        let mut pre: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "74e5c659-acdd-4cad-a632-a25bf63c20e2",
+        "name": "remotess",
+        "enabled": true,
+        "access_method": {
+          "custom": {
+            "shadowsocks": {
+              "peer": "1.3.3.7:1080",
+              "password": "mypass",
+              "cipher": "aes-128-cfb"
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let post: serde_json::Value = serde_json::from_str(
+            r#"
+{
+  "api_access_methods": {
+    "access_method_settings": [
+      {
+        "id": "74e5c659-acdd-4cad-a632-a25bf63c20e2",
+        "name": "remotess",
+        "enabled": true,
+        "access_method": {
+          "custom": {
+            "shadowsocks": {
+              "endpoint": "1.3.3.7:1080",
+              "password": "mypass",
+              "cipher": "aes-128-cfb"
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#,
+        )
+        .unwrap();
+
+        migrate_api_access_settings(&mut pre).unwrap();
+        assert_eq!(pre, post);
+    }
+}

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -462,8 +462,18 @@ mod test {
                 }
               },
               "bridge_settings": {
+                "bridge_type": "normal",
                 "normal": {
                   "location": "any"
+                },
+                "custom": {
+                  "socks5_local": {
+                    "local_port": 1080,
+                    "remote_endpoint": {
+                      "address": "1.3.3.7:22",
+                      "protocol": "tcp"
+                    }
+                  }
                 }
               },
               "bridge_state": "auto",
@@ -482,7 +492,7 @@ mod test {
                   "enable_ipv6": true
                 }
               },
-              "settings_version": 5,
+              "settings_version": 8,
               "show_beta_releases": false,
               "custom_lists": {
                 "custom_lists": []

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -260,36 +260,19 @@ enum Ownership {
 }
 
 message BridgeSettings {
+  enum BridgeType {
+    NORMAL = 0;
+    CUSTOM = 1;
+  }
   message BridgeConstraints {
     LocationConstraint location = 1;
     repeated string providers = 2;
     Ownership ownership = 3;
   }
 
-  message LocalProxySettings {
-    uint32 port = 1;
-    string peer = 2;
-  }
-  message RemoteProxySettings {
-    string address = 1;
-    RemoteProxyAuth auth = 2;
-  }
-  message RemoteProxyAuth {
-    string username = 1;
-    string password = 2;
-  }
-  message ShadowsocksProxySettings {
-    string peer = 1;
-    string password = 2;
-    string cipher = 3;
-  }
-
-  oneof type {
-    BridgeConstraints normal = 1;
-    LocalProxySettings local = 2;
-    RemoteProxySettings remote = 3;
-    ShadowsocksProxySettings shadowsocks = 4;
-  }
+  BridgeType bridge_type = 1;
+  BridgeConstraints normal = 2;
+  CustomProxy custom = 3;
 }
 
 message LocationConstraint {
@@ -334,30 +317,39 @@ message CustomList {
 
 message CustomListSettings { repeated CustomList custom_lists = 1; }
 
+message Socks5Local {
+  string remote_ip = 1;
+  uint32 remote_port = 2;
+  TransportProtocol remote_transport_protocol = 3;
+  uint32 local_port = 4;
+}
+message SocksAuth {
+  string username = 1;
+  string password = 2;
+}
+message Socks5Remote {
+  string ip = 1;
+  uint32 port = 2;
+  SocksAuth auth = 3;
+}
+message Shadowsocks {
+  string ip = 1;
+  uint32 port = 2;
+  string password = 3;
+  string cipher = 4;
+}
+
+message CustomProxy {
+  oneof proxy_method {
+    Socks5Local socks5local = 1;
+    Socks5Remote socks5remote = 2;
+    Shadowsocks shadowsocks = 3;
+  }
+}
+
 message AccessMethod {
   message Direct {}
   message Bridges {}
-  message Socks5Local {
-    string remote_ip = 1;
-    uint32 remote_port = 2;
-    TransportProtocol remote_transport_protocol = 3;
-    uint32 local_port = 4;
-  }
-  message SocksAuth {
-    string username = 1;
-    string password = 2;
-  }
-  message Socks5Remote {
-    string ip = 1;
-    uint32 port = 2;
-    SocksAuth authentication = 3;
-  }
-  message Shadowsocks {
-    string ip = 1;
-    uint32 port = 2;
-    string password = 3;
-    string cipher = 4;
-  }
   oneof access_method {
     Direct direct = 1;
     Bridges bridges = 2;

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -1,10 +1,9 @@
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
-use talpid_types::net::{Endpoint, TransportProtocol};
+use talpid_types::net::proxy::{CustomProxy, Shadowsocks, Socks5Local, Socks5Remote};
 
-/// Daemon settings for API access methods.
+/// Dttings for API access methods.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Settings {
     pub access_method_settings: Vec<AccessMethodSetting>,
@@ -136,7 +135,7 @@ impl std::fmt::Display for Id {
 #[serde(rename_all = "snake_case")]
 pub enum AccessMethod {
     BuiltIn(BuiltInAccessMethod),
-    Custom(CustomAccessMethod),
+    Custom(CustomProxy),
 }
 
 impl AccessMethodSetting {
@@ -179,7 +178,7 @@ impl AccessMethodSetting {
         self.enabled
     }
 
-    pub fn as_custom(&self) -> Option<&CustomAccessMethod> {
+    pub fn as_custom(&self) -> Option<&CustomProxy> {
         self.access_method.as_custom()
     }
 
@@ -206,53 +205,8 @@ pub enum BuiltInAccessMethod {
     Bridge,
 }
 
-/// Custom access method datastructure.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-pub enum CustomAccessMethod {
-    Shadowsocks(Shadowsocks),
-    Socks5(Socks5),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-pub enum Socks5 {
-    Local(Socks5Local),
-    Remote(Socks5Remote),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct Shadowsocks {
-    pub peer: SocketAddr,
-    pub password: String,
-    /// One of [`shadowsocks_ciphers`].
-    /// Gets validated at a later stage. Is assumed to be valid.
-    ///
-    /// shadowsocks_ciphers: talpid_types::net::openvpn::SHADOWSOCKS_CIPHERS
-    pub cipher: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct Socks5Local {
-    pub remote_endpoint: Endpoint,
-    /// Port on localhost where the SOCKS5-proxy listens to.
-    pub local_port: u16,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct Socks5Remote {
-    pub peer: SocketAddr,
-    pub authentication: Option<SocksAuth>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct SocksAuth {
-    pub username: String,
-    pub password: String,
-}
-
 impl AccessMethod {
-    pub fn as_custom(&self) -> Option<&CustomAccessMethod> {
+    pub fn as_custom(&self) -> Option<&CustomProxy> {
         match self {
             AccessMethod::BuiltIn(_) => None,
             AccessMethod::Custom(access_method) => Some(access_method),
@@ -269,98 +223,32 @@ impl BuiltInAccessMethod {
     }
 }
 
-impl Shadowsocks {
-    pub fn new<I: Into<SocketAddr>>(peer: I, cipher: String, password: String) -> Self {
-        Shadowsocks {
-            peer: peer.into(),
-            password,
-            cipher,
-        }
-    }
-}
-
-impl Socks5Local {
-    pub fn new<I: Into<SocketAddr>>(remote_peer: I, local_port: u16) -> Self {
-        let transport_protocol = TransportProtocol::Tcp;
-        Self::new_with_transport_protocol(remote_peer, local_port, transport_protocol)
-    }
-
-    pub fn new_with_transport_protocol<I: Into<SocketAddr>>(
-        remote_peer: I,
-        local_port: u16,
-        transport_protocol: TransportProtocol,
-    ) -> Self {
-        let remote_endpoint = Endpoint::from_socket_address(remote_peer.into(), transport_protocol);
-        Self {
-            remote_endpoint,
-            local_port,
-        }
-    }
-}
-
-impl Socks5Remote {
-    pub fn new<I: Into<SocketAddr>>(peer: I) -> Self {
-        Self {
-            peer: peer.into(),
-            authentication: None,
-        }
-    }
-
-    pub fn new_with_authentication<I: Into<SocketAddr>>(
-        peer: I,
-        authentication: SocksAuth,
-    ) -> Self {
-        Self {
-            peer: peer.into(),
-            authentication: Some(authentication),
-        }
-    }
-}
-
 impl From<BuiltInAccessMethod> for AccessMethod {
     fn from(value: BuiltInAccessMethod) -> Self {
         AccessMethod::BuiltIn(value)
     }
 }
 
-impl From<CustomAccessMethod> for AccessMethod {
-    fn from(value: CustomAccessMethod) -> Self {
+impl From<CustomProxy> for AccessMethod {
+    fn from(value: CustomProxy) -> Self {
         AccessMethod::Custom(value)
-    }
-}
-
-impl From<Shadowsocks> for AccessMethod {
-    fn from(value: Shadowsocks) -> Self {
-        CustomAccessMethod::Shadowsocks(value).into()
-    }
-}
-
-impl From<Socks5> for AccessMethod {
-    fn from(value: Socks5) -> Self {
-        AccessMethod::from(CustomAccessMethod::Socks5(value))
     }
 }
 
 impl From<Socks5Remote> for AccessMethod {
     fn from(value: Socks5Remote) -> Self {
-        Socks5::Remote(value).into()
+        CustomProxy::Socks5Remote(value).into()
     }
 }
 
 impl From<Socks5Local> for AccessMethod {
     fn from(value: Socks5Local) -> Self {
-        Socks5::Local(value).into()
+        CustomProxy::Socks5Local(value).into()
     }
 }
 
-impl From<Socks5Remote> for Socks5 {
-    fn from(value: Socks5Remote) -> Self {
-        Socks5::Remote(value)
-    }
-}
-
-impl From<Socks5Local> for Socks5 {
-    fn from(value: Socks5Local) -> Self {
-        Socks5::Local(value)
+impl From<Shadowsocks> for AccessMethod {
+    fn from(value: Shadowsocks) -> Self {
+        CustomProxy::Shadowsocks(value).into()
     }
 }

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -6,7 +6,7 @@ use std::{
     fmt, io,
     net::{IpAddr, SocketAddr, ToSocketAddrs},
 };
-use talpid_types::net::{openvpn, wireguard, Endpoint, TunnelParameters};
+use talpid_types::net::{openvpn, proxy::CustomProxy, wireguard, Endpoint, TunnelParameters};
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
@@ -42,7 +42,7 @@ impl CustomTunnelEndpoint {
     pub fn to_tunnel_parameters(
         &self,
         tunnel_options: TunnelOptions,
-        proxy: Option<openvpn::ProxySettings>,
+        proxy: Option<CustomProxy>,
     ) -> Result<TunnelParameters, Error> {
         let ip = resolve_to_ip(&self.host)?;
         let mut config = self.config.clone();

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -4,7 +4,7 @@ use jnix::IntoJava;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use talpid_types::net::{
-    openvpn::{ProxySettings, ShadowsocksProxySettings},
+    proxy::{CustomProxy, Shadowsocks},
     wireguard, TransportProtocol,
 };
 
@@ -207,17 +207,11 @@ pub struct ShadowsocksEndpointData {
 }
 
 impl ShadowsocksEndpointData {
-    pub fn to_proxy_settings(
-        &self,
-        addr: IpAddr,
-        #[cfg(target_os = "linux")] fwmark: u32,
-    ) -> ProxySettings {
-        ProxySettings::Shadowsocks(ShadowsocksProxySettings {
-            peer: SocketAddr::new(addr, self.port),
+    pub fn to_proxy_settings(&self, addr: IpAddr) -> CustomProxy {
+        CustomProxy::Shadowsocks(Shadowsocks {
+            endpoint: SocketAddr::new(addr, self.port),
             password: self.password.clone(),
             cipher: self.cipher.clone(),
-            #[cfg(target_os = "linux")]
-            fwmark: Some(fwmark),
         })
     }
 }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -2,8 +2,8 @@ use crate::{
     access_method,
     custom_list::CustomListsSettings,
     relay_constraints::{
-        BridgeConstraints, BridgeSettings, BridgeState, Constraint, GeographicLocationConstraint,
-        LocationConstraint, ObfuscationSettings, RelayConstraints, RelayOverride, RelaySettings,
+        BridgeSettings, BridgeState, Constraint, GeographicLocationConstraint, LocationConstraint,
+        ObfuscationSettings, RelayConstraints, RelayOverride, RelaySettings,
         RelaySettingsFormatter, SelectedObfuscation, WireguardConstraints,
     },
     wireguard,
@@ -32,6 +32,7 @@ pub enum SettingsVersion {
     V5 = 5,
     V6 = 6,
     V7 = 7,
+    V8 = 8,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -46,6 +47,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V5 as u32 => Ok(SettingsVersion::V5),
             v if v == SettingsVersion::V6 as u32 => Ok(SettingsVersion::V6),
             v if v == SettingsVersion::V7 as u32 => Ok(SettingsVersion::V7),
+            v if v == SettingsVersion::V8 as u32 => Ok(SettingsVersion::V8),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),
@@ -128,7 +130,7 @@ impl Default for Settings {
                 },
                 ..Default::default()
             }),
-            bridge_settings: BridgeSettings::Normal(BridgeConstraints::default()),
+            bridge_settings: BridgeSettings::default(),
             obfuscation_settings: ObfuscationSettings {
                 selected_obfuscation: SelectedObfuscation::Off,
                 ..Default::default()

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -1,12 +1,10 @@
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use once_cell::sync::Lazy;
-#[cfg(windows)]
-use std::path::PathBuf;
 use std::{
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
-use talpid_types::net::{AllowedEndpoint, AllowedTunnelTraffic, Endpoint};
+use talpid_types::net::{AllowedEndpoint, AllowedTunnelTraffic};
 
 #[cfg(target_os = "macos")]
 #[path = "macos.rs"]
@@ -116,7 +114,7 @@ pub enum FirewallPolicy {
     /// Allow traffic only to server
     Connecting {
         /// The peer endpoint that should be allowed.
-        peer_endpoint: Endpoint,
+        peer_endpoint: AllowedEndpoint,
         /// Metadata about the tunnel and tunnel interface.
         tunnel: Option<crate::tunnel::TunnelMetadata>,
         /// Flag setting if communication with LAN networks should be possible.
@@ -125,15 +123,12 @@ pub enum FirewallPolicy {
         allowed_endpoint: AllowedEndpoint,
         /// Networks for which to permit in-tunnel traffic.
         allowed_tunnel_traffic: AllowedTunnelTraffic,
-        /// A process that is allowed to send packets to the relay.
-        #[cfg(windows)]
-        relay_client: PathBuf,
     },
 
     /// Allow traffic only to server and over tunnel interface
     Connected {
         /// The peer endpoint that should be allowed.
-        peer_endpoint: Endpoint,
+        peer_endpoint: AllowedEndpoint,
         /// Metadata about the tunnel and tunnel interface.
         tunnel: crate::tunnel::TunnelMetadata,
         /// Flag setting if communication with LAN networks should be possible.
@@ -141,9 +136,6 @@ pub enum FirewallPolicy {
         /// Servers that are allowed to respond to DNS requests.
         #[cfg(not(target_os = "android"))]
         dns_servers: Vec<IpAddr>,
-        /// A process that is allowed to send packets to the relay.
-        #[cfg(windows)]
-        relay_client: PathBuf,
     },
 
     /// Block all network traffic in and out from the computer.

--- a/talpid-openvpn/src/proxy/mod.rs
+++ b/talpid-openvpn/src/proxy/mod.rs
@@ -3,8 +3,8 @@ mod shadowsocks;
 
 use self::shadowsocks::ShadowsocksProxyMonitor;
 use async_trait::async_trait;
-use std::{fmt, io, path::PathBuf};
-use talpid_types::net::openvpn;
+use std::{fmt, io};
+use talpid_types::net::proxy::CustomProxy;
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {
@@ -39,33 +39,30 @@ pub trait ProxyMonitorCloseHandle: Send {
     fn close(self: Box<Self>) -> Result<()>;
 }
 
-/// Variables that define the environment to help
-/// proxy implementations find their way around.
-/// TODO: Move struct to wider scope and use more generic name.
-pub struct ProxyResourceData {
-    pub resource_dir: PathBuf,
-    pub log_dir: Option<PathBuf>,
-}
-
 pub async fn start_proxy(
-    settings: &openvpn::ProxySettings,
-    resource_data: &ProxyResourceData,
+    settings: &CustomProxy,
+    #[cfg(target_os = "linux")] fwmark: u32,
 ) -> Result<Box<dyn ProxyMonitor>> {
     match settings {
-        openvpn::ProxySettings::Local(local_settings) => {
+        CustomProxy::Socks5Local(local_settings) => {
             // These are generic proxy settings with the proxy client not managed by us.
             Ok(Box::new(noop::NoopProxyMonitor::start(
-                local_settings.port,
+                local_settings.local_port,
             )?))
         }
-        openvpn::ProxySettings::Remote(remote_settings) => {
+        CustomProxy::Socks5Remote(remote_settings) => {
             // These are generic proxy settings with the proxy client not managed by us.
             Ok(Box::new(noop::NoopProxyMonitor::start(
-                remote_settings.address.port(),
+                remote_settings.endpoint.port(),
             )?))
         }
-        openvpn::ProxySettings::Shadowsocks(ss_settings) => Ok(Box::new(
-            ShadowsocksProxyMonitor::start(ss_settings, resource_data).await?,
+        CustomProxy::Shadowsocks(ss_settings) => Ok(Box::new(
+            ShadowsocksProxyMonitor::start(
+                ss_settings,
+                #[cfg(target_os = "linux")]
+                fwmark,
+            )
+            .await?,
         )),
     }
 }

--- a/talpid-types/src/net/openvpn.rs
+++ b/talpid-types/src/net/openvpn.rs
@@ -1,9 +1,7 @@
-use crate::net::{
-    proxy::{ProxyEndpoint, ProxyType},
-    Endpoint, GenericTunnelOptions, TransportProtocol,
-};
+use crate::net::{Endpoint, GenericTunnelOptions};
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
+
+use super::proxy::CustomProxy;
 
 /// Information needed by `OpenVpnMonitor` to establish a tunnel connection.
 /// See [`crate::net::TunnelParameters`].
@@ -12,7 +10,7 @@ pub struct TunnelParameters {
     pub config: ConnectionConfig,
     pub options: TunnelOptions,
     pub generic_options: GenericTunnelOptions,
-    pub proxy: Option<ProxySettings>,
+    pub proxy: Option<CustomProxy>,
     #[cfg(target_os = "linux")]
     pub fwmark: u32,
 }
@@ -44,157 +42,4 @@ pub struct TunnelOptions {
     /// Optional argument for openvpn to try and limit TCP packet size,
     /// as discussed [here](https://openvpn.net/archive/openvpn-users/2003-11/msg00154.html)
     pub mssfix: Option<u16>,
-}
-
-/// Proxy server options to be used by `OpenVpnMonitor` when starting a tunnel.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ProxySettings {
-    Local(LocalProxySettings),
-    Remote(RemoteProxySettings),
-    Shadowsocks(ShadowsocksProxySettings),
-}
-
-impl ProxySettings {
-    pub fn get_endpoint(&self) -> ProxyEndpoint {
-        match self {
-            ProxySettings::Local(settings) => ProxyEndpoint {
-                endpoint: settings.get_endpoint(),
-                proxy_type: ProxyType::Custom,
-            },
-            ProxySettings::Remote(settings) => ProxyEndpoint {
-                endpoint: settings.get_endpoint(),
-                proxy_type: ProxyType::Custom,
-            },
-            ProxySettings::Shadowsocks(settings) => ProxyEndpoint {
-                endpoint: settings.get_endpoint(),
-                proxy_type: ProxyType::Shadowsocks,
-            },
-        }
-    }
-}
-
-/// Options for a generic proxy running on localhost.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct LocalProxySettings {
-    pub port: u16,
-    pub peer: SocketAddr,
-}
-
-impl LocalProxySettings {
-    pub fn get_endpoint(&self) -> Endpoint {
-        Endpoint {
-            address: self.peer,
-            protocol: TransportProtocol::Tcp,
-        }
-    }
-}
-
-/// Options for a generic proxy running on remote host.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct RemoteProxySettings {
-    pub address: SocketAddr,
-    pub auth: Option<ProxyAuth>,
-}
-
-impl RemoteProxySettings {
-    pub fn get_endpoint(&self) -> Endpoint {
-        Endpoint {
-            address: self.address,
-            protocol: TransportProtocol::Tcp,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct ProxyAuth {
-    pub username: String,
-    pub password: String,
-}
-
-/// Options for a bundled Shadowsocks proxy.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct ShadowsocksProxySettings {
-    pub peer: SocketAddr,
-    /// Password on peer.
-    pub password: String,
-    pub cipher: String,
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<u32>,
-}
-
-impl ShadowsocksProxySettings {
-    pub fn get_endpoint(&self) -> Endpoint {
-        Endpoint {
-            address: self.peer,
-            protocol: TransportProtocol::Tcp,
-        }
-    }
-}
-
-/// List of ciphers usable by a Shadowsocks proxy.
-/// Cf. [`ShadowsocksProxySettings::cipher`].
-pub const SHADOWSOCKS_CIPHERS: [&str; 19] = [
-    // Stream ciphers.
-    "aes-128-cfb",
-    "aes-128-cfb1",
-    "aes-128-cfb8",
-    "aes-128-cfb128",
-    "aes-256-cfb",
-    "aes-256-cfb1",
-    "aes-256-cfb8",
-    "aes-256-cfb128",
-    "rc4",
-    "rc4-md5",
-    "chacha20",
-    "salsa20",
-    "chacha20-ietf",
-    // AEAD ciphers.
-    "aes-128-gcm",
-    "aes-256-gcm",
-    "chacha20-ietf-poly1305",
-    "xchacha20-ietf-poly1305",
-    "aes-128-pmac-siv",
-    "aes-256-pmac-siv",
-];
-
-/// Checks whether the proxy settings to be used by `OpenVpnMonitor` are valid.
-pub fn validate_proxy_settings(proxy: &ProxySettings) -> Result<(), String> {
-    match proxy {
-        ProxySettings::Local(local) => {
-            if local.port == 0 {
-                return Err(String::from("Invalid local port number"));
-            }
-            if local.peer.ip().is_loopback() {
-                return Err(String::from(
-                    "localhost is not a valid peer in this context",
-                ));
-            }
-            if local.peer.port() == 0 {
-                return Err(String::from("Invalid remote port number"));
-            }
-        }
-        ProxySettings::Remote(remote) => {
-            if remote.address.port() == 0 {
-                return Err(String::from("Invalid port number"));
-            }
-            if remote.address.ip().is_loopback() {
-                return Err(String::from("localhost is not a valid remote server"));
-            }
-        }
-        ProxySettings::Shadowsocks(ss) => {
-            if ss.peer.ip().is_loopback() {
-                return Err(String::from(
-                    "localhost is not a valid peer in this context",
-                ));
-            }
-            if ss.peer.port() == 0 {
-                return Err(String::from("Invalid remote port number"));
-            }
-            if !SHADOWSOCKS_CIPHERS.contains(&ss.cipher.as_str()) {
-                return Err(String::from("Invalid cipher"));
-            }
-        }
-    };
-    Ok(())
 }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -1,6 +1,8 @@
 use crate::net::Endpoint;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, net::SocketAddr};
+
+use super::TransportProtocol;
 
 /// Types of bridges that can be used to proxy a connection to a tunnel
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -27,3 +29,136 @@ pub struct ProxyEndpoint {
     pub endpoint: Endpoint,
     pub proxy_type: ProxyType,
 }
+
+/// User customized proxy used for obfuscation.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum CustomProxy {
+    Shadowsocks(Shadowsocks),
+    Socks5Local(Socks5Local),
+    Socks5Remote(Socks5Remote),
+}
+
+impl CustomProxy {
+    pub fn get_remote_endpoint(&self) -> ProxyEndpoint {
+        match self {
+            CustomProxy::Socks5Local(settings) => ProxyEndpoint {
+                endpoint: settings.remote_endpoint,
+                proxy_type: ProxyType::Custom,
+            },
+            CustomProxy::Socks5Remote(settings) => ProxyEndpoint {
+                endpoint: Endpoint::from_socket_address(settings.endpoint, TransportProtocol::Tcp),
+                proxy_type: ProxyType::Custom,
+            },
+            CustomProxy::Shadowsocks(settings) => ProxyEndpoint {
+                endpoint: Endpoint::from_socket_address(settings.endpoint, TransportProtocol::Tcp),
+                proxy_type: ProxyType::Shadowsocks,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Shadowsocks {
+    pub endpoint: SocketAddr,
+    pub password: String,
+    /// One of [`shadowsocks_ciphers`].
+    /// Gets validated at a later stage. Is assumed to be valid.
+    ///
+    /// shadowsocks_ciphers: talpid_types::net::openvpn::SHADOWSOCKS_CIPHERS
+    pub cipher: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Socks5Local {
+    pub remote_endpoint: Endpoint,
+    /// Port on localhost where the SOCKS5-proxy listens to.
+    pub local_port: u16,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Socks5Remote {
+    pub endpoint: SocketAddr,
+    pub auth: Option<SocksAuth>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SocksAuth {
+    pub username: String,
+    pub password: String,
+}
+
+impl Shadowsocks {
+    pub fn new<I: Into<SocketAddr>>(endpoint: I, cipher: String, password: String) -> Self {
+        Shadowsocks {
+            endpoint: endpoint.into(),
+            password,
+            cipher,
+        }
+    }
+}
+
+impl Socks5Local {
+    pub fn new<I: Into<SocketAddr>>(remote_endpoint: I, local_port: u16) -> Self {
+        let transport_protocol = TransportProtocol::Tcp;
+        Self::new_with_transport_protocol(remote_endpoint, local_port, transport_protocol)
+    }
+
+    pub fn new_with_transport_protocol<I: Into<SocketAddr>>(
+        remote_endpoint: I,
+        local_port: u16,
+        transport_protocol: TransportProtocol,
+    ) -> Self {
+        let remote_endpoint =
+            Endpoint::from_socket_address(remote_endpoint.into(), transport_protocol);
+        Self {
+            remote_endpoint,
+            local_port,
+        }
+    }
+}
+
+impl Socks5Remote {
+    pub fn new<I: Into<SocketAddr>>(endpoint: I) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            auth: None,
+        }
+    }
+
+    pub fn new_with_authentication<I: Into<SocketAddr>>(
+        endpoint: I,
+        authentication: SocksAuth,
+    ) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            auth: Some(authentication),
+        }
+    }
+}
+
+/// List of ciphers usable by a Shadowsocks proxy.
+/// Cf. [`ShadowsocksProxySettings::cipher`].
+pub const SHADOWSOCKS_CIPHERS: [&str; 19] = [
+    // Stream ciphers.
+    "aes-128-cfb",
+    "aes-128-cfb1",
+    "aes-128-cfb8",
+    "aes-128-cfb128",
+    "aes-256-cfb",
+    "aes-256-cfb1",
+    "aes-256-cfb8",
+    "aes-256-cfb128",
+    "rc4",
+    "rc4-md5",
+    "chacha20",
+    "salsa20",
+    "chacha20-ietf",
+    // AEAD ciphers.
+    "aes-128-gcm",
+    "aes-256-gcm",
+    "chacha20-ietf-poly1305",
+    "xchacha20-ietf-poly1305",
+    "aes-128-pmac-siv",
+    "aes-256-pmac-siv",
+];

--- a/test/test-manager/src/tests/tunnel.rs
+++ b/test/test-manager/src/tests/tunnel.rs
@@ -6,8 +6,8 @@ use super::{Error, TestContext};
 use crate::network_monitor::{start_packet_monitor, MonitorOptions};
 use mullvad_management_interface::{types, ManagementServiceClient};
 use mullvad_types::relay_constraints::{
-    BridgeConstraints, BridgeSettings, BridgeState, Constraint, ObfuscationSettings,
-    OpenVpnConstraints, RelayConstraints, RelaySettings, SelectedObfuscation, TransportPort,
+    BridgeSettings, BridgeState, Constraint, ObfuscationSettings, OpenVpnConstraints,
+    RelayConstraints, RelaySettings, SelectedObfuscation, TransportPort,
     Udp2TcpObfuscationSettings, WireguardConstraints,
 };
 use mullvad_types::wireguard;
@@ -209,12 +209,9 @@ pub async fn test_bridge(
         .await
         .expect("failed to enable bridge mode");
 
-    set_bridge_settings(
-        &mut mullvad_client,
-        BridgeSettings::Normal(BridgeConstraints::default()),
-    )
-    .await
-    .expect("failed to update bridge settings");
+    set_bridge_settings(&mut mullvad_client, BridgeSettings::default())
+        .await
+        .expect("failed to update bridge settings");
 
     set_relay_settings(
         &mut mullvad_client,

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -81,7 +81,7 @@ void AppendRelayRules
 (
 	FwContext::Ruleset &ruleset,
 	const WinFwEndpoint &relay,
-	const std::wstring &relayClient
+	const std::vector<std::wstring> &relayClients
 )
 {
 	auto sublayer =
@@ -95,7 +95,7 @@ void AppendRelayRules
 		wfp::IpAddress(relay.ip),
 		relay.port,
 		relay.protocol,
-		relayClient,
+		relayClients,
 		sublayer
 	));
 }
@@ -185,7 +185,7 @@ bool FwContext::applyPolicyConnecting
 (
 	const WinFwSettings &settings,
 	const WinFwEndpoint &relay,
-	const std::wstring &relayClient,
+	const std::vector<std::wstring> &relayClients,
 	const std::optional<std::wstring> &tunnelInterfaceAlias,
 	const std::optional<WinFwAllowedEndpoint> &allowedEndpoint,
 	const WinFwAllowedTunnelTraffic &allowedTunnelTraffic
@@ -195,7 +195,7 @@ bool FwContext::applyPolicyConnecting
 
 	AppendNetBlockedRules(ruleset);
 	AppendSettingsRules(ruleset, settings);
-	AppendRelayRules(ruleset, relay, relayClient);
+	AppendRelayRules(ruleset, relay, relayClients);
 
 	if (allowedEndpoint.has_value())
 	{
@@ -280,7 +280,7 @@ bool FwContext::applyPolicyConnected
 (
 	const WinFwSettings &settings,
 	const WinFwEndpoint &relay,
-	const std::wstring &relayClient,
+	const std::vector<std::wstring> &relayClient,
 	const std::wstring &tunnelInterfaceAlias,
 	const std::vector<wfp::IpAddress> &tunnelDnsServers,
 	const std::vector<wfp::IpAddress> &nonTunnelDnsServers

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -28,7 +28,7 @@ public:
 	(
 		const WinFwSettings &settings,
 		const WinFwEndpoint &relay,
-		const std::wstring &relayClient,
+		const std::vector<std::wstring> &relayClients,
 		const std::optional<std::wstring> &tunnelInterfaceAlias,
 		const std::optional<WinFwAllowedEndpoint> &allowedEndpoint,
 		const WinFwAllowedTunnelTraffic &allowedTunnelTraffic
@@ -38,7 +38,7 @@ public:
 	(
 		const WinFwSettings &settings,
 		const WinFwEndpoint &relay,
-		const std::wstring &relayClient,
+		const std::vector<std::wstring> &relayClients,
 		const std::wstring &tunnelInterfaceAlias,
 		const std::vector<wfp::IpAddress> &tunnelDnsServers,
 		const std::vector<wfp::IpAddress> &nonTunnelDnsServers

--- a/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
+++ b/windows/winfw/src/winfw/rules/multi/permitvpnrelay.cpp
@@ -52,13 +52,13 @@ PermitVpnRelay::PermitVpnRelay
 	const wfp::IpAddress &relay,
 	uint16_t relayPort,
 	WinFwProtocol protocol,
-	const std::wstring &relayClient,
+	const std::vector<std::wstring> &relayClients,
 	Sublayer sublayer
 )
 	: m_relay(relay)
 	, m_relayPort(relayPort)
 	, m_protocol(protocol)
-	, m_relayClient(relayClient)
+	, m_relayClients(relayClients)
 	, m_sublayer(sublayer)
 {
 }
@@ -86,7 +86,10 @@ bool PermitVpnRelay::apply(IObjectInstaller &objectInstaller)
 	conditionBuilder.add_condition(ConditionIp::Remote(m_relay));
 	conditionBuilder.add_condition(ConditionPort::Remote(m_relayPort));
 	conditionBuilder.add_condition(CreateProtocolCondition(m_protocol));
-	conditionBuilder.add_condition(std::make_unique<ConditionApplication>(m_relayClient));
+
+	for(auto relayClient : m_relayClients) {
+		conditionBuilder.add_condition(std::make_unique<ConditionApplication>(relayClient));
+	}
 
 	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
 }

--- a/windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
+++ b/windows/winfw/src/winfw/rules/multi/permitvpnrelay.h
@@ -23,7 +23,7 @@ public:
 		const wfp::IpAddress &relay,
 		uint16_t relayPort,
 		WinFwProtocol protocol,
-		const std::wstring &relayClient,
+		const std::vector<std::wstring> &relayClients,
 		Sublayer sublayer
 	);
 	
@@ -34,7 +34,7 @@ private:
 	const wfp::IpAddress m_relay;
 	const uint16_t m_relayPort;
 	const WinFwProtocol m_protocol;
-	const std::wstring m_relayClient;
+	const std::vector<std::wstring> m_relayClients;
 	const Sublayer m_sublayer;
 };
 

--- a/windows/winfw/src/winfw/winfw.cpp
+++ b/windows/winfw/src/winfw/winfw.cpp
@@ -231,7 +231,8 @@ WINFW_API
 WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
 	const WinFwEndpoint *relay,
-	const wchar_t *relayClient,
+	const wchar_t **relayClients,
+	size_t relayClientsLen,
 	const wchar_t *tunnelInterfaceAlias,
 	const WinFwAllowedEndpoint *allowedEndpoint,
 	const WinFwAllowedTunnelTraffic *allowedTunnelTraffic
@@ -254,20 +255,21 @@ WinFw_ApplyPolicyConnecting(
 			THROW_ERROR("Invalid argument: relay");
 		}
 
-		if (nullptr == relayClient)
-		{
-			THROW_ERROR("Invalid argument: relayClient");
-		}
-
 		if (nullptr == allowedTunnelTraffic)
 		{
 			THROW_ERROR("Invalid argument: allowedTunnelTraffic");
 		}
 
+		std::vector<std::wstring> relayClientWstrings;
+		relayClientWstrings.reserve(relayClientsLen);
+		for(int i = 0; i < relayClientsLen; i++) {
+			relayClientWstrings.push_back(relayClients[i]);
+		}
+
 		return g_fwContext->applyPolicyConnecting(
 			*settings,
 			*relay,
-			relayClient,
+			relayClientWstrings,
 			tunnelInterfaceAlias != nullptr ? std::make_optional(tunnelInterfaceAlias) : std::nullopt,
 			MakeOptional(allowedEndpoint),
 			*allowedTunnelTraffic
@@ -298,7 +300,8 @@ WINFW_API
 WinFw_ApplyPolicyConnected(
 	const WinFwSettings *settings,
 	const WinFwEndpoint *relay,
-	const wchar_t *relayClient,
+	const wchar_t **relayClients,
+	size_t relayClientsLen,
 	const wchar_t *tunnelInterfaceAlias,
 	const wchar_t *v4Gateway,
 	const wchar_t *v6Gateway,
@@ -321,11 +324,6 @@ WinFw_ApplyPolicyConnected(
 		if (nullptr == relay)
 		{
 			THROW_ERROR("Invalid argument: relay");
-		}
-
-		if (nullptr == relayClient)
-		{
-			THROW_ERROR("Invalid argument: relayClient");
 		}
 
 		if (nullptr == tunnelInterfaceAlias)
@@ -407,10 +405,16 @@ WinFw_ApplyPolicyConnected(
 			g_logSink(MULLVAD_LOG_LEVEL_DEBUG, ss.str().c_str(), g_logSinkContext);
 		}
 
+		std::vector<std::wstring> relayClientWstrings;
+		relayClientWstrings.reserve(relayClientsLen);
+		for(int i = 0; i < relayClientsLen; i++) {
+			relayClientWstrings.push_back(relayClients[i]);
+		}
+
 		return g_fwContext->applyPolicyConnected(
 			*settings,
 			*relay,
-			relayClient,
+			relayClientWstrings,
 			tunnelInterfaceAlias,
 			tunnelDnsServers,
 			nonTunnelDnsServers

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -164,7 +164,8 @@ WINFW_API
 WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
 	const WinFwEndpoint *relay,
-	const wchar_t *relayClient,
+	const wchar_t **relayClient,
+	size_t relayClientLen,
 	const wchar_t *tunnelInterfaceAlias,
 	const WinFwAllowedEndpoint *allowedEndpoint,
 	const WinFwAllowedTunnelTraffic *allowedTunnelTraffic
@@ -194,7 +195,8 @@ WINFW_API
 WinFw_ApplyPolicyConnected(
 	const WinFwSettings *settings,
 	const WinFwEndpoint *relay,
-	const wchar_t *relayClient,
+	const wchar_t **relayClient,
+	size_t relayClientLen,
 	const wchar_t *tunnelInterfaceAlias,
 	const wchar_t *v4Gateway,
 	const wchar_t *v6Gateway,


### PR DESCRIPTION
This PR is meant to make it easier for us to use a socks5 server as an obfuscation layer for OpenVPN connections.
It aims to make local socks5 servers work without having to use split tunneling, create a CLI UI to allow easily setting this up.
To set up for easy integration into the UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5587)
<!-- Reviewable:end -->
