### PR TITLE
Remove redundant imports

### DIFF
--- a/mullvad-api/src/bin/relay_list.rs
+++ b/mullvad-api/src/bin/relay_list.rs
@@ -2,7 +2,7 @@
 //! Used by the installer artifact packer to bundle the latest available
 //! relay list at the time of creating the installer.
 
-use mullvad_api::{self, proxy::ApiConnectionMode, rest::Error as RestError, RelayListProxy};
+use mullvad_api::{proxy::ApiConnectionMode, rest::Error as RestError, RelayListProxy};
 use std::process;
 use talpid_types::ErrorExt;
 

--- a/mullvad-daemon/src/exception_logging/unix.rs
+++ b/mullvad-daemon/src/exception_logging/unix.rs
@@ -4,7 +4,6 @@ use libc::siginfo_t;
 use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
 
 use std::{
-    convert::TryFrom,
     ffi::{c_int, c_void},
     sync::Once,
 };

--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -1,10 +1,7 @@
 use std::time::Duration;
 
 use futures::join;
-use mullvad_api::{
-    self,
-    rest::{Error, RequestServiceHandle},
-};
+use mullvad_api::rest::{Error, RequestServiceHandle};
 use mullvad_types::location::{AmIMullvad, GeoIpLocation, LocationEventData};
 use once_cell::sync::Lazy;
 use talpid_core::mpsc::Sender;

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -8,7 +8,6 @@ use mullvad_management_interface::{
     types::{self, daemon_event, management_service_server::ManagementService},
     Code, Request, Response, Status,
 };
