### PR TITLE
Minor CLI improvement

### DIFF
--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -26,7 +26,7 @@ mullvad-version = { path = "../mullvad-version" }
 talpid-types = { path = "../talpid-types" }
 
 mullvad-management-interface = { path = "../mullvad-management-interface" }
-tokio = { workspace = true, features =  ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features =  ["macros", "rt-multi-thread", "fs"] }
 
 [target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 clap_complete = { version = "4.2.1" }

--- a/mullvad-cli/src/cmds/patch.rs
+++ b/mullvad-cli/src/cmds/patch.rs
@@ -2,15 +2,23 @@ use anyhow::{Context, Result};
 use mullvad_management_interface::MullvadProxyClient;
 use std::{
     fs::File,
-    io::{stdin, BufReader, Read},
+    io::{read_to_string, stdin, BufReader},
 };
 
-/// If source is specified, read from the provided file and send it as a settings patch to the
-/// daemon. Otherwise, read the patch from standard input.
+/// Read a settings patch and send it to the daemon for validation and
+/// application.
+///
+/// * If `source` is "-", read the patch from standard input
+/// * Otherwise, interpret `source` as a filepath and read from the provided
+///   file
 pub async fn import(source: String) -> Result<()> {
-    let json_blob = tokio::task::spawn_blocking(|| get_blob(source))
-        .await
-        .unwrap()?;
+    let json_blob = tokio::task::spawn_blocking(move || match source.as_str() {
+        "-" => read_to_string(BufReader::new(stdin())).context("Failed to read from stdin"),
+        _ => read_to_string(File::open(&source)?)
+            .context(format!("Failed to read from path: {source}")),
+    })
+    .await
+    .unwrap()?;
 
     let mut rpc = MullvadProxyClient::new().await?;
     rpc.apply_json_settings(json_blob)
@@ -22,8 +30,11 @@ pub async fn import(source: String) -> Result<()> {
     Ok(())
 }
 
-/// If source is specified, write a patch to the file. Otherwise, write the patch to standard
-/// output.
+/// Output a settings patch including all currently patchable settings.
+///
+/// * If `source` is "-", write the patch to standard output
+/// * Otherwise, interpret `source` as a filepath and write to the provided
+///   file
 pub async fn export(dest: String) -> Result<()> {
     let mut rpc = MullvadProxyClient::new().await?;
     let blob = rpc
@@ -40,21 +51,4 @@ pub async fn export(dest: String) -> Result<()> {
             .await
             .context(format!("Failed to write to path {dest}")),
     }
-}
-
-fn get_blob(source: String) -> Result<String> {
-    match source.as_str() {
-        "-" => {
-            read_settings_from_reader(BufReader::new(stdin())).context("Failed to read from stdin")
-        }
-        _ => read_settings_from_reader(File::open(&source)?)
-            .context(format!("Failed to read from path: {source}")),
-    }
-}
-
-/// Read until EOF or until newline when the last pair of braces has been closed
-fn read_settings_from_reader(mut reader: impl Read) -> Result<String> {
-    let mut s = String::new();
-    reader.read_to_string(&mut s)?;
-    Ok(s)
 }


### PR DESCRIPTION
Follow-up to #5668. I realized that things could be made even slightly simpler by using `io::read_to_string` instead of `Read::read_to_string`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5676)
<!-- Reviewable:end -->
