### PR TITLE
Fix LocationDataSource crash in MockRelease build

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
@@ -26,7 +26,10 @@ final class LocationDataSource: UITableViewDiffableDataSource<SelectLocationSect
         customLists: LocationDataSourceProtocol
     ) {
         self.tableView = tableView
+
+        #if DEBUG
         self.dataSources.append(customLists)
+        #endif
         self.dataSources.append(allLocations)
 
         let locationCellFactory = LocationCellFactory(
@@ -76,14 +79,16 @@ final class LocationDataSource: UITableViewDiffableDataSource<SelectLocationSect
                 .map { LocationCellViewModel(group: group, location: $0) }
         }
 
-        updateDataSnapshot(with: list, reloadExisting: !searchString.isEmpty)
-
-        if searchString.isEmpty {
-            setSelectedRelayLocation(selectedRelayLocation, animated: false, completion: {
-                self.scrollToSelectedRelay()
-            })
-        } else {
-            scrollToTop(animated: false)
+        updateDataSnapshot(with: list, reloadExisting: !searchString.isEmpty) {
+            DispatchQueue.main.async {
+                if searchString.isEmpty {
+                    self.setSelectedRelayLocation(self.selectedRelayLocation, animated: false, completion: {
+                        self.scrollToSelectedRelay()
+                    })
+                } else {
+                    self.scrollToTop(animated: false)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
In `setRelays(_ response: REST.ServerRelaysResponse, filter: RelayFilter)` we construct a list of item lists by looking at the number of data sources (2) and then try to index match with all section cases (1). This causes an index overflow.

Fix for the above, plus fix for row scrolling being slightly off.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5886)
<!-- Reviewable:end -->
