### PR TITLE
Refactor TunnelManager account setting methods replacing callbacks with async

### DIFF
--- a/ios/MullvadVPN/Coordinators/AccountCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/AccountCoordinator.swift
@@ -141,7 +141,7 @@ final class AccountCoordinator: Coordinator, Presentable, Presenting {
         )
 
         let alertPresenter = AlertPresenter(context: self)
-        
+
         Task {
             await interactor.logout()
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [weak self] in

--- a/ios/MullvadVPN/Coordinators/AccountCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/AccountCoordinator.swift
@@ -141,8 +141,9 @@ final class AccountCoordinator: Coordinator, Presentable, Presenting {
         )
 
         let alertPresenter = AlertPresenter(context: self)
-
-        interactor.logout {
+        
+        Task {
+            await interactor.logout()
             DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [weak self] in
                 guard let self else { return }
 

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -342,8 +342,10 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     }
 
     private func logoutRevokedDevice() {
-        tunnelManager.unsetAccount { [weak self] in
-            self?.continueFlow(animated: true)
+        Task { [weak self] in
+            guard let self else { return }
+            await tunnelManager.unsetAccount()
+            continueFlow(animated: true)
         }
     }
 

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -310,7 +310,7 @@ final class TunnelManager: StorePaymentObserver {
 
         operationQueue.addOperation(operation)
     }
-    
+
     func setNewAccount() async throws -> StoredAccountData {
         try await setAccount(action: .new)!
     }

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -310,7 +310,6 @@ final class TunnelManager: StorePaymentObserver {
 
         operationQueue.addOperation(operation)
     }
-
     
     func setNewAccount() async throws -> StoredAccountData {
         try await setAccount(action: .new)!
@@ -367,7 +366,7 @@ final class TunnelManager: StorePaymentObserver {
 
         operationQueue.addOperation(operation)
     }
-    
+
     private func setAccount(action: SetAccountAction) async throws -> StoredAccountData? {
         try await withCheckedThrowingContinuation { continuation in
             setAccount(action: action) { result in

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -311,19 +311,13 @@ final class TunnelManager: StorePaymentObserver {
         operationQueue.addOperation(operation)
     }
 
-    func setNewAccount(completion: @escaping (Result<StoredAccountData, Error>) -> Void) {
-        setAccount(action: .new) { result in
-            completion(result.map { $0! })
-        }
+    
+    func setNewAccount() async throws -> StoredAccountData {
+        try await setAccount(action: .new)!
     }
 
-    func setExistingAccount(
-        accountNumber: String,
-        completion: @escaping (Result<StoredAccountData, Error>) -> Void
-    ) {
-        setAccount(action: .existing(accountNumber)) { result in
-            completion(result.map { $0! })
-        }
+    func setExistingAccount(accountNumber: String) async throws -> StoredAccountData {
+        try await setAccount(action: .existing(accountNumber))!
     }
 
     private func setAccount(
@@ -373,11 +367,17 @@ final class TunnelManager: StorePaymentObserver {
 
         operationQueue.addOperation(operation)
     }
-
-    func unsetAccount(completionHandler: @escaping () -> Void) {
-        setAccount(action: .unset) { _ in
-            completionHandler()
+    
+    private func setAccount(action: SetAccountAction) async throws -> StoredAccountData? {
+        try await withCheckedThrowingContinuation { continuation in
+            setAccount(action: action) { result in
+                continuation.resume(with: result)
+            }
         }
+    }
+
+    func unsetAccount() async {
+        _ = try? await setAccount(action: .unset)
     }
 
     func updateAccountData(_ completionHandler: ((Error?) -> Void)? = nil) {
@@ -435,13 +435,8 @@ final class TunnelManager: StorePaymentObserver {
         return operation
     }
 
-    func deleteAccount(
-        accountNumber: String,
-        completion: ((Error?) -> Void)? = nil
-    ) {
-        setAccount(action: .delete(accountNumber)) { result in
-            completion?(result.error)
-        }
+    func deleteAccount(accountNumber: String) async throws {
+        _ = try await setAccount(action: .delete(accountNumber))
     }
 
     func updateDeviceData(_ completionHandler: ((Error?) -> Void)? = nil) {

--- a/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
@@ -52,7 +52,7 @@ final class AccountInteractor {
     var deviceState: DeviceState {
         tunnelManager.deviceState
     }
-    
+
     func logout() async {
         await tunnelManager.unsetAccount()
     }

--- a/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
@@ -52,9 +52,9 @@ final class AccountInteractor {
     var deviceState: DeviceState {
         tunnelManager.deviceState
     }
-
-    func logout(_ completion: @escaping () -> Void) {
-        tunnelManager.unsetAccount(completionHandler: completion)
+    
+    func logout() async {
+        await tunnelManager.unsetAccount()
     }
 
     func addPayment(_ payment: SKPayment, for accountNumber: String) {

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionInteractor.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionInteractor.swift
@@ -48,7 +48,7 @@ class AccountDeletionInteractor {
         }
     }
 
-    func delete(accountNumber: String, completionHandler: @escaping (Error?) -> Void) {
-        tunnelManager.deleteAccount(accountNumber: accountNumber, completion: completionHandler)
+    func delete(accountNumber: String) async throws {
+        try await tunnelManager.deleteAccount(accountNumber: accountNumber)
     }
 }

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewController.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewController.swift
@@ -62,14 +62,15 @@ class AccountDeletionViewController: UIViewController {
 
     private func submit(accountNumber: String) {
         contentView.state = .loading
-        interactor.delete(accountNumber: accountNumber) { [weak self] error in
+        Task { [weak self] in
             guard let self else { return }
-            guard let error else {
+            do {
+                try await interactor.delete(accountNumber: accountNumber)
                 self.contentView.state = .initial
                 self.delegate?.deleteAccountDidSucceed(controller: self)
-                return
+            } catch {
+                self.contentView.state = .failure(error)
             }
-            self.contentView.state = .failure(error)
         }
     }
 }

--- a/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
@@ -21,17 +21,12 @@ final class LoginInteractor {
         self.tunnelManager = tunnelManager
     }
 
-    func setAccount(accountNumber: String, completion: @escaping (Error?) -> Void) {
-        tunnelManager.setExistingAccount(accountNumber: accountNumber) { result in
-            completion(result.error)
-        }
+    func setAccount(accountNumber: String) async throws {
+        _ = try await tunnelManager.setExistingAccount(accountNumber: accountNumber)
     }
 
-    func createAccount(completion: @escaping (Result<String, Error>) -> Void) {
-        tunnelManager.setNewAccount { [weak self] result in
-            self?.didCreateAccount?()
-            completion(result.map { $0.number })
-        }
+    func createAccount() async throws -> String {
+        try await tunnelManager.setNewAccount().number
     }
 
     func getLastUsedAccount() -> String? {

--- a/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
@@ -193,21 +193,21 @@ class LoginViewController: UIViewController, RootContainment {
 
     func start(action: LoginAction) {
         beginLogin(action)
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                switch action {
+                case .createAccount:
+                    self.contentView.accountInputGroup.setAccount(try await interactor.createAccount())
 
-        switch action {
-        case .createAccount:
-            interactor.createAccount { [weak self] result in
-                if let newAccountNumber = result.value {
-                    self?.contentView.accountInputGroup.setAccount(newAccountNumber)
+                case let .useExistingAccount(accountNumber):
+                    try await interactor.setAccount(accountNumber: accountNumber)
                 }
-
-                self?.endLogin(action: action, error: result.error)
+                self.endLogin(action: action, error: nil)
+            } catch {
+                self.endLogin(action: action, error: error)
             }
 
-        case let .useExistingAccount(accountNumber):
-            interactor.setAccount(accountNumber: accountNumber) { [weak self] error in
-                self?.endLogin(action: action, error: error)
-            }
         }
     }
 

--- a/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
@@ -207,7 +207,6 @@ class LoginViewController: UIViewController, RootContainment {
             } catch {
                 self.endLogin(action: action, error: error)
             }
-
         }
     }
 

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherInteractor.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherInteractor.swift
@@ -46,16 +46,10 @@ final class RedeemVoucherInteractor {
         })
     }
 
-    func logout(completionHandler: @escaping () -> Void) {
-        preferredAccountNumber.flatMap { accountNumber in
-            tunnelManager.unsetAccount { [weak self] in
-                guard let self else {
-                    return
-                }
-                completionHandler()
-                didLogout?(accountNumber)
-            }
-        }
+    func logout() async {
+        guard let accountNumber = preferredAccountNumber else { return }
+        await tunnelManager.unsetAccount()
+        didLogout?(accountNumber)
     }
 
     func cancelAll() {

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
@@ -137,9 +137,12 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
         contentView.isEditing = false
 
         contentView.state = .logout
-
-        interactor.logout { [weak self] in
-            self?.contentView.state = .initial
+        
+        Task {
+            [weak self] in
+            guard let self else { return }
+            await interactor.logout()
+            contentView.state = .initial
         }
     }
 }

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
@@ -137,7 +137,7 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
         contentView.isEditing = false
 
         contentView.state = .logout
-        
+
         Task {
             [weak self] in
             guard let self else { return }


### PR DESCRIPTION
This PR replaces public methods in TunnelManager, and their downstream consumers, which have used callbacks with versions using async instead, in the interest of modernising the codebase to use modern Swift concurrency.

The affected code deals with logging in, creating new accounts, deleting accounts, logging out and being bumped out due to device deletion.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5748)
<!-- Reviewable:end -->
