### PR TITLE
Handle Device revoked on connect screen

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
@@ -43,6 +43,7 @@ import net.mullvad.mullvadvpn.compose.component.ScaffoldWithTopBarAndDeviceName
 import net.mullvad.mullvadvpn.compose.component.drawVerticalScrollbar
 import net.mullvad.mullvadvpn.compose.component.notificationbanner.NotificationBanner
 import net.mullvad.mullvadvpn.compose.destinations.AccountDestination
+import net.mullvad.mullvadvpn.compose.destinations.DeviceRevokedDestination
 import net.mullvad.mullvadvpn.compose.destinations.OutOfTimeDestination
 import net.mullvad.mullvadvpn.compose.destinations.SelectLocationDestination
 import net.mullvad.mullvadvpn.compose.destinations.SettingsDestination
@@ -94,6 +95,12 @@ fun Connect(navigator: DestinationsNavigator) {
                 }
                 is ConnectViewModel.UiSideEffect.OutOfTime -> {
                     navigator.navigate(OutOfTimeDestination) {
+                        launchSingleTop = true
+                        popUpTo(NavGraphs.root) { inclusive = true }
+                    }
+                }
+                ConnectViewModel.UiSideEffect.RevokedDevice -> {
+                    navigator.navigate(DeviceRevokedDestination) {
                         launchSingleTop = true
                         popUpTo(NavGraphs.root) { inclusive = true }
                     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceRevokedScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceRevokedScreen.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -34,6 +34,7 @@ import net.mullvad.mullvadvpn.compose.destinations.SettingsDestination
 import net.mullvad.mullvadvpn.compose.state.DeviceRevokedUiState
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
+import net.mullvad.mullvadvpn.viewmodel.DeviceRevokedSideEffect
 import net.mullvad.mullvadvpn.viewmodel.DeviceRevokedViewModel
 import org.koin.androidx.compose.koinViewModel
 
@@ -49,15 +50,24 @@ fun DeviceRevoked(navigator: DestinationsNavigator) {
     val viewModel = koinViewModel<DeviceRevokedViewModel>()
 
     val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.uiSideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                DeviceRevokedSideEffect.NavigateToLogin -> {
+                    navigator.navigate(LoginDestination()) {
+                        launchSingleTop = true
+                        popUpTo(NavGraphs.root) { inclusive = true }
+                    }
+                }
+            }
+        }
+    }
+
     DeviceRevokedScreen(
         state = state,
         onSettingsClicked = { navigator.navigate(SettingsDestination) { launchSingleTop = true } },
-        onGoToLoginClicked = {
-            navigator.navigate(LoginDestination(null)) {
-                launchSingleTop = true
-                popUpTo(NavGraphs.root) { inclusive = true }
-            }
-        }
+        onGoToLoginClicked = viewModel::onGoToLoginClicked
     )
 }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.compose.state.ConnectUiState
+import net.mullvad.mullvadvpn.model.DeviceState
 import net.mullvad.mullvadvpn.model.GeoIpLocation
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.repository.AccountRepository
@@ -137,9 +138,15 @@ class ConnectViewModel(
 
     init {
         viewModelScope.launch {
-            // This once we get isOutOfTime true we will navigate to OutOfTime view.
+            // When we get isOutOfTime true we will navigate to OutOfTime view.
             outOfTimeUseCase.isOutOfTime().first { it == true }
             _uiSideEffect.send(UiSideEffect.OutOfTime)
+        }
+
+        viewModelScope.launch {
+            // When we get a revoked DeviceState we navigate to the RevokedDevice screen.
+            deviceRepository.deviceState.filterIsInstance<DeviceState.Revoked>().first()
+            _uiSideEffect.send(UiSideEffect.RevokedDevice)
         }
 
         viewModelScope.launch {
@@ -194,6 +201,8 @@ class ConnectViewModel(
         data class OpenAccountManagementPageInBrowser(val token: String) : UiSideEffect
 
         data object OutOfTime : UiSideEffect
+
+        data object RevokedDevice : UiSideEffect
     }
 
     companion object {

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import net.mullvad.mullvadvpn.compose.state.DeviceRevokedUiState
+import net.mullvad.mullvadvpn.lib.common.test.TestCoroutineRule
 import net.mullvad.mullvadvpn.model.TunnelState
 import net.mullvad.mullvadvpn.repository.AccountRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
@@ -26,9 +27,11 @@ import net.mullvad.talpid.util.EventNotifier
 import net.mullvad.talpid.util.callbackFlowFromSubscription
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class DeviceRevokedViewModelTest {
+    @get:Rule val testCoroutineRule = TestCoroutineRule()
 
     @MockK private lateinit var mockedAccountRepository: AccountRepository
 


### PR DESCRIPTION
This PR handles the event of a device being revoked on the Connect screen, a regression from migrating to compose navigation. It also makes sure that we properly logout the user when "Go to login" is pressed in DeviceRevoked screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5604)
<!-- Reviewable:end -->
