### PR TITLE
Clean up old Unix domain socket on Android

### DIFF
--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -32,6 +32,7 @@ mullvad-relay-selector = { path = "../mullvad-relay-selector" }
 mullvad-types = { path = "../mullvad-types" }
 mullvad-api = { path = "../mullvad-api" }
 mullvad-fs = { path = "../mullvad-fs" }
+mullvad-paths = { path = "../mullvad-paths" }
 mullvad-version = { path = "../mullvad-version" }
 talpid-core = { path = "../talpid-core" }
 talpid-future = { path = "../talpid-future" }
@@ -43,7 +44,6 @@ talpid-types = { path = "../talpid-types" }
 clap = { workspace = true }
 log-panics = "2.0.0"
 mullvad-management-interface = { path = "../mullvad-management-interface" }
-mullvad-paths = { path = "../mullvad-paths" }
 
 [target.'cfg(target_os="android")'.dependencies]
 android_logger = "0.8"

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2786,3 +2786,19 @@ fn oneshot_map<T1: Send + 'static, T2: Send + 'static>(
     });
     new_tx
 }
+
+/// TODO: Change name
+/// TODO: Document
+#[cfg(not(target_os = "windows"))]
+pub async fn cleanup_old_rpc_socket() {
+    if let Err(err) = tokio::fs::remove_file(mullvad_paths::get_rpc_socket_path()).await {
+        if err.kind() != std::io::ErrorKind::NotFound {
+            log::error!("Failed to remove old RPC socket: {}", err);
+        }
+    }
+}
+
+/// NOP on Windows
+#[cfg(target_os = "windows")]
+#[allow(clippy::unused_async)]
+async fn cleanup_old_rpc_socket() {}

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -19,7 +19,7 @@ use jnix::{
 };
 use mullvad_api::{rest::Error as RestError, StatusCode};
 use mullvad_daemon::{
-    device, exception_logging, logging, runtime::new_multi_thread,
+    cleanup_old_rpc_socket, device, exception_logging, logging, runtime::new_multi_thread,
     settings::patch::Error as PatchError, version, Daemon, DaemonCommandChannel,
 };
 use mullvad_types::{
@@ -573,6 +573,9 @@ fn spawn_daemon(
                 log::warn!("Ignoring API settings (already initialized)");
             }
         }
+
+        // TODO: Move
+        runtime.block_on(cleanup_old_rpc_socket());
 
         let daemon = runtime.block_on(Daemon::start(
             Some(resource_dir.clone()),


### PR DESCRIPTION
If there exists a left-over Unix domain socket which was used as the management interface device, the daemon will clean it up on startup. This PR enables that clean up code to run on Android.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6111)
<!-- Reviewable:end -->
