### PR TITLE
Improve git commit message check

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -14,8 +14,8 @@ jobs:
         with:
           # Commit messages are allowed to be subject only, no body
           allow-one-liners: 'true'
-          # This action defaults to 50 char subjects, but 74 is fine.
-          max-subject-line-length: '74'
+          # This action defaults to 50 char subjects, but 72 is fine.
+          max-subject-line-length: '72'
           # The action's wordlist is a bit short. Add more accepted verbs
           additional-verbs: 'restart, coalesce'
 

--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -9,16 +9,6 @@ jobs:
     name: Check commit message style
     runs-on: ubuntu-latest
     steps:
-      - name: Check against guidelines
-        uses: mristin/opinionated-commit-message@v3.1.0
-        with:
-          # Commit messages are allowed to be subject only, no body
-          allow-one-liners: 'true'
-          # This action defaults to 50 char subjects, but 72 is fine.
-          max-subject-line-length: '72'
-          # The action's wordlist is a bit short. Add more accepted verbs
-          additional-verbs: 'restart, coalesce'
-
       - name: Check for unicode whitespaces
         uses: gsactions/commit-message-checker@v2
         with:
@@ -30,3 +20,13 @@ jobs:
           error: 'Detected unicode whitespace character in commit message.'
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # only required if checkAllCommitMessages is true
+
+      - name: Check against guidelines
+        uses: mristin/opinionated-commit-message@v3.1.0
+        with:
+          # Commit messages are allowed to be subject only, no body
+          allow-one-liners: 'true'
+          # This action defaults to 50 char subjects, but 72 is fine.
+          max-subject-line-length: '72'
+          # The action's wordlist is a bit short. Add more accepted verbs
+          additional-verbs: 'restart, coalesce'


### PR DESCRIPTION
The combined diff is not the easiest way to view this PR. Per commit is way more logical.

Commit 1: Change `max-subject-line-length` from 74 to 72. This was just an error when I initially added the job. I invalidly thought 74 was the default body line length (this is where vim and other git aware editors automatically insert a line break), but it is of course 72! So I'm just correcting this. Nothing major really.

Commit 2: Move the `Check for unicode whitespaces` step to run first. This is because the mristin/opinionated-commit-message action can sometimes fail on things we don't consider blocking/hard errors. Such as a correct imperative verb that does not happen to be in the action's wordlist. In these cases the job is aborted and the whitespace checking step is never executed, leading to a larger risk of accidentally merging invalid whitespaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5997)
<!-- Reviewable:end -->
