### PR TITLE
Fix local proxy not working if started before connecting

### DIFF
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -285,7 +285,6 @@ impl Firewall {
             .to(relay_endpoint.endpoint.address)
             .proto(pfctl_proto)
             .keep_state(pfctl::StatePolicy::Keep)
-            .tcp_flags(Self::get_tcp_flags())
             .quick(true);
 
         if !relay_endpoint.clients.allow_all() {


### PR DESCRIPTION
Previously, only the first SYN packet was allowed in the firewall. If the connection to the custom proxy server was initiated before connecting to the VPN, this packet was never seen, so PF blocked the connection.

Note: This prevents PF from blocking connections to the first hop that were initiated before the rules were added.

Introduced in [#5587](https://github.com/mullvad/mullvadvpn-app/pull/5587)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5647)
<!-- Reviewable:end -->
