### PR TITLE
Add package metadata to crates in testing framework

### DIFF
--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace.package]
+authors = ["Mullvad VPN"]
+repository = "https://github.com/mullvad/mullvadvpn-app/"
+license = "GPL-3.0"
+edition = "2021"
+
 [workspace]
 resolver = "2"
 members = [

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "test-manager"
-edition = "2021"
+description = "Manager process orchestrating e2e tests of the Mullvad VPN app"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/test/test-manager/test_macro/Cargo.toml
+++ b/test/test-manager/test_macro/Cargo.toml
@@ -1,9 +1,13 @@
+[package]
+name = "test_macro"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
 [lib]
 proc-macro = true
 
-[package]
-name = "test_macro"
-edition = "2021"
 
 [dependencies]
 syn = "1.0"

--- a/test/test-rpc/Cargo.toml
+++ b/test/test-rpc/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "test-rpc"
-version = "0.1.0"
-edition = "2021"
 description = "Supports IPC between test-runner and test-manager"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "test-runner"
-edition = "2021"
+description = "Runs inside the VM where the Mullvad VPN app is being tested"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
I realized our testing framework was a bit short on metadata. Both for consistency and correctness I propose we add this so it's the same as in the main workspace.

I aim to later add a `rust-version` field, and that prompted me to have a `package` section with already set up workspace inheritance. So this is a pre-step to that.