### PR TITLE
Rework side effects

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/DnsDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/DnsDialog.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,6 +21,7 @@ import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.button.NegativeButton
 import net.mullvad.mullvadvpn.compose.button.PrimaryButton
 import net.mullvad.mullvadvpn.compose.textfield.DnsTextField
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.viewmodel.DnsDialogSideEffect
@@ -100,11 +100,9 @@ fun DnsDialog(
     val viewModel =
         koinViewModel<DnsDialogViewModel>(parameters = { parametersOf(initialValue, index) })
 
-    LaunchedEffect(Unit) {
-        viewModel.uiSideEffect.collect {
-            when (it) {
-                DnsDialogSideEffect.Complete -> resultNavigator.navigateBack(result = true)
-            }
+    LaunchedEffectCollect(viewModel.uiSideEffect) {
+        when (it) {
+            DnsDialogSideEffect.Complete -> resultNavigator.navigateBack(result = true)
         }
     }
     val state by viewModel.uiState.collectAsStateWithLifecycle()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/MtuDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/MtuDialog.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -21,6 +20,7 @@ import com.ramcosta.composedestinations.spec.DestinationStyle
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.button.PrimaryButton
 import net.mullvad.mullvadvpn.compose.textfield.MtuTextField
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.constant.MTU_MAX_VALUE
 import net.mullvad.mullvadvpn.constant.MTU_MIN_VALUE
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
@@ -42,11 +42,9 @@ private fun PreviewMtuDialog() {
 fun MtuDialog(mtuInitial: Int?, navigator: DestinationsNavigator) {
     val viewModel = koinViewModel<MtuDialogViewModel>()
 
-    LaunchedEffect(Unit) {
-        viewModel.uiSideEffect.collect {
-            when (it) {
-                MtuDialogSideEffect.Complete -> navigator.navigateUp()
-            }
+    LaunchedEffectCollect(viewModel.uiSideEffect) {
+        when (it) {
+            MtuDialogSideEffect.Complete -> navigator.navigateUp()
         }
     }
     MtuDialog(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/payment/PaymentDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/payment/PaymentDialog.kt
@@ -20,6 +20,7 @@ import com.ramcosta.composedestinations.spec.DestinationStyle
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.button.PrimaryButton
 import net.mullvad.mullvadvpn.compose.component.MullvadCircularProgressIndicatorMedium
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.lib.payment.model.ProductId
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaDescription
@@ -125,12 +126,10 @@ fun Payment(productId: ProductId, resultBackNavigator: ResultBackNavigator<Boole
     val vm = koinViewModel<PaymentViewModel>()
     val state by vm.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        vm.uiSideEffect.collect {
-            when (it) {
-                is PaymentUiSideEffect.PaymentCancelled ->
-                    resultBackNavigator.navigateBack(result = false)
-            }
+    LaunchedEffectCollect(vm.uiSideEffect) {
+        when (it) {
+            is PaymentUiSideEffect.PaymentCancelled ->
+                resultBackNavigator.navigateBack(result = false)
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AccountScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AccountScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -55,6 +54,7 @@ import net.mullvad.mullvadvpn.compose.destinations.RedeemVoucherDestination
 import net.mullvad.mullvadvpn.compose.destinations.VerificationPendingDialogDestination
 import net.mullvad.mullvadvpn.compose.state.PaymentState
 import net.mullvad.mullvadvpn.compose.transitions.SlideInFromBottomTransition
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.compose.util.SecureScreenWhileInView
 import net.mullvad.mullvadvpn.lib.common.util.openAccountPageInBrowser
 import net.mullvad.mullvadvpn.lib.payment.model.PaymentProduct
@@ -171,22 +171,20 @@ fun AccountScreen(
     val clipboardManager = LocalClipboardManager.current
     val snackbarHostState = remember { SnackbarHostState() }
     val copyTextString = stringResource(id = R.string.copied_mullvad_account_number)
-    LaunchedEffect(Unit) {
-        uiSideEffect.collect { uiSideEffect ->
-            when (uiSideEffect) {
-                AccountViewModel.UiSideEffect.NavigateToLogin -> navigateToLogin()
-                is AccountViewModel.UiSideEffect.OpenAccountManagementPageInBrowser ->
-                    context.openAccountPageInBrowser(uiSideEffect.token)
-                is AccountViewModel.UiSideEffect.CopyAccountNumber ->
-                    launch {
-                        clipboardManager.setText(AnnotatedString(uiSideEffect.accountNumber))
+    LaunchedEffectCollect(uiSideEffect) { sideEffect ->
+        when (sideEffect) {
+            AccountViewModel.UiSideEffect.NavigateToLogin -> navigateToLogin()
+            is AccountViewModel.UiSideEffect.OpenAccountManagementPageInBrowser ->
+                context.openAccountPageInBrowser(sideEffect.token)
+            is AccountViewModel.UiSideEffect.CopyAccountNumber ->
+                launch {
+                    clipboardManager.setText(AnnotatedString(sideEffect.accountNumber))
 
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                            snackbarHostState.currentSnackbarData?.dismiss()
-                            snackbarHostState.showSnackbar(message = copyTextString)
-                        }
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                        snackbarHostState.currentSnackbarData?.dismiss()
+                        snackbarHostState.showSnackbar(message = copyTextString)
                     }
-            }
+                }
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
@@ -38,8 +38,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.navigation.popUpTo

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
@@ -66,6 +66,7 @@ import net.mullvad.mullvadvpn.compose.test.RECONNECT_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.SCROLLABLE_COLUMN_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.SELECT_LOCATION_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.compose.transitions.HomeTransition
+import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.constant.SECURE_ZOOM
 import net.mullvad.mullvadvpn.constant.SECURE_ZOOM_ANIMATION_MILLIS
 import net.mullvad.mullvadvpn.constant.UNSECURE_ZOOM

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -40,6 +39,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.Lifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.navigation.popUpTo
@@ -112,27 +112,28 @@ fun Connect(navigator: DestinationsNavigator) {
     val state by connectViewModel.uiState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
-    LaunchedEffect(key1 = Unit) {
-        connectViewModel.uiSideEffect.collect { uiSideEffect ->
-            when (uiSideEffect) {
-                is ConnectViewModel.UiSideEffect.OpenAccountManagementPageInBrowser -> {
-                    context.openAccountPageInBrowser(uiSideEffect.token)
-                }
-                is ConnectViewModel.UiSideEffect.OutOfTime -> {
-                    navigator.navigate(OutOfTimeDestination) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
-                }
-                ConnectViewModel.UiSideEffect.RevokedDevice -> {
-                    navigator.navigate(DeviceRevokedDestination) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
-                }
+
+    CollectSideEffectWithLifecycle(
+        connectViewModel.uiSideEffect,
+        minActiveState = Lifecycle.State.RESUMED
+    ) { sideEffect ->
+        when (sideEffect) {
+            is ConnectViewModel.UiSideEffect.OpenAccountManagementPageInBrowser -> {
+                context.openAccountPageInBrowser(sideEffect.token)
             }
+            is ConnectViewModel.UiSideEffect.OutOfTime ->
+                navigator.navigate(OutOfTimeDestination, true) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
+                }
+            ConnectViewModel.UiSideEffect.RevokedDevice ->
+                navigator.navigate(DeviceRevokedDestination, true) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
+                }
         }
     }
+
     ConnectScreen(
         state = state,
         onDisconnectClick = connectViewModel::onDisconnectClick,
@@ -140,7 +141,7 @@ fun Connect(navigator: DestinationsNavigator) {
         onConnectClick = connectViewModel::onConnectClick,
         onCancelClick = connectViewModel::onCancelClick,
         onSwitchLocationClick = {
-            navigator.navigate(SelectLocationDestination) { launchSingleTop = true }
+            navigator.navigate(SelectLocationDestination, true) { launchSingleTop = true }
         },
         onUpdateVersionClick = {
             val intent =
@@ -156,8 +157,12 @@ fun Connect(navigator: DestinationsNavigator) {
             context.startActivity(intent)
         },
         onManageAccountClick = connectViewModel::onManageAccountClick,
-        onSettingsClick = { navigator.navigate(SettingsDestination) { launchSingleTop = true } },
-        onAccountClick = { navigator.navigate(AccountDestination) { launchSingleTop = true } },
+        onSettingsClick = {
+            navigator.navigate(SettingsDestination, true) { launchSingleTop = true }
+        },
+        onAccountClick = {
+            navigator.navigate(AccountDestination, true) { launchSingleTop = true }
+        },
         onDismissNewDeviceClick = connectViewModel::dismissNewDeviceNotification,
     )
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceRevokedScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceRevokedScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -32,6 +31,7 @@ import net.mullvad.mullvadvpn.compose.component.ScaffoldWithTopBar
 import net.mullvad.mullvadvpn.compose.destinations.LoginDestination
 import net.mullvad.mullvadvpn.compose.destinations.SettingsDestination
 import net.mullvad.mullvadvpn.compose.state.DeviceRevokedUiState
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.viewmodel.DeviceRevokedSideEffect
@@ -51,16 +51,13 @@ fun DeviceRevoked(navigator: DestinationsNavigator) {
 
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        viewModel.uiSideEffect.collect { sideEffect ->
-            when (sideEffect) {
-                DeviceRevokedSideEffect.NavigateToLogin -> {
-                    navigator.navigate(LoginDestination()) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+    LaunchedEffectCollect(viewModel.uiSideEffect) { sideEffect ->
+        when (sideEffect) {
+            DeviceRevokedSideEffect.NavigateToLogin ->
+                navigator.navigate(LoginDestination()) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-            }
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/FilterScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/FilterScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -39,6 +38,7 @@ import net.mullvad.mullvadvpn.compose.extensions.itemWithDivider
 import net.mullvad.mullvadvpn.compose.extensions.itemsWithDivider
 import net.mullvad.mullvadvpn.compose.state.RelayFilterState
 import net.mullvad.mullvadvpn.compose.transitions.SlideInFromRightTransition
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.model.Ownership
@@ -72,11 +72,9 @@ fun FilterScreen(navigator: DestinationsNavigator) {
     val viewModel = koinViewModel<FilterViewModel>()
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        viewModel.uiSideEffect.collect {
-            when (it) {
-                FilterScreenSideEffect.CloseScreen -> navigator.navigateUp()
-            }
+    LaunchedEffectCollect(viewModel.uiSideEffect) {
+        when (it) {
+            FilterScreenSideEffect.CloseScreen -> navigator.navigateUp()
         }
     }
     FilterScreen(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
@@ -80,6 +80,7 @@ import net.mullvad.mullvadvpn.compose.util.accountTokenVisualTransformation
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaTopBar
+import net.mullvad.mullvadvpn.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.viewmodel.LoginUiSideEffect
 import net.mullvad.mullvadvpn.viewmodel.LoginViewModel
 import org.koin.androidx.compose.koinViewModel
@@ -131,32 +132,27 @@ fun Login(
         }
     }
 
-    LaunchedEffect(Unit) {
-        vm.uiSideEffect.collect {
-            when (it) {
-                LoginUiSideEffect.NavigateToWelcome -> {
-                    navigator.navigate(WelcomeDestination) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+    CollectSideEffectWithLifecycle(vm.uiSideEffect) {
+        when (it) {
+            LoginUiSideEffect.NavigateToWelcome ->
+                navigator.navigate(WelcomeDestination) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-                is LoginUiSideEffect.NavigateToConnect -> {
-                    navigator.navigate(ConnectDestination) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+            is LoginUiSideEffect.NavigateToConnect ->
+                navigator.navigate(ConnectDestination) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-                is LoginUiSideEffect.TooManyDevices -> {
-                    navigator.navigate(DeviceListDestination(it.accountToken.value)) {
-                        launchSingleTop = true
-                    }
+            is LoginUiSideEffect.TooManyDevices ->
+                navigator.navigate(DeviceListDestination(it.accountToken.value)) {
+                    launchSingleTop = true
                 }
-                LoginUiSideEffect.NavigateToOutOfTime ->
-                    navigator.navigate(OutOfTimeDestination) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
-            }
+            LoginUiSideEffect.NavigateToOutOfTime ->
+                navigator.navigate(OutOfTimeDestination) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
+                }
         }
     }
     LoginScreen(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
@@ -80,7 +80,6 @@ import net.mullvad.mullvadvpn.compose.util.accountTokenVisualTransformation
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaTopBar
-import net.mullvad.mullvadvpn.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.viewmodel.LoginUiSideEffect
 import net.mullvad.mullvadvpn.viewmodel.LoginViewModel
 import org.koin.androidx.compose.koinViewModel

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
@@ -75,6 +75,7 @@ import net.mullvad.mullvadvpn.compose.test.LOGIN_INPUT_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LOGIN_TITLE_TEST_TAG
 import net.mullvad.mullvadvpn.compose.textfield.mullvadWhiteTextFieldColors
 import net.mullvad.mullvadvpn.compose.transitions.LoginTransition
+import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.compose.util.accountTokenVisualTransformation
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/OutOfTimeScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/OutOfTimeScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,6 +21,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
@@ -46,6 +46,7 @@ import net.mullvad.mullvadvpn.compose.extensions.createOpenAccountPageHook
 import net.mullvad.mullvadvpn.compose.state.OutOfTimeUiState
 import net.mullvad.mullvadvpn.compose.test.OUT_OF_TIME_SCREEN_TITLE_TEST_TAG
 import net.mullvad.mullvadvpn.compose.transitions.HomeTransition
+import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.lib.payment.model.ProductId
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
@@ -135,18 +136,15 @@ fun OutOfTime(
     }
 
     val openAccountPage = LocalUriHandler.current.createOpenAccountPageHook()
-    LaunchedEffect(Unit) {
-        vm.uiSideEffect.collect { uiSideEffect ->
-            when (uiSideEffect) {
-                is OutOfTimeViewModel.UiSideEffect.OpenAccountView ->
-                    openAccountPage(uiSideEffect.token)
-                OutOfTimeViewModel.UiSideEffect.OpenConnectScreen -> {
-                    navigator.navigate(ConnectDestination) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+    CollectSideEffectWithLifecycle(vm.uiSideEffect, Lifecycle.State.RESUMED) { uiSideEffect ->
+        when (uiSideEffect) {
+            is OutOfTimeViewModel.UiSideEffect.OpenAccountView ->
+                openAccountPage(uiSideEffect.token)
+            OutOfTimeViewModel.UiSideEffect.OpenConnectScreen ->
+                navigator.navigate(ConnectDestination) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-            }
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ReportProblemScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ReportProblemScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -42,6 +41,7 @@ import net.mullvad.mullvadvpn.compose.destinations.ReportProblemNoEmailDialogDes
 import net.mullvad.mullvadvpn.compose.destinations.ViewLogsDestination
 import net.mullvad.mullvadvpn.compose.textfield.mullvadWhiteTextFieldColors
 import net.mullvad.mullvadvpn.compose.transitions.SlideInFromRightTransition
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.compose.util.SecureScreenWhileInView
 import net.mullvad.mullvadvpn.dataproxy.SendProblemReportResult
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
@@ -102,13 +102,10 @@ fun ReportProblem(
     val vm = koinViewModel<ReportProblemViewModel>()
     val state by vm.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        vm.uiSideEffect.collect {
-            when (it) {
-                is ReportProblemSideEffect.ShowConfirmNoEmail -> {
-                    navigator.navigate(ReportProblemNoEmailDialogDestination)
-                }
-            }
+    LaunchedEffectCollect(vm.uiSideEffect) {
+        when (it) {
+            is ReportProblemSideEffect.ShowConfirmNoEmail ->
+                navigator.navigate(ReportProblemNoEmailDialogDestination)
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
@@ -51,6 +51,7 @@ import net.mullvad.mullvadvpn.compose.state.SelectLocationUiState
 import net.mullvad.mullvadvpn.compose.test.CIRCULAR_PROGRESS_INDICATOR
 import net.mullvad.mullvadvpn.compose.textfield.SearchTextField
 import net.mullvad.mullvadvpn.compose.transitions.SelectLocationTransition
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaScrollbar
@@ -86,11 +87,9 @@ private fun PreviewSelectLocationScreen() {
 fun SelectLocation(navigator: DestinationsNavigator) {
     val vm = koinViewModel<SelectLocationViewModel>()
     val state by vm.uiState.collectAsStateWithLifecycle()
-    LaunchedEffect(Unit) {
-        vm.uiSideEffect.collect {
-            when (it) {
-                SelectLocationSideEffect.CloseScreen -> navigator.navigateUp()
-            }
+    LaunchedEffectCollect(vm.uiSideEffect) {
+        when (it) {
+            SelectLocationSideEffect.CloseScreen -> navigator.navigateUp()
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
@@ -99,7 +99,7 @@ fun SelectLocation(navigator: DestinationsNavigator) {
         onSelectRelay = vm::selectRelay,
         onSearchTermInput = vm::onSearchTermInput,
         onBackClick = navigator::navigateUp,
-        onFilterClick = { navigator.navigate(FilterScreenDestination) },
+        onFilterClick = { navigator.navigate(FilterScreenDestination, true) },
         removeOwnershipFilter = vm::removeOwnerFilter,
         removeProviderFilter = vm::removeProviderFilter
     )

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SplashScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SplashScreen.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn.compose.screen
 
-import android.window.SplashScreen
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.compositeOver
@@ -54,36 +52,30 @@ private fun PreviewLoadingScreen() {
 fun Splash(navigator: DestinationsNavigator) {
     val viewModel: SplashViewModel = koinViewModel()
 
-    LaunchedEffect(Unit) {
-        viewModel.uiSideEffect.collect {
-            when (it) {
-                SplashUiSideEffect.NavigateToConnect -> {
-                    navigator.navigate(ConnectDestination) {
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+    // We use CollectSideEffectWithLifecycle to re-evaluate the splash decision if the user
+    // navigates away from the app to the resume before we leave the splash screen
+    CollectSideEffectWithLifecycle(viewModel.uiSideEffect) {
+        when (it) {
+            SplashUiSideEffect.NavigateToConnect ->
+                navigator.navigate(ConnectDestination) {
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-                SplashUiSideEffect.NavigateToLogin -> {
-                    navigator.navigate(LoginDestination()) {
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+            SplashUiSideEffect.NavigateToLogin ->
+                navigator.navigate(LoginDestination()) {
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-                SplashUiSideEffect.NavigateToPrivacyDisclaimer -> {
-                    navigator.navigate(PrivacyDisclaimerDestination) { popUpTo(NavGraphs.root) {} }
+            SplashUiSideEffect.NavigateToPrivacyDisclaimer ->
+                navigator.navigate(PrivacyDisclaimerDestination) { popUpTo(NavGraphs.root) {} }
+            SplashUiSideEffect.NavigateToRevoked ->
+                navigator.navigate(DeviceRevokedDestination) {
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-                SplashUiSideEffect.NavigateToRevoked -> {
-                    navigator.navigate(DeviceRevokedDestination) {
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+            SplashUiSideEffect.NavigateToOutOfTime ->
+                navigator.navigate(OutOfTimeDestination) {
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-                SplashUiSideEffect.NavigateToOutOfTime ->
-                    navigator.navigate(OutOfTimeDestination) {
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
-            }
         }
     }
-
-    LaunchedEffect(Unit) { viewModel.start() }
 
     SplashScreen()
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SplashScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SplashScreen.kt
@@ -33,6 +33,7 @@ import net.mullvad.mullvadvpn.compose.destinations.LoginDestination
 import net.mullvad.mullvadvpn.compose.destinations.OutOfTimeDestination
 import net.mullvad.mullvadvpn.compose.destinations.PrivacyDisclaimerDestination
 import net.mullvad.mullvadvpn.compose.transitions.DefaultTransition
+import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaDescription

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,6 +74,7 @@ import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_WIREGUARD_CUSTOM_PORT_NUMBE
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_WIREGUARD_CUSTOM_PORT_TEXT_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_WIREGUARD_PORT_ITEM_X_TEST_TAG
 import net.mullvad.mullvadvpn.compose.transitions.SlideInFromRightTransition
+import net.mullvad.mullvadvpn.compose.util.LaunchedEffectCollect
 import net.mullvad.mullvadvpn.constant.WIREGUARD_PRESET_PORTS
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
@@ -158,17 +158,15 @@ fun VpnSettings(
     }
 
     val snackbarHostState = remember { SnackbarHostState() }
-    LaunchedEffect(Unit) {
-        vm.uiSideEffect.collect {
-            when (it) {
-                is VpnSettingsSideEffect.ShowToast ->
-                    launch {
-                        snackbarHostState.currentSnackbarData?.dismiss()
-                        snackbarHostState.showSnackbar(message = it.message)
-                    }
-                VpnSettingsSideEffect.NavigateToDnsDialog ->
-                    navigator.navigate(DnsDialogDestination(null, null)) { launchSingleTop = true }
-            }
+    LaunchedEffectCollect(vm.uiSideEffect) {
+        when (it) {
+            is VpnSettingsSideEffect.ShowToast ->
+                launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
+                    snackbarHostState.showSnackbar(message = it.message)
+                }
+            VpnSettingsSideEffect.NavigateToDnsDialog ->
+                navigator.navigate(DnsDialogDestination(null, null)) { launchSingleTop = true }
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/WelcomeScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/WelcomeScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -26,6 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
@@ -50,6 +50,7 @@ import net.mullvad.mullvadvpn.compose.destinations.VerificationPendingDialogDest
 import net.mullvad.mullvadvpn.compose.state.PaymentState
 import net.mullvad.mullvadvpn.compose.state.WelcomeUiState
 import net.mullvad.mullvadvpn.compose.transitions.HomeTransition
+import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.compose.util.createCopyToClipboardHandle
 import net.mullvad.mullvadvpn.lib.common.util.groupWithSpaces
 import net.mullvad.mullvadvpn.lib.common.util.openAccountPageInBrowser
@@ -126,18 +127,17 @@ fun Welcome(
     }
 
     val context = LocalContext.current
-    LaunchedEffect(Unit) {
-        vm.uiSideEffect.collect { uiSideEffect ->
-            when (uiSideEffect) {
-                is WelcomeViewModel.UiSideEffect.OpenAccountView ->
-                    context.openAccountPageInBrowser(uiSideEffect.token)
-                WelcomeViewModel.UiSideEffect.OpenConnectScreen -> {
-                    navigator.navigate(ConnectDestination) {
-                        launchSingleTop = true
-                        popUpTo(NavGraphs.root) { inclusive = true }
-                    }
+
+    CollectSideEffectWithLifecycle(sideEffect = vm.uiSideEffect, Lifecycle.State.RESUMED) {
+        uiSideEffect ->
+        when (uiSideEffect) {
+            is WelcomeViewModel.UiSideEffect.OpenAccountView ->
+                context.openAccountPageInBrowser(uiSideEffect.token)
+            WelcomeViewModel.UiSideEffect.OpenConnectScreen ->
+                navigator.navigate(ConnectDestination) {
+                    launchSingleTop = true
+                    popUpTo(NavGraphs.root) { inclusive = true }
                 }
-            }
         }
     }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/Effect.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/Effect.kt
@@ -22,13 +22,15 @@ inline fun <T> LaunchedEffectCollect(
 @Composable
 inline fun <T> CollectSideEffectWithLifecycle(
     sideEffect: Flow<T>,
-    key: Any = Unit,
     minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+    key: Any? = Unit,
     crossinline collector: suspend CoroutineScope.(T) -> Unit
 ) {
-    val lifecycle = LocalLifecycleOwner.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-    LaunchedEffect(lifecycle, key) {
-        sideEffect.flowWithLifecycle(lifecycle.lifecycle, minActiveState).collect { collector(it) }
+    LaunchedEffect(lifecycleOwner, key) {
+        sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle, minActiveState).collect {
+            collector(it)
+        }
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/Effect.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/Effect.kt
@@ -1,0 +1,34 @@
+package net.mullvad.mullvadvpn.compose.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+inline fun <T> LaunchedEffectCollect(
+    sideEffect: Flow<T>,
+    key: Any = Unit,
+    crossinline collector: suspend CoroutineScope.(T) -> Unit
+) {
+    LaunchedEffect(key) { sideEffect.collect { collector(it) } }
+}
+
+// This function will restart collection on Start/Stop events, e.g if the user navigates to home
+// screen collection will stop, and then be restarted when the user opens the app again
+@Composable
+inline fun <T> CollectSideEffectWithLifecycle(
+    sideEffect: Flow<T>,
+    key: Any = Unit,
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+    crossinline collector: suspend CoroutineScope.(T) -> Unit
+) {
+    val lifecycle = LocalLifecycleOwner.current
+
+    LaunchedEffect(lifecycle, key) {
+        sideEffect.flowWithLifecycle(lifecycle.lifecycle, minActiveState).collect { collector(it) }
+    }
+}

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -108,7 +108,7 @@ val uiModule = module {
     single { NewDeviceNotificationUseCase(get()) }
     single { PortRangeUseCase(get()) }
     single { RelayListUseCase(get(), get()) }
-    single { OutOfTimeUseCase(get(), get()) }
+    single { OutOfTimeUseCase(get(), get(), MainScope()) }
     single { ConnectivityUseCase(get()) }
     single { SystemVpnSettingsUseCase(androidContext()) }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -154,7 +154,7 @@ val uiModule = module {
     viewModel { SplashViewModel(get(), get(), get()) }
     viewModel { VoucherDialogViewModel(get(), get()) }
     viewModel { VpnSettingsViewModel(get(), get(), get(), get(), get()) }
-    viewModel { WelcomeViewModel(get(), get(), get(), get(), get(), isPlayBuild = IS_PLAY_BUILD) }
+    viewModel { WelcomeViewModel(get(), get(), get(), get(), isPlayBuild = IS_PLAY_BUILD) }
     viewModel { ReportProblemViewModel(get(), get()) }
     viewModel { ViewLogsViewModel(get()) }
     viewModel { OutOfTimeViewModel(get(), get(), get(), get(), get(), isPlayBuild = IS_PLAY_BUILD) }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/usecase/OutOfTimeUseCase.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/usecase/OutOfTimeUseCase.kt
@@ -1,12 +1,18 @@
 package net.mullvad.mullvadvpn.usecase
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import net.mullvad.mullvadvpn.lib.ipc.Event
 import net.mullvad.mullvadvpn.lib.ipc.MessageHandler
 import net.mullvad.mullvadvpn.lib.ipc.events
@@ -16,21 +22,19 @@ import net.mullvad.mullvadvpn.repository.AccountRepository
 import net.mullvad.talpid.tunnel.ErrorStateCause
 import org.joda.time.DateTime
 
-const val accountRefreshIntervalMillis = 60L * 1000L // 1 minute
-const val bufferTimeMillis = 60L * 1000L // 1 minute
-
 class OutOfTimeUseCase(
     private val repository: AccountRepository,
-    private val messageHandler: MessageHandler
+    private val messageHandler: MessageHandler,
+    scope: CoroutineScope
 ) {
 
-    fun isOutOfTime(): Flow<Boolean?> =
+    val isOutOfTime: StateFlow<Boolean?> =
         combine(pastAccountExpiry(), isTunnelBlockedBecauseOutOfTime()) {
                 accountExpiryHasPast,
                 tunnelOutOfTime ->
                 reduce(accountExpiryHasPast, tunnelOutOfTime)
             }
-            .distinctUntilChanged()
+            .stateIn(scope, SharingStarted.Eagerly, null)
 
     private fun reduce(vararg outOfTimeProperty: Boolean?): Boolean? =
         when {
@@ -42,7 +46,7 @@ class OutOfTimeUseCase(
             else -> null
         }
 
-    private fun isTunnelBlockedBecauseOutOfTime() =
+    private fun isTunnelBlockedBecauseOutOfTime(): Flow<Boolean> =
         messageHandler
             .events<Event.TunnelStateChange>()
             .map { it.tunnelState.isTunnelErrorStateDueToExpiredAccount() }
@@ -54,23 +58,22 @@ class OutOfTimeUseCase(
     }
 
     private fun pastAccountExpiry(): Flow<Boolean?> =
-        combine(
-            repository.accountExpiryState.map {
+        repository.accountExpiryState
+            .flatMapLatest {
                 if (it is AccountExpiry.Available) {
-                    it.date()
+                    flow {
+                        val millisUntilExpiry = it.expiryDateTime.millis - DateTime.now().millis
+                        if (millisUntilExpiry > 0) {
+                            emit(false)
+                            delay(millisUntilExpiry)
+                            emit(true)
+                        } else {
+                            emit(true)
+                        }
+                    }
                 } else {
-                    null
+                    flowOf<Boolean?>(null)
                 }
-            },
-            timeFlow()
-        ) { expiryDate, time ->
-            expiryDate?.isBefore(time.plus(bufferTimeMillis))
-        }
-
-    private fun timeFlow() = flow {
-        while (true) {
-            emit(DateTime.now())
-            delay(accountRefreshIntervalMillis)
-        }
-    }
+            }
+            .distinctUntilChanged()
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/AccountViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/AccountViewModel.kt
@@ -3,7 +3,6 @@ package net.mullvad.mullvadvpn.viewmodel
 import android.app.Activity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -30,7 +29,7 @@ class AccountViewModel(
     deviceRepository: DeviceRepository,
     private val isPlayBuild: Boolean,
 ) : ViewModel() {
-    private val _uiSideEffect = Channel<UiSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<UiSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     val uiState: StateFlow<AccountUiState> =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceListViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceListViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -36,7 +35,7 @@ class DeviceListViewModel(
 ) : ViewModel() {
     private val _loadingDevices = MutableStateFlow<List<DeviceId>>(emptyList())
 
-    private val _uiSideEffect = Channel<DeviceListSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<DeviceListSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     private var cachedDeviceList: List<Device>? = null

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceRevokedViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flatMapLatest
@@ -46,7 +45,7 @@ class DeviceRevokedViewModel(
                 initialValue = DeviceRevokedUiState.UNKNOWN
             )
 
-    private val _uiSideEffect = Channel<DeviceRevokedSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<DeviceRevokedSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     fun onGoToLoginClicked() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DnsDialogViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DnsDialogViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import java.net.InetAddress
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -81,7 +80,7 @@ class DnsDialogViewModel(
                 createViewState(_ipAddressInput.value, vmState.value)
             )
 
-    private val _uiSideEffect = Channel<DnsDialogSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<DnsDialogSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     private fun createViewState(ipAddress: String, vmState: DnsDialogViewModelState) =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/FilterViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/FilterViewModel.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -24,7 +23,7 @@ import net.mullvad.mullvadvpn.usecase.RelayListFilterUseCase
 class FilterViewModel(
     private val relayListFilterUseCase: RelayListFilterUseCase,
 ) : ViewModel() {
-    private val _uiSideEffect = Channel<FilterScreenSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<FilterScreenSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     private val selectedOwnership = MutableStateFlow<Ownership?>(null)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/MtuDialogViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/MtuDialogViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -16,7 +15,7 @@ class MtuDialogViewModel(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
 
-    private val _uiSideEffect = Channel<MtuDialogSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<MtuDialogSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     fun onSaveClick(mtuValue: Int) =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/PrivacyDisclaimerViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/PrivacyDisclaimerViewModel.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -19,8 +18,7 @@ class PrivacyDisclaimerViewModel(
     private val _uiState = MutableStateFlow(PrivacyDisclaimerViewState(false))
     val uiState = _uiState
 
-    private val _uiSideEffect =
-        Channel<PrivacyDisclaimerUiSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<PrivacyDisclaimerUiSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     fun setPrivacyDisclosureAccepted() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ReportProblemViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ReportProblemViewModel.kt
@@ -3,7 +3,6 @@ package net.mullvad.mullvadvpn.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,7 +55,7 @@ class ReportProblemViewModel(
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ReportProblemUiState())
 
-    private val _uiSideEffect = Channel<ReportProblemSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<ReportProblemSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     fun sendReport(email: String, description: String, skipEmptyEmailCheck: Boolean = false) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SelectLocationViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SelectLocationViewModel.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -82,7 +81,7 @@ class SelectLocationViewModel(
                 SelectLocationUiState.Loading
             )
 
-    private val _uiSideEffect = Channel<SelectLocationSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<SelectLocationSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     init {
@@ -93,7 +92,7 @@ class SelectLocationViewModel(
         val locationConstraint = relayItem.toLocationConstraint()
         relayListUseCase.updateSelectedRelayLocation(locationConstraint)
         serviceConnectionManager.connectionProxy()?.connect()
-        viewModelScope.launch { _uiSideEffect.send(SelectLocationSideEffect.CloseScreen) }
+        _uiSideEffect.trySend(SelectLocationSideEffect.CloseScreen)
     }
 
     fun onSearchTermInput(searchTerm: String) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/VpnSettingsViewModel.kt
@@ -8,7 +8,6 @@ import java.net.InetAddress
 import java.net.UnknownHostException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -54,7 +53,7 @@ class VpnSettingsViewModel(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
 
-    private val _uiSideEffect = Channel<VpnSettingsSideEffect>(1, BufferOverflow.DROP_OLDEST)
+    private val _uiSideEffect = Channel<VpnSettingsSideEffect>()
     val uiSideEffect = _uiSideEffect.receiveAsFlow()
 
     private val customPort = MutableStateFlow<Constraint<Port>?>(null)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModel.kt
@@ -14,7 +14,9 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -27,7 +29,6 @@ import net.mullvad.mullvadvpn.ui.serviceconnection.ConnectionProxy
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionState
 import net.mullvad.mullvadvpn.ui.serviceconnection.authTokenCache
-import net.mullvad.mullvadvpn.usecase.OutOfTimeUseCase
 import net.mullvad.mullvadvpn.usecase.PaymentUseCase
 import net.mullvad.mullvadvpn.util.UNKNOWN_STATE_DEBOUNCE_DELAY_MILLISECONDS
 import net.mullvad.mullvadvpn.util.addDebounceForUnknownState
@@ -40,12 +41,11 @@ class WelcomeViewModel(
     private val deviceRepository: DeviceRepository,
     private val serviceConnectionManager: ServiceConnectionManager,
     private val paymentUseCase: PaymentUseCase,
-    private val outOfTimeUseCase: OutOfTimeUseCase,
     private val pollAccountExpiry: Boolean = true,
     private val isPlayBuild: Boolean
 ) : ViewModel() {
     private val _uiSideEffect = Channel<UiSideEffect>()
-    val uiSideEffect = merge(_uiSideEffect.receiveAsFlow(), notOutOfTimeEffect())
+    val uiSideEffect = merge(_uiSideEffect.receiveAsFlow(), hasAddedTimeEffect())
 
     val uiState =
         serviceConnectionManager.connectionState
@@ -86,13 +86,12 @@ class WelcomeViewModel(
         fetchPaymentAvailability()
     }
 
-    private fun notOutOfTimeEffect() =
-        outOfTimeUseCase.isOutOfTime
-            .filter { it == false }
-            .map {
-                paymentUseCase.resetPurchaseResult()
-                UiSideEffect.OpenConnectScreen
-            }
+    private fun hasAddedTimeEffect() =
+        accountRepository.accountExpiryState
+            .mapNotNull { it.date() }
+            .filter { it.minusHours(MIN_HOURS_PAST_ACCOUNT_EXPIRY).isAfterNow }
+            .onEach { paymentUseCase.resetPurchaseResult() }
+            .map { UiSideEffect.OpenConnectScreen }
 
     private fun ConnectionProxy.tunnelUiStateFlow(): Flow<TunnelState> =
         callbackFlowFromNotifier(this.onUiStateChange)
@@ -143,5 +142,9 @@ class WelcomeViewModel(
         data class OpenAccountView(val token: String) : UiSideEffect
 
         data object OpenConnectScreen : UiSideEffect
+    }
+
+    companion object {
+        private const val MIN_HOURS_PAST_ACCOUNT_EXPIRY = 20
     }
 }

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/OutOfTimeUseCaseTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/OutOfTimeUseCaseTest.kt
@@ -3,10 +3,19 @@ package net.mullvad.mullvadvpn.usecase
 import app.cash.turbine.test
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.unmockkAll
 import kotlin.test.assertEquals
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlin.time.Duration.Companion.days
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import net.mullvad.mullvadvpn.lib.ipc.Event
 import net.mullvad.mullvadvpn.lib.ipc.MessageHandler
 import net.mullvad.mullvadvpn.lib.ipc.events
@@ -16,6 +25,7 @@ import net.mullvad.mullvadvpn.repository.AccountRepository
 import net.mullvad.talpid.tunnel.ErrorState
 import net.mullvad.talpid.tunnel.ErrorStateCause
 import org.joda.time.DateTime
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -23,106 +33,194 @@ class OutOfTimeUseCaseTest {
     private val mockAccountRepository: AccountRepository = mockk()
     private val mockMessageHandler: MessageHandler = mockk()
 
-    private val events = MutableSharedFlow<Event.TunnelStateChange>()
-    private val expiry = MutableStateFlow<AccountExpiry>(AccountExpiry.Missing)
+    private lateinit var events: Channel<Event.TunnelStateChange>
+    private lateinit var expiry: MutableStateFlow<AccountExpiry>
 
-    lateinit var outOfTimeUseCase: OutOfTimeUseCase
+    private val dispatcher = StandardTestDispatcher()
+    private val scope = TestScope(dispatcher)
+
+    private lateinit var outOfTimeUseCase: OutOfTimeUseCase
 
     @BeforeEach
     fun setup() {
+        events = Channel()
+        expiry = MutableStateFlow(AccountExpiry.Missing)
         every { mockAccountRepository.accountExpiryState } returns expiry
-        every { mockMessageHandler.events<Event.TunnelStateChange>() } returns events
-        outOfTimeUseCase = OutOfTimeUseCase(mockAccountRepository, mockMessageHandler)
+        every { mockMessageHandler.events<Event.TunnelStateChange>() } returns
+            events.receiveAsFlow()
+
+        Dispatchers.setMain(dispatcher)
+
+        outOfTimeUseCase =
+            OutOfTimeUseCase(mockAccountRepository, mockMessageHandler, scope.backgroundScope)
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+        unmockkAll()
     }
 
     @Test
-    fun `no events should result in no expiry`() = runTest {
-        // Arrange
-        // Act, Assert
-        outOfTimeUseCase.isOutOfTime().test { assertEquals(null, awaitItem()) }
-    }
-
-    @Test
-    fun `tunnel is blocking because out of time should emit true`() = runTest {
-        // Arrange
-        // Act, Assert
-        val errorStateCause = ErrorStateCause.AuthFailed("[EXPIRED_ACCOUNT]")
-        val tunnelStateError = TunnelState.Error(ErrorState(errorStateCause, true))
-        val errorChange = Event.TunnelStateChange(tunnelStateError)
-
-        outOfTimeUseCase.isOutOfTime().test {
-            assertEquals(null, awaitItem())
-            events.emit(errorChange)
-            assertEquals(true, awaitItem())
+    fun `no events should result in no expiry`() =
+        scope.runTest {
+            // Arrange
+            // Act, Assert
+            outOfTimeUseCase.isOutOfTime.test { assertEquals(null, awaitItem()) }
         }
-    }
 
     @Test
-    fun `tunnel is connected should emit false`() = runTest {
+    fun `tunnel is blocking because out of time should emit true`() =
+        scope.runTest {
+            // Arrange
+            // Act, Assert
+            val errorStateCause = ErrorStateCause.AuthFailed("[EXPIRED_ACCOUNT]")
+            val tunnelStateError = TunnelState.Error(ErrorState(errorStateCause, true))
+            val errorChange = Event.TunnelStateChange(tunnelStateError)
+
+            outOfTimeUseCase.isOutOfTime.test {
+                assertEquals(null, awaitItem())
+                events.send(errorChange)
+                assertEquals(true, awaitItem())
+            }
+        }
+
+    @Test
+    fun `tunnel is connected should emit false`() =
+        scope.runTest {
+            // Arrange
+            val expiredAccountExpiry = AccountExpiry.Available(DateTime.now().plusDays(1))
+            val tunnelStateChanges =
+                listOf(
+                        TunnelState.Disconnected(),
+                        TunnelState.Connected(mockk(), null),
+                        TunnelState.Connecting(null, null),
+                        TunnelState.Disconnecting(mockk()),
+                        TunnelState.Error(ErrorState(ErrorStateCause.StartTunnelError, false)),
+                    )
+                    .map(Event::TunnelStateChange)
+
+            // Act, Assert
+            outOfTimeUseCase.isOutOfTime.test {
+                assertEquals(null, awaitItem())
+                events.send(tunnelStateChanges.first())
+                expiry.emit(expiredAccountExpiry)
+                assertEquals(false, awaitItem())
+
+                tunnelStateChanges.forEach { events.send(it) }
+
+                // Should not emit again
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `account expiry that has expired should emit true`() =
+        scope.runTest {
+            // Arrange
+            val expiredAccountExpiry = AccountExpiry.Available(DateTime.now().minusDays(1))
+            // Act, Assert
+            outOfTimeUseCase.isOutOfTime.test {
+                assertEquals(null, awaitItem())
+                expiry.emit(expiredAccountExpiry)
+                assertEquals(true, awaitItem())
+            }
+        }
+
+    @Test
+    fun `account expiry that has not expired should emit false`() =
+        scope.runTest {
+            // Arrange
+            val notExpiredAccountExpiry = AccountExpiry.Available(DateTime.now().plusDays(1))
+
+            // Act, Assert
+            outOfTimeUseCase.isOutOfTime.test {
+                assertEquals(null, awaitItem())
+                expiry.emit(notExpiredAccountExpiry)
+                assertEquals(false, awaitItem())
+            }
+        }
+
+    @Test
+    fun `account that expires without new expiry event should emit true`() =
+        runTest(dispatcher) {
+            // Arrange
+            val expiredAccountExpiry = AccountExpiry.Available(DateTime.now().plusSeconds(100))
+            // Act, Assert
+            outOfTimeUseCase.isOutOfTime.test {
+                // Initial event
+                assertEquals(null, awaitItem())
+
+                expiry.emit(expiredAccountExpiry)
+                assertEquals(false, awaitItem())
+
+                // After 50 seconds we should still not emitted out of time
+                advanceTimeBy(50_000)
+                expectNoEvents()
+
+                // After additional 50 seconds we should be out of time since account is now expired
+                advanceTimeBy(50_000)
+                assertEquals(true, awaitItem())
+            }
+        }
+
+    @Test
+    fun `account that is about to expire but is refilled should emit false`() = runTest {
         // Arrange
-        val expiredAccountExpiry = AccountExpiry.Available(DateTime.now().plusDays(1))
-        val tunnelStateChanges =
-            listOf(
-                    TunnelState.Disconnected(),
-                    TunnelState.Connected(mockk(), null),
-                    TunnelState.Connecting(null, null),
-                    TunnelState.Disconnecting(mockk()),
-                    TunnelState.Error(ErrorState(ErrorStateCause.StartTunnelError, false)),
-                )
-                .map(Event::TunnelStateChange)
+        val initialAccountExpiry = AccountExpiry.Available(DateTime.now().plusSeconds(100))
+        val updatedExpiry =
+            AccountExpiry.Available(initialAccountExpiry.expiryDateTime.plusDays(30))
 
         // Act, Assert
-        outOfTimeUseCase.isOutOfTime().test {
+        outOfTimeUseCase.isOutOfTime.test {
+            // Initial event
             assertEquals(null, awaitItem())
-            events.emit(tunnelStateChanges.first())
-            expiry.emit(expiredAccountExpiry)
+
+            expiry.emit(initialAccountExpiry)
             assertEquals(false, awaitItem())
+            advanceTimeBy(90_000)
+            expectNoEvents()
 
-            tunnelStateChanges.forEach { events.emit(it) }
+            // User fills up with more time 30 seconds before expiry
+            expiry.emit(updatedExpiry)
+            advanceTimeBy(1.days)
+            expectNoEvents()
 
-            // Should not emit again
+            // Expect no more emissions while user has time.
+            advanceTimeBy(29.days)
+            assertEquals(true, awaitItem())
             expectNoEvents()
         }
     }
 
     @Test
-    fun `account expiry that has expired should emit true`() = runTest {
+    fun `expired account that is refilled should emit false`() = runTest {
         // Arrange
-        val expiredAccountExpiry = AccountExpiry.Available(DateTime.now().minusDays(1))
+        val initialAccountExpiry = AccountExpiry.Available(DateTime.now().plusSeconds(100))
+        val updatedExpiry =
+            AccountExpiry.Available(initialAccountExpiry.expiryDateTime.plusDays(30))
         // Act, Assert
-        outOfTimeUseCase.isOutOfTime().test {
-            assertEquals(null, awaitItem())
-            expiry.emit(expiredAccountExpiry)
-            assertEquals(true, awaitItem())
-        }
-    }
-
-    @Test
-    fun `account expiry that has not expired should emit false`() = runTest {
-        // Arrange
-        val expiredAccountExpiry = AccountExpiry.Available(DateTime.now().plusDays(1))
-
-        // Act, Assert
-        outOfTimeUseCase.isOutOfTime().test {
-            assertEquals(null, awaitItem())
-            expiry.emit(expiredAccountExpiry)
-            assertEquals(false, awaitItem())
-        }
-    }
-
-    @Test
-    fun `account that expires without new expiry event should emit true`() = runTest {
-        // Arrange
-        val expiredAccountExpiry = AccountExpiry.Available(DateTime.now().plusSeconds(62))
-
-        // Act, Assert
-        outOfTimeUseCase.isOutOfTime().test {
+        outOfTimeUseCase.isOutOfTime.test {
             // Initial event
             assertEquals(null, awaitItem())
 
-            expiry.emit(expiredAccountExpiry)
+            expiry.emit(initialAccountExpiry)
             assertEquals(false, awaitItem())
+
+            // After 100 seconds we expire
+            advanceTimeBy(100_000)
             assertEquals(true, awaitItem())
+            expectNoEvents()
+
+            // We then fill up our account and should no longer be out of time
+            expiry.emit(updatedExpiry)
+            assertEquals(false, awaitItem())
+            expectNoEvents()
+
+            // Advance the time to the updated expiry
+            advanceTimeBy(30.days)
+            assertEquals(true, awaitItem())
+            expectNoEvents()
         }
     }
 }

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModelTest.kt
@@ -132,7 +132,7 @@ class ConnectViewModelTest {
         // Flows
         every { mockRelayListUseCase.selectedRelayItem() } returns selectedRelayItemFlow
 
-        every { outOfTimeUseCase.isOutOfTime() } returns outOfTimeViewFlow
+        every { outOfTimeUseCase.isOutOfTime } returns outOfTimeViewFlow
         viewModel =
             ConnectViewModel(
                 serviceConnectionManager = mockServiceConnectionManager,

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/OutOfTimeViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/OutOfTimeViewModelTest.kt
@@ -89,7 +89,7 @@ class OutOfTimeViewModelTest {
 
         coEvery { mockPaymentUseCase.paymentAvailability } returns paymentAvailabilityFlow
 
-        coEvery { mockOutOfTimeUseCase.isOutOfTime() } returns outOfTimeFlow
+        coEvery { mockOutOfTimeUseCase.isOutOfTime } returns outOfTimeFlow
 
         viewModel =
             OutOfTimeViewModel(

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
@@ -87,7 +87,7 @@ class WelcomeViewModelTest {
 
         coEvery { mockPaymentUseCase.paymentAvailability } returns paymentAvailabilityFlow
 
-        coEvery { mockOutOfTimeUseCase.isOutOfTime() } returns outOfTimeFlow
+        coEvery { mockOutOfTimeUseCase.isOutOfTime } returns outOfTimeFlow
 
         viewModel =
             WelcomeViewModel(

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
@@ -32,11 +32,9 @@ import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionContainer
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionState
 import net.mullvad.mullvadvpn.ui.serviceconnection.authTokenCache
-import net.mullvad.mullvadvpn.usecase.OutOfTimeUseCase
 import net.mullvad.mullvadvpn.usecase.PaymentUseCase
 import net.mullvad.talpid.util.EventNotifier
 import org.joda.time.DateTime
-import org.joda.time.ReadableInstant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -51,7 +49,6 @@ class WelcomeViewModelTest {
     private val accountExpiryStateFlow = MutableStateFlow<AccountExpiry>(AccountExpiry.Missing)
     private val purchaseResultFlow = MutableStateFlow<PurchaseResult?>(null)
     private val paymentAvailabilityFlow = MutableStateFlow<PaymentAvailability?>(null)
-    private val outOfTimeFlow = MutableStateFlow(true)
 
     // Service connections
     private val mockServiceConnectionContainer: ServiceConnectionContainer = mockk()
@@ -64,7 +61,6 @@ class WelcomeViewModelTest {
     private val mockDeviceRepository: DeviceRepository = mockk()
     private val mockServiceConnectionManager: ServiceConnectionManager = mockk()
     private val mockPaymentUseCase: PaymentUseCase = mockk(relaxed = true)
-    private val mockOutOfTimeUseCase: OutOfTimeUseCase = mockk(relaxed = true)
 
     private lateinit var viewModel: WelcomeViewModel
 
@@ -87,15 +83,12 @@ class WelcomeViewModelTest {
 
         coEvery { mockPaymentUseCase.paymentAvailability } returns paymentAvailabilityFlow
 
-        coEvery { mockOutOfTimeUseCase.isOutOfTime } returns outOfTimeFlow
-
         viewModel =
             WelcomeViewModel(
                 accountRepository = mockAccountRepository,
                 deviceRepository = mockDeviceRepository,
                 serviceConnectionManager = mockServiceConnectionManager,
                 paymentUseCase = mockPaymentUseCase,
-                outOfTimeUseCase = mockOutOfTimeUseCase,
                 pollAccountExpiry = false,
                 isPlayBuild = false
             )
@@ -164,19 +157,16 @@ class WelcomeViewModelTest {
         }
 
     @Test
-    fun `when OutOfTimeUseCase return false uiSideEffect should emit OpenConnectScreen`() =
-        runTest {
-            // Arrange
-            val mockExpiryDate: DateTime = mockk()
-            every { mockExpiryDate.isAfter(any<ReadableInstant>()) } returns true
+    fun `when user has added time then uiSideEffect should emit OpenConnectScreen`() = runTest {
+        // Arrange
+        accountExpiryStateFlow.emit(AccountExpiry.Available(DateTime().plusDays(1)))
 
-            // Act, Assert
-            viewModel.uiSideEffect.test {
-                outOfTimeFlow.value = false
-                val action = awaitItem()
-                assertIs<WelcomeViewModel.UiSideEffect.OpenConnectScreen>(action)
-            }
+        // Act, Assert
+        viewModel.uiSideEffect.test {
+            val action = awaitItem()
+            assertIs<WelcomeViewModel.UiSideEffect.OpenConnectScreen>(action)
         }
+    }
 
     @Test
     fun `when paymentAvailability emits ProductsUnavailable uiState should include state NoPayment`() =

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountExpiryMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountExpiryMockApiTest.kt
@@ -10,7 +10,6 @@ import net.mullvad.mullvadvpn.test.mockapi.constant.DUMMY_DEVICE_NAME_2
 import net.mullvad.mullvadvpn.test.mockapi.constant.DUMMY_ID_2
 import net.mullvad.mullvadvpn.test.mockapi.util.currentUtcTimeWithOffsetZero
 import net.mullvad.mullvadvpn.util.toExpiryDateString
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class AccountExpiryMockApiTest : MockApiTest() {
@@ -50,10 +49,6 @@ class AccountExpiryMockApiTest : MockApiTest() {
     }
 
     @Test
-    @Disabled(
-        "Disabled since we have a bug in the app that makes it unstable. " +
-            "We can restore it after the bug has been fixed"
-    )
     fun testAccountTimeExpiredWhileUsingTheAppShouldShowOutOfTimeScreen() {
         // Arrange
         val validAccountToken = "1234123412341234"


### PR DESCRIPTION
Summary: This PR fixes some sideeffect issues we've seen. E.g when Navigation to the Account view, and OutOfTime view overriding and showing instead. It does this by reworking the OutOfTimeUseCase and rewriting how we handle side effects.

Details:
We have different ways side effects happens in our app here are some unique examples:
- User action caused effect (user does an action, which then may or may not result in side effect, e.g conditional navigation)
- Delayed effect (user does an action, but may result in a delayed effect, e.g in the Login screen, user logs in but then navigation happens after 1 seconds of us showing success screen)
- External effect (External component causes a side effect to happen, e.g user happens to become OutOfTime)

These types of side effects needs to be taken into consideration and discussions made on a case by case basis. This PR changes so we no longer buffer old side effects and then at a later time accidentally executes them. We then have to choose when executing a side effect if we want it to be blocking (`send`) or non-blocking as an attempt (`trySend`)

The biggest changes to this PR is:

`Connect Screen`, `Welcome`, `OutOfTime`, we now expect that, when subscribing to side effects, all side effects that can happen should emit at subscription. Previously the subscription of e.g OutOfTime happened on view model init, this is now moved to the subscription of `uiSideEffects`. This means if we stop subscribe (e.g because we are navigating away, the event will still be able to be consumed once we resume the view (e.g come back from account view)

`LoginScreen`: We no longer depend on the value being buffered but rather `send` blocking.

`Splash Screen`: We now re-evaluate on each Resume which destination we should go to. Edge case scenario, if user opens app, quickly closes it, come back it to a later stage, event though we never left the splash screen the destination was already evaluated and then invoked when user already left the app. Now we will re-evaluate when the splash screen is opened.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5873)
<!-- Reviewable:end -->
