### PR TITLE
Enable quantum-resistant tunnels by default on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Migrate to Compose Navigation which also improves screen transition animations.
 
+#### Linux
+- Enable quantum resistant tunnels by default (when set to `auto`). On other platforms, `auto` still
+  always means the same thing as `off`.
+
 ### Security
 #### Android
 - Change from singleTask to singleInstance to fix Task Affinity Vulnerability in Android 8.

--- a/mullvad-types/src/custom_tunnel.rs
+++ b/mullvad-types/src/custom_tunnel.rs
@@ -58,13 +58,20 @@ impl CustomTunnelEndpoint {
                 fwmark: crate::TUNNEL_FWMARK,
             }
             .into(),
-            ConnectionConfig::Wireguard(connection) => wireguard::TunnelParameters {
-                connection,
-                options: tunnel_options.wireguard.into_talpid_tunnel_options(),
-                generic_options: tunnel_options.generic,
-                obfuscation: None,
+            ConnectionConfig::Wireguard(connection) => {
+                let mut options = tunnel_options.wireguard.into_talpid_tunnel_options();
+                if options.quantum_resistant {
+                    options.quantum_resistant = false;
+                    log::info!("Ignoring quantum resistant option for custom tunnel");
+                }
+                wireguard::TunnelParameters {
+                    connection,
+                    options,
+                    generic_options: tunnel_options.generic,
+                    obfuscation: None,
+                }
+                .into()
             }
-            .into(),
         };
         Ok(parameters)
     }

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -10,9 +10,10 @@ pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_secs(1 * 24 * 60 * 60
 pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(14 * 24 * 60 * 60);
 pub const DEFAULT_ROTATION_INTERVAL: Duration = MAX_ROTATION_INTERVAL;
 
-/// Whether to enable or disable quantum resistant tunnels when the setting
-/// is set to `QuantumResistantState::Auto`.
-const QUANTUM_RESISTANT_AUTO_STATE: bool = false;
+/// Whether to enable or disable quantum resistant tunnels when the setting is set to
+/// `QuantumResistantState::Auto`. It is currently enabled by default on Linux but disabled on all
+/// other platforms.
+const QUANTUM_RESISTANT_AUTO_STATE: bool = cfg!(target_os = "linux");
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(target_os = "android", derive(IntoJava, FromJava))]

--- a/test/test-manager/src/tests/tunnel_state.rs
+++ b/test/test-manager/src/tests/tunnel_state.rs
@@ -294,7 +294,7 @@ pub async fn test_connected_state(
                         },
                     // TODO: Consider the type of `relay` / `relay_filter` instead
                     tunnel_type: TunnelType::Wireguard,
-                    quantum_resistant: false,
+                    quantum_resistant: _,
                     proxy: None,
                     obfuscation: None,
                     entry_endpoint: None,


### PR DESCRIPTION
When the setting is set to `auto`.

Close DES-556.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5692)
<!-- Reviewable:end -->
