### PR TITLE
routing: update nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -2193,19 +2199,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.1"
-source = "git+https://github.com/nix-rust/nix?rev=b13b7d18e0d2f4a8c05e41576c7ebf26d6dbfb28#b13b7d18e0d2f4a8c05e41576c7ebf26d6dbfb28"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.8.0",
- "pin-utils",
- "static_assertions",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -2213,6 +2206,19 @@ dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -3433,12 +3439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,7 +3678,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-sys",
- "nix 0.26.1",
+ "nix 0.28.0",
  "once_cell",
  "rtnetlink",
  "system-configuration",

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -28,8 +28,7 @@ netlink-packet-route = { version = "0.13", features = ["rich_nlas"] }
 netlink-sys = "0.8.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# TODO: The PF socket type isn't released yet
-nix = { git = "https://github.com/nix-rust/nix", rev = "b13b7d18e0d2f4a8c05e41576c7ebf26d6dbfb28", features = ["socket"] }
+nix = { version = "0.28", features = ["socket", "fs", "net"] }
 libc = "0.2"
 bitflags = "1.2"
 system-configuration = "0.5.1"

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -307,7 +307,7 @@ fn is_active_interface(interface_name: &str, family: Family) -> io::Result<bool>
             if let Some(addr) = addr.address {
                 // Check if family matches; ignore if link-local address
                 match family {
-                    Family::V4 => matches!(addr.as_sockaddr_in(), Some(addr_in) if is_routable_v4(&Ipv4Addr::from(addr_in.ip()))),
+                    Family::V4 => matches!(addr.as_sockaddr_in(), Some(addr_in) if is_routable_v4(&addr_in.ip())),
                     Family::V6 => {
                         matches!(addr.as_sockaddr_in6(), Some(addr_in) if is_routable_v6(&addr_in.ip()))
                     }


### PR DESCRIPTION
This PR bumps nix to the latest 0.28 and also fixes `OwnedFd` to `File` fiddling as Rust now supports the relevant `From` trait. Also replaced esoteric `std::os::unix::prelude` includes with `std::os::fd`, hope that doesn't break Linux builds in any way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5913)
<!-- Reviewable:end -->
