### PR TITLE
Alphabetical sorting for custom list locations ios 604

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/CustomListLocationNodeBuilder.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/CustomListLocationNodeBuilder.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MullvadSettings
+import MullvadTypes
 
 struct CustomListLocationNodeBuilder {
     let customList: CustomList
@@ -18,6 +19,7 @@ struct CustomListLocationNodeBuilder {
             name: customList.name,
             code: customList.name.lowercased(),
             locations: customList.locations,
+            isActive: !customList.locations.isEmpty,
             customList: customList
         )
 
@@ -44,6 +46,33 @@ struct CustomListLocationNodeBuilder {
                     .copy(withParent: listNode)
             }
         }
+
+        listNode.sort()
         return listNode
     }
+}
+
+private extension CustomListLocationNode {
+    func sort() {
+        let sortedChildren = Dictionary(grouping: children, by: {
+            return switch RelayLocation(dashSeparatedString: $0.code)! {
+            case .country:
+                LocationGroup.country
+            case .city:
+                LocationGroup.city
+            case .hostname:
+                LocationGroup.host
+            }
+        })
+        .sorted(by: { $0.key < $1.key })
+        .reduce([]) {
+            return $0 + $1.value.sorted(by: { $0.name < $1.name })
+        }
+
+        children = sortedChildren
+    }
+}
+
+private enum LocationGroup: CaseIterable, Comparable {
+    case country, city, host
 }


### PR DESCRIPTION
This pull request introduces functionality to display the locations of a custom list in alphabetical sorting within each location group. To achieve this, the following steps were taken:

1. Grouping the locations of a custom list based on `Country` `City`, and `Host`.
2. Implementing alphabetical sorting for each location group.
3. Concatenating them together to create a flat array.
4. Disabling custom lists that have no children, making them unselectable.


 <table >
        <tr>
                <th height="30" bgcolor="#002387">before</th>
                <th height="30" bgcolor="#002387">after</th>
            </tr>
            <tr>
                <td><img src = "https://github.com/mullvad/mullvadvpn-app/assets/129863230/554f11bd-48a8-42a4-9b64-9110c1c6432c" width = "200"/></td>
                <td><img src = "https://github.com/mullvad/mullvadvpn-app/assets/129863230/71dd4642-c145-42e4-a39a-14af2da7eb32" width = "200"/></td>
            </tr>
 </table>




<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6106)
<!-- Reviewable:end -->
