### PR TITLE
Speed up builds on macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -268,7 +268,7 @@ function build {
         local destination_dir="dist-assets"
     fi
 
-    for binary in ${BINARIES[*]}; do
+    for binary in "${BINARIES[@]}"; do
         local source="$cargo_output_dir/$binary"
         local destination="$destination_dir/$binary"
 
@@ -303,7 +303,7 @@ fi
 
 # Compile for all defined targets, or the current architecture if unspecified.
 if [[ -n ${TARGETS:-""} ]]; then
-    for t in ${TARGETS[*]}; do
+    for t in "${TARGETS[@]}"; do
         source env.sh "$t"
         build "$t"
     done

--- a/build.sh
+++ b/build.sh
@@ -188,7 +188,7 @@ function sign_win {
 # sign them, strip them of debug symbols and copy to `dist-assets/`.
 function build {
     local current_target=${1:-""}
-    local for_target_string=""
+    local for_target_string=" for local target $ENV_TARGET"
     local stripbin="strip"
     if [[ -n $current_target ]]; then
         for_target_string=" for $current_target"

--- a/build.sh
+++ b/build.sh
@@ -315,8 +315,7 @@ if [[ "$(uname -s)" == "MINGW"* ]]; then
     fi
 fi
 
-EMPTY=()
-for t in "${TARGETS[@]:-"${EMPTY[@]}"}"; do
+for t in "${TARGETS[@]:-""}"; do
     source env.sh "$t"
     build "$t"
 done


### PR DESCRIPTION
Fixes DES-193.

An issue with the `--target` flag to cargo build caused caching not to work properly on macOS slowing down the CI.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5602)
<!-- Reviewable:end -->
