### PR TITLE
Add mock api test for testing the account history feature

### DIFF
--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountHistoryMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountHistoryMockApiTest.kt
@@ -1,0 +1,49 @@
+package net.mullvad.mullvadvpn.test.mockapi
+
+import androidx.test.uiautomator.By
+import net.mullvad.mullvadvpn.compose.test.LOGIN_INPUT_TEST_TAG
+import net.mullvad.mullvadvpn.lib.common.util.groupWithSpaces
+import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
+import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
+import net.mullvad.mullvadvpn.test.common.extension.dismissChangelogDialogIfShown
+import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+import net.mullvad.mullvadvpn.test.mockapi.constant.DEFAULT_DEVICE_LIST
+import net.mullvad.mullvadvpn.test.mockapi.constant.DUMMY_DEVICE_NAME_2
+import net.mullvad.mullvadvpn.test.mockapi.constant.DUMMY_ID_2
+import net.mullvad.mullvadvpn.test.mockapi.util.currentUtcTimeWithOffsetZero
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class AccountHistoryMockApiTest : MockApiTest() {
+
+    @Test
+    fun testShowAccountHistory() {
+        // Arrange
+        val validAccountToken = "1234123412341234"
+        apiDispatcher.apply {
+            expectedAccountToken = validAccountToken
+            accountExpiry = currentUtcTimeWithOffsetZero().plusMonths(1)
+            devices = DEFAULT_DEVICE_LIST.toMutableMap()
+            devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
+        }
+
+        // Act
+        app.launch(endpoint)
+        device.clickAgreeOnPrivacyDisclaimer()
+        device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
+        device.dismissChangelogDialogIfShown()
+        app.waitForLoginPrompt()
+        app.attemptLogin(validAccountToken)
+        app.ensureLoggedIn()
+        app.clickAccountCog()
+        app.clickActionButtonByText("Log out")
+        device.findObjectWithTimeout(By.res(LOGIN_INPUT_TEST_TAG)).click()
+
+        // Assert
+        assertNotNull(device.findObjectWithTimeout(By.text(validAccountToken.groupWithSpaces())))
+
+        // Try to login with the same account again
+        device.findObjectWithTimeout(By.text(validAccountToken.groupWithSpaces())).click()
+        app.ensureLoggedIn()
+    }
+}

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
@@ -62,7 +62,7 @@ class LoginMockApiTest : MockApiTest() {
         app.attemptLogin(validAccountToken)
 
         // Assert
-        device.findObjectWithTimeout(By.text("UNSECURED CONNECTION"))
+        app.ensureLoggedIn()
     }
 
     @Test

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LogoutMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LogoutMockApiTest.kt
@@ -32,7 +32,7 @@ class LogoutMockApiTest : MockApiTest() {
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
         app.attemptLogin(validAccountToken)
-        device.findObjectWithTimeout(By.text("UNSECURED CONNECTION"))
+        app.ensureLoggedIn()
         app.clickAccountCog()
         app.clickActionButtonByText("Log out")
 

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
@@ -62,6 +62,6 @@ class TooManyDevicesMockApiTest : MockApiTest() {
         app.clickActionButtonByText("Continue with login")
 
         // Assert that we are logged in
-        device.findObjectWithTimeout(By.text("UNSECURED CONNECTION"))
+        app.ensureLoggedIn()
     }
 }


### PR DESCRIPTION
Tests that the last account number is shown after logging out of an account. Also checks that clicking on that number will log the user into the account again.
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5711)
<!-- Reviewable:end -->
