### PR TITLE
Detect available IP versions

### DIFF
--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -77,18 +77,9 @@ impl Settings {
     /// Check that `self` contains atleast one enabled access methods. If not,
     /// the `Direct` access method is re-enabled.
     fn ensure_consistent_state(&mut self) {
-        if self.collect_enabled().is_empty() {
+        if self.iter().all(|access_method| access_method.disabled()) {
             self.direct.enable();
         }
-    }
-
-    // TODO(markus): This can surely be removed.
-    /// Retrieve all [`AccessMethodSetting`]s which are enabled.
-    pub fn collect_enabled(&self) -> Vec<AccessMethodSetting> {
-        self.iter()
-            .filter(|access_method| access_method.enabled)
-            .cloned()
-            .collect()
     }
 
     /// Iterate over references of built-in & custom access methods.
@@ -128,8 +119,7 @@ impl Settings {
         &self.mullvad_bridges
     }
 
-    // TODO(markus): This can probably be made private
-    pub fn create_direct() -> AccessMethodSetting {
+    fn create_direct() -> AccessMethodSetting {
         let method = BuiltInAccessMethod::Direct;
         AccessMethodSetting::new(method.canonical_name(), true, AccessMethod::from(method))
     }

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 use talpid_routing::{self, RouteManagerHandle};
-use talpid_types::ErrorExt;
+use talpid_types::{net::Connectivity, ErrorExt};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -18,30 +18,31 @@ pub enum Error {
 pub struct MonitorHandle {
     route_manager: RouteManagerHandle,
     fwmark: Option<u32>,
-    _notify_tx: Arc<UnboundedSender<bool>>,
+    _notify_tx: Arc<UnboundedSender<Connectivity>>,
 }
 
+/// A non-local IPv4 address.
 const PUBLIC_INTERNET_ADDRESS_V4: IpAddr = IpAddr::V4(Ipv4Addr::new(193, 138, 218, 78));
+/// A non-local IPv6 address.
 const PUBLIC_INTERNET_ADDRESS_V6: IpAddr =
     IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6));
 
 impl MonitorHandle {
-    pub async fn host_is_offline(&self) -> bool {
-        match public_ip_unreachable(&self.route_manager, self.fwmark).await {
-            Ok(is_offline) => is_offline,
-            Err(err) => {
+    pub async fn connectivity(&self) -> Connectivity {
+        public_ip_unreachable(&self.route_manager, self.fwmark)
+            .await
+            .unwrap_or_else(|err| {
                 log::error!(
                     "Failed to verify offline state: {}. Presuming connectivity",
                     err
                 );
-                false
-            }
-        }
+                Connectivity::PresumeOnline
+            })
     }
 }
 
 pub async fn spawn_monitor(
-    notify_tx: UnboundedSender<bool>,
+    notify_tx: UnboundedSender<Connectivity>,
     route_manager: RouteManagerHandle,
     fwmark: Option<u32>,
 ) -> Result<MonitorHandle> {
@@ -71,7 +72,7 @@ pub async fn spawn_monitor(
                                 "{}",
                                 err.display_chain_with_msg("Failed to infer offline state")
                             );
-                            false
+                            Connectivity::PresumeOnline
                         });
                     if new_offline_state != is_offline {
                         is_offline = new_offline_state;
@@ -86,15 +87,20 @@ pub async fn spawn_monitor(
     Ok(monitor_handle)
 }
 
-async fn public_ip_unreachable(handle: &RouteManagerHandle, fwmark: Option<u32>) -> Result<bool> {
-    Ok(handle
-        .get_destination_route(PUBLIC_INTERNET_ADDRESS_V4, fwmark)
-        .await
-        .map_err(Error::RouteManagerError)?
-        .is_none()
-        && handle
-            .get_destination_route(PUBLIC_INTERNET_ADDRESS_V6, fwmark)
+async fn public_ip_unreachable(
+    handle: &RouteManagerHandle,
+    fwmark: Option<u32>,
+) -> Result<Connectivity> {
+    let route_exists = |destination| async move {
+        handle
+            .get_destination_route(destination, fwmark)
             .await
-            .unwrap_or(None)
-            .is_none())
+            .map_err(Error::RouteManagerError)
+            .map(|route| route.is_some())
+    };
+    let connectivity = Connectivity::Status {
+        ipv4: route_exists(PUBLIC_INTERNET_ADDRESS_V4).await?,
+        ipv6: route_exists(PUBLIC_INTERNET_ADDRESS_V6).await?,
+    };
+    Ok(connectivity)
 }

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -18,6 +18,7 @@ use std::{
     time::Duration,
 };
 use talpid_routing::{DefaultRouteEvent, RouteManagerHandle};
+use talpid_types::net::Connectivity;
 
 const SYNTHETIC_OFFLINE_DURATION: Duration = Duration::from_secs(1);
 
@@ -28,33 +29,42 @@ pub enum Error {
 }
 
 pub struct MonitorHandle {
-    state: Arc<Mutex<ConnectivityState>>,
-    _notify_tx: Arc<UnboundedSender<bool>>,
-}
-
-#[derive(Clone)]
-struct ConnectivityState {
-    v4_connectivity: bool,
-    v6_connectivity: bool,
-}
-
-impl ConnectivityState {
-    fn get_connectivity(&self) -> bool {
-        self.v4_connectivity || self.v6_connectivity
-    }
+    state: Arc<Mutex<ConnectivityInner>>,
+    _notify_tx: Arc<UnboundedSender<Connectivity>>,
 }
 
 impl MonitorHandle {
     /// Return whether the host is offline
     #[allow(clippy::unused_async)]
-    pub async fn host_is_offline(&self) -> bool {
+    pub async fn connectivity(&self) -> Connectivity {
         let state = self.state.lock().unwrap();
-        !state.get_connectivity()
+        state.into_connectivity()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ConnectivityInner {
+    /// Whether IPv4 connectivity seems to be available on the host.
+    ipv4: bool,
+    /// Whether IPv6 connectivity seems to be available on the host.
+    ipv6: bool,
+}
+
+impl ConnectivityInner {
+    fn into_connectivity(self) -> Connectivity {
+        Connectivity::Status {
+            ipv4: self.ipv4,
+            ipv6: self.ipv6,
+        }
+    }
+
+    fn is_online(&self) -> bool {
+        self.into_connectivity().is_online()
     }
 }
 
 pub async fn spawn_monitor(
-    notify_tx: UnboundedSender<bool>,
+    notify_tx: UnboundedSender<Connectivity>,
     route_manager_handle: RouteManagerHandle,
 ) -> Result<MonitorHandle, Error> {
     let notify_tx = Arc::new(notify_tx);
@@ -62,7 +72,7 @@ pub async fn spawn_monitor(
     // note: begin observing before initializing the state
     let route_listener = route_manager_handle.default_route_listener().await?;
 
-    let (v4_connectivity, v6_connectivity) = match route_manager_handle.get_default_routes().await {
+    let (ipv4, ipv6) = match route_manager_handle.get_default_routes().await {
         Ok((v4_route, v6_route)) => (v4_route.is_some(), v6_route.is_some()),
         Err(error) => {
             log::warn!("Failed to initialize offline monitor: {error}");
@@ -72,11 +82,8 @@ pub async fn spawn_monitor(
         }
     };
 
-    let state = ConnectivityState {
-        v4_connectivity,
-        v6_connectivity,
-    };
-    let mut real_state = state.clone();
+    let state = ConnectivityInner { ipv4, ipv6 };
+    let mut real_state = state;
 
     let state = Arc::new(Mutex::new(state));
 
@@ -95,16 +102,17 @@ pub async fn spawn_monitor(
                     let Some(state) = weak_state.upgrade() else {
                         break;
                     };
-                    let mut state = state.lock().unwrap();
-                    *state = real_state.clone();
 
-                    if state.get_connectivity() {
+                    let mut state = state.lock().unwrap();
+                    if real_state.is_online() {
                         log::info!("Connectivity changed: Connected");
                         let Some(tx) = weak_notify_tx.upgrade() else {
                             break;
                         };
-                        let _ = tx.unbounded_send(false);
+                        let _ = tx.unbounded_send(real_state.into_connectivity());
                     }
+
+                    *state = real_state;
                 }
 
                 route_event = route_listener.next() => {
@@ -115,16 +123,16 @@ pub async fn spawn_monitor(
                     // Update real state
                     match event {
                         DefaultRouteEvent::AddedOrChangedV4 => {
-                            real_state.v4_connectivity = true;
+                            real_state.ipv4 = true;
                         }
                         DefaultRouteEvent::AddedOrChangedV6 => {
-                            real_state.v6_connectivity = true;
+                            real_state.ipv6 = true;
                         }
                         DefaultRouteEvent::RemovedV4 => {
-                            real_state.v4_connectivity = false;
+                            real_state.ipv4 = false;
                         }
                         DefaultRouteEvent::RemovedV6 => {
-                            real_state.v6_connectivity = false;
+                            real_state.ipv6 = false;
                         }
                     }
 
@@ -134,18 +142,19 @@ pub async fn spawn_monitor(
                         break;
                     };
                     let mut state = state.lock().unwrap();
-                    let previous_connectivity = state.get_connectivity();
-                    state.v4_connectivity = false;
-                    state.v6_connectivity = false;
+                    let previous_connectivity = *state;
+                    state.ipv4 = false;
+                    state.ipv6 = false;
 
-                    if previous_connectivity {
+                    if previous_connectivity.is_online() {
                         let Some(tx) = weak_notify_tx.upgrade() else {
                             break;
                         };
-                        let _ = tx.unbounded_send(true);
+                        let _ = tx.unbounded_send(state.into_connectivity());
                         log::info!("Connectivity changed: Offline");
                     }
-                    if real_state.get_connectivity() {
+
+                    if real_state.is_online() {
                         timeout = Box::pin(tokio::time::sleep(SYNTHETIC_OFFLINE_DURATION)).fuse();
                     }
                 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -298,9 +298,9 @@ impl ConnectedState {
                 let _ = complete_tx.send(());
                 SameState(self)
             }
-            Some(TunnelCommand::IsOffline(is_offline)) => {
-                shared_values.is_offline = is_offline;
-                if is_offline {
+            Some(TunnelCommand::Connectivity(connectivity)) => {
+                shared_values.connectivity = connectivity;
+                if connectivity.is_offline() {
                     self.disconnect(
                         shared_values,
                         AfterDisconnect::Block(ErrorStateCause::IsOffline),

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -57,7 +57,7 @@ impl ConnectingState {
         shared_values: &mut SharedTunnelStateValues,
         retry_attempt: u32,
     ) -> (Box<dyn TunnelState>, TunnelStateTransition) {
-        if shared_values.is_offline {
+        if shared_values.connectivity.is_offline() {
             // FIXME: Temporary: Nudge route manager to update the default interface
             #[cfg(target_os = "macos")]
             if let Ok(handle) = shared_values.route_manager.handle() {
@@ -457,9 +457,9 @@ impl ConnectingState {
                 let _ = complete_tx.send(());
                 SameState(self)
             }
-            Some(TunnelCommand::IsOffline(is_offline)) => {
-                shared_values.is_offline = is_offline;
-                if is_offline {
+            Some(TunnelCommand::Connectivity(connectivity)) => {
+                shared_values.connectivity = connectivity;
+                if connectivity.is_offline() {
                     self.disconnect(
                         shared_values,
                         AfterDisconnect::Block(ErrorStateCause::IsOffline),

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -200,8 +200,8 @@ impl TunnelState for DisconnectedState {
                     SameState(self)
                 }
             }
-            Some(TunnelCommand::IsOffline(is_offline)) => {
-                shared_values.is_offline = is_offline;
+            Some(TunnelCommand::Connectivity(connectivity)) => {
+                shared_values.connectivity = connectivity;
                 SameState(self)
             }
             Some(TunnelCommand::Connect) => NewState(ConnectingState::enter(shared_values, 0)),

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -63,8 +63,8 @@ impl DisconnectingState {
                     let _ = complete_tx.send(());
                     AfterDisconnect::Nothing
                 }
-                Some(TunnelCommand::IsOffline(is_offline)) => {
-                    shared_values.is_offline = is_offline;
+                Some(TunnelCommand::Connectivity(connectivity)) => {
+                    shared_values.connectivity = connectivity;
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::Connect) => AfterDisconnect::Reconnect(0),
@@ -105,9 +105,9 @@ impl DisconnectingState {
                     let _ = complete_tx.send(());
                     AfterDisconnect::Block(reason)
                 }
-                Some(TunnelCommand::IsOffline(is_offline)) => {
-                    shared_values.is_offline = is_offline;
-                    if !is_offline && matches!(reason, ErrorStateCause::IsOffline) {
+                Some(TunnelCommand::Connectivity(connectivity)) => {
+                    shared_values.connectivity = connectivity;
+                    if !connectivity.is_offline() && matches!(reason, ErrorStateCause::IsOffline) {
                         AfterDisconnect::Reconnect(0)
                     } else {
                         AfterDisconnect::Block(reason)
@@ -152,9 +152,9 @@ impl DisconnectingState {
                     let _ = complete_tx.send(());
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
-                Some(TunnelCommand::IsOffline(is_offline)) => {
-                    shared_values.is_offline = is_offline;
-                    if is_offline {
+                Some(TunnelCommand::Connectivity(connectivity)) => {
+                    shared_values.connectivity = connectivity;
+                    if connectivity.is_offline() {
                         AfterDisconnect::Block(ErrorStateCause::IsOffline)
                     } else {
                         AfterDisconnect::Reconnect(retry_attempt)

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -181,9 +181,11 @@ impl TunnelState for ErrorState {
                 let _ = complete_tx.send(());
                 SameState(self)
             }
-            Some(TunnelCommand::IsOffline(is_offline)) => {
-                shared_values.is_offline = is_offline;
-                if !is_offline && matches!(self.block_reason, ErrorStateCause::IsOffline) {
+            Some(TunnelCommand::Connectivity(connectivity)) => {
+                shared_values.connectivity = connectivity;
+                if !connectivity.is_offline()
+                    && matches!(self.block_reason, ErrorStateCause::IsOffline)
+                {
                     Self::reset_dns(shared_values);
                     NewState(ConnectingState::enter(shared_values, 0))
                 } else {

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -25,9 +25,7 @@ use netlink_packet_route::rtnl::constants::RT_TABLE_MAIN;
 #[cfg(target_os = "macos")]
 pub use imp::{imp::RouteError, DefaultRouteEvent, PlatformError};
 
-pub use imp::{Error, RouteManager};
-
-pub use imp::RouteManagerHandle;
+pub use imp::{Error, RouteManager, RouteManagerHandle};
 
 /// A network route with a specific network node, destination and an optional metric.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]


### PR DESCRIPTION
Try to detect available IP versions by looking at the available routes on the host.

* On Linux, we check if there exists IPv4 and/or IPv6 routes to some public IP addresses. 
* On macOS and Windows, we check if there exists default routes for IPv4 and/or IPv6.

The intention is to be able to generate better default constraints for tunnel endpoints. If we can detect "working" IPv4 and/or IPv6 and forward this information to a `TunnelParametersGenerator`, we may choose to connect to a Wireguard relay using IPv6 as part of our retry-strategy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5761)
<!-- Reviewable:end -->
