### PR TITLE
Exit if `ssh-setup.sh` fails

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "test-manager"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-tempfile",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "test-runner"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "test_macro"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/test/scripts/ssh-setup.sh
+++ b/test/scripts/ssh-setup.sh
@@ -106,5 +106,8 @@ fi
 setup_systemd
 
 # Install required packages
-which apt &>/dev/null && apt install -f xvfb wireguard-tools
-which dnf &>/dev/null && dnf install -y xorg-x11-server-Xvfb wireguard-tools
+if which apt &>/dev/null; then
+    apt install -f xvfb wireguard-tools
+elif which dnf &>/dev/null; then
+    dnf install -y xorg-x11-server-Xvfb wireguard-tools
+fi


### PR DESCRIPTION
Currently, this script silently fails. This is pretty frustrating, as you don't notice when packages cannot be installed, etc. The output is also logged now.

Close DES-551.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5669)
<!-- Reviewable:end -->
