### PR TITLE
Make the 'Clear all overrides' button only active when there are overrides

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideInteractor.swift
@@ -11,10 +11,11 @@ import MullvadLogging
 import MullvadSettings
 import MullvadTypes
 
-struct IPOverrideInteractor {
+final class IPOverrideInteractor {
     private let logger = Logger(label: "IPOverrideInteractor")
     private let repository: IPOverrideRepositoryProtocol
     private let tunnelManager: TunnelManager
+    private var statusWorkItem: DispatchWorkItem?
 
     private let statusSubject = CurrentValueSubject<IPOverrideStatus, Never>(.noImports)
     var statusPublisher: AnyPublisher<IPOverrideStatus, Never> {
@@ -87,8 +88,14 @@ struct IPOverrideInteractor {
     }
 
     private func resetToDefaultStatus(delay: Duration = .zero) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay.timeInterval) {
-            statusSubject.send(defaultStatus)
+        statusWorkItem?.cancel()
+
+        let statusWorkItem = DispatchWorkItem { [weak self] in
+            guard let self, self.statusWorkItem?.isCancelled == false else { return }
+            self.statusSubject.send(self.defaultStatus)
         }
+        self.statusWorkItem = statusWorkItem
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay.timeInterval, execute: statusWorkItem)
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideStatus.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideStatus.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-enum IPOverrideStatus: CustomStringConvertible {
+enum IPOverrideStatus: Equatable, CustomStringConvertible {
     case active, noImports, importSuccessful(Context), importFailed(Context)
 
     enum Context {

--- a/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideViewController.swift
@@ -66,6 +66,7 @@ class IPOverrideViewController: UIViewController {
 
         interactor.statusPublisher.sink { [weak self] status in
             self?.statusView.setStatus(status)
+            self?.clearButton.isEnabled = self?.interactor.defaultStatus == .active
         }.store(in: &cancellables)
     }
 


### PR DESCRIPTION
Currently, the button is always active. According to the specs, we should make sure it is not active if there are no overrides being enabled.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5912)
<!-- Reviewable:end -->
