### PR TITLE
Sort e2e test summary and add list-tests command

### DIFF
--- a/test/test-manager/src/main.rs
+++ b/test/test-manager/src/main.rs
@@ -59,6 +59,9 @@ enum Commands {
         keep_changes: bool,
     },
 
+    /// List all tests and their priority.
+    ListTests,
+
     /// Spawn a runner instance and run tests
     RunTests {
         /// Name of the runner config
@@ -196,6 +199,17 @@ async fn main() -> Result<()> {
 
             instance.wait().await;
 
+            Ok(())
+        }
+        Commands::ListTests => {
+            println!("priority\tname");
+            for test in tests::get_tests() {
+                println!(
+                    "{priority:8}\t{name}",
+                    name = test.name,
+                    priority = test.priority.unwrap_or(0),
+                );
+            }
             Ok(())
         }
         Commands::RunTests {

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -2,8 +2,7 @@ use crate::{
     logging::{panic_as_string, TestOutput},
     mullvad_daemon,
     summary::{self, maybe_log_test_result},
-    tests,
-    tests::{config::TEST_CONFIG, TestContext},
+    tests::{self, config::TEST_CONFIG, get_tests, TestContext},
     vm,
 };
 use anyhow::{Context, Result};
@@ -50,10 +49,9 @@ pub async fn run(
 
     print_os_version(&client).await;
 
-    let mut tests: Vec<_> = inventory::iter::<tests::TestMetadata>()
-        .filter(|test| test.should_run_on_os(TEST_CONFIG.os))
-        .collect();
-    tests.sort_by_key(|test| test.priority.unwrap_or(0));
+    let mut tests = get_tests();
+
+    tests.retain(|test| test.should_run_on_os(TEST_CONFIG.os));
 
     if !test_filters.is_empty() {
         tests.retain(|test| {

--- a/test/test-manager/src/summary.rs
+++ b/test/test-manager/src/summary.rs
@@ -199,7 +199,7 @@ impl Summary {
 /// be parsed, we should not abort the entire summarization.
 pub async fn print_summary_table<P: AsRef<Path>>(summary_files: &[P]) {
     // Collect test details
-    let tests: Vec<_> = inventory::iter::<crate::tests::TestMetadata>().collect();
+    let tests = crate::tests::get_tests();
 
     let mut summaries = vec![];
     let mut failed_to_parse = vec![];

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -64,6 +64,13 @@ pub enum Error {
     Other(String),
 }
 
+/// Get a list of all tests, sorted by priority.
+pub fn get_tests() -> Vec<&'static TestMetadata> {
+    let mut tests: Vec<_> = inventory::iter::<TestMetadata>().collect();
+    tests.sort_by_key(|test| test.priority.unwrap_or(0));
+    tests
+}
+
 /// Restore settings to the defaults.
 pub async fn cleanup_after_test(mullvad_client: &mut MullvadProxyClient) -> anyhow::Result<()> {
     log::debug!("Cleaning up daemon in test cleanup");


### PR DESCRIPTION
This PR
- sorts the E2E test result matrix in the same order as the tests are run,
- and adds the `test-manager list-tests` command, which I found helpful when testing :)

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6097)
<!-- Reviewable:end -->
