### PR TITLE
Add quantum resistance settings to preferences view if DEBUG is set

### DIFF
--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -84,6 +84,11 @@ public enum AccessibilityIdentifier: String {
     case dnsServer
     case dnsServerInfo
 
+    // Quantum resistance
+    case quantumResistanceAutomatic
+    case quantumResistanceOff
+    case quantumResistanceOn
+
     // Error
     case unknown
 }

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -536,6 +536,16 @@ final class TunnelManager: StorePaymentObserver {
         )
     }
 
+    func setQuantumResistance(_ newSetting: TunnelQuantumResistance) {
+        scheduleSettingsUpdate(
+            taskName: "Set quantum resistance",
+            modificationBlock: { settings in
+                settings.tunnelQuantumResistance = newSetting
+            },
+            completionHandler: nil
+        )
+    }
+
     func refreshRelayCacheTracker() throws {
         try relayCacheTracker.refreshCachedRelays()
     }

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesCellFactory.swift
@@ -155,6 +155,43 @@ final class PreferencesCellFactory: CellFactoryProtocol {
             )
             cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.rawValue) (\(portString))"
             cell.applySubCellStyling()
+
+        #if DEBUG
+        case .quantumResistanceAutomatic:
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "QUANTUM_RESISTANCE_AUTOMATIC_LABEL",
+                tableName: "Preferences",
+                value: "Automatic",
+                comment: ""
+            )
+            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.applySubCellStyling()
+
+        case .quantumResistanceOn:
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "QUANTUM_RESISTANCE_ON_LABEL",
+                tableName: "Preferences",
+                value: "On",
+                comment: ""
+            )
+            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.applySubCellStyling()
+        case .quantumResistanceOff:
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "QUANTUM_RESISTANCE_OFF_LABEL",
+                tableName: "Preferences",
+                value: "Off",
+                comment: ""
+            )
+            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.applySubCellStyling()
+        #endif
         }
     }
 }

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesDataSource.swift
@@ -21,6 +21,7 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case wireGuardCustomPort
         case wireGuardObfuscation
         case wireGuardObfuscationPort
+        case quantumResistance
         var reusableViewClass: AnyClass {
             switch self {
             case .dnsSettings:
@@ -32,6 +33,8 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
             case .wireGuardObfuscation:
                 return SelectableSettingsCell.self
             case .wireGuardObfuscationPort:
+                return SelectableSettingsCell.self
+            case .quantumResistance:
                 return SelectableSettingsCell.self
             }
         }
@@ -50,6 +53,9 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case wireGuardPorts
         case wireGuardObfuscation
         case wireGuardObfuscationPort
+        #if DEBUG
+        case quantumResistance
+        #endif
     }
 
     enum Item: Hashable {
@@ -60,6 +66,11 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case wireGuardObfuscationOn
         case wireGuardObfuscationOff
         case wireGuardObfuscationPort(_ port: UInt16)
+        #if DEBUG
+        case quantumResistanceAutomatic
+        case quantumResistanceOn
+        case quantumResistanceOff
+        #endif
 
         static var wireGuardPorts: [Item] {
             let defaultPorts = PreferencesViewModel.defaultWireGuardPorts.map {
@@ -75,6 +86,12 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         static var wireGuardObfuscationPort: [Item] {
             [.wireGuardObfuscationPort(0), wireGuardObfuscationPort(80), wireGuardObfuscationPort(5001)]
         }
+
+        #if DEBUG
+        static var quantumResistance: [Item] {
+            [.quantumResistanceAutomatic, .quantumResistanceOn, .quantumResistanceOff]
+        }
+        #endif
 
         var accessibilityIdentifier: AccessibilityIdentifier {
             switch self {
@@ -92,6 +109,14 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                 return .wireGuardObfuscationOff
             case .wireGuardObfuscationPort:
                 return .wireGuardObfuscationAutomatic
+            #if DEBUG
+            case .quantumResistanceAutomatic:
+                return .quantumResistanceAutomatic
+            case .quantumResistanceOn:
+                return .quantumResistanceOn
+            case .quantumResistanceOff:
+                return .quantumResistanceOff
+            #endif
             }
         }
 
@@ -107,6 +132,10 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
                 return .wireGuardObfuscation
             case .wireGuardObfuscationPort:
                 return .wireGuardObfuscationPort
+            #if DEBUG
+            case .quantumResistanceAutomatic, .quantumResistanceOn, .quantumResistanceOff:
+                return .quantumResistance
+            #endif
             }
         }
     }
