### PR TITLE
Modified ad blocking test flow

### DIFF
--- a/ios/MullvadVPNUITests/Pages/Page.swift
+++ b/ios/MullvadVPNUITests/Pages/Page.swift
@@ -30,4 +30,10 @@ class Page {
         app.typeText(text)
         return self
     }
+
+    /// Fast swipe down action to dismiss a modal view. Will swipe on the middle of the screen.
+    @discardableResult func swipeDownToDismissModal() -> Self {
+        app.swipeDown(velocity: .fast)
+        return self
+    }
 }

--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -11,6 +11,16 @@ import XCTest
 
 class RelayTests: LoggedInWithTimeUITestCase {
     func testAdBlockingViaDNS() throws {
+        HeaderBar(app)
+            .tapSettingsButton()
+
+        SettingsPage(app)
+            .tapVPNSettingsCell()
+            .tapDNSSettingsCell()
+            .tapDNSContentBlockingHeaderExpandButton()
+            .tapBlockAdsSwitch()
+            .swipeDownToDismissModal()
+
         TunnelControlPage(app)
             .tapSelectLocationButton()
 
@@ -22,17 +32,6 @@ class RelayTests: LoggedInWithTimeUITestCase {
         allowAddVPNConfigurations() // Allow adding VPN configurations iOS permission
 
         TunnelControlPage(app) // Make sure we're taken back to tunnel control page again
-
-        verifyCanReachAdServingDomain()
-
-        HeaderBar(app)
-            .tapSettingsButton()
-
-        SettingsPage(app)
-            .tapVPNSettingsCell()
-            .tapDNSSettingsCell()
-            .tapDNSContentBlockingHeaderExpandButton()
-            .tapBlockAdsSwitch()
 
         verifyCannotReachAdServingDomain()
     }


### PR DESCRIPTION
In the ad blocking test there's a race condition when enabling ad blocking and then verifying that an ad blocking domain cannot be reached. The problem is that changing the setting triggers a reconnect and there is no visual update in the app to wait for in order to make sure we're connected again before verifying that the ad blocking domain no longer can be reached. 

We decided to modify the test flow to:
1. Log into an account
2. Enable the ad blocking relay
3. Connect
4. Verify if the ad-serving domain is not reachable

See issue in Linear https://linear.app/mullvad/issue/IOS-466/race-condition-in-ad-blocking-test

The changes in this PR can be tested by running the `testAdBlockingViaDNS` test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5731)
<!-- Reviewable:end -->
