### PR TITLE
Add custom lists to iOS changelog

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -22,10 +22,12 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Add ability to create custom lists.
 
 ## [2024.2 - 2024-02-26]
 ### Added
-- Add IP Overrides
+- Add IP Overrides.
 
 ## [2024.1 - 2024-01-06]
 ### Added


### PR DESCRIPTION
We've made custom lists available in release builds - our changelog should reflect that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6104)
<!-- Reviewable:end -->
