### PR TITLE
Force environment variables when running on iOS

### DIFF
--- a/ios/MullvadVPNUITests/MullvadApi.swift
+++ b/ios/MullvadVPNUITests/MullvadApi.swift
@@ -32,6 +32,9 @@ struct InitMutableBufferError: Error {
     let description = "Failed to allocate memory for mutable buffer"
 }
 
+/// - Warning: Do not change the `apiAddress` or the `hostname` after the time `MullvadApi.init` has been invoked
+/// The Mullvad API crate is using a global static variable to store those. They will be initialized only once.
+///
 class MullvadApi {
     private var clientContext = MullvadApiClient()
 

--- a/mullvad-api/src/ffi/mod.rs
+++ b/mullvad-api/src/ffi/mod.rs
@@ -68,6 +68,10 @@ impl FfiClient {
             )
         })?;
 
+        std::env::set_var(crate::env::API_HOST_VAR, &api_hostname);
+        std::env::set_var(crate::env::API_ADDR_VAR, &addr_str);
+        std::env::set_var(crate::env::API_FORCE_DIRECT_VAR, "0");
+        std::env::set_var(crate::env::DISABLE_TLS_VAR, "0");
         let mut runtime_builder = tokio::runtime::Builder::new_multi_thread();
 
         runtime_builder.worker_threads(2).enable_all();

--- a/mullvad-api/src/ffi/mod.rs
+++ b/mullvad-api/src/ffi/mod.rs
@@ -68,6 +68,8 @@ impl FfiClient {
             )
         })?;
 
+        // The call site guarantees that
+        // api_hostname and api_address will never change after the first call to new.
         std::env::set_var(crate::env::API_HOST_VAR, &api_hostname);
         std::env::set_var(crate::env::API_ADDR_VAR, &addr_str);
         std::env::set_var(crate::env::API_FORCE_DIRECT_VAR, "0");


### PR DESCRIPTION
This PR tricks rust into believing environment variables have been set properly when running on iOS. 

With this, we can then add the `--features` flag when building crates for iOS to allow overriding the API when running in a staging environment for example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5899)
<!-- Reviewable:end -->
