### PR TITLE
Avoid rendering bitmaps above 100MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix pointless API access method rotations for concurrent requests.
 - Fix daemon rotating logs on startup even if another daemon is already running.
 
+#### Android
+- Fix crash in Split Tunneling screen caused by apps provding icons bigger than 100MB.
+
 ### Security
 #### Android
 - Change from singleTask to singleInstance to fix Task Affinity Vulnerability in Android 8.

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SplitTunnelingCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SplitTunnelingCell.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.compose.component.SpacedColumn
+import net.mullvad.mullvadvpn.compose.util.isBelowMaxBitmapSize
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.Alpha40
@@ -75,7 +76,9 @@ fun SplitTunnelingCell(
     LaunchedEffect(packageName) {
         launch(Dispatchers.IO) {
             val bitmap = onResolveIcon(packageName ?: "")
-            icon = bitmap?.asImageBitmap()
+            if (bitmap != null && bitmap.isBelowMaxBitmapSize()) {
+                icon = bitmap.asImageBitmap()
+            }
         }
     }
     BaseCell(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/Bitmap.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/Bitmap.kt
@@ -1,0 +1,7 @@
+package net.mullvad.mullvadvpn.compose.util
+
+import android.graphics.Bitmap
+
+private const val MAX_BITMAP_SIZE_BYTES = 100 * 1024 * 1024
+
+fun Bitmap.isBelowMaxBitmapSize(): Boolean = byteCount < MAX_BITMAP_SIZE_BYTES

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/PackageManagerExtensions.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/PackageManagerExtensions.kt
@@ -13,4 +13,7 @@ fun PackageManager.getApplicationIconBitmapOrNull(packageName: String): Bitmap? 
     } catch (e: IllegalArgumentException) {
         // IllegalArgumentException is thrown if the application has an invalid icon
         null
+    } catch (e: OutOfMemoryError) {
+        // OutOfMemoryError is thrown if the icon is too large
+        null
     }


### PR DESCRIPTION
Also add a out of memory check for even larger app icons.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6071)
<!-- Reviewable:end -->
