### PR TITLE
Fix CI by removing unused function

### DIFF
--- a/talpid-tunnel/src/tun_provider/unix.rs
+++ b/talpid-tunnel/src/tun_provider/unix.rs
@@ -107,9 +107,6 @@ pub trait NetworkInterface: Sized {
     /// Set host IPs for interface
     fn set_ip(&mut self, ip: IpAddr) -> Result<(), NetworkInterfaceError>;
 
-    /// Set MTU for interface
-    fn set_mtu(&mut self, mtu: u16) -> Result<(), NetworkInterfaceError>;
-
     /// Get name of interface
     fn get_name(&self) -> &str;
 }
@@ -197,12 +194,6 @@ impl NetworkInterface for TunnelDevice {
     fn set_up(&mut self, up: bool) -> Result<(), NetworkInterfaceError> {
         self.dev
             .enabled(up)
-            .map_err(NetworkInterfaceError::ToggleDevice)
-    }
-
-    fn set_mtu(&mut self, mtu: u16) -> Result<(), NetworkInterfaceError> {
-        self.dev
-            .set_mtu(i32::from(mtu))
             .map_err(NetworkInterfaceError::ToggleDevice)
     }
 


### PR DESCRIPTION
An unused function suddenly caused CI to fail when bumping the version of the nightly Rust compiler https://github.com/mullvad/mullvadvpn-app/pull/5785. This PR simply removes the offending function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5791)
<!-- Reviewable:end -->
