### PR TITLE
Add time left properly displayed test

### DIFF
--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -57,6 +57,7 @@ public enum AccessibilityIdentifier: String {
     case quantumResistantTunnelCell
 
     // Labels
+    case accountPagePaidUntilLabel
     case headerDeviceNameLabel
     case connectionStatusConnectedLabel
     case connectionStatusNotConnectedLabel

--- a/ios/MullvadVPN/View controllers/Account/AccountExpiryRow.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountExpiryRow.swift
@@ -62,6 +62,7 @@ class AccountExpiryRow: UIView {
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
         valueLabel.font = UIFont.systemFont(ofSize: 17)
         valueLabel.textColor = .white
+        valueLabel.accessibilityIdentifier = .accountPagePaidUntilLabel
         return valueLabel
     }()
 

--- a/ios/MullvadVPNUITests/AccountTests.swift
+++ b/ios/MullvadVPNUITests/AccountTests.swift
@@ -89,4 +89,16 @@ class AccountTests: LoggedOutUITestCase {
         XCTAssertEqual(try MullvadAPIWrapper().getDevices(newAccountNumber).count, 0)
         try MullvadAPIWrapper().deleteAccount(newAccountNumber)
     }
+
+    func testTimeLeft() throws {
+        login(accountNumber: hasTimeAccountNumber)
+
+        let accountExpiry = try MullvadAPIWrapper().getAccountExpiry(hasTimeAccountNumber)
+
+        HeaderBar(app)
+            .tapAccountButton()
+
+        AccountPage(app)
+            .verifyPaidUntil(accountExpiry)
+    }
 }

--- a/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
+++ b/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
@@ -88,9 +88,11 @@ class MullvadAPIWrapper {
         }
     }
 
-    func getAccountExpiry(_ account: String) throws -> UInt64 {
+    func getAccountExpiry(_ account: String) throws -> Date {
         do {
-            return try mullvadAPI.getExpiry(forAccount: account)
+            let accountExpiryTimestamp = Double(try mullvadAPI.getExpiry(forAccount: account))
+            let accountExpiryDate = Date(timeIntervalSince1970: accountExpiryTimestamp)
+            return accountExpiryDate
         } catch {
             throw MullvadAPIError.requestError
         }

--- a/ios/MullvadVPNUITests/Pages/AccountPage.swift
+++ b/ios/MullvadVPNUITests/Pages/AccountPage.swift
@@ -41,4 +41,29 @@ class AccountPage: Page {
         app.buttons[AccessibilityIdentifier.deleteButton.rawValue].tap()
         return self
     }
+
+    @discardableResult func verifyPaidUntil(_ date: Date) -> Self {
+        // Strip seconds from date, since the app don't display seconds
+        let calendar = Calendar.current
+        var components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        components.second = 0
+        guard let strippedDate = calendar.date(from: components) else {
+            XCTFail("Failed to remove seconds from date")
+            return self
+        }
+
+        let paidUntilLabelText = app.staticTexts[AccessibilityIdentifier.accountPagePaidUntilLabel].label
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+
+        guard let paidUntilLabelDate = dateFormatter.date(from: paidUntilLabelText) else {
+            XCTFail("Failed to convert presented date to Date object")
+            return self
+        }
+
+        XCTAssertEqual(strippedDate, paidUntilLabelDate)
+
+        return self
+    }
 }


### PR DESCRIPTION
Implemented test verifying that time left is properly displayed. To test the changes in this PR run the test `testTimeLeft` under `AccountTests`.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6049)
<!-- Reviewable:end -->
