### PR TITLE
Remove konsist workaround

### DIFF
--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/GeneralTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/GeneralTest.kt
@@ -3,7 +3,6 @@ package net.mullvad.mullvadvpn.test.arch
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.ext.list.properties
 import com.lemonappdev.konsist.api.verify.assertFalse
-import com.lemonappdev.konsist.api.verify.assertNot
 import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -14,7 +13,7 @@ class GeneralTest {
 
     @Test
     fun `ensure no field should have 'm' prefix`() =
-        Konsist.scopeFromProject().classes().properties().assertNot {
+        Konsist.scopeFromProject().classes().properties().assertFalse {
             val secondCharacterIsUppercase = it.name.getOrNull(1)?.isUpperCase() ?: false
             it.name.startsWith('m') && secondCharacterIsUppercase
         }

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/JUnitTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/JUnitTest.kt
@@ -1,6 +1,7 @@
 package net.mullvad.mullvadvpn.test.arch
 
 import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withAnnotationOf
 import com.lemonappdev.konsist.api.verify.assertEmpty
 import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
@@ -48,9 +49,7 @@ class JUnitTest {
     private fun allNonAndroidTests() =
         Konsist.scopeFromTest()
             .functions()
-            // withAnnotationOf is broken in latest Consist version, so we filter manually
-            // https://github.com/LemonAppDev/konsist/discussions/738
-            .filter { it.annotations.any { it.text == "@Test" } }
+            .withAnnotationOf(Test::class)
             .filter { it.sourceSetName != "androidTest" }
             .filter { function ->
                 ignoredTestPackages.none { function.packagee!!.fullyQualifiedName.startsWith(it) }


### PR DESCRIPTION
This PR removes the workaround that was fixed in `0.14.0` of Konsist.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5940)
<!-- Reviewable:end -->
