### PR TITLE
Bump opinionated-commit-message github action to version with more verbs

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -22,11 +22,9 @@ jobs:
           accessToken: ${{ secrets.GITHUB_TOKEN }} # only required if checkAllCommitMessages is true
 
       - name: Check against guidelines
-        uses: mristin/opinionated-commit-message@v3.1.0
+        uses: mristin/opinionated-commit-message@f3b9cec249cabffbae7cd564542fd302cc576827 #v3.1.1
         with:
           # Commit messages are allowed to be subject only, no body
           allow-one-liners: 'true'
           # This action defaults to 50 char subjects, but 72 is fine.
           max-subject-line-length: '72'
-          # The action's wordlist is a bit short. Add more accepted verbs
-          additional-verbs: 'restart, coalesce'


### PR DESCRIPTION
Includes our contributions to the action with ~185 more allowed imperative verbs. That's also why we no longer need to specify any `additional-verbs`.

Pins the action to a commit hash rather than tag. For supply chain security. We might want to do this with way more third party actions, but this is mostly a test to try this out for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6034)
<!-- Reviewable:end -->
