### PR TITLE
Add OS version RPC to test framework

### DIFF
--- a/talpid-platform-metadata/src/windows.rs
+++ b/talpid-platform-metadata/src/windows.rs
@@ -80,20 +80,28 @@ impl WindowsVersion {
             return "Server".to_owned();
         }
 
+        match self.release_version() {
+            (major, 0) => major.to_string(),
+            (major, minor) => format!("{major}.{minor}"),
+        }
+    }
+
+    /// Release version. E.g. `(10, 0)` for Windows 10, or `(8, 0)` for Windows 8.1.
+    pub fn release_version(&self) -> (u32, u32) {
         // Check https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions#Personal_computer_versions 'Release version' column
         // for the correct NT versions for specific windows releases.
         match (self.major_version(), self.minor_version()) {
-            (6, 1) => "7".into(),
-            (6, 2) => "8".into(),
-            (6, 3) => "8.1".into(),
+            (6, 1) => (7, 0),
+            (6, 2) => (8, 0),
+            (6, 3) => (8, 1),
             (10, 0) => {
                 if self.build_number() < 22000 {
-                    "10".into()
+                    (10, 0)
                 } else {
-                    "11".into()
+                    (11, 0)
                 }
             }
-            (major, minor) => format!("{}.{}", major, minor),
+            (major, minor) => (major, minor),
         }
     }
 

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -49,6 +49,8 @@ pub async fn run(
     let mullvad_client =
         mullvad_daemon::new_rpc_client(connection_handle, mullvad_daemon_transport);
 
+    print_os_version(&client).await;
+
     let mut tests: Vec<_> = inventory::iter::<tests::TestMetadata>()
         .filter(|test| test.should_run_on_os(TEST_CONFIG.os))
         .collect();
@@ -218,5 +220,16 @@ where
         test_name,
         error_messages: output,
         result,
+    }
+}
+
+async fn print_os_version(client: &ServiceClient) {
+    match client.get_os_version().await {
+        Ok(version) => {
+            log::debug!("Guest OS version: {version}");
+        }
+        Err(error) => {
+            log::debug!("Failed to obtain guest OS version: {error}");
+        }
     }
 }

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -378,4 +378,10 @@ impl ServiceClient {
             .close_child_stdin(tarpc::context::current(), pid)
             .await?
     }
+
+    pub async fn get_os_version(&self) -> Result<meta::OsVersion, Error> {
+        self.client
+            .get_os_version(tarpc::context::current())
+            .await?
+    }
 }

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -244,6 +244,9 @@ mod service {
 
         /// Kill a process spawned through [Service::spawn].
         async fn kill_child(pid: u32) -> Result<(), Error>;
+
+        /// Returns operating system details
+        async fn get_os_version() -> Result<meta::OsVersion, Error>;
     }
 }
 

--- a/test/test-rpc/src/meta.rs
+++ b/test/test-rpc/src/meta.rs
@@ -1,6 +1,24 @@
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum OsVersion {
+    Linux,
+    Macos(MacosVersion),
+    Windows(WindowsVersion),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct MacosVersion {
+    pub major: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct WindowsVersion {
+    pub major: u32,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Os {

--- a/test/test-rpc/src/meta.rs
+++ b/test/test-rpc/src/meta.rs
@@ -9,6 +9,16 @@ pub enum OsVersion {
     Windows(WindowsVersion),
 }
 
+impl std::fmt::Display for OsVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OsVersion::Linux => f.write_str("Linux"),
+            OsVersion::Macos(version) => write!(f, "macOS {}", version.major),
+            OsVersion::Windows(version) => write!(f, "Windows {}", version.major),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct MacosVersion {
     pub major: u32,

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -12,6 +12,7 @@ use util::OnDrop;
 
 use tarpc::{context, server::Channel};
 use test_rpc::{
+    meta::OsVersion,
     mullvad_daemon::{ServiceStatus, SOCKET_PATH},
     net::SockHandleId,
     package::Package,
@@ -532,6 +533,10 @@ impl Service for TestServer {
         drop(child); // I swear officer, it's not what you think!
 
         Ok(())
+    }
+
+    async fn get_os_version(self, _: context::Context) -> Result<OsVersion, test_rpc::Error> {
+        sys::get_os_version()
     }
 }
 


### PR DESCRIPTION
This can be expanded as needed. Currently, we only need to obtain the major version on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6087)
<!-- Reviewable:end -->
