### PR TITLE
Lint all targets in CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -64,7 +64,7 @@ jobs:
           RUSTFLAGS: --deny warnings
         run: |
           source env.sh
-          time cargo clippy --locked
+          time cargo clippy --locked --all-targets
 
   clippy-check-android:
     name: Clippy linting, Android

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           RUSTFLAGS: --deny warnings
         run: |
-          time cargo clippy --locked -- -W clippy::unused_async
+          time cargo clippy --locked
 
   clippy-check-test-windows:
     name: Clippy linting of test workspace (Windows)
@@ -70,4 +70,4 @@ jobs:
           RUSTFLAGS: --deny warnings
         run: |
           # Exclude checking test-manager on Windows, since it is not a supported compilation target.
-          time cargo clippy --workspace --exclude test-manager --locked -- -W clippy::unused_async
+          time cargo clippy --workspace --exclude test-manager --locked

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           RUSTFLAGS: --deny warnings
         run: |
-          time cargo clippy --locked
+          time cargo clippy --locked --all-targets
 
   clippy-check-test-windows:
     name: Clippy linting of test workspace (Windows)
@@ -70,4 +70,4 @@ jobs:
           RUSTFLAGS: --deny warnings
         run: |
           # Exclude checking test-manager on Windows, since it is not a supported compilation target.
-          time cargo clippy --workspace --exclude test-manager --locked
+          time cargo clippy  --all-targets --workspace --exclude test-manager --locked


### PR DESCRIPTION
Make Clippy lints in the CI pipeline capture problems inside tests by using the `--all-targets` flag.

Note that "targets" does not refer to OS/architectures, it has the same meaning as for `cargo build`:
```
> cargo build --help
...
Target Selection:
      --lib               Build only this package's library
      --bins              Build all binaries
      --bin [<NAME>]      Build only the specified binary
      --examples          Build all examples
      --example [<NAME>]  Build only the specified example
      --tests             Build all test targets
      --test [<NAME>]     Build only the specified test target
      --benches           Build all bench targets
      --bench [<NAME>]    Build only the specified bench target
      --all-targets       Build all targets
```

Also remove outdated explicit warn flags that are not needed anymore since workspace lint configuration were added.

Fixes DES-546.
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5659)
<!-- Reviewable:end -->
