### PR TITLE
routing: update bitflags to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3671,7 +3671,7 @@ dependencies = [
 name = "talpid-routing"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "futures",
  "ipnetwork",
  "libc",

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -31,7 +31,7 @@ netlink-sys = "0.8.3"
 # TODO: The PF socket type isn't released yet
 nix = { git = "https://github.com/nix-rust/nix", rev = "b13b7d18e0d2f4a8c05e41576c7ebf26d6dbfb28", features = ["socket"] }
 libc = "0.2"
-bitflags = "1.2"
+bitflags = "2"
 system-configuration = "0.5.1"
 
 

--- a/talpid-routing/src/unix/macos/data.rs
+++ b/talpid-routing/src/unix/macos/data.rs
@@ -655,6 +655,7 @@ impl Interface {
 bitflags::bitflags! {
     /// All enum values of address flags can be iterated via `flag <<= 1`, starting from 1.
     /// See https://www.manpagez.com/man/4/route/.
+    #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
     pub struct AddressFlag: i32 {
         /// Destination socket address
         const RTA_DST       = 0x1;
@@ -678,6 +679,7 @@ bitflags::bitflags! {
 bitflags::bitflags! {
     /// Types of routing messages
     /// See https://www.manpagez.com/man/4/route/.
+    #[derive(Debug)]
     pub struct MessageType: u8 {
         /// Add Route
         const RTM_ADD         = 0x1;
@@ -715,6 +717,7 @@ bitflags::bitflags! {
 
     /// Routing message flags
     /// See https://www.manpagez.com/man/4/route/.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct RouteFlag: i32 {
         /// route usable
         const RTF_UP = 0x1;


### PR DESCRIPTION
Bitflags 1.x is five years old. It's time to dust it off and bump it to version 2.