### PR TITLE
Relay selector evaluates only first location constraint when a custom list is selected

### DIFF
--- a/ios/MullvadREST/Relay/RelaySelector.swift
+++ b/ios/MullvadREST/Relay/RelaySelector.swift
@@ -136,7 +136,7 @@ public enum RelaySelector {
     }
 
     /// Produce a list of `RelayWithLocation` items satisfying the given constraints
-    private static func applyConstraints<T: AnyRelay>(
+    static func applyConstraints<T: AnyRelay>(
         _ constraints: RelayConstraints,
         relays: [RelayWithLocation<T>]
     ) -> [RelayWithLocation<T>] {
@@ -154,24 +154,10 @@ public enum RelaySelector {
             case .any:
                 return true
             case let .only(relayConstraint):
-                for location in relayConstraint.locations {
-                    switch location {
-                    case let .country(countryCode):
-                        return relayWithLocation.serverLocation.countryCode == countryCode &&
-                            relayWithLocation.relay.includeInCountry
-
-                    case let .city(countryCode, cityCode):
-                        return relayWithLocation.serverLocation.countryCode == countryCode &&
-                            relayWithLocation.serverLocation.cityCode == cityCode
-
-                    case let .hostname(countryCode, cityCode, hostname):
-                        return relayWithLocation.serverLocation.countryCode == countryCode &&
-                            relayWithLocation.serverLocation.cityCode == cityCode &&
-                            relayWithLocation.relay.hostname == hostname
-                    }
+                // At least one location must match the relay under test.
+                return relayConstraint.locations.contains { location in
+                    relayWithLocation.matches(location: location)
                 }
-
-                return false
             }
         }.filter { relayWithLocation -> Bool in
             relayWithLocation.relay.active
@@ -310,9 +296,26 @@ public struct RelaySelectorResult: Codable, Equatable {
     public var location: Location
 }
 
-private struct RelayWithLocation<T: AnyRelay> {
+struct RelayWithLocation<T: AnyRelay> {
     let relay: T
     let serverLocation: Location
+
+    func matches(location: RelayLocation) -> Bool {
+        switch location {
+        case let .country(countryCode):
+            serverLocation.countryCode == countryCode &&
+                relay.includeInCountry
+
+        case let .city(countryCode, cityCode):
+            serverLocation.countryCode == countryCode &&
+                serverLocation.cityCode == cityCode
+
+        case let .hostname(countryCode, cityCode, hostname):
+            serverLocation.countryCode == countryCode &&
+                serverLocation.cityCode == cityCode &&
+                relay.hostname == hostname
+        }
+    }
 }
 
 private struct RelayWithDistance<T: AnyRelay> {

--- a/ios/MullvadVPNTests/ServerRelaysResponse+Stubs.swift
+++ b/ios/MullvadVPNTests/ServerRelaysResponse+Stubs.swift
@@ -63,6 +63,12 @@ enum ServerRelaysResponseStubs {
                 latitude: 32.89748,
                 longitude: -97.040443
             ),
+            "us-nyc": REST.ServerLocation(
+                country: "USA",
+                city: "New York, NY",
+                latitude: 40.6963302,
+                longitude: -74.6034843
+            ),
         ],
         wireguard: REST.ServerWireguardTunnels(
             ipv4Gateway: .loopback,


### PR DESCRIPTION
Fixes the bug by evaluating all locations before returning the result.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5874)
<!-- Reviewable:end -->
