### PR TITLE
Remove lots of dependencies from mullvad relay selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,6 @@ dependencies = [
  "mullvad-api",
  "mullvad-types",
  "once_cell",
- "parking_lot",
  "rand 0.8.5",
  "serde_json",
  "talpid-future",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,17 +2013,13 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "err-derive",
- "futures",
  "ipnetwork",
  "log",
- "mullvad-api",
  "mullvad-types",
  "once_cell",
  "rand 0.8.5",
  "serde_json",
- "talpid-future",
  "talpid-types",
- "tokio",
 ]
 
 [[package]]

--- a/mullvad-daemon/src/relay_list/mod.rs
+++ b/mullvad-daemon/src/relay_list/mod.rs
@@ -1,0 +1,3 @@
+//! Relay list
+
+pub mod updater;

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -16,7 +16,6 @@ err-derive = { workspace = true }
 futures = "0.3"
 ipnetwork = "0.16"
 log = { workspace = true }
-parking_lot = "0.12.0"
 rand = "0.8.5"
 serde_json = "1.0"
 tokio = { workspace = true, features =  ["fs", "io-util", "time"] }

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -13,16 +13,12 @@ workspace = true
 [dependencies]
 chrono = { workspace = true }
 err-derive = { workspace = true }
-futures = "0.3"
 ipnetwork = "0.16"
 log = { workspace = true }
 rand = "0.8.5"
 serde_json = "1.0"
-tokio = { workspace = true, features =  ["fs", "io-util", "time"] }
 
-talpid-future = { path = "../talpid-future" }
 talpid-types = { path = "../talpid-types" }
-mullvad-api = { path = "../mullvad-api" }
 mullvad-types = { path = "../mullvad-types" }
 
 [dev-dependencies]

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -18,14 +18,13 @@ use mullvad_types::{
     settings::Settings,
     CustomTunnelEndpoint,
 };
