### PR TITLE
Ignore RUSTSEC-2023-0081

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -38,4 +38,5 @@ jobs:
           # put into removing items from the list.
           # RUSTSEC-2023-0057,RUSTSEC-2023-0058 - Unsoundness in `inventory`.
           # RUSTSEC-2023-0079 - KyberSlash in `pqc_kyber`.
-          ignore: RUSTSEC-2023-0057,RUSTSEC-2023-0058,RUSTSEC-2023-0079
+          # RUSTSEC-2023-0081 - `safemem` is unmaintained: https://github.com/ebarnard/rust-plist/pull/134
+          ignore: RUSTSEC-2023-0057,RUSTSEC-2023-0058,RUSTSEC-2023-0079,RUSTSEC-2023-0081


### PR DESCRIPTION
Temporarily ignore `RUSTSEC-2023-0081` in `cargo-audit` CI job. This should be reversed ASAP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5869)
<!-- Reviewable:end -->
