### PR TITLE
Document and test patch format

### DIFF
--- a/docs/patch-examples/override-relay-ips.json
+++ b/docs/patch-examples/override-relay-ips.json
@@ -1,0 +1,7 @@
+{
+    "relay_overrides": [
+        { "hostname": "test1", "ipv4_addr_in": "1.3.3.7" },
+        { "hostname": "test2", "ipv6_addr_in": "::1" },
+        { "hostname": "test3", "ipv4_addr_in": "1.2.3.4", "ipv6_addr_in": "::1" }
+    ]
+}

--- a/docs/settings-patch-format.md
+++ b/docs/settings-patch-format.md
@@ -1,0 +1,56 @@
+# Settings patches
+
+Mullvad settings patch is a JSON format used to apply changes to Mullvad app settings. The purpose
+is to make it easy to share or distribute useful configurations of the app, for example to make it
+work better in censored locations.
+
+A patch consists of a JSON object. Each key in the object refers to a setting to be edited by the
+patch. The type of the value depends on the setting/key itself. How the setting is updated (merge
+strategy) also depends on the setting/key.
+
+If any part of a patch is not supported on a platform (or any platform), for any reason, the app
+must reject the entire patch and not apply any changes to the settings. If possible, the reason for
+the rejection should be clear to the user.
+
+The format is shared by apps on all platforms. Not all platforms are guaranteed to support all
+settings at all times, however.
+
+## Supported settings
+
+Only a subset of all available app settings are patchable, and all of these settings are described
+below.
+
+### Relay overrides
+
+The following settings patch sets the *relay IP override* setting for servers `a` and `b`:
+
+```json
+{
+    "relay_overrides": [
+        { "hostname": "a", "ipv4_addr_in": "1.2.3.4" },
+        { "hostname": "b", "ipv4_addr_in": "1.2.3.4", "ipv6_addr_in": "::1" }
+    ]
+}
+```
+
+The merge strategy for overrides is "append or replace":
+
+* Overrides for hostnames not present in the array must remain unchanged. For example, in the above
+  patch, overrides for some hostname `c` are completely unaffected.
+* For any given hostname, only specified overrides should change. For example, the above patch has
+  no effect on the value of `ipv6_addr_in` for the hostname `a`.
+* Overrides that *are* specified are added or replaced. For example, `ipv4_addr_in` should be set
+  to `1.2.3.4`, regardless of what the override was previously set to.
+
+There is no way to remove an existing override (without replacing it) using a patch.
+
+## Versioning and backward compatibility
+
+Patches are not versioned as backward compatibility is not considered important, though
+compatibility should not be broken for no good reason.
+
+## Security
+
+Patches must not edit any settings that may compromise security. For example, enabling custom DNS
+should not be allowed.
+

--- a/docs/settings-patch-format.md
+++ b/docs/settings-patch-format.md
@@ -54,3 +54,6 @@ compatibility should not be broken for no good reason.
 Patches must not edit any settings that may compromise security. For example, enabling custom DNS
 should not be allowed.
 
+## Examples
+
+See [patch-examples](./patch-examples) for examples of patch files.

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -100,6 +100,7 @@ service ManagementService {
   rpc CheckVolumes(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
   // Apply a JSON blob to the settings
+  // See ../../docs/settings-patch-format.md for a description of the format
   rpc ApplyJsonSettings(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
 }
 


### PR DESCRIPTION
This PR adds a spec for the patch format to `./docs/settings-patch-format.md`. It also adds an example of a working patch file to `./docs/patch-examples`, along with a unit test that fails if the patch is rejected.

Closes DES-545.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5664)
<!-- Reviewable:end -->
