### PR TITLE
Change wireguard obfuscation default from off to auto and migrate users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add ability to import server IP overrides in GUI.
 
+### Changed
+- Change default obfuscation setting to `auto`.
+- Migrate obfuscation settings for existing users from `off` to `auto`.
+
 #### Android
 - Add support for all screen orientations.
 - Add toggle for enabling or disabling split tunneling.

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -52,6 +52,7 @@ mod v4;
 mod v5;
 mod v6;
 mod v7;
+mod v8;
 
 const SETTINGS_FILE: &str = "settings.json";
 
@@ -181,6 +182,7 @@ async fn migrate_settings(
     let migration_data = v5::migrate(settings)?;
     v6::migrate(settings)?;
     v7::migrate(settings)?;
+    v8::migrate(settings)?;
 
     Ok(migration_data)
 }

--- a/mullvad-daemon/src/migrations/v6.rs
+++ b/mullvad-daemon/src/migrations/v6.rs
@@ -16,18 +16,15 @@ pub enum QuantumResistantState {
 
 // ======================================================
 
-/// This is an open ended migration. There is no v7 yet!
-/// The migrations performed by this function are still backwards compatible.
-/// The JSON coming out of this migration can be read by any v6 compatible daemon.
-///
-/// When further migrations are needed, add them here and if they are not backwards
-/// compatible then create v7 and "close" this migration for further modification.
+/// This is a closed migration.
 ///
 /// The `use_pq_safe_psk` tunnel option is replaced by `quantum_resistant`, which
 /// is optional. `false` is mapped to `None`. `true` is mapped to `Some(true)`.
 ///
 /// Migrate WireGuard over TCP port setting away from Only(443) (to auto),
 /// since it's no longer a valid port.
+///
+/// Migrate location constraints from `GeographicLocationConstraint` to `LocationConstraint`.
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {
         return Ok(());

--- a/mullvad-daemon/src/migrations/v8.rs
+++ b/mullvad-daemon/src/migrations/v8.rs
@@ -1,0 +1,302 @@
+use super::Result;
+use mullvad_types::settings::SettingsVersion;
+
+// This migration doesn't vendor any types.
+
+/// This is a closed migraton.
+///
+/// If `ofuscation_settings.selected_obfuscation` is `off`, set it to `auto`.
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to V9");
+
+    migrate_selected_obfuscaton(settings)?;
+
+    settings["settings_version"] = serde_json::json!(SettingsVersion::V9);
+
+    Ok(())
+}
+
+fn migrate_selected_obfuscaton(settings: &mut serde_json::Value) -> Result<()> {
+    let Some(selected_obfuscation) = settings
+        .get_mut("obfuscation_settings")
+        .and_then(|obfuscation_settings| obfuscation_settings.get_mut("selected_obfuscation"))
+    else {
+        return Ok(());
+    };
+
+    if selected_obfuscation == "off" {
+        *selected_obfuscation = "auto".into();
+    }
+
+    Ok(())
+}
+
+fn version_matches(settings: &serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V8 as u64)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{migrate, migrate_selected_obfuscaton, version_matches};
+
+    pub const V8_SETTINGS: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "off",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "5b11a427-a06e-4a06-9864-0d3df7402ee4",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "bf03faf6-229e-4b1e-a7bd-32e0786ca5cb",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "settings_version": 8
+}
+"#;
+
+    pub const V9_SETTINGS: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "5b11a427-a06e-4a06-9864-0d3df7402ee4",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "bf03faf6-229e-4b1e-a7bd-32e0786ca5cb",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "settings_version": 9
+}
+"#;
+
+    #[test]
+    fn test_v8_to_v9_migration() {
+        let mut old_settings = serde_json::from_str(V8_SETTINGS).unwrap();
+
+        assert!(version_matches(&old_settings));
+        migrate(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = serde_json::from_str(V9_SETTINGS).unwrap();
+
+        assert_eq!(&old_settings, &new_settings);
+    }
+
+    /// For obfuscation_settings
+    /// obfuscation_settings: { selected_obfuscation: "on" } should be not be changed.
+    #[test]
+    fn migrate_seleted_obfuscation_from_on() {
+        let mut migrated_settings: serde_json::Value =
+            serde_json::from_str(r#"{ "obfuscation_settings": { "selected_obfuscation": "on" } }"#)
+                .unwrap();
+        let expected_settings = migrated_settings.clone();
+
+        migrate_selected_obfuscaton(&mut migrated_settings).unwrap();
+
+        assert_eq!(migrated_settings, expected_settings);
+    }
+
+    /// For obfuscation_settings
+    /// obfuscation_settings: { selected_obfuscation: "off" } should be replaced with
+    /// obfuscation_settings: { selected_obfuscation: "auto" }
+    #[test]
+    fn migrate_seleted_obfuscation_from_off() {
+        let mut migrated_settings: serde_json::Value = serde_json::from_str(
+            r#"{ "obfuscation_settings": { "selected_obfuscation": "off" } }"#,
+        )
+        .unwrap();
+        migrate_selected_obfuscaton(&mut migrated_settings).unwrap();
+
+        let expected_settings: serde_json::Value = serde_json::from_str(
+            r#"{ "obfuscation_settings": { "selected_obfuscation": "auto" } }"#,
+        )
+        .unwrap();
+
+        assert_eq!(migrated_settings, expected_settings);
+    }
+}

--- a/mullvad-daemon/src/migrations/vX.rs.template
+++ b/mullvad-daemon/src/migrations/vX.rs.template
@@ -26,7 +26,7 @@ pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     Ok(())
 }
 
