### PR TITLE
Move API IP updater out of mullvad-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Line wrap the file at 100 chars.                                              Th
 - Fix connectivity issues that would occur when using quantum-resistant tunnels with an incorrectly
   configured MTU.
 - Fix custom list name validation by not allowing empty names.
+- Continual excessive attempts to update the API IP were made after testing access methods.
+- Fix pointless API access method rotations for concurrent requests.
 
 #### Linux
 - Fix Bash shell completions for subcommands in the CLI.

--- a/mullvad-api/src/address_cache.rs
+++ b/mullvad-api/src/address_cache.rs
@@ -1,3 +1,5 @@
+//! This module keeps track of the last known good API IP address and reads and stores it on disk.
+
 use super::API;
 use std::{io, net::SocketAddr, path::Path, sync::Arc};
 use tokio::{

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -308,7 +308,7 @@ impl ApiEndpoint {
 /// A type that helps with the creation of API connections.
 pub struct Runtime {
     handle: tokio::runtime::Handle,
-    pub address_cache: AddressCache,
+    address_cache: AddressCache,
     api_availability: availability::ApiAvailability,
     #[cfg(target_os = "android")]
     socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
@@ -437,12 +437,7 @@ impl Runtime {
         let token_store = access::AccessTokenStore::new(service.clone());
         let factory = rest::RequestFactory::new(API.host(), Some(token_store));
 
-        rest::MullvadRestHandle::new(
-            service,
-            factory,
-            self.address_cache.clone(),
-            self.availability_handle(),
-        )
+        rest::MullvadRestHandle::new(service, factory, self.availability_handle())
     }
 
     /// This is only to be used in test code
@@ -456,12 +451,7 @@ impl Runtime {
         let token_store = access::AccessTokenStore::new(service.clone());
         let factory = rest::RequestFactory::new(hostname, Some(token_store));
 
-        rest::MullvadRestHandle::new(
-            service,
-            factory,
-            self.address_cache.clone(),
-            self.availability_handle(),
-        )
+        rest::MullvadRestHandle::new(service, factory, self.availability_handle())
     }
 
     /// Returns a new request service handle
@@ -480,6 +470,10 @@ impl Runtime {
 
     pub fn availability_handle(&self) -> ApiAvailabilityHandle {
         self.api_availability.handle()
+    }
+
+    pub fn address_cache(&self) -> &AddressCache {
+        &self.address_cache
     }
 }
 

--- a/mullvad-daemon/src/api_address_updater.rs
+++ b/mullvad-daemon/src/api_address_updater.rs
@@ -1,0 +1,55 @@
+//! A small updater that keeps the API IP address cache up to date by fetching changes from the
+//! Mullvad API.
+use mullvad_api::{rest::MullvadRestHandle, AddressCache, ApiProxy};
+use std::time::Duration;
+
+const API_IP_CHECK_INITIAL: Duration = Duration::from_secs(15 * 60);
+const API_IP_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+const API_IP_CHECK_ERROR_INTERVAL: Duration = Duration::from_secs(15 * 60);
+
+pub async fn run_api_address_fetcher(address_cache: AddressCache, handle: MullvadRestHandle) {
+    #[cfg(feature = "api-override")]
+    if API.disable_address_cache {
+        return;
+    }
+
+    let availability = handle.availability.clone();
+    let api_proxy = ApiProxy::new(handle);
+    let mut next_delay = API_IP_CHECK_INITIAL;
+
+    loop {
+        talpid_time::sleep(next_delay).await;
+
+        if let Err(error) = availability.wait_background().await {
+            log::error!("Failed while waiting for API: {}", error);
+            continue;
+        }
+        match api_proxy.clone().get_api_addrs().await {
+            Ok(new_addrs) => {
+                if let Some(addr) = new_addrs.first() {
+                    log::debug!(
+                        "Fetched new API address {:?}. Fetching again in {} hours",
+                        addr,
+                        API_IP_CHECK_INTERVAL.as_secs() / (60 * 60)
+                    );
+                    if let Err(err) = address_cache.set_address(*addr).await {
+                        log::error!("Failed to save newly updated API address: {}", err);
+                    }
+                } else {
+                    log::error!("API returned no API addresses");
+                }
+
+                next_delay = API_IP_CHECK_INTERVAL;
+            }
+            Err(err) => {
+                log::error!(
+                    "Failed to fetch new API addresses: {}. Retrying in {} seconds",
+                    err,
+                    API_IP_CHECK_ERROR_INTERVAL.as_secs()
+                );
+
+                next_delay = API_IP_CHECK_ERROR_INTERVAL;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously, the API IP updater spawned as a side effect when creating a Mullvad REST client/handle. This forced users of the API client to be aware of this (usually unwanted) behavior.

The PR moves this logic to `mullvad-daemon` and forces the daemon explicitly instantiate the updater.

Fixes DES-637.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5825)
<!-- Reviewable:end -->
