### PR TITLE
Validate SOCKS5 credentials when authentication is used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "err-derive",
  "futures",
  "itertools",
  "mullvad-management-interface",

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -17,9 +17,10 @@ path = "src/main.rs"
 anyhow = "1.0"
 chrono = { workspace = true }
 clap = { workspace = true }
+err-derive = { workspace = true }
 futures = "0.3"
-natord = "1.0.9"
 itertools = "0.10"
+natord = "1.0.9"
 
 mullvad-types = { path = "../mullvad-types", features = ["clap"] }
 mullvad-version = { path = "../mullvad-version" }

--- a/mullvad-cli/src/cmds/bridge.rs
+++ b/mullvad-cli/src/cmds/bridge.rs
@@ -303,7 +303,7 @@ impl Bridge {
         match custom_bridge {
             CustomProxy::Shadowsocks(ss) => *ss = edit.merge_shadowsocks(ss),
             CustomProxy::Socks5Local(local) => *local = edit.merge_socks_local(local),
-            CustomProxy::Socks5Remote(remote) => *remote = edit.merge_socks_remote(remote),
+            CustomProxy::Socks5Remote(remote) => *remote = edit.merge_socks_remote(remote)?,
         };
 
         rpc.set_bridge_settings(settings.bridge_settings)
@@ -343,7 +343,7 @@ impl Bridge {
                 CustomProxy::Socks5Local(Socks5Local::from(add))
             }
             AddCustomCommands::Socks5(AddSocks5Commands::Remote { add }) => {
-                CustomProxy::Socks5Remote(Socks5Remote::from(add))
+                CustomProxy::Socks5Remote(Socks5Remote::try_from(add)?)
             }
             AddCustomCommands::Shadowsocks { add } => {
                 CustomProxy::Shadowsocks(Shadowsocks::from(add))

--- a/mullvad-daemon/src/migrations/v7.rs
+++ b/mullvad-daemon/src/migrations/v7.rs
@@ -182,10 +182,9 @@ fn migrate_bridge_settings(settings: &mut serde_json::Value) -> Result<()> {
                     .parse()
                     .map_err(|_| Error::InvalidSettingsContent)?,
                 auth: custom_bridge_remote.get("auth").and_then(|auth| {
-                    Some(SocksAuth {
-                        username: auth.get("username")?.to_string(),
-                        password: auth.get("password")?.to_string(),
-                    })
+                    let username = auth.get("username")?.to_string();
+                    let password = auth.get("password")?.to_string();
+                    SocksAuth::new(username, password).ok()
                 }),
             })),
         }

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -528,8 +528,8 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
         if let Some(CustomProxy::Socks5Remote(ref remote_proxy)) = proxy_settings {
             if let Some(ref proxy_auth) = remote_proxy.auth {
                 return Ok(Some(Self::create_credentials_file(
-                    &proxy_auth.username,
-                    &proxy_auth.password,
+                    proxy_auth.username(),
+                    proxy_auth.password(),
                 )?));
             }
         }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -4,6 +4,13 @@ use std::{fmt, net::SocketAddr};
 
 use super::TransportProtocol;
 
+#[derive(err_derive::Error, Debug)]
+pub enum Error {
+    /// Validation of SOCKS5 username or password failed.
+    #[error(display = "Invalid SOCKS5 authentication credentials: {}", _0)]
+    InvalidSocksAuthValues(&'static str),
+}
+
 /// Types of bridges that can be used to proxy a connection to a tunnel
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -82,10 +89,83 @@ pub struct Socks5Remote {
     pub auth: Option<SocksAuth>,
 }
 
+/// A valid SOCKS5 username/password authentication according to
+/// RFC 1929: <https://datatracker.ietf.org/doc/html/rfc1929>.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SocksAuth {
-    pub username: String,
-    pub password: String,
+    username: String,
+    password: String,
+}
+
+impl SocksAuth {
+    /// Validate a SOCKS5 username/password based authentication.
+    ///
+    /// # Examples
+    ///
+    /// A valid username and password both have to be between 1 and 255 bytes.
+    ///
+    /// ```
+    /// use talpid_types::net::proxy::SocksAuth;
+    ///
+    /// let valid_auth = SocksAuth::new("FooBar".to_string(), "hunter2".to_string());
+    /// assert!(valid_auth.is_ok());
+    /// ```
+    ///
+    /// An empty username or password is not valid.
+    ///
+    /// ```
+    /// use talpid_types::net::proxy::SocksAuth;
+    ///
+    /// // An empty username is not a valid username.
+    /// let invalid_username = SocksAuth::new("".to_string(), "hunter2".to_string());
+    /// assert!(invalid_username.is_err());
+    ///
+    /// // Likeweise, an empty password is not a valid password.
+    /// let invalid_password = SocksAuth::new("FooBar".to_string(), "".to_string());
+    /// assert!(invalid_password.is_err());
+    /// ```
+    ///
+    /// The upper limit for a valid username and password is 255 bytes
+    ///
+    /// ```
+    /// use talpid_types::net::proxy::SocksAuth;
+    ///
+    /// let max_valid_username = SocksAuth::new("x".repeat(255), "hunter2".to_string());
+    /// assert!(max_valid_username.is_ok());
+    ///
+    /// let too_long_username = SocksAuth::new("x".repeat(256), "hunter2".to_string());
+    /// assert!(too_long_username.is_err());
+    ///
+    /// let max_valid_password = SocksAuth::new("FooBar".to_string(), "x".repeat(255));
+    /// assert!(max_valid_username.is_ok());
+    ///
+    /// let too_long_password = SocksAuth::new("FooBar".to_string(), "x".repeat(256));
+    /// assert!(too_long_username.is_err());
+    /// ```
+    pub fn new(username: String, password: String) -> Result<Self, Error> {
+        if !(1..=255).contains(&password.as_bytes().len()) {
+            return Err(Error::InvalidSocksAuthValues(
+                "Password length should between 1 and 255 bytes",
+            ));
+        }
+        if !(1..=255).contains(&username.as_bytes().len()) {
+            return Err(Error::InvalidSocksAuthValues(
+                "Username length should between 1 and 255 bytes",
+            ));
+        }
+
+        Ok(SocksAuth { username, password })
+    }
+
+    /// Read the username.
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    /// Read the password.
+    pub fn password(&self) -> &str {
+        &self.password
+    }
 }
 
 impl Shadowsocks {


### PR DESCRIPTION
Validate SOCKS credentials by checking that both `username` and `password` both have a length between 1 and 255 bytes.

Link to RFC detailing SOCKS5 username/password authentication: https://datatracker.ietf.org/doc/html/rfc1929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5681)
<!-- Reviewable:end -->
