### PR TITLE
Preliminary unit tests for key rotation in TunnelManager

### DIFF
--- a/ios/MullvadREST/ApiHandlers/RESTAccountsProxy.swift
+++ b/ios/MullvadREST/ApiHandlers/RESTAccountsProxy.swift
@@ -145,3 +145,17 @@ extension REST {
         public let number: String
     }
 }
+
+extension REST.NewAccountData {
+    public static func mockValue() -> REST.NewAccountData {
+        return REST.NewAccountData(
+            id: UUID().uuidString,
+            expiry: Date().addingTimeInterval(3600),
+            maxPorts: 2,
+            canAddPorts: false,
+            maxDevices: 5,
+            canAddDevices: false,
+            number: "1234567890123456"
+        )
+    }
+}

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -61,7 +61,8 @@ final class TunnelManager: StorePaymentObserver {
     private var networkMonitor: NWPathMonitor?
 
     private var privateKeyRotationTimer: DispatchSourceTimer?
-    private var isRunningPeriodicPrivateKeyRotation = false
+    public private(set) var isRunningPeriodicPrivateKeyRotation = false
+    public private(set) var nextKeyRotationDate: Date? = nil
 
     private var tunnelStatusPollTimer: DispatchSourceTimer?
     private var isPolling = false
@@ -144,9 +145,11 @@ final class TunnelManager: StorePaymentObserver {
 
         privateKeyRotationTimer?.cancel()
         privateKeyRotationTimer = nil
+        nextKeyRotationDate = nil
 
         guard isRunningPeriodicPrivateKeyRotation,
               let scheduleDate = getNextKeyRotationDate() else { return }
+        nextKeyRotationDate = scheduleDate
 
         let timer = DispatchSource.makeTimerSource(queue: .main)
 

--- a/ios/MullvadVPNTests/AccountsProxy+Stubs.swift
+++ b/ios/MullvadVPNTests/AccountsProxy+Stubs.swift
@@ -11,11 +11,15 @@ import Foundation
 @testable import MullvadTypes
 
 struct AccountsProxyStub: RESTAccountHandling {
+    var createAccountResult: Result<REST.NewAccountData, Error>?
     func createAccount(
         retryStrategy: REST.RetryStrategy,
         completion: @escaping MullvadREST.ProxyCompletionHandler<REST.NewAccountData>
     ) -> Cancellable {
-        AnyCancellable()
+        if let createAccountResult = createAccountResult {
+            completion(createAccountResult)
+        }
+        return AnyCancellable()
     }
 
     func getAccountData(accountNumber: String) -> any RESTRequestExecutor<Account> {

--- a/ios/MullvadVPNTests/DevicesProxy+Stubs.swift
+++ b/ios/MullvadVPNTests/DevicesProxy+Stubs.swift
@@ -12,6 +12,15 @@ import Foundation
 @testable import WireGuardKitTypes
 
 struct DevicesProxyStub: DeviceHandling {
+    let mockDevice = Device(
+        id: "device-id",
+        name: "Devicey McDeviceface",
+        pubkey: PrivateKey().publicKey,
+        hijackDNS: false,
+        created: Date(),
+        ipv4Address: IPAddressRange(from: "127.0.0.1/32")!,
+        ipv6Address: IPAddressRange(from: "::ff/64")!
+    )
     func getDevice(
         accountNumber: String,
         identifier: String,
@@ -35,7 +44,8 @@ struct DevicesProxyStub: DeviceHandling {
         retryStrategy: REST.RetryStrategy,
         completion: @escaping ProxyCompletionHandler<Device>
     ) -> Cancellable {
-        AnyCancellable()
+        completion(.success(mockDevice))
+        return AnyCancellable()
     }
 
     func deleteDevice(

--- a/ios/MullvadVPNTests/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/TunnelManagerTests.swift
@@ -6,9 +6,21 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadREST
+@testable import MullvadSettings
 import XCTest
 
 final class TunnelManagerTests: XCTestCase {
+    static let store = InMemorySettingsStore<SettingNotFound>()
+
+    override class func setUp() {
+        SettingsManager.unitTestStore = store
+    }
+
+    override class func tearDown() {
+        SettingsManager.unitTestStore = nil
+    }
+
     func testTunnelManager() {
         let application = UIApplicationStub()
         let tunnelStore = TunnelStoreStub()
@@ -17,7 +29,6 @@ final class TunnelManagerTests: XCTestCase {
         let devicesProxy = DevicesProxyStub()
         let apiProxy = APIProxyStub()
         let accessTokenManager = AccessTokenManagerStub()
-
         let tunnelManager = TunnelManager(
             application: application,
             tunnelStore: tunnelStore,
@@ -27,7 +38,54 @@ final class TunnelManagerTests: XCTestCase {
             apiProxy: apiProxy,
             accessTokenManager: accessTokenManager
         )
-
         XCTAssertNotNil(tunnelManager)
+    }
+
+    func testLogInStartsKeyRotations() async throws {
+        let application = UIApplicationStub()
+        let tunnelStore = TunnelStoreStub()
+        let relayCacheTracker = RelayCacheTrackerStub()
+        var accountProxy = AccountsProxyStub()
+        let devicesProxy = DevicesProxyStub()
+        let apiProxy = APIProxyStub()
+        let accessTokenManager = AccessTokenManagerStub()
+        accountProxy.createAccountResult = .success(REST.NewAccountData.mockValue())
+        let tunnelManager = TunnelManager(
+            application: application,
+            tunnelStore: tunnelStore,
+            relayCacheTracker: relayCacheTracker,
+            accountsProxy: accountProxy,
+            devicesProxy: devicesProxy,
+            apiProxy: apiProxy,
+            accessTokenManager: accessTokenManager
+        )
+        tunnelManager.startPeriodicPrivateKeyRotation()
+        let previousTimer = tunnelManager.nextKeyRotationDate
+        _ = try await tunnelManager.setNewAccount()
+        XCTAssertNotEqual(previousTimer, tunnelManager.nextKeyRotationDate)
+    }
+
+    func testLogOutStopsKeyRotations() async throws {
+        let application = UIApplicationStub()
+        let tunnelStore = TunnelStoreStub()
+        let relayCacheTracker = RelayCacheTrackerStub()
+        var accountProxy = AccountsProxyStub()
+        let devicesProxy = DevicesProxyStub()
+        let apiProxy = APIProxyStub()
+        let accessTokenManager = AccessTokenManagerStub()
+        accountProxy.createAccountResult = .success(REST.NewAccountData.mockValue())
+        let tunnelManager = TunnelManager(
+            application: application,
+            tunnelStore: tunnelStore,
+            relayCacheTracker: relayCacheTracker,
+            accountsProxy: accountProxy,
+            devicesProxy: devicesProxy,
+            apiProxy: apiProxy,
+            accessTokenManager: accessTokenManager
+        )
+        tunnelManager.startPeriodicPrivateKeyRotation()
+        await tunnelManager.unsetAccount()
+        // This currently fails, as isRunningPeriodicPrivateKeyRotation is not changed.
+        XCTAssertEqual(tunnelManager.isRunningPeriodicPrivateKeyRotation, false)
     }
 }


### PR DESCRIPTION
The first test (rotation timer is started on account set) works, the second one (account timer is stopped on account unset) currently doesn't.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
