### PR TITLE
Enter blocking state correctly in upgrade test

### DIFF
--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -67,8 +67,7 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> Result<()
     //
     log::debug!("Entering blocking error state");
 
-    // TODO: Update this to `rpc.exec("mullvad", ["debug", "block-connection"])` when 2023.6 is released.
-    rpc.exec("mullvad", ["relay", "set", "location", "xx"])
+    rpc.exec("mullvad", ["debug", "block-connection"])
         .await
         .expect("Failed to set relay location");
     rpc.exec("mullvad", ["connect"])


### PR DESCRIPTION
`mullvad relay set location xx` no longer works (https://github.com/mullvad/mullvadvpn-app/actions/runs/8420230971/job/23054624667#step:4:850). The PR switches to using `mullvad debug block-connection` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6026)
<!-- Reviewable:end -->
