### PR TITLE
Enable more of the Allowed-by-default lints in rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,17 @@ members = [
 # Security
 non_ascii_idents = "forbid"
 
-# Modern, easy to read style and opinionated best practices
+# Deny old style Rust
 rust_2018_idioms = "deny"
+macro_use_extern_crate = "deny"
+absolute_paths_not_starting_with_crate = "deny"
+
+# Easy to read style and opinionated best practices
+explicit_outlives_requirements = "warn"
+missing_abi = "deny"
+unused_lifetimes = "warn"
+unused_macro_rules = "warn"
+
 
 [workspace.lints.clippy]
 unused_async = "deny"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -20,8 +20,16 @@ members = [
 # Security
 non_ascii_idents = "forbid"
 
-# Modern, easy to read style and opinionated best practices
+# Deny old style Rust
 rust_2018_idioms = "deny"
+macro_use_extern_crate = "deny"
+absolute_paths_not_starting_with_crate = "deny"
+
+# Easy to read style and opinionated best practices
+explicit_outlives_requirements = "warn"
+missing_abi = "deny"
+unused_lifetimes = "warn"
+unused_macro_rules = "warn"
 
 [workspace.lints.clippy]
 unused_async = "deny"


### PR DESCRIPTION
I went through the list at https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html and decided to warn/deny a few more lints. Mostly for cleanliness and consistency. The intention is to keep the code more modern, consistent and get rid of unused code.

* `macro_use_extern_crate` - Forbid #[macro_use] to bring macros into global scope. Even using `extern crate` is deprecated by now, so just extra protection against that
* `explicit_outlives_requirements` - Warn aginst explicit lifetime bounds that can be inferred from the code. Keeps noise away.
* `absolute_paths_not_starting_with_crate` - Catches Rust 2015 style absolute paths and denies them.
* `missing_abi` - Force explicitly stating the ABI of `extern` items. Less implicit code
* `unused_lifetimes` - Warn if you have lifetimes that are not used. Same reason as warning against unused variables
* `unused_macro_rules` - Warn if you have a declarative macro with a rule that is never used. Basically same reason as warning on unused variables. Removes dead code

I have tried to avoid allow-by-default lints that seem very nice but that has a warning that it has a fair amount of false positives. I don't want the linting to be a hindrance to productivity or force us to create weird workaround just to please a bad lint. Please tell me if you think some of these lints are going to be more of a problem than a solution.

As you can see, no code changes were needed. We already adhere to all these lints. So it could be argued that they are not needed also. But I think they are a security guarantee that we'll avoid these "mistakes" in the future also.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6050)
<!-- Reviewable:end -->