-use parking_lot::{Mutex, MutexGuard};
 use rand::{seq::SliceRandom, Rng};
 use std::{
     collections::HashMap,
     io,
     net::{IpAddr, SocketAddr},
     path::Path,
-    sync::Arc,
+    sync::{Arc, Mutex, MutexGuard},
     time::{self, SystemTime},
 };
 use talpid_types::{
@@ -291,15 +290,26 @@ impl RelaySelector {
     }
 
     pub fn set_config(&mut self, config: SelectorConfig) {
-        let mut parsed_relays = self.parsed_relays.lock();
-        parsed_relays.set_overrides(&config.relay_overrides);
-        *self.config.lock() = config;
+        self.set_overrides(&config.relay_overrides);
+        let mut config_mutex = self.config.lock().unwrap();
+        *config_mutex = config;
+    }
+
+    pub fn set_relays(&self, relays: RelayList) {
+        let mut parsed_relays = self.parsed_relays.lock().unwrap();
+        parsed_relays.update(relays);
+    }
+
+    fn set_overrides(&mut self, relay_overrides: &[RelayOverride]) {
+        let mut parsed_relays = self.parsed_relays.lock().unwrap();
+        parsed_relays.set_overrides(relay_overrides);
     }
 
     /// Returns all countries and cities. The cities in the object returned does not have any
     /// relays in them.
-    pub fn get_locations(&mut self) -> RelayList {
-        self.parsed_relays.lock().original_list.clone()
+    pub fn get_relays(&mut self) -> RelayList {
+        let parsed_relays = self.parsed_relays.lock().unwrap();
+        parsed_relays.original_list.clone()
     }
 
     /// Returns a random relay and relay endpoint matching the current constraints.
@@ -314,17 +324,17 @@ impl RelaySelector {
         ),
         Error,
     > {
-        let config = self.config.lock();
-        match &config.relay_settings {
+        let config_mutex = self.config.lock().unwrap();
+        match &config_mutex.relay_settings {
             RelaySettings::CustomTunnelEndpoint(custom_relay) => {
                 Ok((SelectedRelay::Custom(custom_relay.clone()), None, None))
             }
             RelaySettings::Normal(constraints) => {
                 let relay = self.get_tunnel_endpoint(
                     constraints,
-                    config.bridge_state,
+                    config_mutex.bridge_state,
                     retry_attempt,
-                    &config.custom_lists,
+                    &config_mutex.custom_lists,
                 )?;
                 let bridge = match relay.endpoint {
                     MullvadEndpoint::OpenVpn(endpoint)
@@ -335,7 +345,12 @@ impl RelaySelector {
                             .location
                             .as_ref()
                             .expect("Relay has no location set");
-                        self.get_bridge_for(&config, location, retry_attempt, &config.custom_lists)?
+                        self.get_bridge_for(
+                            &config_mutex,
+                            location,
+                            retry_attempt,
+                            &config_mutex.custom_lists,
+                        )?
                     }
                     _ => None,
                 };
@@ -344,7 +359,7 @@ impl RelaySelector {
                         let obfuscator_relay =
                             relay.entry_relay.as_ref().unwrap_or(&relay.exit_relay);
                         self.get_obfuscator_inner(
-                            &config,
+                            &config_mutex,
                             obfuscator_relay,
                             endpoint,
                             retry_attempt,
@@ -405,7 +420,7 @@ impl RelaySelector {
         }
 
         let (openvpn_data, wireguard_data) = {
-            let relays = self.parsed_relays.lock();
+            let relays = self.parsed_relays.lock().unwrap();
             (
                 relays.parsed_list.openvpn.clone(),
                 relays.parsed_list.wireguard.clone(),
@@ -419,12 +434,14 @@ impl RelaySelector {
             custom_lists,
         );
 
-        let parsed_relays = self.parsed_relays.lock();
-        let mut matching_locations: Vec<Location> = matcher
-            .filter_matching_relay_list(parsed_relays.relays())
-            .into_iter()
-            .filter_map(|relay| relay.location)
-            .collect();
+        let mut matching_locations: Vec<Location> = {
+            let parsed_relays = self.parsed_relays.lock().unwrap();
+            matcher
+                .filter_matching_relay_list(parsed_relays.relays())
+                .into_iter()
+                .filter_map(|relay| relay.location)
+                .collect()
+        };
         matching_locations.dedup_by(|a, b| a.has_same_city(b));
 
         if matching_locations.is_empty() {
@@ -450,10 +467,10 @@ impl RelaySelector {
             ),
             providers: relay_constraints.providers.clone(),
             ownership: relay_constraints.ownership,
-            endpoint_matcher: OpenVpnMatcher::new(
-                relay_constraints.openvpn_constraints,
-                self.parsed_relays.lock().parsed_list.openvpn.clone(),
-            ),
+            endpoint_matcher: OpenVpnMatcher::new(relay_constraints.openvpn_constraints, {
+                let parsed_relays = self.parsed_relays.lock().unwrap();
+                parsed_relays.parsed_list.openvpn.clone()
+            }),
         };
 
         if relay_matcher.endpoint_matcher.constraints.port.is_any()
@@ -560,7 +577,10 @@ impl RelaySelector {
         retry_attempt: u32,
         custom_lists: &CustomListsSettings,
     ) -> Result<NormalSelectedRelay, Error> {
-        let wg_endpoint_data = self.parsed_relays.lock().parsed_list.wireguard.clone();
+        let wg_endpoint_data = {
+            let parsed_relays = self.parsed_relays.lock().unwrap();
+            parsed_relays.parsed_list.wireguard.clone()
+        };
 
         // NOTE: If not using multihop then `location` is set as the only location constraint.
         // If using multihop then location is the exit constraint and
@@ -626,7 +646,7 @@ impl RelaySelector {
         custom_lists: &CustomListsSettings,
     ) -> Result<NormalSelectedRelay, Error> {
         let (openvpn_data, wireguard_data) = {
-            let relays = self.parsed_relays.lock();
+            let relays = self.parsed_relays.lock().unwrap();
             (
                 relays.parsed_list.openvpn.clone(),
                 relays.parsed_list.wireguard.clone(),
@@ -840,10 +860,13 @@ impl RelaySelector {
         &self,
         matcher: &RelayMatcher<WireguardMatcher>,
     ) -> Result<(Relay, MullvadWireguardEndpoint), Error> {
-        let matching_relays: Vec<Relay> = matcher
-            .filter_matching_relay_list(self.parsed_relays.lock().relays())
-            .into_iter()
-            .collect();
+        let matching_relays: Vec<Relay> = {
+            let parsed_relays = self.parsed_relays.lock().unwrap();
+            matcher
+                .filter_matching_relay_list(parsed_relays.relays())
+                .into_iter()
+                .collect()
+        };
 
         let relay = self
             .pick_random_relay(&matching_relays)
@@ -917,16 +940,24 @@ impl RelaySelector {
     /// Returns a non-custom bridge based on the relay and bridge constraints, ignoring the bridge
     /// state.
     pub fn get_bridge_forced(&self) -> Option<CustomProxy> {
-        let config = self.config.lock();
+        let config = self.config.lock().unwrap();
+        // let relay_settings = {
+        //     let config = self.config.lock().unwrap();
+        //     config.relay_settings.clone()
+        // };
 
         let near_location = match &config.relay_settings {
             RelaySettings::Normal(settings) => {
-                self.get_relay_midpoint(settings, &config.custom_lists)
+                let custom_lists = {
+                    // let config = self.config.lock().unwrap();
+                    config.custom_lists.clone()
+                };
+                self.get_relay_midpoint(settings, &custom_lists)
             }
             _ => None,
         };
-
-        let constraints = match config.bridge_settings.resolve() {
+        let bridge_settings = &config.bridge_settings;
+        let constraints = match bridge_settings.resolve() {
             Ok(ResolvedBridgeSettings::Normal(settings)) => InternalBridgeConstraints {
                 location: settings.location.clone(),
                 providers: settings.providers.clone(),
@@ -941,7 +972,8 @@ impl RelaySelector {
             },
         };
 
-        self.get_proxy_settings(&constraints, near_location, &config.custom_lists)
+        let custom_lists = &config.custom_lists;
+        self.get_proxy_settings(&constraints, near_location, custom_lists)
             .map(|(settings, _relay)| settings)
     }
 
@@ -970,8 +1002,11 @@ impl RelaySelector {
             ownership: constraints.ownership,
             endpoint_matcher: BridgeMatcher(()),
         };
-        let matching_relays: Vec<Relay> =
-            matcher.filter_matching_relay_list(self.parsed_relays.lock().relays());
+
+        let matching_relays: Vec<Relay> = {
+            let parsed_relays = self.parsed_relays.lock().unwrap();
+            matcher.filter_matching_relay_list(parsed_relays.relays())
+        };
 
         if matching_relays.is_empty() {
             return None;
@@ -1021,7 +1056,9 @@ impl RelaySelector {
             self.pick_random_relay(&matching_relays).cloned()
         };
         relay.and_then(|relay| {
-            self.pick_random_bridge(&self.parsed_relays.lock().parsed_list.bridge, &relay)
+            let parsed_relays = self.parsed_relays.lock().unwrap();
+            let bridge = &parsed_relays.parsed_list.bridge;
+            self.pick_random_bridge(bridge, &relay)
                 .map(|bridge| (bridge, relay.clone()))
         })
     }
@@ -1084,12 +1121,15 @@ impl RelaySelector {
         endpoint: &MullvadWireguardEndpoint,
         retry_attempt: u32,
     ) -> Option<SelectedObfuscator> {
-        let udp2tcp_ports = &self
-            .parsed_relays
-            .lock()
-            .parsed_list
-            .wireguard
-            .udp2tcp_ports;
+        let udp2tcp_ports = {
+            &self
+                .parsed_relays
+                .lock()
+                .unwrap()
+                .parsed_list
+                .wireguard
+                .udp2tcp_ports
+        };
         let udp2tcp_endpoint = if obfuscation_settings.port.is_only() {
             udp2tcp_ports
                 .iter()
@@ -1115,18 +1155,22 @@ impl RelaySelector {
         providers: &Constraint<Providers>,
         ownership: Constraint<Ownership>,
     ) -> (Constraint<u16>, TransportProtocol, TunnelType) {
-        let parsed_relays = self.parsed_relays.lock();
-        let mut active_location_relays = parsed_relays.relays().filter(|relay| {
-            relay.active
-                && location.matches_with_opts(relay, true)
-                && providers.matches(relay)
-                && ownership.matches(relay)
-        });
-        let location_supports_wg = active_location_relays
-            .clone()
-            .any(|relay| matches!(relay.endpoint_data, RelayEndpointData::Wireguard(_)));
-        let location_supports_openvpn = active_location_relays
-            .any(|relay| matches!(relay.endpoint_data, RelayEndpointData::Openvpn));
+        let (location_supports_wg, location_supports_openvpn) = {
+            let parsed_relays = self.parsed_relays.lock().unwrap();
+            let mut active_location_relays = parsed_relays.relays().filter(|relay| {
+                relay.active
+                    && location.matches_with_opts(relay, true)
+                    && providers.matches(relay)
+                    && ownership.matches(relay)
+            });
+            let location_supports_wg = active_location_relays
+                .clone()
+                .any(|relay| matches!(relay.endpoint_data, RelayEndpointData::Wireguard(_)));
+            let location_supports_openvpn = active_location_relays
+                .any(|relay| matches!(relay.endpoint_data, RelayEndpointData::Openvpn));
+
+            (location_supports_wg, location_supports_openvpn)
+        };
         match (location_supports_wg, location_supports_openvpn) {
             (true, true) | (false, false) => Self::preferred_tunnel_constraints(retry_attempt),
             (true, false) => {
@@ -1191,10 +1235,13 @@ impl RelaySelector {
         &self,
         matcher: &RelayMatcher<T>,
     ) -> Result<NormalSelectedRelay, Error> {
-        let matching_relays: Vec<Relay> = matcher
-            .filter_matching_relay_list(self.parsed_relays.lock().relays())
-            .into_iter()
-            .collect();
+        let matching_relays: Vec<Relay> = {
+            let parsed_relays = self.parsed_relays.lock().unwrap();
+            matcher
+                .filter_matching_relay_list(parsed_relays.relays())
+                .into_iter()
+                .collect()
+        };
 
         self.pick_random_relay(&matching_relays)
             .and_then(|selected_relay| {
@@ -1264,9 +1311,15 @@ impl RelaySelector {
     }
 
     fn wireguard_exit_matcher(&self) -> WireguardMatcher {
-        let mut tunnel = WireguardMatcher::from_endpoint(
-            self.parsed_relays.lock().parsed_list.wireguard.clone(),
-        );
+        let wg = {
+            self.parsed_relays
+                .lock()
+                .unwrap()
+                .parsed_list
+                .wireguard
+                .clone()
+        };
+        let mut tunnel = WireguardMatcher::from_endpoint(wg);
         tunnel.ip_version = WIREGUARD_EXIT_IP_VERSION;
         tunnel.port = WIREGUARD_EXIT_PORT;
         tunnel
@@ -1347,7 +1400,7 @@ mod test {
             endpoint: &MullvadWireguardEndpoint,
             retry_attempt: u32,
         ) -> Result<Option<SelectedObfuscator>, Error> {
-            self.get_obfuscator_inner(&self.config.lock(), relay, endpoint, retry_attempt)
+            self.get_obfuscator_inner(&self.config.lock().unwrap(), relay, endpoint, retry_attempt)
         }
     }
 
@@ -1974,10 +2027,12 @@ mod test {
         assert!(result.entry_relay.is_none());
         assert!(matches!(result.endpoint, MullvadEndpoint::Wireguard { .. }));
 
-        relay_selector.config.lock().obfuscation_settings = ObfuscationSettings {
-            selected_obfuscation: SelectedObfuscation::Udp2Tcp,
-            ..ObfuscationSettings::default()
-        };
+        {
+            relay_selector.config.lock().unwrap().obfuscation_settings = ObfuscationSettings {
+                selected_obfuscation: SelectedObfuscation::Udp2Tcp,
+                ..ObfuscationSettings::default()
+            };
+        }
 
         let obfs_config = relay_selector
             .get_obfuscator(&result.exit_relay, result.endpoint.unwrap_wireguard(), 0)
@@ -2003,10 +2058,12 @@ mod test {
         assert!(result.entry_relay.is_none());
         assert!(matches!(result.endpoint, MullvadEndpoint::Wireguard { .. }));
 
-        relay_selector.config.lock().obfuscation_settings = ObfuscationSettings {
-            selected_obfuscation: SelectedObfuscation::Auto,
-            ..ObfuscationSettings::default()
-        };
+        {
+            relay_selector.config.lock().unwrap().obfuscation_settings = ObfuscationSettings {
+                selected_obfuscation: SelectedObfuscation::Auto,
+                ..ObfuscationSettings::default()
+            };
+        }
 
         assert!(relay_selector
             .get_obfuscator(&result.exit_relay, result.endpoint.unwrap_wireguard(), 0,)
@@ -2030,10 +2087,12 @@ mod test {
 
         const TCP2UDP_PORTS: [u16; 3] = [80, 443, 5001];
 
-        relay_selector.config.lock().obfuscation_settings = ObfuscationSettings {
-            selected_obfuscation: SelectedObfuscation::Udp2Tcp,
-            ..ObfuscationSettings::default()
-        };
+        {
+            relay_selector.config.lock().unwrap().obfuscation_settings = ObfuscationSettings {
+                selected_obfuscation: SelectedObfuscation::Udp2Tcp,
+                ..ObfuscationSettings::default()
+            };
+        }
 
         for attempt in 0..1000 {
             let result = relay_selector
@@ -2123,7 +2182,7 @@ mod test {
             Constraint::Only(TunnelType::OpenVpn),
         ] {
             {
-                let mut config = relay_selector.config.lock();
+                let mut config = relay_selector.config.lock().unwrap();
                 config.relay_settings = RelaySettings::Normal(RelayConstraints {
                     tunnel_protocol,
                     location: Constraint::Only(LocationConstraint::from(
@@ -2194,7 +2253,7 @@ mod test {
         let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
 
         {
-            let mut config = relay_selector.config.lock();
+            let mut config = relay_selector.config.lock().unwrap();
             config.bridge_state = BridgeState::Auto;
         }
 
@@ -2207,7 +2266,7 @@ mod test {
 
         // Verify that bridges are ignored when tunnel protocol is WireGuard
         {
-            let mut config = relay_selector.config.lock();
+            let mut config = relay_selector.config.lock().unwrap();
             config.relay_settings = RelaySettings::Normal(RelayConstraints {
                 tunnel_protocol: Constraint::Only(TunnelType::Wireguard),
                 ..RelayConstraints::default()

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -1789,17 +1789,12 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "err-derive",
- "futures",
  "ipnetwork 0.16.0",
  "log",
- "mullvad-api",
  "mullvad-types",
- "parking_lot 0.12.1",
  "rand 0.8.5",
  "serde_json",
- "talpid-future",
  "talpid-types",
- "tokio",
 ]
 
 [[package]]
@@ -3044,14 +3039,6 @@ dependencies = [
  "log",
  "once_cell",
  "tokio",
-]
-
-[[package]]
-name = "talpid-future"
-version = "0.0.0"
-dependencies = [
- "rand 0.8.5",
- "talpid-time",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR is one in a series of PRs which aims to make working with the relay selector easier.

The goal of this PR is to strip the relay selector of some dependencies & code where possible, trying to focus its purpose.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5837)
<!-- Reviewable:end -->