@@ -129,14 +158,30 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case .off: .wireGuardObfuscationOff
         case .on: .wireGuardObfuscationOn
         }
+        #if DEBUG
+        let quantumResistanceItem: Item = switch viewModel.quantumResistance {
+        case .automatic: .quantumResistanceAutomatic
+        case .off: .quantumResistanceOff
+        case .on: .quantumResistanceOn
+        }
+        #endif
 
         let obfuscationPortItem: Item = .wireGuardObfuscationPort(viewModel.obfuscationPort.portValue)
 
+        #if DEBUG
         return [
-            indexPath(for: wireGuardPortItem),
-            indexPath(for: obfuscationStateItem),
-            indexPath(for: obfuscationPortItem),
-        ].compactMap { $0 }
+            wireGuardPortItem,
+            obfuscationStateItem,
+            obfuscationPortItem,
+            quantumResistanceItem,
+        ].compactMap { indexPath(for: $0) }
+        #else
+        return [
+            wireGuardPortItem,
+            obfuscationStateItem,
+            obfuscationPortItem,
+        ].compactMap { indexPath(for: $0) }
+        #endif
     }
 
     init(tableView: UITableView) {
@@ -240,6 +285,18 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case let .wireGuardObfuscationPort(port):
             selectObfuscationPort(port)
             delegate?.didChangeViewModel(viewModel)
+
+        #if DEBUG
+        case .quantumResistanceAutomatic:
+            selectQuantumResistance(.automatic)
+            delegate?.didChangeViewModel(viewModel)
+        case .quantumResistanceOn:
+            selectQuantumResistance(.on)
+            delegate?.didChangeViewModel(viewModel)
+        case .quantumResistanceOff:
+            selectQuantumResistance(.off)
+            delegate?.didChangeViewModel(viewModel)
+        #endif
         default:
             break
         }
@@ -277,6 +334,12 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         case .wireGuardObfuscationPort:
             configureObfuscationPortHeader(view)
             return view
+        #if DEBUG
+        case .quantumResistance:
+            configureQuantumResistanceHeader(view)
+            return view
+        #endif
+
         default:
             return nil
         }
@@ -459,6 +522,36 @@ final class PreferencesDataSource: UITableViewDiffableDataSource<
         }
     }
 
+    #if DEBUG
+    private func configureQuantumResistanceHeader(_ header: SettingsHeaderView) {
+        let title = NSLocalizedString(
+            "QUANTUM_RESISTANCE_HEADER_LABEL",
+            tableName: "Preferences",
+            value: "Quantum-resistant tunnel",
+            comment: ""
+        )
+
+        header.titleLabel.text = title
+        header.accessibilityCustomActionName = title
+        header.didCollapseHandler = { [weak self] header in
+            guard let self else { return }
+
+            var snapshot = snapshot()
+            if header.isExpanded {
+                snapshot.deleteItems(Item.quantumResistance)
+            } else {
+                snapshot.appendItems(Item.quantumResistance, toSection: .quantumResistance)
+            }
+            header.isExpanded.toggle()
+            applySnapshot(snapshot, animated: true)
+        }
+
+        header.infoButtonHandler = { [weak self] in
+            self.map { $0.delegate?.showInfo(for: .quantumResistance) }
+        }
+    }
+    #endif
+
     private func selectRow(at indexPath: IndexPath?, animated: Bool = false) {
         tableView?.selectRow(at: indexPath, animated: animated, scrollPosition: .none)
     }
