### PR TITLE
Prevent fragmentation in tunnel when using multihop on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Line wrap the file at 100 chars.                                              Th
   address.
 - Fix app sometimes getting stuck in error state when the connection is unstable. This occurred
   when the default route was removed while connecting.
+- Improve multihop performance by preventing fragmentation in the tunnel. This is done by setting
+  an MTU on the default route.
 
 ### Changed
 - Remove `--location` flag from `mullvad status` CLI. Location and IP will now always

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -37,7 +37,7 @@ pub struct Route {
     metric: Option<u32>,
     #[cfg(target_os = "linux")]
     table_id: u32,
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     mtu: Option<u32>,
 }
 
@@ -50,7 +50,7 @@ impl Route {
             metric: None,
             #[cfg(target_os = "linux")]
             table_id: u32::from(RT_TABLE_MAIN),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             mtu: None,
         }
     }
@@ -95,7 +95,7 @@ pub struct RequiredRoute {
     #[cfg(target_os = "linux")]
     main_table: bool,
     /// Specifies route MTU
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     mtu: Option<u16>,
 }
 
@@ -107,7 +107,7 @@ impl RequiredRoute {
             prefix,
             #[cfg(target_os = "linux")]
             main_table: true,
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
             mtu: None,
         }
     }
@@ -120,7 +120,7 @@ impl RequiredRoute {
     }
 
     /// Set route MTU to the given value.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn mtu(mut self, mtu: u16) -> Self {
         self.mtu = Some(mtu);
         self


### PR DESCRIPTION
Follow-up to #5501. This PR makes the same change but for macOS.

Fix DES-465.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5721)
<!-- Reviewable:end -->
