### PR TITLE
Fix bug where offline servers can be selected

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/AllLocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/AllLocationDataSource.swift
@@ -64,7 +64,7 @@ class AllLocationDataSource: LocationDataSourceProtocol {
                 name: serverLocation.country,
                 code: LocationNode.combineNodeCodes([countryCode]),
                 locations: [location],
-                isActive: relay.active
+                isActive: true // Defaults to true, updated when children are populated.
             )
 
             if !rootNode.children.contains(countryNode) {
@@ -77,7 +77,7 @@ class AllLocationDataSource: LocationDataSourceProtocol {
                 name: serverLocation.city,
                 code: LocationNode.combineNodeCodes([countryCode, cityCode]),
                 locations: [location],
-                isActive: relay.active
+                isActive: true // Defaults to true, updated when children are populated.
             )
 
             if let countryNode = rootNode.countryFor(code: countryCode),
@@ -101,6 +101,14 @@ class AllLocationDataSource: LocationDataSourceProtocol {
                 hostNode.parent = cityNode
                 cityNode.children.append(hostNode)
                 cityNode.children.sort()
+
+                cityNode.isActive = cityNode.children.contains(where: { hostNode in
+                    hostNode.isActive
+                })
+
+                countryNode.isActive = countryNode.children.contains(where: { cityNode in
+                    cityNode.isActive
+                })
             }
         }
     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
@@ -236,6 +236,10 @@ extension LocationDataSource: UITableViewDelegate {
         }
     }
 
+    func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        itemIdentifier(for: indexPath)?.node.isActive ?? false
+    }
+
     func tableView(_ tableView: UITableView, indentationLevelForRowAt indexPath: IndexPath) -> Int {
         itemIdentifier(for: indexPath)?.indentationLevel ?? 0
     }


### PR DESCRIPTION
This PR takes care of two issues:

- Inactive locations should not be selectable.
- Parent nodes (ie country/city) should not be marked inactive if at least one child is active.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
