### PR TITLE
Make `mullvad status` print if lockdown mode is enabled while disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 - Respect OS prefer-reduced-motion setting
 - Add CLI command for exporting settings patches: `mullvad export-settings`. Currently, it generates
   a patch containing all patchable settings, which only includes relay IP overrides.
+- Make `mullvad status` prints if lockdown mode is enabled when disconnected.
 
 #### Android
 - Add support for all screen orientations.

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -39,7 +39,10 @@ impl Status {
                         // match statement checks for duplicate tunnel states and skips the second
                         // print to avoid spamming the user.
                         match (&previous_tunnel_state, &new_state) {
-                            (Some(TunnelState::Disconnected(_)), TunnelState::Disconnected(_))
+                            (
+                                Some(TunnelState::Disconnected { .. }),
+                                TunnelState::Disconnected { .. },
+                            )
                             | (
                                 Some(TunnelState::Connected { .. }),
                                 TunnelState::Connected { .. },
@@ -91,7 +94,7 @@ pub async fn handle(cmd: Option<Status>, args: StatusArgs) -> Result<()> {
     let state = rpc.get_tunnel_state().await?;
     let device = rpc.get_device().await?;
 
-    print_account_loggedout(&state, &device);
+    print_account_logged_out(&state, &device);
 
     if args.debug {
         println!("Tunnel state: {state:#?}");
@@ -106,7 +109,7 @@ pub async fn handle(cmd: Option<Status>, args: StatusArgs) -> Result<()> {
     Ok(())
 }
 
-fn print_account_loggedout(state: &TunnelState, device: &DeviceState) {
+fn print_account_logged_out(state: &TunnelState, device: &DeviceState) {
     match state {
         TunnelState::Connecting { .. } | TunnelState::Connected { .. } | TunnelState::Error(_) => {
             match device {
@@ -117,6 +120,6 @@ fn print_account_loggedout(state: &TunnelState, device: &DeviceState) {
                 DeviceState::LoggedIn(_) => (),
             }
         }
-        TunnelState::Disconnected(_) | TunnelState::Disconnecting(_) => (),
+        TunnelState::Disconnected { .. } | TunnelState::Disconnecting(_) => (),
     }
 }

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -37,8 +37,15 @@ pub fn print_state(state: &TunnelState, verbose: bool) {
                 format_relay_connection(endpoint, location.as_ref(), verbose)
             );
         }
-        Disconnected(_) => {
-            println!("Disconnected");
+        Disconnected {
+            location: _,
+            locked_down,
+        } => {
+            if *locked_down {
+                println!("Disconnected (Internet access is blocked due to lockdown mode)");
+            } else {
+                println!("Disconnected");
+            }
         }
         Disconnecting(_) => println!("Disconnecting..."),
     }
@@ -46,7 +53,10 @@ pub fn print_state(state: &TunnelState, verbose: bool) {
 
 pub fn print_location(state: &TunnelState) {
     let location = match state {
-        TunnelState::Disconnected(location) => location,
+        TunnelState::Disconnected {
+            location,
+            locked_down: _,
+        } => location,
         TunnelState::Connected { location, .. } => location,
         _ => return,
     };

--- a/mullvad-daemon/src/device/mod.rs
+++ b/mullvad-daemon/src/device/mod.rs
@@ -1282,7 +1282,7 @@ impl TunnelStateChangeHandler {
             }
             TunnelStateTransition::Error(_)
             | TunnelStateTransition::Connected(_)
-            | TunnelStateTransition::Disconnected => 0,
+            | TunnelStateTransition::Disconnected { .. } => 0,
             _ => retry_attempt,
         }
     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1002,10 +1002,9 @@ where
             .handle_state_transition(&tunnel_state_transition);
 
         let tunnel_state = match tunnel_state_transition {
-            TunnelStateTransition::Disconnected => TunnelState::Disconnected {
+            TunnelStateTransition::Disconnected { locked_down } => TunnelState::Disconnected {
                 location: None,
-                // If lockdown mode is enabled and state is disconnected
-                locked_down: self.settings.block_when_disconnected,
+                locked_down,
             },
             TunnelStateTransition::Connecting(endpoint) => TunnelState::Connecting {
                 endpoint,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -439,7 +439,7 @@ impl DaemonExecutionState {
         match self {
             Running => {
                 match tunnel_state {
-                    TunnelState::Disconnected(_) => mem::replace(self, Finished),
+                    TunnelState::Disconnected { .. } => mem::replace(self, Finished),
                     _ => mem::replace(self, Exiting),
                 };
             }
@@ -856,7 +856,10 @@ where
         );
 
         let daemon = Daemon {
-            tunnel_state: TunnelState::Disconnected(None),
+            tunnel_state: TunnelState::Disconnected {
+                location: None,
+                locked_down: settings.block_when_disconnected,
+            },
             target_state,
             state: DaemonExecutionState::Running,
             #[cfg(target_os = "linux")]
@@ -999,7 +1002,11 @@ where
             .handle_state_transition(&tunnel_state_transition);
 
         let tunnel_state = match tunnel_state_transition {
-            TunnelStateTransition::Disconnected => TunnelState::Disconnected(None),
+            TunnelStateTransition::Disconnected => TunnelState::Disconnected {
+                location: None,
+                // If lockdown mode is enabled and state is disconnected
+                locked_down: self.settings.block_when_disconnected,
+            },
             TunnelStateTransition::Connecting(endpoint) => TunnelState::Connecting {
                 endpoint,
                 location: self.parameters_generator.get_last_location().await,
@@ -1024,7 +1031,7 @@ where
         log::debug!("New tunnel state: {:?}", tunnel_state);
 
         match tunnel_state {
-            TunnelState::Disconnected(_) => {
+            TunnelState::Disconnected { .. } => {
                 self.api_handle.availability.reset_inactivity_timer();
             }
             _ => {
@@ -1033,7 +1040,7 @@ where
         }
 
         match &tunnel_state {
-            TunnelState::Disconnected(_) => self.state.disconnected(),
+            TunnelState::Disconnected { .. } => self.state.disconnected(),
             TunnelState::Connecting { .. } => {
                 log::debug!("Settings: {}", self.settings.summary());
             }
@@ -1079,7 +1086,7 @@ where
             TunnelState::Connected { .. } => self.settings.tunnel_options.generic.enable_ipv6,
             // If not connected, we have to guess whether the users local connection supports IPv6.
             // The only thing we have to go on is the wireguard setting.
-            TunnelState::Disconnected(_) => {
+            TunnelState::Disconnected { .. } => {
                 if let RelaySettings::Normal(relay_constraints) = &self.settings.relay_settings {
                     // Note that `Constraint::Any` corresponds to just IPv4
                     matches!(
@@ -1098,7 +1105,7 @@ where
         self.location_handler.send_geo_location_request(use_ipv6);
     }
 
-    /// Recieves and handles the geographical exit location received from am.i.mullvad.net, i.e. the
+    /// Receives and handles the geographical exit location received from am.i.mullvad.net, i.e. the
     /// [`InternalDaemonEvent::LocationEvent`] event.
     fn handle_location_event(&mut self, location_data: LocationEventData) {
         let LocationEventData {
@@ -1112,7 +1119,10 @@ where
         }
 
         match self.tunnel_state {
-            TunnelState::Disconnected(ref mut location) => *location = Some(fetched_location),
+            TunnelState::Disconnected {
+                ref mut location,
+                locked_down: _,
+            } => *location = Some(fetched_location),
             TunnelState::Connected {
                 ref mut location, ..
             } => {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -177,7 +177,10 @@ message ErrorState {
 }
 
 message TunnelState {
-  message Disconnected { GeoIpLocation disconnected_location = 1; }
+  message Disconnected {
+    GeoIpLocation disconnected_location = 1;
+    bool locked_down = 2;
+  }
   message Connecting { TunnelStateRelayInfo relay_info = 1; }
   message Connected { TunnelStateRelayInfo relay_info = 1; }
   message Disconnecting { AfterDisconnect after_disconnect = 1; }

--- a/mullvad-management-interface/src/types/conversions/states.rs
+++ b/mullvad-management-interface/src/types/conversions/states.rs
@@ -32,11 +32,13 @@ impl From<mullvad_types::states::TunnelState> for proto::TunnelState {
             };
 
         let state = match state {
-            MullvadTunnelState::Disconnected(disconnected_location) => {
-                proto::tunnel_state::State::Disconnected(proto::tunnel_state::Disconnected {
-                    disconnected_location: disconnected_location.map(proto::GeoIpLocation::from),
-                })
-            }
+            MullvadTunnelState::Disconnected {
+                location: disconnected_location,
+                locked_down,
+            } => proto::tunnel_state::State::Disconnected(proto::tunnel_state::Disconnected {
+                disconnected_location: disconnected_location.map(proto::GeoIpLocation::from),
+                locked_down,
+            }),
             MullvadTunnelState::Connecting { endpoint, location } => {
                 proto::tunnel_state::State::Connecting(proto::tunnel_state::Connecting {
                     relay_info: Some(proto::TunnelStateRelayInfo {
@@ -193,11 +195,13 @@ impl TryFrom<proto::TunnelState> for mullvad_types::states::TunnelState {
         let state = match state.state {
             Some(proto::tunnel_state::State::Disconnected(proto::tunnel_state::Disconnected {
                 disconnected_location,
-            })) => MullvadState::Disconnected(
-                disconnected_location
+                locked_down,
+            })) => MullvadState::Disconnected {
+                location: disconnected_location
                     .map(mullvad_types::location::GeoIpLocation::try_from)
                     .transpose()?,
-            ),
+                locked_down,
+            },
             Some(proto::tunnel_state::State::Connecting(proto::tunnel_state::Connecting {
                 relay_info:
                     Some(proto::TunnelStateRelayInfo {

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -34,7 +34,11 @@ impl fmt::Display for TargetState {
 #[cfg_attr(target_os = "android", derive(IntoJava))]
 #[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub enum TunnelState {
-    Disconnected(Option<GeoIpLocation>),
+    Disconnected {
+        location: Option<GeoIpLocation>,
+        /// Whether internet access is blocked due to lockdown mode
+        locked_down: bool,
+    },
     Connecting {
         endpoint: TunnelEndpoint,
         location: Option<GeoIpLocation>,
@@ -60,6 +64,6 @@ impl TunnelState {
 
     /// Returns true if the tunnel state is in the disconnected state.
     pub fn is_disconnected(&self) -> bool {
-        matches!(self, TunnelState::Disconnected(_))
+        matches!(self, TunnelState::Disconnected { .. })
     }
 }

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -1,6 +1,4 @@
 use crate::location::GeoIpLocation;
-#[cfg(target_os = "android")]
-use jnix::IntoJava;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use talpid_types::{
@@ -31,8 +29,6 @@ impl fmt::Display for TargetState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "state", content = "details")]
-#[cfg_attr(target_os = "android", derive(IntoJava))]
-#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub enum TunnelState {
     Disconnected {
         location: Option<GeoIpLocation>,
@@ -65,5 +61,118 @@ impl TunnelState {
     /// Returns true if the tunnel state is in the disconnected state.
     pub fn is_disconnected(&self) -> bool {
         matches!(self, TunnelState::Disconnected { .. })
+    }
+}
+
+#[cfg(target_os = "android")]
+// Here we manually implement the `IntoJava` trait of jnix to skip the `locked_down` field of
+// `TunnelState::Disconnected`. The derive macro currently does not support skipping fields in
+// struct variants of enums. It was decided that this solution is the preferred to updating the
+// macro since the jnix crate will be dropped once android implements gRPC.
+impl<'borrow, 'env> jnix::IntoJava<'borrow, 'env> for TunnelState
+where
+    'env: 'borrow,
+{
+    const JNI_SIGNATURE: &'static str = "Lnet/mullvad/mullvadvpn/model/TunnelState;";
+    type JavaType = jnix::jni::objects::AutoLocal<'env, 'borrow>;
+    #[allow(non_snake_case)]
+    fn into_java(self, env: &'borrow jnix::JnixEnv<'env>) -> Self::JavaType {
+        match self {
+            Self::Disconnected {
+                location,
+                locked_down: _,
+            } => {
+                let constructor_signature = format!("({})V", location.jni_signature());
+
+                let location_java = location.into_java(env);
+                let parameters = [jnix::AsJValue::as_jvalue(&location_java)];
+
+                let class = env.get_class("net/mullvad/mullvadvpn/model/TunnelState$Disconnected");
+
+                let object = env
+                    .new_object(&class, constructor_signature, &parameters)
+                    .expect(
+                        "Failed to convert TunnelState::Disconnected Rust type into net.mullvad.mullvadvpn.model.TunnelState.Disconnected Java object",
+                    );
+                env.auto_local(object)
+            }
+            Self::Connecting { endpoint, location } => {
+                let constructor_signature = format!(
+                    "({}{})V",
+                    endpoint.jni_signature(),
+                    location.jni_signature()
+                );
+
+                let endpoint_java = endpoint.into_java(env);
+                let location_java = location.into_java(env);
+                let parameters = [
+                    jnix::AsJValue::as_jvalue(&endpoint_java),
+                    jnix::AsJValue::as_jvalue(&location_java),
+                ];
+
+                let class = env.get_class("net/mullvad/mullvadvpn/model/TunnelState$Connecting");
+
+                let object = env
+                    .new_object(&class, constructor_signature, &parameters)
+                    .expect(
+                        "Failed to convert TunnelState::Connecting Rust type into net.mullvad.mullvadvpn.model.TunnelState.Connecting Java object",
+                    );
+                env.auto_local(object)
+            }
+            Self::Connected { endpoint, location } => {
+                let constructor_signature = format!(
+                    "({}{})V",
+                    endpoint.jni_signature(),
+                    location.jni_signature()
+                );
+
+                let endpoint_java = endpoint.into_java(env);
+                let location_java = location.into_java(env);
+                let parameters = [
+                    jnix::AsJValue::as_jvalue(&endpoint_java),
+                    jnix::AsJValue::as_jvalue(&location_java),
+                ];
+
+                let class = env.get_class("net/mullvad/mullvadvpn/model/TunnelState$Connected");
+
+                let object = env
+                    .new_object(&class, constructor_signature, &parameters)
+                    .expect(
+                        "Failed to convert TunnelState::Connected Rust type into net.mullvad.mullvadvpn.model.TunnelState.Connected Java object",
+                    );
+                env.auto_local(object)
+            }
+            Self::Disconnecting(action_after_disconnect) => {
+                let constructor_signature =
+                    format!("({})V", action_after_disconnect.jni_signature());
+
+                let action_after_disconnect_java = action_after_disconnect.into_java(env);
+                let parameters = [jnix::AsJValue::as_jvalue(&action_after_disconnect_java)];
+
+                let class = env.get_class("net/mullvad/mullvadvpn/model/TunnelState$Disconnecting");
+
+                let object = env
+                    .new_object(&class, constructor_signature, &parameters)
+                    .expect(
+                        "Failed to convert TunnelState::Disconnecting Rust type into net.mullvad.mullvadvpn.model.TunnelState.Disconnecting Java object",
+                    );
+                env.auto_local(object)
+            }
+            Self::Error(error_state) => {
+                let constructor_signature = format!("({})V", error_state.jni_signature());
+
+                let error_state_java = error_state.into_java(env);
+                let parameters = [jnix::AsJValue::as_jvalue(&error_state_java)];
+
+                let class = env.get_class("net/mullvad/mullvadvpn/model/TunnelState$Error");
+
+                let object = env
+                    .new_object(&class, constructor_signature, &parameters)
+                    .expect(
+                        "Failed to convert TunnelState::Error Rust type into net.mullvad.mullvadvpn.model.TunnelState.Error Java object",
+                    );
+                env.auto_local(object)
+            }
+        }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -34,7 +34,6 @@ impl DisconnectedState {
                 error.display_chain_with_msg("Unable to disable filtering resolver")
             );
         }
-
         #[cfg(windows)]
         Self::register_split_tunnel_addresses(shared_values, should_reset_firewall);
         Self::set_firewall_policy(shared_values, should_reset_firewall);
@@ -43,9 +42,19 @@ impl DisconnectedState {
         #[cfg(target_os = "android")]
         shared_values.tun_provider.lock().unwrap().close_tun();
 
+        Self::construct_state_transition(shared_values)
+    }
+
+    fn construct_state_transition(
+        shared_values: &mut SharedTunnelStateValues,
+    ) -> (Box<dyn TunnelState>, TunnelStateTransition) {
         (
             Box::new(DisconnectedState(())),
-            TunnelStateTransition::Disconnected,
+            TunnelStateTransition::Disconnected {
+                // Being disconnected and having lockdown mode enabled implies that your internet
+                // access is locked down
+                locked_down: shared_values.block_when_disconnected,
+            },
         )
     }
 
@@ -160,6 +169,12 @@ impl TunnelState for DisconnectedState {
             Some(TunnelCommand::BlockWhenDisconnected(block_when_disconnected, complete_tx)) => {
                 if shared_values.block_when_disconnected != block_when_disconnected {
                     shared_values.block_when_disconnected = block_when_disconnected;
+
+                    // TODO: Investigate if we can simply return
+                    // `NewState(Self::enter(shared_values, true))`.
+                    // The logic for updating the firewall in `DisconnectedState::enter` is
+                    // identical but it does not enter the error state if setting the local DNS
+                    // fails.
                     Self::set_firewall_policy(shared_values, true);
                     #[cfg(windows)]
                     Self::register_split_tunnel_addresses(shared_values, true);
@@ -178,9 +193,12 @@ impl TunnelState for DisconnectedState {
                     } else {
                         Self::reset_dns(shared_values);
                     }
+                    let _ = complete_tx.send(());
+                    NewState(Self::construct_state_transition(shared_values))
+                } else {
+                    let _ = complete_tx.send(());
+                    SameState(self)
                 }
-                let _ = complete_tx.send(());
-                SameState(self)
             }
             Some(TunnelCommand::IsOffline(is_offline)) => {
                 shared_values.is_offline = is_offline;

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -11,7 +11,10 @@ use std::net::IpAddr;
 #[derive(Clone, Debug)]
 pub enum TunnelStateTransition {
     /// No connection is established and network is unsecured.
-    Disconnected,
+    Disconnected {
+        /// Whether internet access is blocked due to lockdown mode
+        locked_down: bool,
+    },
     /// Network is secured but tunnel is still connecting.
     Connecting(TunnelEndpoint),
     /// Tunnel is connected.

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -227,7 +227,7 @@ pub async fn disconnect_and_wait(mullvad_client: &mut MullvadProxyClient) -> Res
         .await
         .map_err(|error| Error::Daemon(format!("failed to begin disconnecting: {}", error)))?;
     wait_for_tunnel_state(mullvad_client.clone(), |state| {
-        matches!(state, TunnelState::Disconnected(_))
+        matches!(state, TunnelState::Disconnected { .. })
     })
     .await?;
 

--- a/test/test-manager/src/tests/settings.rs
+++ b/test/test-manager/src/tests/settings.rs
@@ -107,7 +107,7 @@ pub async fn test_lockdown(
     let inet_destination: SocketAddr = "1.1.1.1:1337".parse().unwrap();
 
     log::info!("Verify tunnel state: disconnected");
-    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected(_));
+    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected { .. });
 
     // Enable lockdown mode
     //

--- a/test/test-manager/src/tests/tunnel_state.rs
+++ b/test/test-manager/src/tests/tunnel_state.rs
@@ -32,7 +32,7 @@ pub async fn test_disconnected_state(
     let inet_destination = "1.3.3.7:1337".parse().unwrap();
 
     log::info!("Verify tunnel state: disconnected");
-    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected(_));
+    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected { .. });
 
     // Test whether outgoing packets can be observed
     //
@@ -89,7 +89,7 @@ pub async fn test_connecting_state(
     let lan_dns: SocketAddr = SocketAddr::new(IpAddr::V4(DUMMY_LAN_INTERFACE_IP), 53);
 
     log::info!("Verify tunnel state: disconnected");
-    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected(_));
+    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected { .. });
 
     let relay_settings = RelaySettings::CustomTunnelEndpoint(CustomTunnelEndpoint {
         host: "1.3.3.7".to_owned(),
@@ -171,7 +171,7 @@ pub async fn test_error_state(
     let lan_dns: SocketAddr = SocketAddr::new(IpAddr::V4(DUMMY_LAN_INTERFACE_IP), 53);
 
     log::info!("Verify tunnel state: disconnected");
-    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected(_));
+    assert_tunnel_state!(&mut mullvad_client, TunnelState::Disconnected { .. });
 
     // Connect to non-existent location
     //


### PR DESCRIPTION
Fixes DES-535

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5656)
<!-- Reviewable:end -->
