### PR TITLE
Run `clippy` with `all-features` in CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -64,7 +64,8 @@ jobs:
           RUSTFLAGS: --deny warnings
         run: |
           source env.sh
-          time cargo clippy --locked --all-targets
+          time cargo clippy --locked --all-targets --benches --tests
+          time cargo clippy --locked --all-targets --all-features --benches --tests
 
   clippy-check-android:
     name: Clippy linting, Android
@@ -86,4 +87,5 @@ jobs:
         env:
           RUSTFLAGS: --deny warnings
         run: |
-          cargo clippy --locked --target x86_64-linux-android --package mullvad-jni
+          cargo clippy --locked --target x86_64-linux-android --package mullvad-jni --benches --tests
+          cargo clippy --locked --target x86_64-linux-android --package mullvad-jni --all-features --benches --tests

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -44,6 +44,7 @@ jobs:
           RUSTFLAGS: --deny warnings
         run: |
           time cargo clippy --locked --all-targets
+          time cargo clippy --locked --all-targets --all-features
 
   clippy-check-test-windows:
     name: Clippy linting of test workspace (Windows)
@@ -71,3 +72,4 @@ jobs:
         run: |
           # Exclude checking test-manager on Windows, since it is not a supported compilation target.
           time cargo clippy  --all-targets --workspace --exclude test-manager --locked
+          time cargo clippy  --all-targets --all-features --workspace --exclude test-manager --locked


### PR DESCRIPTION
Run `clippy` with `all-features`, (and `--tests` & `benches` where applicable) in CI to get more coverage and catch more mistakes earlier. This is in addition to the old behavior to cover all possible combinations of feature flags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5831)
<!-- Reviewable:end -->
