### PR TITLE
Remove redundant relay selector updates

### DIFF
--- a/mullvad-daemon/src/custom_list.rs
+++ b/mullvad-daemon/src/custom_list.rs
@@ -54,8 +54,6 @@ where
             .map_err(Error::SettingsError);
 
         if let Ok(true) = settings_changed {
-            self.event_listener
-                .notify_settings(self.settings.to_settings());
             self.relay_selector
                 .set_config(new_selector_config(&self.settings));
 
@@ -100,8 +98,6 @@ where
             .map_err(Error::SettingsError);
 
         if let Ok(true) = settings_changed {
-            self.event_listener
-                .notify_settings(self.settings.to_settings());
             self.relay_selector
                 .set_config(new_selector_config(&self.settings));
 

--- a/mullvad-daemon/src/custom_list.rs
+++ b/mullvad-daemon/src/custom_list.rs
@@ -24,22 +24,13 @@ where
         let new_list = CustomList::new(name);
         let id = new_list.id;
 
-        let settings_changed = self
-            .settings
+        self.settings
             .update(|settings| {
                 settings.custom_lists.add(new_list);
             })
             .await
-            .map_err(Error::SettingsError);
+            .map_err(Error::SettingsError)?;
 
-        if let Ok(true) = settings_changed {
-            self.event_listener
-                .notify_settings(self.settings.to_settings());
-            self.relay_selector
-                .set_config(new_selector_config(&self.settings));
-        }
-
-        settings_changed?;
         Ok(id)
     }
 


### PR DESCRIPTION
The relay selector will be notified about settings changes already, so there is no need to apply the changes twice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5832)
<!-- Reviewable:end -->
