### PR TITLE
Prevent translation of Split tunneling in settings view

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1087,11 +1087,6 @@ msgctxt "settings-view"
 msgid "App version"
 msgstr ""
 
-#. Navigation button to the 'Split tunneling' view
-msgctxt "settings-view"
-msgid "Split tunneling"
-msgstr ""
-
 msgctxt "settings-view"
 msgid "Support"
 msgstr ""

--- a/gui/src/renderer/components/Settings.tsx
+++ b/gui/src/renderer/components/Settings.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { colors } from '../../config.json';
+import { colors, strings } from '../../config.json';
 import { messages } from '../../shared/gettext';
 import { getDownloadUrl } from '../../shared/version';
 import { useAppContext } from '../context';
@@ -131,12 +131,7 @@ function SplitTunnelingButton() {
 
   return (
     <Cell.CellNavigationButton onClick={navigate}>
-      <Cell.Label>
-        {
-          // TRANSLATORS: Navigation button to the 'Split tunneling' view
-          messages.pgettext('settings-view', 'Split tunneling')
-        }
-      </Cell.Label>
+      <Cell.Label>{strings.splitTunneling}</Cell.Label>
     </Cell.CellNavigationButton>
   );
 }


### PR DESCRIPTION
We don't want names of technologies to be translated, this includes "Split tunneling". This was by mistake added to be translated for the navigation button in the settings view.

Fixes DES-348

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5626)
<!-- Reviewable:end -->
