### PR TITLE
Temporarily allow `non_local_definitions` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"
+non_local_definitions = "allow" # TODO: Remove after fixing warnings generated from `err-derive`
 
 [workspace.lints.clippy]
 unused_async = "deny"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -16,6 +16,7 @@ members = [
 
 [workspace.lints.rust]
 rust_2018_idioms = "deny"
+non_local_definitions = "allow" # TODO: Remove after fixing warnings generated from `err-derive`
 
 [workspace.lints.clippy]
 unused_async = "deny"


### PR DESCRIPTION
This PR silences warnings generated from `err-derive` due to the newly introduced `non_local_definitions` lint merged into `rustc`. We are currently investigating solutions to fix the root cause of the warnings, but in the meantime CI should not fail due to this nightly-only warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5864)
<!-- Reviewable:end -->
