### PR TITLE
Fix flaky tests caused by messed up daemon environment

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -2123,15 +2123,16 @@ dependencies = [
 
 [[package]]
 name = "pcap"
-version = "0.10.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da544c8115cc65b474554569c7654fc94a4f6a167f79192536e148fd654e17a"
+checksum = "99e935fc73d54a89fff576526c2ccd42bbf8247aae05b358693475b14fd4ff79"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
  "futures",
  "libc",
  "libloading",
+ "pkg-config",
  "regex",
  "tokio",
  "windows-sys 0.36.1",

--- a/test/socks-server/src/lib.rs
+++ b/test/socks-server/src/lib.rs
@@ -1,3 +1,4 @@
+use fast_socks5::server::{AcceptAuthentication, Socks5Server};
 use futures::StreamExt;
 use std::{io, net::SocketAddr};
 
@@ -13,10 +14,9 @@ pub struct Handle {
 
 /// Spawn a SOCKS server bound to `bind_addr`
 pub async fn spawn(bind_addr: SocketAddr) -> Result<Handle, Error> {
-    let socks_server: fast_socks5::server::Socks5Server =
-        fast_socks5::server::Socks5Server::bind(bind_addr)
-            .await
-            .map_err(Error::StartSocksServer)?;
+    let socks_server: Socks5Server<AcceptAuthentication> = Socks5Server::bind(bind_addr)
+        .await
+        .map_err(Error::StartSocksServer)?;
 
     let handle = tokio::spawn(async move {
         let mut incoming = socks_server.incoming();

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = { workspace = true }
 tokio-serde = { workspace = true }
 log = { workspace = true }
 
-pcap = { version = "0.10.1", features = ["capture-stream"] }
+pcap = { version = "1.3", features = ["capture-stream"] }
 pnet_packet = "0.31.0"
 
 test-rpc = { path = "../test-rpc" }

--- a/test/test-manager/src/mullvad_daemon.rs
+++ b/test/test-manager/src/mullvad_daemon.rs
@@ -51,14 +51,17 @@ pub struct RpcClientProvider {
     service: DummyService,
 }
 
+pub enum MullvadClientArgument {
+    WithClient(MullvadProxyClient),
+    None,
+}
+
 impl RpcClientProvider {
-    pub async fn as_type(
-        &self,
-        client_type: MullvadClientVersion,
-    ) -> Box<dyn std::any::Any + Send> {
+    /// Whether a [test case](test_macro::test_function) needs a [`MullvadProxyClient`].
+    pub async fn mullvad_client(&self, client_type: MullvadClientVersion) -> MullvadClientArgument {
         match client_type {
-            MullvadClientVersion::New => Box::new(self.new_client().await),
-            MullvadClientVersion::None => Box::new(()),
+            MullvadClientVersion::New => MullvadClientArgument::WithClient(self.new_client().await),
+            MullvadClientVersion::None => MullvadClientArgument::None,
         }
     }
 

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -105,8 +105,8 @@ pub async fn run(
             // Try to reset the daemon state if the test failed OR if the test doesn't explicitly
             // disabled cleanup.
             if test.cleanup || matches!(test_result.result, Err(_) | Ok(Err(_))) {
-                let mut client = test_context.rpc_provider.new_client().await;
-                crate::tests::cleanup_after_test(&mut client).await?;
+                crate::tests::cleanup_after_test(client.clone(), &test_context.rpc_provider)
+                    .await?;
             }
         }
 

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     logging::{panic_as_string, TestOutput},
-    mullvad_daemon,
+    mullvad_daemon::{self, MullvadClientArgument},
     summary::{self, maybe_log_test_result},
     tests::{self, config::TEST_CONFIG, get_tests, TestContext},
     vm,
@@ -80,9 +80,9 @@ pub async fn run(
     let logger = super::logging::Logger::get_or_init();
 
     for test in tests {
-        let mclient = test_context
+        let mullvad_client = test_context
             .rpc_provider
-            .as_type(test.mullvad_client_version)
+            .mullvad_client(test.mullvad_client_version)
             .await;
 
         log::info!("Running {}", test.name);
@@ -94,7 +94,7 @@ pub async fn run(
 
         let test_result = run_test(
             client.clone(),
-            mclient,
+            mullvad_client,
             &test.func,
             test.name,
             test_context.clone(),
@@ -175,15 +175,15 @@ pub async fn run(
     final_result
 }
 
-pub async fn run_test<F, R, MullvadClient>(
+pub async fn run_test<F, R>(
     runner_rpc: ServiceClient,
-    mullvad_rpc: MullvadClient,
+    mullvad_rpc: MullvadClientArgument,
     test: &F,
     test_name: &'static str,
     test_context: super::tests::TestContext,
 ) -> TestOutput
 where
-    F: Fn(super::tests::TestContext, ServiceClient, MullvadClient) -> R,
+    F: Fn(super::tests::TestContext, ServiceClient, MullvadClientArgument) -> R,
     R: Future<Output = anyhow::Result<()>>,
 {
     let _flushed = runner_rpc.try_poll_output().await;

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -13,7 +13,7 @@ mod tunnel;
 mod tunnel_state;
 mod ui;
 
-use crate::mullvad_daemon::RpcClientProvider;
+use crate::mullvad_daemon::{MullvadClientArgument, RpcClientProvider};
 use anyhow::Context;
 pub use test_metadata::TestMetadata;
 use test_rpc::ServiceClient;
@@ -30,11 +30,8 @@ pub struct TestContext {
     pub rpc_provider: RpcClientProvider,
 }
 
-pub type TestWrapperFunction = fn(
-    TestContext,
-    ServiceClient,
-    Box<dyn std::any::Any + Send>,
-) -> BoxFuture<'static, anyhow::Result<()>>;
+pub type TestWrapperFunction =
+    fn(TestContext, ServiceClient, MullvadClientArgument) -> BoxFuture<'static, anyhow::Result<()>>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -314,6 +314,20 @@ impl ServiceClient {
         Ok(())
     }
 
+    /// Get the current daemon's environment variables.
+    ///
+    /// # Returns
+    /// - `Result::Ok(env)` if the current environment variables could be read.
+    /// - `Result::Err(Error)` if communication with the daemon failed or the environment values
+    /// could not be parsed.
+    pub async fn get_daemon_environment(&self) -> Result<HashMap<String, String>, Error> {
+        let env = self
+            .client
+            .get_daemon_environment(tarpc::context::current())
+            .await??;
+        Ok(env)
+    }
+
     pub async fn copy_file(&self, src: String, dest: String) -> Result<(), Error> {
         log::debug!("Copying \"{src}\" to \"{dest}\"");
         self.client

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -59,8 +59,17 @@ pub enum Error {
     TcpForward,
     #[error("Unknown process ID: {0}")]
     UnknownPid(u32),
+    #[error("Failed to join tokio task: {0}")]
+    TokioJoinError(String),
     #[error("{0}")]
     Other(String),
+}
+
+impl Error {
+    /// Convenient mapping from a Tokio error to the test_rpc Error type.
+    pub fn from_tokio_join_error(error: tokio::task::JoinError) -> Error {
+        Error::TokioJoinError(error.to_string())
+    }
 }
 
 /// Response from am.i.mullvad.net
@@ -212,6 +221,9 @@ mod service {
         /// Set environment variables for the daemon service. This will restart the daemon system
         /// service.
         async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), Error>;
+
+        /// Get the environment variables for the running daemon service.
+        async fn get_daemon_environment() -> Result<HashMap<String, String>, Error>;
 
         /// Copy a file from `src` to `dest` on the test runner.
         async fn copy_file(src: String, dest: String) -> Result<(), Error>;

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -309,6 +309,13 @@ impl Service for TestServer {
         sys::set_daemon_environment(env).await
     }
 
+    async fn get_daemon_environment(
+        self,
+        _: context::Context,
+    ) -> Result<HashMap<String, String>, test_rpc::Error> {
+        sys::get_daemon_environment().await
+    }
+
     async fn copy_file(
         self,
         _: context::Context,

--- a/test/test-runner/src/sys.rs
+++ b/test/test-runner/src/sys.rs
@@ -4,12 +4,21 @@ use std::io;
 use test_rpc::{meta::OsVersion, mullvad_daemon::Verbosity};
 
 #[cfg(target_os = "windows")]
-use std::ffi::OsString;
+use std::{ffi::OsString, path::Path};
 #[cfg(target_os = "windows")]
 use windows_service::{
     service::{ServiceAccess, ServiceInfo},
     service_manager::{ServiceManager, ServiceManagerAccess},
 };
+
+#[cfg(target_os = "linux")]
+const SYSTEMD_OVERRIDE_FILE: &str = "/etc/systemd/system/mullvad-daemon.service.d/override.conf";
+
+#[cfg(target_os = "macos")]
+const PLIST_OVERRIDE_FILE: &str = "/Library/LaunchDaemons/net.mullvad.daemon.plist";
+
+#[cfg(target_os = "windows")]
+const MULLVAD_WIN_REGISTRY: &str = r"SYSTEM\CurrentControlSet\Services\Mullvad VPN";
 
 #[cfg(target_os = "windows")]
 pub fn reboot() -> Result<(), test_rpc::Error> {
@@ -154,9 +163,6 @@ pub fn reboot() -> Result<(), test_rpc::Error> {
 #[cfg(target_os = "linux")]
 pub async fn set_daemon_log_level(verbosity_level: Verbosity) -> Result<(), test_rpc::Error> {
     use tokio::io::AsyncWriteExt;
-    const SYSTEMD_OVERRIDE_FILE: &str =
-        "/etc/systemd/system/mullvad-daemon.service.d/override.conf";
-
     log::debug!("Setting log level");
 
     let verbosity = match verbosity_level {
@@ -389,17 +395,57 @@ pub async fn set_daemon_log_level(_verbosity_level: Verbosity) -> Result<(), tes
 }
 
 #[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct EnvVar {
+    var: String,
+    value: String,
+}
+
+#[cfg(target_os = "linux")]
+impl EnvVar {
+    fn from_systemd_string(s: &str) -> Result<Self, &'static str> {
+        // Here, we are only concerned with parsing a line that starts with "Environment".
+        let error = "Failed to parse systemd env-config";
+        let mut input = s.trim().split('=');
+        let pre = input.next().ok_or(error)?;
+        match pre {
+            "Environment" => {
+                // Proccess the input just a bit more - remove the leading and trailing quote (").
+                let var = input
+                    .next()
+                    .ok_or(error)?
+                    .trim_start_matches('"')
+                    .to_string();
+                let value = input.next().ok_or(error)?.trim_end_matches('"').to_string();
+                Ok(EnvVar { var, value })
+            }
+            _ => Err(error),
+        }
+    }
+
+    fn to_systemd_string(&self) -> String {
+        format!(
+            "Environment=\"{key}={value}\"",
+            key = self.var,
+            value = self.value
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
 pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), test_rpc::Error> {
     use std::fmt::Write;
-    use tokio::io::AsyncWriteExt;
-
-    const SYSTEMD_OVERRIDE_FILE: &str = "/etc/systemd/system/mullvad-daemon.service.d/env.conf";
 
     let mut override_content = String::new();
     override_content.push_str("[Service]\n");
 
-    for (k, v) in env {
-        writeln!(&mut override_content, "Environment=\"{k}={v}\"").unwrap();
+    for env_var in env
+        .into_iter()
+        .map(|(var, value)| EnvVar { var, value })
+        .map(|env_var| env_var.to_systemd_string())
+    {
+        writeln!(&mut override_content, "{env_var}")
+            .map_err(|err| test_rpc::Error::Service(err.to_string()))?;
     }
 
     let override_path = std::path::Path::new(SYSTEMD_OVERRIDE_FILE);
@@ -409,15 +455,7 @@ pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), 
             .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
     }
 
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(override_path)
-        .await
-        .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
-
-    file.write_all(override_content.as_bytes())
+    tokio::fs::write(override_path, override_content)
         .await
         .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
 
@@ -440,13 +478,25 @@ pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), 
 #[cfg(target_os = "windows")]
 pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), test_rpc::Error> {
     // Set environment globally (not for service) to prevent it from being lost on upgrade
-    for (k, v) in env {
+    for (k, v) in env.clone() {
         tokio::process::Command::new("setx")
             .arg("/m")
             .args([k, v])
             .status()
             .await
             .map_err(|e| test_rpc::Error::Registry(e.to_string()))?;
+    }
+    // Persist the changed environment variables, such that we can retrieve them at will.
+    use winreg::{enums::*, RegKey};
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    let path = Path::new(MULLVAD_WIN_REGISTRY).join("Environment");
+    let (registry, _) = hklm.create_subkey(&path).map_err(|error| {
+        test_rpc::Error::Registry(format!("Failed to open Mullvad VPN subkey: {}", error))
+    })?;
+    for (k, v) in env {
+        registry.set_value(k, &v).map_err(|error| {
+            test_rpc::Error::Registry(format!("Failed to set Environment var: {}", error))
+        })?;
     }
 
     // Restart service
@@ -464,7 +514,7 @@ pub fn get_system_path_var() -> Result<String, test_rpc::Error> {
     let key = hklm
         .open_subkey("SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment")
         .map_err(|error| {
-            test_rpc::Error::Registry(format!("Failed to open environment subkey: {}", error))
+            test_rpc::Error::Registry(format!("Failed to open Environment subkey: {}", error))
         })?;
 
     let path: String = key
@@ -476,14 +526,11 @@ pub fn get_system_path_var() -> Result<String, test_rpc::Error> {
 
 #[cfg(target_os = "macos")]
 pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), test_rpc::Error> {
-    const PLIST_PATH: &str = "/Library/LaunchDaemons/net.mullvad.daemon.plist";
-
     tokio::task::spawn_blocking(|| {
-        let mut parsed_plist: plist::Value = plist::from_file(PLIST_PATH)
+        let mut parsed_plist = plist::Value::from_file(PLIST_OVERRIDE_FILE)
             .map_err(|error| test_rpc::Error::Service(format!("failed to parse plist: {error}")))?;
 
         let mut vars = plist::Dictionary::new();
-
         for (k, v) in env {
             // Set environment globally (not for service) to prevent it from being lost on upgrade
             std::process::Command::new("launchctl")
@@ -503,10 +550,7 @@ pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), 
                 plist::Value::Dictionary(vars),
             );
 
-        let daemon_plist = std::fs::OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .open(PLIST_PATH)
+        let daemon_plist = std::fs::File::create(PLIST_OVERRIDE_FILE)
             .map_err(|e| test_rpc::Error::Service(format!("failed to open plist: {e}")))?;
 
         parsed_plist
@@ -532,12 +576,105 @@ async fn set_launch_daemon_state(on: bool) -> Result<(), test_rpc::Error> {
         .args([
             if on { "load" } else { "unload" },
             "-w",
-            "/Library/LaunchDaemons/net.mullvad.daemon.plist",
+            PLIST_OVERRIDE_FILE,
         ])
         .status()
         .await
         .map_err(|e| test_rpc::Error::Service(e.to_string()))?;
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub async fn get_daemon_environment() -> Result<HashMap<String, String>, test_rpc::Error> {
+    let text = tokio::fs::read_to_string(SYSTEMD_OVERRIDE_FILE)
+        .await
+        .map_err(|err| test_rpc::Error::FileSystem(err.to_string()))?;
+
+    let env: HashMap<String, String> = parse_systemd_env_file(&text)
+        .map(|EnvVar { var, value }| (var, value))
+        .collect();
+    Ok(env)
+}
+
+/// Parse a systemd env-file. `input` is assumed to be the entire text content of a systemd-env file.
+///
+/// Example systemd-env file:
+/// ```
+/// [Service]
+/// Environment="VAR1=pGNqduRFkB4K9C2vijOmUDa2kPtUhArN"
+/// Environment="VAR2=JP8YLOc2bsNlrGuD6LVTq7L36obpjzxd"
+/// ```
+#[cfg(target_os = "linux")]
+fn parse_systemd_env_file(input: &str) -> impl Iterator<Item = EnvVar> + '_ {
+    input
+        .lines()
+        .map(EnvVar::from_systemd_string)
+        .filter_map(|env_var| env_var.ok())
+        .inspect(|env_var| log::trace!("Parsed {env_var:?}"))
+}
+
+#[cfg(target_os = "windows")]
+pub async fn get_daemon_environment() -> Result<HashMap<String, String>, test_rpc::Error> {
+    use winreg::{enums::*, RegKey};
+
+    let env =
+        tokio::task::spawn_blocking(|| -> Result<HashMap<String, String>, test_rpc::Error> {
+            let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+            let key = hklm.open_subkey(MULLVAD_WIN_REGISTRY).map_err(|error| {
+                test_rpc::Error::Registry(format!("Failed to open Mullvad VPN subkey: {}", error))
+            })?;
+
+            // The Strings will be quoted (surrounded by ") when read from the registry - we should trim that!
+            let trim = |string: String| string.trim_matches('"').to_owned();
+            let env = key
+                .open_subkey("Environment")
+                .map_err(|error| {
+                    test_rpc::Error::Registry(format!(
+                        "Failed to open Environment subkey: {}",
+                        error
+                    ))
+                })?
+                .enum_values()
+                .filter_map(|x| x.inspect_err(|err| log::trace!("{err}")).ok())
+                .map(|(k, v)| (trim(k), trim(v.to_string())))
+                .collect();
+            Ok(env)
+        })
+        .await
+        .map_err(test_rpc::Error::from_tokio_join_error)??;
+
+    Ok(env)
+}
+
+#[cfg(target_os = "macos")]
+pub async fn get_daemon_environment() -> Result<HashMap<String, String>, test_rpc::Error> {
+    let plist = tokio::task::spawn_blocking(|| {
+        let parsed_plist = plist::Value::from_file(PLIST_OVERRIDE_FILE)
+            .map_err(|error| test_rpc::Error::Service(format!("failed to parse plist: {error}")))?;
+
+        Ok::<plist::Value, test_rpc::Error>(parsed_plist)
+    })
+    .await
+    .map_err(test_rpc::Error::from_tokio_join_error)??;
+
+    let plist_tree = plist
+        .as_dictionary()
+        .ok_or_else(|| test_rpc::Error::Service("plist missing dict".to_owned()))?;
+    let Some(env_vars) = plist_tree.get("EnvironmentVariables") else {
+        // `EnvironmentVariables` does not exist in plist file, so there are no env variables to parse.
+        return Ok(HashMap::new());
+    };
+    let env_vars = env_vars.as_dictionary().ok_or_else(|| {
+        test_rpc::Error::Service("`EnvironmentVariables` is not a dict".to_owned())
+    })?;
+
+    let env = env_vars
+        .clone()
+        .into_iter()
+        .filter_map(|(key, value)| Some((key, value.into_string()?)))
+        .collect();
+
+    Ok(env)
 }
 
 #[cfg(target_os = "linux")]
@@ -617,4 +754,32 @@ pub fn get_os_version() -> Result<OsVersion, test_rpc::Error> {
 #[cfg(target_os = "linux")]
 pub fn get_os_version() -> Result<OsVersion, test_rpc::Error> {
     Ok(OsVersion::Linux)
+}
+
+#[cfg(test)]
+mod test {
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_systemd_environment_variables() {
+        use super::parse_systemd_env_file;
+        // Define an example systemd environment file
+        let systemd_file = "
+        [Service]
+        Environment=\"var1=value1\"
+        Environment=\"var2=value2\"
+        ";
+
+        // Parse the "file"
+        let env_vars: Vec<_> = parse_systemd_env_file(systemd_file).collect();
+
+        // Assert that the environment variables it defines are parsed as expected.
+        assert_eq!(env_vars.len(), 2);
+        let first = env_vars.first().unwrap();
+        assert_eq!(first.var, "var1");
+        assert_eq!(first.value, "value1");
+        let second = env_vars.get(1).unwrap();
+        assert_eq!(second.var, "var2");
+        assert_eq!(second.value, "value2");
+    }
 }


### PR DESCRIPTION
## What? :detective:
This PR addresses an issue in the test framework where some test would mess with the daemon's environment variables without resetting them to their expected default values. 
## Why? 🤔
This could lead to subsequent tests failing for unforeseen reasons, which was very confusing.
## How? :hammer:  :carpentry_saw: 
After each test is finished, we check whether the daemon's environment variables deviate from the one's specified by the current test configuration. If so, we restart the daemon with the 'expected values'. This all happens in the existing clean up routine, which means that no tests *should* have to clean up this particular mess themselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6108)
<!-- Reviewable:end -->
