### PR TITLE
Add vulnerability scanning with OSV scanner

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -17,6 +17,7 @@ on:
       - '!scripts/**'
       - '!windows/**'
       - '!**/**.md'
+      - '!**/osv-scanner.toml'
   schedule:
     # At 06:20 UTC every day.
     # Notifications for scheduled workflows are sent to the user who last modified the cron

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -22,6 +22,7 @@ on:
       - '!prepare-release.sh'
       - '!rustfmt.toml'
       - '!.yamllint'
+      - '!**/osv-scanner.toml'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,18 @@
+---
+name: OSV-Scanner PR Scan
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+  actions: read
+
+jobs:
+  scan-pr:
+    # yamllint disable rule:line-length
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@dfa8609a7da62968d73f63f279418e504c1f523f"  # v1.8.1

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,0 +1,21 @@
+---
+name: OSV-Scanner Scheduled Scan
+
+on:
+  schedule:
+    - cron: "30 12 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+  actions: read
+
+jobs:
+  scan-scheduled:
+    # yamllint disable rule:line-length
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@dfa8609a7da62968d73f63f279418e504c1f523f"  # v1.8.1

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -3,7 +3,7 @@ name: OSV-Scanner Scheduled Scan
 
 on:
   schedule:
-    - cron: "30 12 * * 1"
+    - cron: "30 7 * * MON-FRI"
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -23,6 +23,7 @@ on:
       - '!prepare-release.sh'
       - '!rustfmt.toml'
       - '!.yamllint'
+      - '!**/osv-scanner.toml'
   workflow_dispatch:
 jobs:
   prepare-build-test-framework-linux:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -8,6 +8,7 @@ on:
       - android/lib/resource/src/**/plurals.xml
       - android/lib/resource/src/**/strings.xml
       - gui/**
+      - '!**/osv-scanner.toml'
   workflow_dispatch:
 jobs:
   check-translations:

--- a/android/gradle/osv-scanner.toml
+++ b/android/gradle/osv-scanner.toml
@@ -1,0 +1,89 @@
+# See repository root `osv-scanner.toml` for instructions and rules for this file.
+#
+# Temporarily ignoring all reported android vulnerabilites with a one month deadline
+# since we plan to examine the vulnerabilites and bootstrap this file with proper
+# ignore reasons (or address by bumping dependencies).
+#
+# Also worth mentioning that we're already using the OWASP Dependency-Check tool
+# for the android code base as of before.
+
+[[IgnoredVulns]]
+id = "CVE-2022-45868" # GHSA-22wj-vf5f-wrvj
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2023-3635" # GHSA-w33c-445m-f8w7
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2024-29025" # GHSA-5jpm-x58v-624v
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2023-44487" # GHSA-xpw8-rcwv-8f8p
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2023-34462" # GHSA-6mjq-h674-j845
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2024-26308" # GHSA-4265-ccf5-phj5
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2024-25710" # GHSA-4g9r-vxhx-9pgx
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2020-13956" # GHSA-7r82-7xv7-xcpj
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2023-51775" # GHSA-6qvw-249j-h44c
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2023-31582" # GHSA-7g24-qg88-p43q
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "GHSA-jgvc-jfgh-rjvv"
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[IgnoredVulns]]
+id = "CVE-2022-24329" # GHSA-2qp4-g3q3-f92w
+ignoreUntil = 2024-08-02
+reason = "See top comment"
+
+[[PackageOverrides]]
+name = "org.bouncycastle:bcprov-jdk15on"
+ecosystem = "Maven"
+ignore = true
+effectiveUntil = 2024-08-02
+reason = "See top comment"
+
+[[PackageOverrides]]
+name = "org.bouncycastle:bcprov-jdk18on"
+ecosystem = "Maven"
+ignore = true
+effectiveUntil = 2024-08-02
+reason = "See top comment"
+
+[[PackageOverrides]]
+name = "org.bouncycastle:bcpkix-jdk18on"
+ecosystem = "Maven"
+ignore = true
+effectiveUntil = 2024-08-02
+reason = "See top comment"

--- a/gui/osv-scanner.toml
+++ b/gui/osv-scanner.toml
@@ -1,0 +1,26 @@
+# See repository root `osv-scanner.toml` for instructions and rules for this file.
+
+# @grpc/grpc-js: There are two separate code paths in which memory can be allocated per message in
+# excess of the grpc.max_receive_message_length channel option
+[[IgnoredVulns]]
+id = "CVE-2024-37168" # GHSA-7v5v-9h63-cj86
+ignoreUntil = 2024-09-05
+reason = "This component only receives gRPC messages from the trusted mullvad-daemon"
+
+# yargs-parser Vulnerable to Prototype Pollution
+[[IgnoredVulns]]
+id = "CVE-2020-7608" # GHSA-p9pc-299p-vxgp
+ignoreUntil = 2024-09-05
+reason = "This package is only used to parse commands run by either us or trusted libraries"
+
+# PostCSS line return parsing error
+[[IgnoredVulns]]
+id = "CVE-2023-44270" # GHSA-7fh5-64p2-3v2j
+ignoreUntil = 2024-09-05
+reason = "This project does not use PostCSS to parse untrusted CSS"
+
+# braces: Uncontrolled resource consumption
+[[IgnoredVulns]]
+id = "CVE-2024-4068" # GHSA-grv7-fg5c-xmjg
+ignoreUntil = 2024-09-05
+reason = "This package is only used to match paths from either us or trusted libraries"

