### PR TITLE
Prevent duplicate list names in custom lists

### DIFF
--- a/ios/MullvadSettings/CustomListRepository.swift
+++ b/ios/MullvadSettings/CustomListRepository.swift
@@ -39,11 +39,12 @@ public struct CustomListRepository: CustomListRepositoryProtocol {
     public func save(list: CustomList) throws {
         var lists = fetchAll()
 
-        if let index = lists.firstIndex(where: { $0.id == list.id }) {
+        if let listWithSameName = lists.first(where: { $0.name.caseInsensitiveCompare(list.name) == .orderedSame }),
+           listWithSameName.id != list.id {
+            throw CustomRelayListError.duplicateName
+        } else if let index = lists.firstIndex(where: { $0.id == list.id }) {
             lists[index] = list
             try write(lists)
-        } else if lists.contains(where: { $0.name == list.name }) {
-            throw CustomRelayListError.duplicateName
         } else {
             lists.append(list)
             try write(lists)


### PR DESCRIPTION
It shouldn't be possible to save a custom list with an already existing list name.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6105)
<!-- Reviewable:end -->
