### PR TITLE
Properly pass arguments to Cargo in `build-apk.sh`

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -15,7 +15,7 @@ BUILD_TYPE="release"
 GRADLE_BUILD_TYPE="release"
 GRADLE_TASKS=(createOssProdReleaseDistApk createPlayProdReleaseDistApk)
 BUNDLE_TASKS=(createPlayProdReleaseDistBundle)
-CARGO_ARGS="--release"
+CARGO_ARGS=( "--release" )
 EXTRA_WGGO_ARGS=""
 BUILD_BUNDLE="no"
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"target"}
@@ -25,7 +25,7 @@ while [ -n "${1:-""}" ]; do
     if [[ "${1:-""}" == "--dev-build" ]]; then
         BUILD_TYPE="debug"
         GRADLE_BUILD_TYPE="debug"
-        CARGO_ARGS=""
+        CARGO_ARGS=()
         GRADLE_TASKS=(createOssProdDebugDistApk)
         BUNDLE_TASKS=(createOssProdDebugDistBundle)
     elif [[ "${1:-""}" == "--fdroid" ]]; then
@@ -55,9 +55,9 @@ fi
 if [[ "$BUILD_TYPE" == "release" && "$PRODUCT_VERSION" != *"-dev-"* ]]; then
     echo "Removing old Rust build artifacts"
     cargo clean
-    CARGO_ARGS+=" --locked"
+    CARGO_ARGS+=( "--locked" )
 else
-    CARGO_ARGS+=" --features api-override"
+    CARGO_ARGS+=( "--features" "api-override" )
     GRADLE_TASKS+=(createPlayDevmoleReleaseDistApk createPlayStagemoleReleaseDistApk)
     BUNDLE_TASKS+=(createPlayDevmoleReleaseDistBundle createPlayStagemoleReleaseDistBundle)
 fi
@@ -103,7 +103,7 @@ for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
     esac
 
     echo "Building mullvad-daemon for $TARGET"
-    cargo build "$CARGO_ARGS" --target "$TARGET" --package mullvad-jni
+    cargo build "${CARGO_ARGS[@]}" --target "$TARGET" --package mullvad-jni
 
     STRIP_TOOL="${NDK_TOOLCHAIN_DIR}/llvm-strip"
     TARGET_LIB_PATH="$SCRIPT_DIR/android/app/build/extraJni/$ABI/libmullvad_jni.so"
@@ -117,7 +117,7 @@ for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
 done
 
 echo "Updating relays.json..."
-cargo run --bin relay_list "$CARGO_ARGS" > build/relays.json
+cargo run --bin relay_list "${CARGO_ARGS[@]}" > build/relays.json
 
 cd "$SCRIPT_DIR/android"
 $GRADLE_CMD --console plain "${GRADLE_TASKS[@]}"


### PR DESCRIPTION
The `build-apk.sh` script broke in b6e0545e1b5ae2fbcb6655bd4d28739cf9f943d6 due to quoting a variable containing a string with space seperated arguments. While it is best practice to quote variables to prevent word splitting, word splitting was the behavior that we wanted in this particular case.

This commit fixes this issue by building an array of arguments instead, which when expanded will pass along the arguments to `cargo build` properly as multiple strings. The script now works, and `shellcheck` is happy!

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5756)
<!-- Reviewable:end -->
