### PR TITLE
Intercept back button when leaving an unsaved custom list

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -540,6 +540,7 @@
 		7A6F2FAB2AFD3097006D0856 /* CustomDNSCellFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FAA2AFD3097006D0856 /* CustomDNSCellFactory.swift */; };
 		7A6F2FAD2AFD3DA7006D0856 /* CustomDNSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FAC2AFD3DA7006D0856 /* CustomDNSViewController.swift */; };
 		7A6F2FAF2AFE36E7006D0856 /* VPNSettingsInfoButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FAE2AFE36E7006D0856 /* VPNSettingsInfoButtonItem.swift */; };
+		7A7907332BC0280A00B61F81 /* InterceptibleNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7907322BC0280A00B61F81 /* InterceptibleNavigationController.swift */; };
 		7A7AD28D29DC677800480EF1 /* FirstTimeLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7AD28C29DC677800480EF1 /* FirstTimeLaunch.swift */; };
 		7A818F1F29F0305800C7F0F4 /* RootConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A818F1E29F0305800C7F0F4 /* RootConfiguration.swift */; };
 		7A83A0C62B29A750008B5CE7 /* APIAccessMethodsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A83A0C52B29A750008B5CE7 /* APIAccessMethodsTests.swift */; };
@@ -1805,6 +1806,7 @@
 		7A6F2FAA2AFD3097006D0856 /* CustomDNSCellFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDNSCellFactory.swift; sourceTree = "<group>"; };
 		7A6F2FAC2AFD3DA7006D0856 /* CustomDNSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDNSViewController.swift; sourceTree = "<group>"; };
 		7A6F2FAE2AFE36E7006D0856 /* VPNSettingsInfoButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNSettingsInfoButtonItem.swift; sourceTree = "<group>"; };
+		7A7907322BC0280A00B61F81 /* InterceptibleNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterceptibleNavigationController.swift; sourceTree = "<group>"; };
 		7A7AD28C29DC677800480EF1 /* FirstTimeLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstTimeLaunch.swift; sourceTree = "<group>"; };
 		7A818F1E29F0305800C7F0F4 /* RootConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootConfiguration.swift; sourceTree = "<group>"; };
 		7A83A0C52B29A750008B5CE7 /* APIAccessMethodsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAccessMethodsTests.swift; sourceTree = "<group>"; };
@@ -2694,6 +2696,7 @@
 				58138E60294871C600684F0C /* DeviceDataThrottling.swift */,
 				7A7AD28C29DC677800480EF1 /* FirstTimeLaunch.swift */,
 				582AE30F2440A6CA00E6733A /* InputTextFormatter.swift */,
+				7A7907322BC0280A00B61F81 /* InterceptibleNavigationController.swift */,
 				58DFF7D12B0256A300F864E0 /* MarkdownStylingOptions.swift */,
 				58CC40EE24A601900019D96E /* ObserverList.swift */,
 			);
@@ -5463,6 +5466,7 @@
 				7A42DEC92A05164100B209BE /* SettingsInputCell.swift in Sources */,
 				5803B4B22940A48700C23744 /* TunnelStore.swift in Sources */,
 				586A950F29012BEE007BAF2B /* AddressCacheTracker.swift in Sources */,
+				7A7907332BC0280A00B61F81 /* InterceptibleNavigationController.swift in Sources */,
 				F02F41A02B9723AF00625A4F /* AddLocationsViewController.swift in Sources */,
 				587B753D2666468F00DEF7E9 /* NotificationController.swift in Sources */,
 			);

