### PR TITLE
Upgrade go to 1.21 in `go.mod`

### DIFF
--- a/wireguard/libwg/go.mod
+++ b/wireguard/libwg/go.mod
@@ -1,6 +1,6 @@
 module github.com/mullvad/mullvadvpn-app/wireguard/libwg
 
-go 1.20
+go 1.21
 
 require (
 	golang.org/x/sys v0.6.0


### PR DESCRIPTION
We already use go 1.21 in our build containers and build servers. So this does not change what version we actually use, only makes go.mod reflect reality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6040)
<!-- Reviewable:end -->
