### PR TITLE
Add instructions to enable Windows time service in Windows test runners

### DIFF
--- a/test/docs/BUILD_OS_IMAGE.md
+++ b/test/docs/BUILD_OS_IMAGE.md
@@ -166,6 +166,15 @@ This can be achieved as follows:
     * Enable "Run task as soon as possible after a scheduled start is missed".
     * Enable "If the task fails, restart every: 1 minute".
 
+* In the guest, make sure that the time service is enabled and running
+
+    First, enable the Windows Time service (`W32Time`):
+    https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings?tabs=config#set-the-client-to-sync-time-automatically-from-a-domain-source
+
+    ```
+    schtasks /create /tn "Synchronize Time Service" /tr "cmd.exe /c 'w32tm /resync'" /sc onlogon /rl HIGHEST
+    ```
+
 * In the guest, disable Windows Update.
 
     * Open `services.msc`.


### PR DESCRIPTION
Add instructions to ensure that the Windows time service is enabled in the test runners. This should prevent the test runner clock from getting out of sync.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5769)
<!-- Reviewable:end -->
