### PR TITLE
Run cargo audit in test framework also

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -33,4 +33,5 @@ jobs:
           # Ignored audit issues. This list should be kept short, and effort should be
           # put into removing items from the list.
           # RUSTSEC-2023-0057,RUSTSEC-2023-0058 - Unsoundness in `inventory`.
-          ignore: RUSTSEC-2023-0057,RUSTSEC-2023-0058
+          # RUSTSEC-2020-0168 - `mach` is unmaintained. Can be fixed by upgrading `serialport`.
+          ignore: RUSTSEC-2023-0057,RUSTSEC-2023-0058,RUSTSEC-2020-0168

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/cargo-audit.yml
       - Cargo.lock
+      - test/Cargo.lock
   schedule:
     # At 06:20 UTC every day. Will create an issue if a CVE is found.
     - cron: '20 6 * * *'
@@ -18,7 +19,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: actions-rust-lang/audit@v1
+      - uses: actions-rust-lang/audit@v1.1.11
         name: Audit Rust Dependencies
         with:
+          file: Cargo.lock
           denyWarnings: true
+
+      - uses: actions-rust-lang/audit@v1.1.11
+        name: Audit testrunner Rust Dependencies
+        with:
+          file: test/Cargo.lock
+          denyWarnings: true
+          # Ignored audit issues. This list should be kept short, and effort should be
+          # put into removing items from the list.
+          # RUSTSEC-2023-0057,RUSTSEC-2023-0058 - Unsoundness in `inventory`.
+          ignore: RUSTSEC-2023-0057,RUSTSEC-2023-0058


### PR DESCRIPTION
As part of the effort to run better CI on the testingframework I here add Cargo audit checking.

Replacing `inventory` was a non-trivial task, so I ignore that RUSTSEC for now. Better to have some audit checking in place and ignoring a few issues than having no audit checking at all.

At the time of posting this PR it will fail on `RUSTSEC-2020-0168` against `mach` dependency being unmaintained. But a separate PR tries to upgrade that. This PR will be rebased and tested against `main` once that is done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5725)
<!-- Reviewable:end -->
