### PR TITLE
Improve error handling in macOS routing module

### DIFF
--- a/talpid-routing/src/unix/macos/data.rs
+++ b/talpid-routing/src/unix/macos/data.rs
@@ -649,14 +649,6 @@ impl Interface {
     }
 }
 
-// #define RTA_DST         0x1     /* destination sockaddr present */
-// #define RTA_GATEWAY     0x2     /* gateway sockaddr present */
-// #define RTA_NETMASK     0x4     /* netmask sockaddr present */
-// #define RTA_GENMASK     0x8     /* cloning mask sockaddr present */
-// #define RTA_IFP         0x10    /* interface name sockaddr present */
-// #define RTA_IFA         0x20    /* interface addr sockaddr present */
-// #define RTA_AUTHOR      0x40    /* sockaddr for author of redirect */
-// #define RTA_BRD         0x80    /* for NEWADDR, broadcast or p-p dest addr */
 bitflags::bitflags! {
     /// All enum values of address flags can be iterated via `flag <<= 1`, starting from 1.
     /// See https://www.manpagez.com/man/4/route/.

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -363,7 +363,12 @@ impl RouteManagerImpl {
             // ignore all other message types
             Ok(_) => {}
             Err(err) => {
-                log::error!("Failed to receive a message from the routing table: {err}");
+                log::error!(
+                    "{}",
+                    err.display_chain_with_msg(
+                        "Failed to receive a message from the routing table"
+                    )
+                );
             }
         }
     }

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -51,7 +51,7 @@ pub enum Error {
 
     /// Received message isn't valid
     #[error("Invalid data")]
-    InvalidData(data::Error),
+    InvalidData(#[source] data::Error),
 }
 
 /// Convenience macro to get the current default route. Macro because I don't want to borrow `self`

--- a/talpid-routing/src/unix/macos/routing_socket.rs
+++ b/talpid-routing/src/unix/macos/routing_socket.rs
@@ -23,11 +23,11 @@ use tokio::io::{unix::AsyncFd, AsyncWrite, AsyncWriteExt};
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Failed to open routing socket")]
-    OpenSocket(io::Error),
+    OpenSocket(#[source] io::Error),
     #[error("Failed to write to routing socket")]
-    Write(io::Error),
+    Write(#[source] io::Error),
     #[error("Failed to read from routing socket")]
-    Read(io::Error),
+    Read(#[source] io::Error),
     #[error("Received a message that's too small")]
     MessageTooSmall(usize),
     #[error("Failed to receive response to route message")]

--- a/talpid-routing/src/unix/macos/watch.rs
+++ b/talpid-routing/src/unix/macos/watch.rs
@@ -14,7 +14,7 @@ pub enum Error {
     RoutingSocket(#[source] routing_socket::Error),
     /// Failed to parse route message
     #[error("Invalid message")]
-    InvalidMessage(data::Error),
+    InvalidMessage(#[source] data::Error),
     /// Failed to send route message
     #[error("Failed to send routing message")]
     Send(#[source] routing_socket::Error),

--- a/talpid-routing/src/unix/macos/watch.rs
+++ b/talpid-routing/src/unix/macos/watch.rs
@@ -10,14 +10,14 @@ type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Generic routing socket error
-    #[error("Routing socket error: {0}")]
-    RoutingSocket(routing_socket::Error),
+    #[error("Routing socket error")]
+    RoutingSocket(#[source] routing_socket::Error),
     /// Failed to parse route message
     #[error("Invalid message")]
     InvalidMessage(data::Error),
     /// Failed to send route message
     #[error("Failed to send routing message")]
-    Send(routing_socket::Error),
+    Send(#[source] routing_socket::Error),
     /// Received unexpected response to route message
     #[error("Unexpected message type")]
     UnexpectedMessageType(RouteSocketMessage, MessageType),


### PR DESCRIPTION
Mainly to print all of the source errors. This includes some other minor cleanup as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5929)
<!-- Reviewable:end -->
