### PR TITLE
Fix `clippy` lint 'suspicious_open_options'

### DIFF
--- a/mullvad-exclude/src/main.rs
+++ b/mullvad-exclude/src/main.rs
@@ -94,6 +94,7 @@ fn run() -> Result<Infallible, Error> {
     let file = fs::OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(false)
         .open(procs_path)
         .map_err(Error::AddProcToCGroup)?;
 

--- a/talpid-core/src/split_tunnel/linux.rs
+++ b/talpid-core/src/split_tunnel/linux.rs
@@ -113,6 +113,7 @@ impl PidManager {
         let mut file = fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(exclusions_path)
             .map_err(Error::AddCGroupPid)?;
 
@@ -172,6 +173,7 @@ impl PidManager {
         fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(self.net_cls_path.join("cgroup.procs"))
     }
 }

--- a/test/test-runner/src/sys.rs
+++ b/test/test-runner/src/sys.rs
@@ -178,6 +178,7 @@ ExecStart=/usr/bin/mullvad-daemon --disable-stdout-timestamps {verbosity}"#
 
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(override_path)
         .await
@@ -409,6 +410,7 @@ pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), 
 
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .open(override_path)
         .await


### PR DESCRIPTION
This PR fixes `clippy` lint [suspicious_open_options](https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options) added in `1.75`.

`truncate(false)` is supposedly the default behavior, but maybe we want to change this to `true`. Thoughts?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5862)
<!-- Reviewable:end -->
