### PR TITLE
Execute screenshot tests after merging to main

### DIFF
--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -1,0 +1,57 @@
+---
+name: iOS create screenshots
+on:
+  push:
+    tags:
+      - ios/*
+  workflow_dispatch:
+jobs:
+  test:
+    name: Take screenshots
+    runs-on: macos-13-xlarge
+    env:
+      SOURCE_PACKAGES_PATH: .spm
+      TEST_ACCOUNT: ${{ secrets.IOS_TEST_ACCOUNT_NUMBER }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup go-lang
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.5
+
+      - name: Set up yeetd to workaround XCode being slow in CI
+        run: |
+          wget https://github.com/biscuitehh/yeetd/releases/download/1.0/yeetd-normal.pkg
+          sudo installer -pkg yeetd-normal.pkg -target /
+          yeetd &
+      - name: Configure Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.0.1'
+      - name: Configure Rust
+        run: rustup target add aarch64-apple-ios-sim x86_64-apple-ios
+
+      - name: Configure Xcode project
+        run: |
+          cp Base.xcconfig.template Base.xcconfig
+          cp App.xcconfig.template App.xcconfig
+          cp PacketTunnel.xcconfig.template PacketTunnel.xcconfig
+          cp Screenshots.xcconfig.template Screenshots.xcconfig
+          sed -i "" "s/MULLVAD_ACCOUNT_TOKEN = /MULLVAD_ACCOUNT_TOKEN = $TEST_ACCOUNT/g" Screenshots.xcconfig
+        working-directory: ios/Configurations
+
+      - name: Bundle
+        run: bundle install
+        working-directory: ios
+
+      - name: Create screenshots
+        run: bundle exec fastlane snapshot --cloned_source_packages_path "$SOURCE_PACKAGES_PATH"
+        working-directory: ios
+
+      - name: Upload screenshot artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ios-screenshots
+          path: ios/Screenshots

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -1,13 +1,21 @@
 ---
-name: iOS screenshots
+name: iOS test screenshots
 on:
-  push:
-    tags:
-      - ios/*
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - .github/workflows/ios.yml
+      - ios/.swiftformat
+      - ios/**/*.swift
+      - ios/**/*.xctestplan
   workflow_dispatch:
 jobs:
   test:
-    name: Take screenshots
+    if: github.event.pull_request.merged
+    name: Screenshot tests
     runs-on: macos-13-xlarge
     env:
       SOURCE_PACKAGES_PATH: .spm
@@ -15,6 +23,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Configure cache
+        uses: actions/cache@v3
+        with:
+          path: ios/${{ env.SOURCE_PACKAGES_PATH }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('ios/**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       - name: Setup go-lang
         uses: actions/setup-go@v3
@@ -31,7 +47,7 @@ jobs:
         with:
           xcode-version: '15.0.1'
       - name: Configure Rust
-        run: rustup target add aarch64-apple-ios-sim x86_64-apple-ios
+        run: rustup target add aarch64-apple-ios-sim
 
       - name: Configure Xcode project
         run: |
@@ -42,16 +58,18 @@ jobs:
           sed -i "" "s/MULLVAD_ACCOUNT_TOKEN = /MULLVAD_ACCOUNT_TOKEN = $TEST_ACCOUNT/g" Screenshots.xcconfig
         working-directory: ios/Configurations
 
-      - name: Bundle
-        run: bundle install
-        working-directory: ios
+      - name: Install xcbeautify
+        run: |
+          brew update
+          brew install xcbeautify
 
-      - name: Create screenshots
-        run: bundle exec fastlane snapshot --cloned_source_packages_path "$SOURCE_PACKAGES_PATH"
-        working-directory: ios
-
-      - name: Upload screenshot artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ios-screenshots
-          path: ios/Screenshots
+      - name: Run screenshot tests
+        run: |
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
+            -project MullvadVPN.xcodeproj \
+            -scheme MullvadVPN \
+            -testPlan MullvadVPNScreenshots \
+            -destination "platform=iOS Simulator,name=iPhone 15" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            test 2>&1 | xcbeautify
+        working-directory: ios/

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -46,7 +46,6 @@ jobs:
     runs-on: macos-13-xlarge
     env:
       SOURCE_PACKAGES_PATH: .spm
-      TEST_ACCOUNT: ${{ secrets.IOS_TEST_ACCOUNT_NUMBER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -82,7 +81,6 @@ jobs:
           cp App.xcconfig.template App.xcconfig
           cp PacketTunnel.xcconfig.template PacketTunnel.xcconfig
           cp Screenshots.xcconfig.template Screenshots.xcconfig
-          sed -i "" "s/MULLVAD_ACCOUNT_TOKEN = /MULLVAD_ACCOUNT_TOKEN = $TEST_ACCOUNT/g" Screenshots.xcconfig
         working-directory: ios/Configurations
 
       - name: Install xcbeautify
@@ -96,13 +94,6 @@ jobs:
             -project MullvadVPN.xcodeproj \
             -scheme MullvadVPN \
             -testPlan MullvadVPNCI \
-            -destination "platform=iOS Simulator,name=iPhone 15" \
-            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
-            test 2>&1 | xcbeautify
-          set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
-            -project MullvadVPN.xcodeproj \
-            -scheme MullvadVPN \
-            -testPlan MullvadVPNScreenshots \
             -destination "platform=iOS Simulator,name=iPhone 15" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
             test 2>&1 | xcbeautify


### PR DESCRIPTION
Currently, the screenshot test is executed right after all other unit tests in the ios GH workflow. This is slow, and we'd like to get our CI job to run for 5-6 minutes instead of 7 to 9 minutes. 

To get the CI job to be faster, we should create a separate GH workflow that runs the screenshot tests exclusively, only after merge commits on main and only if ios/ directory was changed.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5589)
<!-- Reviewable:end -->
