### PR TITLE
Remove settings only on app uninstall

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -502,7 +502,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
 
                 SettingsManager.resetStore(completely: true)
+
                 self.accessMethodRepository.reloadWithDefaultsAfterDataRemoval()
+                // At app startup, the relay cache tracker will get populated with a list of overriden IPs.
+                // The overriden IPs will get wiped, therefore, the cache needs to be pruned as well.
+                try? self.relayCacheTracker.refreshCachedRelays()
             }
 
             FirstTimeLaunch.setHasFinished()

--- a/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
@@ -161,8 +161,6 @@ class SetAccountOperation: ResultOperation<StoredAccountData?> {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         deleteAccount(accountNumber: accountNumber) { [self] result in
-            interactor.setSettings(LatestTunnelSettings(), persist: true)
-
             if result.isSuccess {
                 interactor.removeLastUsedAccount()
             }
@@ -230,9 +228,6 @@ class SetAccountOperation: ResultOperation<StoredAccountData?> {
                 privateKey: newDevice.privateKey
             )
         )
-
-        // Reset tunnel settings.
-        interactor.setSettings(LatestTunnelSettings(), persist: true)
 
         // Transition device state to logged in.
         interactor.setDeviceState(.loggedIn(accountData, storedDeviceData), persist: true)

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -1092,8 +1092,6 @@ final class TunnelManager: StorePaymentObserver {
     }
 
     private func unsetTunnelConfiguration(completion: @escaping () -> Void) {
-        setSettings(LatestTunnelSettings(), persist: true)
-
         // Tell the caller to unsubscribe from VPN status notifications.
         prepareForVPNConfigurationDeletion()
 


### PR DESCRIPTION
We should not remove any settings when a user logs out or explicitly deletes an account. Or rather, only app uninstall should trigger a removal of app settings.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6024)
<!-- Reviewable:end -->
