### PR TITLE
Ignore RUSTSEC-2023-0079

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           file: Cargo.lock
           denyWarnings: true
+          # Ignored audit issues. This list should be kept short, and effort should be
+          # put into removing items from the list.
+          # RUSTSEC-2023-0079 - KyberSlash in `pqc_kyber`.
+          ignore: RUSTSEC-2023-0079
 
       - uses: actions-rust-lang/audit@v1.1.11
         name: Audit testrunner Rust Dependencies


### PR DESCRIPTION
Temporarily ignore `RUSTSEC-2023-0079` in `cargo-audit` CI job. This should be reversed ASAP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5794)
<!-- Reviewable:end -->
