### PR TITLE
Replace duplicated cascades of case statements with utility methods on State

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -108,9 +108,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 if connectionState.connectionAttemptCount > 1 {
                     return
                 }
-            case let .negotiatingKey(connectionState):
-                try await startPostQuantumKeyExchange()
-                return
             default:
                 break
             }
@@ -126,65 +123,65 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 //
 //        try await startPostQuantumKeyExchange()
 //    }
-
-    func selectGothenburgRelay() throws -> MullvadEndpoint {
-        let constraints = RelayConstraints(
-            locations: .only(UserSelectedRelays(locations: [.city("se", "got")]))
-        )
-        let relay = try relaySelector.selectRelay(with: constraints, connectionAttemptFailureCount: 0)
-        return relay.endpoint
-    }
-
-    var pqTCPConnection: NWTCPConnection?
-
-    func startPostQuantumKeyExchange() async throws {
-        let settingsReader = SettingsReader()
-        let settings: Settings = try settingsReader.read()
-        let privateKey = settings.privateKey
-        let postQuantumSharedKey = PrivateKey() // This will become the new private key of the device
-
-        let IPv4Gateway = IPv4Address("10.64.0.1")!
-        let gothenburgRelay = try selectGothenburgRelay()
-
-        let configurationBuilder = ConfigurationBuilder(
-            privateKey: settings.privateKey,
-            interfaceAddresses: settings.interfaceAddresses,
-            dns: settings.dnsServers,
-            endpoint: gothenburgRelay,
-            allowedIPs: [
-                IPAddressRange(from: "10.64.0.1/8")!,
-            ]
-        )
-
-        try await adapter.start(configuration: configurationBuilder.makeConfiguration())
-
-        let negotiator = PostQuantumKeyNegotiatior()
-        let gatewayEndpoint = NWHostEndpoint(hostname: "10.64.0.1", port: "1337")
-
-        pqTCPConnection = createTCPConnectionThroughTunnel(
-            to: gatewayEndpoint,
-            enableTLS: false,
-            tlsParameters: nil,
-            delegate: nil
-        )
-        guard let pqTCPConnection else { return }
-
-        // This will work as long as there is a detached, top-level task here.
-        // It might be due to the async runtime environment for `override func startTunnel(options: [String: NSObject]? = nil) async throws`
-        // There is a strong chance that the function's async availability was not properly declared by Apple.
-        Task.detached {
-            for await isViable in pqTCPConnection.viability where isViable == true {
-                negotiator.negotiateKey(
-                    gatewayIP: IPv4Gateway,
-                    devicePublicKey: privateKey.publicKey,
-                    presharedKey: postQuantumSharedKey.publicKey,
-                    packetTunnel: self,
-                    tcpConnection: self.pqTCPConnection!
-                )
-                break
-            }
-        }
-    }
+//
+//    func selectGothenburgRelay() throws -> MullvadEndpoint {
+//        let constraints = RelayConstraints(
+//            locations: .only(UserSelectedRelays(locations: [.city("se", "got")]))
+//        )
+//        let relay = try relaySelector.selectRelay(with: constraints, connectionAttemptFailureCount: 0)
+//        return relay.endpoint
+//    }
+//
+//    var pqTCPConnection: NWTCPConnection?
+//
+//    func startPostQuantumKeyExchange() async throws {
+//        let settingsReader = SettingsReader()
+//        let settings: Settings = try settingsReader.read()
+//        let privateKey = settings.privateKey
+//        let postQuantumSharedKey = PrivateKey() // This will become the new private key of the device
+//
+//        let IPv4Gateway = IPv4Address("10.64.0.1")!
+//        let gothenburgRelay = try selectGothenburgRelay()
+//
+//        let configurationBuilder = ConfigurationBuilder(
+//            privateKey: settings.privateKey,
+//            interfaceAddresses: settings.interfaceAddresses,
+//            dns: settings.dnsServers,
+//            endpoint: gothenburgRelay,
+//            allowedIPs: [
+//                IPAddressRange(from: "10.64.0.1/8")!,
+//            ]
+//        )
+//
+//        try await adapter.start(configuration: configurationBuilder.makeConfiguration())
+//
+//        let negotiator = PostQuantumKeyNegotiatior()
+//        let gatewayEndpoint = NWHostEndpoint(hostname: "10.64.0.1", port: "1337")
+//
+//        pqTCPConnection = createTCPConnectionThroughTunnel(
+//            to: gatewayEndpoint,
+//            enableTLS: false,
+//            tlsParameters: nil,
+//            delegate: nil
+//        )
+//        guard let pqTCPConnection else { return }
+//
+//        // This will work as long as there is a detached, top-level task here.
+//        // It might be due to the async runtime environment for `override func startTunnel(options: [String: NSObject]? = nil) async throws`
+//        // There is a strong chance that the function's async availability was not properly declared by Apple.
+//        Task.detached {
+//            for await isViable in pqTCPConnection.viability where isViable == true {
+//                negotiator.negotiateKey(
+//                    gatewayIP: IPv4Gateway,
+//                    devicePublicKey: privateKey.publicKey,
+//                    presharedKey: postQuantumSharedKey.publicKey,
+//                    packetTunnel: self,
+//                    tcpConnection: self.pqTCPConnection!
+//                )
+//                break
+//            }
+//        }
+//    }
 
     // MARK: - End testing Post Quantum key exchange
 

