### PR TITLE
Revise navigation for empty Custom Lists

### DIFF
--- a/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListCoordinator.swift
@@ -62,9 +62,7 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
             guard let self else { return }
             popToList()
             editCustomListCoordinator.removeFromParent()
-
             self.updateRelayConstraints(for: action, in: list)
-            self.listViewController.updateDataSource(reloadExisting: action == .save)
         }
 
         coordinator.start()
@@ -97,9 +95,13 @@ class ListCustomListCoordinator: Coordinator, Presentable, Presenting {
     }
 
     private func popToList() {
-        guard let listController = navigationController.viewControllers
-            .first(where: { $0 is ListCustomListViewController }) else { return }
-
-        navigationController.popToViewController(listController, animated: true)
+        if interactor.fetchAll().isEmpty {
+            navigationController.dismiss(animated: true)
+            didFinish?(self)
+        } else if let listController = navigationController.viewControllers
+            .first(where: { $0 is ListCustomListViewController }) {
+            navigationController.popToViewController(listController, animated: true)
+            listViewController.updateDataSource(reloadExisting: true, animated: false)
+        }
     }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListViewController.swift
@@ -34,22 +34,6 @@ class ListCustomListViewController: UIViewController {
     private var dataSource: DataSource?
     private var fetchedItems: [CustomList] = []
     private var tableView = UITableView(frame: .zero, style: .plain)
-
-    private let emptyListLabel: UILabel = {
-        let textLabel = UILabel()
-        textLabel.font = .preferredFont(forTextStyle: .title2)
-        textLabel.textColor = .secondaryTextColor
-        textLabel.textAlignment = .center
-        textLabel.numberOfLines = .zero
-        textLabel.lineBreakStrategy = []
-        textLabel.text = NSLocalizedString(
-            "CustomList",
-            value: "No custom list to display",
-            comment: ""
-        )
-        return textLabel
-    }()
-
     var didSelectItem: ((CustomList) -> Void)?
     var didFinish: (() -> Void)?
 
@@ -75,7 +59,6 @@ class ListCustomListViewController: UIViewController {
 
     func updateDataSource(reloadExisting: Bool, animated: Bool = true) {
         fetchedItems = interactor.fetchAll()
-        tableView.backgroundView = fetchedItems.isEmpty ? emptyListLabel : nil
         var snapshot = NSDiffableDataSourceSnapshot<SectionIdentifier, ItemIdentifier>()
         snapshot.appendSections([.default])
 


### PR DESCRIPTION
When the last custom list is deleted, it's preferable to navigate the user to the "select location" view instead of displaying an empty list. This PR introduces this functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6103)
<!-- Reviewable:end -->
