### PR TITLE
Check git commit message style

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -16,3 +16,15 @@ jobs:
           allow-one-liners: 'true'
           # This action defaults to 50 char subjects, but 74 is fine.
           max-subject-line-length: '74'
+
+      - name: Check for unicode whitespaces
+        uses: gsactions/commit-message-checker@v2
+        with:
+          # Pattern matches strings not containing weird unicode whitespace/separator characters
+          # \P{Z} = All non-whitespace characters (the u-flag is needed to enable \P{Z})
+          # [ \t\n] = Allowed whitespace characters
+          pattern: '^(\P{Z}|[ \t\n])+$'
+          flags: 'u'
+          error: 'Detected unicode whitespace character in commit message.'
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # only required if checkAllCommitMessages is true

--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -1,0 +1,18 @@
+---
+name: Git - Check commit message style
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  check-commit-message-style:
+    name: Check commit message style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check against guidlines
+        uses: mristin/opinionated-commit-message@v3.1.0
+        with:
+          # Commit messages are allowed to be subject only, no body
+          allow-one-liners: 'true'
+          # This action defaults to 50 char subjects, but 74 is fine.
+          max-subject-line-length: '74'


### PR DESCRIPTION
Add CI checks to constrain git commit messages to our [preferred style](https://github.com/mullvad/coding-guidelines/?tab=readme-ov-file#commit-messages). There just happened to be an existing Github action that do the checking more or less according to our existing guidelines.

I wish the imperative form verb check could be disabled. Even though it is the preferred style, I'm afraid it's overly nitpicky. But we can try and see if we think it's OK or too annoying.

Added separate check with regex that catches any whitespace that is not a space, tab (`\t`) or newline (`\n`). Prevents non-visible unexpected whitespaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5946)
<!-- Reviewable:end -->
