### PR TITLE
Hardcode a low MTU/MSS for the tunnel config client socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for all screen orientations.
 
 ### Fixed
+- Fix connectivity issues that would occur when using quantum-resistant tunnels with an incorrectly
+  configured MTU.
+
 #### Linux
 - Fix Bash shell completions for subcommands in the CLI
 - Out IP missing forever when am.i.mullvad.net returns error


### PR DESCRIPTION
This works around PQ connectivity issues caused by the actual MTU being lower than the tunnel MTU.

Close DES-573.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5707)
<!-- Reviewable:end -->
