### PR TITLE
Unify test class suffix

### DIFF
--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ArchitectureTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ArchitectureTest.kt
@@ -5,7 +5,7 @@ import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArch
 import com.lemonappdev.konsist.api.architecture.Layer
 import org.junit.jupiter.api.Test
 
-class ArchitectureTests {
+class ArchitectureTest {
 
     @Test
     fun `ensure model layer depends on nothing`() =

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/GeneralTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/GeneralTest.kt
@@ -6,7 +6,7 @@ import com.lemonappdev.konsist.api.verify.assert
 import com.lemonappdev.konsist.api.verify.assertNot
 import org.junit.jupiter.api.Test
 
-class GeneralTests {
+class GeneralTest {
     @Test
     fun `ensure package name must match file path`() =
         Konsist.scopeFromProject().packages.assert { it.hasMatchingPath }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/GeneralTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/GeneralTest.kt
@@ -2,14 +2,15 @@ package net.mullvad.mullvadvpn.test.arch
 
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.properties
-import com.lemonappdev.konsist.api.verify.assert
+import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertNot
+import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
 class GeneralTest {
     @Test
     fun `ensure package name must match file path`() =
-        Konsist.scopeFromProject().packages.assert { it.hasMatchingPath }
+        Konsist.scopeFromProject().packages.assertTrue { it.hasMatchingPath }
 
     @Test
     fun `ensure no field should have 'm' prefix`() =
@@ -20,5 +21,5 @@ class GeneralTest {
 
     @Test
     fun `ensure no empty files allowed`() =
-        Konsist.scopeFromProject().files.assertNot { it.text.isEmpty() }
+        Konsist.scopeFromProject().files.assertFalse { it.text.isEmpty() }
 }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/JUnitTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/JUnitTest.kt
@@ -4,7 +4,7 @@ import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.verify.assertEmpty
 import org.junit.jupiter.api.Test
 
-class JUnitTests {
+class JUnitTest {
 
     @Test
     fun `ensure only junit5 annotations are used for functions`() =

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/KonsistTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/KonsistTest.kt
@@ -5,7 +5,7 @@ import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
 import com.lemonappdev.konsist.api.verify.assert
 import org.junit.jupiter.api.Test
 
-class KonsistTests {
+class KonsistTest {
     @Test
     fun `ensure konsist tests have 'ensure ' prefix`() =
         Konsist.scopeFromModule("test/arch").functions().withAnnotationOf(Test::class).assert {

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/KonsistTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/KonsistTest.kt
@@ -2,13 +2,13 @@ package net.mullvad.mullvadvpn.test.arch
 
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
-import com.lemonappdev.konsist.api.verify.assert
+import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
 class KonsistTest {
     @Test
     fun `ensure konsist tests have 'ensure ' prefix`() =
-        Konsist.scopeFromModule("test/arch").functions().withAnnotationOf(Test::class).assert {
+        Konsist.scopeFromModule("test/arch").functions().withAnnotationOf(Test::class).assertTrue {
             it.hasNameStartingWith("ensure ")
         }
 }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ViewModelTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ViewModelTest.kt
@@ -6,27 +6,29 @@ import com.lemonappdev.konsist.api.ext.list.functions
 import com.lemonappdev.konsist.api.ext.list.modifierprovider.withPublicOrDefaultModifier
 import com.lemonappdev.konsist.api.ext.list.properties
 import com.lemonappdev.konsist.api.ext.list.withAllParentsOf
-import com.lemonappdev.konsist.api.verify.assert
-import com.lemonappdev.konsist.api.verify.assertNot
+import com.lemonappdev.konsist.api.verify.assertFalse
+import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
 class ViewModelTest {
     @Test
     fun `ensure view models have view model suffix`() =
-        allViewModels().assert { it.name.endsWith("ViewModel") }
+        allViewModels().assertTrue { it.name.endsWith("ViewModel") }
 
     // The purpose of this check is to both keep the naming consistent and also to avoid exposing
     // properties that shouldn't be exposed.
     @Test
     fun `ensure public properties use permitted names`() =
-        allViewModels().properties(includeNested = false).withPublicOrDefaultModifier().assert {
-            property ->
-            property.name == "uiState" || property.name == "uiSideEffect"
-        }
+        allViewModels()
+            .properties(includeNested = false)
+            .withPublicOrDefaultModifier()
+            .assertTrue { property ->
+                property.name == "uiState" || property.name == "uiSideEffect"
+            }
 
     @Test
     fun `ensure public functions have no return type`() =
-        allViewModels().functions().withPublicOrDefaultModifier().assertNot { function ->
+        allViewModels().functions().withPublicOrDefaultModifier().assertFalse { function ->
             function.hasReturnType()
         }
 

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ViewModelTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ViewModelTest.kt
@@ -10,7 +10,7 @@ import com.lemonappdev.konsist.api.verify.assert
 import com.lemonappdev.konsist.api.verify.assertNot
 import org.junit.jupiter.api.Test
 
-class ViewModelTests {
+class ViewModelTest {
     @Test
     fun `ensure view models have view model suffix`() =
         allViewModels().assert { it.name.endsWith("ViewModel") }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/ClassTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/ClassTest.kt
@@ -4,7 +4,7 @@ import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
-class ClassTests {
+class ClassTest {
     @Test
     fun `ensure companion object is last declaration in the class`() =
         Konsist.scopeFromProject().classes(includeNested = true).assertTrue {
@@ -20,5 +20,7 @@ class ClassTests {
 
     @Test
     fun `ensure test classes have 'Test' suffix`() =
-        Konsist.scopeFromTest().classes().assertTrue { it.hasNameEndingWith("Test") }
+        Konsist.scopeFromTest().classes(includeNested = false).assertTrue {
+            it.hasNameEndingWith("Test")
+        }
 }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/ClassTests.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/ClassTests.kt
@@ -1,13 +1,13 @@
 package net.mullvad.mullvadvpn.test.arch.classes
 
 import com.lemonappdev.konsist.api.Konsist
-import com.lemonappdev.konsist.api.verify.assert
+import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
 class ClassTests {
     @Test
     fun `ensure companion object is last declaration in the class`() =
-        Konsist.scopeFromProject().classes(includeNested = true).assert {
+        Konsist.scopeFromProject().classes(includeNested = true).assertTrue {
             val companionObject =
                 it.objects(includeNested = false).lastOrNull { obj -> obj.hasCompanionModifier }
             if (companionObject != null) {
@@ -17,4 +17,8 @@ class ClassTests {
                 true
             }
         }
+
+    @Test
+    fun `ensure test classes have 'Test' suffix`() =
+        Konsist.scopeFromTest().classes().assertTrue { it.hasNameEndingWith("Test") }
 }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/DataClassTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/DataClassTest.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.test.arch.classes
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.modifierprovider.withDataModifier
 import com.lemonappdev.konsist.api.ext.list.properties
-import com.lemonappdev.konsist.api.verify.assertNot
+import com.lemonappdev.konsist.api.verify.assertFalse
 import org.junit.jupiter.api.Test
 
 class DataClassTest {
@@ -13,5 +13,5 @@ class DataClassTest {
             .classes(includeNested = true)
             .withDataModifier()
             .properties(includeNested = false, includeLocal = false)
-            .assertNot { it.hasVarModifier }
+            .assertFalse { it.hasVarModifier }
 }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/DataClassTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/DataClassTest.kt
@@ -6,7 +6,7 @@ import com.lemonappdev.konsist.api.ext.list.properties
 import com.lemonappdev.konsist.api.verify.assertNot
 import org.junit.jupiter.api.Test
 
-class DataClassTests {
+class DataClassTest {
     @Test
     fun `ensure data classes only use immutable properties`() =
         Konsist.scopeFromProject()

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/ValueClassTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/classes/ValueClassTest.kt
@@ -5,7 +5,7 @@ import com.lemonappdev.konsist.api.ext.list.modifierprovider.withValueModifier
 import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
-class ValueClassTests {
+class ValueClassTest {
     @Test
     fun `ensure value classes property is named value`() {
         Konsist.scopeFromProject().classes(includeNested = true).withValueModifier().assertTrue {

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposePreviewTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposePreviewTest.kt
@@ -6,7 +6,7 @@ import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
 import com.lemonappdev.konsist.api.verify.assert
 import org.junit.jupiter.api.Test
 
-class ComposePreviewTests {
+class ComposePreviewTest {
     @Test
     fun `ensure all preview functions are private`() =
         allPreviewFunctions().assert { it.hasPrivateModifier }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposePreviewTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposePreviewTest.kt
@@ -3,17 +3,17 @@ package net.mullvad.mullvadvpn.test.arch.compose
 import androidx.compose.ui.tooling.preview.Preview
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
-import com.lemonappdev.konsist.api.verify.assert
+import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
 class ComposePreviewTest {
     @Test
     fun `ensure all preview functions are private`() =
-        allPreviewFunctions().assert { it.hasPrivateModifier }
+        allPreviewFunctions().assertTrue { it.hasPrivateModifier }
 
     @Test
     fun `ensure all preview functions are prefixed with 'Preview'`() =
-        allPreviewFunctions().assert { it.name.startsWith("Preview") }
+        allPreviewFunctions().assertTrue { it.name.startsWith("Preview") }
 
     private fun allPreviewFunctions() =
         Konsist.scopeFromProduction("app").functions().withAllAnnotationsOf(Preview::class)

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposeTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposeTest.kt
@@ -6,7 +6,7 @@ import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
 import com.lemonappdev.konsist.api.verify.assert
 import org.junit.jupiter.api.Test
 
-class ComposeTests {
+class ComposeTest {
     @Test
     fun `ensure all app composables are in the compose package`() =
         allAppComposeFunctions().assert { it.resideInPackage("net.mullvad.mullvadvpn.compose..") }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposeTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/compose/ComposeTest.kt
@@ -3,13 +3,15 @@ package net.mullvad.mullvadvpn.test.arch.compose
 import androidx.compose.runtime.Composable
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.withAllAnnotationsOf
-import com.lemonappdev.konsist.api.verify.assert
+import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
 class ComposeTest {
     @Test
     fun `ensure all app composables are in the compose package`() =
-        allAppComposeFunctions().assert { it.resideInPackage("net.mullvad.mullvadvpn.compose..") }
+        allAppComposeFunctions().assertTrue {
+            it.resideInPackage("net.mullvad.mullvadvpn.compose..")
+        }
 
     private fun allAppComposeFunctions() =
         Konsist.scopeFromProduction("app").functions().withAllAnnotationsOf(Composable::class)


### PR DESCRIPTION
This PR aims to unify the test class suffix used in the project by:
* Adding a konsist check to check the test class suffix.
* Making sure the code is compliant with the new konsist check.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
