### PR TITLE
Fix floating effect for custom list description

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
@@ -320,6 +320,7 @@ fun SelectLocationScreen(
                             customLists(
                                 customLists = state.filteredCustomLists,
                                 selectedItem = state.selectedItem,
+                                backgroundColor = backgroundColor,
                                 onSelectRelay = onSelectRelay,
                                 onShowCustomListBottomSheet = {
                                     bottomSheetState =
@@ -375,6 +376,7 @@ private fun LazyListScope.loading() {
 private fun LazyListScope.customLists(
     customLists: List<RelayItem.CustomList>,
     selectedItem: RelayItem?,
+    backgroundColor: Color,
     onSelectRelay: (item: RelayItem) -> Unit,
     onShowCustomListBottomSheet: () -> Unit,
     onShowEditBottomSheet: (RelayItem.CustomList) -> Unit
@@ -413,14 +415,16 @@ private fun LazyListScope.customLists(
         item {
             SwitchComposeSubtitleCell(
                 text = stringResource(R.string.to_add_locations_to_a_list),
-                modifier = Modifier.animateItemPlacement().animateContentSize()
+                modifier =
+                    Modifier.background(backgroundColor).animateItemPlacement().animateContentSize()
             )
         }
     } else {
         item(contentType = ContentType.EMPTY_TEXT) {
             SwitchComposeSubtitleCell(
                 text = stringResource(R.string.to_create_a_custom_list),
-                modifier = Modifier.animateItemPlacement().animateContentSize()
+                modifier =
+                    Modifier.background(backgroundColor).animateItemPlacement().animateContentSize()
             )
         }
     }


### PR DESCRIPTION
This fixes the effect of custom list description text "floating" above other items during the expand/collapse animation for custom lists in the select location screen.
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6061)
<!-- Reviewable:end -->
