### PR TITLE
Remove `version` and `publish` from cargo metadata

### DIFF
--- a/.github/workflows/rust-supply-chain.yml
+++ b/.github/workflows/rust-supply-chain.yml
@@ -20,4 +20,5 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v1
         with:
           log-level: warn
+          rust-version: stable
           command: check all

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 env:
   # Pinning nightly just to avoid random breakage. It's fine to bump this at any time
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2023-08-03
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-01-07
 jobs:
   prepare-containers:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,8 @@
 [workspace.package]
-version = "0.0.0"
 authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
 edition = "2021"
-publish = false
 
 [workspace]
 resolver = "2"

--- a/android/translations-converter/Cargo.toml
+++ b/android/translations-converter/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "translations-converter"
 description = "Converts between PO and Android style localization formats"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/ios/MullvadREST/Transport/Shadowsocks/shadowsocks-proxy/Cargo.toml
+++ b/ios/MullvadREST/Transport/Shadowsocks/shadowsocks-proxy/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "shadowsocks-proxy"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
+++ b/ios/TunnelObfuscation/tunnel-obfuscator-proxy/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "tunnel-obfuscator-proxy"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-api"
 description = "Mullvad VPN API clients. Providing an interface to query our infrastructure for information."
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-cli"
 description = "Manage the Mullvad VPN daemon via a convenient CLI"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-daemon"
 description = "Mullvad VPN daemon. Runs and controls the VPN tunnels"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-exclude/Cargo.toml
+++ b/mullvad-exclude/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-exclude"
 description = "Runs programs outside the Mullvad VPN tunnel on Linux"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-fs/Cargo.toml
+++ b/mullvad-fs/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-fs"
 description = "File utility library"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-jni"
 description = "JNI interface for the Mullvad daemon"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-management-interface"
 description = "Mullvad VPN IPC. Contains types and functions for IPC clients and servers."
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-nsis/Cargo.toml
+++ b/mullvad-nsis/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-nsis"
 description = "Helper library used by Mullvad NSIS plugins"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-paths/Cargo.toml
+++ b/mullvad-paths/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-paths"
 description = "Mullvad VPN application paths and directories"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-problem-report"
 description = "Collect Mullvad VPN logs into a report and send it to support"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-relay-selector"
 description = "Mullvad VPN relay selector"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-setup/Cargo.toml
+++ b/mullvad-setup/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-setup"
 description = "Tool used to manage daemon setup"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "mullvad-types"
 description = "Common base data structures for Mullvad VPN client"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/mullvad-version/Cargo.toml
+++ b/mullvad-version/Cargo.toml
@@ -6,12 +6,10 @@ what version string a build should have. This crate is responsible for computing
 `-dev-$git_hash` suffix as well as transforming the version into semver, Android versionCode
 and other formats.
 """
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-core"
 description = "Privacy preserving and secure VPN client library"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-dbus/Cargo.toml
+++ b/talpid-dbus/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "talpid-dbus"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-openvpn-plugin"
 description = "OpenVPN shared library plugin for relaying OpenVPN events to talpid_core"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-openvpn"
 description = "Library for creating OpenVPN tunnels"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-platform-metadata/Cargo.toml
+++ b/talpid-platform-metadata/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-platform-metadata"
 description = "Platform metadata detection functions"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-routing"
 description = "Library for managing routing tables"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-time/Cargo.toml
+++ b/talpid-time/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-time"
 description = "Time functions"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-tunnel-config-client"
 description = "Uses the relay RPC service to set up PQ-safe peers, etc."
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-tunnel"
 description = "Library for creating tunnel devices and interfacing with various VPN tunnels"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-types"
 description = "Common base structures for talpid"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-windows"
 description = "Nice abstractions for Windows"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "talpid-wireguard"
 description = "Library for creating various WireGuard tunnels"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "test-manager"
-version = "0.1.0"
 edition = "2021"
 
 [lints]

--- a/test/test-manager/test_macro/Cargo.toml
+++ b/test/test-manager/test_macro/Cargo.toml
@@ -3,7 +3,6 @@ proc-macro = true
 
 [package]
 name = "test_macro"
-version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "test-runner"
-version = "0.1.0"
 edition = "2021"
 
 [lints]

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "tunnel-obfuscation"
 description = "Provides different types of obfuscation layers for WireGuard"
-version.workspace = true
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Since Rust 1.75.0 the [`version` field is optional](https://github.com/rust-lang/cargo/pull/12786). The version defaults to "0.0.0" if it's not specified, and `publish` defaults to false if no version has been given. So by not specifying a version we get both `version = "0.0.0"` and `publish = false` "for free". This means we can get away with a bit less metadata boilerplate :sparkles:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5660)
<!-- Reviewable:end -->
