### PR TITLE
Add VMWare error message and troubleshooting instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ Line wrap the file at 100 chars.                                              Th
 - Enable quantum resistant tunnels by default (when set to `auto`). On other platforms, `auto` still
   always means the same thing as `off`.
 
+#### Windows
+- Add information to error notification about an error that is often caused by an incompatibility
+  with VMWare.
+
 ### Security
 #### Android
 - Change from singleTask to singleInstance to fix Task Affinity Vulnerability in Android 8.

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -1094,6 +1094,10 @@ msgid "Unable to start tunnel connection. Please send a problem report."
 msgstr ""
 
 msgctxt "notifications"
+msgid "Unable to start tunnel connection. This could be caused by incompatibility with VMware, please troubleshoot."
+msgstr ""
+
+msgctxt "notifications"
 msgid "Update available. Install the latest app version to stay up to date"
 msgstr ""
 
@@ -1557,11 +1561,23 @@ msgid "Try restarting your device."
 msgstr ""
 
 msgctxt "troubleshoot"
+msgid "Try to reinstall VMware"
+msgstr ""
+
+msgctxt "troubleshoot"
 msgid "Try to turn Wi-Fi Calling off in the FaceTime app settings and restart the Mac."
 msgstr ""
 
 msgctxt "troubleshoot"
+msgid "Try to uninstall VMware"
+msgstr ""
+
+msgctxt "troubleshoot"
 msgid "Unable to communicate with Mullvad kernel driver."
+msgstr ""
+
+msgctxt "troubleshoot"
+msgid "Unable to start tunnel connection because of a failure when creating the tunnel device. This is often caused by an issue with the VMware Bridge Protocol."
 msgstr ""
 
 msgctxt "troubleshoot"

--- a/gui/src/shared/notifications/error.ts
+++ b/gui/src/shared/notifications/error.ts
@@ -165,9 +165,12 @@ function getMessage(errorState: ErrorState): string {
         );
       case ErrorStateCause.createTunnelDeviceError:
         if (errorState.osError === 4319) {
-          // TODO: add improved error for network device conflicts
+          return messages.pgettext(
+            'notifications',
+            'Unable to start tunnel connection. This could be caused by incompatibility with VMware, please troubleshoot.',
+          );
         }
-        // TODO: 'Failed to create tunnel device. Please send a problem report.',
+
         return messages.pgettext(
           'notifications',
           'Unable to start tunnel connection. Please send a problem report.',
@@ -272,6 +275,23 @@ function getActions(errorState: ErrorState): InAppNotificationAction | void {
         steps: [
           messages.pgettext('troubleshoot', 'Try reconnecting.'),
           messages.pgettext('troubleshoot', 'Try restarting your device.'),
+        ],
+      },
+    };
+  } else if (
+    errorState.cause === ErrorStateCause.createTunnelDeviceError &&
+    errorState.osError === 4319
+  ) {
+    return {
+      type: 'troubleshoot-dialog',
+      troubleshoot: {
+        details: messages.pgettext(
+          'troubleshoot',
+          'Unable to start tunnel connection because of a failure when creating the tunnel device. This is often caused by an issue with the VMware Bridge Protocol.',
+        ),
+        steps: [
+          messages.pgettext('troubleshoot', 'Try to reinstall VMware'),
+          messages.pgettext('troubleshoot', 'Try to uninstall VMware'),
         ],
       },
     };


### PR DESCRIPTION
This PR adds information around the VMWare incompatibility and instructions on how to solve it.

Thread about the issue in the VMware forums: https://communities.vmware.com/t5/VMware-Workstation-Player/Unable-to-uninstall-VMware-Bridge-Protocol/td-p/2683023

This is how the info is presented:
![Screenshot 2024-01-31 at 14 37 30](https://github.com/mullvad/mullvadvpn-app/assets/3668602/35874270-9c5b-4486-8238-b22312c13bdf)
![image](https://github.com/mullvad/mullvadvpn-app/assets/3668602/c4b90b27-84b3-4660-aac4-51d4e152b04a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5743)
<!-- Reviewable:end -->
