### PR TITLE
Fix not showing the correct api access method in use on app reinstall

### DIFF
--- a/ios/MullvadREST/Transport/AccessMethodIterator.swift
+++ b/ios/MullvadREST/Transport/AccessMethodIterator.swift
@@ -37,14 +37,12 @@ class AccessMethodIterator {
     }
 
     private func refreshCacheIfNeeded() {
-        /// Validating the index of `lastReachableApiAccessCache` after any changes in `AccessMethodRepository`
-        if let firstIndex = enabledConfigurations.firstIndex(where: { $0.id == self.lastReachableApiAccessId }) {
+        // Validating the index of `lastReachableApiAccessCache` after any changes in `AccessMethodRepository`
+        if let firstIndex = enabledConfigurations.firstIndex(where: { $0.id == lastReachableApiAccessId }) {
             index = firstIndex
-        } else {
-            /// When `firstIndex` is `nil`, that means the current configuration is not valid anymore
-            /// Invalidating cache by replacing the `current` to the next enabled access method
-            dataSource.saveLastReachable(pick())
         }
+
+        dataSource.saveLastReachable(pick())
     }
 
     func rotate() {


### PR DESCRIPTION
When "Direct" is disabled and "Mullvad bridges" is in use, if app is then removed and reinstalled, "Direct" is enabled again (correct) and "Mullvad bridges" in use (wrong, should be "Direct").

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6004)
<!-- Reviewable:end -->
