### PR TITLE
Change action sheet tint color

### DIFF
--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -197,6 +197,9 @@ extension LocationCoordinator: LocationViewControllerDelegate {
             preferredStyle: UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
         )
 
+        actionSheet.overrideUserInterfaceStyle = .dark
+        actionSheet.view.tintColor = UIColor(red: 0.0, green: 0.59, blue: 1.0, alpha: 1)
+
         actionSheet.addAction(UIAlertAction(
             title: NSLocalizedString(
                 "CUSTOM_LIST_ACTION_SHEET_ADD_LIST_BUTTON",
@@ -235,9 +238,6 @@ extension LocationCoordinator: LocationViewControllerDelegate {
             style: .cancel,
             handler: nil
         ))
-
-        actionSheet.overrideUserInterfaceStyle = .dark
-        actionSheet.view.tintColor = .white
 
         presentationContext.present(actionSheet, animated: true)
     }


### PR DESCRIPTION

To enhance the differentiation between enabled and disabled actions, we've opted for a more distinct color that ensures better visibility. This PR implements this change.

<img src="https://github.com/mullvad/mullvadvpn-app/assets/129863230/c827e389-5dcc-453a-ad27-e51895d3259b" alt="Flowers in Chania" width = 300>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6096)
<!-- Reviewable:end -->
