### PR TITLE
Additional refactoring of PacketTunnelActor State; mostly placing clearly subordinate types under appropriate namespaces

### DIFF
--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -95,7 +95,7 @@ extension PacketTunnelActor {
     private func mapConnectionState(
         _ connState: State.ConnectionData,
         reason: BlockedStateReason,
-        priorState: StatePriorToBlockedState
+        priorState: State.BlockingData.PriorState
     ) -> State.BlockingData {
         State.BlockingData(
             reason: reason,

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+KeyPolicy.swift
@@ -90,7 +90,7 @@ extension PacketTunnelActor {
      - Parameter keyPolicy: a reference to key policy held either in connection state or blocked state struct.
      - Returns: `true` when the policy was modified, otherwise `false`.
      */
-    private func setCurrentKeyPolicy(_ keyPolicy: inout KeyPolicy) {
+    private func setCurrentKeyPolicy(_ keyPolicy: inout State.KeyPolicy) {
         if case .usePrior = keyPolicy {
             keyPolicy = .useCurrent
         }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -305,7 +305,7 @@ extension PacketTunnelActor {
         settings: Settings,
         reason: ReconnectReason
     ) throws -> State.ConnectionData? {
-        var keyPolicy: KeyPolicy = .useCurrent
+        var keyPolicy: State.KeyPolicy = .useCurrent
         var networkReachability = defaultPathObserver.defaultPath?.networkReachability ?? .undetermined
         var lastKeyRotation: Date?
 

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -124,6 +124,16 @@ public actor PacketTunnelActor {
 // MARK: -
 
 extension PacketTunnelActor {
+    /// Describes the reason for reconnection request.
+    enum ReconnectReason {
+        /// Initiated by user.
+        case userInitiated
+
+        /// Initiated by tunnel monitor due to loss of connectivity.
+        /// Actor will increment the connection attempt counter before picking next relay.
+        case connectionLoss
+    }
+
     /**
      Start the tunnel.
 

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -154,7 +154,7 @@ extension State {
     }
 }
 
-extension KeyPolicy {
+extension State.KeyPolicy {
     func logFormat() -> String {
         switch self {
         case .useCurrent:
@@ -165,8 +165,8 @@ extension KeyPolicy {
     }
 }
 
-extension KeyPolicy: Equatable {
-    static func == (lhs: KeyPolicy, rhs: KeyPolicy) -> Bool {
+extension State.KeyPolicy: Equatable {
+    static func == (lhs: State.KeyPolicy, rhs: State.KeyPolicy) -> Bool {
         switch (lhs, rhs) {
         case (.useCurrent, .useCurrent): true
         case let (.usePrior(priorA, _), .usePrior(priorB, _)): priorA == priorB

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -11,6 +11,11 @@ import MullvadTypes
 import WireGuardKitTypes
 
 extension State {
+    /// Target state the actor should transition into upon request to either start (connect) or reconnect.
+    enum TargetStateForReconnect {
+        case reconnecting, connecting
+    }
+
     /// Returns the target state to which the actor state should transition when requested to reconnect.
     /// It returns `nil` when reconnection is not supported such as when already `.disconnecting` or `.disconnected` states.
     var targetStateForReconnect: TargetStateForReconnect? {

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -232,13 +232,3 @@ public enum NextRelay: Equatable, Codable {
     /// Use pre-selected relay.
     case preSelected(SelectedRelay)
 }
-
-/// Describes the reason for reconnection request.
-enum ReconnectReason {
-    /// Initiated by user.
-    case userInitiated
-
-    /// Initiated by tunnel monitor due to loss of connectivity.
-    /// Actor will increment the connection attempt counter before picking next relay.
-    case connectionLoss
-}

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -221,11 +221,6 @@ extension State.BlockingData {
     }
 }
 
-/// Target state the actor should transition into upon request to either start (connect) or reconnect.
-enum TargetStateForReconnect {
-    case reconnecting, connecting
-}
-
 /// Describes which relay the tunnel should connect to next.
 public enum NextRelay: Equatable, Codable {
     /// Select next relay randomly.

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -173,7 +173,7 @@ extension State {
         public var recoveryTask: AutoCancellingTask?
 
         /// Prior state of the actor before entering blocked state
-        public var priorState: StatePriorToBlockedState
+        public var priorState: PriorState
     }
 }
 
@@ -214,9 +214,11 @@ public enum BlockedStateReason: String, Codable, Equatable {
     case unknown
 }
 
-/// Legal states that can precede error state.
-enum StatePriorToBlockedState: Equatable {
-    case initial, connecting, connected, reconnecting
+extension State.BlockingData {
+    /// Legal states that can precede error state.
+    enum PriorState: Equatable {
+        case initial, connecting, connected, reconnecting
+    }
 }
 
 /// Target state the actor should transition into upon request to either start (connect) or reconnect.

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -82,15 +82,6 @@ enum State: Equatable {
     case error(BlockingData)
 }
 
-/// Policy describing what WG key to use for tunnel communication.
-enum KeyPolicy {
-    /// Use current key stored in device data.
-    case useCurrent
-
-    /// Use prior key until timer fires.
-    case usePrior(_ priorKey: PrivateKey, _ timerTask: AutoCancellingTask)
-}
-
 /// Enum describing network availability.
 public enum NetworkReachability: Equatable, Codable {
     case undetermined, reachable, unreachable
@@ -98,12 +89,21 @@ public enum NetworkReachability: Equatable, Codable {
 
 protocol StateAssociatedData {
     var currentKey: PrivateKey? { get set }
-    var keyPolicy: KeyPolicy { get set }
+    var keyPolicy: State.KeyPolicy { get set }
     var networkReachability: NetworkReachability { get set }
     var lastKeyRotation: Date? { get set }
 }
 
 extension State {
+    /// Policy describing what WG key to use for tunnel communication.
+    enum KeyPolicy {
+        /// Use current key stored in device data.
+        case useCurrent
+
+        /// Use prior key until timer fires.
+        case usePrior(_ priorKey: PrivateKey, _ timerTask: AutoCancellingTask)
+    }
+
     /// Data associated with states that hold connection data.
     struct ConnectionData: Equatable, StateAssociatedData {
         /// Current selected relay.


### PR DESCRIPTION
This continues the refactoring merged to main earlier. In this:

- `KeyPolicy` becomes `State.KeyPolicy`
- `ReconnectReason` becomes `PacketTunnelActor.ReconnectReason`
- `TargetStateForReconnect` moves under `State`
- `StatePriorToBlockedState` becomes `State.BlockingData.PriorState`

All these types have been evaluated to be structurally subordinate to the namespaces they have been moved under, meaning that these changes do not introduce any ambiguities, but merely declutter the namespace. 

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6070)
<!-- Reviewable:end -->
