### PR TITLE
Add out of time redirect

### DIFF
--- a/gui/src/renderer/app.tsx
+++ b/gui/src/renderer/app.tsx
@@ -933,10 +933,6 @@ export default class AppRenderer {
   }
 
   private setAccountExpiry(expiry?: string) {
-    if (window.env.e2e && expiry) {
-      log.verbose('Expiry of account:', expiry);
-    }
-
     const state = this.reduxStore.getState();
     const previousExpiry = state.account.expiry;
 

--- a/gui/test/e2e/installed/state-dependent/login.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/login.spec.ts
@@ -49,12 +49,12 @@ test('App should create account', async () => {
   const title = page.locator('h1')
   const subtitle = page.getByTestId('subtitle');
 
-  await page.getByText('Create account').click();
+  expect(await util.waitForNavigation(async () => {
+    await page.getByText('Create account').click();
 
-  await expect(title).toHaveText('Account created');
-  await expect(subtitle).toHaveText('Logged in');
-
-  expect(await util.waitForNavigation()).toEqual(RoutePath.expired);
+    await expect(title).toHaveText('Account created');
+    await expect(subtitle).toHaveText('Logged in');
+  })).toEqual(RoutePath.expired);
 
   const outOfTimeTitle = page.getByTestId('title');
   await expect(outOfTimeTitle).toHaveText('Congrats!');
@@ -80,13 +80,14 @@ test('App should log in', async () => {
   await expect(title).toHaveText('Login');
   await expect(subtitle).toHaveText('Enter your account number');
 
-  await loginInput.type(process.env.ACCOUNT_NUMBER!);
-  await loginInput.press('Enter');
+  await loginInput.fill(process.env.ACCOUNT_NUMBER!);
 
-  await expect(title).toHaveText('Logged in');
-  await expect(subtitle).toHaveText('Valid account number');
+  expect(await util.waitForNavigation(async () => {
+    await loginInput.press('Enter');
 
-  expect(await util.waitForNavigation()).toEqual(RoutePath.main);
+    await expect(title).toHaveText('Logged in');
+    await expect(subtitle).toHaveText('Valid account number');
+  })).toEqual(RoutePath.main);
   await expectDisconnected(page);
 });
 
@@ -115,13 +116,11 @@ test('App should log in to expired account', async () => {
   await expect(title).toHaveText('Login');
   await expect(subtitle).toHaveText('Enter your account number');
 
-  await loginInput.type(accountNumber);
-  await loginInput.press('Enter');
+  await loginInput.fill(accountNumber);
 
-  await expect(title).toHaveText('Logged in');
-  await expect(subtitle).toHaveText('Valid account number');
-
-  expect(await util.waitForNavigation()).toEqual(RoutePath.expired);
+  expect(await util.waitForNavigation(async () => {
+    await loginInput.press('Enter');
+  })).toEqual(RoutePath.expired);
 
   const outOfTimeTitle = page.getByTestId('title');
   await expect(outOfTimeTitle).toHaveText('Out of time');

--- a/gui/test/e2e/mocked/expired-account-error-view.spec.ts
+++ b/gui/test/e2e/mocked/expired-account-error-view.spec.ts
@@ -4,15 +4,16 @@ import { expect, test } from '@playwright/test';
 import { IAccountData } from '../../../src/shared/daemon-rpc-types';
 import { getBackgroundColor } from '../utils';
 import { colors } from '../../../src/config.json';
+import { RoutePath } from '../../../src/renderer/lib/routes';
 
 let page: Page;
 let util: MockedTestUtils;
 
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   ({ page, util } = await startMockedApp());
 });
 
-test.afterAll(async () => {
+test.afterEach(async () => {
   await page.close();
 });
 
@@ -30,4 +31,16 @@ test('App should show Expired Account Error View', async () => {
   const redeemVoucherButton = page.locator('button:has-text("Redeem voucher")');
   await expect(redeemVoucherButton).toBeVisible();
   expect(await getBackgroundColor(redeemVoucherButton)).toBe(colors.green);
+});
+
+test('App should show out of time view after running out of time', async () => {
+  const expiryDate = new Date();
+  expiryDate.setSeconds(expiryDate.getSeconds() + 2);
+
+  expect(await util.waitForNavigation(async () => {
+    await util.sendMockIpcResponse<IAccountData>({
+      channel: 'account-',
+      response: { expiry: expiryDate.toISOString() },
+    });
+  })).toEqual(RoutePath.expired);
 });


### PR DESCRIPTION
From what I could find the app doesn't redirect to the out of time view when the account expires. It
redirected first when the app received focus or navigating to the account view or main view. I've
also added a test that verifies this.

I've also improved the logging for debugging account expiry issues in the test framework.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5751)
<!-- Reviewable:end -->
