### PR TITLE
Fix app getting stuck in error state on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Fix default route not being restored when disconnecting when the gateway was a link-local IPv6
   address.
+- Fix app sometimes getting stuck in error state when the connection is unstable. This occurred
+  when the default route was removed while connecting.
 
 ### Changed
 - Remove `--location` flag from `mullvad status` CLI. Location and IP will now always

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -23,7 +23,7 @@ mod imp;
 use netlink_packet_route::rtnl::constants::RT_TABLE_MAIN;
 
 #[cfg(target_os = "macos")]
-pub use imp::{DefaultRouteEvent, PlatformError};
+pub use imp::{imp::RouteError, DefaultRouteEvent, PlatformError};
 
 pub use imp::{Error, RouteManager};
 

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -23,6 +23,8 @@ mod interface;
 mod routing_socket;
 mod watch;
 
+pub use watch::Error as RouteError;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 const BURST_BUFFER_PERIOD: Duration = Duration::from_millis(200);
@@ -36,7 +38,7 @@ pub enum Error {
     #[error(display = "Error occurred when interfacing with the routing table")]
     RoutingTable(#[error(source)] watch::Error),
 
-    /// Failed to remvoe route
+    /// Failed to remove route
     #[error(display = "Error occurred when deleting a route")]
     DeleteRoute(#[error(source)] watch::Error),
 

--- a/talpid-routing/src/unix/macos/watch.rs
+++ b/talpid-routing/src/unix/macos/watch.rs
@@ -6,20 +6,28 @@ use std::io;
 
 type Result<T> = std::result::Result<T, Error>;
 
+/// Errors that can occur for a PF_ROUTE socket
 #[derive(Debug, err_derive::Error)]
 pub enum Error {
+    /// Generic routing socket error
     #[error(display = "Routing socket error: {}", _0)]
     RoutingSocket(routing_socket::Error),
+    /// Failed to parse route message
     #[error(display = "Invalid message")]
     InvalidMessage(data::Error),
+    /// Failed to send route message
     #[error(display = "Failed to send routing message")]
     Send(routing_socket::Error),
+    /// Received unexpected response to route message
     #[error(display = "Unexpected message type")]
     UnexpectedMessageType(RouteSocketMessage, MessageType),
+    /// Route not found
     #[error(display = "Route not found")]
     RouteNotFound,
+    /// No route to destination
     #[error(display = "Destination unreachable")]
     Unreachable,
+    /// Failed to delete route
     #[error(display = "Failed to delete a route")]
     Deletion(RouteMessage),
 }


### PR DESCRIPTION
Previously, the app would get stuck in the error state when a default route was removed while connecting. Specifically, this occurred if the default was missing while adding tunnel routes, but before the offline monitor had had time to catch it. That caused adding routes to fail due to `ENETUNREACH`.

This PR fixes it by simply retrying/reconnecting when adding routes fails due to an unreachable destination.

Closes DES-496.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5687)
<!-- Reviewable:end -->
