### PR TITLE
Bind to the service in a coroutine to avoid a crash

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -9,8 +9,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.compose.screen.MullvadApp
 import net.mullvad.mullvadvpn.di.paymentModule
 import net.mullvad.mullvadvpn.di.uiModule
@@ -60,46 +64,40 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent { AppTheme { MullvadApp() } }
+
+        // We use lifecycleScope here to get less start service in background exceptions
+        // Se this article for more information:
+        // https://medium.com/@lepicekmichal/android-background-service-without-hiccup-501e4479110f
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                if (privacyDisclaimerRepository.hasAcceptedPrivacyDisclosure()) {
+                    startServiceSuspend(waitForConnectedReady = false)
+                }
+            }
+        }
     }
 
-    fun initializeStateHandlerAndServiceConnection() {
+    suspend fun startServiceSuspend(waitForConnectedReady: Boolean = true) {
         requestNotificationPermissionIfMissing(requestNotificationPermissionLauncher)
         serviceConnectionManager.bind(
             vpnPermissionRequestHandler = ::requestVpnPermission,
             apiEndpointConfiguration = intent?.getApiEndpointConfigurationExtras()
         )
-    }
-
-    suspend fun startServiceSuspend() {
-        requestNotificationPermissionIfMissing(requestNotificationPermissionLauncher)
-        serviceConnectionManager.bind(
-            vpnPermissionRequestHandler = ::requestVpnPermission,
-            apiEndpointConfiguration = intent?.getApiEndpointConfigurationExtras()
-        )
-        // Ensure we wait until the service is ready
-        serviceConnectionManager.connectionState
-            .filterIsInstance<ServiceConnectionState.ConnectedReady>()
-            .first()
+        if (waitForConnectedReady) {
+            // Ensure we wait until the service is ready
+            serviceConnectionManager.connectionState
+                .filterIsInstance<ServiceConnectionState.ConnectedReady>()
+                .first()
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
         serviceConnectionManager.onVpnPermissionResult(resultCode == Activity.RESULT_OK)
     }
 
-    override fun onStart() {
-        super.onStart()
-
-        if (privacyDisclaimerRepository.hasAcceptedPrivacyDisclosure()) {
-            initializeStateHandlerAndServiceConnection()
-        }
-    }
-
     override fun onStop() {
         Log.d("mullvad", "Stopping main activity")
         super.onStop()
-
-        // NOTE: `super.onStop()` must be called before unbinding due to the fragment state handling
-        // otherwise the fragments will believe there was an unexpected disconnect.
         serviceConnectionManager.unbind()
     }
 


### PR DESCRIPTION
We have a crash on Google Play that throws android.app.BackgroundServiceStartNotAllowedException.
Now this exception is thrown when a background service is started by an app in the background.
Since we are attempting to start our service in `onStart` the app should be in the foreground when the service is starting so it is a bit unclear under which conditions this exception is thrown. Even more so since there's a grace period of about 30 seconds after the app is moved to the background that the app is still allowed to start a background service.
I have thought about two possible scenarios:
1. The app is started up and for some reason the app is for some reason not yet considered to be in the foreground when start service is called. This is mitigated by only running the coroutine when the lifecycle state changes to OnStart.
2. The app is backgrounded but the call to start services is delayed/blocked for some reason and then it is continued after the app has been in the background for quite some time. This partially fixed by cancelling the coroutine in onStop, but there are scenarios that I have tested that even though the coroutine is cancelled that start service is called anyway.

So my hope is that this will decrease the amount of crashes.
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5697)
<!-- Reviewable:end -->
