### PR TITLE
Remove excessive logging of interfaces on macOS

### DIFF
--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -133,10 +133,7 @@ impl PrimaryInterfaceMonitor {
                 log::debug!("Found primary interface for {family}");
                 vec![iface]
             })
-            .unwrap_or_else(|| {
-                log::debug!("No primary interface for {family}. Checking service order");
-                self.network_services(family)
-            });
+            .unwrap_or_else(|| self.network_services(family));
 
         let (iface, index) = ifaces
             .into_iter()
@@ -225,11 +222,7 @@ impl PrimaryInterfaceMonitor {
                 let ip_dict = self
                     .store
                     .get(CFString::new(&key))
-                    .and_then(|v| v.downcast_into::<CFDictionary>())
-                    .or_else(|| {
-                        log::debug!("No {family} dict for {service_id_s}");
-                        None
-                    })?;
+                    .and_then(|v| v.downcast_into::<CFDictionary>())?;
                 let name = ip_dict
                     .find(unsafe { kSCPropInterfaceName }.to_void())
                     .map(|s| unsafe { CFType::wrap_under_get_rule(*s) })


### PR DESCRIPTION
This ends up being logged whenever a default is added or removed, if there's no primary IPv6 interface:
```
[2024-01-01 01:05:08.494][talpid_routing::imp::imp::interface][DEBUG] Found primary interface for V4
[2024-01-01 01:05:08.495][talpid_routing::imp::imp::interface][DEBUG] No primary interface for V6. Checking service order
[2024-01-01 01:05:08.495][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.495][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.495][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.495][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.495][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.496][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.496][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.496][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
[2024-01-01 01:05:08.496][talpid_routing::imp::imp::interface][DEBUG] No V6 dict for [REDACTED]
```
It is not useful, so this PR removes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5642)
<!-- Reviewable:end -->
