### PR TITLE
Fix test_installation_idempotency

### DIFF
--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -277,7 +277,7 @@ pub async fn test_install_new_app(_: TestContext, rpc: ServiceClient) -> Result<
 ///
 /// This test is supposed to guard against regressions to this fix included in
 /// the 2021.3-beta1 release:
-/// https://github.com/mullvad/mullvadvpn-app/blob/main/CHANGELOG.md#security-10
+/// https://github.com/mullvad/mullvadvpn-app/blob/2021.3-beta1/CHANGELOG.md#security
 #[test_function(priority = -150)]
 pub async fn test_installation_idempotency(
     _: TestContext,

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -58,6 +58,9 @@ pub enum Error {
     #[error(display = "The daemon returned an error: {}", _0)]
     Daemon(String),
 
+    #[error(display = "The daemon ended up in the error state")]
+    UnexpectedErrorState(talpid_types::tunnel::ErrorState),
+
     #[error(display = "The gRPC client ran into an error: {}", _0)]
     ManagementInterface(#[source] mullvad_management_interface::Error),
 


### PR DESCRIPTION
The test currently fails when the daemon is not logged in. This always happens since `test_login` runs after this test.

This PR fixes it by failing whenever the daemon starts in the `disconnected` state instead.

Close DES-565.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5699)
<!-- Reviewable:end -->
