### PR TITLE
Fix memory leak at LocationNode

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationNode.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationNode.swift
@@ -13,7 +13,7 @@ class LocationNode {
     let name: String
     var code: String
     var locations: [RelayLocation]
-    var parent: LocationNode?
+    weak var parent: LocationNode?
     var children: [LocationNode]
     var showsChildren: Bool
     var isHiddenFromSearch: Bool


### PR DESCRIPTION

It seems that maintaining a strong reference from a parent to a location node can cause a memory leak. Making that reference weak allows the automatic reference counting (ARC) system to release the memory when the object is no longer needed or exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5962)
<!-- Reviewable:end -->
