### PR TITLE
Add connection retry logic test

### DIFF
--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -17,6 +17,7 @@ public enum AccessibilityIdentifier: String {
     case cancelButton
     case connectionPanelButton
     case collapseButton
+    case expandButton
     case createAccountButton
     case deleteButton
     case disconnectButton
@@ -57,7 +58,8 @@ public enum AccessibilityIdentifier: String {
 
     // Labels
     case headerDeviceNameLabel
-    case connectionStatusLabel
+    case connectionStatusConnectedLabel
+    case connectionStatusNotConnectedLabel
     case welcomeAccountNumberLabel
     case connectionPanelDetailLabel
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -49,7 +49,6 @@ class LocationCell: UITableViewCell {
 
     private let collapseButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.accessibilityIdentifier = .collapseButton
         button.isAccessibilityElement = false
         button.tintColor = .white
         return button
@@ -267,6 +266,7 @@ class LocationCell: UITableViewCell {
     private func updateCollapseImage() {
         let image = isExpanded ? chevronUp : chevronDown
 
+        collapseButton.accessibilityIdentifier = isExpanded ? .collapseButton : .expandButton
         collapseButton.setImage(image, for: .normal)
     }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -55,6 +55,7 @@ final class LocationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.accessibilityIdentifier = .selectLocationView
         view.backgroundColor = .secondaryColor
 
         navigationItem.title = NSLocalizedString(

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
@@ -121,8 +121,6 @@ final class TunnelControlView: UIView {
         accessibilityContainerType = .semanticGroup
         accessibilityIdentifier = .tunnelControlView
 
-        secureLabel.accessibilityIdentifier = .connectionStatusLabel
-
         addSubviews()
         addButtonHandlers()
     }
@@ -187,6 +185,13 @@ final class TunnelControlView: UIView {
     private func updateSecureLabel(tunnelState: TunnelState) {
         secureLabel.text = tunnelState.localizedTitleForSecureLabel.uppercased()
         secureLabel.textColor = tunnelState.textColorForSecureLabel
+
+        switch tunnelState {
+        case .connected:
+            secureLabel.accessibilityIdentifier = .connectionStatusConnectedLabel
+        default:
+            secureLabel.accessibilityIdentifier = .connectionStatusNotConnectedLabel
+        }
     }
 
     private func updateButtonTitles(tunnelState: TunnelState) {

--- a/ios/MullvadVPNUITests/Networking/FirewallRule.swift
+++ b/ios/MullvadVPNUITests/Networking/FirewallRule.swift
@@ -45,6 +45,16 @@ struct FirewallRule {
         )
     }
 
+    public static func makeBlockAllTrafficRule(toIPAddress: String) throws -> FirewallRule {
+        let deviceIPAddress = try Networking.getIPAddress()
+
+        return FirewallRule(
+            fromIPAddress: deviceIPAddress,
+            toIPAddress: toIPAddress,
+            protocols: [.ICMP, .TCP, .UDP]
+        )
+    }
+
     public static func makeBlockUDPTrafficRule(toIPAddress: String) throws -> FirewallRule {
         let deviceIPAddress = try Networking.getIPAddress()
 

--- a/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
+++ b/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
@@ -22,14 +22,19 @@ class SelectLocationPage: Page {
         return self
     }
 
-    @discardableResult func tapLocationCellExpandCollapseButton(withName name: String) -> Self {
+    @discardableResult func tapLocationCellExpandButton(withName name: String) -> Self {
         let table = app.tables[AccessibilityIdentifier.selectLocationTableView]
         let matchingCells = table.cells.containing(.any, identifier: name)
         let buttons = matchingCells.buttons
-        let expandButton = buttons[AccessibilityIdentifier.collapseButton]
+        let expandButton = buttons[AccessibilityIdentifier.expandButton]
 
         expandButton.tap()
 
         return self
+    }
+
+    func locationCellIsExpanded(_ name: String) -> Bool {
+        let matchingCells = app.cells.containing(.any, identifier: name)
+        return matchingCells.buttons[AccessibilityIdentifier.expandButton].exists ? false : true
     }
 }

--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -55,6 +55,27 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapDisconnectButton()
     }
 
+    func testConnectionRetryLogic() throws {
+        FirewallAPIClient().removeRules()
+        removeFirewallRulesInTearDown = true
+
+        // First get relay IP address
+        let relayIPAddress = getGot001WireGuardRelayIPAddress()
+
+        // Run actual test
+        try FirewallAPIClient().createRule(
+            FirewallRule.makeBlockAllTrafficRule(toIPAddress: relayIPAddress)
+        )
+
+        TunnelControlPage(app)
+            .tapSecureConnectionButton()
+
+        // Should be two UDP connection attempts but sometimes only one is shown in the UI
+        TunnelControlPage(app)
+            .verifyConnectionAttemptsOrder()
+            .tapCancelButton()
+    }
+
     func testWireGuardOverTCPManually() throws {
         HeaderBar(app)
             .tapSettingsButton()
@@ -86,29 +107,11 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
     /// Test automatic switching to TCP is functioning when UDP traffic to relay is blocked. This test first connects to a realy to get the IP address of it, in order to block UDP traffic to this relay.
     func testWireGuardOverTCPAutomatically() throws {
-        let wireGuardGot001RelayName = "se-got-wg-001"
-
         FirewallAPIClient().removeRules()
         removeFirewallRulesInTearDown = true
 
         // First get relay IP address
-        TunnelControlPage(app)
-            .tapSelectLocationButton()
-
-        SelectLocationPage(app)
-            .tapLocationCellExpandCollapseButton(withName: "Sweden")
-            .tapLocationCellExpandCollapseButton(withName: "Gothenburg")
-            .tapLocationCell(withName: wireGuardGot001RelayName)
-
-        allowAddVPNConfigurationsIfAsked()
-
-        let relayIPAddress = TunnelControlPage(app)
-            .waitForSecureConnectionLabel()
-            .tapRelayStatusExpandCollapseButton()
-            .getInIPAddressFromConnectionStatus()
-
-        TunnelControlPage(app)
-            .tapDisconnectButton()
+        let relayIPAddress = getGot001WireGuardRelayIPAddress()
 
         // Run actual test
         try FirewallAPIClient().createRule(
@@ -162,5 +165,36 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapRelayStatusExpandCollapseButton()
             .verifyConnectingToPort("4001")
             .tapDisconnectButton()
+    }
+
+    /// Get got001 WireGuard relay IP address by connecting to it and checking which IP address the app connects to. Assumes user is logged on and at tunnel control page.
+    private func getGot001WireGuardRelayIPAddress() -> String {
+        let wireGuardGot001RelayName = "se-got-wg-001"
+
+        TunnelControlPage(app)
+            .tapSelectLocationButton()
+
+        if SelectLocationPage(app).locationCellIsExpanded("Sweden") {
+            // Already expanded - just make sure correct relay is selected
+            SelectLocationPage(app)
+                .tapLocationCell(withName: wireGuardGot001RelayName)
+        } else {
+            SelectLocationPage(app)
+                .tapLocationCellExpandButton(withName: "Sweden")
+                .tapLocationCellExpandButton(withName: "Gothenburg")
+                .tapLocationCell(withName: wireGuardGot001RelayName)
+        }
+
+        allowAddVPNConfigurationsIfAsked()
+
+        let relayIPAddress = TunnelControlPage(app)
+            .waitForSecureConnectionLabel()
+            .tapRelayStatusExpandCollapseButton()
+            .getInIPAddressFromConnectionStatus()
+
+        TunnelControlPage(app)
+            .tapDisconnectButton()
+
+        return relayIPAddress
     }
 }


### PR DESCRIPTION
Implemented connection retry logic test which blocks all connections to a relay then let the app connect to it and observes the connection attempts made by the app in order to verify that they're done in the correct order.

Note that there's a UI bug which most of the time prevent one of the first two UDP connection attempts from being shown in the app even though the attempt is actually made. Therefor the test also allows for this incorrect flow of attempts where only one UDP connection attempt is displayed instead of two.

To test the changes in this PR your phone must be on the `app-team-ios-tests` wifi. Run `testConnectionRetryLogic` under `RelayTests`.


<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6064)
<!-- Reviewable:end -->