--- a/gui/scripts/osv-scanner.toml
+++ b/gui/scripts/osv-scanner.toml
@@ -1,0 +1,43 @@
+# See repository root `osv-scanner.toml` for instructions and rules for this file.
+
+# Pillow arbitrary code execution
+[[IgnoredVulns]]
+id = "CVE-2023-50447" # GHSA-3f63-hfp8-52jq
+ignoreUntil = 2024-09-05
+reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
+
+# Pillow buffer overflow
+[[IgnoredVulns]]
+id = "CVE-2024-28219" # GHSA-44wm-f244-xhp3
+ignoreUntil = 2024-09-05
+reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
+
+# Pillow DoS
+[[IgnoredVulns]]
+id = "CVE-2023-44271" # GHSA-8ghj-p4vj-mr35
+ignoreUntil = 2024-09-05
+reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
+
+# libwebp: OOB write in BuildHuffmanTable
+[[IgnoredVulns]]
+id = "CVE-2023-5129" # GHSA-j7hp-h8jx-5ppr
+ignoreUntil = 2024-09-05
+reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
+
+# Pillow versions before v10.0.1 bundled libwebp binaries in wheels that are vulnerable to CVE-2023-5129 (previously CVE-2023-4863)
+[[IgnoredVulns]]
+id = "PYSEC-2023-175"
+ignoreUntil = 2024-09-05
+reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
+
+# Pillow versions before v10.0.1 bundled libwebp binaries in wheels that are vulnerable to CVE-2023-5129 (previously CVE-2023-4863)
+[[IgnoredVulns]]
+id = "GHSA-56pw-mpj4-fxww"
+ignoreUntil = 2024-09-05
+reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
+
+# Pillow vulnerable to Data Amplification attack.
+[[IgnoredVulns]]
+id = "CVE-2022-45198" # GHSA-m2vv-5vj5-2hm7
+ignoreUntil = 2024-09-05
+reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,52 @@
+# List of ignored known vulnerabilities
+#
+# A vulnerability should only be ignored if it cannot be upgraded to a fixed version, or if
+# upgrading it has significant other downsides.
+#
+# Every ignored vulnerability entry must have an `ignoreUntil`.
+# * It is not allowed to ignore a vulnerability indefinitely.
+# * The default should be to ignore a vulnerability for three months.
+# * A vulnerability can be ignored for up to a year at most (Use extremely sparsely).
+# * If anything above three months is used, write a short comment about why this ignore is longer.
+#
+# Try to use the "original" identifier as `id`. This means the identifier used by the original
+# vulnerability database it originates from. These are usually listed as "Aliases" on osv.dev.
+# Feel free to add more identifiers as comments after the `id`.
+#
+# In the `reason` field explain why this vulnerability does not affect us,
+# and why we can't change to an unaffected version.
+#
+# Write a comment above each entry specifying what dependency it is about and what type of
+# vulnerability it is. The other fields do not convey this.
+#
+# Remove the ignore as soon as we upgrade or otherwise get rid of the vulnerable dependency from
+# our product.
+#
+# When an `ignoreUntil` expire and start yielding errors on a previously ignored issue, follow
+# these steps:
+# 1. Try to upgrade away from the vulnerable versions and get rid of the ignore.
+# 2. Update any outdated info in this ignore.
+# 3. Bump the `ignoreUntil` following the same rules as when initially adding an ignore entry.
+
+# Example entry:
+#
+# ```
+# # libbaz remote code execution in get_date() function
+# [[IgnoredVulns]]
+# id = "CVE-2020-12345" # GHSA-abcd-efgh-1234
+# ignoreUntil = 2024-12-05 # Ignored for six months at a time. Unlikely to be fixed, but also unlikely to be an issue for us.
+# reason = """
+# The vulnerable code path is currently not triggered by us or our dependencies.
+# `renderer-helper` currently depend on this version of libbaz, preventing us from upgrading to a fixed version.
+# """
+# ```
+
+# KyberSlash timing attack against Kyber PQ KEM
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0079"
+ignoreUntil = 2024-12-05 # Ignored for six months at a time. This class of timing based attacks are not exploitable in our protocol design
+reason = """
+KyberSlash is not exploitable in our usage of it:
+https://mullvad.net/en/blog/mullvads-usage-of-kyber-is-not-affected-by-kyberslash
+And no patched version is available.
+"""

--- a/test/osv-scanner.toml
+++ b/test/osv-scanner.toml
@@ -1,0 +1,1 @@
+# See repository root `osv-scanner.toml` for instructions and rules for this file.


### PR DESCRIPTION
Adding (yet another) scanner for known vulnerabilities in our dependency tree(s). This one actually checks some places we have not looked at before.

Draft until we have figured out what lockfiles we want to check (if not all) and fixed or ignored all existing reported vulns.

The vulns it reports can be found here: https://github.com/mullvad/mullvadvpn-app/security/code-scanning?page=1&query=pr%3A6001+is%3Aopen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6001)
<!-- Reviewable:end -->
