### PR TITLE
Fix a race condition bug involving timers and async tasks

### DIFF
--- a/ios/PacketTunnelCore/Actor/Task+Duration.swift
+++ b/ios/PacketTunnelCore/Actor/Task+Duration.swift
@@ -40,10 +40,21 @@ extension Task where Success == Never, Failure == Never {
 
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
+                // The `continuation` handler should never be `resume`'d more than once.
+                // Setting the eventHandler on the timer after it has been cancelled will be ignored.
+                // https://github.com/apple/swift-corelibs-libdispatch/blob/77766345740dfe3075f2f60bead854b29b0cfa24/src/source.c#L338
+                // Therefore, set a flag indicating `resume` has already been called to avoid `resume`ing more than once.
+                // Cancelling the timer does not cancel an  event handler that is already running however,
+                // the cancel handler will be scheduled after the event handler has finished.
+                // https://developer.apple.com/documentation/dispatch/1385604-dispatch_source_cancel
+                // Therefore, there it is safe to do this here.
+                var hasResumed = false
                 timer.setEventHandler {
+                    hasResumed = true
                     continuation.resume()
                 }
                 timer.setCancelHandler {
+                    guard hasResumed == false else { return }
                     continuation.resume(throwing: TaskCancellationError())
                 }
                 timer.schedule(wallDeadline: .now() + DispatchTimeInterval.milliseconds(duration.milliseconds))

--- a/ios/PacketTunnelCoreTests/TaskSleepTests.swift
+++ b/ios/PacketTunnelCoreTests/TaskSleepTests.swift
@@ -30,9 +30,9 @@ final class TaskSleepTests: XCTestCase {
     /// cancel a `DispatchSourceTimer` in a `Task` trying to call `resume` on its continuation handler more than once
     func testSuccessfulEventHandlerRemovesCancellation() async throws {
         for _ in 0 ... 20 {
-            var task = recoveryTask()
+            let task = recoveryTask()
             try await Task.sleep(duration: .milliseconds(10))
-            task.doAnythingToSilenceAWarning()
+            task.callDummyFunctionToForceConcurrencyWait()
         }
     }
 
@@ -46,5 +46,10 @@ final class TaskSleepTests: XCTestCase {
 }
 
 private extension AutoCancellingTask {
-    func doAnythingToSilenceAWarning() {}
+    /// This function is here to silence a warning about unused variables in `testSuccessfulEventHandlerRemovesCancellation`
+    /// The following construct `_ = recoveryTask()` cannot be used as the resulting `AutoCancellingTask`
+    /// would immediately get `deinit`ed, changing the test scenario.
+    /// A dummy function is needed to make sure the task is not cancelled before concurrency is forced
+    /// by having a call to `Task.sleep`
+    func callDummyFunctionToForceConcurrencyWait() {}
 }


### PR DESCRIPTION
This PR fixes a subtle bug where a `DispatchSourceTimer` is used alongside swift async code in an unsafe way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6045)
<!-- Reviewable:end -->
