### PR TITLE
Use type safe protobuf client in test framework

### DIFF
--- a/test/clippy.toml
+++ b/test/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-types = [
+    { path = "mullvad_management_interface::ManagementServiceClient", reason = "use `mullvad_management_interface::MullvadProxyClient` instead" },
+]

--- a/test/test-manager/README.md
+++ b/test/test-manager/README.md
@@ -13,7 +13,7 @@ with the `#[test_function]` attribute
 #[test_function]
 pub async fn test(
     rpc: ServiceClient,
-    mut mullvad_client: mullvad_management_interface::ManagementServiceClient,
+    mut mullvad_client: mullvad_management_interface::MullvadProxyClient,
 ) -> Result<(), Error> {
     Ok(())
 }

--- a/test/test-manager/src/mullvad_daemon.rs
+++ b/test/test-manager/src/mullvad_daemon.rs
@@ -1,7 +1,8 @@
+#![allow(clippy::disallowed_types)]
 use std::{io, time::Duration};
 
 use futures::{channel::mpsc, future::BoxFuture, pin_mut, FutureExt, SinkExt, StreamExt};
-use mullvad_management_interface::ManagementServiceClient;
+use mullvad_management_interface::{ManagementServiceClient, MullvadProxyClient};
 use test_rpc::{
     mullvad_daemon::MullvadClientVersion,
     transport::{ConnectionHandle, GrpcForwarder},
@@ -61,7 +62,7 @@ impl RpcClientProvider {
         }
     }
 
