### PR TITLE
Temporarily disable Rust nightly builds for the daemon

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -57,7 +57,11 @@ jobs:
 
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        # FIXME: Temporarily disable nightly builds due to an issue with curve25519-dalek
+        # Once this has been fixed, enable nightly builds again:
+        # https://github.com/dalek-cryptography/curve25519-dalek/pull/619
+        #rust: [stable, beta, nightly]
+        rust: [stable, beta]
     continue-on-error: true
     steps:
       # Fix for HOME path overridden by GH runners when building in containers, see:


### PR DESCRIPTION
Temporarily disable nightly builds due to an issue with curve25519-dalek. This should be reverted once it has been fixed: https://github.com/dalek-cryptography/curve25519-dalek/pull/619

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5772)
<!-- Reviewable:end -->
