### PR TITLE
Fix `install.log` reporting wrong Windows version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ version = "0.0.0"
 dependencies = [
  "cbindgen",
  "mullvad-paths",
+ "talpid-platform-metadata",
 ]
 
 [[package]]

--- a/mullvad-nsis/Cargo.toml
+++ b/mullvad-nsis/Cargo.toml
@@ -15,6 +15,7 @@ crate_type = ["staticlib"]
 
 [target.i686-pc-windows-msvc.dependencies]
 mullvad-paths = { path = "../mullvad-paths" }
+talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 
 [target.i686-pc-windows-msvc.build-dependencies]
 cbindgen = { version = "0.24.3", default-features = false }

--- a/mullvad-nsis/include/mullvad-nsis.h
+++ b/mullvad-nsis/include/mullvad-nsis.h
@@ -23,4 +23,6 @@ Status get_system_local_appdata(uint16_t *buffer, uintptr_t *buffer_size);
 
 Status create_privileged_directory(const uint16_t* path);
 
+Status get_system_version(uint16_t *buffer, uintptr_t *buffer_size);
+
 } // extern "C"


### PR DESCRIPTION
Get Windows version using `talpid-platform-metadata`, which is the way that `mullvad-problem-report` reports the correct build number.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5787)
<!-- Reviewable:end -->
