### PR TITLE
Refactor PacketTunnelActor State, decoupling state from ancilliary data

### DIFF
--- a/ios/PacketTunnelCore/Actor/ObservedState.swift
+++ b/ios/PacketTunnelCore/Actor/ObservedState.swift
@@ -86,8 +86,8 @@ extension State {
     }
 }
 
-extension ConnectionState {
-    /// Map `ConnectionState` to `ObservedConnectionState`.
+extension State.ConnectionData {
+    /// Map `State.ConnectionData` to `ObservedConnectionState`.
     var observedConnectionState: ObservedConnectionState {
         ObservedConnectionState(
             selectedRelay: selectedRelay,
@@ -101,8 +101,8 @@ extension ConnectionState {
     }
 }
 
-extension BlockedState {
-    /// Map `BlockedState` to `ObservedBlockedState`
+extension State.BlockingData {
+    /// Map `State.BlockingData` to `ObservedBlockedState`
     var observedBlockedState: ObservedBlockedState {
         return ObservedBlockedState(reason: reason, relayConstraints: relayConstraints)
     }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -54,10 +54,10 @@ extension PacketTunnelActor {
      - Returns: New blocked state that should be assigned to error state, otherwise `nil` when actor is past or at `disconnecting` phase or
                 when actor is already in the error state and no changes need to be made.
      */
-    private func makeBlockedState(reason: BlockedStateReason) -> BlockedState? {
+    private func makeBlockedState(reason: BlockedStateReason) -> State.BlockingData? {
         switch state {
         case .initial:
-            return BlockedState(
+            return State.BlockingData(
                 reason: reason,
                 relayConstraints: nil,
                 currentKey: nil,
@@ -93,11 +93,11 @@ extension PacketTunnelActor {
      Map connection state to blocked state.
      */
     private func mapConnectionState(
-        _ connState: ConnectionState,
+        _ connState: State.ConnectionData,
         reason: BlockedStateReason,
         priorState: StatePriorToBlockedState
-    ) -> BlockedState {
-        BlockedState(
+    ) -> State.BlockingData {
+        State.BlockingData(
             reason: reason,
             relayConstraints: connState.relayConstraints,
             currentKey: connState.currentKey,

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
@@ -23,7 +23,6 @@ extension PacketTunnelActor {
      - Parameter lastKeyRotation: date when last key rotation took place.
      */
     func cacheActiveKey(lastKeyRotation: Date?) {
-        // There should be a way to rationalise these two identical functions into one.
         state.mutateAssociatedData { stateData in
             guard
                 stateData.keyPolicy == .useCurrent,

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -43,43 +43,6 @@ extension PacketTunnelActor {
 
         let newReachability = networkPath.networkReachability
 
-        func mutateConnectionState(_ connState: inout ConnectionState) -> Bool {
-            if connState.networkReachability != newReachability {
-                connState.networkReachability = newReachability
-                return true
-            }
-            return false
-        }
-
-        switch state {
-        case var .connecting(connState):
-            if mutateConnectionState(&connState) {
-                state = .connecting(connState)
-            }
-
-        case var .connected(connState):
-            if mutateConnectionState(&connState) {
-                state = .connected(connState)
-            }
-
-        case var .reconnecting(connState):
-            if mutateConnectionState(&connState) {
-                state = .reconnecting(connState)
-            }
-
-        case var .disconnecting(connState):
-            if mutateConnectionState(&connState) {
-                state = .disconnecting(connState)
-            }
-
-        case var .error(blockedState):
-            if blockedState.networkReachability != newReachability {
-                blockedState.networkReachability = newReachability
-                state = .error(blockedState)
-            }
-
-        case .initial, .disconnected:
-            break
-        }
+        state.mutateAssociatedData { $0.networkReachability = newReachability }
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -27,7 +27,8 @@ import WireGuardKitTypes
  */
 public actor PacketTunnelActor {
     var state: State = .initial {
-        didSet {
+        didSet(oldValue) {
+            guard state != oldValue else { return }
             logger.debug("\(state.logFormat())")
             observedState = state.observedState
         }
@@ -293,7 +294,7 @@ extension PacketTunnelActor {
         nextRelay: NextRelay,
         settings: Settings,
         reason: ReconnectReason
-    ) throws -> ConnectionState? {
+    ) throws -> State.ConnectionData? {
         var keyPolicy: KeyPolicy = .useCurrent
         var networkReachability = defaultPathObserver.defaultPath?.networkReachability ?? .undetermined
         var lastKeyRotation: Date?
@@ -332,7 +333,7 @@ extension PacketTunnelActor {
             return nil
         }
         let selectedRelay = try callRelaySelector(nil, 0)
-        return ConnectionState(
+        return State.ConnectionData(
             selectedRelay: selectedRelay,
             relayConstraints: settings.relayConstraints,
             currentKey: settings.privateKey,
@@ -350,7 +351,7 @@ extension PacketTunnelActor {
         nextRelay: NextRelay,
         settings: Settings,
         reason: ReconnectReason
-    ) throws -> ConnectionState? {
+    ) throws -> State.ConnectionData? {
         guard let connectionState = try makeConnectionState(nextRelay: nextRelay, settings: settings, reason: reason)
         else { return nil }
 
@@ -361,7 +362,7 @@ extension PacketTunnelActor {
         )
 
         let transportLayer = protocolObfuscator.transportLayer.map { $0 } ?? .udp
-        return ConnectionState(
+        return State.ConnectionData(
             selectedRelay: connectionState.selectedRelay,
             relayConstraints: connectionState.relayConstraints,
             currentKey: settings.privateKey,

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -54,22 +54,22 @@ import WireGuardKitTypes
  `.connecting`, `.reconnecting`, `.error` can be interrupted if the tunnel is requested to stop, which should segue actor towards `.disconnected` state.
 
  */
-enum State {
+enum State: Equatable {
     /// Initial state at the time when actor is initialized but before the first connection attempt.
     case initial
 
     /// Tunnel is attempting to connect.
     /// The actor should remain in this state until the very first connection is established, i.e determined by tunnel monitor.
-    case connecting(ConnectionState)
+    case connecting(ConnectionData)
 
     /// Tunnel is connected.
-    case connected(ConnectionState)
+    case connected(ConnectionData)
 
     /// Tunnel is attempting to reconnect.
-    case reconnecting(ConnectionState)
+    case reconnecting(ConnectionData)
 
     /// Tunnel is disconnecting.
-    case disconnecting(ConnectionState)
+    case disconnecting(ConnectionData)
 
     /// Tunnel is disconnected.
     /// Normally the process is shutdown after entering this state.
@@ -79,7 +79,7 @@ enum State {
     /// This state is normally entered when the tunnel is unable to start or reconnect.
     /// In this state the tunnel blocks all nework connectivity by setting up a peerless WireGuard tunnel, and either awaits user action or, in certain
     /// circumstances, attempts to recover automatically using a repeating timer.
-    case error(BlockedState)
+    case error(BlockingData)
 }
 
 /// Policy describing what WG key to use for tunnel communication.
@@ -96,76 +96,85 @@ public enum NetworkReachability: Equatable, Codable {
     case undetermined, reachable, unreachable
 }
 
-/// Data associated with states that hold connection data.
-struct ConnectionState {
-    /// Current selected relay.
-    public var selectedRelay: SelectedRelay
-
-    /// Last relay constraints read from settings.
-    /// This is primarily used by packet tunnel for updating constraints in tunnel provider.
-    public var relayConstraints: RelayConstraints
-
-    /// Last WG key read from settings.
-    /// Can be `nil` if moved to `keyPolicy`.
-    public var currentKey: PrivateKey?
-
-    /// Policy describing the current key that should be used by the tunnel.
-    public var keyPolicy: KeyPolicy
-
-    /// Whether network connectivity outside of tunnel is available.
-    public var networkReachability: NetworkReachability
-
-    /// Connection attempt counter.
-    /// Reset to zero once connection is established.
-    public var connectionAttemptCount: UInt
-
-    /// Last time packet tunnel rotated the key.
-    public var lastKeyRotation: Date?
-
-    /// Increment connection attempt counter by one, wrapping to zero on overflow.
-    public mutating func incrementAttemptCount() {
-        let (value, isOverflow) = connectionAttemptCount.addingReportingOverflow(1)
-        connectionAttemptCount = isOverflow ? 0 : value
-    }
-
-    /// The actual endpoint fed to WireGuard, can be a local endpoint if obfuscation is used.
-    public let connectedEndpoint: MullvadEndpoint
-    /// Via which transport protocol was the connection made to the relay
-    public let transportLayer: TransportLayer
-
-    /// The remote port that was chosen to connect to `connectedEndpoint`
-    public let remotePort: UInt16
+protocol StateAssociatedData {
+    var currentKey: PrivateKey? { get set }
+    var keyPolicy: KeyPolicy { get set }
+    var networkReachability: NetworkReachability { get set }
+    var lastKeyRotation: Date? { get set }
 }
 
-/// Data associated with error state.
-struct BlockedState {
-    /// Reason why block state was entered.
-    public var reason: BlockedStateReason
+extension State {
+    /// Data associated with states that hold connection data.
+    struct ConnectionData: Equatable, StateAssociatedData {
+        /// Current selected relay.
+        public var selectedRelay: SelectedRelay
 
-    /// Last relay constraints read from settings.
-    /// This is primarily used by packet tunnel for updating constraints in tunnel provider.
-    public var relayConstraints: RelayConstraints?
+        /// Last relay constraints read from settings.
+        /// This is primarily used by packet tunnel for updating constraints in tunnel provider.
+        public var relayConstraints: RelayConstraints
 
-    /// Last WG key read from setings.
-    /// Can be `nil` if moved to `keyPolicy` or when it's uknown.
-    public var currentKey: PrivateKey?
+        /// Last WG key read from settings.
+        /// Can be `nil` if moved to `keyPolicy`.
+        public var currentKey: PrivateKey?
 
-    /// Policy describing the current key that should be used by the tunnel.
-    public var keyPolicy: KeyPolicy
+        /// Policy describing the current key that should be used by the tunnel.
+        public var keyPolicy: KeyPolicy
 
-    /// Whether network connectivity outside of tunnel is available.
-    public var networkReachability: NetworkReachability
+        /// Whether network connectivity outside of tunnel is available.
+        public var networkReachability: NetworkReachability
 
-    /// Last time packet tunnel rotated or attempted to rotate the key.
-    /// This is used by `TunnelManager` to detect when it needs to refresh device state from Keychain.
-    public var lastKeyRotation: Date?
+        /// Connection attempt counter.
+        /// Reset to zero once connection is established.
+        public var connectionAttemptCount: UInt
 
-    /// Task responsible for periodically calling actor to restart the tunnel.
-    /// Initiated based on the error that led to blocked state.
-    public var recoveryTask: AutoCancellingTask?
+        /// Last time packet tunnel rotated the key.
+        public var lastKeyRotation: Date?
 
-    /// Prior state of the actor before entering blocked state
-    public var priorState: StatePriorToBlockedState
+        /// Increment connection attempt counter by one, wrapping to zero on overflow.
+        public mutating func incrementAttemptCount() {
+            let (value, isOverflow) = connectionAttemptCount.addingReportingOverflow(1)
+            connectionAttemptCount = isOverflow ? 0 : value
+        }
+
+        /// The actual endpoint fed to WireGuard, can be a local endpoint if obfuscation is used.
+        public let connectedEndpoint: MullvadEndpoint
+        /// Via which transport protocol was the connection made to the relay
+        public let transportLayer: TransportLayer
+
+        /// The remote port that was chosen to connect to `connectedEndpoint`
+        public let remotePort: UInt16
+    }
+
+    /// Data associated with error state.
+    struct BlockingData: StateAssociatedData {
+        /// Reason why block state was entered.
+        public var reason: BlockedStateReason
+
+        /// Last relay constraints read from settings.
+        /// This is primarily used by packet tunnel for updating constraints in tunnel provider.
+        public var relayConstraints: RelayConstraints?
+
+        /// Last WG key read from setings.
+        /// Can be `nil` if moved to `keyPolicy` or when it's uknown.
+        public var currentKey: PrivateKey?
+
+        /// Policy describing the current key that should be used by the tunnel.
+        public var keyPolicy: KeyPolicy
+
+        /// Whether network connectivity outside of tunnel is available.
+        public var networkReachability: NetworkReachability
+
+        /// Last time packet tunnel rotated or attempted to rotate the key.
+        /// This is used by `TunnelManager` to detect when it needs to refresh device state from Keychain.
+        public var lastKeyRotation: Date?
+
+        /// Task responsible for periodically calling actor to restart the tunnel.
+        /// Initiated based on the error that led to blocked state.
+        public var recoveryTask: AutoCancellingTask?
+
+        /// Prior state of the actor before entering blocked state
+        public var priorState: StatePriorToBlockedState
+    }
 }
 
 /// Reason why packet tunnel entered error state.
@@ -206,7 +215,7 @@ public enum BlockedStateReason: String, Codable, Equatable {
 }
 
 /// Legal states that can precede error state.
-enum StatePriorToBlockedState {
+enum StatePriorToBlockedState: Equatable {
     case initial, connecting, connected, reconnecting
 }
 

--- a/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
+++ b/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
@@ -197,13 +197,14 @@ final class PacketTunnelActorTests: XCTestCase {
         }
 
         var isFirstReadAttempt = true
+        let privateKey = PrivateKey()
         let settingsReader = SettingsReaderStub {
             if isFirstReadAttempt {
                 isFirstReadAttempt = false
                 throw POSIXError(.EPERM)
             } else {
                 return Settings(
-                    privateKey: PrivateKey(),
+                    privateKey: privateKey,
                     interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!],
                     relayConstraints: RelayConstraints(),
                     dnsServers: .gateway,


### PR DESCRIPTION
This involves:
* defining a protocol, `StateAssociatedData`, which encompasses common fields of the connection data for connected states and blockage data for error states
* implementing a method, `mutateAssociatedData`, which applies a mutating function to the data, if present, and replacing a lot of case statements with this
* renaming `ConnectionState` and `BlockedState` to `State.ConnectionData` and `State.BlockingData`, for clarity and namespace hygiene
* making `State` `Èquatable` (within reason), and using equality testing in lieu of keeping track of whether a change was made

The result: a lot of business logic that acts on/modifies connection/blockage data is now considerably shorter, as it no longer needs to know about what the state is or which states may exist.

This was made in the course of the post-quantum functionality, and merged into that feature branch. This pull request is a backport of this to `main`.
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6042)
<!-- Reviewable:end -->
