### PR TITLE
Revert and rename the auto connect option on non tv devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 #### Android
 - Add support for all screen orientations.
 - Add toggle for enabling or disabling split tunneling.
-- Replace auto connect with auto connect and lockdown mode guide on platforms that has
-  system vpn settings.
+- Add auto connect and lockdown mode guide on platforms that has system vpn settings.
 - Add 3D map to Connect screen.
 
 ### Changed
@@ -40,7 +39,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Android
 - Migrate to Compose Navigation which also improves screen transition animations.
-- Increase focus highlight opacity
+- Increase focus highlight opacity.
+- Set auto-connect setting as legacy on platforms with system vpn settings.
 
 ### Fixed
 - Continual excessive attempts to update the API IP were made after testing access methods.

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/BaseCell.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -109,6 +110,11 @@ internal fun BaseCellTitle(
 
 @Composable
 fun BaseSubtitleCell(text: String, modifier: Modifier = Modifier) {
+    BaseSubtitleCell(text = AnnotatedString(text), modifier = modifier)
+}
+
+@Composable
+fun BaseSubtitleCell(text: AnnotatedString, modifier: Modifier = Modifier) {
     Text(
         text = text,
         style = MaterialTheme.typography.labelMedium,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SwitchComposeCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SwitchComposeCell.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -191,5 +192,10 @@ fun CustomDnsCellSubtitle(isCellClickable: Boolean, modifier: Modifier) {
 
 @Composable
 fun SwitchComposeSubtitleCell(text: String, modifier: Modifier = Modifier) {
+    BaseSubtitleCell(text = text, modifier = modifier)
+}
+
+@Composable
+fun SwitchComposeSubtitleCell(text: AnnotatedString, modifier: Modifier = Modifier) {
     BaseSubtitleCell(text = text, modifier = modifier)
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/VpnSettingsScreen.kt
@@ -22,8 +22,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.text.HtmlCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -49,6 +51,7 @@ import net.mullvad.mullvadvpn.compose.cell.SelectableCell
 import net.mullvad.mullvadvpn.compose.cell.SwitchComposeSubtitleCell
 import net.mullvad.mullvadvpn.compose.component.NavigateBackIconButton
 import net.mullvad.mullvadvpn.compose.component.ScaffoldWithMediumTopBar
+import net.mullvad.mullvadvpn.compose.component.textResource
 import net.mullvad.mullvadvpn.compose.destinations.AutoConnectAndLockdownModeDestination
 import net.mullvad.mullvadvpn.compose.destinations.ContentBlockersInfoDialogDestination
 import net.mullvad.mullvadvpn.compose.destinations.CustomDnsInfoDialogDestination
@@ -65,6 +68,7 @@ import net.mullvad.mullvadvpn.compose.dialog.WireguardCustomPortNavArgs
 import net.mullvad.mullvadvpn.compose.dialog.WireguardPortInfoDialogArgument
 import net.mullvad.mullvadvpn.compose.extensions.itemWithDivider
 import net.mullvad.mullvadvpn.compose.extensions.itemsIndexedWithDivider
+import net.mullvad.mullvadvpn.compose.extensions.toAnnotatedString
 import net.mullvad.mullvadvpn.compose.state.VpnSettingsUiState
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_LAST_ITEM_TEST_TAG
 import net.mullvad.mullvadvpn.compose.test.LAZY_LIST_QUANTUM_ITEM_OFF_TEST_TAG
@@ -305,21 +309,39 @@ fun VpnSettingsScreen(
                         text = stringResource(id = R.string.auto_connect_and_lockdown_mode_footer)
                     )
                 }
-            } else {
-                item {
-                    Spacer(modifier = Modifier.height(Dimens.cellLabelVerticalPadding))
-                    HeaderSwitchComposeCell(
-                        title = stringResource(R.string.auto_connect),
-                        isToggled = state.isAutoConnectEnabled,
-                        isEnabled = true,
-                        onCellClicked = { newValue -> onToggleAutoConnect(newValue) }
-                    )
-                }
-                item {
-                    SwitchComposeSubtitleCell(
-                        text = stringResource(id = R.string.auto_connect_footer)
-                    )
-                }
+            }
+            item {
+                Spacer(modifier = Modifier.height(Dimens.cellLabelVerticalPadding))
+                HeaderSwitchComposeCell(
+                    title =
+                        stringResource(
+                            if (state.systemVpnSettingsAvailable) {
+                                R.string.auto_connect_legacy
+                            } else {
+                                R.string.auto_connect
+                            }
+                        ),
+                    isToggled = state.isAutoConnectEnabled,
+                    isEnabled = true,
+                    onCellClicked = { newValue -> onToggleAutoConnect(newValue) }
+                )
+            }
+            item {
+                SwitchComposeSubtitleCell(
+                    text =
+                        HtmlCompat.fromHtml(
+                                if (state.systemVpnSettingsAvailable) {
+                                    textResource(
+                                        R.string.auto_connect_footer_legacy,
+                                        textResource(R.string.auto_connect_and_lockdown_mode)
+                                    )
+                                } else {
+                                    textResource(R.string.auto_connect_footer)
+                                },
+                                HtmlCompat.FROM_HTML_MODE_COMPACT
+                            )
+                            .toAnnotatedString(boldFontWeight = FontWeight.ExtraBold)
+                )
             }
             item {
                 Spacer(modifier = Modifier.height(Dimens.cellLabelVerticalPadding))

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -280,4 +280,6 @@
     <string name="loading_verifying">Verifying purchase...</string>
     <string name="copied_logs_to_clipboard">Copied logs to clipboard</string>
     <string name="split_tunneling_disabled_description">Split tunneling is disabled.</string>
+    <string name="auto_connect_legacy">Auto-connect (legacy)</string>
+    <string name="auto_connect_footer_legacy"><![CDATA[Please use the <b>Always-on</b> system setting instead by following the guide in <b>%s</b> above.]]></string>
 </resources>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2061,6 +2061,9 @@ msgstr ""
 msgid "Auto-connect & \\nLockdown mode"
 msgstr ""
 
+msgid "Auto-connect (legacy)"
+msgstr ""
+
 msgid "Auto-connect is called Always-on VPN in the Android system settings and it makes sure you are constantly connected to the VPN tunnel and auto connects after restart."
 msgstr ""
 
@@ -2134,6 +2137,9 @@ msgid "Mullvad services unavailable"
 msgstr ""
 
 msgid "No internet connection"
+msgstr ""
+
+msgid "Please use the <b>Always-on</b> system setting instead by following the guide in <b>%s</b> above."
 msgstr ""
 
 msgid "Preferences"


### PR DESCRIPTION
Revert so that we once again are showing the Auto-connect option on non-TV devices, but mark it as legacy.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5945)
<!-- Reviewable:end -->
