### PR TITLE
Do daemon uniqueness check before rotating logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Continual excessive attempts to update the API IP were made after testing access methods.
 - Fix pointless API access method rotations for concurrent requests.
+- Fix daemon rotating logs on startup even if another daemon is already running.
 
 ### Security
 #### Android


### PR DESCRIPTION
fixes #5763 

Moved RPC uniqueness check to before logging is initialized (and log file is rotated). Consequently, this means that we won't get any log output from `runtime.build` or the uniqueness check, but that's probably fine.

Not sure how this interacts with the `initialize_firewall_and_exit` mode, needs to be tested.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5847)
<!-- Reviewable:end -->
