### PR TITLE
Add app version to start of each log file

### DIFF
--- a/ios/MullvadLogging/Logging.swift
+++ b/ios/MullvadLogging/Logging.swift
@@ -21,8 +21,11 @@ public struct LoggerBuilder {
 
     public var metadata: Logger.Metadata = [:]
     public var logLevel: Logger.Level = .debug
+    public var header: String
 
-    public init() {}
+    public init(header: String) {
+        self.header = header
+    }
 
     public mutating func addFileOutput(fileURL: URL) {
         let logsDirectoryURL = fileURL.deletingLastPathComponent()
@@ -42,19 +45,18 @@ public struct LoggerBuilder {
             logRotationErrors.append(error)
         }
 
-        outputs.append(.fileOutput(LogFileOutputStream(fileURL: fileURL)))
+        outputs.append(.fileOutput(LogFileOutputStream(fileURL: fileURL, header: header)))
     }
 
     public mutating func addOSLogOutput(subsystem: String) {
         outputs.append(.osLogOutput(subsystem))
     }
 
-    public func install(header: String) {
+    public func install() {
         LoggingSystem.bootstrap { label -> LogHandler in
             let logHandlers: [LogHandler] = outputs.map { output in
                 switch output {
                 case let .fileOutput(stream):
-                    stream.write("\(header)\n")
                     return CustomFormatLogHandler(label: label, streams: [stream])
 
                 case let .osLogOutput(subsystem):

--- a/ios/MullvadLogging/Logging.swift
+++ b/ios/MullvadLogging/Logging.swift
@@ -49,11 +49,12 @@ public struct LoggerBuilder {
         outputs.append(.osLogOutput(subsystem))
     }
 
-    public func install() {
+    public func install(header: String) {
         LoggingSystem.bootstrap { label -> LogHandler in
             let logHandlers: [LogHandler] = outputs.map { output in
                 switch output {
                 case let .fileOutput(stream):
+                    stream.write("\(header)\n")
                     return CustomFormatLogHandler(label: label, streams: [stream])
 
                 case let .osLogOutput(subsystem):

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		449EB9FD2B95F8AD00DFA4EB /* DeviceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449EB9FC2B95F8AD00DFA4EB /* DeviceMock.swift */; };
 		449EB9FF2B95FF2500DFA4EB /* AccountMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449EB9FE2B95FF2500DFA4EB /* AccountMock.swift */; };
 		449EBA262B975B9700DFA4EB /* PostQuantumKeyReceiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449EBA252B975B9700DFA4EB /* PostQuantumKeyReceiving.swift */; };
+		44B02E3B2BC5732D008EDF34 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B02E3A2BC5732D008EDF34 /* LoggingTests.swift */; };
 		44DD7D242B6CFFD70005F67F /* StartTunnelOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DD7D232B6CFFD70005F67F /* StartTunnelOperationTests.swift */; };
 		44DD7D272B6D18FB0005F67F /* MockTunnelInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DD7D262B6D18FB0005F67F /* MockTunnelInteractor.swift */; };
 		44DD7D292B7113CA0005F67F /* MockTunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DD7D282B7113CA0005F67F /* MockTunnel.swift */; };
@@ -1328,6 +1329,7 @@
 		449EB9FC2B95F8AD00DFA4EB /* DeviceMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMock.swift; sourceTree = "<group>"; };
 		449EB9FE2B95FF2500DFA4EB /* AccountMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountMock.swift; sourceTree = "<group>"; };
 		449EBA252B975B9700DFA4EB /* PostQuantumKeyReceiving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostQuantumKeyReceiving.swift; sourceTree = "<group>"; };
+		44B02E3A2BC5732D008EDF34 /* LoggingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
 		44DD7D232B6CFFD70005F67F /* StartTunnelOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartTunnelOperationTests.swift; sourceTree = "<group>"; };
 		44DD7D262B6D18FB0005F67F /* MockTunnelInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTunnelInteractor.swift; sourceTree = "<group>"; };
 		44DD7D282B7113CA0005F67F /* MockTunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTunnel.swift; sourceTree = "<group>"; };
@@ -2948,7 +2950,6 @@
 				7A83A0C52B29A750008B5CE7 /* APIAccessMethodsTests.swift */,
 				A900E9BD2ACC654100C95F67 /* APIProxy+Stubs.swift */,
 				A9EC20E72A5D3A8C0040D56E /* CoordinatesTests.swift */,
-				01168B192BBEE7F800D5F382 /* LoggingTests.swift */,
 				5896AE85246D6AD8005B36CB /* CustomDateComponentsFormattingTests.swift */,
 				58915D622A25F8400066445B /* DeviceCheckOperationTests.swift */,
 				A900E9BB2ACC609200C95F67 /* DevicesProxy+Stubs.swift */,
@@ -2963,6 +2964,7 @@
 				7AB4CCB82B69097E006037F5 /* IPOverrideTests.swift */,
 				7A516C3B2B712F0B00BBD33D /* IPOverrideWrapperTests.swift */,
 				7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */,
+				44B02E3A2BC5732D008EDF34 /* LoggingTests.swift */,
 				A9B6AC172ADE8F4300F7802A /* MigrationManagerTests.swift */,
 				58C3FA652A38549D006A450A /* MockFileCache.swift */,
 				F09D04B42AE93CB6003D4F89 /* OutgoingConnectionProxy+Stub.swift */,
@@ -4980,6 +4982,7 @@
 				7AA513862BC91C6B00D081A4 /* LogRotationTests.swift in Sources */,
 				F04413622BA45CE30018A6EE /* CustomListLocationNodeBuilder.swift in Sources */,
 				A9A5FA302ACB05160083449F /* InputTextFormatterTests.swift in Sources */,
+				44B02E3B2BC5732D008EDF34 /* LoggingTests.swift in Sources */,
 				F0B0E6972AFE6E7E001DC66B /* XCTest+Async.swift in Sources */,
 				449EB9FF2B95FF2500DFA4EB /* AccountMock.swift in Sources */,
 				7ADCB2DA2B6A730400C88F89 /* IPOverrideRepositoryStub.swift in Sources */,
@@ -5113,7 +5116,6 @@
 				7A3FD1B52AD4465A0042BEA6 /* AppMessageHandlerTests.swift in Sources */,
 				58C7A4702A8649ED0060C66F /* PingerTests.swift in Sources */,
 				A97D25B22B0CB02D00946B2D /* ProtocolObfuscatorTests.swift in Sources */,
-				01168B1A2BBEE7F800D5F382 /* LoggingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -2948,6 +2948,7 @@
 				7A83A0C52B29A750008B5CE7 /* APIAccessMethodsTests.swift */,
 				A900E9BD2ACC654100C95F67 /* APIProxy+Stubs.swift */,
 				A9EC20E72A5D3A8C0040D56E /* CoordinatesTests.swift */,
+				01168B192BBEE7F800D5F382 /* LoggingTests.swift */,
 				5896AE85246D6AD8005B36CB /* CustomDateComponentsFormattingTests.swift */,
 				58915D622A25F8400066445B /* DeviceCheckOperationTests.swift */,
 				A900E9BB2ACC609200C95F67 /* DevicesProxy+Stubs.swift */,
@@ -5112,6 +5113,7 @@
 				7A3FD1B52AD4465A0042BEA6 /* AppMessageHandlerTests.swift in Sources */,
 				58C7A4702A8649ED0060C66F /* PingerTests.swift in Sources */,
 				A97D25B22B0CB02D00946B2D /* ProtocolObfuscatorTests.swift in Sources */,
+				01168B1A2BBEE7F800D5F382 /* LoggingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		449EB9FF2B95FF2500DFA4EB /* AccountMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449EB9FE2B95FF2500DFA4EB /* AccountMock.swift */; };
 		449EBA262B975B9700DFA4EB /* PostQuantumKeyReceiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449EBA252B975B9700DFA4EB /* PostQuantumKeyReceiving.swift */; };
 		44B02E3B2BC5732D008EDF34 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B02E3A2BC5732D008EDF34 /* LoggingTests.swift */; };
+		44B02E3C2BC5B8A5008EDF34 /* Bundle+ProductVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5891BF1B25E3E3EB006D6FB0 /* Bundle+ProductVersion.swift */; };
 		44DD7D242B6CFFD70005F67F /* StartTunnelOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DD7D232B6CFFD70005F67F /* StartTunnelOperationTests.swift */; };
 		44DD7D272B6D18FB0005F67F /* MockTunnelInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DD7D262B6D18FB0005F67F /* MockTunnelInteractor.swift */; };
 		44DD7D292B7113CA0005F67F /* MockTunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DD7D282B7113CA0005F67F /* MockTunnel.swift */; };
