### PR TITLE
Fix Relayselector not resolving locations under certain constraints

### DIFF
--- a/ios/MullvadREST/Relay/RelaySelector.swift
+++ b/ios/MullvadREST/Relay/RelaySelector.swift
@@ -140,7 +140,7 @@ public enum RelaySelector {
         _ constraints: RelayConstraints,
         relays: [RelayWithLocation<T>]
     ) -> [RelayWithLocation<T>] {
-        return relays.filter { relayWithLocation -> Bool in
+        let filteredRelays = relays.filter { relayWithLocation -> Bool in
             switch constraints.filter {
             case .any:
                 break
@@ -162,6 +162,30 @@ public enum RelaySelector {
         }.filter { relayWithLocation -> Bool in
             relayWithLocation.relay.active
         }
+
+        filteredRelays.filter { relayWithLocation in
+            switch constraints.locations {
+            case .any:
+                return true
+            case let .only(relayConstraint):
+                // At least one location must match the relay under test.
+                return relayConstraint.locations.contains { location in
+                    relayWithLocation.matches(location: location)
+                }
+            }
+            if case let .country(countryCode) = constraints.locations. {
+
+            }
+            return true
+        }
+
+//        filteredRelays.filter { relayWithLocation in
+//            if case let .country(countryCode) = relayWithLocation {
+//
+//            }
+//        }
+
+        return relayWithLocations
     }
 
     /// Produce a port that is either user provided or randomly selected, satisfying the given constraints.
@@ -301,10 +325,9 @@ struct RelayWithLocation<T: AnyRelay> {
     let serverLocation: Location
 
     func matches(location: RelayLocation) -> Bool {
-        switch location {
+        return switch location {
         case let .country(countryCode):
-            serverLocation.countryCode == countryCode &&
-                relay.includeInCountry
+            serverLocation.countryCode == countryCode
 
         case let .city(countryCode, cityCode):
             serverLocation.countryCode == countryCode &&


### PR DESCRIPTION
Steps to reproduce the issue:

1. Connect to a relay
2. Filter providers, select 31173
3. Tap switch location
4. Select USA as a country
5. Enter blocked mode
6. Tap switch location again
7. Add 100 TB as a provider
8. Select USA
9. Enter blocked connection, despite having locations match in the USA

The underlying issue is that relays can be set to not be included in a country when a user sets a country location constraint, i.e. there are relays that should not be considered for selection even though they'd match a location constraint. However, it can be the case that all relays provided by a specific provider are marked to not be included in a country, which is the case for 100TB and US. In this case, the relay selector should disregard the flag and allow the relays anyway. The iOS behavior here should mimic desktop - https://github.com/mullvad/mullvadvpn-app/blob/main/mullvad-relay-selector/src/relay_selector/matcher.rs#L17-L62

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6062)
<!-- Reviewable:end -->
