### PR TITLE
Update `deny.toml` files for new `version = 2` format, and other cleanups.

### DIFF
--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/verify-locked-down-signatures.yml
       - Cargo.lock
       - deny.toml
+      - test/deny.toml
       - gui/package-lock.json
       - wireguard/libwg/go.sum
       - ci/keys/**

--- a/deny.toml
+++ b/deny.toml
@@ -103,7 +103,6 @@ skip-tree = []
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 
 # We should never depend on git repositories outside our own github organization.
 # We can't say anything about their availability. They might go away at any point

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,6 @@ multiple-versions = "warn"
 wildcards = "warn"
 highlight = "all"
 
-allow = []
 deny = [
     # We are using Rustls for TLS. We don't want to accidentally pull in
     # anything OpenSSL related
@@ -81,12 +80,8 @@ deny = [
     { name = "openssl-probe" },
     { name = "clap", version = "2" },
     { name = "clap", version = "3" },
-    # `atty` is an unmaintained crate with a CVE: RUSTSEC-2021-0145
-    { name = "atty" },
     { name = "time", version = "0.1"},
 ]
-skip = []
-skip-tree = []
 
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -21,22 +21,14 @@ targets = [
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-db-path = "~/.cargo/advisory-db"
-db-urls = ["https://github.com/rustsec/advisory-db"]
-
-vulnerability = "deny"
-unmaintained = "warn"
+version = 2 # https://github.com/EmbarkStudios/cargo-deny/pull/611
 yanked = "deny"
-notice = "deny"
-
 ignore = [
     # Ignored audit issues. This list should be kept short, and effort should be
     # put into removing items from the list.
     # RUSTSEC-2023-0079 - KyberSlash in `pqc_kyber`.
     "RUSTSEC-2023-0079"
 ]
-
-#severity-threshold =
 
 
 # This section is considered when running `cargo deny check licenses`

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,20 @@
+[graph]
+# cargo deny will only evaluate dependencies pulled in by these
+# targets (the ones we ship Rust code to)
 targets = [
+    # Desktop
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-pc-windows-gnu" },
     { triple = "x86_64-apple-darwin" },
-    { triple = "aarch64-apple-darwin" }
+    { triple = "aarch64-apple-darwin" },
+    # Android
+    { triple = "x86_64-linux-android" },
+    { triple = "i686-linux-android" },
+    { triple = "aarch64-linux-android" },
+    { triple = "armv7-linux-androideabi" },
+    # iOS
+    { triple = "x86_64-apple-ios" },
+    { triple = "aarch64-apple-ios" },
 ]
 
 # This section is considered when running `cargo deny check advisories`

--- a/deny.toml
+++ b/deny.toml
@@ -43,15 +43,14 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
+version = 2 # https://github.com/EmbarkStudios/cargo-deny/pull/611
 
-# Adding a license here has to be done carefully. Should not be changed
-# by individual developers.
+# Adding a license here has to be done carefully. Should only be done by team leads.
 allow = [
     "GPL-3.0",
     "Apache-2.0",
     "MIT",
+    "MPL-2.0",
     "WTFPL",
     "ISC",
     "BSD-3-Clause",
@@ -62,15 +61,6 @@ allow = [
     "Unicode-DFS-2016"
 ]
 
-deny = []
-
-copyleft = "allow"
-allow-osi-fsf-free = "neither"
-default = "deny"
-confidence-threshold = 0.8
-
-exceptions = []
-
 [[licenses.clarify]]
 name = "ring"
 expression = "LicenseRef-ring"
@@ -80,7 +70,6 @@ license-files = [
 
 [licenses.private]
 ignore = false
-registries = []
 
 
 # This section is considered when running `cargo deny check bans`.

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -14,15 +14,11 @@ targets = [
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 version = 2 # https://github.com/EmbarkStudios/cargo-deny/pull/611
-db-path = "~/.cargo/advisory-db"
-db-urls = ["https://github.com/rustsec/advisory-db"]
-
+yanked = "deny"
 ignore = [
     # Ignored audit issues. This list should be kept short, and effort should be
     # put into removing items from the list.
 ]
-
-#severity-threshold =
 
 
 # This section is considered when running `cargo deny check licenses`

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -31,26 +31,21 @@ ignore = [
 [licenses]
 version = 2 # https://github.com/EmbarkStudios/cargo-deny/pull/611
 
-# Adding a license here has to be done carefully. Should not be changed
-# by individual developers.
+# Adding a license here has to be done carefully. Should only be done by team leads.
 allow = [
     "GPL-3.0",
     "Apache-2.0",
     "MIT",
+    "MPL-2.0",
     "WTFPL",
     "ISC",
     "BSD-3-Clause",
     "BSD-2-Clause",
     "CC0-1.0",
-    "MPL-2.0",
     # https://github.com/briansmith/ring/issues/902
     "LicenseRef-ring",
     "Unicode-DFS-2016"
 ]
-
-confidence-threshold = 0.8
-
-exceptions = []
 
 [[licenses.clarify]]
 name = "ring"
@@ -61,7 +56,6 @@ license-files = [
 
 [licenses.private]
 ignore = false
-registries = []
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -65,12 +65,8 @@ allow = []
 deny = [
     { name = "clap", version = "2" },
     { name = "clap", version = "3" },
-    # `atty` is an unmaintained crate with a CVE: RUSTSEC-2021-0145
-    { name = "atty" },
     { name = "time", version = "0.1"},
 ]
-skip = []
-skip-tree = []
 
 
 # This section is considered when running `cargo deny check sources`.

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -76,16 +76,21 @@ deny = [
 skip = []
 skip-tree = []
 
+
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# If we need to temporarily depend on a git repository in our Rust dependency tree,
-# it has to be added here. We should try to keep this list minimal. Having git
-# dependencies is not recommended.
+
+# We should never depend on git repositories outside our own github organization.
+# We can't say anything about their availability. They might go away at any point
+# in time. Instead of using third party git repositories, always fork the repository
+# into our github organization and depend on that.
+#
+# But if possible, always avoid git dependencies and try to have the developers publish
+# releases to crates.io instead.
 allow-git = []
 
 [sources.allow-org]

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -1,3 +1,14 @@
+[graph]
+# cargo deny will only evaluate dependencies pulled in by these
+# targets (the ones we run the test runner on)
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-pc-windows-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" }
+]
+
+
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
@@ -86,11 +97,3 @@ allow-git = []
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
 github = ["mullvad"]
-
-[graph]
-targets = [
-    { triple = "x86_64-unknown-linux-gnu" },
-    { triple = "x86_64-pc-windows-gnu" },
-    { triple = "x86_64-apple-darwin" },
-    { triple = "aarch64-apple-darwin" }
-]


### PR DESCRIPTION
This PR does a bunch of housekeeping around our usage of `cargo deny`. I saw that running `cargo deny` produced a bunch of warnings, since we use deprecated fields. This PR fixes that and more.

This PR is probably easiest to review per commit!

* Add `version = 2` where suitable and remove deprecated fields
* Remove fields which were set to default values anyway. No need to explicitly set them, just noisy.
* Require signatures to changes to `test/deny.toml` - Arguably way less important than the main `deny.toml` but still in some ways affect supply chain security and licenses, so should be signed.
* Adds more targets. Since we do build this software for Android and iOS also, we should check it strictly
* No need to explicitly deny `atty` I feel. That crate has a CVE registered against it anyway, so any CVE checking tool will catch if we accidentally get it into our dependency tree again.
* Add comment about us not wanting to have git dependencies, and if we do they should be on our own github org.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6029)
<!-- Reviewable:end -->