-    pub async fn new_client(&self) -> ManagementServiceClient {
+    pub async fn new_client(&self) -> MullvadProxyClient {
         // FIXME: Ugly workaround to ensure that we don't receive stuff from a
         // previous RPC session.
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -72,7 +73,7 @@ impl RpcClientProvider {
             .await
             .unwrap();
 
-        ManagementServiceClient::new(channel)
+        MullvadProxyClient::from_rpc_client(ManagementServiceClient::new(channel))
     }
 }
 

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use futures::FutureExt;
-use mullvad_management_interface::ManagementServiceClient;
+use mullvad_management_interface::MullvadProxyClient;
 use std::future::Future;
 use std::panic;
 use std::time::Duration;
@@ -84,7 +84,7 @@ pub async fn run(
             .as_type(test.mullvad_client_version)
             .await;
 
-        if let Some(client) = mclient.downcast_mut::<ManagementServiceClient>() {
+        if let Some(client) = mclient.downcast_mut::<MullvadProxyClient>() {
             crate::tests::init_default_settings(client).await;
         }
 

--- a/test/test-manager/src/tests/account.rs
+++ b/test/test-manager/src/tests/account.rs
@@ -1,8 +1,8 @@
 use super::config::TEST_CONFIG;
 use super::{helpers, ui, Error, TestContext};
 use mullvad_api::DevicesProxy;
-use mullvad_management_interface::{types, Code, ManagementServiceClient};
-use mullvad_types::device::Device;
+use mullvad_management_interface::{self, client::DaemonEvent, MullvadProxyClient};
+use mullvad_types::device::{Device, DeviceState};
 use mullvad_types::states::TunnelState;
 use std::net::ToSocketAddrs;
 use std::time::Duration;
@@ -17,7 +17,7 @@ const THROTTLE_RETRY_DELAY: Duration = Duration::from_secs(120);
 pub async fn test_login(
     _: TestContext,
     _rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     //
     // Instruct daemon to log in
@@ -33,7 +33,7 @@ pub async fn test_login(
         .expect("login failed");
 
     // Wait for the relay list to be updated
-    helpers::ensure_updated_relay_list(&mut mullvad_client).await;
+    helpers::ensure_updated_relay_list(&mut mullvad_client).await?;
 
     Ok(())
 }
@@ -44,12 +44,12 @@ pub async fn test_login(
 pub async fn test_logout(
     _: TestContext,
     _rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     log::info!("Removing device");
 
     mullvad_client
-        .logout_account(())
+        .logout_account()
         .await
         .expect("logout failed");
 
@@ -61,7 +61,7 @@ pub async fn test_logout(
 pub async fn test_too_many_devices(
     _: TestContext,
     rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     log::info!("Using up all devices");
 
@@ -97,7 +97,10 @@ pub async fn test_too_many_devices(
     log::info!("Log in with too many devices");
     let login_result = login_with_retries(&mut mullvad_client).await;
 
-    assert!(matches!(login_result, Err(status) if status.code() == Code::ResourceExhausted));
+    assert!(matches!(
+        login_result,
+        Err(mullvad_management_interface::Error::TooManyDevices)
+    ));
 
     // Run UI test
     let ui_result = ui::run_test_env(
@@ -128,7 +131,7 @@ pub async fn test_too_many_devices(
 pub async fn test_revoked_device(
     _: TestContext,
     rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     log::info!("Logging in/generating device");
     login_with_retries(&mut mullvad_client)
@@ -136,14 +139,12 @@ pub async fn test_revoked_device(
         .expect("login failed");
 
     let device_id = mullvad_client
-        .get_device(())
+        .get_device()
         .await
         .expect("failed to get device data")
-        .into_inner()
-        .device
+        .into_device()
         .unwrap()
         .device
-        .unwrap()
         .id;
 
     helpers::connect_and_wait(&mut mullvad_client).await?;
@@ -165,16 +166,16 @@ pub async fn test_revoked_device(
     // Begin listening to tunnel state changes first, so that we catch changes due to
     // `update_device`.
     let events = mullvad_client
-        .events_listen(())
+        .events_listen()
         .await
-        .expect("failed to begin listening for state changes")
-        .into_inner();
+        .expect("failed to begin listening for state changes");
     let next_state =
         helpers::find_next_tunnel_state(events, |state| matches!(state, TunnelState::Error(..),));
 
     log::debug!("Update device state");
 
-    let _update_status = mullvad_client.update_device(()).await;
+    // Update the device status, which performs a device validation.
+    let _ = mullvad_client.update_device().await;
 
     // Ensure that the tunnel state transitions to "error". Fail if it transitions to some other
     // state.
@@ -186,12 +187,11 @@ pub async fn test_revoked_device(
 
     // Verify that the device state is `Revoked`.
     let device_state = mullvad_client
-        .get_device(())
+        .get_device()
         .await
         .expect("failed to get device data");
-    assert_eq!(
-        device_state.into_inner().state,
-        i32::from(types::device_state::State::Revoked),
+    assert!(
+        matches!(device_state, DeviceState::Revoked),
         "expected device to be revoked"
     );
 
@@ -244,28 +244,26 @@ pub async fn new_device_client() -> DevicesProxy {
 
 /// Log in and retry if it fails due to throttling
 pub async fn login_with_retries(
-    mullvad_client: &mut ManagementServiceClient,
-) -> Result<(), mullvad_management_interface::Status> {
+    mullvad_client: &mut MullvadProxyClient,
+) -> Result<(), mullvad_management_interface::Error> {
     loop {
-        let result = mullvad_client
+        match mullvad_client
             .login_account(TEST_CONFIG.account_number.clone())
-            .await;
+            .await
+        {
+            Err(mullvad_management_interface::Error::Rpc(status))
+                if status.message().to_uppercase().contains("THROTTLED") =>
+            {
+                // Work around throttling errors by sleeping
+                log::debug!(
+                    "Login failed due to throttling. Sleeping for {} seconds",
+                    THROTTLE_RETRY_DELAY.as_secs()
+                );
 
-        if let Err(error) = result {
-            if !error.message().contains("THROTTLED") {
-                return Err(error);
+                tokio::time::sleep(THROTTLE_RETRY_DELAY).await;
             }
-
-            // Work around throttling errors by sleeping
-
-            log::debug!(
-                "Login failed due to throttling. Sleeping for {} seconds",
-                THROTTLE_RETRY_DELAY.as_secs()
-            );
-
-            tokio::time::sleep(THROTTLE_RETRY_DELAY).await;
-        } else {
-            break Ok(());
+            Err(err) => break Err(err),
+            Ok(_) => break Ok(()),
         }
     }
 }
@@ -306,18 +304,16 @@ pub async fn retry_if_throttled<
 pub async fn test_automatic_wireguard_rotation(
     ctx: TestContext,
     rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     // Make note of current WG key
     let old_key = mullvad_client
-        .get_device(())
+        .get_device()
         .await
+        .unwrap()
+        .into_device()
         .expect("Could not get device")
-        .into_inner()
         .device
-        .unwrap()
-        .device
-        .unwrap()
         .pubkey;
 
     // Stop daemon
@@ -343,36 +339,26 @@ pub async fn test_automatic_wireguard_rotation(
     // Verify rotation has happened after a minute
     const KEY_ROTATION_TIMEOUT: Duration = Duration::from_secs(100);
 
-    let mut event_stream = mullvad_client.events_listen(()).await.unwrap().into_inner();
-    let get_pub_key_event = async {
-        loop {
-            let message = event_stream.message().await;
-            if let Ok(Some(event)) = message {
-                match event.event.unwrap() {
-                    mullvad_management_interface::types::daemon_event::Event::Device(
-                        device_event,
-                    ) => {
-                        let pubkey = device_event
-                            .new_state
-                            .unwrap()
-                            .device
-                            .unwrap()
-                            .device
-                            .unwrap()
-                            .pubkey;
-                        return Ok(pubkey);
-                    }
-                    _ => continue,
-                }
-            }
-            return Err(message);
-        }
-    };
-
-    let new_key = tokio::time::timeout(KEY_ROTATION_TIMEOUT, get_pub_key_event)
-        .await
-        .unwrap()
-        .unwrap();
+    let new_key = tokio::time::timeout(
+        KEY_ROTATION_TIMEOUT,
+        helpers::find_daemon_event(
+            mullvad_client.events_listen().await.unwrap(),
+            |daemon_event| match daemon_event {
+                DaemonEvent::Device(device_event) => Some(device_event),
+                _ => None,
+            },
+        ),
+    )
+    .await
+    .map_err(|_error| Error::Daemon(String::from("Tunnel event listener timed out")))?
+    .map(|device_event| {
+        device_event
+            .new_state
+            .into_device()
+            .expect("Could not get device")
+            .device
+            .pubkey
+    })?;
 
     assert_ne!(old_key, new_key);
     Ok(())

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -3,7 +3,7 @@ use crate::network_monitor::{
     self, start_packet_monitor, MonitorOptions, MonitorUnexpectedlyStopped, PacketMonitor,
 };
 use futures::StreamExt;
-use mullvad_management_interface::{types, ManagementServiceClient, MullvadProxyClient};
+use mullvad_management_interface::{client::DaemonEvent, MullvadProxyClient};
 use mullvad_types::{
     location::Location,
     relay_constraints::{
@@ -27,7 +27,7 @@ use tokio::time::timeout;
 #[macro_export]
 macro_rules! assert_tunnel_state {
     ($mullvad_client:expr, $pattern:pat) => {{
-        let state = get_tunnel_state($mullvad_client).await;
+        let state = $mullvad_client.get_tunnel_state().await?;
         assert!(matches!(state, $pattern), "state: {:?}", state);
     }};
 }
@@ -85,8 +85,7 @@ pub async fn using_mullvad_exit(rpc: &ServiceClient) -> bool {
 }
 
 /// Get VPN tunnel interface name
-pub async fn get_tunnel_interface(rpc: ManagementServiceClient) -> Option<String> {
-    let mut client = MullvadProxyClient::from_rpc_client(rpc);
+pub async fn get_tunnel_interface(client: &mut MullvadProxyClient) -> Option<String> {
     match client.get_tunnel_state().await.ok()? {
         TunnelState::Connecting { endpoint, .. } | TunnelState::Connected { endpoint, .. } => {
             endpoint.tunnel_interface
@@ -194,11 +193,11 @@ pub async fn ping_with_timeout(
 ///
 /// If that fails for whatever reason, the Mullvad daemon ends up in the
 /// [`TunnelState::Error`] state & [`Error::DaemonError`] is returned.
-pub async fn connect_and_wait(mullvad_client: &mut ManagementServiceClient) -> Result<(), Error> {
+pub async fn connect_and_wait(mullvad_client: &mut MullvadProxyClient) -> Result<(), Error> {
     log::info!("Connecting");
 
     mullvad_client
-        .connect_tunnel(())
+        .connect_tunnel()
         .await
         .map_err(|error| Error::Daemon(format!("failed to begin connecting: {}", error)))?;
 
@@ -219,13 +218,11 @@ pub async fn connect_and_wait(mullvad_client: &mut ManagementServiceClient) -> R
     Ok(())
 }
 
-pub async fn disconnect_and_wait(
-    mullvad_client: &mut ManagementServiceClient,
-) -> Result<(), Error> {
+pub async fn disconnect_and_wait(mullvad_client: &mut MullvadProxyClient) -> Result<(), Error> {
     log::info!("Disconnecting");
 
     mullvad_client
-        .disconnect_tunnel(())
+        .disconnect_tunnel()
         .await
         .map_err(|error| Error::Daemon(format!("failed to begin disconnecting: {}", error)))?;
     wait_for_tunnel_state(mullvad_client.clone(), |state| {
@@ -239,58 +236,55 @@ pub async fn disconnect_and_wait(
 }
 
 pub async fn wait_for_tunnel_state(
-    mut rpc: mullvad_management_interface::ManagementServiceClient,
+    mut rpc: MullvadProxyClient,
     accept_state_fn: impl Fn(&mullvad_types::states::TunnelState) -> bool,
 ) -> Result<mullvad_types::states::TunnelState, Error> {
     let events = rpc
-        .events_listen(())
+        .events_listen()
         .await
         .map_err(|status| Error::Daemon(format!("Failed to get event stream: {}", status)))?;
 
-    let state = mullvad_types::states::TunnelState::try_from(
-        rpc.get_tunnel_state(())
-            .await
-            .map_err(|error| Error::Daemon(format!("Failed to get tunnel state: {:?}", error)))?
-            .into_inner(),
-    )
-    .map_err(|error| Error::Daemon(format!("Invalid tunnel state: {:?}", error)))?;
+    let state = rpc
+        .get_tunnel_state()
+        .await
+        .map_err(|error| Error::Daemon(format!("Failed to get tunnel state: {:?}", error)))?;
+
     if accept_state_fn(&state) {
         return Ok(state);
     }
 
-    find_next_tunnel_state(events.into_inner(), accept_state_fn).await
+    find_next_tunnel_state(events, accept_state_fn).await
 }
 
 pub async fn find_next_tunnel_state(
-    stream: impl futures::Stream<Item = Result<types::DaemonEvent, tonic::Status>> + Unpin,
+    stream: impl futures::Stream<Item = Result<DaemonEvent, mullvad_management_interface::Error>>
+        + Unpin,
     accept_state_fn: impl Fn(&mullvad_types::states::TunnelState) -> bool,
 ) -> Result<mullvad_types::states::TunnelState, Error> {
     tokio::time::timeout(
         WAIT_FOR_TUNNEL_STATE_TIMEOUT,
-        find_next_tunnel_state_inner(stream, accept_state_fn),
+        find_daemon_event(stream, |daemon_event| match daemon_event {
+            DaemonEvent::TunnelState(state) if accept_state_fn(&state) => Some(state),
+            _ => None,
+        }),
     )
     .await
     .map_err(|_error| Error::Daemon(String::from("Tunnel event listener timed out")))?
 }
 
-async fn find_next_tunnel_state_inner(
-    mut stream: impl futures::Stream<Item = Result<types::DaemonEvent, tonic::Status>> + Unpin,
-    accept_state_fn: impl Fn(&mullvad_types::states::TunnelState) -> bool,
-) -> Result<mullvad_types::states::TunnelState, Error> {
+pub async fn find_daemon_event<Accept, AcceptedEvent>(
+    mut event_stream: impl futures::Stream<Item = Result<DaemonEvent, mullvad_management_interface::Error>>
+        + Unpin,
+    accept_event: Accept,
+) -> Result<AcceptedEvent, Error>
+where
+    Accept: Fn(DaemonEvent) -> Option<AcceptedEvent>,
+{
     loop {
-        match stream.next().await {
-            Some(Ok(event)) => match event.event.unwrap() {
-                mullvad_management_interface::types::daemon_event::Event::TunnelState(
-                    new_state,
-                ) => {
-                    let state = mullvad_types::states::TunnelState::try_from(new_state).map_err(
-                        |error| Error::Daemon(format!("Invalid tunnel state: {:?}", error)),
-                    )?;
-                    if accept_state_fn(&state) {
-                        return Ok(state);
-                    }
-                }
-                _ => continue,
+        match event_stream.next().await {
+            Some(Ok(daemon_event)) => match accept_event(daemon_event) {
+                Some(accepted_event) => break Ok(accepted_event),
+                None => continue,
             },
             Some(Err(status)) => {
                 break Err(Error::Daemon(format!(
@@ -351,9 +345,7 @@ impl<T> Drop for AbortOnDrop<T> {
 ///   see [`mullvad_types::relay_constraints::WireguardConstraints`] for details.
 /// * OpenVPN settings are default (i.e. any port is used, no obfuscation ..)
 ///   see [`mullvad_types::relay_constraints::OpenVpnConstraints`] for details.
-pub async fn reset_relay_settings(
-    mullvad_client: &mut ManagementServiceClient,
-) -> Result<(), Error> {
+pub async fn reset_relay_settings(mullvad_client: &mut MullvadProxyClient) -> Result<(), Error> {
     disconnect_and_wait(mullvad_client).await?;
 
     let relay_settings = RelaySettings::Normal(RelayConstraints {
@@ -372,12 +364,12 @@ pub async fn reset_relay_settings(
         .map_err(|error| Error::Daemon(format!("Failed to reset relay settings: {}", error)))?;
 
     mullvad_client
-        .set_bridge_state(types::BridgeState::from(bridge_state))
+        .set_bridge_state(bridge_state)
         .await
         .map_err(|error| Error::Daemon(format!("Failed to reset bridge mode: {}", error)))?;
 
     mullvad_client
-        .set_obfuscation_settings(types::ObfuscationSettings::from(obfuscation_settings))
+        .set_obfuscation_settings(obfuscation_settings)
         .await
         .map_err(|error| Error::Daemon(format!("Failed to reset obfuscation: {}", error)))?;
 
@@ -385,62 +377,44 @@ pub async fn reset_relay_settings(
 }
 
 pub async fn set_relay_settings(
-    mullvad_client: &mut ManagementServiceClient,
+    mullvad_client: &mut MullvadProxyClient,
     relay_settings: RelaySettings,
 ) -> Result<(), Error> {
-    let new_settings = types::RelaySettings::from(relay_settings);
-
     mullvad_client
-        .set_relay_settings(new_settings)
+        .set_relay_settings(relay_settings)
         .await
-        .map_err(|error| Error::Daemon(format!("Failed to set relay settings: {}", error)))?;
-    Ok(())
+        .map_err(|error| Error::Daemon(format!("Failed to set relay settings: {}", error)))
 }
 
 pub async fn set_bridge_settings(
-    mullvad_client: &mut ManagementServiceClient,
+    mullvad_client: &mut MullvadProxyClient,
     bridge_settings: BridgeSettings,
 ) -> Result<(), Error> {
-    let new_settings = types::BridgeSettings::from(bridge_settings);
-
     mullvad_client
-        .set_bridge_settings(new_settings)
+        .set_bridge_settings(bridge_settings)
         .await
-        .map_err(|error| Error::Daemon(format!("Failed to set bridge settings: {}", error)))?;
-    Ok(())
-}
-
-pub async fn get_tunnel_state(mullvad_client: &mut ManagementServiceClient) -> TunnelState {
-    let state = mullvad_client
-        .get_tunnel_state(())
-        .await
-        .expect("mullvad RPC failed")
-        .into_inner();
-    TunnelState::try_from(state).unwrap()
+        .map_err(|error| Error::Daemon(format!("Failed to set bridge settings: {}", error)))
 }
 
 /// Wait for the relay list to be updated, to make sure we have the overridden one.
 /// Time out after a while.
-pub async fn ensure_updated_relay_list(mullvad_client: &mut ManagementServiceClient) {
-    let mut events = mullvad_client.events_listen(()).await.unwrap().into_inner();
-    mullvad_client.update_relay_locations(()).await.unwrap();
+pub async fn ensure_updated_relay_list(
+    mullvad_client: &mut MullvadProxyClient,
+) -> Result<(), mullvad_management_interface::Error> {
+    let mut events = mullvad_client.events_listen().await?;
+    mullvad_client.update_relay_locations().await?;
 
-    let wait_for_relay_update = async move {
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(3), async move {
         while let Some(Ok(event)) = events.next().await {
-            if matches!(
-                event,
-                mullvad_management_interface::types::DaemonEvent {
-                    event: Some(
-                        mullvad_management_interface::types::daemon_event::Event::RelayList { .. }
-                    )
-                }
-            ) {
+            if matches!(event, DaemonEvent::RelayList(_)) {
                 log::debug!("Received new relay list");
                 break;
             }
         }
-    };
-    let _ = tokio::time::timeout(std::time::Duration::from_secs(3), wait_for_relay_update).await;
+    })
+    .await;
+
+    Ok(())
 }
 
 pub fn unreachable_wireguard_tunnel() -> talpid_types::net::wireguard::ConnectionConfig {
@@ -471,18 +445,16 @@ pub fn unreachable_wireguard_tunnel() -> talpid_types::net::wireguard::Connectio
 /// * `mullvad_client` - An interface to the Mullvad daemon.
 /// * `critera` - A function used to determine which relays to return.
 pub async fn filter_relays<Filter>(
-    mullvad_client: &mut ManagementServiceClient,
+    mullvad_client: &mut MullvadProxyClient,
     criteria: Filter,
 ) -> Result<Vec<Relay>, Error>
 where
     Filter: Fn(&Relay) -> bool,
 {
     let relay_list: RelayList = mullvad_client
-        .get_relay_locations(())
+        .get_relay_locations()
         .await
-        .map_err(|error| Error::Daemon(format!("Failed to obtain relay list: {}", error)))?
-        .into_inner()
-        .try_into()?;
+        .map_err(|error| Error::Daemon(format!("Failed to obtain relay list: {}", error)))?;
 
     Ok(relay_list
         .relays()

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -18,10 +18,7 @@ use test_rpc::ServiceClient;
 
 use futures::future::BoxFuture;
 
-use mullvad_management_interface::{
-    types::{self, Settings},
-    ManagementServiceClient,
-};
+use mullvad_management_interface::MullvadProxyClient;
 use once_cell::sync::OnceCell;
 use std::time::Duration;
 
@@ -61,24 +58,23 @@ pub enum Error {
     #[error(display = "The daemon returned an error: {}", _0)]
     Daemon(String),
 
-    #[error(display = "Failed to parse gRPC response")]
-    InvalidGrpcResponse(#[error(source)] types::FromProtobufTypeError),
+    #[error(display = "The gRPC client ran into an error: {}", _0)]
+    ManagementInterface(#[source] mullvad_management_interface::Error),
 
     #[cfg(target_os = "macos")]
     #[error(display = "An error occurred: {}", _0)]
     Other(String),
 }
 
-static DEFAULT_SETTINGS: OnceCell<Settings> = OnceCell::new();
+static DEFAULT_SETTINGS: OnceCell<mullvad_types::settings::Settings> = OnceCell::new();
 
 /// Initializes `DEFAULT_SETTINGS`. This has only has an effect the first time it's called.
-pub async fn init_default_settings(mullvad_client: &mut ManagementServiceClient) {
+pub async fn init_default_settings(mullvad_client: &mut MullvadProxyClient) {
     if DEFAULT_SETTINGS.get().is_none() {
-        let settings: Settings = mullvad_client
-            .get_settings(())
+        let settings = mullvad_client
+            .get_settings()
             .await
-            .expect("Failed to obtain settings")
-            .into_inner();
+            .expect("Failed to obtain settings");
         DEFAULT_SETTINGS.set(settings).unwrap();
     }
 }
@@ -89,9 +85,7 @@ pub async fn init_default_settings(mullvad_client: &mut ManagementServiceClient)
 ///
 /// `DEFAULT_SETTINGS` must be initialized using `init_default_settings` before any settings are
 /// modified, or this function panics.
-pub async fn cleanup_after_test(
-    mullvad_client: &mut ManagementServiceClient,
-) -> anyhow::Result<()> {
+pub async fn cleanup_after_test(mullvad_client: &mut MullvadProxyClient) -> anyhow::Result<()> {
     log::debug!("Cleaning up daemon in test cleanup");
 
     let default_settings = DEFAULT_SETTINGS
@@ -113,56 +107,37 @@ pub async fn cleanup_after_test(
         .await
         .context("Could not set show beta releases in cleanup")?;
     mullvad_client
-        .set_bridge_state(default_settings.bridge_state.clone().unwrap())
+        .set_bridge_state(default_settings.bridge_state)
         .await
         .context("Could not set bridge state in cleanup")?;
     mullvad_client
-        .set_bridge_settings(default_settings.bridge_settings.clone().unwrap())
+        .set_bridge_settings(default_settings.bridge_settings.clone())
         .await
         .context("Could not set bridge settings in cleanup")?;
     mullvad_client
-        .set_obfuscation_settings(default_settings.obfuscation_settings.clone().unwrap())
+        .set_obfuscation_settings(default_settings.obfuscation_settings.clone())
         .await
         .context("Could set obfuscation settings in cleanup")?;
     mullvad_client
         .set_block_when_disconnected(default_settings.block_when_disconnected)
         .await
         .context("Could not set block when disconnected setting in cleanup")?;
+    #[cfg(target_os = "windows")]
     mullvad_client
-        .clear_split_tunnel_apps(())
+        .clear_split_tunnel_apps()
         .await
         .context("Could not clear split tunnel apps in cleanup")?;
+    #[cfg(target_os = "linux")]
     mullvad_client
-        .clear_split_tunnel_processes(())
+        .clear_split_tunnel_processes()
         .await
         .context("Could not clear split tunnel processes in cleanup")?;
     mullvad_client
-        .set_dns_options(
-            default_settings
-                .tunnel_options
-                .as_ref()
-                .unwrap()
-                .dns_options
-                .as_ref()
-                .unwrap()
-                .clone(),
-        )
+        .set_dns_options(default_settings.tunnel_options.dns_options.clone())
         .await
         .context("Could not clear dns options in cleanup")?;
     mullvad_client
-        .set_quantum_resistant_tunnel(
-            default_settings
-                .tunnel_options
-                .as_ref()
-                .unwrap()
-                .wireguard
-                .as_ref()
-                .unwrap()
-                .quantum_resistant
-                .as_ref()
-                .unwrap()
-                .clone(),
-        )
+        .set_quantum_resistant_tunnel(default_settings.tunnel_options.wireguard.quantum_resistant)
         .await
         .context("Could not clear PQ options in cleanup")?;
 

--- a/test/test-manager/src/tests/settings.rs
+++ b/test/test-manager/src/tests/settings.rs
@@ -1,10 +1,10 @@
 use super::helpers;
-use super::helpers::{connect_and_wait, get_tunnel_state, send_guest_probes};
+use super::helpers::{connect_and_wait, send_guest_probes};
 use super::{Error, TestContext};
 use crate::assert_tunnel_state;
 use crate::vm::network::DUMMY_LAN_INTERFACE_IP;
 
-use mullvad_management_interface::ManagementServiceClient;
+use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::states::TunnelState;
 use std::net::{IpAddr, SocketAddr};
 use test_macro::test_function;
@@ -19,7 +19,7 @@ use test_rpc::ServiceClient;
 pub async fn test_lan(
     _: TestContext,
     rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     let lan_destination = SocketAddr::new(IpAddr::V4(DUMMY_LAN_INTERFACE_IP), 1234);
 
@@ -101,7 +101,7 @@ pub async fn test_lan(
 pub async fn test_lockdown(
     _: TestContext,
     rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     let lan_destination: SocketAddr = SocketAddr::new(IpAddr::V4(DUMMY_LAN_INTERFACE_IP), 1337);
     let inet_destination: SocketAddr = "1.1.1.1:1337".parse().unwrap();

--- a/test/test-manager/src/tests/software.rs
+++ b/test/test-manager/src/tests/software.rs
@@ -1,7 +1,7 @@
 //! Tests of interoperability with other software
 
 use super::{helpers, Error, TestContext};
-use mullvad_management_interface::ManagementServiceClient;
+use mullvad_management_interface::MullvadProxyClient;
 use test_macro::test_function;
 use test_rpc::{ExecResult, ServiceClient};
 
@@ -10,7 +10,7 @@ use test_rpc::{ExecResult, ServiceClient};
 pub async fn test_containers(
     _: TestContext,
     rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     let result = probe_container_connectivity(&rpc).await?;
     assert!(

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -1,7 +1,7 @@
 use super::config::TEST_CONFIG;
 use super::helpers;
 use super::{Error, TestContext};
-use mullvad_management_interface::ManagementServiceClient;
+use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::relay_constraints::{RelayConstraints, RelaySettings};
 use mullvad_types::relay_list::{Relay, RelayEndpointData};
 use std::{
@@ -84,7 +84,7 @@ pub async fn run_test_env<
 pub async fn test_ui_tunnel_settings(
     _: TestContext,
     rpc: ServiceClient,
-    mut mullvad_client: ManagementServiceClient,
+    mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     // tunnel-state.spec precondition: a single WireGuard relay should be selected
     log::info!("Select WireGuard relay");

--- a/test/test-manager/test_macro/src/lib.rs
+++ b/test/test-manager/test_macro/src/lib.rs
@@ -11,11 +11,11 @@ use syn::{AttributeArgs, Lit, Meta, NestedMeta};
 /// be used to perform arbitrary network requests, inspect the local file
 /// system, rebooting ..
 ///
-/// * `mullvad_client` - a
-/// [`mullvad_management_interface::ManagementServiceClient`] which provides a
-/// bi-directional communication channel with the `mullvad-daemon` running
-/// inside of the virtual machine. All RPC-calls as defined by
-/// [`mullvad_management_interface::client`] are available on `mullvad_client`.
+/// * `mullvad_client` - a [`mullvad_management_interface::MullvadProxyClient`]
+/// which provides a bi-directional communication channel with the
+/// `mullvad-daemon` running inside of the virtual machine. All RPC-calls as
+/// defined in [`mullvad_management_interface::MullvadProxyClient`] are
+/// available on `mullvad_client`.
 ///
 ///# Arguments
 ///
@@ -47,11 +47,11 @@ use syn::{AttributeArgs, Lit, Meta, NestedMeta};
 /// Remember that [`test_function`] will inject `rpc` and `mullvad_client` for
 /// us.
 ///
-/// ```
+/// ```ignore
 /// #[test_function]
 /// pub async fn test_function(
 ///     rpc: ServiceClient,
-///     mut mullvad_client: mullvad_management_interface::ManagementServiceClient,
+///     mut mullvad_client: mullvad_management_interface::MullvadProxyClient,
 /// ) -> Result<(), Error> {
 ///     Ok(())
 /// }
@@ -62,11 +62,11 @@ use syn::{AttributeArgs, Lit, Meta, NestedMeta};
 /// This test will run early in the test loop, won't perform any cleanup, must
 /// succeed and will always run.
 ///
-/// ```
+/// ```ignore
 /// #[test_function(priority = -1337, cleanup = false, must_succeed = true, always_run = true)]
 /// pub async fn test_function(
 ///     rpc: ServiceClient,
-///     mut mullvad_client: mullvad_management_interface::ManagementServiceClient,
+///     mut mullvad_client: mullvad_management_interface::MullvadProxyClient,
 /// ) -> Result<(), Error> {
 ///     Ok(())
 /// }
@@ -274,7 +274,7 @@ fn get_test_function_parameters(
                 let mullvad_client = match &*pat_type.ty {
                     syn::Type::Path(syn::TypePath { path, .. }) => {
                         match path.segments[0].ident.to_string().as_str() {
-                            "mullvad_management_interface" | "ManagementServiceClient" => {
+                            "mullvad_management_interface" | "MullvadProxyClient" => {
                                 let mullvad_client_version =
                                     quote! { test_rpc::mullvad_daemon::MullvadClientVersion::New };
                                 MullvadClient::New {


### PR DESCRIPTION
Re-write some code in the test framework to prefer the type safe wrapper around the Mullvad app gRPC client instead of its auto-generated dito.

`ManagementServiceClient` is automatically generated from the protobuf definitions found in `management_interface.proto`, and contains some very crude types. The `MullvadProxyClient` is a type-safe wrapper around `ManagementServiceClient` which performs conversions & validation of the data types from the gRPC server (the daemon) to their respective mappings in the `talpid-*` and `mullvad-*` crates. These types are more ergonomic to work with, and since we already have the conversions in place we should prefer those.

This PR also adds a `clippy.toml` to the test framework workspace. The only configuration for now is the lint `disallowed-types` which will warn on use of `ManagementServiceClient`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5682)
<!-- Reviewable:end -->
