### PR TITLE
Remove buildconfig from properties

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -122,7 +122,10 @@ android {
         }
     }
 
-    buildFeatures { compose = true }
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
 
     composeOptions { kotlinCompilerExtensionVersion = Versions.kotlinCompilerExtensionVersion }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,4 @@
 android.enableR8.fullMode=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.useAndroidX=true
 kotlin.code.style=official

--- a/android/lib/endpoint/build.gradle.kts
+++ b/android/lib/endpoint/build.gradle.kts
@@ -22,6 +22,9 @@ android {
         abortOnError = true
         warningsAsErrors = true
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies { implementation(Dependencies.Kotlin.stdlib) }

--- a/android/lib/map/build.gradle.kts
+++ b/android/lib/map/build.gradle.kts
@@ -20,7 +20,10 @@ android {
         jvmTarget = Versions.jvmTarget
     }
 
-    buildFeatures { compose = true }
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
 
     composeOptions { kotlinCompilerExtensionVersion = Versions.kotlinCompilerExtensionVersion }
 

--- a/android/service/build.gradle.kts
+++ b/android/service/build.gradle.kts
@@ -44,6 +44,9 @@ android {
             buildConfigField("String", "API_ENDPOINT", "\"api.stagemole.eu\"")
         }
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/android/test/e2e/build.gradle.kts
+++ b/android/test/e2e/build.gradle.kts
@@ -97,6 +97,9 @@ android {
                 )
         }
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 androidComponents {


### PR DESCRIPTION
Perform migration of buildconfig in `gradle.properties` to use `buildFeatures` block instead

 <!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5887)
<!-- Reviewable:end -->
