### PR TITLE
Add -disableAutomaticPackageResolution to xcodebuild command

### DIFF
--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -57,6 +57,7 @@ jobs:
             -configuration Debug \
             -testPlan MullvadVPNUITestsSmoke \
             -destination "platform=iOS,id=$TEST_DEVICE_UDID" \
+            -disableAutomaticPackageResolution \
             test 2>&1 | xcbeautify --report junit --report-path test-report
         working-directory: ios/
 

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -72,5 +72,6 @@ jobs:
             -testPlan MullvadVPNScreenshots \
             -destination "platform=iOS Simulator,name=iPhone 15" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
             test 2>&1 | xcbeautify
         working-directory: ios/

--- a/.github/workflows/ios-validate-build-schemas.yml
+++ b/.github/workflows/ios-validate-build-schemas.yml
@@ -72,6 +72,7 @@ jobs:
             -configuration MockRelease \
             -destination "platform=iOS Simulator,name=iPhone 15" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
             build
           set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
             -project MullvadVPN.xcodeproj \
@@ -79,6 +80,7 @@ jobs:
             -configuration Staging \
             -destination "platform=iOS Simulator,name=iPhone 15" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
             build
           set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
             -project MullvadVPN.xcodeproj \
@@ -86,5 +88,6 @@ jobs:
             -configuration Debug \
             -destination "platform=iOS Simulator,name=iPhone 15" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
             build
         working-directory: ios/

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -98,5 +98,6 @@ jobs:
             -testPlan MullvadVPNCI \
             -destination "platform=iOS Simulator,name=iPhone 15" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
             test 2>&1 | xcbeautify
         working-directory: ios/

--- a/ios/build.sh
+++ b/ios/build.sh
@@ -93,6 +93,7 @@ release_build() {
     -sdk iphoneos \
     -configuration Release \
     -derivedDataPath "$DERIVED_DATA_DIR" \
+    -disableAutomaticPackageResolution \
     "$@"
 }
 
@@ -107,4 +108,5 @@ xcodebuild \
     -exportArchive \
     -archivePath "$XCODE_ARCHIVE_DIR" \
     -exportOptionsPlist "$EXPORT_OPTIONS_PATH" \
-    -exportPath "$BUILD_OUTPUT_DIR"
+    -exportPath "$BUILD_OUTPUT_DIR" \
+    -disableAutomaticPackageResolution


### PR DESCRIPTION
To improve supply chain security we should add the flag -disableAutomaticPackageResolution to xcodebuild command. This will ensure all swift dependencies (currently very few) are integrity verified against the checksums commited to the ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved file.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5928)
<!-- Reviewable:end -->
