### PR TITLE
Remove manual cargo:rerun-if-changed when building protos

### DIFF
--- a/mullvad-management-interface/build.rs
+++ b/mullvad-management-interface/build.rs
@@ -1,5 +1,3 @@
 fn main() {
-    const PROTO_FILE: &str = "proto/management_interface.proto";
-    tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={PROTO_FILE}");
+    tonic_build::compile_protos("proto/management_interface.proto").unwrap();
 }

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -62,7 +62,5 @@ fn main() {
 }
 
 fn generate_grpc_code() {
-    const PROTO_FILE: &str = "../talpid-openvpn-plugin/proto/openvpn_plugin.proto";
-    tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={PROTO_FILE}");
+    tonic_build::compile_protos("../talpid-openvpn-plugin/proto/openvpn_plugin.proto").unwrap();
 }

--- a/talpid-openvpn-plugin/build.rs
+++ b/talpid-openvpn-plugin/build.rs
@@ -4,9 +4,7 @@ fn make_lang_id(p: u16, s: u16) -> u16 {
 }
 
 fn main() {
-    const PROTO_FILE: &str = "proto/openvpn_plugin.proto";
-    tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={PROTO_FILE}");
+    tonic_build::compile_protos("proto/openvpn_plugin.proto").unwrap();
 
     #[cfg(windows)]
     {

--- a/talpid-openvpn/build.rs
+++ b/talpid-openvpn/build.rs
@@ -3,7 +3,5 @@ fn main() {
 }
 
 fn generate_grpc_code() {
-    const PROTO_FILE: &str = "../talpid-openvpn-plugin/proto/openvpn_plugin.proto";
-    tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={PROTO_FILE}");
+    tonic_build::compile_protos("../talpid-openvpn-plugin/proto/openvpn_plugin.proto").unwrap();
 }

--- a/talpid-tunnel-config-client/build.rs
+++ b/talpid-tunnel-config-client/build.rs
@@ -1,5 +1,3 @@
 fn main() {
-    const PROTO_FILE: &str = "proto/tunnel_config.proto";
-    tonic_build::compile_protos(PROTO_FILE).unwrap();
-    println!("cargo:rerun-if-changed={PROTO_FILE}");
+    tonic_build::compile_protos("proto/tunnel_config.proto").unwrap();
 }


### PR DESCRIPTION
It seems that `tonic_build::compile_protos()` already injects "cargo:rerun-if-changed" statements for cargo: https://github.com/hyperium/tonic/blob/v0.10.0/tonic-build/src/prost.rs#L40

If you run `cargo build -vv` you'll see the following statements already added by `tonic_build`:

```
[mullvad-management-interface 0.0.0] cargo:rerun-if-changed=proto/management_interface.proto
[mullvad-management-interface 0.0.0] cargo:rerun-if-changed=proto
```

Hence no need to do that manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5750)
<!-- Reviewable:end -->
