### PR TITLE
Enable API access methods for release builds

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -24,6 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add UDP-over-TCP WireGuard obfuscation.
+- Add custom API access methods.
 
 ## [2023.7 - 2023-11-23]
 ### Added

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodInteractor.swift
@@ -17,16 +17,20 @@ struct ListAccessMethodInteractor: ListAccessMethodInteractorProtocol {
         self.repository = repository
     }
 
-    var itemsPublisher: any Publisher<[ListAccessMethodItem], Never> {
-        repository.accessMethodsPublisher.map { methods in
-            methods.map { $0.toListItem() }
-        }
+    var itemsPublisher: AnyPublisher<[ListAccessMethodItem], Never> {
+        repository.accessMethodsPublisher
+            .receive(on: RunLoop.main)
+            .map { methods in
+                methods.map { $0.toListItem() }
+            }
+            .eraseToAnyPublisher()
     }
 
-    var itemInUsePublisher: any Publisher<ListAccessMethodItem?, Never> {
-        repository.lastReachableAccessMethodPublisher.map { method in
-            method.toListItem()
-        }
+    var itemInUsePublisher: AnyPublisher<ListAccessMethodItem?, Never> {
+        repository.lastReachableAccessMethodPublisher
+            .receive(on: RunLoop.main)
+            .map { $0.toListItem() }
+            .eraseToAnyPublisher()
     }
 
     func item(by id: UUID) -> ListAccessMethodItem? {

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodInteractorProtocol.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodInteractorProtocol.swift
@@ -12,10 +12,10 @@ import MullvadSettings
 /// Types describing API access list interactor.
 protocol ListAccessMethodInteractorProtocol {
     /// Publisher that produces a list of method items upon persistent store modifications.
-    var itemsPublisher: any Publisher<[ListAccessMethodItem], Never> { get }
+    var itemsPublisher: AnyPublisher<[ListAccessMethodItem], Never> { get }
 
     /// Publisher that produces the last reachable method item upon persistent store modifications.
-    var itemInUsePublisher: any Publisher<ListAccessMethodItem?, Never> { get }
+    var itemInUsePublisher: AnyPublisher<ListAccessMethodItem?, Never> { get }
 
     /// Returns an item by id.
     func item(by id: UUID) -> ListAccessMethodItem?

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
@@ -146,17 +146,13 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
     private func updateDataSnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
 
+        snapshot.appendSections([.main])
+
         if interactor.deviceState.isLoggedIn {
-            snapshot.appendSections([.main])
             snapshot.appendItems([.preferences], toSection: .main)
         }
 
-        #if DEBUG
-        if !snapshot.sectionIdentifiers.contains(.main) {
-            snapshot.appendSections([.main])
-        }
         snapshot.appendItems([.apiAccess], toSection: .main)
-        #endif
 
         #if DEBUG
         snapshot.appendItems([.ipOverride], toSection: .main)


### PR DESCRIPTION
API access methods are currently only enabled for debug builds. We need to remove this limitation to publicly release the feature.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5739)
<!-- Reviewable:end -->
