### PR TITLE
Add "wrap" to list of allowed imperative verbs in git commit messages

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -32,4 +32,4 @@ jobs:
           # This action defaults to 50 char subjects, but 72 is fine.
           max-subject-line-length: '72'
           # The action's wordlist is a bit short. Add more accepted verbs
-          additional-verbs: 'tidy'
+          additional-verbs: 'tidy, wrap'


### PR DESCRIPTION
@dlon You recently used "wrap" and this job triggered. So let's add it! A perfectly fine verb I think

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6068)
<!-- Reviewable:end -->
