### PR TITLE
Enable building features in crates on iOS

### DIFF
--- a/ios/build-rust-library.sh
+++ b/ios/build-rust-library.sh
@@ -2,7 +2,7 @@
 
 set -euvx
 
-if [ "$#" -gt 2 ]
+if [ "$#" -gt 2 ] || [ "$#" -eq 0 ]
 then
     echo "Usage (note: only call inside xcode!):"
     echo "build-rust-library.sh <FFI_TARGET> [FFI_FEATURES]"
@@ -13,6 +13,8 @@ fi
 FFI_TARGET=$1
 
 # Enable cargo features by passing feature names to this script, i.e. build-rust-library.sh mullvad-api api-override
+# If more than one feature flag needs to be enabled, pass in a single argument all the features flags separated by spaces
+# build-rust-library.sh mullvad-api "featureA featureB featureC"
 FEATURE_FLAGS=
 if [[ "$#" -eq 2 ]] ; then
 FEATURE_FLAGS=$2

--- a/ios/build-rust-library.sh
+++ b/ios/build-rust-library.sh
@@ -2,15 +2,23 @@
 
 set -euvx
 
-if [ "$#" -ne 1 ]
+if [ "$#" -gt 2 ]
 then
     echo "Usage (note: only call inside xcode!):"
-    echo "build-rust-library.sh <FFI_TARGET>"
+    echo "build-rust-library.sh <FFI_TARGET> [FFI_FEATURES]"
     exit 1
 fi
 
 # what to pass to cargo build -p, e.g. your_lib_ffi
 FFI_TARGET=$1
+
+# Enable cargo features by passing feature names to this script, i.e. build-rust-library.sh mullvad-api api-override
+FEATURE_FLAGS=
+if [[ "$#" -eq 2 ]] ; then
+FEATURE_FLAGS=$2
+echo ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
+fi
+
 
 RELFLAG=
 if [[ "$CONFIGURATION" == "Release" ]]; then
@@ -43,18 +51,18 @@ for arch in $ARCHS; do
 
       # Intel iOS simulator
       export CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios"
-      "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target x86_64-apple-ios
-      "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target x86_64-apple-ios
+      "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target x86_64-apple-ios ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
+      "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target x86_64-apple-ios ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
       ;;
 
     arm64)
       if [ $IS_SIMULATOR -eq 0 ]; then
         # Hardware iOS targets
-        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target aarch64-apple-ios
-        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target aarch64-apple-ios
+        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target aarch64-apple-ios ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
+        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target aarch64-apple-ios ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
       else
-        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target aarch64-apple-ios-sim
-        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target aarch64-apple-ios-sim
+        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target aarch64-apple-ios-sim ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
+        "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target aarch64-apple-ios-sim ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
       fi
   esac
 done


### PR DESCRIPTION
This PR will enable us building rust crate features by passing a second argument to the `build-rust-library.sh` script. 

For example
`build-rust-library.sh mullvad-api api-override`

If we need to build more than one feature flag, we can pass in a single argument, all the features separated by spaces
`build-rust-library.sh mullvad-api "featureA featureB featureC"`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5944)
<!-- Reviewable:end -->
