### PR TITLE
Run settings import UI tests in test framework

### DIFF
--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -220,3 +220,14 @@ async fn test_custom_access_methods_gui(
 
     Ok(())
 }
+
+/// Test settings import / IP overrides in the GUI
+///
+/// # Note
+/// This test expects the daemon to be logged in
+#[test_function]
+pub async fn test_import_settings_ui(_: TestContext, rpc: ServiceClient) -> Result<(), Error> {
+    let ui_result = run_test(&rpc, &["settings-import.spec"]).await?;
+    assert!(ui_result.success());
+    Ok(())
+}


### PR DESCRIPTION
As the title suggests, this PR enables `settings-import.spec.ts` to be run in the test framework.

Link to a complete E2E test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/7918451759

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5819)
<!-- Reviewable:end -->
