### PR TITLE
Use infallible HeaderValue::from() when converting from usize

### DIFF
--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -503,15 +503,11 @@ impl RequestFactory {
         let mut request = self.hyper_request(path, method)?;
 
         let json_body = serde_json::to_string(&body)?;
-        let body_length = json_body.as_bytes().len() as u64;
+        let body_length = json_body.as_bytes().len();
         *request.body_mut() = json_body.into_bytes().into();
 
         let headers = request.headers_mut();
-        headers.insert(
-            header::CONTENT_LENGTH,
-            HeaderValue::from_str(&body_length.to_string())
-                .map_err(|_| Error::InvalidHeaderError)?,
-        );
+        headers.insert(header::CONTENT_LENGTH, HeaderValue::from(body_length));
         headers.insert(
             header::CONTENT_TYPE,
             HeaderValue::from_static("application/json"),


### PR DESCRIPTION
`HeaderValue` in hyper support a multitude of `From` traits, which are infallible for primitives such as `usize` but fallible for strings. This minor refactoring PR removes the need for going via string when setting the `Content-Length` header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5715)
<!-- Reviewable:end -->
