### PR TITLE
Fix filter screen selection

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/FilterConstrainExtensions.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/FilterConstrainExtensions.kt
@@ -17,11 +17,11 @@ fun Ownership?.toOwnershipConstraint(): Constraint<Ownership> =
         else -> Constraint.Only(this)
     }
 
-fun Constraint<Providers>.toSelectedProviders(allProviders: List<Provider>): List<Provider>? =
+fun Constraint<Providers>.toSelectedProviders(allProviders: List<Provider>): List<Provider> =
     when (this) {
-        is Constraint.Any -> null
+        is Constraint.Any -> allProviders
         is Constraint.Only ->
-            this.value.providers.toList().mapNotNull { providerName ->
+            value.providers.toList().mapNotNull { providerName ->
                 allProviders.firstOrNull { it.name == providerName }
             }
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/FilterViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/FilterViewModel.kt
@@ -39,7 +39,7 @@ class FilterViewModel(
                     ) { allProviders, selectedConstraintProviders ->
                         selectedConstraintProviders.toSelectedProviders(allProviders)
                     }
-                    .first() ?: emptyList()
+                    .first()
 
             val ownershipConstraint = relayListFilterUseCase.selectedOwnership().first()
             selectedOwnership.value = ownershipConstraint.toNullableOwnership()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SelectLocationViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SelectLocationViewModel.kt
@@ -48,11 +48,15 @@ class SelectLocationViewModel(
                 selectedConstraintProviders ->
                 val selectedOwnershipItem = selectedOwnership.toNullableOwnership()
                 val selectedProvidersCount =
-                    filterSelectedProvidersByOwnership(
-                            selectedConstraintProviders.toSelectedProviders(allProviders),
-                            selectedOwnershipItem
-                        )
-                        ?.size
+                    when (selectedConstraintProviders) {
+                        is Constraint.Any -> null
+                        is Constraint.Only ->
+                            filterSelectedProvidersByOwnership(
+                                    selectedConstraintProviders.toSelectedProviders(allProviders),
+                                    selectedOwnershipItem
+                                )
+                                .size
+                    }
 
                 val filteredRelayCountries =
                     relayCountries.filterOnSearchTerm(searchTerm, selectedItem)
@@ -97,15 +101,13 @@ class SelectLocationViewModel(
     }
 
     private fun filterSelectedProvidersByOwnership(
-        selectedProviders: List<Provider>?,
+        selectedProviders: List<Provider>,
         selectedOwnership: Ownership?
-    ): List<Provider>? =
-        selectedProviders?.let {
-            when (selectedOwnership) {
-                Ownership.MullvadOwned -> selectedProviders.filter { it.mullvadOwned }
-                Ownership.Rented -> selectedProviders.filterNot { it.mullvadOwned }
-                else -> selectedProviders
-            }
+    ): List<Provider> =
+        when (selectedOwnership) {
+            Ownership.MullvadOwned -> selectedProviders.filter { it.mullvadOwned }
+            Ownership.Rented -> selectedProviders.filterNot { it.mullvadOwned }
+            else -> selectedProviders
         }
 
     fun removeOwnerFilter() {


### PR DESCRIPTION
This PR fixes a regression where entering the filter screen did not select all provider by default when `Constraint` was `Any`

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5920)
<!-- Reviewable:end -->
