### PR TITLE
Point the hickory-dns dependency to our own fork of the repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hickory-proto"
 version = "0.24.0"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=9e8f8c67fbcb6d2985503027362a3fb022529802#9e8f8c67fbcb6d2985503027362a3fb022529802"
+source = "git+https://github.com/mullvad/hickory-dns?rev=9e8f8c67fbcb6d2985503027362a3fb022529802#9e8f8c67fbcb6d2985503027362a3fb022529802"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "hickory-resolver"
 version = "0.24.0"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=9e8f8c67fbcb6d2985503027362a3fb022529802#9e8f8c67fbcb6d2985503027362a3fb022529802"
+source = "git+https://github.com/mullvad/hickory-dns?rev=9e8f8c67fbcb6d2985503027362a3fb022529802#9e8f8c67fbcb6d2985503027362a3fb022529802"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1290,7 +1290,7 @@ dependencies = [
 [[package]]
 name = "hickory-server"
 version = "0.24.0"
-source = "git+https://github.com/hickory-dns/hickory-dns?rev=9e8f8c67fbcb6d2985503027362a3fb022529802#9e8f8c67fbcb6d2985503027362a3fb022529802"
+source = "git+https://github.com/mullvad/hickory-dns?rev=9e8f8c67fbcb6d2985503027362a3fb022529802#9e8f8c67fbcb6d2985503027362a3fb022529802"
 dependencies = [
  "async-trait",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -103,11 +103,15 @@ skip-tree = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# If we need to temporarily depend on a git repository in our Rust dependency tree,
-# it has to be added here. We should try to keep this list minimal. Having git
-# dependencies is not recommended.
-# TODO: Remove git dependency for hickory-dns after new release
-allow-git = ["https://github.com/hickory-dns/hickory-dns"]
+
+# We should never depend on git repositories outside our own github organization.
+# We can't say anything about their availability. They might go away at any point
+# in time. Instead of using third party git repositories, always fork the repository
+# into our github organization and depend on that.
+#
+# But if possible, always avoid git dependencies and try to have the developers publish
+# releases to crates.io instead.
+allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -51,8 +51,8 @@ duct = "0.13"
 pfctl = "0.4.4"
 subslice = "0.2"
 system-configuration = "0.5.1"
-hickory-proto = { git = "https://github.com/hickory-dns/hickory-dns", rev = "9e8f8c67fbcb6d2985503027362a3fb022529802" }
-hickory-server = { git = "https://github.com/hickory-dns/hickory-dns", rev = "9e8f8c67fbcb6d2985503027362a3fb022529802", features = ["resolver"] }
+hickory-proto = { git = "https://github.com/mullvad/hickory-dns", rev = "9e8f8c67fbcb6d2985503027362a3fb022529802" }
+hickory-server = { git = "https://github.com/mullvad/hickory-dns", rev = "9e8f8c67fbcb6d2985503027362a3fb022529802", features = ["resolver"] }
 
 [target.'cfg(windows)'.dependencies]
 bitflags = "1.2"


### PR DESCRIPTION
We should avoid depending on git repositories outside our own control. The hickory-dns organization or repository can go away at any point in time. That will make it way harder to re-build old versions of the app.

I also asked the maintainers if they could publish a patch release, because we should avoid git dependencies altogether when we can :pray:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6015)
<!-- Reviewable:end -->
