### PR TITLE
Enable reading Quantum Resistance settings from SettingsReader

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider/SettingsReader.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/SettingsReader.swift
@@ -21,7 +21,8 @@ struct SettingsReader: SettingsReaderProtocol {
             interfaceAddresses: [deviceData.ipv4Address, deviceData.ipv6Address],
             relayConstraints: settings.relayConstraints,
             dnsServers: settings.dnsSettings.selectedDNSServers,
-            obfuscation: settings.wireGuardObfuscation
+            obfuscation: settings.wireGuardObfuscation,
+            quantumResistance: settings.tunnelQuantumResistance
         )
     }
 }

--- a/ios/PacketTunnelCore/Actor/ObservedState+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/ObservedState+Extensions.swift
@@ -12,7 +12,8 @@ import MullvadTypes
 extension ObservedState {
     public var relayConstraints: RelayConstraints? {
         switch self {
-        case let .connecting(connState), let .connected(connState), let .reconnecting(connState), let .negotiatingKey(connState):
+        case let .connecting(connState), let .connected(connState), let .reconnecting(connState),
+             let .negotiatingKey(connState):
             connState.relayConstraints
 
         case let .error(blockedState):

--- a/ios/PacketTunnelCore/Actor/Protocols/SettingsReaderProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/SettingsReaderProtocol.swift
@@ -40,18 +40,22 @@ public struct Settings {
     /// Obfuscation settings
     public var obfuscation: WireGuardObfuscationSettings
 
+    public var quantumResistance: TunnelQuantumResistance
+
     public init(
         privateKey: PrivateKey,
         interfaceAddresses: [IPAddressRange],
         relayConstraints: RelayConstraints,
         dnsServers: SelectedDNSServers,
-        obfuscation: WireGuardObfuscationSettings
+        obfuscation: WireGuardObfuscationSettings,
+        quantumResistance: TunnelQuantumResistance
     ) {
         self.privateKey = privateKey
         self.interfaceAddresses = interfaceAddresses
         self.relayConstraints = relayConstraints
         self.dnsServers = dnsServers
         self.obfuscation = obfuscation
+        self.quantumResistance = quantumResistance
     }
 }
 

--- a/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
@@ -29,7 +29,8 @@ extension SettingsReaderStub {
             interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!],
             relayConstraints: RelayConstraints(),
             dnsServers: .gateway,
-            obfuscation: WireGuardObfuscationSettings(state: .off, port: .automatic)
+            obfuscation: WireGuardObfuscationSettings(state: .off, port: .automatic),
+            quantumResistance: .automatic
         )
 
         return SettingsReaderStub {

--- a/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
+++ b/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
@@ -207,7 +207,8 @@ final class PacketTunnelActorTests: XCTestCase {
                     interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!],
                     relayConstraints: RelayConstraints(),
                     dnsServers: .gateway,
-                    obfuscation: WireGuardObfuscationSettings(state: .off, port: .automatic)
+                    obfuscation: WireGuardObfuscationSettings(state: .off, port: .automatic),
+                    quantumResistance: .automatic
                 )
             }
         }

--- a/ios/PacketTunnelCoreTests/ProtocolObfuscatorTests.swift
+++ b/ios/PacketTunnelCoreTests/ProtocolObfuscatorTests.swift
@@ -34,14 +34,14 @@ final class ProtocolObfuscatorTests: XCTestCase {
     }
 
     func testObfuscateOffDoesNotChangeEndpoint() {
-        let settings = settings(.off, obfuscationPort: .automatic)
+        let settings = settings(.off, obfuscationPort: .automatic, quantumResistance: .automatic)
         let nonObfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings)
 
         XCTAssertEqual(endpoint, nonObfuscatedEndpoint)
     }
 
     func testObfuscateOnPort80() throws {
-        let settings = settings(.on, obfuscationPort: .port80)
+        let settings = settings(.on, obfuscationPort: .port80, quantumResistance: .automatic)
         let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
@@ -49,7 +49,7 @@ final class ProtocolObfuscatorTests: XCTestCase {
     }
 
     func testObfuscateOnPort5001() throws {
-        let settings = settings(.on, obfuscationPort: .port5001)
+        let settings = settings(.on, obfuscationPort: .port5001, quantumResistance: .automatic)
         let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
@@ -57,7 +57,7 @@ final class ProtocolObfuscatorTests: XCTestCase {
     }
 
     func testObfuscateOnPortAutomaticIsPort80OnEvenRetryAttempts() throws {
-        let settings = settings(.on, obfuscationPort: .automatic)
+        let settings = settings(.on, obfuscationPort: .automatic, quantumResistance: .automatic)
         let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings, retryAttempts: 2)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
@@ -65,7 +65,7 @@ final class ProtocolObfuscatorTests: XCTestCase {
     }
 
     func testObfuscateOnPortAutomaticIsPort5001OnOddRetryAttempts() throws {
-        let settings = settings(.on, obfuscationPort: .automatic)
+        let settings = settings(.on, obfuscationPort: .automatic, quantumResistance: .automatic)
         let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings, retryAttempts: 3)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
@@ -73,7 +73,7 @@ final class ProtocolObfuscatorTests: XCTestCase {
     }
 
     func testObfuscateAutomaticIsPort80EveryThirdAttempts() throws {
-        let settings = settings(.automatic, obfuscationPort: .automatic)
+        let settings = settings(.automatic, obfuscationPort: .automatic, quantumResistance: .automatic)
         let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings, retryAttempts: 6)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
@@ -81,7 +81,7 @@ final class ProtocolObfuscatorTests: XCTestCase {
     }
 
     func testObfuscateAutomaticIsPort5001EveryFourthAttempts() throws {
-        let settings = settings(.automatic, obfuscationPort: .automatic)
+        let settings = settings(.automatic, obfuscationPort: .automatic, quantumResistance: .automatic)
         let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings, retryAttempts: 7)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
@@ -100,7 +100,8 @@ final class ProtocolObfuscatorTests: XCTestCase {
 
     private func settings(
         _ obfuscationState: WireGuardObfuscationState,
-        obfuscationPort: WireGuardObfuscationPort
+        obfuscationPort: WireGuardObfuscationPort,
+        quantumResistance: TunnelQuantumResistance
     ) -> Settings {
         Settings(
             privateKey: PrivateKey(),
@@ -110,7 +111,7 @@ final class ProtocolObfuscatorTests: XCTestCase {
             obfuscation: WireGuardObfuscationSettings(
                 state: obfuscationState,
                 port: obfuscationPort
-            )
+            ), quantumResistance: quantumResistance
         )
     }
 }


### PR DESCRIPTION
This PR enables reading the Quantum Resistance settings from the `SettingsReader` object, which will help deciding when to request Post Quantum key exchange.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5993)
<!-- Reviewable:end -->
