### PR TITLE
Respect prefer-reduced-motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add account UUID to verbose 'mullvad account get -v' output.
+- Respect OS prefer-reduced-motion setting
 
 #### Android
 - Add support for all screen orientations.

--- a/gui/assets/css/global.css
+++ b/gui/assets/css/global.css
@@ -30,3 +30,13 @@ body {
   width: 100%;
   display: flex;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 1ms !important;
+  }
+
+  .map-zoomable-group {
+    transition-duration: 0ms !important;
+  }
+}

--- a/gui/src/renderer/components/SvgMap.tsx
+++ b/gui/src/renderer/components/SvgMap.tsx
@@ -232,6 +232,7 @@ function SvgMap(props: IProps) {
       projectionConfig={projectionConfig}>
       <ZoomableGroup
         center={zoomCenter}
+        className="map-zoomable-group"
         zoom={zoomLevel}
         onTransitionEnd={removeOldViewportBboxes}
         style={zoomableGroupStyle}


### PR DESCRIPTION
This PR adds support for `prefer-reduced-motion` by disabling movement transitions when that setting is on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5628)
<!-- Reviewable:end -->