@@ -5486,6 +5487,7 @@
 			files = (
 				581DA2762A1E2FD10046ED47 /* WgKeyRotation.swift in Sources */,
 				580810E52A30E13A00B74552 /* DeviceStateAccessorProtocol.swift in Sources */,
+				44B02E3C2BC5B8A5008EDF34 /* Bundle+ProductVersion.swift in Sources */,
 				580810E82A30E15500B74552 /* DeviceCheckRemoteServiceProtocol.swift in Sources */,
 				58C9B8CE2ABB252E00040B46 /* DeviceCheck.swift in Sources */,
 				58915D682A25FA080066445B /* DeviceCheckRemoteService.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -357,9 +357,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         #if DEBUG
         loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.mainApp.bundleIdentifier)
         #endif
-        loggerBuilder.install()
+        loggerBuilder.install(header: "TODO: Add version info here")
 
         logger = Logger(label: "AppDelegate")
+
+        loggerBuilder.logLevel = .debug
     }
 
     private func addApplicationNotifications(application: UIApplication) {

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -352,12 +352,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // MARK: - Private
 
     private func configureLogging() {
-        var loggerBuilder = LoggerBuilder()
-        loggerBuilder.addFileOutput(fileURL: ApplicationConfiguration.newLogFileURL(for: .mainApp))
+        var loggerBuilder = LoggerBuilder(header: "MullvadVPN version \(Bundle.main.productVersion)")
+        loggerBuilder.addFileOutput(fileURL: ApplicationConfiguration.logFileURL(for: .mainApp))
         #if DEBUG
         loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.mainApp.bundleIdentifier)
         #endif
-        loggerBuilder.install(header: "MullvadVPN version \(Bundle.main.productVersion)")
+        loggerBuilder.install()
 
         logger = Logger(label: "AppDelegate")
 

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -357,7 +357,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         #if DEBUG
         loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.mainApp.bundleIdentifier)
         #endif
-        loggerBuilder.install(header: "TODO: Add version info here")
+        loggerBuilder.install(header: "MullvadVPN version \(Bundle.main.productVersion)")
 
         logger = Logger(label: "AppDelegate")
 

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -360,8 +360,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         loggerBuilder.install()
 
         logger = Logger(label: "AppDelegate")
-
-        loggerBuilder.logLevel = .debug
     }
 
     private func addApplicationNotifications(application: UIApplication) {

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -353,7 +353,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     private func configureLogging() {
         var loggerBuilder = LoggerBuilder(header: "MullvadVPN version \(Bundle.main.productVersion)")
-        loggerBuilder.addFileOutput(fileURL: ApplicationConfiguration.logFileURL(for: .mainApp))
+        loggerBuilder.addFileOutput(fileURL: ApplicationConfiguration.newLogFileURL(for: .mainApp))
         #if DEBUG
         loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.mainApp.bundleIdentifier)
         #endif

--- a/ios/MullvadVPNTests/LoggingTests.swift
+++ b/ios/MullvadVPNTests/LoggingTests.swift
@@ -1,0 +1,31 @@
+//
+//  LoggingTests.swift
+//  MullvadVPNTests
+//
+//  Created by Emils on 04/04/2024.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import MullvadLogging
+
+class MullvadLoggingTests: XCTestCase {
+    func testLogHeader() {
+        let dummySig = "test-sgi";
+        let testFileName = "test"
+        let expectedHeader = "Header of a log file"
+        
+        var builder = LoggerBuilder()
+        try! builder.addFileOutput(securityGroupIdentifier: dummySig, basename: testFileName)
+        
+        builder.install(header: expectedHeader)
+        
+        let logFileUrl = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: dummySig)!.appendingPathComponent("Logs", isDirectory: true).appendingPathComponent("\(testFileName).log", isDirectory: false)
+        
+        let contents = String(decoding: try! Data(contentsOf: logFileUrl), as: UTF8.self)
+        
+        XCTAssert(contents.hasPrefix(expectedHeader))
+        XCTAssertEqual("\(expectedHeader)\n", contents)
+    }
+}

--- a/ios/MullvadVPNTests/LoggingTests.swift
+++ b/ios/MullvadVPNTests/LoggingTests.swift
@@ -7,18 +7,16 @@
 //
 
 import Foundation
-import XCTest
 @testable import MullvadLogging
+import XCTest
 
 class MullvadLoggingTests: XCTestCase {
-    
     func temporaryFileURL() -> URL {
-        
         // Create a URL for an unique file in the system's temporary directory.
         let directory = NSTemporaryDirectory()
         let filename = UUID().uuidString
         let fileURL = URL(fileURLWithPath: directory).appendingPathComponent(filename)
-        
+
         // Add a teardown block to delete any file at `fileURL`.
         addTeardownBlock {
             do {
@@ -33,22 +31,24 @@ class MullvadLoggingTests: XCTestCase {
                 XCTFail("Error while deleting temporary file: \(error)")
             }
         }
-        
+
         // Return the temporary file URL for use in a test method.
         return fileURL
     }
 
     func testLogHeader() {
         let expectedHeader = "Header of a log file"
-        
-        var builder = LoggerBuilder()
+
+        var builder = LoggerBuilder(header: expectedHeader)
         let fileURL = temporaryFileURL()
         builder.addFileOutput(fileURL: fileURL)
-        
-        builder.install(header: expectedHeader)
-                
+
+        builder.install()
+
+        Logger(label: "test").info(":-P")
+
         let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
-        
+
         XCTAssert(contents.hasPrefix(expectedHeader))
     }
 }

--- a/ios/MullvadVPNTests/LoggingTests.swift
+++ b/ios/MullvadVPNTests/LoggingTests.swift
@@ -26,6 +26,18 @@ class MullvadLoggingTests: XCTestCase {
         return fileURL
     }
 
+    func testLogFileOutputStreamWritesHeader() {
+        let headerText = "This is a header"
+        let logMessage = "And this is a log message\n"
+        let fileURL = temporaryFileURL()
+        let stream = LogFileOutputStream(fileURL: fileURL, header: headerText)
+        stream.write(logMessage)
+        sync()
+
+        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
+        XCTAssertEqual(contents, "\(headerText)\n\(logMessage)")
+    }
+
     func testLogHeader() {
         let expectedHeader = "Header of a log file"
 
@@ -37,8 +49,7 @@ class MullvadLoggingTests: XCTestCase {
 
         Logger(label: "test").info(":-P")
 
-        // Wait for the log file to settle
-        usleep(100000)
+        sync()
 
         let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
 

--- a/ios/MullvadVPNTests/LoggingTests.swift
+++ b/ios/MullvadVPNTests/LoggingTests.swift
@@ -47,8 +47,9 @@ class MullvadLoggingTests: XCTestCase {
 
         Logger(label: "test").info(":-P")
 
-        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
-
-        XCTAssert(contents.hasPrefix(expectedHeader))
+// For some reason, reading the file fails here, despite the file existing. Manual inspection reveals the file to have the correct header. ¯\_(ツ)_/¯
+//        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
+//
+//        XCTAssert(contents.hasPrefix(expectedHeader))
     }
 }

--- a/ios/MullvadVPNTests/LoggingTests.swift
+++ b/ios/MullvadVPNTests/LoggingTests.swift
@@ -19,17 +19,7 @@ class MullvadLoggingTests: XCTestCase {
 
         // Add a teardown block to delete any file at `fileURL`.
         addTeardownBlock {
-            do {
-                let fileManager = FileManager.default
-                // Check that the file exists before trying to delete it.
-                if fileManager.fileExists(atPath: fileURL.path) {
-                    // Perform the deletion.
-                    try fileManager.removeItem(at: fileURL)
-                }
-            } catch {
-                // Treat any errors during file deletion as a test failure.
-                XCTFail("Error while deleting temporary file: \(error)")
-            }
+            try? FileManager.default.removeItem(at: fileURL)
         }
 
         // Return the temporary file URL for use in a test method.

--- a/ios/MullvadVPNTests/LoggingTests.swift
+++ b/ios/MullvadVPNTests/LoggingTests.swift
@@ -37,9 +37,11 @@ class MullvadLoggingTests: XCTestCase {
 
         Logger(label: "test").info(":-P")
 
-        // For some reason, reading the file fails here, despite the file existing. Manual inspection reveals the file to have the correct header. ¯\_(ツ)_/¯
-//        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
-//
-//        XCTAssert(contents.hasPrefix(expectedHeader))
+        // Wait for the log file to settle
+        usleep(100000)
+
+        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
+
+        XCTAssert(contents.hasPrefix(expectedHeader))
     }
 }

--- a/ios/MullvadVPNTests/LoggingTests.swift
+++ b/ios/MullvadVPNTests/LoggingTests.swift
@@ -47,7 +47,7 @@ class MullvadLoggingTests: XCTestCase {
 
         Logger(label: "test").info(":-P")
 
-// For some reason, reading the file fails here, despite the file existing. Manual inspection reveals the file to have the correct header. ¯\_(ツ)_/¯
+        // For some reason, reading the file fails here, despite the file existing. Manual inspection reveals the file to have the correct header. ¯\_(ツ)_/¯
 //        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
 //
 //        XCTAssert(contents.hasPrefix(expectedHeader))

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -167,7 +167,7 @@ extension PacketTunnelProvider {
         #if DEBUG
         loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.packetTunnel.bundleIdentifier)
         #endif
-        loggerBuilder.install()
+        loggerBuilder.install(header: "PacketTunnel version \(Bundle.main.productVersion)")
     }
 
     private func parseStartOptions(_ options: [String: NSObject]) -> StartOptions {

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -160,14 +160,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
 extension PacketTunnelProvider {
     private static func configureLogging() {
-        var loggerBuilder = LoggerBuilder()
+        var loggerBuilder = LoggerBuilder(header: "PacketTunnel version \(Bundle.main.productVersion)")
         let pid = ProcessInfo.processInfo.processIdentifier
         loggerBuilder.metadata["pid"] = .string("\(pid)")
         loggerBuilder.addFileOutput(fileURL: ApplicationConfiguration.newLogFileURL(for: .packetTunnel))
         #if DEBUG
         loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.packetTunnel.bundleIdentifier)
         #endif
-        loggerBuilder.install(header: "PacketTunnel version \(Bundle.main.productVersion)")
+        loggerBuilder.install()
     }
 
     private func parseStartOptions(_ options: [String: NSObject]) -> StartOptions {


### PR DESCRIPTION
This PR adds a header line to the start of each log file at creation time; this contains the product version.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6101)
<!-- Reviewable:end -->
