### PR TITLE
Updated iOS end to end tests workflow condition

### DIFF
--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -10,6 +10,9 @@ on:
       - closed
     branches:
       - main
+    paths:
+      - .github/workflows/ios-end-to-end-tests.yml
+      - ios/**
   workflow_dispatch:
 jobs:
   test:


### PR DESCRIPTION
Updated iOS end to end tests workflow to only be triggered on merge to main when any file under `ios` or the workflow file itself has changed.

Have verified it to be working as expected by creating a PR in my fork changing `README.md` in root directory which didn't trigger the workflow and created a PR changing `AccountTests.swift` under `ios` directory which did trigger the workflow to run.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
