### PR TITLE
Fix default route not being restored when the gateway address is link-local IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Out IP missing forever when am.i.mullvad.net returns error
 
+#### macOS
+- Fix default route not being restored when disconnecting when the gateway was a link-local IPv6
+  address.
+
 ### Changed
 - Remove `--location` flag from `mullvad status` CLI. Location and IP will now always
   be printed (if available). `mullvad status listen` no longer prints location info.

--- a/talpid-routing/src/unix/macos/data.rs
+++ b/talpid-routing/src/unix/macos/data.rs
@@ -179,8 +179,7 @@ impl RouteMessage {
         self
     }
 
-    pub fn set_gateway_addr(mut self, addr: IpAddr) -> Self {
-        let gateway: SocketAddr = (addr, 0).into();
+    pub fn set_gateway_addr(mut self, gateway: impl Into<SockaddrStorage>) -> Self {
         self.insert_sockaddr(RouteSocketAddress::Gateway(Some(gateway.into())));
         self.route_flags |= RouteFlag::RTF_GATEWAY;
 


### PR DESCRIPTION
Previously, the default route failed to be restored when disconnecting: 

```
[2024-01-05 15:44:25.339][talpid_routing::imp::imp::interface][DEBUG] Found primary interface for V4
[2024-01-05 15:44:25.340][talpid_routing::imp::imp::interface][DEBUG] Found primary interface for V6
[2024-01-05 15:44:25.341][talpid_routing::imp::imp][TRACE] Failed to add unscoped default V6 route: Destination unreachable
```

Fixes DES-520.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5662)
<!-- Reviewable:end -->
