### PR TITLE
Fix background color in report view controller

### DIFF
--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
@@ -54,6 +54,7 @@ class ProblemReportReviewViewController: UIViewController {
             ofSize: UIFont.systemFontSize,
             weight: .regular
         )
+        textView.backgroundColor = .systemBackground
 
         view.addSubview(textView)
 


### PR DESCRIPTION
The report view controller's background color was not appearing correctly on certain platforms. 
This PR fixes that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5781)
<!-- Reviewable:end -->
