### PR TITLE
Fix format of IPv6 addresses in allow lan info dialog

### DIFF
--- a/gui/src/renderer/components/VpnSettings.tsx
+++ b/gui/src/renderer/components/VpnSettings.tsx
@@ -220,8 +220,8 @@ function AllowLan() {
                 <li>172.16.0.0/12</li>
                 <li>192.168.0.0/16</li>
                 <li>169.254.0.0/16</li>
-                <li>0xfe80::/10</li>
-                <li>0xfc00::/7</li>
+                <li>fe80::/10</li>
+                <li>fc00::/7</li>
               </LanIpRanges>
             </ModalMessage>
           </InfoButton>


### PR DESCRIPTION
Fix IPv6 address format in "Local network sharing" info dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5623)
<!-- Reviewable:end -->
