### PR TITLE
Fix build error due to missing import

### DIFF
--- a/mullvad-daemon/src/api_address_updater.rs
+++ b/mullvad-daemon/src/api_address_updater.rs
@@ -9,7 +9,7 @@ const API_IP_CHECK_ERROR_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
 pub async fn run_api_address_fetcher(address_cache: AddressCache, handle: MullvadRestHandle) {
     #[cfg(feature = "api-override")]
-    if API.disable_address_cache {
+    if mullvad_api::API.disable_address_cache {
         return;
     }
 


### PR DESCRIPTION
This PR fixes build error due to referring to a value which was not imported/qualified.
This regression was introduced in df37a0da43149c63e60ae604d4d7fefba2de9b5c.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5829)
<!-- Reviewable:end -->
