### PR TITLE
Add a list of additional accepted verbs in git commit messages

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -22,7 +22,7 @@ jobs:
           accessToken: ${{ secrets.GITHUB_TOKEN }} # only required if checkAllCommitMessages is true
 
       - name: Check against guidelines
-        uses: mristin/opinionated-commit-message@623037eb118a24335513cd7c4b2d4adabf292a8d
+        uses: mullvad/opinionated-commit-message@e310131b14110bed10e8572566259b863080bba5
         with:
           # Commit messages are allowed to be subject only, no body
           allow-one-liners: 'true'

--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -22,11 +22,9 @@ jobs:
           accessToken: ${{ secrets.GITHUB_TOKEN }} # only required if checkAllCommitMessages is true
 
       - name: Check against guidelines
-        uses: mristin/opinionated-commit-message@v3.1.0
+        uses: mristin/opinionated-commit-message@623037eb118a24335513cd7c4b2d4adabf292a8d
         with:
           # Commit messages are allowed to be subject only, no body
           allow-one-liners: 'true'
-          # This action defaults to 50 char subjects, but 72 is fine.
-          max-subject-line-length: '72'
-          # The action's wordlist is a bit short. Add more accepted verbs
-          additional-verbs: 'restart, coalesce'
+          # This action defaults to 50 char subjects, but 74 is fine.
+          max-subject-line-length: '74'


### PR DESCRIPTION
Follow up to #5975. We realized we also miss `queue`. Instead of adding one to two words at a time, it's probably more efficient to look at our history and see what verbs we actually do use. Turns out we used 184 unique verbs that I classify as OK imperative verbs that were not already in the list.

The list was long. So I might have made a mistake or two while going through it. Please read the list and suggest words to remove or add :pray: 

I have also submitted a PR to start getting these upstreamed. If the upstreaming goes smooth we will *hopefully* not need to maintain this list ourselves. Having it upstream has the valuable benefit of easily checking more than one repo without needing to duplicate this wordlist. https://github.com/mristin/opinionated-commit-message/pull/131

These were taken from our own git history with:
```bash
git log --format=%s | \
    awk '{print tolower($1)}' | \
    tr -cd '\n[:alnum:]._-' | \
    sort -u > first-words
```

And then filtered against the verbs the action already accepts:
```bash
for word in $(cat first-words); do
    if ! grep -x "  '$word'," mostFrequentEnglishVerbs.ts > /dev/null; then
        echo "$word";
    fi;
done
```

And then manually inspect the result, since there is lots of invalid words

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5992)
<!-- Reviewable:end -->