-fn version_matches(settings: &mut serde_json::Value) -> bool {
+fn version_matches(settings: &serde_json::Value) -> bool {
   settings
       .get("settings_version")
       // TODO
@@ -37,7 +37,6 @@ fn version_matches(settings: &mut serde_json::Value) -> bool {
 #[cfg(test)]
 mod test {
     use super::{migrate, version_matches};
-    use serde_json;
 
     // TODO: Implement tests. Look at other migration modules for inspiration.
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -886,8 +886,8 @@ impl BridgeSettings {
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum SelectedObfuscation {
-    Auto,
     #[default]
+    Auto,
     Off,
     #[cfg_attr(feature = "clap", clap(name = "udp2tcp"))]
     Udp2Tcp,

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -21,7 +21,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V8;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V9;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -33,6 +33,7 @@ pub enum SettingsVersion {
     V6 = 6,
     V7 = 7,
     V8 = 8,
+    V9 = 9,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -48,6 +49,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V6 as u32 => Ok(SettingsVersion::V6),
             v if v == SettingsVersion::V7 as u32 => Ok(SettingsVersion::V7),
             v if v == SettingsVersion::V8 as u32 => Ok(SettingsVersion::V8),
+            v if v == SettingsVersion::V9 as u32 => Ok(SettingsVersion::V9),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),
@@ -131,7 +133,7 @@ impl Default for Settings {
             }),
             bridge_settings: BridgeSettings::default(),
             obfuscation_settings: ObfuscationSettings {
-                selected_obfuscation: SelectedObfuscation::Off,
+                selected_obfuscation: SelectedObfuscation::Auto,
                 ..Default::default()
             },
             bridge_state: BridgeState::Auto,


### PR DESCRIPTION
- Change default obfuscation setting to `auto`.
- Add settings v9 and migrate existing users settings from `off` to `auto`
- Tweak migration template
- Fix incorrect doc comment in v6.rs

`auto` should arguably have been the default from the start, so this PR intends to address that. We believe the benefit to Mullvad users from defaulting obfuscation to `auto` (which in practice will mean `on`) outweighs the potential consequences of turning obfuscation on after they have explicitly decided to turn it off.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5870)
<!-- Reviewable:end -->
