### PR TITLE
Handle `PF_ROUTE` socket being unexpectedly closed

### DIFF
--- a/talpid-routing/src/unix/macos/routing_socket.rs
+++ b/talpid-routing/src/unix/macos/routing_socket.rs
@@ -78,7 +78,7 @@ impl RoutingSocket {
 
     pub async fn recv_msg(&mut self, mut buf: &mut [u8]) -> Result<usize> {
         if let Some(buffered_msg) = self.buf.pop_front() {
-            let bytes_written = buf.write(&buffered_msg).map_err(Error::Write)?;
+            let bytes_written = buf.write(&buffered_msg).map_err(Error::Read)?;
             return Ok(bytes_written);
         }
         self.read_next_msg(buf).await

--- a/talpid-routing/src/unix/macos/routing_socket.rs
+++ b/talpid-routing/src/unix/macos/routing_socket.rs
@@ -102,7 +102,7 @@ impl RoutingSocket {
         }
     }
 
-    pub async fn wait_for_response(&mut self, response_num: i32) -> Result<Vec<u8>> {
+    async fn wait_for_response(&mut self, response_num: i32) -> Result<Vec<u8>> {
         loop {
             talpid_types::detect_flood!();
 


### PR DESCRIPTION
Previously, we would just continue trying to receive data from it, but failing every time. This fix just replaces the socket when necessary.

Fix DES-682.

Related: #5949  

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5947)
<!-- Reviewable:end -->
