### PR TITLE
Allow testing access methods before saving them

### DIFF
--- a/mullvad-daemon/src/access_method.rs
+++ b/mullvad-daemon/src/access_method.rs
@@ -3,7 +3,7 @@ use crate::{
     settings::{self, MadeChanges},
     Daemon, EventListener,
 };
-use mullvad_api::rest;
+use mullvad_api::{proxy::ApiConnectionMode, rest, ApiProxy};
 use mullvad_types::{
     access_method::{self, AccessMethod, AccessMethodSetting},
     settings::Settings,
@@ -24,10 +24,11 @@ pub enum Error {
     #[error(display = "Access method could not be rotated")]
     RotationFailed,
     /// Some error occured in the daemon's state of handling
-    /// [`AccessMethodSetting`]s & [`ApiConnectionMode`]s.
+    /// [`AccessMethodSetting`]s & [`ApiConnectionMode`]s
     #[error(display = "Error occured when handling connection settings & details")]
-    ConnectionMode(#[error(source)] api::Error),
-    #[error(display = "API endpoint rotation failed")]
+    ApiService(#[error(source)] api::Error),
+    /// A REST request failed
+    #[error(display = "Reset request failed")]
     Rest(#[error(source)] rest::Error),
     /// Access methods settings error
     #[error(display = "Settings error")]
@@ -211,7 +212,7 @@ where
             .get_current()
             .await
             .map(|current| current.setting)
-            .map_err(Error::ConnectionMode)
+            .map_err(Error::ApiService)
     }
 
     /// Change which [`AccessMethodSetting`] which will be used as the Mullvad
@@ -225,6 +226,62 @@ where
                 log::error!("Failed to rotate API endpoint: {}", error);
                 Error::RotationFailed
             })
+    }
+
+    /// Test if the API is reachable via `proxy`.
+    ///
+    /// This function tests if [`AccessMethod`] can be used to reach the API.
+    /// Its parameters are as low-level as possible to promot re-use between
+    /// different kinds of testing contexts, such as testing
+    /// [`AccessMethodSetting`]s or on the fly testing of
+    /// [`talpid_types::net::proxy::CustomProxy`]s.
+    pub(crate) async fn test_access_method(
+        proxy: talpid_types::net::AllowedEndpoint,
+        access_method_selector: api::AccessModeSelectorHandle,
+        daemon_event_sender: crate::DaemonEventSender<(
+            api::AccessMethodEvent,
+            futures::channel::oneshot::Sender<()>,
+        )>,
+        api_proxy: ApiProxy,
+    ) -> Result<bool, Error> {
+        let reset = access_method_selector
+            .get_current()
+            .await
+            .map(|connection_mode| connection_mode.endpoint)?;
+
+        api::AccessMethodEvent::Allow { endpoint: proxy }
+            .send(daemon_event_sender.clone())
+            .await?;
+
+        let result = Self::perform_api_request(api_proxy).await;
+
+        api::AccessMethodEvent::Allow { endpoint: reset }
+            .send(daemon_event_sender)
+            .await?;
+
+        result
+    }
+
+    /// Create an [`ApiProxy`] which will perform all REST requests against one
+    /// specific endpoint `proxy_provider`.
+    pub async fn create_limited_api_proxy(
+        &mut self,
+        proxy_provider: ApiConnectionMode,
+    ) -> ApiProxy {
+        let rest_handle = self
+            .api_runtime
+            .mullvad_rest_handle(proxy_provider.into_repeat())
+            .await;
+        ApiProxy::new(rest_handle)
+    }
+
+    /// Perform some REST request against the Mullvad API.
+    ///
+    /// * Returns `Ok(true)` if the API returned the expected result
+    /// * Returns `Ok(false)` if the API returned an unexpected result
+    /// * Returns `Err(..)` if the API could not be reached
+    async fn perform_api_request(api_proxy: ApiProxy) -> Result<bool, Error> {
+        api_proxy.api_addrs_available().await.map_err(Error::Rest)
     }
 
     /// If settings were changed due to an update, notify all listeners.

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -80,7 +80,8 @@ service ManagementService {
   rpc SetApiAccessMethod(UUID) returns (google.protobuf.Empty) {}
   rpc UpdateApiAccessMethod(AccessMethodSetting) returns (google.protobuf.Empty) {}
   rpc GetCurrentApiAccessMethod(google.protobuf.Empty) returns (AccessMethodSetting) {}
-  rpc TestApiAccessMethod(UUID) returns (google.protobuf.BoolValue) {}
+  rpc TestCustomApiAccessMethod(CustomProxy) returns (google.protobuf.BoolValue) {}
+  rpc TestApiAccessMethodById(UUID) returns (google.protobuf.BoolValue) {}
 
   // Split tunneling (Linux)
   rpc GetSplitTunnelProcesses(google.protobuf.Empty) returns (stream google.protobuf.Int32Value) {}
@@ -359,9 +360,7 @@ message AccessMethod {
   oneof access_method {
     Direct direct = 1;
     Bridges bridges = 2;
-    Socks5Local socks5local = 3;
-    Socks5Remote socks5remote = 4;
-    Shadowsocks shadowsocks = 5;
+    CustomProxy custom = 3;
   }
 }
 

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -216,7 +216,19 @@ impl MullvadProxyClient {
     pub async fn test_api_access_method(&mut self, id: access_method::Id) -> Result<bool> {
         let result = self
             .0
-            .test_api_access_method(types::Uuid::from(id))
+            .test_api_access_method_by_id(types::Uuid::from(id))
+            .await
+            .map_err(Error::Rpc)?;
+        Ok(result.into_inner())
+    }
+
+    pub async fn test_custom_api_access_method(
+        &mut self,
+        config: talpid_types::net::proxy::CustomProxy,
+    ) -> Result<bool> {
+        let result = self
+            .0
+            .test_custom_api_access_method(types::CustomProxy::from(config))
             .await
             .map_err(Error::Rpc)?;
         Ok(result.into_inner())

--- a/mullvad-management-interface/src/types/conversions/access_method.rs
+++ b/mullvad-management-interface/src/types/conversions/access_method.rs
@@ -104,14 +104,8 @@ mod data {
             Ok(match access_method {
                 proto::access_method::AccessMethod::Direct(direct) => AccessMethod::from(direct),
                 proto::access_method::AccessMethod::Bridges(bridge) => AccessMethod::from(bridge),
-                proto::access_method::AccessMethod::Socks5local(sockslocal) => {
-                    AccessMethod::try_from(sockslocal)?
-                }
-                proto::access_method::AccessMethod::Socks5remote(socksremote) => {
-                    AccessMethod::try_from(socksremote)?
-                }
-                proto::access_method::AccessMethod::Shadowsocks(shadowsocks) => {
-                    AccessMethod::try_from(shadowsocks)?
+                proto::access_method::AccessMethod::Custom(custom) => {
+                    CustomProxy::try_from(custom).map(AccessMethod::from)?
                 }
             })
         }
@@ -193,23 +187,7 @@ mod data {
 
     impl From<CustomProxy> for proto::access_method::AccessMethod {
         fn from(value: CustomProxy) -> Self {
-            match value {
-                CustomProxy::Shadowsocks(config) => {
-                    proto::access_method::AccessMethod::Shadowsocks(proto::Shadowsocks::from(
-                        config,
-                    ))
-                }
-                CustomProxy::Socks5Local(config) => {
-                    proto::access_method::AccessMethod::Socks5local(proto::Socks5Local::from(
-                        config,
-                    ))
-                }
-                CustomProxy::Socks5Remote(config) => {
-                    proto::access_method::AccessMethod::Socks5remote(proto::Socks5Remote::from(
-                        config,
-                    ))
-                }
-            }
+            proto::access_method::AccessMethod::Custom(proto::CustomProxy::from(value))
         }
     }
 


### PR DESCRIPTION
Add a new RPC call `TestAccessMethod` for testing access methods on the fly, without having to save them to the daemon settings first. This only works for custom access method.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5705)
<!-- Reviewable:end -->
