### PR TITLE
Ignore "block" tunnel command except in secured states

### DIFF
--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -1,10 +1,10 @@
 use super::{
-    ConnectingState, ErrorState, EventConsequence, SharedTunnelStateValues, TunnelCommand,
+    ConnectingState, EventConsequence, SharedTunnelStateValues, TunnelCommand,
     TunnelCommandReceiver, TunnelState, TunnelStateTransition,
 };
-#[cfg(target_os = "macos")]
-use crate::dns;
 use crate::firewall::FirewallPolicy;
+#[cfg(target_os = "macos")]
+use crate::{dns, tunnel_state_machine::ErrorState};
 use futures::StreamExt;
 #[cfg(target_os = "macos")]
 use std::net::Ipv4Addr;
@@ -205,10 +205,7 @@ impl TunnelState for DisconnectedState {
                 SameState(self)
             }
             Some(TunnelCommand::Connect) => NewState(ConnectingState::enter(shared_values, 0)),
-            Some(TunnelCommand::Block(reason)) => {
-                Self::reset_dns(shared_values);
-                NewState(ErrorState::enter(shared_values, reason))
-            }
+            Some(TunnelCommand::Block(_reason)) => SameState(self),
             #[cfg(target_os = "android")]
             Some(TunnelCommand::BypassSocket(fd, done_tx)) => {
                 shared_values.bypass_socket(fd, done_tx);

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -68,8 +68,9 @@ impl DisconnectingState {
                     AfterDisconnect::Nothing
                 }
                 Some(TunnelCommand::Connect) => AfterDisconnect::Reconnect(0),
-                Some(TunnelCommand::Disconnect) | None => AfterDisconnect::Nothing,
-                Some(TunnelCommand::Block(reason)) => AfterDisconnect::Block(reason),
+                Some(TunnelCommand::Disconnect) | Some(TunnelCommand::Block(_)) | None => {
+                    AfterDisconnect::Nothing
+                }
                 #[cfg(target_os = "android")]
                 Some(TunnelCommand::BypassSocket(fd, done_tx)) => {
                     shared_values.bypass_socket(fd, done_tx);

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -204,7 +204,7 @@ pub enum TunnelCommand {
     Connect,
     /// Close tunnel connection.
     Disconnect,
-    /// Disconnect any open tunnel and block all network access
+    /// Block all network access unless tunnel is disconnecting or disconnected
     Block(ErrorStateCause),
     /// Bypass a socket, allowing traffic to flow through outside the tunnel.
     #[cfg(target_os = "android")]


### PR DESCRIPTION
Currently, its effect is to always enter the error state, regardless of the current state. Its new behavior is to do nothing when disconnected or leaving a secured state. This shouldn't affect any existing code since we do not rely on entering the blocked state when disconnected.

Related: #5844

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6032)
<!-- Reviewable:end -->
