### PR TITLE
Pin rust version

### DIFF
--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -72,17 +72,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install nightly Rust toolchain
-        run: |
-          rustup default $RUST_NIGHTLY_TOOLCHAIN
-          rustup target add aarch64-linux-android
+      - name: Install nightly Rust
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+          profile: minimal
+          target: aarch64-linux-android
 
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-udeps
 
       - name: Check for unused dependencies
-        run: cargo udeps --target aarch64-linux-android --package mullvad-jni
+        run: cargo +$RUST_NIGHTLY_TOOLCHAIN udeps --target aarch64-linux-android --package mullvad-jni
 
   cargo-udeps:
     strategy:
@@ -99,11 +101,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust
+      - name: Install nightly Rust
         uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          default: true
           profile: minimal
 
       - uses: taiki-e/install-action@v2
@@ -112,4 +113,4 @@ jobs:
 
       - name: Check for unused dependencies
         shell: bash
-        run: cargo udeps --workspace
+        run: cargo +$RUST_NIGHTLY_TOOLCHAIN udeps --workspace

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -84,7 +84,7 @@ jobs:
           tool: cargo-udeps
 
       - name: Check for unused dependencies
-        run: cargo +$RUST_NIGHTLY_TOOLCHAIN udeps --target aarch64-linux-android --package mullvad-jni
+        run: cargo +${{ env.RUST_NIGHTLY_TOOLCHAIN }} udeps --target aarch64-linux-android --package mullvad-jni
 
   cargo-udeps:
     strategy:
@@ -113,4 +113,4 @@ jobs:
 
       - name: Check for unused dependencies
         shell: bash
-        run: cargo +$RUST_NIGHTLY_TOOLCHAIN udeps --workspace
+        run: cargo +${{ env.RUST_NIGHTLY_TOOLCHAIN }} udeps --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
 edition = "2021"
+# Keep in sync with `channel` in `rust-toolchain.toml`
 rust-version = "1.77.0"
 
 [workspace]

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -51,11 +51,13 @@ RUN dpkg --add-architecture arm64 && apt-get update -y && apt-get install -y \
 
 # === Rust ===
 
-# Install latest stable Rust toolchain for both x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu,
+ARG RUST_VERSION=stable
+
+# Install the Rust toolchain for both x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu,
 # plus x86_64-pc-windows-gnu for Windows cross-compilation/linting
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y \
-    --default-toolchain stable \
+    --default-toolchain $RUST_VERSION \
     --profile minimal \
     --component clippy \
     --target aarch64-unknown-linux-gnu \

--- a/building/build-and-publish-container-image.sh
+++ b/building/build-and-publish-container-image.sh
@@ -35,8 +35,11 @@ case ${1-:""} in
 esac
 full_container_name="$REGISTRY_HOST/$REGISTRY_ORG/$container_name"
 
+RUST_VERSION=$(rg -o "channel = \"(.*)\"" -r '$1' "$REPO_DIR/rust-toolchain.toml")
+
 log_header "Building $full_container_name tagged as '$tag' and 'latest'"
 podman build -f "$containerfile_path" "$container_context_dir" --no-cache \
+    --build-arg="RUST_VERSION=$RUST_VERSION" \
     -t "$full_container_name:$tag" \
     -t "$full_container_name:latest"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+# Keep in sync with `rust-version` in `Cargo.toml`
+channel = "1.77.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 # Keep in sync with `rust-version` in `Cargo.toml`
 channel = "1.77.0"
+targets = ["i686-pc-windows-msvc"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,6 @@
 [toolchain]
 # Keep in sync with `rust-version` in `Cargo.toml`
 channel = "1.77.0"
+
+[toolchain.i686-pc-windows-msvc]
 targets = ["i686-pc-windows-msvc"]


### PR DESCRIPTION
Adds pinning of Rust version to this repository. Still work in progress!


## Benefits
* Developers do not need to manually run `rustup update`. Cargo will take care of getting the correct version of Rust for every build command
* Build servers do not need separate logic to update Rust. They will automatically use the version specified in `rust-toolchain.toml` so bumping that is enough.
* Building of the containers are not time-sensitive in the same sence. Which Rust version is picked is deterministic compared to just picking whatever happens to be `stable` at the time.

## Cons
* Since the Rust version is a specific version and not `stable`, over time developers will sit with many toolchains installed on their systems that they manually need to clean out to free disk space.
* This is not how `rust-toolchain.toml` is supposed to be used really, so there might be dragons we have not found yet.
* Rust `target`s are per release channel. So if you install the target for `x86_64-pc-windows-msvc` for Rust `1.77.0` then you will not automatically get it when installing `1.78.0`. This is a major pain point with this approach.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5680)
<!-- Reviewable:end -->