--- a/ios/PacketTunnelCore/Actor/ObservedState.swift
+++ b/ios/PacketTunnelCore/Actor/ObservedState.swift
@@ -86,8 +86,8 @@ extension State {
     }
 }
 
-extension ConnectionState {
-    /// Map `ConnectionState` to `ObservedConnectionState`.
+extension State.ConnectionData {
+    /// Map `State.ConnectionData` to `ObservedConnectionState`.
     var observedConnectionState: ObservedConnectionState {
         ObservedConnectionState(
             selectedRelay: selectedRelay,
@@ -101,8 +101,8 @@ extension ConnectionState {
     }
 }
 
-extension BlockedState {
-    /// Map `BlockedState` to `ObservedBlockedState`
+extension State.BlockingData {
+    /// Map `State.BlockingData` to `ObservedBlockedState`
     var observedBlockedState: ObservedBlockedState {
         return ObservedBlockedState(reason: reason, relayConstraints: relayConstraints)
     }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -54,10 +54,10 @@ extension PacketTunnelActor {
      - Returns: New blocked state that should be assigned to error state, otherwise `nil` when actor is past or at `disconnecting` phase or
                 when actor is already in the error state and no changes need to be made.
      */
-    private func makeBlockedState(reason: BlockedStateReason) -> BlockedState? {
+    private func makeBlockedState(reason: BlockedStateReason) -> State.BlockingData? {
         switch state {
         case .initial:
-            return BlockedState(
+            return State.BlockingData(
                 reason: reason,
                 relayConstraints: nil,
                 currentKey: nil,
@@ -93,11 +93,11 @@ extension PacketTunnelActor {
      Map connection state to blocked state.
      */
     private func mapConnectionState(
-        _ connState: ConnectionState,
+        _ connState: State.ConnectionData,
         reason: BlockedStateReason,
         priorState: StatePriorToBlockedState
-    ) -> BlockedState {
-        BlockedState(
+    ) -> State.BlockingData {
+        State.BlockingData(
             reason: reason,
             relayConstraints: connState.relayConstraints,
             currentKey: connState.currentKey,

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
@@ -25,7 +25,7 @@ extension PacketTunnelActor {
     func cacheActiveKey(lastKeyRotation: Date?) {
         // There should be a way to rationalise these two identical functions into one.
         state.mutateAssociatedData { stateData in
-            guard 
+            guard
                 stateData.keyPolicy == .useCurrent,
                 let currentKey = stateData.currentKey
             else { return }
@@ -33,7 +33,7 @@ extension PacketTunnelActor {
             // Therefore perform the key switch as normal with one exception that it shouldn't reconnect the tunnel
             // automatically.
             stateData.lastKeyRotation = lastKeyRotation
-            
+
             // Move currentKey into keyPolicy.
             stateData.keyPolicy = .usePrior(currentKey, startKeySwitchTask())
             stateData.currentKey = nil

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
@@ -24,18 +24,20 @@ extension PacketTunnelActor {
      */
     func cacheActiveKey(lastKeyRotation: Date?) {
         // There should be a way to rationalise these two identical functions into one.
-        func connectionStateMutator(_ connState: inout ConnectionOrBlockedState) {
-            guard connState.keyPolicy == .useCurrent, let currentKey = connState.currentKey else { return }
+        state.mutateAssociatedData { stateData in
+            guard 
+                stateData.keyPolicy == .useCurrent,
+                let currentKey = stateData.currentKey
+            else { return }
             // Key policy is preserved between states and key rotation may still happen while in blocked state.
             // Therefore perform the key switch as normal with one exception that it shouldn't reconnect the tunnel
             // automatically.
-            connState.lastKeyRotation = lastKeyRotation
-
+            stateData.lastKeyRotation = lastKeyRotation
+            
             // Move currentKey into keyPolicy.
-            connState.keyPolicy = .usePrior(currentKey, startKeySwitchTask())
-            connState.currentKey = nil
+            stateData.keyPolicy = .usePrior(currentKey, startKeySwitchTask())
+            stateData.currentKey = nil
         }
-        state.mutateConnectionOrBlockedState(connectionStateMutator)
     }
 
     /**

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
@@ -112,37 +112,6 @@ extension PacketTunnelActor {
         // Prevent tunnel from reconnecting when in blocked state.
         guard case .error = state else { return changed }
         return false
-//        switch state {
-//        case var .connecting(connState):
-//            if setCurrentKeyPolicy(&connState.keyPolicy) {
-//                state = .connecting(connState)
-//                return true
-//            }
-//
-//        case var .connected(connState):
-//            if setCurrentKeyPolicy(&connState.keyPolicy) {
-//                state = .connected(connState)
-//                return true
-//            }
-//
-//        case var .reconnecting(connState):
-//            if setCurrentKeyPolicy(&connState.keyPolicy) {
-//                state = .reconnecting(connState)
-//                return true
-//            }
-//
-//        case var .error(blockedState):
-//            if setCurrentKeyPolicy(&blockedState.keyPolicy) {
-//                state = .error(blockedState)
-//
-//                // Prevent tunnel from reconnecting when in blocked state.
-//                return false
-//            }
-//
-//        case .disconnected, .disconnecting, .initial:
-//            break
-//        }
-//        return false
     }
 
     /**

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -51,35 +51,14 @@ extension PacketTunnelActor {
             return false
         }
 
-        switch state {
-        case var .connecting(connState):
-            if mutateConnectionState(&connState) {
-                state = .connecting(connState)
+        if !state.mutateConnectionState(mutateConnectionState) {
+            state.mutateBlockedState { blockedState in
+                if blockedState.networkReachability != newReachability {
+                    blockedState.networkReachability = newReachability
+                    return true
+                }
+                return false
             }
-
-        case var .connected(connState):
-            if mutateConnectionState(&connState) {
-                state = .connected(connState)
-            }
-
-        case var .reconnecting(connState):
-            if mutateConnectionState(&connState) {
-                state = .reconnecting(connState)
-            }
-
-        case var .disconnecting(connState):
-            if mutateConnectionState(&connState) {
-                state = .disconnecting(connState)
-            }
-
-        case var .error(blockedState):
-            if blockedState.networkReachability != newReachability {
-                blockedState.networkReachability = newReachability
-                state = .error(blockedState)
-            }
-
-        case .initial, .disconnected:
-            break
         }
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -43,22 +43,16 @@ extension PacketTunnelActor {
 
         let newReachability = networkPath.networkReachability
 
-        func mutateConnectionState(_ connState: inout ConnectionState) -> Bool {
-            if connState.networkReachability != newReachability {
-                connState.networkReachability = newReachability
-                return true
-            }
-            return false
+        func connectionStateMutator(_ connState: inout ConnectionState) -> Bool {
+            connState.networkReachability = newReachability
+            return true
         }
 
-        if !state.mutateConnectionState(mutateConnectionState) {
-            state.mutateBlockedState { blockedState in
-                if blockedState.networkReachability != newReachability {
-                    blockedState.networkReachability = newReachability
-                    return true
-                }
-                return false
-            }
+        func blockedStateMutator(_ blockedState: inout BlockedState) -> Bool {
+            blockedState.networkReachability = newReachability
+            return true
         }
+
+        _ = state.mutateConnectionState(connectionStateMutator) || state.mutateBlockedState(blockedStateMutator)
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -43,16 +43,6 @@ extension PacketTunnelActor {
 
         let newReachability = networkPath.networkReachability
 
-        func connectionStateMutator(_ connState: inout ConnectionState) -> Bool {
-            connState.networkReachability = newReachability
-            return true
-        }
-
-        func blockedStateMutator(_ blockedState: inout BlockedState) -> Bool {
-            blockedState.networkReachability = newReachability
-            return true
-        }
-
-        _ = state.mutateConnectionState(connectionStateMutator) || state.mutateBlockedState(blockedStateMutator)
+        state.mutateConnectionOrBlockedState { $0.networkReachability = newReachability }
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -43,6 +43,6 @@ extension PacketTunnelActor {
 
         let newReachability = networkPath.networkReachability
 
-        state.mutateConnectionOrBlockedState { $0.networkReachability = newReachability }
+        state.mutateAssociatedData { $0.networkReachability = newReachability }
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -294,7 +294,7 @@ extension PacketTunnelActor {
         nextRelay: NextRelay,
         settings: Settings,
         reason: ReconnectReason
-    ) throws -> ConnectionState? {
+    ) throws -> State.ConnectionData? {
         var keyPolicy: KeyPolicy = .useCurrent
         var networkReachability = defaultPathObserver.defaultPath?.networkReachability ?? .undetermined
         var lastKeyRotation: Date?
@@ -333,7 +333,7 @@ extension PacketTunnelActor {
             return nil
         }
         let selectedRelay = try callRelaySelector(nil, 0)
-        return ConnectionState(
+        return State.ConnectionData(
             selectedRelay: selectedRelay,
             relayConstraints: settings.relayConstraints,
             currentKey: settings.privateKey,
@@ -351,7 +351,7 @@ extension PacketTunnelActor {
         nextRelay: NextRelay,
         settings: Settings,
         reason: ReconnectReason
-    ) throws -> ConnectionState? {
+    ) throws -> State.ConnectionData? {
         guard let connectionState = try makeConnectionState(nextRelay: nextRelay, settings: settings, reason: reason)
         else { return nil }
 
@@ -362,7 +362,7 @@ extension PacketTunnelActor {
         )
 
         let transportLayer = protocolObfuscator.transportLayer.map { $0 } ?? .udp
-        return ConnectionState(
+        return State.ConnectionData(
             selectedRelay: connectionState.selectedRelay,
             relayConstraints: connectionState.relayConstraints,
             currentKey: settings.privateKey,

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -27,7 +27,8 @@ import WireGuardKitTypes
  */
 public actor PacketTunnelActor {
     var state: State = .initial {
-        didSet {
+        didSet(oldValue) {
+            guard state != oldValue else { return }
             logger.debug("\(state.logFormat())")
             observedState = state.observedState
         }

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -129,12 +129,12 @@ extension State {
             var associatedData: StateAssociatedData = connState
             modifier(&associatedData)
             self = self.replacingConnectionData(with: associatedData as! ConnectionData)
-            
+
         case let .error(blockedState):
             var associatedData: StateAssociatedData = blockedState
             modifier(&associatedData)
             self = .error(associatedData as! BlockingData)
-            
+
         default:
             break
         }

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -128,11 +128,13 @@ extension State {
              let .disconnecting(connState):
             var associatedData: StateAssociatedData = connState
             modifier(&associatedData)
+            // swiftlint:disable:next force_cast
             self = self.replacingConnectionData(with: associatedData as! ConnectionData)
 
         case let .error(blockedState):
             var associatedData: StateAssociatedData = blockedState
             modifier(&associatedData)
+            // swiftlint:disable:next force_cast
             self = .error(associatedData as! BlockingData)
 
         default:

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -96,7 +96,6 @@ public enum NetworkReachability: Equatable, Codable {
     case undetermined, reachable, unreachable
 }
 
-// perhaps this should have a better name?
 protocol StateAssociatedData {
     var currentKey: PrivateKey? { get set }
     var keyPolicy: KeyPolicy { get set }

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -54,7 +54,7 @@ import WireGuardKitTypes
  `.connecting`, `.reconnecting`, `.error` can be interrupted if the tunnel is requested to stop, which should segue actor towards `.disconnected` state.
 
  */
-enum State {
+enum State: Equatable {
     /// Initial state at the time when actor is initialized but before the first connection attempt.
     case initial
 
@@ -97,7 +97,7 @@ public enum NetworkReachability: Equatable, Codable {
 }
 
 /// Data associated with states that hold connection data.
-struct ConnectionState {
+struct ConnectionState: Equatable {
     /// Current selected relay.
     public var selectedRelay: SelectedRelay
 
@@ -206,7 +206,7 @@ public enum BlockedStateReason: String, Codable, Equatable {
 }
 
 /// Legal states that can precede error state.
-enum StatePriorToBlockedState {
+enum StatePriorToBlockedState: Equatable {
     case initial, connecting, connected, reconnecting
 }
 

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -109,39 +109,39 @@ extension State {
     struct ConnectionData: Equatable, StateAssociatedData {
         /// Current selected relay.
         public var selectedRelay: SelectedRelay
-        
+
         /// Last relay constraints read from settings.
         /// This is primarily used by packet tunnel for updating constraints in tunnel provider.
         public var relayConstraints: RelayConstraints
-        
+
         /// Last WG key read from settings.
         /// Can be `nil` if moved to `keyPolicy`.
         public var currentKey: PrivateKey?
-        
+
         /// Policy describing the current key that should be used by the tunnel.
         public var keyPolicy: KeyPolicy
-        
+
         /// Whether network connectivity outside of tunnel is available.
         public var networkReachability: NetworkReachability
-        
+
         /// Connection attempt counter.
         /// Reset to zero once connection is established.
         public var connectionAttemptCount: UInt
-        
+
         /// Last time packet tunnel rotated the key.
         public var lastKeyRotation: Date?
-        
+
         /// Increment connection attempt counter by one, wrapping to zero on overflow.
         public mutating func incrementAttemptCount() {
             let (value, isOverflow) = connectionAttemptCount.addingReportingOverflow(1)
             connectionAttemptCount = isOverflow ? 0 : value
         }
-        
+
         /// The actual endpoint fed to WireGuard, can be a local endpoint if obfuscation is used.
         public let connectedEndpoint: MullvadEndpoint
         /// Via which transport protocol was the connection made to the relay
         public let transportLayer: TransportLayer
-        
+
         /// The remote port that was chosen to connect to `connectedEndpoint`
         public let remotePort: UInt16
     }
@@ -177,7 +177,6 @@ extension State {
         public var priorState: StatePriorToBlockedState
     }
 }
-
 
 /// Reason why packet tunnel entered error state.
 public enum BlockedStateReason: String, Codable, Equatable {

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -96,8 +96,16 @@ public enum NetworkReachability: Equatable, Codable {
     case undetermined, reachable, unreachable
 }
 
+// perhaps this should have a better name?
+protocol ConnectionOrBlockedState {
+    var currentKey: PrivateKey? { get set }
+    var keyPolicy: KeyPolicy { get set }
+    var networkReachability: NetworkReachability { get set }
+    var lastKeyRotation: Date? { get set }
+}
+
 /// Data associated with states that hold connection data.
-struct ConnectionState: Equatable {
+struct ConnectionState: Equatable, ConnectionOrBlockedState {
     /// Current selected relay.
     public var selectedRelay: SelectedRelay
 
@@ -138,7 +146,7 @@ struct ConnectionState: Equatable {
 }
 
 /// Data associated with error state.
-struct BlockedState {
+struct BlockedState: ConnectionOrBlockedState {
     /// Reason why block state was entered.
     public var reason: BlockedStateReason
 


### PR DESCRIPTION
This replaces recurring cascades of case statements that mutate `State`'s associated values with one utility method on State: `mutateAssociatedData`, which take a function that might modify the appropriate associated value, and if the current state has such a value, applies it and returns whether a modification took place.  The function is given a `StateAssociatedData` type, which is a protocol encompassing both the connection and blocked state data's common fields.

The benefit of this change is increased separation of concerns: code that cares only about the connection/error state no longer needs to know which states exist, which will make changing the logic of the state machine simpler, as there will be fewer places where changes are needed.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5982)
<!-- Reviewable:end -->
