### PR TITLE
Add more allowed git commit message verbs

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check commit message style
     runs-on: ubuntu-latest
     steps:
-      - name: Check against guidlines
+      - name: Check against guidelines
         uses: mristin/opinionated-commit-message@v3.1.0
         with:
           # Commit messages are allowed to be subject only, no body

--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -16,6 +16,8 @@ jobs:
           allow-one-liners: 'true'
           # This action defaults to 50 char subjects, but 74 is fine.
           max-subject-line-length: '74'
+          # The action's wordlist is a bit short. Add more accepted verbs
+          additional-verbs: 'restart, coalesce'
 
       - name: Check for unicode whitespaces
         uses: gsactions/commit-message-checker@v2


### PR DESCRIPTION
Feel free to suggest even more verbs that you think you might have good use for. But we can also extend it later as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5975)
<!-- Reviewable:end -->
