### PR TITLE
Include 100.64.0.0/10 in ALLOWED_LAN_NETS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add automatic MTU detection for desktop platforms. This currently only uses information about
   dropped packets and does not take fragmentation into account.
 - Add ability to import server IP overrides in GUI.
+- Allow the 100.64.0.0/10 RFC6598 shared address space in addition to the other networks allowed when local network sharing is enabled.
 
 #### Android
 - Add support for all screen orientations.

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -25,9 +25,10 @@ mod imp;
 pub use self::imp::Error;
 
 /// When "allow local network" is enabled the app will allow traffic to and from these networks.
-pub(crate) static ALLOWED_LAN_NETS: Lazy<[IpNetwork; 6]> = Lazy::new(|| {
+pub(crate) static ALLOWED_LAN_NETS: Lazy<[IpNetwork; 7]> = Lazy::new(|| {
     [
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap()),
+        IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 0), 10).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(172, 16, 0, 0), 12).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16).unwrap()),
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(169, 254, 0, 0), 16).unwrap()),


### PR DESCRIPTION
I added the 100.64.0.0/10 address space to ALLOWED_LAN_NETS.

100.64.0.0/10 is reserved by IANA as Shared Address Space, is filtered on the public Internet through routing filters (May not be advertised) and can therefore be treated as local.
https://datatracker.ietf.org/doc/html/rfc6598

It mainly serves ISPs, but can also be used on the internal network by organizations of any kind.

Please merge my PR, so that users will be able to access parts of their network where this address space is used, while still being connected to the Mullvad VPN.

Closes #6086

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6089)
<!-- Reviewable:end -->
