### PR TITLE
retry: remove unnecessary 'static lifetimes

### DIFF
--- a/talpid-future/src/retry.rs
+++ b/talpid-future/src/retry.rs
@@ -6,9 +6,9 @@ use talpid_time::sleep;
 /// Retries a future until it should stop as determined by the retry function, or when
 /// the iterator returns `None`.
 pub async fn retry_future<
-    F: FnMut() -> O + 'static,
-    R: FnMut(&T) -> bool + 'static,
-    D: Iterator<Item = Duration> + 'static,
+    F: FnMut() -> O,
+    R: FnMut(&T) -> bool,
+    D: Iterator<Item = Duration>,
     O: Future<Output = T>,
     T,
 >(


### PR DESCRIPTION
`'static` lifetimes in `retry::retry_future()` prevent borrowing in async contexts and strictly unnecessary as I believe compiler can figure out lifetimes on its own. For example retry in its current impl will not allow this:


```rs
#[async_trait]
impl MyAsyncTrait for MyType {
    async fn foo(
        &self,
        addr: &SocketAddr,
    ) -> Result<u32> {
         retry::retry_future(
             || self.bar(addr),  // this will not compile with static lifetime as addr has its own lifetime.
             |result| { true }, 
             RETRY_BACKOFF_STRATEGY
          ).await
    }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5941)
<!-- Reviewable:end -->
