### PR TITLE
Forbid unicode identifiers in rust

### DIFF
--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     paths:
       - .github/workflows/verify-locked-down-signatures.yml
+      - Cargo.toml
+      - test/Cargo.toml
       - Cargo.lock
+      - test/Cargo.lock
       - deny.toml
       - test/deny.toml
       - gui/package-lock.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,12 @@ members = [
     "tunnel-obfuscation",
 ]
 
+# Keep all lints in sync with `test/Cargo.toml`
 [workspace.lints.rust]
+# Security
+non_ascii_idents = "forbid"
+
+# Modern, easy to read style and opinionated best practices
 rust_2018_idioms = "deny"
 
 [workspace.lints.clippy]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -15,7 +15,12 @@ members = [
     "connection-checker",
 ]
 
+# Keep all lints in sync with `../Cargo.toml`
 [workspace.lints.rust]
+# Security
+non_ascii_idents = "forbid"
+
+# Modern, easy to read style and opinionated best practices
 rust_2018_idioms = "deny"
 
 [workspace.lints.clippy]


### PR DESCRIPTION
A small but nice step towards preventing [homograph attacks](https://en.wikipedia.org/wiki/IDN_homograph_attack). We always use English in code and variable names anyway. We have no reason to use non-ascii characters in identifiers (variable and function names) so we can easily forbid them.

Since this makes `Cargo.toml` contain supply chain security related config, I mark it as needing signatures to be changed.

Ideally I'd like a linter/code scanning tool that is language aware and can make sure everything that is not a comment or a string literal is ascii only. Those are the only places where I see legitimate use for non-ascii code points in our product.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6047)
<!-- Reviewable:end -->
