### PR TITLE
Don't pin serialport to a fork. Use upgraded upstream version 4.3.0

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -33,5 +33,4 @@ jobs:
           # Ignored audit issues. This list should be kept short, and effort should be
           # put into removing items from the list.
           # RUSTSEC-2023-0057,RUSTSEC-2023-0058 - Unsoundness in `inventory`.
-          # RUSTSEC-2020-0168 - `mach` is unmaintained. Can be fixed by upgrading `serialport`.
-          ignore: RUSTSEC-2023-0057,RUSTSEC-2023-0058,RUSTSEC-2020-0168
+          ignore: RUSTSEC-2023-0057,RUSTSEC-2023-0058

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -3,27 +3,6 @@
 version = 3
 
 [[package]]
-name = "CoreFoundation-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
-dependencies = [
- "libc",
- "mach 0.1.2",
-]
-
-[[package]]
-name = "IOKit-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
-dependencies = [
- "CoreFoundation-sys",
- "libc",
- "mach 0.1.2",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "ioctl-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,19 +1586,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.1.2"
+name = "mach2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
@@ -1802,17 +1782,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -2763,16 +2732,19 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.2.0"
-source = "git+https://github.com/mullvad/serialport-rs?rev=1401c9d39e4a89685e3506a7160869b2c8e9ceb0#1401c9d39e4a89685e3506a7160869b2c8e9ceb0"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5a15d0be940df84846264b09b51b10b931fb2f275becb80934e3568a016828"
 dependencies = [
- "CoreFoundation-sys",
- "IOKit-sys",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
- "mach 0.3.2",
- "nix 0.24.3",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "mach2",
+ "nix 0.26.4",
  "regex",
+ "scopeguard",
+ "unescaper",
  "winapi",
 ]
 
@@ -3622,6 +3594,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unescaper"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adf6ad32eb5b3cadff915f7b770faaac8f7ff0476633aa29eb0d9584d889d34"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -19,9 +19,6 @@ rust_2018_idioms = "deny"
 [workspace.lints.clippy]
 unused_async = "deny"
 
-[patch.crates-io]
-serialport = { git = "https://github.com/mullvad/serialport-rs", rev = "1401c9d39e4a89685e3506a7160869b2c8e9ceb0" }
-
 [workspace.dependencies]
 futures = "0.3"
 tokio = { version = "1.8", features = ["macros", "rt", "process", "time", "fs", "io-util", "rt-multi-thread"] }

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -15,7 +15,12 @@ use std::time::Duration;
 use test_rpc::logging::Output;
 use test_rpc::{mullvad_daemon::MullvadClientVersion, ServiceClient};
 
-const BAUD: u32 = 115200;
+/// The baud rate of the serial connection between the test manager and the test runner.
+/// There is a known issue with setting a baud rate at all or macOS, and the workaround
+/// is to set it to zero: https://github.com/serialport/serialport-rs/pull/58
+///
+/// Keep this constant in sync with `test-runner/src/main.rs`
+const BAUD: u32 = if cfg!(target_os = "macos") { 0 } else { 115200 };
 
 pub async fn run(
     config: tests::config::TestConfig,

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -299,7 +299,12 @@ fn get_pipe_status() -> ServiceStatus {
     }
 }
 
-const BAUD: u32 = 115200;
+/// The baud rate of the serial connection between the test manager and the test runner.
+/// There is a known issue with setting a baud rate at all or macOS, and the workaround
+/// is to set it to zero: https://github.com/serialport/serialport-rs/pull/58
+///
+/// Keep this constant in sync with `test-manager/src/run_tests.rs`
+const BAUD: u32 = if cfg!(target_os = "macos") { 0 } else { 115200 };
 
 #[derive(err_derive::Error, Debug)]
 pub enum Error {


### PR DESCRIPTION
This PR does not look like much, but it has a bunch of nice outcomes:

* Gets rid of a git dependency. Git dependencies are not good, since the availability of a specific git repo or commit is harder to maintain than crates.io dependencies. Especially since we have not (yet) pushed any tag to the pinned commit even :see_no_evil: (we really should do that in order to be able to build older versions of the testframework)
* Fixes `RUSTSEC-2020-0168` by getting rid of the transitive dependency `mach` that is unmaintained.
* Getting rid of some *really* outdated and unmaintained macOS bindings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5726)
<!-- Reviewable:end -->
