### PR TITLE
Test logging out

### DIFF
--- a/ios/MullvadVPN/View controllers/Alert/AlertViewController.swift
+++ b/ios/MullvadVPN/View controllers/Alert/AlertViewController.swift
@@ -108,10 +108,8 @@ class AlertViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.accessibilityIdentifier = presentation.accessibilityIdentifier ?? .alertContainerView
         view.backgroundColor = .black.withAlphaComponent(0.5)
-
-        let accessibilityIdentifier = presentation.accessibilityIdentifier ?? .alertContainerView
-        view.accessibilityIdentifier = accessibilityIdentifier
 
         setContent()
         setConstraints()

--- a/ios/MullvadVPNUITests/AccountTests.swift
+++ b/ios/MullvadVPNUITests/AccountTests.swift
@@ -72,4 +72,21 @@ class AccountTests: LoggedOutUITestCase {
             .verifyFailIconShown()
             .waitForPageToBeShown() // Verify still on login page
     }
+
+    func testLogOut() throws {
+        let newAccountNumber = try MullvadAPIWrapper().createAccount()
+        login(accountNumber: newAccountNumber)
+        XCTAssertEqual(try MullvadAPIWrapper().getDevices(newAccountNumber).count, 1)
+
+        HeaderBar(app)
+            .tapAccountButton()
+
+        AccountPage(app)
+            .tapLogOutButton()
+
+        LoginPage(app)
+
+        XCTAssertEqual(try MullvadAPIWrapper().getDevices(newAccountNumber).count, 0)
+        try MullvadAPIWrapper().deleteAccount(newAccountNumber)
+    }
 }

--- a/ios/MullvadVPNUITests/MullvadApi.swift
+++ b/ios/MullvadVPNUITests/MullvadApi.swift
@@ -32,6 +32,16 @@ struct InitMutableBufferError: Error {
     let description = "Failed to allocate memory for mutable buffer"
 }
 
+struct Device {
+    let name: String
+    let id: UUID
+
+    init(device_struct: MullvadApiDevice) {
+        name = String(cString: device_struct.name_ptr)
+        id = UUID(uuid: device_struct.id)
+    }
+}
+
 /// - Warning: Do not change the `apiAddress` or the `hostname` after the time `MullvadApi.init` has been invoked
 /// The Mullvad API crate is using a global static variable to store those. They will be initialized only once.
 ///
@@ -111,16 +121,6 @@ class MullvadApi {
 
     deinit {
         mullvad_api_client_drop(clientContext)
-    }
-
-    struct Device {
-        let name: String
-        let id: UUID
-
-        init(device_struct: MullvadApiDevice) {
-            name = String(cString: device_struct.name_ptr)
-            id = UUID(uuid: device_struct.id)
-        }
     }
 
     class DeviceIterator {

--- a/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
+++ b/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
@@ -95,4 +95,12 @@ class MullvadAPIWrapper {
             throw MullvadAPIError.requestError
         }
     }
+
+    func getDevices(_ account: String) throws -> [Device] {
+        do {
+            return try mullvadAPI.listDevices(forAccount: account)
+        } catch {
+            throw MullvadAPIError.requestError
+        }
+    }
 }


### PR DESCRIPTION
Note that this PR builds upon changes from https://github.com/mullvad/mullvadvpn-app/pull/5855 so not ready for review until it has been merged and marked as draft for now.

Introduced log out test which validates that device is created when logging in and removed when logging out. Note that the implementation slightly differs from the issue description in Linear because the issue mentions reading the device name but the implementation don't. I think it wouldn't serve any purpose since the test makes sure that one device is created and then removed?

To test the changes run `testLogOut` under `AccountTests`.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5878)
<!-- Reviewable:end -->
