### PR TITLE
Upgrade build containers to use Rust 1.77

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.77.0"
 
 [workspace]
 resolver = "2"

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -19,7 +19,7 @@
 # patch for a given go version can be identified by checking the wireguard-android
 # repo: https://git.zx2c4.com/wireguard-android/tree/tunnel/tools/libwg-go.
 # It's also important to keep the go path in sync.
-FROM ghcr.io/mullvad/mullvadvpn-app-build:1b882ccbc
+FROM ghcr.io/mullvad/mullvadvpn-app-build:01a98bb5b
 
 # === Metadata ===
 LABEL org.opencontainers.image.source=https://github.com/mullvad/mullvadvpn-app

--- a/building/android-container-image.txt
+++ b/building/android-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build-android:169361256
+ghcr.io/mullvad/mullvadvpn-app-build-android:8fecd91cb

--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:1b882ccbc
+ghcr.io/mullvad/mullvadvpn-app-build:01a98bb5b

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.77.0"
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
Upgrade build containers. The new containers have already been built and their signatures has been push to main already in 18622145f371cce037e385e37b614a5b28b6ea2b and 0bda1107d189189298aaf989baa13d4099f7c164.

This PR can be merged once we have verified the apps can be properly built from these new containers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6010)
<!-- Reviewable:end -->
