### PR TITLE
Strip binaries with cargo instead of build.sh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ once_cell = "1.13"
 [profile.release]
 opt-level = 3
 lto = true
+strip = true
 
 # Key generation may take over one minute without optimizations
 # enabled.

--- a/build.sh
+++ b/build.sh
@@ -200,17 +200,12 @@ function sign_win {
 }
 
 # Build the daemon and other Rust/C++ binaries, optionally
-# sign them, strip them of debug symbols and copy to `dist-assets/`.
+# sign them, and copy to `dist-assets/`.
 function build {
     local current_target=${1:-""}
     local for_target_string=" for local target $HOST"
-    local stripbin="strip"
     if [[ -n $current_target ]]; then
         for_target_string=" for $current_target"
-
-        if [[ "$current_target" == "aarch64-unknown-linux-gnu" && "$(uname -m)" != "aarch64" ]]; then
-            stripbin="aarch64-linux-gnu-strip"
-        fi
     fi
 
     ################################################################################
@@ -287,13 +282,8 @@ function build {
         local source="$cargo_output_dir/$binary"
         local destination="$destination_dir/$binary"
 
-        if [[ "$(uname -s)" == "MINGW"* || "$binary" == *.dylib ]]; then
-            log_info "Copying $source => $destination"
-            cp "$source" "$destination"
-        else
-            log_info "Stripping $source => $destination"
-            "${stripbin}" "$source" -o "$destination"
-        fi
+        log_info "Copying $source => $destination"
+        cp "$source" "$destination"
 
         if [[ "$SIGN" == "true" && "$(uname -s)" == "MINGW"* ]]; then
             sign_win "$destination"


### PR DESCRIPTION
I found this neat little blog post: https://kobzol.github.io/rust/cargo/2024/01/23/making-rust-binaries-smaller-by-default.html

On nightly Rust cargo will now by default strip debuginfo (coming to stable later). However symbols are still there. We have a more complex solution where we manually invoke `strip` on the produced binaries to yield the same result as we can get by setting `strip = true` in `Cargo.toml`.

This project fixes that, and simplifies build.sh. We also get stripping for anyone manually invoking `cargo build --release`. I see no downsides.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5723)
<!-- Reviewable:end -->
