### PR TITLE
Remove socks5 authentication check from the TransportStrategy layer

### DIFF
--- a/ios/MullvadREST/Transport/TransportStrategy.swift
+++ b/ios/MullvadREST/Transport/TransportStrategy.swift
@@ -91,16 +91,11 @@ public class TransportStrategy: Equatable {
                 cipher: configuration.cipher.rawValue.description
             ))
         case let .socks5(configuration):
-            switch configuration.authentication {
-            case .noAuthentication:
-                return .socks5(configuration: Socks5Configuration(proxyEndpoint: configuration.toAnyIPEndpoint))
-            case let .usernamePassword(username, password):
-                return .socks5(configuration: Socks5Configuration(
-                    proxyEndpoint: configuration.toAnyIPEndpoint,
-                    username: username,
-                    password: password
-                ))
-            }
+            return .socks5(configuration: Socks5Configuration(
+                proxyEndpoint: configuration.toAnyIPEndpoint,
+                username: configuration.credential?.username,
+                password: configuration.credential?.password
+            ))
         }
     }
 

--- a/ios/MullvadRESTTests/TransportStrategyTests.swift
+++ b/ios/MullvadRESTTests/TransportStrategyTests.swift
@@ -196,10 +196,11 @@ class TransportStrategyTests: XCTestCase {
     func testUsesSocks5WithAuthenticationWhenItReaches() throws {
         let username = "user"
         let password = "pass"
-        let authentication = PersistentProxyConfiguration.SocksAuthentication.usernamePassword(
-            username: username,
-            password: password
-        )
+        let authentication = PersistentProxyConfiguration.SocksAuthentication
+            .authentication(PersistentProxyConfiguration.UserCredential(
+                username: username,
+                password: password
+            ))
         let socks5Configuration = PersistentProxyConfiguration.SocksConfiguration(
             server: .ipv4(.loopback),
             port: 1080,

--- a/ios/MullvadSettings/PersistentAccessMethod.swift
+++ b/ios/MullvadSettings/PersistentAccessMethod.swift
@@ -55,7 +55,17 @@ extension PersistentProxyConfiguration {
     /// Socks autentication method.
     public enum SocksAuthentication: Codable {
         case noAuthentication
-        case usernamePassword(username: String, password: String)
+        case authentication(UserCredential)
+    }
+
+    public struct UserCredential: Codable {
+        public let username: String
+        public let password: String
+
+        public init(username: String, password: String) {
+            self.username = username
+            self.password = password
+        }
     }
 
     /// Socks v5 proxy configuration.
@@ -73,6 +83,13 @@ extension PersistentProxyConfiguration {
             self.server = server
             self.port = port
             self.authentication = authentication
+        }
+
+        public var credential: UserCredential? {
+            guard case let .authentication(credential) = authentication else {
+                return nil
+            }
+            return credential
         }
 
         public var toAnyIPEndpoint: AnyIPEndpoint {

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodViewModel+Persistent.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodViewModel+Persistent.swift
@@ -87,7 +87,10 @@ extension AccessMethodViewModel.Socks {
                     context: context
                 ))
             } else {
-                draftConfiguration.authentication = .usernamePassword(username: username, password: password)
+                draftConfiguration.authentication = .authentication(PersistentProxyConfiguration.UserCredential(
+                    username: username,
+                    password: password
+                ))
             }
         }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/PersistentProxyConfiguration+ViewModel.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/PersistentProxyConfiguration+ViewModel.swift
@@ -22,9 +22,9 @@ extension PersistentProxyConfiguration {
         )
 
         switch config.authentication {
-        case let .usernamePassword(username, password):
-            socks.username = username
-            socks.password = password
+        case let .authentication(userCredential):
+            socks.username = userCredential.username
+            socks.password = userCredential.password
             socks.authenticate = true
 
         case .noAuthentication:


### PR DESCRIPTION
We don't necessarily need a switch-case for SOCKS authentication that involves retrieving credentials in the `TransportStrategy` when we can achieve the same outcome using an optional value for the authentication part. This pull request transforms the `SocksAuthentication` enum into a struct and makes it an optional variable in `SocksConfiguration`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5708)
<!-- Reviewable:end -->
