### PR TITLE
Use workspace level lints

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -64,7 +64,7 @@ jobs:
           RUSTFLAGS: --deny warnings
         run: |
           source env.sh
-          time cargo clippy --locked -- -W clippy::unused_async
+          time cargo clippy --locked
 
   clippy-check-android:
     name: Clippy linting, Android
@@ -86,4 +86,4 @@ jobs:
         env:
           RUSTFLAGS: --deny warnings
         run: |
-          cargo clippy --locked --target x86_64-linux-android --package mullvad-jni -- -W clippy::unused_async
+          cargo clippy --locked --target x86_64-linux-android --package mullvad-jni

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,12 @@ members = [
     "tunnel-obfuscation",
 ]
 
+[workspace.lints.rust]
+rust_2018_idioms = "deny"
+
+[workspace.lints.clippy]
+unused_async = "deny"
+
 [workspace.dependencies]
 tokio = { version = "1.8" }
 # Tonic and related crates

--- a/android/translations-converter/Cargo.toml
+++ b/android/translations-converter/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 err-derive = { workspace = true }
 htmlize = { version = "1.0.2", features = ["unescape"] }

--- a/android/translations-converter/src/main.rs
+++ b/android/translations-converter/src/main.rs
@@ -31,8 +31,6 @@
 //! most cases, it is important to keep in mind that this is just a helper tool and manual steps are
 //! likely to be needed from time to time.
 
-#![deny(rust_2018_idioms)]
-
 mod android;
 mod gettext;
 mod normalize;

--- a/ios/MullvadREST/Transport/Shadowsocks/shadowsocks-proxy/Cargo.toml
+++ b/ios/MullvadREST/Transport/Shadowsocks/shadowsocks-proxy/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = [ "rlib", "staticlib" ]
 bench = false

--- a/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
+++ b/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = [ "rlib", "staticlib" ]
 bench = false

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # Allow the API server to use to be configured via MULLVAD_API_HOST and MULLVAD_API_ADDR.
 api-override = []

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 #[cfg(target_os = "android")]
 use futures::channel::mpsc;
 use futures::Stream;

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
 
 [[bin]]
 name = "mullvad"

--- a/mullvad-cli/src/main.rs
+++ b/mullvad-cli/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 #[cfg(all(unix, not(target_os = "android")))]
 use anyhow::anyhow;
 use anyhow::Result;

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override"]

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(rust_2018_idioms)]
 #![recursion_limit = "512"]
 
 mod access_method;

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use mullvad_daemon::{
     logging,
     management_interface::{ManagementInterfaceEventBroadcaster, ManagementInterfaceServer},

--- a/mullvad-exclude/Cargo.toml
+++ b/mullvad-exclude/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.23"
 err-derive = { workspace = true }

--- a/mullvad-fs/Cargo.toml
+++ b/mullvad-fs/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 log = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt"] }

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override"]

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -31,7 +31,7 @@ pub enum Error {
     UpdateSettings,
 
     #[error(display = "Daemon returned an error")]
-    OtherError(#[error(source)] mullvad_daemon::Error),
+    Other(#[error(source)] mullvad_daemon::Error),
 }
 
 impl From<mullvad_daemon::Error> for Error {
@@ -44,7 +44,7 @@ impl From<mullvad_daemon::Error> for Error {
             mullvad_daemon::Error::ListDevicesError(device::Error::OtherRestError(error)) => {
                 Error::Api(error)
             }
-            error => Error::OtherError(error),
+            error => Error::Other(error),
         }
     }
 }

--- a/mullvad-jni/src/jni_event_listener.rs
+++ b/mullvad-jni/src/jni_event_listener.rs
@@ -34,8 +34,8 @@ enum Event {
     Settings(Settings),
     Tunnel(TunnelState),
     AppVersionInfo(AppVersionInfo),
-    DeviceEvent(DeviceEvent),
-    RemoveDeviceEvent(RemoveDeviceEvent),
+    Device(DeviceEvent),
+    RemoveDevice(RemoveDeviceEvent),
 }
 
 #[derive(Clone, Debug)]
@@ -65,11 +65,11 @@ impl EventListener for JniEventListener {
     }
 
     fn notify_device_event(&self, event: DeviceEvent) {
-        let _ = self.0.send(Event::DeviceEvent(event));
+        let _ = self.0.send(Event::Device(event));
     }
 
     fn notify_remove_device_event(&self, event: RemoveDeviceEvent) {
-        let _ = self.0.send(Event::RemoveDeviceEvent(event));
+        let _ = self.0.send(Event::RemoveDevice(event));
     }
 }
 
@@ -190,15 +190,13 @@ impl<'env> JniEventHandler<'env> {
         while let Ok(event) = self.events.recv() {
             match event {
                 Event::RelayList(relay_list) => self.handle_relay_list_event(relay_list),
-                Event::Settings(settings) => self.handle_settings(settings),
+                Event::Settings(settings) => self.handle_settings_event(settings),
                 Event::Tunnel(tunnel_event) => self.handle_tunnel_event(tunnel_event),
                 Event::AppVersionInfo(app_version_info) => {
                     self.handle_app_version_info_event(app_version_info)
                 }
-                Event::DeviceEvent(device_event) => self.handle_device_event(device_event),
-                Event::RemoveDeviceEvent(device_event) => {
-                    self.handle_remove_device_event(device_event)
-                }
+                Event::Device(device_event) => self.handle_device_event(device_event),
+                Event::RemoveDevice(device_event) => self.handle_remove_device_event(device_event),
             }
         }
     }
@@ -258,7 +256,7 @@ impl<'env> JniEventHandler<'env> {
         }
     }
 
