### PR TITLE
Disable map in e2e tests

### DIFF
--- a/gui/src/renderer/components/Map.tsx
+++ b/gui/src/renderer/components/Map.tsx
@@ -33,6 +33,10 @@ export default function Map() {
     return hasLocationValue ? connection : defaultLocation;
   }, [hasLocationValue, connection.latitude, connection.longitude]);
 
+  if (window.env.e2e) {
+    return null;
+  }
+
   const connectionState = getConnectionState(hasLocationValue, connection.status.state);
 
   const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;


### PR DESCRIPTION
The e2e tests are run headless and we're seeing some errors in the test logs. Since the map isn't useful for that view I'm disabling it in this PR. It is now conditionally rendered when not running tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5777)
<!-- Reviewable:end -->
