### PR TITLE
Always destroy tunnel when reconfiguring

### DIFF
--- a/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
+++ b/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
@@ -32,7 +32,8 @@ struct WgAdapter: TunnelAdapterProtocol {
     func start(configuration: TunnelAdapterConfiguration) async throws {
         let wgConfig = configuration.asWgConfig
         do {
-            try await adapter.update(tunnelConfiguration: wgConfig)
+            try await adapter.stop()
+            try await adapter.start(tunnelConfiguration: wgConfig)
         } catch WireGuardAdapterError.invalidState {
             try await adapter.start(tunnelConfiguration: wgConfig)
         }


### PR DESCRIPTION
Let's always stop the tunnel before applying a new config to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5783)
<!-- Reviewable:end -->
