### PR TITLE
Remove `RouteManagerHandle`

### DIFF
--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -65,14 +65,14 @@ impl ConnectivityInner {
 
 pub async fn spawn_monitor(
     notify_tx: UnboundedSender<Connectivity>,
-    route_manager_handle: RouteManagerHandle,
+    route_manager: RouteManagerHandle,
 ) -> Result<MonitorHandle, Error> {
     let notify_tx = Arc::new(notify_tx);
 
     // note: begin observing before initializing the state
-    let route_listener = route_manager_handle.default_route_listener().await?;
+    let route_listener = route_manager.default_route_listener().await?;
 
-    let (ipv4, ipv6) = match route_manager_handle.get_default_routes().await {
+    let (ipv4, ipv6) = match route_manager.get_default_routes().await {
         Ok((v4_route, v6_route)) => (v4_route.is_some(), v6_route.is_some()),
         Err(error) => {
             log::warn!("Failed to initialize offline monitor: {error}");

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -18,7 +18,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use talpid_routing::RouteManager;
+use talpid_routing::RouteManagerHandle;
 use talpid_tunnel::{tun_provider::TunProvider, TunnelArgs, TunnelEvent, TunnelMetadata};
 use talpid_types::{
     net::{AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, TunnelParameters},
@@ -60,9 +60,9 @@ impl ConnectingState {
         if shared_values.connectivity.is_offline() {
             // FIXME: Temporary: Nudge route manager to update the default interface
             #[cfg(target_os = "macos")]
-            if let Ok(handle) = shared_values.route_manager.handle() {
+            {
                 log::debug!("Poking route manager to update default routes");
-                let _ = handle.refresh_routes();
+                let _ = shared_values.route_manager.refresh_routes();
             }
             return ErrorState::enter(shared_values, ErrorStateCause::IsOffline);
         }
@@ -189,7 +189,7 @@ impl ConnectingState {
         log_dir: &Option<PathBuf>,
         resource_dir: &Path,
         tun_provider: Arc<Mutex<TunProvider>>,
-        route_manager: &RouteManager,
+        route_manager: &RouteManagerHandle,
         retry_attempt: u32,
     ) -> Self {
         let (event_tx, event_rx) = mpsc::unbounded();
@@ -202,7 +202,7 @@ impl ConnectingState {
                 })
             };
 
-        let route_manager_handle = route_manager.handle();
+        let route_manager = route_manager.clone();
         let log_dir = log_dir.clone();
         let resource_dir = resource_dir.to_path_buf();
 
@@ -214,25 +214,6 @@ impl ConnectingState {
         tokio::task::spawn_blocking(move || {
             let start = Instant::now();
 
-            let route_manager_handle = match route_manager_handle {
-                Ok(handle) => handle,
-                Err(error) => {
-                    if tunnel_close_event_tx
-                        .send(Some(ErrorStateCause::StartTunnelError))
-                        .is_err()
-                    {
-                        log::warn!(
-                            "Tunnel state machine stopped before receiving tunnel closed event"
-                        );
-                    }
-                    log::error!(
-                        "{}",
-                        error.display_chain_with_msg("Failed to obtain route monitor handle")
-                    );
-                    return;
-                }
-            };
-
             let args = TunnelArgs {
                 runtime,
                 resource_dir: &resource_dir,
@@ -240,7 +221,7 @@ impl ConnectingState {
                 tunnel_close_rx,
                 tun_provider,
                 retry_attempt,
-                route_manager: route_manager_handle,
+                route_manager,
             };
 
             let block_reason = match TunnelMonitor::start(&mut tunnel_parameters, &log_dir, args) {

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -312,7 +312,7 @@ impl OpenVpnMonitor<OpenVpnCommand> {
                 proxy_auth_file_path: proxy_auth_file_path.clone(),
                 abort_server_tx: event_server_abort_tx,
                 proxy: params.proxy.clone(),
-                route_manager_handle: route_manager,
+                route_manager,
                 #[cfg(target_os = "linux")]
                 ipv6_enabled,
             },
@@ -817,7 +817,7 @@ mod event_server {
         pub proxy_auth_file_path: Option<super::PathBuf>,
         pub abort_server_tx: triggered::Trigger,
         pub proxy: Option<CustomProxy>,
-        pub route_manager_handle: talpid_routing::RouteManagerHandle,
+        pub route_manager: talpid_routing::RouteManagerHandle,
         #[cfg(target_os = "linux")]
         pub ipv6_enabled: bool,
     }
@@ -864,7 +864,7 @@ mod event_server {
                 let route = talpid_routing::RequiredRoute::new(network, node);
                 routes.insert(route);
             }
-            let route_handle = self.route_manager_handle.clone();
+            let route_handle = self.route_manager.clone();
 
             #[cfg(target_os = "linux")]
             {

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -25,7 +25,7 @@ use netlink_packet_route::rtnl::constants::RT_TABLE_MAIN;
 #[cfg(target_os = "macos")]
 pub use imp::{imp::RouteError, DefaultRouteEvent, PlatformError};
 
-pub use imp::{Error, RouteManager, RouteManagerHandle};
+pub use imp::{Error, RouteManagerHandle};
 
 /// A network route with a specific network node, destination and an optional metric.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -81,7 +81,7 @@ impl fmt::Display for Route {
     }
 }
 
-/// A network route that should be applied by the RouteManager.
+/// A network route that should be applied by the route manager.
 /// It can either be routed through a specific network node or it can be routed through the current
 /// default route.
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
@@ -130,7 +130,7 @@ impl RequiredRoute {
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub enum NetNode {
     /// A real node will be used to set a regular route that will remain unchanged for the lifetime
-    /// of the RouteManager
+    /// of the route manager
     RealNode(Node),
     /// A default node is a symbolic node that will resolve to the network node used in the current
     /// most preferable default route

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -718,7 +718,7 @@ impl WireguardMonitor {
         resource_dir: &Path,
         tun_provider: Arc<Mutex<TunProvider>>,
         #[cfg(target_os = "android")] psk_negotiation: bool,
-        #[cfg(windows)] route_manager_handle: crate::routing::RouteManagerHandle,
+        #[cfg(windows)] route_manager: crate::routing::RouteManagerHandle,
         #[cfg(windows)] setup_done_tx: mpsc::Sender<std::result::Result<(), BoxedError>>,
     ) -> Result<Box<dyn Tunnel>> {
         log::debug!("Tunnel MTU: {}", config.mtu);


### PR DESCRIPTION
Follow up to #5934. `RouteManager` and `RouteManagerHandle` are both handles that interact with the same actor. The main difference is that `RouteManager` calls `stop` when dropped. This is unnecessary since the manager is also stopped when all copies of the sender are dropped, which is a pattern that we rely on a lot, so this PR merges them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5937)
<!-- Reviewable:end -->
