### PR TITLE
Wrap AbortableStream abort receiver in Fuse

### DIFF
--- a/mullvad-api/src/abortable_stream.rs
+++ b/mullvad-api/src/abortable_stream.rs
@@ -2,6 +2,8 @@
 //! immediately instead of after the socket times out.
 
 use futures::channel::oneshot;
+use futures::future::Fuse;
+use futures::FutureExt;
 use hyper::client::connect::{Connected, Connection};
 use std::{
     future::Future,
@@ -41,7 +43,7 @@ impl AbortableStreamHandle {
 
 pub struct AbortableStream<S: Unpin> {
     stream: S,
-    shutdown_rx: oneshot::Receiver<()>,
+    shutdown_rx: Fuse<oneshot::Receiver<()>>,
 }
 
 impl<S> AbortableStream<S>
@@ -56,7 +58,7 @@ where
         (
             Self {
                 stream,
-                shutdown_rx: rx,
+                shutdown_rx: rx.fuse(),
             },
             stream_handle,
         )


### PR DESCRIPTION
The contract of [`FusedFuture`](https://docs.rs/futures/latest/futures/future/trait.FusedFuture.html) says that a future implementing the trait keeps track of when it has been resolved, but not that it is safe to poll it afterwards. As it turns out, it is safe to poll `oneshot::Receiver` when it has been resolved, but this is arguably an implementation detail. `Fuse`, however, [promises](https://docs.rs/futures/latest/futures/future/trait.FutureExt.html#method.fuse) to always return `Pending`.

Close DES-688.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6052)
<!-- Reviewable:end -->
