### PR TITLE
Reduce risk of notification icon displaying when it shouldn't and improve logging

### DIFF
--- a/gui/src/main/account.ts
+++ b/gui/src/main/account.ts
@@ -120,6 +120,8 @@ export default class Account {
   }
 
   public handleDeviceEvent(deviceEvent: DeviceEvent) {
+    this.delegate.closeNotificationsInCategory(SystemNotificationCategory.expiry);
+
     this.deviceStateValue = deviceEvent.deviceState;
 
     switch (deviceEvent.deviceState.type) {

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -487,6 +487,10 @@ class ApplicationMain
 
     log.info('Connected to the daemon');
 
+    this.notificationController.closeNotificationsInCategory(
+      SystemNotificationCategory.tunnelState,
+    );
+
     // subscribe to events
     try {
       this.daemonEventListener = this.subscribeEvents();
@@ -622,6 +626,10 @@ class ApplicationMain
     }
     // Reset the daemon event listener since it's going to be invalidated on disconnect
     this.daemonEventListener = undefined;
+
+    this.notificationController.closeNotificationsInCategory(
+      SystemNotificationCategory.tunnelState,
+    );
 
     if (this.tunnelState.tunnelState.state !== 'disconnected') {
       this.notificationController.notifyDaemonDisconnected(

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -1036,7 +1036,8 @@ class ApplicationMain
       return shell.openExternal(url);
     }
   };
-  public showNotificationIcon = (value: boolean) => this.userInterface?.showNotificationIcon(value);
+  public showNotificationIcon = (value: boolean, reason?: string) =>
+    this.userInterface?.showNotificationIcon(value, reason);
 
   // NotificationSender
   public notify = (notification: SystemNotification) => {

--- a/gui/src/main/tray-icon-controller.ts
+++ b/gui/src/main/tray-icon-controller.ts
@@ -19,6 +19,8 @@ export default class TrayIconController {
 
   private updateThrottlePromise?: Promise<void>;
 
+  private previousNotificationIconReason?: string;
+
   constructor(
     private tray: Tray,
     private iconTypeValue: TrayIconType,
@@ -57,7 +59,16 @@ export default class TrayIconController {
     void this.updateIconParameters({ monochromatic: monochromaticIcon });
   }
 
-  public showNotificationIcon(notificationIcon: boolean) {
+  public showNotificationIcon(notificationIcon: boolean, reason?: string) {
+    if (reason !== this.previousNotificationIconReason) {
+      this.previousNotificationIconReason = reason;
+      if (notificationIcon) {
+        log.info('Showing notification icon:', reason);
+      } else {
+        log.info('Hiding notification icon');
+      }
+    }
+
     void this.updateIconParameters({ notification: notificationIcon });
   }
 

--- a/gui/src/main/user-interface.ts
+++ b/gui/src/main/user-interface.ts
@@ -189,8 +189,8 @@ export default class UserInterface implements WindowControllerDelegate {
   public updateTrayTheme = () => this.trayIconController?.updateTheme() ?? Promise.resolve();
   public setMonochromaticIcon = (value: boolean) =>
     this.trayIconController?.setMonochromaticIcon(value);
-  public showNotificationIcon = (value: boolean) =>
-    this.trayIconController?.showNotificationIcon(value);
+  public showNotificationIcon = (value: boolean, reason?: string) =>
+    this.trayIconController?.showNotificationIcon(value, reason);
   public setWindowIcon = (icon: string) => this.windowController.window?.setIcon(icon);
 
   public updateTrayIcon(tunnelState: TunnelState, blockWhenDisconnected: boolean) {


### PR DESCRIPTION
This PR adds dismissal of tunnel state notification in the beginning of `onDaemonConnected` and `onDaemonDisconnected`. This prevents the notification dot from remaining in this state if it shouldn't.

I've also added logging to easier find the cause of the notification dot being displayed when it shouldn't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/5999)
<!-- Reviewable:end -->