@@ -504,6 +597,10 @@ extension PreferencesDataSource: PreferencesCellEventHandler {
     func selectObfuscationPort(_ port: UInt16) {
         let selectedPort = WireGuardObfuscationPort(rawValue: port)!
         viewModel.setWireGuardObfuscationPort(selectedPort)
+    }
+
+    func selectQuantumResistance(_ state: TunnelQuantumResistance) {
+        viewModel.setQuantumResistance(state)
     }
 }
 

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesInfoButtonItem.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesInfoButtonItem.swift
@@ -12,4 +12,5 @@ enum PreferencesInfoButtonItem {
     case wireGuardPorts
     case wireGuardObfuscation
     case wireGuardObfuscationPort
+    case quantumResistance
 }

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesInteractor.swift
@@ -55,6 +55,10 @@ final class PreferencesInteractor {
 
         tunnelManager.setRelayConstraints(relayConstraints, completionHandler: completion)
     }
+
+    func setQuantumResistance(_ newSetting: TunnelQuantumResistance) {
+        tunnelManager.setQuantumResistance(newSetting)
+    }
 }
 
 extension PreferencesInteractor: RelayCacheTrackerObserver {

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesViewController.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesViewController.swift
@@ -105,6 +105,7 @@ class PreferencesViewController: UITableViewController, PreferencesDataSourceDel
             state: viewModel.obfuscationState,
             port: viewModel.obfuscationPort
         ))
+        interactor.setQuantumResistance(viewModel.quantumResistance)
     }
 
     func showInfo(for item: PreferencesInfoButtonItem) {
@@ -149,6 +150,18 @@ class PreferencesViewController: UITableViewController, PreferencesDataSourceDel
                 "PREFERENCES_WIRE_GUARD_OBFUSCATION_PORT_GENERAL",
                 tableName: "WireGuardObfuscation",
                 value: "Which TCP port the UDP-over-TCP obfuscation protocol should connect to on the VPN server.",
+                comment: ""
+            )
+
+        case .quantumResistance:
+            message = NSLocalizedString(
+                "PREFERENCES_QUANTUM_RESISTANCE_GENERAL",
+                tableName: "QuantumResistance",
+                value: """
+                This feature makes the WireGuard tunnel resistant to potential attacks from quantum computers.
+                It does this by performing an extra key exchange using a quantum safe algorithm and mixing the result into WireGuard’s regular encryption.
+                This extra step uses approximately 500 kiB of traffic every time a new tunnel is established.
+                """,
                 comment: ""
             )
 

--- a/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Preferences/PreferencesViewModel.swift
@@ -98,6 +98,8 @@ struct PreferencesViewModel: Equatable {
     private(set) var obfuscationState: WireGuardObfuscationState
     private(set) var obfuscationPort: WireGuardObfuscationPort
 
+    private(set) var quantumResistance: TunnelQuantumResistance
+
     static let defaultWireGuardPorts: [UInt16] = [51820, 53]
 
     mutating func setBlockAdvertising(_ newValue: Bool) {
@@ -148,6 +150,10 @@ struct PreferencesViewModel: Equatable {
         obfuscationPort = newPort
     }
 
+    mutating func setQuantumResistance(_ newState: TunnelQuantumResistance) {
+        quantumResistance = newState
+    }
+
     /// Precondition for enabling Custom DNS.
     var customDNSPrecondition: CustomDNSPrecondition {
         if blockAdvertising || blockTracking || blockMalware ||
@@ -193,6 +199,8 @@ struct PreferencesViewModel: Equatable {
 
         obfuscationState = tunnelSettings.wireGuardObfuscation.state
         obfuscationPort = tunnelSettings.wireGuardObfuscation.port
+
+        quantumResistance = tunnelSettings.tunnelQuantumResistance
     }
 
     /// Produce merged view model keeping entry `identifier` for matching DNS entries.


### PR DESCRIPTION
This adds a "Quantum resistance" menu to the VPN options with three modes: On, Off and Automatic. It is disabled if DEBUG is not set.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5806)
<!-- Reviewable:end -->
