### PR TITLE
Make sure all settings are cleared in between E2E tests.

### DIFF
--- a/mullvad-daemon/src/access_method.rs
+++ b/mullvad-daemon/src/access_method.rs
@@ -128,6 +128,17 @@ where
         Ok(())
     }
 
+    /// Remove all custom [`AccessMethodSetting`].
+    pub async fn clear_custom_api_access_methods(&mut self) -> Result<(), Error> {
+        self.settings
+            .update(|settings: &mut Settings| {
+                settings.api_access_methods.clear_custom();
+            })
+            .await?;
+
+        Ok(())
+    }
+
     /// Return the [`AccessMethodSetting`] which is currently used to access the
     /// Mullvad API.
     pub async fn get_current_access_method(&self) -> Result<AccessMethodSetting, Error> {

--- a/mullvad-daemon/src/custom_list.rs
+++ b/mullvad-daemon/src/custom_list.rs
@@ -10,6 +10,9 @@ impl<L> Daemon<L>
 where
     L: EventListener + Clone + Send + 'static,
 {
+    /// Create a new custom list.
+    ///
+    /// Returns an error if the name is not unique.
     pub async fn create_custom_list(&mut self, name: String) -> Result<Id, crate::Error> {
         if self
             .settings
@@ -33,6 +36,9 @@ where
         Ok(id)
     }
 
+    /// Update a custom list.
+    ///
+    /// Returns an error if the list doesn't exist.
     pub async fn delete_custom_list(&mut self, id: Id) -> Result<(), Error> {
         let Some(list_index) = self
             .settings
@@ -56,7 +62,7 @@ where
             self.relay_selector
                 .set_config(new_selector_config(&self.settings));
 
-            if self.change_should_cause_reconnect(id) {
+            if self.change_should_cause_reconnect(Some(id)) {
                 log::info!("Initiating tunnel restart because a selected custom list was deleted");
                 self.reconnect_tunnel();
             }
@@ -66,6 +72,11 @@ where
         Ok(())
     }
 
+    /// Update a custom list.
+    ///
+    /// Returns an error if...
+    /// - there is no existing list with the same ID,
+    /// - or the existing list has a different name.
     pub async fn update_custom_list(&mut self, new_list: CustomList) -> Result<(), Error> {
         let Some((list_index, old_list)) = self
             .settings
@@ -100,7 +111,7 @@ where
             self.relay_selector
                 .set_config(new_selector_config(&self.settings));
 
-            if self.change_should_cause_reconnect(id) {
+            if self.change_should_cause_reconnect(Some(id)) {
                 log::info!("Initiating tunnel restart because a selected custom list changed");
                 self.reconnect_tunnel();
             }
@@ -110,48 +121,78 @@ where
         Ok(())
     }
 
-    fn change_should_cause_reconnect(&self, custom_list_id: Id) -> bool {
+    /// Remove all custom lists.
+    pub async fn clear_custom_lists(&mut self) -> Result<(), Error> {
+        let settings_changed = self
+            .settings
+            .update(|settings| {
+                settings.custom_lists.clear();
+            })
+            .await
+            .map_err(Error::SettingsError);
+
+        if let Ok(true) = settings_changed {
+            self.relay_selector
+                .set_config(new_selector_config(&self.settings));
+
+            if self.change_should_cause_reconnect(None) {
+                log::info!("Initiating tunnel restart because a selected custom list was deleted");
+                self.reconnect_tunnel();
+            }
+        }
+
+        settings_changed?;
+        Ok(())
+    }
+
+    /// Check whether we need to reconnect after changing custom lists.
+    ///
+    /// If `custom_list_id` is `Some`, only changes to that custom list will trigger a reconnect.
+    fn change_should_cause_reconnect(&self, custom_list_id: Option<Id>) -> bool {
         use mullvad_types::states::TunnelState;
         let mut need_to_reconnect = false;
 
-        if let RelaySettings::Normal(relay_settings) = &self.settings.relay_settings {
-            if let Constraint::Only(LocationConstraint::CustomList { list_id }) =
-                &relay_settings.location
-            {
-                need_to_reconnect |= list_id == &custom_list_id;
-            }
+        let RelaySettings::Normal(relay_settings) = &self.settings.relay_settings else {
+            return false;
+        };
 
-            if let TunnelState::Connecting {
-                endpoint,
-                location: _,
-            }
-            | TunnelState::Connected {
-                endpoint,
-                location: _,
-            } = &self.tunnel_state
-            {
-                match endpoint.tunnel_type {
-                    TunnelType::Wireguard => {
-                        if relay_settings.wireguard_constraints.multihop() {
-                            if let Constraint::Only(LocationConstraint::CustomList { list_id }) =
-                                &relay_settings.wireguard_constraints.entry_location
-                            {
-                                need_to_reconnect |= list_id == &custom_list_id;
-                            }
+        if let Constraint::Only(LocationConstraint::CustomList { list_id }) =
+            &relay_settings.location
+        {
+            need_to_reconnect |= custom_list_id.map(|id| &id == list_id).unwrap_or(true);
+        }
+
+        if let TunnelState::Connecting {
+            endpoint,
+            location: _,
+        }
+        | TunnelState::Connected {
+            endpoint,
+            location: _,
+        } = &self.tunnel_state
+        {
+            match endpoint.tunnel_type {
+                TunnelType::Wireguard => {
+                    if relay_settings.wireguard_constraints.multihop() {
+                        if let Constraint::Only(LocationConstraint::CustomList { list_id }) =
+                            &relay_settings.wireguard_constraints.entry_location
+                        {
+                            need_to_reconnect |=
+                                custom_list_id.map(|id| &id == list_id).unwrap_or(true);
                         }
                     }
+                }
 
-                    TunnelType::OpenVpn => {
-                        if !matches!(self.settings.bridge_state, BridgeState::Off) {
-                            if let Ok(ResolvedBridgeSettings::Normal(bridge_settings)) =
-                                self.settings.bridge_settings.resolve()
+                TunnelType::OpenVpn => {
+                    if !matches!(self.settings.bridge_state, BridgeState::Off) {
+                        if let Ok(ResolvedBridgeSettings::Normal(bridge_settings)) =
+                            self.settings.bridge_settings.resolve()
+                        {
+                            if let Constraint::Only(LocationConstraint::CustomList { list_id }) =
+                                &bridge_settings.location
                             {
-                                if let Constraint::Only(LocationConstraint::CustomList {
-                                    list_id,
-                                }) = &bridge_settings.location
-                                {
-                                    need_to_reconnect |= list_id == &custom_list_id;
-                                }
+                                need_to_reconnect |=
+                                    custom_list_id.map(|id| &id == list_id).unwrap_or(true);
                             }
                         }
                     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -292,6 +292,8 @@ pub enum DaemonCommand {
     SetApiAccessMethod(ResponseTx<(), Error>, mullvad_types::access_method::Id),
     /// Edit an API access method
     UpdateApiAccessMethod(ResponseTx<(), Error>, AccessMethodSetting),
+    /// Remove all custom API access methods
+    ClearCustomApiAccessMethods(ResponseTx<(), Error>),
     /// Get the currently used API access method
     GetCurrentAccessMethod(ResponseTx<AccessMethodSetting, Error>),
     /// Test an API access method
@@ -1260,6 +1262,7 @@ where
             }
             RemoveApiAccessMethod(tx, method) => self.on_remove_api_access_method(tx, method).await,
             UpdateApiAccessMethod(tx, method) => self.on_update_api_access_method(tx, method).await,
+            ClearCustomApiAccessMethods(tx) => self.on_clear_custom_api_access_methods(tx).await,
             GetCurrentAccessMethod(tx) => self.on_get_current_api_access_method(tx),
             SetApiAccessMethod(tx, method) => self.on_set_api_access_method(tx, method).await,
             TestApiAccessMethodById(tx, method) => self.on_test_api_access_method(tx, method).await,
@@ -2480,6 +2483,14 @@ where
             .await
             .map_err(Error::AccessMethodError);
         Self::oneshot_send(tx, result, "update_api_access_method response");
+    }
+
+    async fn on_clear_custom_api_access_methods(&mut self, tx: ResponseTx<(), Error>) {
+        let result = self
+            .clear_custom_api_access_methods()
+            .await
+            .map_err(Error::AccessMethodError);
+        Self::oneshot_send(tx, result, "clear_custom_api_access_methods response");
     }
 
     fn on_get_current_api_access_method(&mut self, tx: ResponseTx<AccessMethodSetting, Error>) {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -279,6 +279,8 @@ pub enum DaemonCommand {
     DeleteCustomList(ResponseTx<(), Error>, mullvad_types::custom_list::Id),
     /// Update a custom list with a given id
     UpdateCustomList(ResponseTx<(), Error>, CustomList),
+    /// Remove all custom lists
+    ClearCustomLists(ResponseTx<(), Error>),
     /// Add API access methods
     AddApiAccessMethod(
         ResponseTx<mullvad_types::access_method::Id, Error>,
@@ -1255,6 +1257,7 @@ where
             CreateCustomList(tx, name) => self.on_create_custom_list(tx, name).await,
             DeleteCustomList(tx, id) => self.on_delete_custom_list(tx, id).await,
             UpdateCustomList(tx, update) => self.on_update_custom_list(tx, update).await,
+            ClearCustomLists(tx) => self.on_clear_custom_lists(tx).await,
             GetVersionInfo(tx) => self.on_get_version_info(tx),
             AddApiAccessMethod(tx, name, enabled, access_method) => {
                 self.on_add_access_method(tx, name, enabled, access_method)
@@ -2433,6 +2436,11 @@ where
     async fn on_update_custom_list(&mut self, tx: ResponseTx<(), Error>, new_list: CustomList) {
         let result = self.update_custom_list(new_list).await;
         Self::oneshot_send(tx, result, "update_custom_list response");
+    }
+
+    async fn on_clear_custom_lists(&mut self, tx: ResponseTx<(), Error>) {
+        let result = self.clear_custom_lists().await;
+        Self::oneshot_send(tx, result, "clear_custom_lists response");
     }
 
     async fn on_add_access_method(

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -598,6 +598,16 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
     }
 
+    async fn clear_custom_lists(&self, _: Request<()>) -> ServiceResult<()> {
+        log::debug!("clear_custom_lists");
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::ClearCustomLists(tx))?;
+        self.wait_for_result(rx)
+            .await?
+            .map(Response::new)
+            .map_err(map_daemon_error)
+    }
+
     // Access Methods
 
     async fn add_api_access_method(

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -663,6 +663,16 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
     }
 
+    async fn clear_custom_api_access_methods(&self, _: Request<()>) -> ServiceResult<()> {
+        log::debug!("clear_custom_api_access_methods");
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::ClearCustomApiAccessMethods(tx))?;
+        self.wait_for_result(rx)
+            .await?
+            .map(Response::new)
+            .map_err(map_daemon_error)
+    }
+
     /// Return the [`types::AccessMethodSetting`] which the daemon is using to
     /// connect to the Mullvad API.
     async fn get_current_api_access_method(

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -73,6 +73,7 @@ service ManagementService {
   rpc CreateCustomList(google.protobuf.StringValue) returns (google.protobuf.StringValue) {}
   rpc DeleteCustomList(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
   rpc UpdateCustomList(CustomList) returns (google.protobuf.Empty) {}
+  rpc ClearCustomLists(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
   // Access methods
   rpc AddApiAccessMethod(NewAccessMethodSetting) returns (UUID) {}

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -79,6 +79,7 @@ service ManagementService {
   rpc RemoveApiAccessMethod(UUID) returns (google.protobuf.Empty) {}
   rpc SetApiAccessMethod(UUID) returns (google.protobuf.Empty) {}
   rpc UpdateApiAccessMethod(AccessMethodSetting) returns (google.protobuf.Empty) {}
+  rpc ClearCustomApiAccessMethods(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc GetCurrentApiAccessMethod(google.protobuf.Empty) returns (AccessMethodSetting) {}
   rpc TestCustomApiAccessMethod(CustomProxy) returns (google.protobuf.BoolValue) {}
   rpc TestApiAccessMethodById(UUID) returns (google.protobuf.BoolValue) {}

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -575,6 +575,15 @@ impl MullvadProxyClient {
             .map(drop)
     }
 
+    /// Remove all custom API access methods.
+    pub async fn clear_custom_access_methods(&mut self) -> Result<()> {
+        self.0
+            .clear_custom_api_access_methods(())
+            .await
+            .map_err(Error::Rpc)
+            .map(drop)
+    }
+
     /// Set the [`AccessMethod`] which [`ApiConnectionModeProvider`] should
     /// pick.
     ///

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -535,6 +535,15 @@ impl MullvadProxyClient {
         Ok(())
     }
 
+    /// Remove all custom lists.
+    pub async fn clear_custom_lists(&mut self) -> Result<()> {
+        self.0
+            .clear_custom_lists(())
+            .await
+            .map_err(map_custom_list_error)?;
+        Ok(())
+    }
+
     pub async fn add_access_method(
         &mut self,
         name: String,

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -74,6 +74,12 @@ impl Settings {
         updated
     }
 
+    /// Remove all custom access methods.
+    pub fn clear_custom(&mut self) {
+        self.custom.clear();
+        self.ensure_consistent_state();
+    }
+
     /// Check that `self` contains atleast one enabled access methods. If not,
     /// the `Direct` access method is re-enabled.
     fn ensure_consistent_state(&mut self) {

--- a/mullvad-types/src/custom_list.rs
+++ b/mullvad-types/src/custom_list.rs
@@ -98,6 +98,11 @@ impl CustomListsSettings {
     pub fn remove(&mut self, index: usize) {
         self.custom_lists.remove(index);
     }
+
+    /// Remove all custom lists
+    pub fn clear(&mut self) {
+        self.custom_lists.clear();
+    }
 }
 
 impl IntoIterator for CustomListsSettings {

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -171,12 +171,11 @@ pub async fn cleanup_after_test(mullvad_client: &mut MullvadProxyClient) -> anyh
         .await
         .context("Could not clear PQ options in cleanup")?;
 
-    for custom_list in custom_lists {
-        mullvad_client
-            .delete_custom_list(custom_list.name)
-            .await
-            .context("Could not remove custom list")?;
-    }
+    let _ = custom_lists;
+    mullvad_client
+        .clear_custom_lists()
+        .await
+        .context("Could not remove custom list")?;
 
     Ok(())
 }

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -95,6 +95,17 @@ pub async fn cleanup_after_test(mullvad_client: &mut MullvadProxyClient) -> anyh
     } = Default::default();
 
     mullvad_client
+        .clear_custom_access_methods()
+        .await
+        .context("Could not clear custom api access methods")?;
+    for access_method in api_access_methods.iter() {
+        mullvad_client
+            .update_access_method(access_method.clone())
+            .await
+            .context("Could not reset default access method")?;
+    }
+
+    mullvad_client
         .set_relay_settings(relay_settings)
         .await
         .context("Could not set relay settings")?;

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -77,58 +77,95 @@ pub async fn cleanup_after_test(mullvad_client: &mut MullvadProxyClient) -> anyh
 
     helpers::disconnect_and_wait(mullvad_client).await?;
 
-    let default_settings = mullvad_types::settings::Settings::default();
+    // Bring all the settings into scope so we remember to reset them.
+    let mullvad_types::settings::Settings {
+        relay_settings,
+        bridge_settings,
+        obfuscation_settings,
+        bridge_state,
+        custom_lists,
+        api_access_methods,
+        allow_lan,
+        block_when_disconnected,
+        auto_connect,
+        tunnel_options,
+        relay_overrides,
+        show_beta_releases,
+        settings_version: _, // N/A
+    } = Default::default();
 
     mullvad_client
-        .set_relay_settings(default_settings.relay_settings)
+        .set_relay_settings(relay_settings)
         .await
         .context("Could not set relay settings")?;
+
+    let _ = relay_overrides;
     mullvad_client
-        .set_auto_connect(default_settings.auto_connect)
+        .clear_all_relay_overrides()
+        .await
+        .context("Could not set relay overrides")?;
+
+    mullvad_client
+        .set_auto_connect(auto_connect)
         .await
         .context("Could not set auto connect in cleanup")?;
+
     mullvad_client
-        .set_allow_lan(default_settings.allow_lan)
+        .set_allow_lan(allow_lan)
         .await
         .context("Could not set allow lan in cleanup")?;
+
     mullvad_client
-        .set_show_beta_releases(default_settings.show_beta_releases)
+        .set_show_beta_releases(show_beta_releases)
         .await
         .context("Could not set show beta releases in cleanup")?;
+
     mullvad_client
-        .set_bridge_state(default_settings.bridge_state)
+        .set_bridge_state(bridge_state)
         .await
         .context("Could not set bridge state in cleanup")?;
+
     mullvad_client
-        .set_bridge_settings(default_settings.bridge_settings.clone())
+        .set_bridge_settings(bridge_settings.clone())
         .await
         .context("Could not set bridge settings in cleanup")?;
+
     mullvad_client
-        .set_obfuscation_settings(default_settings.obfuscation_settings.clone())
+        .set_obfuscation_settings(obfuscation_settings.clone())
         .await
         .context("Could set obfuscation settings in cleanup")?;
+
     mullvad_client
-        .set_block_when_disconnected(default_settings.block_when_disconnected)
+        .set_block_when_disconnected(block_when_disconnected)
         .await
         .context("Could not set block when disconnected setting in cleanup")?;
-    #[cfg(target_os = "windows")]
+
     mullvad_client
         .clear_split_tunnel_apps()
         .await
         .context("Could not clear split tunnel apps in cleanup")?;
-    #[cfg(target_os = "linux")]
+
     mullvad_client
         .clear_split_tunnel_processes()
         .await
         .context("Could not clear split tunnel processes in cleanup")?;
+
     mullvad_client
-        .set_dns_options(default_settings.tunnel_options.dns_options.clone())
+        .set_dns_options(tunnel_options.dns_options.clone())
         .await
         .context("Could not clear dns options in cleanup")?;
+
     mullvad_client
-        .set_quantum_resistant_tunnel(default_settings.tunnel_options.wireguard.quantum_resistant)
+        .set_quantum_resistant_tunnel(tunnel_options.wireguard.quantum_resistant)
         .await
         .context("Could not clear PQ options in cleanup")?;
+
+    for custom_list in custom_lists {
+        mullvad_client
+            .delete_custom_list(custom_list.name)
+            .await
+            .context("Could not remove custom list")?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
I noticed the `cleanup_after_test` seemed to omit a few settings, namely:
- `api_access_methods`
- `relay_overrides`
- `custom_lists`

So I added those to the cleanup function.

I also noticed that `clear_split_tunnel_processes` and `clear_split_tunnel_apps` were gated behind `#[cfg(target_os)]`, which doesn't seem right since that only checks the host machine, not the test runner. So I removed the cfg gate, hopefully that doesn't break anything.

Lastly, I added a GRPC call to clear all the custom API access methods, mostly to support the cleanup function. This may be overkill.

Update: Added a GRPC call to clear custom lists as well

## TODO
- [x] Test the new GRPC calls
  - [ ] <del>(maybe add a new e2e test? woah, meta.)</del>
- [x] Test all the tests
- [x] Test all the tests on a Mac host
- [x] Make sure I haven't broken Android
- [ ] <del>Maybe add cli command to reset access methods?</del>
- [ ] <del>Maybe add cli command to clear custom lists?</del>

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6099)
<!-- Reviewable:end -->
