### PR TITLE
Fix broken e2e tests 

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/LocationInfo.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/LocationInfo.kt
@@ -10,10 +10,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.compose.test.LOCATION_INFO_CONNECTION_OUT_TEST_TAG
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaInactive
@@ -111,9 +113,10 @@ fun LocationInfo(
             color = colorExpanded,
             style = MaterialTheme.typography.labelMedium,
             modifier =
-                Modifier.alpha(
-                    if (isExpanded && outAddress.isNotEmpty()) AlphaVisible else AlphaInvisible
-                )
+                Modifier.testTag(LOCATION_INFO_CONNECTION_OUT_TEST_TAG)
+                    .alpha(
+                        if (isExpanded && outAddress.isNotEmpty()) AlphaVisible else AlphaInvisible
+                    )
         )
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/test/ComposeTestTagConstants.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/test/ComposeTestTagConstants.kt
@@ -25,6 +25,7 @@ const val SELECT_LOCATION_BUTTON_TEST_TAG = "select_location_button_test_tag"
 const val CONNECT_BUTTON_TEST_TAG = "connect_button_test_tag"
 const val RECONNECT_BUTTON_TEST_TAG = "reconnect_button_test_tag"
 const val LOCATION_INFO_TEST_TAG = "location_info_test_tag"
+const val LOCATION_INFO_CONNECTION_OUT_TEST_TAG = "location_info_connection_out_test_tag"
 
 // ConnectScreen - Notification banner
 const val NOTIFICATION_BANNER = "notification_banner"

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -13,9 +13,6 @@ import net.mullvad.mullvadvpn.test.common.constant.CONNECTION_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.constant.LOGIN_PROMPT_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.constant.LOGIN_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.constant.MULLVAD_PACKAGE
-import net.mullvad.mullvadvpn.test.common.constant.SETTINGS_COG_ID
-import net.mullvad.mullvadvpn.test.common.constant.TUNNEL_INFO_ID
-import net.mullvad.mullvadvpn.test.common.constant.TUNNEL_OUT_ADDRESS_ID
 import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
@@ -78,15 +75,18 @@ class AppInteractor(private val device: UiDevice, private val targetContext: Con
     }
 
     fun extractIpAddress(): String {
-        device.findObjectWithTimeout(By.res(TUNNEL_INFO_ID)).click()
+        device.findObjectWithTimeout(By.res("location_info_test_tag")).click()
         return device
-            .findObjectWithTimeout(By.res(TUNNEL_OUT_ADDRESS_ID), CONNECTION_TIMEOUT)
+            .findObjectWithTimeout(
+                By.res("location_info_connection_out_test_tag"),
+                CONNECTION_TIMEOUT
+            )
             .text
             .extractIpAddress()
     }
 
     fun clickSettingsCog() {
-        device.findObjectWithTimeout(By.res(SETTINGS_COG_ID)).click()
+        device.findObjectWithTimeout(By.res("top_bar_settings_button")).click()
     }
 
     fun clickAccountCog() {
@@ -106,6 +106,6 @@ class AppInteractor(private val device: UiDevice, private val targetContext: Con
     }
 
     private fun String.extractIpAddress(): String {
-        return split("  ")[1].split(" ")[0]
+        return split(" ")[1].split(" ")[0]
     }
 }

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -49,12 +49,28 @@ class AppInteractor(private val device: UiDevice, private val targetContext: Con
         ensureLoggedIn()
     }
 
+    fun launchAndCreateAccount() {
+        launch()
+        device.clickAgreeOnPrivacyDisclaimer()
+        device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
+        attemptCreateAccount()
+        ensureAccountCreated()
+    }
+
     fun attemptLogin(accountToken: String) {
         val loginObject =
             device.findObjectWithTimeout(By.clazz("android.widget.EditText")).apply {
                 text = accountToken
             }
         loginObject.parent.findObject(By.clazz(Button::class.java)).click()
+    }
+
+    private fun attemptCreateAccount() {
+        device.findObjectWithTimeout(By.text("Create account")).click()
+    }
+
+    private fun ensureAccountCreated() {
+        device.findObjectWithTimeout(By.text("Congrats!"), LOGIN_TIMEOUT)
     }
 
     fun ensureLoggedIn() {

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/EndToEndTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/EndToEndTest.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.test.e2e
 
 import android.Manifest
 import android.content.Context
-import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.runner.AndroidJUnit4
@@ -25,14 +24,10 @@ abstract class EndToEndTest {
     @Rule
     @JvmField
     val permissionRule: GrantPermissionRule =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            GrantPermissionRule.grant(Manifest.permission.READ_MEDIA_IMAGES)
-        } else {
-            GrantPermissionRule.grant(
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            )
-        }
+        GrantPermissionRule.grant(
+            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        )
 
     lateinit var device: UiDevice
     lateinit var targetContext: Context

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.test.e2e
 
 import androidx.test.runner.AndroidJUnit4
 import androidx.test.uiautomator.By
-import junit.framework.Assert.assertNotNull
 import net.mullvad.mullvadvpn.test.common.constant.LOGIN_FAILURE_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
@@ -43,19 +42,5 @@ class LoginTest : EndToEndTest() {
 
         // Then
         app.ensureLoggedIn()
-    }
-
-    @Test
-    fun testLogout() {
-        // Given
-        app.launchAndEnsureLoggedIn(validTestAccountToken)
-
-        // When
-        app.clickSettingsCog()
-        app.clickListItemByText("Account")
-        app.clickActionButtonByText("Log out")
-
-        // Then
-        assertNotNull(device.findObjectWithTimeout(By.text("Login")))
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LogoutTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LogoutTest.kt
@@ -1,0 +1,42 @@
+package net.mullvad.mullvadvpn.test.e2e
+
+import androidx.test.runner.AndroidJUnit4
+import androidx.test.uiautomator.By
+import junit.framework.Assert.assertNotNull
+import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+import net.mullvad.mullvadvpn.test.e2e.misc.CleanupAccountTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LogoutTest : EndToEndTest() {
+
+    @Rule @JvmField val cleanupAccountTestRule = CleanupAccountTestRule()
+
+    @Test
+    fun testLogout() {
+        // Given
+        app.launchAndEnsureLoggedIn(validTestAccountToken)
+
+        // When
+        app.clickAccountCog()
+        app.clickActionButtonByText("Log out")
+
+        // Then
+        assertNotNull(device.findObjectWithTimeout(By.text("Login")))
+    }
+
+    @Test
+    fun testCreateAccountAndLogout() {
+        // Given
+        app.launchAndCreateAccount()
+
+        // When
+        app.clickAccountCog()
+        app.clickActionButtonByText("Log out")
+
+        // Then
+        assertNotNull(device.findObjectWithTimeout(By.text("Login")))
+    }
+}


### PR DESCRIPTION
After migration into android compose and lack of IDs some of ui automate tests stops working.
this are the fixes:

- LoginTest
- ConnectionTest
- WebLinkTest