### PR TITLE
Fix API access methods bugs in GUI

### DIFF
--- a/gui/src/renderer/components/EditApiAccessMethod.tsx
+++ b/gui/src/renderer/components/EditApiAccessMethod.tsx
@@ -280,14 +280,30 @@ function AccessMethodFormImpl(props: EditApiAccessMethodImplProps) {
 
   // State for the name input.
   const name = useRef(props.method?.name ?? '');
-  const updateName = useCallback((value: string) => (name.current = value), []);
+  const method = useRef<AccessMethod | undefined>(props.method);
 
   // When the form makes up a valid method the parent is updated.
-  const updateMethod = useCallback((value: AccessMethod) => {
-    if (name.current !== '') {
-      props.updateMethod({ ...value, name: name.current, enabled: true });
+  const onUpdate = useCallback(() => {
+    if (method.current !== undefined && name.current !== '') {
+      props.updateMethod({ ...method.current, name: name.current, enabled: true });
     }
   }, []);
+
+  const updateName = useCallback(
+    (value: string) => {
+      name.current = value;
+      onUpdate();
+    },
+    [onUpdate],
+  );
+
+  const updateMethod = useCallback(
+    (value: AccessMethod) => {
+      method.current = value;
+      onUpdate();
+    },
+    [onUpdate],
+  );
 
   return (
     <>

--- a/gui/src/renderer/components/EditApiAccessMethod.tsx
+++ b/gui/src/renderer/components/EditApiAccessMethod.tsx
@@ -88,8 +88,8 @@ function AccessMethodForm() {
     }
   }, [updatedMethod, save, history.pop]);
 
-  const title = getTitle(id !== undefined);
-  const subtitle = getSubtitle(id !== undefined);
+  const title = getTitle(id === undefined);
+  const subtitle = getSubtitle(id === undefined);
 
   return (
     <BackAction action={history.pop}>


### PR DESCRIPTION
This PR fixes two bugs in the API access method view.
1. The titles were swapped between add and edit pages
2. New names weren't picked up when editing a method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5738)
<!-- Reviewable:end -->
