### PR TITLE
Remove unused error variants in routing::unix::Error

### DIFF
--- a/talpid-routing/src/unix/mod.rs
+++ b/talpid-routing/src/unix/mod.rs
@@ -7,7 +7,7 @@ use futures::channel::{
     mpsc::{self, UnboundedSender},
     oneshot,
 };
-use std::{collections::HashSet, io, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use futures::stream::Stream;
@@ -41,12 +41,6 @@ pub enum Error {
     /// Platform specific error occurred
     #[error("Internal route manager error")]
     PlatformError(#[from] imp::Error),
-    /// Failed to spawn route manager future
-    #[error("Failed to spawn route manager on the provided executor")]
-    FailedToSpawnManager,
-    /// Failed to spawn route manager runtime
-    #[error("Failed to spawn route manager runtime")]
-    FailedToSpawnRuntime(#[from] io::Error),
     /// Attempt to use route manager that has been dropped
     #[error("Cannot send message to route manager since it is down")]
     RouteManagerDown,


### PR DESCRIPTION
Couldn't find any references for them, seems like a leftover from a prior work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5922)
<!-- Reviewable:end -->
