### PR TITLE
Fix `mullvad-api` build

### DIFF
--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -311,14 +311,12 @@ impl Runtime {
         )
     }
 
-    // TODO: gate for ios only
+    #[cfg(target_os = "ios")]
     pub fn with_static_addr(handle: tokio::runtime::Handle, address: SocketAddr) -> Self {
         Runtime {
             handle,
             address_cache: AddressCache::with_static_addr(address),
             api_availability: ApiAvailability::new(availability::State::default()),
-            #[cfg(target_os = "android")]
-            socket_bypass_tx,
         }
     }
 

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -337,6 +337,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "cbindgen"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
+dependencies = [
+ "heck",
+ "indexmap 1.9.3",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1716,7 @@ dependencies = [
 name = "mullvad-api"
 version = "0.0.0"
 dependencies = [
+ "cbindgen",
  "chrono",
  "err-derive",
  "futures",
@@ -1718,6 +1737,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-socks",
+ "uuid",
 ]
 
 [[package]]
@@ -3420,6 +3440,15 @@ dependencies = [
  "slab",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR address two issues introduced with fb4b924ffe86f92793e087debbb86a87e91a79fc:
* The Android build broke due to missing argument `socket_bypass_tx` in `with_static_addr` - fixed by only building `with_static_addr` on ios.
* The `Cargo.lock` file in `test/` was not updated and subsequently not signed - fixed by updating it and signing that commit.