### PR TITLE
Fix settings version

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -133,23 +133,9 @@ pub async fn migrate_all(cache_dir: &Path, settings_dir: &Path) -> Result<Option
     let mut settings: serde_json::Value =
         serde_json::from_reader(&settings_bytes[..]).map_err(Error::Deserialize)?;
 
-    if !settings.is_object() {
-        return Err(Error::InvalidSettingsContent);
-    }
-
     let old_settings = settings.clone();
 
-    v1::migrate(&mut settings)?;
-    v2::migrate(&mut settings)?;
-    v3::migrate(&mut settings)?;
-    v4::migrate(&mut settings)?;
-
-    account_history::migrate_location(cache_dir, settings_dir).await;
-    account_history::migrate_formats(settings_dir, &mut settings).await?;
-
-    let migration_data = v5::migrate(&mut settings)?;
-    v6::migrate(&mut settings)?;
-    v7::migrate(&mut settings)?;
+    let migration_data = migrate_settings(Some((cache_dir, settings_dir)), &mut settings).await?;
 
     if settings == old_settings {
         // Nothing changed
@@ -171,6 +157,31 @@ pub async fn migrate_all(cache_dir: &Path, settings_dir: &Path) -> Result<Option
     file.sync_data().await.map_err(Error::SyncSettings)?;
 
     log::debug!("Migrated settings. Wrote settings to {}", path.display());
+
+    Ok(migration_data)
+}
+
+async fn migrate_settings(
+    directories: Option<(&Path, &Path)>,
+    settings: &mut serde_json::Value,
+) -> Result<Option<MigrationData>> {
+    if !settings.is_object() {
+        return Err(Error::InvalidSettingsContent);
+    }
+
+    v1::migrate(settings)?;
+    v2::migrate(settings)?;
+    v3::migrate(settings)?;
+    v4::migrate(settings)?;
+
+    if let Some((cache_dir, settings_dir)) = directories {
+        account_history::migrate_location(cache_dir, settings_dir).await;
+        account_history::migrate_formats(settings_dir, settings).await?;
+    }
+
+    let migration_data = v5::migrate(settings)?;
+    v6::migrate(settings)?;
+    v7::migrate(settings)?;
 
     Ok(migration_data)
 }
@@ -381,5 +392,26 @@ mod windows {
 
     fn is_well_known_sid(sid: &SID, well_known_sid_type: WELL_KNOWN_SID_TYPE) -> bool {
         unsafe { IsWellKnownSid(sid as *const SID as *mut _, well_known_sid_type) == 1 }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use mullvad_types::settings::Settings;
+
+    use crate::migrations::migrate_settings;
+
+    /// Ensure that no migration logic runs for the default settings by checking whether anything
+    /// has changed after running the migration code
+    #[tokio::test]
+    async fn test_settings_format_version() {
+        let default_settings = serde_json::to_value(Settings::default()).unwrap();
+        let mut migrated_settings = default_settings.clone();
+
+        migrate_settings(None, &mut migrated_settings)
+            .await
+            .unwrap();
+
+        assert_eq!(default_settings, migrated_settings);
     }
 }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -21,7 +21,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V7;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V8;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]


### PR DESCRIPTION
`settings.json` always uses `7` as the version number. This caused the migration code for V7 -> V8 to always run.

Fix DES-615, DES-616.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5760)
<!-- Reviewable:end -->