-use mullvad_paths;
 #[cfg(not(target_os = "android"))]
 use mullvad_types::settings::DnsOptions;
 use mullvad_types::{
@@ -25,7 +24,6 @@ use mullvad_types::{
 #[cfg(windows)]
 use std::path::PathBuf;
 use std::{
-    convert::{TryFrom, TryInto},
     str::FromStr,
     sync::{Arc, Mutex},
     time::Duration,

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -476,7 +476,6 @@ impl<'a> SettingsSummary<'a> {
 mod test {
     use super::*;
     use mullvad_types::settings::SettingsVersion;
-    use serde_json;
 
     #[test]
     #[should_panic]

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -1330,12 +1330,9 @@ impl NormalSelectedRelay {
 mod test {
     use super::*;
     use mullvad_types::{
-        custom_list::CustomListsSettings,
-        relay_constraints::{
-            GeographicLocationConstraint, RelayConstraints, RelaySettings, WireguardConstraints,
-        },
+        relay_constraints::{GeographicLocationConstraint, WireguardConstraints},
         relay_list::{
-            OpenVpnEndpoint, OpenVpnEndpointData, Relay, RelayListCity, RelayListCountry,
+            OpenVpnEndpoint, OpenVpnEndpointData, RelayListCity, RelayListCountry,
             ShadowsocksEndpointData, WireguardEndpointData, WireguardRelayEndpointData,
         },
     };

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use once_cell::sync::Lazy;
 use std::{path::PathBuf, process, str::FromStr, time::Duration};
 
-use mullvad_api::{self, proxy::ApiConnectionMode, DEVICE_NOT_FOUND};
+use mullvad_api::{proxy::ApiConnectionMode, DEVICE_NOT_FOUND};
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::version::ParsedAppVersion;
 use talpid_core::firewall::{self, Firewall};

--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -3,10 +3,7 @@ use jnix::IntoJava;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::{
-    cmp::{Ord, Ordering, PartialOrd},
-    str::FromStr,
-};
+use std::{cmp::Ordering, str::FromStr};
 
 static STABLE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(\d{4})\.(\d+)$").unwrap());
 static BETA_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(\d{4})\.(\d+)-beta(\d+)$").unwrap());

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -3,7 +3,7 @@ use chrono::{offset::Utc, DateTime};
 #[cfg(target_os = "android")]
 use jnix::{FromJava, IntoJava};
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{convert::TryFrom, fmt, str::FromStr, time::Duration};
+use std::{fmt, str::FromStr, time::Duration};
 use talpid_types::net::wireguard;
 
 pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_secs(1 * 24 * 60 * 60);

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -1,9 +1,7 @@
 use super::{FirewallArguments, FirewallPolicy};
 use crate::{split_tunnel, tunnel};
 use ipnetwork::IpNetwork;
-use libc;
 use nftnl::{
-    self,
     expr::{self, IcmpCode, Payload, RejectionType, Verdict},
     nft_expr, table, Batch, Chain, FinalizedBatch, ProtoFamily, Rule, Table,
 };

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -3,7 +3,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     sync::Arc,
 };
-use talpid_routing::{self, RouteManagerHandle};
+use talpid_routing::RouteManagerHandle;
 use talpid_types::{net::Connectivity, ErrorExt};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -8,7 +8,6 @@ use crate::{tunnel::TunnelMetadata, tunnel_state_machine::TunnelCommand};
 use futures::channel::{mpsc, oneshot};
 use std::{
     collections::HashMap,
-    convert::TryFrom,
     ffi::{OsStr, OsString},
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -3,16 +3,11 @@ use crate::logging;
 use futures::channel::oneshot;
 use std::path;
 #[cfg(not(target_os = "android"))]
-use talpid_openvpn;
-#[cfg(not(target_os = "android"))]
 use talpid_routing::RouteManagerHandle;
 pub use talpid_tunnel::{TunnelArgs, TunnelEvent, TunnelMetadata};
 #[cfg(not(target_os = "android"))]
 use talpid_types::net::openvpn as openvpn_types;
 use talpid_types::net::{wireguard as wireguard_types, TunnelParameters};
-
-/// A module for all WireGuard related tunnel management.
-use talpid_wireguard;
 
 const OPENVPN_LOG_FILENAME: &str = "openvpn.log";
 const WIREGUARD_LOG_FILENAME: &str = "wireguard.log";

--- a/talpid-dbus/src/systemd_resolved.rs
+++ b/talpid-dbus/src/systemd_resolved.rs
@@ -1,5 +1,4 @@
 use dbus::{
-    self,
     arg::{self, RefArg},
     blocking::{
         stdintf::org_freedesktop_dbus::{Properties, PropertiesPropertiesChanged},

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -3,10 +3,7 @@ use parity_tokio_ipc::Endpoint as IpcEndpoint;
 use std::collections::HashMap;
 use tower::service_fn;
 
-use tonic::{
-    self,
-    transport::{Endpoint, Uri},
-};
+use tonic::transport::{Endpoint, Uri};
 
 use tokio::runtime::{self, Runtime};
 

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 #[cfg(target_os = "linux")]
-use talpid_routing::{self, RequiredRoute};
+use talpid_routing::RequiredRoute;
 use talpid_tunnel::TunnelEvent;
 use talpid_types::{
     net::{openvpn, proxy::CustomProxy},
@@ -780,7 +780,6 @@ mod event_server {
     use talpid_types::{net::proxy::CustomProxy, ErrorExt};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use tonic::{
-        self,
         transport::{server::Connected, Server},
         Request, Response,
     };
@@ -1090,10 +1089,7 @@ mod event_server {
 mod tests {
     use super::*;
     use crate::mktemp::TempFile;
-    use std::{
-        path::{Path, PathBuf},
-        sync::{Arc, Mutex},
-    };
+    use std::sync::{Arc, Mutex};
 
     #[cfg(windows)]
     #[derive(Debug)]

--- a/talpid-openvpn/src/process/openvpn.rs
+++ b/talpid-openvpn/src/process/openvpn.rs
@@ -1,5 +1,4 @@
 use futures::channel::oneshot;
-use shell_escape;
 use std::{
     ffi::{OsStr, OsString},
     fmt, io,

--- a/talpid-routing/src/windows/route_manager.rs
+++ b/talpid-routing/src/windows/route_manager.rs
@@ -38,7 +38,6 @@ use windows_sys::Win32::{
 };
 
 type Network = IpNetwork;
-type NodeAddress = SOCKADDR_INET;
 
 /// Callback handle for the default route changed callback. Produced by the RouteManager.
 pub struct CallbackHandle {
@@ -81,12 +80,6 @@ impl PartialEq for RegisteredRoute {
             && (self.next_hop == other.next_hop)
             && (self.network == other.network)
     }
-}
-
-#[derive(Clone)]
-pub struct Node {
-    pub device_name: Option<widestring::U16CString>,
-    pub gateway: Option<NodeAddress>,
 }
 
 #[derive(Clone)]

--- a/talpid-wireguard/src/connectivity_check.rs
+++ b/talpid-wireguard/src/connectivity_check.rs
@@ -394,15 +394,13 @@ mod test {
     use crate::{
         config::Config,
         stats::{self, Stats},
-        TunnelError,
     };
     use std::{
         pin::Pin,
         sync::{
             atomic::{AtomicBool, Ordering},
-            Arc, Mutex,
+            Arc,
         },
-        time::{Duration, Instant},
     };
 
     /// Test if a newly created ConnState won't have timed out or consider itself connected

--- a/talpid-wireguard/src/wireguard_kernel/wg_message.rs
+++ b/talpid-wireguard/src/wireguard_kernel/wg_message.rs
@@ -61,7 +61,6 @@ mod constants {
 }
 
 use constants::*;
-pub use constants::{WG_CMD_GET_DEVICE, WG_CMD_SET_DEVICE};
 
 type PrivateKey = [u8; 32];
 type PublicKey = [u8; 32];

--- a/test/test-manager/src/tests/account.rs
+++ b/test/test-manager/src/tests/account.rs
@@ -1,7 +1,7 @@
 use super::config::TEST_CONFIG;
 use super::{helpers, ui, Error, TestContext};
 use mullvad_api::DevicesProxy;
-use mullvad_management_interface::{self, client::DaemonEvent, MullvadProxyClient};
+use mullvad_management_interface::{client::DaemonEvent, MullvadProxyClient};
 use mullvad_types::device::{Device, DeviceState};
 use mullvad_types::states::TunnelState;
 use std::net::ToSocketAddrs;


### PR DESCRIPTION
Remove redundant imports found when compiling with nightly `rustc`.

Fix DES-639.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5828)
<!-- Reviewable:end -->
