### PR TITLE
Lint against single use lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ explicit_outlives_requirements = "warn"
 missing_abi = "deny"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
+single_use_lifetimes = "warn"
 
 
 [workspace.lints.clippy]

--- a/android/translations-converter/src/gettext/msg_string.rs
+++ b/android/translations-converter/src/gettext/msg_string.rs
@@ -78,7 +78,7 @@ where
     }
 }
 
-impl<'l, 'r> Add<&'r MsgString> for &'l MsgString {
+impl<'r> Add<&'r MsgString> for &MsgString {
     type Output = MsgString;
 
     fn add(self, other: &'r MsgString) -> Self::Output {

--- a/mullvad-cli/src/cmds/api_access.rs
+++ b/mullvad-cli/src/cmds/api_access.rs
@@ -439,7 +439,7 @@ mod pp {
         }
     }
 
-    impl<'a> std::fmt::Display for ApiAccessMethodFormatter<'a> {
+    impl std::fmt::Display for ApiAccessMethodFormatter<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let write_status = |f: &mut std::fmt::Formatter<'_>, enabled: bool| {
                 if enabled {

--- a/mullvad-cli/src/cmds/custom_list.rs
+++ b/mullvad-cli/src/cmds/custom_list.rs
@@ -216,7 +216,7 @@ impl<'a> GeographicLocationConstraintFormatter<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for GeographicLocationConstraintFormatter<'a> {
+impl std::fmt::Display for GeographicLocationConstraintFormatter<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let unwrap_country = |country: Option<String>, constraint: &str| {
             country.unwrap_or(format!("{constraint} <invalid country>"))

--- a/mullvad-cli/src/cmds/proxies.rs
+++ b/mullvad-cli/src/cmds/proxies.rs
@@ -182,7 +182,7 @@ pub mod pp {
         pub custom_proxy: &'a CustomProxy,
     }
 
-    impl<'a> std::fmt::Display for CustomProxyFormatter<'a> {
+    impl std::fmt::Display for CustomProxyFormatter<'_> {
         fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self.custom_proxy {
                 CustomProxy::Shadowsocks(shadowsocks) => {

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -351,7 +351,7 @@ pub struct SettingsSummary<'a> {
     settings: &'a Settings,
 }
 
-impl<'a> Display for SettingsSummary<'a> {
+impl Display for SettingsSummary<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let bool_to_label = |state| {
             if state {
@@ -458,7 +458,7 @@ impl<'a> Display for SettingsSummary<'a> {
     }
 }
 
-impl<'a> SettingsSummary<'a> {
+impl SettingsSummary<'_> {
     fn fmt_option<T: Display>(f: &mut fmt::Formatter<'_>, val: Option<T>) -> fmt::Result {
         if let Some(inner) = &val {
             inner.fmt(f)

--- a/mullvad-jni/src/is_null.rs
+++ b/mullvad-jni/src/is_null.rs
@@ -5,13 +5,13 @@ pub trait IsNull {
     fn is_null(&self) -> bool;
 }
 
-impl<'a> IsNull for JObject<'a> {
+impl IsNull for JObject<'_> {
     fn is_null(&self) -> bool {
         self.deref().is_null()
     }
 }
 
-impl<'a> IsNull for JString<'a> {
+impl IsNull for JString<'_> {
     fn is_null(&self) -> bool {
         self.deref().is_null()
     }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -56,7 +56,7 @@ pub struct RelaySettingsFormatter<'a> {
     pub custom_lists: &'a CustomListsSettings,
 }
 
-impl<'a> fmt::Display for RelaySettingsFormatter<'a> {
+impl fmt::Display for RelaySettingsFormatter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.settings {
             RelaySettings::CustomTunnelEndpoint(endpoint) => {
@@ -96,7 +96,7 @@ impl From<GeographicLocationConstraint> for LocationConstraint {
     }
 }
 
-impl<'a> fmt::Display for LocationConstraintFormatter<'a> {
+impl fmt::Display for LocationConstraintFormatter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.constraint {
             LocationConstraint::Location(location) => write!(f, "{}", location),
@@ -131,7 +131,7 @@ pub struct RelayConstraintsFormatter<'a> {
     pub custom_lists: &'a CustomListsSettings,
 }
 
-impl<'a> fmt::Display for RelayConstraintsFormatter<'a> {
+impl fmt::Display for RelayConstraintsFormatter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
@@ -526,7 +526,7 @@ pub struct WireguardConstraintsFormatter<'a> {
     pub custom_lists: &'a CustomListsSettings,
 }
 
-impl<'a> fmt::Display for WireguardConstraintsFormatter<'a> {
+impl fmt::Display for WireguardConstraintsFormatter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.constraints.port {
             Constraint::Any => write!(f, "any port")?,
@@ -730,7 +730,7 @@ pub struct BridgeConstraintsFormatter<'a> {
     pub custom_lists: &'a CustomListsSettings,
 }
 
-impl<'a> fmt::Display for BridgeConstraintsFormatter<'a> {
+impl fmt::Display for BridgeConstraintsFormatter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.constraints.location {
             Constraint::Any => write!(f, "any location")?,

--- a/talpid-core/src/dns/windows/tcpip.rs
+++ b/talpid-core/src/dns/windows/tcpip.rs
@@ -93,24 +93,24 @@ fn set_dns_inner(
         transaction,
         &guid_str,
         "Tcpip",
-        servers.iter().filter(|addr| addr.is_ipv4()),
+        servers.iter().filter(|addr| addr.is_ipv4()).copied(),
     )?;
 
     config_interface(
         transaction,
         &guid_str,
         "Tcpip6",
-        servers.iter().filter(|addr| addr.is_ipv6()),
+        servers.iter().filter(|addr| addr.is_ipv6()).copied(),
     )?;
 
     Ok(())
 }
 
-fn config_interface<'a>(
+fn config_interface(
     transaction: &Transaction,
     guid: &str,
     service: &str,
-    nameservers: impl Iterator<Item = &'a IpAddr>,
+    nameservers: impl Iterator<Item = IpAddr>,
 ) -> io::Result<()> {
     let nameservers = nameservers
         .map(|addr| addr.to_string())

--- a/talpid-dbus/src/systemd_resolved.rs
+++ b/talpid-dbus/src/systemd_resolved.rs
@@ -294,10 +294,7 @@ impl SystemdResolved {
             .map(|result: (dbus::Path<'static>,)| result.0)
     }
 
-    fn get_link_dns<'a, 'b: 'a>(
-        &'a self,
-        link_object_path: &'b dbus::Path<'static>,
-    ) -> Result<Vec<IpAddr>> {
+    fn get_link_dns(&self, link_object_path: &dbus::Path<'static>) -> Result<Vec<IpAddr>> {
         let servers: Vec<(i32, Vec<u8>)> = self
             .as_link_object(link_object_path.clone())
             .get(LINK_INTERFACE, DNS_SERVERS)
@@ -309,9 +306,9 @@ impl SystemdResolved {
             .collect())
     }
 
-    fn set_link_dns<'a, 'b: 'a>(
-        &'a self,
-        link_object_path: &'b dbus::Path<'static>,
+    fn set_link_dns(
+        &self,
+        link_object_path: &dbus::Path<'static>,
         servers: &[IpAddr],
     ) -> Result<()> {
         let servers = servers
@@ -367,9 +364,9 @@ impl SystemdResolved {
         }).map_err(Error::DBusRpcError)
     }
 
-    fn get_link_dns_domains<'a, 'b: 'a>(
-        &'a self,
-        link_object_path: &'b dbus::Path<'static>,
+    fn get_link_dns_domains(
+        &self,
+        link_object_path: &dbus::Path<'static>,
     ) -> Result<Vec<(String, bool)>> {
         let domains: Vec<(String, bool)> = self
             .as_link_object(link_object_path.clone())
@@ -396,9 +393,9 @@ impl SystemdResolved {
         }
     }
 
-    fn set_link_dns_domains<'a, 'b: 'a>(
-        &'a self,
-        link_object_path: &'b dbus::Path<'static>,
+    fn set_link_dns_domains(
+        &self,
+        link_object_path: &dbus::Path<'static>,
         domains: &[(&str, bool)],
     ) -> Result<()> {
         Proxy::new(

--- a/talpid-routing/src/unix/macos/data.rs
+++ b/talpid-routing/src/unix/macos/data.rs
@@ -982,7 +982,7 @@ impl<'a> RouteSockAddrIterator<'a> {
     }
 }
 
-impl<'a> Iterator for RouteSockAddrIterator<'a> {
+impl Iterator for RouteSockAddrIterator<'_> {
     type Item = Result<RouteSocketAddress>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/talpid-windows/src/net.rs
+++ b/talpid-windows/src/net.rs
@@ -144,7 +144,7 @@ pub struct IpNotifierHandle<'a> {
 
 unsafe impl Send for IpNotifierHandle<'_> {}
 
-impl<'a> Drop for IpNotifierHandle<'a> {
+impl Drop for IpNotifierHandle<'_> {
     fn drop(&mut self) {
         unsafe { CancelMibChangeNotify2(self.handle) };
     }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -30,6 +30,7 @@ explicit_outlives_requirements = "warn"
 missing_abi = "deny"
 unused_lifetimes = "warn"
 unused_macro_rules = "warn"
+single_use_lifetimes = "warn"
 
 [workspace.lints.clippy]
 unused_async = "deny"


### PR DESCRIPTION
Removes superfluous lifetime definitions. Simplifying the code. Here is the docs for this lint: https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#single-use-lifetimes

Since we obviously had a pretty large number of these, I think the lint can help us keep code simpler. The only potential red flag I see is the lint docs saying "Also, there are some known false positives". I did not stumble over any false positives (that I noticed) when doing this small refactoring. If it turns out to be too troublesome we can disable the lint again. Or add `#[allow(single_use_lifetimes)]` to the places where it does not work as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6051)
<!-- Reviewable:end -->