--- a/ios/MullvadVPN/Classes/InterceptibleNavigationController.swift
+++ b/ios/MullvadVPN/Classes/InterceptibleNavigationController.swift
@@ -14,6 +14,7 @@ class InterceptibleNavigationController: CustomNavigationController {
 
     // Called when popping the topmost view controller in the stack, eg. by pressing a navigation
     // bar back button.
+    @discardableResult
     override func popViewController(animated: Bool) -> UIViewController? {
         guard let viewController = viewControllers.last else { return nil }
 
@@ -26,6 +27,7 @@ class InterceptibleNavigationController: CustomNavigationController {
 
     // Called when popping to a specific view controller, eg. by long pressing a navigation bar
     // back button (revealing a navigation menu) and selecting a destination view controller.
+    @discardableResult
     override func popToViewController(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
         if shouldPopToViewController?(viewController) ?? true {
             return super.popToViewController(viewController, animated: animated)

--- a/ios/MullvadVPN/Classes/InterceptibleNavigationController.swift
+++ b/ios/MullvadVPN/Classes/InterceptibleNavigationController.swift
@@ -1,0 +1,36 @@
+//
+//  InterceptibleNavigationController.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2024-04-05.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+class InterceptibleNavigationController: CustomNavigationController {
+    var shouldPopViewController: ((UIViewController) -> Bool)?
+    var shouldPopToViewController: ((UIViewController) -> Bool)?
+
+    // Called when popping the topmost view controller in the stack, eg. by pressing a navigation
+    // bar back button.
+    override func popViewController(animated: Bool) -> UIViewController? {
+        guard let viewController = viewControllers.last else { return nil }
+
+        if shouldPopViewController?(viewController) ?? true {
+            return super.popViewController(animated: animated)
+        } else {
+            return nil
+        }
+    }
+
+    // Called when popping to a specific view controller, eg. by long pressing a navigation bar
+    // back button (revealing a navigation menu) and selecting a destination view controller.
+    override func popToViewController(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {
+        if shouldPopToViewController?(viewController) ?? true {
+            return super.popToViewController(viewController, animated: animated)
+        } else {
+            return nil
+        }
+    }
+}

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddCustomListCoordinator.swift
@@ -84,17 +84,10 @@ extension AddCustomListCoordinator: CustomListViewControllerDelegate {
         let coordinator = AddLocationsCoordinator(
             navigationController: navigationController,
             nodes: nodes,
-            customList: list
+            subject: subject
         )
 
-        coordinator.didFinish = { [weak self] locationsCoordinator, customList in
-            guard let self else { return }
-            subject.send(CustomListViewModel(
-                id: customList.id,
-                name: customList.name,
-                locations: customList.locations,
-                tableSections: subject.value.tableSections
-            ))
+        coordinator.didFinish = { locationsCoordinator in
             locationsCoordinator.removeFromParent()
         }
 

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsCoordinator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+import Combine
 import MullvadSettings
 import MullvadTypes
 import Routing
@@ -14,9 +15,9 @@ import UIKit
 class AddLocationsCoordinator: Coordinator, Presentable, Presenting {
     private let navigationController: UINavigationController
     private let nodes: [LocationNode]
-    private var customList: CustomList
+    private var subject: CurrentValueSubject<CustomListViewModel, Never>
 
-    var didFinish: ((AddLocationsCoordinator, CustomList) -> Void)?
+    var didFinish: ((AddLocationsCoordinator) -> Void)?
 
     var presentedViewController: UIViewController {
         navigationController
@@ -25,17 +26,17 @@ class AddLocationsCoordinator: Coordinator, Presentable, Presenting {
     init(
         navigationController: UINavigationController,
         nodes: [LocationNode],
-        customList: CustomList
+        subject: CurrentValueSubject<CustomListViewModel, Never>
     ) {
         self.navigationController = navigationController
         self.nodes = nodes
-        self.customList = customList
+        self.subject = subject
     }
 
     func start() {
         let controller = AddLocationsViewController(
             allLocationsNodes: nodes,
-            customList: customList
+            subject: subject
         )
         controller.delegate = self
 
@@ -51,11 +52,7 @@ class AddLocationsCoordinator: Coordinator, Presentable, Presenting {
 }
 
 extension AddLocationsCoordinator: AddLocationsViewControllerDelegate {
-    func didUpdateSelectedLocations(locations: [RelayLocation]) {
-        customList.locations = locations
-    }
-
     func didBack() {
-        didFinish?(self, customList)
+        didFinish?(self)
     }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsDataSource.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsDataSource.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+import Combine
 import MullvadSettings
 import MullvadTypes
 import UIKit
@@ -15,20 +16,21 @@ class AddLocationsDataSource:
     LocationDiffableDataSourceProtocol {
     private var customListLocationNode: CustomListLocationNode
     private let nodes: [LocationNode]
-    var didUpdateCustomList: ((CustomListLocationNode) -> Void)?
+    private let subject: CurrentValueSubject<CustomListViewModel, Never>
     let tableView: UITableView
     let sections: [LocationSection]
 
     init(
         tableView: UITableView,
         allLocationNodes: [LocationNode],
-        customList: CustomList
+        subject: CurrentValueSubject<CustomListViewModel, Never>
     ) {
         self.tableView = tableView
         self.nodes = allLocationNodes
+        self.subject = subject
 
         self.customListLocationNode = CustomListLocationNodeBuilder(
-            customList: customList,
+            customList: subject.value.customList,
             allLocations: self.nodes
         ).customListLocationNode
 
@@ -51,10 +53,12 @@ class AddLocationsDataSource:
         reloadWithSelectedLocations()
     }
 
+    // Called from `LocationDiffableDataSourceProtocol`.
     func nodeShowsChildren(_ node: LocationNode) -> Bool {
         isLocationInCustomList(node: node)
     }
 
+    // Called from `LocationDiffableDataSourceProtocol`.
     func nodeShouldBeSelected(_ node: LocationNode) -> Bool {
         customListLocationNode.children.contains(node)
     }
@@ -149,7 +153,10 @@ extension AddLocationsDataSource: LocationCellDelegate {
             customListLocationNode.remove(selectedLocation: item.node, with: locationList)
         }
         updateDataSnapshot(with: [locationList], completion: {
-            self.didUpdateCustomList?(self.customListLocationNode)
+            let locations = self.customListLocationNode.children.reduce([]) { partialResult, locationNode in
+                partialResult + locationNode.locations
+            }
+            self.subject.value.locations = locations
         })
     }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsViewController.swift
@@ -6,19 +6,19 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+import Combine
 import MullvadSettings
 import MullvadTypes
 import UIKit
 
 protocol AddLocationsViewControllerDelegate: AnyObject {
-    func didUpdateSelectedLocations(locations: [RelayLocation])
     func didBack()
 }
 
 class AddLocationsViewController: UIViewController {
     private var dataSource: AddLocationsDataSource?
     private let nodes: [LocationNode]
-    private let customList: CustomList
+    private let subject: CurrentValueSubject<CustomListViewModel, Never>
 
     weak var delegate: AddLocationsViewControllerDelegate?
     private let tableView: UITableView = {
@@ -33,10 +33,10 @@ class AddLocationsViewController: UIViewController {
 
     init(
         allLocationsNodes: [LocationNode],
-        customList: CustomList
+        subject: CurrentValueSubject<CustomListViewModel, Never>
     ) {
         self.nodes = allLocationsNodes
-        self.customList = customList
+        self.subject = subject
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -70,17 +70,8 @@ class AddLocationsViewController: UIViewController {
         dataSource = AddLocationsDataSource(
             tableView: tableView,
             allLocationNodes: nodes.copy(),
-            customList: customList
+            subject: subject
         )
-
-        dataSource?.didUpdateCustomList = { [weak self] customListLocationNode in
-            guard let self else { return }
-            delegate?.didUpdateSelectedLocations(
-                locations: customListLocationNode.children.reduce([]) { partialResult, locationNode in
-                    partialResult + locationNode.locations
-                }
-            )
-        }
     }
 }
 

--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewController.swift
@@ -27,6 +27,14 @@ class CustomListViewController: UIViewController {
     private let alertPresenter: AlertPresenter
     private var validationErrors: Set<CustomListFieldValidationError> = []
 
+    private var persistedCustomList: CustomList? {
+        return interactor.fetchAll().first(where: { $0.id == subject.value.id })
+    }
+
+    private var hasUnsavedChanges: Bool {
+        persistedCustomList != subject.value.customList
+    }
+
     private lazy var cellConfiguration: CustomListCellConfiguration = {
         CustomListCellConfiguration(tableView: tableView, subject: subject)
     }()
@@ -91,7 +99,36 @@ class CustomListViewController: UIViewController {
     }
 
     private func configureNavigationItem() {
+        if let navigationController = navigationController as? InterceptibleNavigationController {
+            interceptNavigation(navigationController)
+        }
+
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
         navigationItem.rightBarButtonItem = saveBarButton
+    }
+
+    private func interceptNavigation(_ navigationController: InterceptibleNavigationController) {
+        navigationController.shouldPopViewController = { [weak self] viewController in
+            guard
+                let self,
+                viewController is Self,
+                hasUnsavedChanges
+            else { return true }
+
+            self.onUnsavedChanges()
+            return false
+        }
+
+        navigationController.shouldPopToViewController = { [weak self] viewController in
+            guard
+                let self,
+                viewController is ListCustomListViewController,
+                hasUnsavedChanges
+            else { return true }
+
+            self.onUnsavedChanges()
+            return false
+        }
     }
 
     private func configureTableView() {
@@ -194,5 +231,69 @@ class CustomListViewController: UIViewController {
         )
 
         alertPresenter.showAlert(presentation: presentation, animated: true)
+    }
+
+    @objc private func onUnsavedChanges() {
+        let message = NSMutableAttributedString(
+            markdownString: NSLocalizedString(
+                "CUSTOM_LISTS_UNSAVED_CHANGES_PROMPT",
+                tableName: "CustomLists",
+                value: "You have unsaved changes.",
+                comment: ""
+            ),
+            options: MarkdownStylingOptions(font: .preferredFont(forTextStyle: .body))
+        )
+
+        let presentation = AlertPresentation(
+            id: "api-custom-lists-unsaved-changes-alert",
+            icon: .alert,
+            attributedMessage: message,
+            buttons: [
+                AlertAction(
+                    title: NSLocalizedString(
+                        "CUSTOM_LISTS_DISCARD_CHANGES_BUTTON",
+                        tableName: "CustomLists",
+                        value: "Discard changes",
+                        comment: ""
+                    ),
+                    style: .destructive,
+                    handler: {
+                        // Reset subject/view model to no longer having unsaved changes.
+                        if let persistedCustomList = self.persistedCustomList {
+                            self.subject.value.update(with: persistedCustomList)
+                        }
+                        self.delegate?.customListDidSave(self.subject.value.customList)
+                    }
+                ),
+                AlertAction(
+                    title: NSLocalizedString(
+                        "CUSTOM_LISTS_BACK_TO_EDITING_BUTTON",
+                        tableName: "CustomLists",
+                        value: "Back to editing",
+                        comment: ""
+                    ),
+                    style: .default
+                ),
+            ]
+        )
+
+        alertPresenter.showAlert(presentation: presentation, animated: true)
+    }
+}
+
+extension CustomListViewController: UIGestureRecognizerDelegate {
+    // For some reason, intercepting `popViewController(animated: Bool)` in `InterceptibleNavigationController`
+    // by SWIPING back leads to weird behaviour where subsequent navigation seem to happen systemwise but not
+    // UI-wise. This leads to the UI freezing up, and the only remedy is to restart the app.
+    //
+    // To get around this issue we can intercept the back swipe gesture and manually perform the transition
+    // instead, thereby bypassing the inner mechanisms that seem to go out of sync.
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer == navigationController?.interactivePopGestureRecognizer else {
+            return true
+        }
+
+        navigationController?.popViewController(animated: true)
+        return false
     }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewModel.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewModel.swift
@@ -18,4 +18,9 @@ struct CustomListViewModel {
     var customList: CustomList {
         CustomList(id: id, name: name, locations: locations)
     }
+
+    mutating func update(with list: CustomList) {
+        name = list.name
+        locations = list.locations
+    }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
@@ -21,12 +21,16 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
     let customList: CustomList
     let nodes: [LocationNode]
     let subject: CurrentValueSubject<CustomListViewModel, Never>
+    private lazy var alertPresenter: AlertPresenter = {
+        AlertPresenter(context: self)
+    }()
 
     var presentedViewController: UIViewController {
         navigationController
     }
 
     var didFinish: ((EditCustomListCoordinator, FinishAction, CustomList) -> Void)?
+    var didCancel: ((EditCustomListCoordinator) -> Void)?
 
     init(
         navigationController: UINavigationController,
@@ -50,7 +54,7 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
         let controller = CustomListViewController(
             interactor: customListInteractor,
             subject: subject,
-            alertPresenter: AlertPresenter(context: self)
+            alertPresenter: alertPresenter
         )
         controller.delegate = self
 
@@ -61,7 +65,77 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
             comment: ""
         )
 
+        navigationController.interactivePopGestureRecognizer?.delegate = self
         navigationController.pushViewController(controller, animated: true)
+
+        guard let interceptibleNavigationController = navigationController as? InterceptibleNavigationController else {
+            return
+        }
+
+        interceptibleNavigationController.shouldPopViewController = { [weak self] viewController in
+            guard
+                let self,
+                let customListViewController = viewController as? CustomListViewController,
+                customListViewController.hasUnsavedChanges
+            else { return true }
+
+            presentUnsavedChangesDialog()
+            return false
+        }
+
+        interceptibleNavigationController.shouldPopToViewController = { [weak self] viewController in
+            guard
+                let self,
+                let customListViewController = viewController as? CustomListViewController,
+                customListViewController.hasUnsavedChanges
+            else { return true }
+
+            presentUnsavedChangesDialog()
+            return false
+        }
+    }
+
+    private func presentUnsavedChangesDialog() {
+        let message = NSMutableAttributedString(
+            markdownString: NSLocalizedString(
+                "CUSTOM_LISTS_UNSAVED_CHANGES_PROMPT",
+                tableName: "CustomLists",
+                value: "You have unsaved changes.",
+                comment: ""
+            ),
+            options: MarkdownStylingOptions(font: .preferredFont(forTextStyle: .body))
+        )
+
+        let presentation = AlertPresentation(
+            id: "api-custom-lists-unsaved-changes-alert",
+            icon: .alert,
+            attributedMessage: message,
+            buttons: [
+                AlertAction(
+                    title: NSLocalizedString(
+                        "CUSTOM_LISTS_DISCARD_CHANGES_BUTTON",
+                        tableName: "CustomLists",
+                        value: "Discard changes",
+                        comment: ""
+                    ),
+                    style: .destructive,
+                    handler: {
+                        self.didCancel?(self)
+                    }
+                ),
+                AlertAction(
+                    title: NSLocalizedString(
+                        "CUSTOM_LISTS_BACK_TO_EDITING_BUTTON",
+                        tableName: "CustomLists",
+                        value: "Back to editing",
+                        comment: ""
+                    ),
+                    style: .default
+                ),
+            ]
+        )
+
+        alertPresenter.showAlert(presentation: presentation, animated: true)
     }
 }
 
@@ -88,5 +162,21 @@ extension EditCustomListCoordinator: CustomListViewControllerDelegate {
         coordinator.start()
 
         addChild(coordinator)
+    }
+}
+
+extension EditCustomListCoordinator: UIGestureRecognizerDelegate {
+    // For some reason, intercepting `popViewController(animated: Bool)` in `InterceptibleNavigationController`
+    // by SWIPING back leads to weird behaviour where subsequent navigation seem to happen systemwise but not
+    // UI-wise. This leads to the UI freezing up, and the only remedy is to restart the app.
+    //
+    // To get around this issue we can intercept the back swipe gesture and manually perform the transition
+    // instead, thereby bypassing the inner mechanisms that seem to go out of sync.
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer == navigationController.interactivePopGestureRecognizer else {
+            return true
+        }
+        navigationController.popViewController(animated: true)
+        return false
     }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
@@ -78,17 +78,10 @@ extension EditCustomListCoordinator: CustomListViewControllerDelegate {
         let coordinator = EditLocationsCoordinator(
             navigationController: navigationController,
             nodes: nodes,
-            customList: list
+            subject: subject
         )
 
-        coordinator.didFinish = { [weak self] locationsCoordinator, customList in
-            guard let self else { return }
-            subject.send(CustomListViewModel(
-                id: customList.id,
-                name: customList.name,
-                locations: customList.locations,
-                tableSections: subject.value.tableSections
-            ))
+        coordinator.didFinish = { locationsCoordinator in
             locationsCoordinator.removeFromParent()
         }
 

--- a/ios/MullvadVPN/Coordinators/CustomLists/EditLocationsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/EditLocationsCoordinator.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+import Combine
 import MullvadSettings
 import MullvadTypes
 import Routing
@@ -14,9 +15,9 @@ import UIKit
 class EditLocationsCoordinator: Coordinator, Presentable, Presenting {
     private let navigationController: UINavigationController
     private let nodes: [LocationNode]
-    private var customList: CustomList
+    private var subject: CurrentValueSubject<CustomListViewModel, Never>
 
-    var didFinish: ((EditLocationsCoordinator, CustomList) -> Void)?
+    var didFinish: ((EditLocationsCoordinator) -> Void)?
 
     var presentedViewController: UIViewController {
         navigationController
@@ -25,17 +26,17 @@ class EditLocationsCoordinator: Coordinator, Presentable, Presenting {
     init(
         navigationController: UINavigationController,
         nodes: [LocationNode],
-        customList: CustomList
+        subject: CurrentValueSubject<CustomListViewModel, Never>
     ) {
         self.navigationController = navigationController
         self.nodes = nodes
-        self.customList = customList
+        self.subject = subject
     }
 
     func start() {
         let controller = AddLocationsViewController(
             allLocationsNodes: nodes,
-            customList: customList
+            subject: subject
         )
         controller.delegate = self
 
@@ -50,11 +51,7 @@ class EditLocationsCoordinator: Coordinator, Presentable, Presenting {
 }
 
 extension EditLocationsCoordinator: AddLocationsViewControllerDelegate {
-    func didUpdateSelectedLocations(locations: [RelayLocation]) {
-        customList.locations = locations
-    }
-
     func didBack() {
-        didFinish?(self, customList)
+        didFinish?(self)
     }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
@@ -65,6 +65,12 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
             self.updateRelayConstraints(for: action, in: list)
         }
 
+        coordinator.didCancel = { [weak self] editCustomListCoordinator in
+            guard let self else { return }
+            popToList()
+            editCustomListCoordinator.removeFromParent()
+        }
+
         coordinator.start()
         addChild(coordinator)
     }
@@ -84,6 +90,14 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
                     customListSelection: UserSelectedRelays.CustomListSelection(listId: list.id, isList: true)
                 )
                 relayConstraints.locations = .only(selectedRelays)
+            } else {
+                let selectedConstraintIsRemovedFromList = list.locations.filter {
+                    relayConstraints.locations.value?.locations.contains($0) ?? false
+                }.isEmpty
+
+                if selectedConstraintIsRemovedFromList {
+                    relayConstraints.locations = .only(UserSelectedRelays(locations: []))
+                }
             }
         case .delete:
             relayConstraints.locations = .only(UserSelectedRelays(locations: []))

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -147,7 +147,7 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
 
     private func showEditCustomLists(nodes: [LocationNode]) {
         let coordinator = ListCustomListCoordinator(
-            navigationController: CustomNavigationController(),
+            navigationController: InterceptibleNavigationController(),
             interactor: CustomListInteractor(repository: customListRepository),
             tunnelManager: tunnelManager,
             nodes: nodes

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
@@ -15,13 +15,16 @@ struct LocationCellViewModel: Hashable {
     var isSelected = false
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(section)
         hasher.combine(node)
+        hasher.combine(node.children.count)
+        hasher.combine(section)
+        hasher.combine(isSelected)
         hasher.combine(indentationLevel)
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.node == rhs.node &&
+            lhs.node.children.count == rhs.node.children.count &&
             lhs.section == rhs.section &&
             lhs.isSelected == rhs.isSelected &&
             lhs.indentationLevel == rhs.indentationLevel

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
@@ -17,12 +17,14 @@ struct LocationCellViewModel: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(section)
         hasher.combine(node)
+        hasher.combine(indentationLevel)
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.node == rhs.node &&
             lhs.section == rhs.section &&
-            lhs.isSelected == rhs.isSelected
+            lhs.isSelected == rhs.isSelected &&
+            lhs.indentationLevel == rhs.indentationLevel
     }
 }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
@@ -185,7 +185,7 @@ final class LocationDataSource:
 
         let rootNode = selectedItem.node.root
 
-        // Exit early if no changes to the node tree are necessary.
+        // Exit early if no changes to the node tree should be made.
         guard selectedItem.node != rootNode else {
             completion?()
             return

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationNode.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationNode.swift
@@ -45,6 +45,12 @@ extension LocationNode {
         parent?.root ?? self
     }
 
+    var hierarchyLevel: Int {
+        var level = 0
+        forEachAncestor { _ in level += 1 }
+        return level
+    }
+
     func countryFor(code: String) -> LocationNode? {
         self.code == code ? self : children.first(where: { $0.code == code })
     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderView.swift
@@ -54,10 +54,9 @@ class LocationSectionHeaderView: UIView, UIContentView {
         addConstrainedSubviews([nameLabel, actionButton]) {
             nameLabel.pinEdgesToSuperviewMargins(.all().excluding(.trailing))
 
-            actionButton.pinEdgesToSuperviewMargins(PinnableEdges([.trailing(.zero)]))
-            actionButton.widthAnchor.constraint(equalToConstant: 24)
-            actionButton.heightAnchor.constraint(equalTo: actionButton.widthAnchor, multiplier: 1)
-            actionButton.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+            actionButton.pinEdgesToSuperview(PinnableEdges([.trailing(8)]))
+            actionButton.heightAnchor.constraint(equalTo: heightAnchor)
+            actionButton.widthAnchor.constraint(equalTo: actionButton.heightAnchor)
 
             actionButton.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 16)
         }


### PR DESCRIPTION
Due to the complexity of changes that can be applied to a custom list, it's best to have the users confirm their changes with a deliberate save action.

Thus, when  a user is clicking to go back from editing a custom list and the list has not been saved yet, the user should be prompted if they want to discard their changes or to go back to editing.

We also need to take menu navigation (long press on back button) into consideration by enforcing the same behaviour when eg. the user tries to navigate directly from add locations view to the list of custom lists.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6079)
<!-- Reviewable:end -->
