### PR TITLE
Fix off-by-one error when choosing access method candidates

### DIFF
--- a/mullvad-api/src/bin/relay_list.rs
+++ b/mullvad-api/src/bin/relay_list.rs
@@ -11,11 +11,10 @@ async fn main() {
     let runtime = mullvad_api::Runtime::new(tokio::runtime::Handle::current())
         .expect("Failed to load runtime");
 
-    let relay_list_request = RelayListProxy::new(
-        runtime
-            .mullvad_rest_handle(ApiConnectionMode::Direct.into_repeat())
-            .await,
-    )
+    let relay_list_request = RelayListProxy::new(runtime.mullvad_rest_handle(
+        ApiConnectionMode::Direct,
+        ApiConnectionMode::Direct.into_repeat(),
+    ))
     .relay_list(None)
     .await;
 

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -382,9 +382,10 @@ impl Runtime {
     }
 
     /// Creates a new request service and returns a handle to it.
-    async fn new_request_service<T: Stream<Item = ApiConnectionMode> + Unpin + Send + 'static>(
+    fn new_request_service<T: Stream<Item = ApiConnectionMode> + Unpin + Send + 'static>(
         &self,
         sni_hostname: Option<String>,
+        initial_connection_mode: ApiConnectionMode,
         proxy_provider: T,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> rest::RequestServiceHandle {
@@ -392,28 +393,26 @@ impl Runtime {
             sni_hostname,
             self.api_availability.handle(),
             self.address_cache.clone(),
+            initial_connection_mode,
             proxy_provider,
             #[cfg(target_os = "android")]
             socket_bypass_tx,
         )
-        .await
     }
 
     /// Returns a request factory initialized to create requests for the master API
-    pub async fn mullvad_rest_handle<
-        T: Stream<Item = ApiConnectionMode> + Unpin + Send + 'static,
-    >(
+    pub fn mullvad_rest_handle<T: Stream<Item = ApiConnectionMode> + Unpin + Send + 'static>(
         &self,
+        initial_connection_mode: ApiConnectionMode,
         proxy_provider: T,
     ) -> rest::MullvadRestHandle {
-        let service = self
-            .new_request_service(
-                Some(API.host().to_string()),
-                proxy_provider,
-                #[cfg(target_os = "android")]
-                self.socket_bypass_tx.clone(),
-            )
-            .await;
+        let service = self.new_request_service(
+            Some(API.host().to_string()),
+            initial_connection_mode,
+            proxy_provider,
+            #[cfg(target_os = "android")]
+            self.socket_bypass_tx.clone(),
+        );
         let token_store = access::AccessTokenStore::new(service.clone());
         let factory = rest::RequestFactory::new(API.host(), Some(token_store));
 
@@ -426,15 +425,14 @@ impl Runtime {
     }
 
     /// This is only to be used in test code
-    pub async fn static_mullvad_rest_handle(&self, hostname: String) -> rest::MullvadRestHandle {
-        let service = self
-            .new_request_service(
-                Some(hostname.clone()),
-                futures::stream::repeat(ApiConnectionMode::Direct),
-                #[cfg(target_os = "android")]
-                self.socket_bypass_tx.clone(),
-            )
-            .await;
+    pub fn static_mullvad_rest_handle(&self, hostname: String) -> rest::MullvadRestHandle {
+        let service = self.new_request_service(
+            Some(hostname.clone()),
+            ApiConnectionMode::Direct,
+            futures::stream::repeat(ApiConnectionMode::Direct),
+            #[cfg(target_os = "android")]
+            self.socket_bypass_tx.clone(),
+        );
         let token_store = access::AccessTokenStore::new(service.clone());
         let factory = rest::RequestFactory::new(hostname, Some(token_store));
 
@@ -447,14 +445,14 @@ impl Runtime {
     }
 
     /// Returns a new request service handle
-    pub async fn rest_handle(&self) -> rest::RequestServiceHandle {
+    pub fn rest_handle(&self) -> rest::RequestServiceHandle {
         self.new_request_service(
             None,
+            ApiConnectionMode::Direct,
             ApiConnectionMode::Direct.into_repeat(),
             #[cfg(target_os = "android")]
             None,
         )
-        .await
     }
 
     pub fn handle(&mut self) -> &mut tokio::runtime::Handle {

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -131,11 +131,12 @@ pub(crate) struct RequestService<T: Stream<Item = ApiConnectionMode>> {
 
 impl<T: Stream<Item = ApiConnectionMode> + Unpin + Send + 'static> RequestService<T> {
     /// Constructs a new request service.
-    pub async fn spawn(
+    pub fn spawn(
         sni_hostname: Option<String>,
         api_availability: ApiAvailabilityHandle,
         address_cache: AddressCache,
-        mut proxy_config_provider: T,
+        initial_connection_mode: ApiConnectionMode,
+        proxy_config_provider: T,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> RequestServiceHandle {
         let (connector, connector_handle) = HttpsConnectorWithSni::new(
@@ -145,9 +146,7 @@ impl<T: Stream<Item = ApiConnectionMode> + Unpin + Send + 'static> RequestServic
             socket_bypass_tx.clone(),
         );
 
-        if let Some(config) = proxy_config_provider.next().await {
-            connector_handle.set_connection_mode(config);
-        }
+        connector_handle.set_connection_mode(initial_connection_mode);
 
         let (command_tx, command_rx) = mpsc::unbounded();
         let client = Client::builder().build(connector);

--- a/mullvad-daemon/src/access_method.rs
+++ b/mullvad-daemon/src/access_method.rs
@@ -260,14 +260,10 @@ where
 
     /// Create an [`ApiProxy`] which will perform all REST requests against one
     /// specific endpoint `proxy_provider`.
-    pub async fn create_limited_api_proxy(
-        &mut self,
-        proxy_provider: ApiConnectionMode,
-    ) -> ApiProxy {
+    pub fn create_limited_api_proxy(&mut self, proxy_provider: ApiConnectionMode) -> ApiProxy {
         let rest_handle = self
             .api_runtime
-            .mullvad_rest_handle(proxy_provider.into_repeat())
-            .await;
+            .mullvad_rest_handle(proxy_provider, futures::stream::empty());
         ApiProxy::new(rest_handle)
     }
 

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -243,7 +243,8 @@ impl AccessModeSelector {
     ) -> Result<AccessModeSelectorHandle> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let (index, next) = Self::get_next_inner(0, &access_method_settings);
+        // Always start looking from the position of `Direct`.
+        let (index, next) = Self::select_next_active(0, &access_method_settings);
         let initial_connection_mode =
             Self::resolve_inner(next, &relay_selector, &address_cache).await;
 
@@ -396,25 +397,28 @@ impl AccessModeSelector {
         if let Some(access_method) = self.set.take() {
             access_method
         } else {
-            let (index, next) = Self::get_next_inner(self.index, &self.access_method_settings);
-            self.index = index;
+            let (next_index, next) =
+                Self::select_next_active(self.index + 1, &self.access_method_settings);
+            self.index = next_index;
             next
         }
     }
 
-    fn get_next_inner(start: usize, access_methods: &Settings) -> (usize, AccessMethodSetting) {
-        let xs: Vec<_> = access_methods.iter().collect();
-        for offset in 1..=access_methods.cardinality() {
-            let index = (start + offset) % access_methods.cardinality();
-            if let Some(&candidate) = xs.get(index) {
-                if candidate.enabled {
-                    return (index, candidate.clone());
-                }
-            }
-        }
-        (0, access_methods.direct().clone())
+    /// Find the next access method to use.
+    ///
+    /// * `start`: From which point in `access_methods` to start the search.
+    /// * `access_methods`: The search space.
+    fn select_next_active(start: usize, access_methods: &Settings) -> (usize, AccessMethodSetting) {
+        access_methods
+            .iter()
+            .cloned()
+            .enumerate()
+            .cycle()
+            .skip(start)
+            .take(access_methods.cardinality())
+            .find(|(_index, access_method)| access_method.enabled())
+            .unwrap_or_else(|| (0, access_methods.direct().clone()))
     }
-
     fn on_update_access_methods(
         &mut self,
         tx: ResponseTx<()>,

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -299,14 +299,9 @@ async fn send_problem_report_inner(
     .await
     .map_err(Error::CreateRpcClientError)?;
 
+    let connection_mode = ApiConnectionMode::try_from_cache(cache_dir).await;
     let api_client = mullvad_api::ProblemReportProxy::new(
-        api_runtime
-            .mullvad_rest_handle(
-                ApiConnectionMode::try_from_cache(cache_dir)
-                    .await
-                    .into_repeat(),
-            )
-            .await,
+        api_runtime.mullvad_rest_handle(connection_mode.clone(), connection_mode.into_repeat()),
     );
 
     for _attempt in 0..MAX_SEND_ATTEMPTS {

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -159,14 +159,9 @@ async fn remove_device() -> Result<(), Error> {
             .await
             .map_err(Error::RpcInitializationError)?;
 
+        let connection_mode = ApiConnectionMode::try_from_cache(&cache_path).await;
         let proxy = mullvad_api::DevicesProxy::new(
-            api_runtime
-                .mullvad_rest_handle(
-                    ApiConnectionMode::try_from_cache(&cache_path)
-                        .await
-                        .into_repeat(),
-                )
-                .await,
+            api_runtime.mullvad_rest_handle(connection_mode.clone(), connection_mode.into_repeat()),
         );
 
         let device_removal = retry_future(

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -83,7 +83,7 @@ impl Settings {
     }
 
     /// Iterate over references of built-in & custom access methods.
-    pub fn iter(&self) -> impl Iterator<Item = &AccessMethodSetting> {
+    pub fn iter(&self) -> impl Iterator<Item = &AccessMethodSetting> + Clone {
         use std::iter::once;
         once(&self.direct)
             .chain(once(&self.mullvad_bridges))

--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -49,7 +49,7 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> Result<()
         return Err(Error::DaemonNotRunning);
     }
 
-    super::account::clear_devices(&super::account::new_device_client().await)
+    super::account::clear_devices(&super::account::new_device_client())
         .await
         .expect("failed to clear devices");
 
@@ -227,10 +227,9 @@ pub async fn test_uninstall_app(
     }
 
     // verify that device was removed
-    let devices =
-        super::account::list_devices_with_retries(&super::account::new_device_client().await)
-            .await
-            .expect("failed to list devices");
+    let devices = super::account::list_devices_with_retries(&super::account::new_device_client())
+        .await
+        .expect("failed to list devices");
 
     assert!(
         !devices.iter().any(|device| device.id == uninstalled_device),


### PR DESCRIPTION
As the code comment says: `get_next_inner` will skip the `start` position, which means that by starting from the back of the available access methods we effectively look for candidates starting from index 0, i.e. the position of the `direct` access method. It's probably a good idea to not default users to bridges/proxies to reach the API.

Edit: The solution was found elsewhere. As it turns out, `mullvad-api` always forced a rotation of access methods whenever `MullvadRestHandle` was initialized, which means that `get_next_inner`/`select_next_active` was called twice at startup. This was subsequently solved by passing along an initial access method to the constructor of `MullvadRestHandle`, as is done with the tunnel state machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5811)
<!-- Reviewable:end -->
