### PR TITLE
Resurface the list of allowedIPs to make it configurable

### DIFF
--- a/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
+++ b/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
@@ -112,10 +112,7 @@ private extension TunnelAdapterConfiguration {
         if let peer {
             var peerConfig = PeerConfiguration(publicKey: peer.publicKey)
             peerConfig.endpoint = peer.endpoint.wgEndpoint
-            peerConfig.allowedIPs = [
-                IPAddressRange(from: "0.0.0.0/0")!,
-                IPAddressRange(from: "::/0")!,
-            ]
+            peerConfig.allowedIPs = allowedIPs
             peers.append(peerConfig)
         }
 

--- a/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
+++ b/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
@@ -26,13 +26,15 @@ struct ConfigurationBuilder {
     var interfaceAddresses: [IPAddressRange]
     var dns: SelectedDNSServers?
     var endpoint: MullvadEndpoint?
+    var allowedIPs: [IPAddressRange]
 
     func makeConfiguration() throws -> TunnelAdapterConfiguration {
         return TunnelAdapterConfiguration(
             privateKey: privateKey,
             interfaceAddresses: interfaceAddresses,
             dns: dnsServers,
-            peer: try peer
+            peer: try peer,
+            allowedIPs: allowedIPs
         )
     }
 

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -114,7 +114,8 @@ extension PacketTunnelActor {
         do {
             let configurationBuilder = ConfigurationBuilder(
                 privateKey: PrivateKey(),
-                interfaceAddresses: []
+                interfaceAddresses: [],
+                allowedIPs: []
             )
             var config = try configurationBuilder.makeConfiguration()
             config.dns = [IPv4Address.loopback]

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -250,7 +250,11 @@ extension PacketTunnelActor {
             privateKey: activeKey,
             interfaceAddresses: settings.interfaceAddresses,
             dns: settings.dnsServers,
-            endpoint: connectionState.connectedEndpoint
+            endpoint: connectionState.connectedEndpoint,
+            allowedIPs: [
+                IPAddressRange(from: "0.0.0.0/0")!,
+                IPAddressRange(from: "::/0")!,
+            ]
         )
 
         /*

--- a/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
@@ -27,6 +27,7 @@ public struct TunnelAdapterConfiguration {
     public var interfaceAddresses: [IPAddressRange]
     public var dns: [IPAddress]
     public var peer: TunnelPeer?
+    public var allowedIPs: [IPAddressRange]
 }
 
 /// Struct describing a single peer.


### PR DESCRIPTION
This PR resurfaces the list of allowed IP address ranges passed to wireguard.
We need to do this in order to change the range when configuring wireguard for doing post quantum key exchange.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5804)
<!-- Reviewable:end -->
