### PR TITLE
Stop quoting RELFLAG in buildscript

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ios.yml
+      - ios/build-rust-library.sh
       - ios/.swiftformat
       - ios/**/*.swift
       - ios/**/*.xctestplan

--- a/ios/build-rust-library.sh
+++ b/ios/build-rust-library.sh
@@ -43,17 +43,17 @@ for arch in $ARCHS; do
 
       # Intel iOS simulator
       export CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios"
-      "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib "$RELFLAG" --target x86_64-apple-ios
+      "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target x86_64-apple-ios
       "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target x86_64-apple-ios
       ;;
 
     arm64)
       if [ $IS_SIMULATOR -eq 0 ]; then
         # Hardware iOS targets
-        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib "$RELFLAG" --target aarch64-apple-ios
+        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target aarch64-apple-ios
         "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target aarch64-apple-ios
       else
-        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib "$RELFLAG" --target aarch64-apple-ios-sim
+        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target aarch64-apple-ios-sim
         "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target aarch64-apple-ios-sim
       fi
   esac


### PR DESCRIPTION
When quoting the RELFlAG variable, an empty argument will get passed and confuse the buildscript.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5755)
<!-- Reviewable:end -->
