### PR TITLE
Move logic of toggling disabled access methods on use to the daemon

### DIFF
--- a/mullvad-cli/src/cmds/api_access.rs
+++ b/mullvad-cli/src/cmds/api_access.rs
@@ -213,7 +213,7 @@ impl ApiAccess {
     /// configured ones.
     async fn set(item: SelectItem) -> Result<()> {
         let mut rpc = MullvadProxyClient::new().await?;
-        let mut new_access_method = Self::get_access_method(&mut rpc, &item).await?;
+        let new_access_method = Self::get_access_method(&mut rpc, &item).await?;
         let current_access_method = rpc.get_current_api_access_method().await?;
         // Try to reach the API with the newly selected access method.
         rpc.test_api_access_method(new_access_method.get_id())
@@ -226,11 +226,6 @@ impl ApiAccess {
         // If the test succeeded, the new access method should be used from now on.
         rpc.set_access_method(new_access_method.get_id()).await?;
         println!("Using access method \"{}\"", new_access_method.get_name());
-        // Toggle the enabled status if needed
-        if !new_access_method.enabled() {
-            new_access_method.enable();
-            rpc.update_access_method(new_access_method).await?;
-        }
         Ok(())
     }
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2451,7 +2451,7 @@ where
         access_method: mullvad_types::access_method::Id,
     ) {
         let result = self
-            .set_api_access_method(access_method)
+            .use_api_access_method(access_method)
             .await
             .map_err(Error::AccessMethodError);
         Self::oneshot_send(tx, result, "set_api_access_method response");


### PR DESCRIPTION
This PR moves the logic for toggling a disabled access method to be enabled if it is actively used from the clients (only the CLI at the moment) to the daemon.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5693)
<!-- Reviewable:end -->
