### PR TITLE
Fix selection of custom list location not being retained

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/CustomListsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/CustomListsDataSource.swift
@@ -85,18 +85,21 @@ class CustomListsDataSource: LocationDataSourceProtocol {
         return switch location {
         case let .country(countryCode):
             rootNode
-                .countryFor(code: countryCode)?.copy(withParent: parentNode)
+                .countryFor(code: countryCode)?
+                .copy(withParent: parentNode)
 
         case let .city(countryCode, cityCode):
             rootNode
-                .countryFor(code: countryCode)?.copy(withParent: parentNode)
-                .cityFor(codes: [countryCode, cityCode])
+                .countryFor(code: countryCode)?
+                .cityFor(codes: [countryCode, cityCode])?
+                .copy(withParent: parentNode)
 
         case let .hostname(countryCode, cityCode, hostCode):
             rootNode
-                .countryFor(code: countryCode)?.copy(withParent: parentNode)
+                .countryFor(code: countryCode)?
                 .cityFor(codes: [countryCode, cityCode])?
-                .hostFor(code: hostCode)
+                .hostFor(code: hostCode)?
+                .copy(withParent: parentNode)
         }
     }
 }

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationNode.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationNode.swift
@@ -80,6 +80,8 @@ extension LocationNode {
 }
 
 extension LocationNode {
+    /// Recursively copies a node, its parent and its descendants from another
+    /// node (tree), with an optional custom root parent.
     func copy(withParent parent: LocationNode? = nil) -> LocationNode {
         let node = LocationNode(
             name: name,

--- a/ios/MullvadVPNTests/Location/CustomListsDataSourceTests.swift
+++ b/ios/MullvadVPNTests/Location/CustomListsDataSourceTests.swift
@@ -32,6 +32,18 @@ class CustomListsDataSourceTests: XCTestCase {
         XCTAssertNotNil(youtubeNode.descendantNodeFor(codes: ["youtube", "us", "dal"]))
     }
 
+    func testParents() throws {
+        let listNode = try XCTUnwrap(dataSource.nodes.first(where: { $0.name == "Netflix" }))
+        let countryNode = try XCTUnwrap(listNode.descendantNodeFor(codes: ["netflix-se"]))
+        let cityNode = try XCTUnwrap(listNode.descendantNodeFor(codes: ["netflix-se-got"]))
+        let hostNode = try XCTUnwrap(listNode.descendantNodeFor(codes: ["netflix-se10-wireguard"]))
+
+        XCTAssertNil(listNode.parent)
+        XCTAssertEqual(countryNode.parent, listNode)
+        XCTAssertEqual(cityNode.parent, countryNode)
+        XCTAssertEqual(hostNode.parent, cityNode)
+    }
+
     func testSearch() throws {
         let nodes = dataSource.search(by: "got")
         let rootNode = RootLocationNode(children: nodes)


### PR DESCRIPTION
Selecting a location in a custom list in location view is not retained when closing and opening the view again. This is due to a bug in how the node tree is created with incorrect parent nodes.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5995)
<!-- Reviewable:end -->
