### PR TITLE
Upload to cdn servers

### DIFF
--- a/ci/buildserver-config.sh
+++ b/ci/buildserver-config.sh
@@ -18,10 +18,10 @@ export SUPPORTED_DEB_CODENAMES
 
 export SUPPORTED_RPM_ARCHITECTURES=("x86_64" "aarch64")
 
-# Servers to upload Linux deb/rpm repositories to
-export DEV_LINUX_REPOSITORY_SERVERS=("cdn.devmole.eu")
-export STAGING_LINUX_REPOSITORY_SERVERS=("cdn.stagemole.eu")
-export PRODUCTION_LINUX_REPOSITORY_SERVERS=("cdn.mullvad.net")
+# Servers to upload Linux deb/rpm repositories and all other build artifacts to.
+export DEV_UPLOAD_SERVERS=("cdn.devmole.eu")
+export STAGING_UPLOAD_SERVERS=("cdn.stagemole.eu")
+export PRODUCTION_UPLOAD_SERVERS=("cdn.mullvad.net")
 
 export DEV_LINUX_REPOSITORY_PUBLIC_URL="https://repository.devmole.eu"
 export STAGING_LINUX_REPOSITORY_PUBLIC_URL="https://repository.stagemole.eu"

--- a/ci/buildserver-config.sh
+++ b/ci/buildserver-config.sh
@@ -19,9 +19,9 @@ export SUPPORTED_DEB_CODENAMES
 export SUPPORTED_RPM_ARCHITECTURES=("x86_64" "aarch64")
 
 # Servers to upload Linux deb/rpm repositories to
-export DEV_LINUX_REPOSITORY_SERVERS=("se-got-cdn-001.devmole.eu" "se-got-cdn-002.devmole.eu")
-export STAGING_LINUX_REPOSITORY_SERVERS=("se-got-cdn-001.stagemole.eu" "se-got-cdn-002.stagemole.eu")
-export PRODUCTION_LINUX_REPOSITORY_SERVERS=("se-got-cdn-111.mullvad.net" "se-mma-cdn-101.mullvad.net")
+export DEV_LINUX_REPOSITORY_SERVERS=("cdn.devmole.eu")
+export STAGING_LINUX_REPOSITORY_SERVERS=("cdn.stagemole.eu")
+export PRODUCTION_LINUX_REPOSITORY_SERVERS=("cdn.mullvad.net")
 
 export DEV_LINUX_REPOSITORY_PUBLIC_URL="https://repository.devmole.eu"
 export STAGING_LINUX_REPOSITORY_PUBLIC_URL="https://repository.stagemole.eu"

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -14,7 +14,10 @@ cd "$UPLOAD_DIR"
 function rsync_upload {
     local file=$1
     local upload_dir=$2
-    rsync -av --mkpath --rsh='ssh -p 1122' "$file" "upload-server-1:$upload_dir/"
+    for server in "${PRODUCTION_UPLOAD_SERVERS[@]}"; do
+        echo "Uploading $file to $server:$upload_dir"
+        rsync -av --mkpath --rsh='ssh -p 1122' "$file" "$server:$upload_dir/"
+    done
 }
 
 while true; do

--- a/ci/publish-linux-repositories.sh
+++ b/ci/publish-linux-repositories.sh
@@ -14,15 +14,15 @@ source "$SCRIPT_DIR/buildserver-config.sh"
 while [ "$#" -gt 0 ]; do
     case "$1" in
         "--production")
-            repository_servers=("${PRODUCTION_LINUX_REPOSITORY_SERVERS[@]}")
+            repository_servers=("${PRODUCTION_UPLOAD_SERVERS[@]}")
             repository_server_url="$PRODUCTION_LINUX_REPOSITORY_PUBLIC_URL"
             ;;
         "--staging")
-            repository_servers=("${STAGING_LINUX_REPOSITORY_SERVERS[@]}")
+            repository_servers=("${STAGING_UPLOAD_SERVERS[@]}")
             repository_server_url="$STAGING_LINUX_REPOSITORY_PUBLIC_URL"
             ;;
         "--dev")
-            repository_servers=("${DEV_LINUX_REPOSITORY_SERVERS[@]}")
+            repository_servers=("${DEV_UPLOAD_SERVERS[@]}")
             repository_server_url="$DEV_LINUX_REPOSITORY_PUBLIC_URL"
             ;;
         "--deb")


### PR DESCRIPTION
The file hosting is now anycasted and available on `cdn.mullvad.net`. So I'm changing the config to match this.

I'm also finally updating `buildserver-upload.sh` to use the same variable and not its own hardcoded upload ssh profile. It's currently hardcoded to production. But nowhere are we uploading these things to dev/staging, so it does not matter.

The variable name `PRODUCTION_LINUX_REPOSITORY_SERVERS` is now not optimal, since it's used for more than just Linux repository uploads. We can fix it if you think we should. Ideas for a better name? If we go down that route I suggest

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5749)
<!-- Reviewable:end -->