-    fn handle_settings(&self, settings: Settings) {
+    fn handle_settings_event(&self, settings: Settings) {
         let java_settings = settings.into_java(&self.env);
 
         let result = self.env.call_method_unchecked(

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -107,7 +107,7 @@ impl From<Result<(), daemon_interface::Error>> for LoginResult {
         match result {
             Ok(()) => LoginResult::Ok,
             Err(error) => match error {
-                daemon_interface::Error::OtherError(mullvad_daemon::Error::LoginError(error)) => {
+                daemon_interface::Error::Other(mullvad_daemon::Error::LoginError(error)) => {
                     match error {
                         device::Error::InvalidAccount => LoginResult::InvalidAccount,
                         device::Error::MaxDevicesReached => LoginResult::MaxDevicesReached,
@@ -136,7 +136,7 @@ impl From<Result<(), daemon_interface::Error>> for RemoveDeviceResult {
         match result {
             Ok(()) => RemoveDeviceResult::Ok,
             Err(error) => match error {
-                daemon_interface::Error::OtherError(mullvad_daemon::Error::LoginError(error)) => {
+                daemon_interface::Error::Other(mullvad_daemon::Error::LoginError(error)) => {
                     match error {
                         device::Error::InvalidAccount => RemoveDeviceResult::RpcError,
                         device::Error::InvalidDevice => RemoveDeviceResult::NotFound,
@@ -179,10 +179,10 @@ impl From<Result<VoucherSubmission, daemon_interface::Error>> for VoucherSubmiss
 impl From<daemon_interface::Error> for VoucherSubmissionError {
     fn from(error: daemon_interface::Error) -> Self {
         match error {
-            daemon_interface::Error::OtherError(mullvad_daemon::Error::VoucherSubmission(
+            daemon_interface::Error::Other(mullvad_daemon::Error::VoucherSubmission(
                 device::Error::InvalidVoucher,
             )) => VoucherSubmissionError::InvalidVoucher,
-            daemon_interface::Error::OtherError(mullvad_daemon::Error::VoucherSubmission(
+            daemon_interface::Error::Other(mullvad_daemon::Error::VoucherSubmission(
                 device::Error::UsedVoucher,
             )) => VoucherSubmissionError::VoucherAlreadyUsed,
             _ => VoucherSubmissionError::OtherError,

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg(target_os = "android")]
-#![deny(rust_2018_idioms)]
 
 mod classes;
 mod daemon_interface;

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono = { workspace = true }
 err-derive = { workspace = true }

--- a/mullvad-nsis/Cargo.toml
+++ b/mullvad-nsis/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate_type = ["staticlib"]
 

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 err-derive = { workspace = true }
 

--- a/mullvad-paths/src/lib.rs
+++ b/mullvad-paths/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 #[cfg(not(target_os = "windows"))]
 use std::fs;
 use std::{io, path::PathBuf};

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 dirs = "5.0.1"
 err-derive = { workspace = true }

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use mullvad_api::proxy::ApiConnectionMode;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use clap::Parser;
 use mullvad_problem_report::{collect_report, Error};
 use std::{

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono = { workspace = true }
 err-derive = { workspace = true }

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "mullvad-setup"
 path = "src/main.rs"

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono = { workspace = true, features = ["clock", "serde"] }
 err-derive = { workspace = true }

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 pub mod access_method;
 pub mod account;
 pub mod auth_failed;

--- a/mullvad-version/Cargo.toml
+++ b/mullvad-version/Cargo.toml
@@ -13,6 +13,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 
 [target.'cfg(not(target_os="android"))'.dependencies]
 regex = "1.6.0"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 err-derive = { workspace = true }
 futures = "0.3.15"

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -1,7 +1,6 @@
 //! The core components of the talpidaemon VPN client.
 
 #![deny(missing_docs)]
-#![deny(rust_2018_idioms)]
 #![recursion_limit = "1024"]
 
 /// Misc FFI utilities.

--- a/talpid-dbus/Cargo.toml
+++ b/talpid-dbus/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9"
 err-derive = { workspace = true }

--- a/talpid-dbus/src/network_manager.rs
+++ b/talpid-dbus/src/network_manager.rs
@@ -454,7 +454,7 @@ impl NetworkManager {
 
         let device = self.as_path(&device_path);
         // Get the last applied connection
-        let (mut settings, version_id): (NetworkSettings, u64) =
+        let (mut settings, version_id): (NetworkSettings<'_>, u64) =
             device.method_call(NM_DEVICE, "GetAppliedConnection", (0u32,))?;
 
         // Keep changed routes.

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/talpid-openvpn-plugin/src/lib.rs
+++ b/talpid-openvpn-plugin/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 use openvpn_plugin::{openvpn_plugin, EventResult, EventType};
 use std::{collections::HashMap, ffi::CString, io, sync::Mutex};
 use talpid_types::ErrorExt;

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -1,7 +1,6 @@
 //! Manage OpenVPN tunnels.
 
 #![deny(missing_docs)]
-#![deny(rust_2018_idioms)]
 
 use crate::proxy::ProxyMonitor;
 #[cfg(windows)]

--- a/talpid-platform-metadata/Cargo.toml
+++ b/talpid-platform-metadata/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rs-release = "0.1.7"

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
 
 [dependencies]
 err-derive = { workspace = true }

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -1,7 +1,6 @@
 //! Manage routing tables on various platforms.
 
 #![deny(missing_docs)]
-#![deny(rust_2018_idioms)]
 
 use ipnetwork::IpNetwork;
 use std::{fmt, net::IpAddr};

--- a/talpid-time/Cargo.toml
+++ b/talpid-time/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 tokio = { workspace = true, features = ["time"] }
 libc = "0.2"

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 log = { workspace = true }
 rand = "0.8"

--- a/talpid-tunnel-config-client/src/classic_mceliece.rs
+++ b/talpid-tunnel-config-client/src/classic_mceliece.rs
@@ -27,7 +27,7 @@ pub async fn generate_keys() -> (PublicKey<'static>, SecretKey<'static>) {
 }
 
 pub fn decapsulate(
-    secret: &SecretKey,
+    secret: &SecretKey<'_>,
     ciphertext_slice: &[u8],
 ) -> Result<SharedSecret<'static>, super::Error> {
     let ciphertext_array =

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 err-derive = { workspace = true }
 cfg-if = "1.0"

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 ipnetwork = "0.16"

--- a/talpid-types/src/lib.rs
+++ b/talpid-types/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 #[cfg(target_os = "android")]
 pub mod android;
 pub mod net;

--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [target.'cfg(windows)'.dependencies]
 err-derive = { workspace = true }
 socket2 = { version = "0.5.3" }

--- a/talpid-windows/src/lib.rs
+++ b/talpid-windows/src/lib.rs
@@ -1,7 +1,6 @@
 //! Interface with low-level Windows-specific bits.
 
 #![deny(missing_docs)]
-#![deny(rust_2018_idioms)]
 #![cfg(windows)]
 
 /// I/O

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
 
 [dependencies]
 err-derive = { workspace = true }

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -1,7 +1,6 @@
 //! Manage WireGuard tunnels.
 
 #![deny(missing_docs)]
-#![deny(rust_2018_idioms)]
 
 use self::config::Config;
 use futures::future::{abortable, AbortHandle as FutureAbortHandle, BoxFuture, Future};

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -6,6 +6,12 @@ members = [
     "test-rpc",
 ]
 
+[workspace.lints.rust]
+rust_2018_idioms = "deny"
+
+[workspace.lints.clippy]
+unused_async = "deny"
+
 [patch.crates-io]
 serialport = { git = "https://github.com/mullvad/serialport-rs", rev = "1401c9d39e4a89685e3506a7160869b2c8e9ceb0" }
 

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -3,6 +3,9 @@ name = "test-manager"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 futures = { workspace = true }

--- a/test/test-manager/src/logging.rs
+++ b/test/test-manager/src/logging.rs
@@ -79,12 +79,12 @@ impl Logger {
 }
 
 impl log::Log for Logger {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
         let inner = self.inner.lock().unwrap();
         inner.env_logger.enabled(metadata)
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         if !self.enabled(record.metadata()) {
             return;
         }

--- a/test/test-manager/src/network_monitor.rs
+++ b/test/test-manager/src/network_monitor.rs
@@ -31,7 +31,7 @@ pub struct ParsedPacket {
 impl PacketCodec for Codec {
     type Item = Option<ParsedPacket>;
 
-    fn decode(&mut self, packet: pcap::Packet) -> Self::Item {
+    fn decode(&mut self, packet: pcap::Packet<'_>) -> Self::Item {
         if self.no_frame {
             // skip utun header specifying an address family
             #[cfg(target_os = "macos")]

--- a/test/test-manager/src/vm/update.rs
+++ b/test/test-manager/src/vm/update.rs
@@ -59,7 +59,7 @@ pub fn packages(config: &VmConfig, guest_ip: std::net::IpAddr) -> Result<Update>
 
 // Pretty-printing for an `Update` action.
 impl fmt::Display for Update {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Update::Nothing => write!(formatter, "Nothing was updated"),
             Update::Logs(output) => output

--- a/test/test-rpc/Cargo.toml
+++ b/test/test-rpc/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 description = "Supports IPC between test-runner and test-manager"
 
+[lints]
+workspace = true
+
 [dependencies]
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/test/test-rpc/src/logging.rs
+++ b/test/test-rpc/src/logging.rs
@@ -1,5 +1,6 @@
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -19,8 +20,8 @@ pub enum Output {
     Other(String),
 }
 
-impl std::fmt::Display for Output {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for Output {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Output::Error(s) => f.write_fmt(format_args!("{}", s.as_str().red())),
             Output::Warning(s) => f.write_fmt(format_args!("{}", s.as_str().yellow())),

--- a/test/test-rpc/src/transport.rs
+++ b/test/test-rpc/src/transport.rs
@@ -107,7 +107,7 @@ impl ConnectionHandle {
     }
 
     /// Returns a future that is notified when `reset_connected_state` is called.
-    pub fn notified_reset(&self) -> Notified {
+    pub fn notified_reset(&self) -> Notified<'_> {
         self.reset_notify.notified()
     }
 

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -3,6 +3,9 @@ name = "test-runner"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 futures = { workspace = true }
 tarpc = { workspace = true }

--- a/test/test-runner/src/logging.rs
+++ b/test/test-runner/src/logging.rs
@@ -29,11 +29,11 @@ pub static LOGGER: Lazy<StdOutBuffer> = Lazy::new(|| {
 pub struct StdOutBuffer(pub Mutex<Receiver<Output>>, pub Sender<Output>);
 
 impl log::Log for StdOutBuffer {
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         metadata.level() <= Level::Info
     }
 
-    fn log(&self, record: &Record) {
+    fn log(&self, record: &Record<'_>) {
         if self.enabled(record.metadata()) {
             match record.metadata().level() {
                 Level::Error => {

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 async-trait = "0.1"
 err-derive = { workspace = true }


### PR DESCRIPTION
New in Rust 1.74 is [cargo managed linting and workspace level lints](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html#lint-configuration-through-cargo). Now when we have bumped our build containers to use newest Rust we can start using these.

This allows us to not explicitly specify deny lints in CI invocations of `cargo clippy`. It also allows us to not have to repeat wanted lints in every crate (`#![deny(rust_2018_idioms)]`), something we naturally forgot to do in a bunch of crates already :shrug:.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5655)
<!-- Reviewable:end -->
