### PR TITLE
Bump key rotation interval to 30 days on iOS

### DIFF
--- a/ios/MullvadVPN/TunnelManager/WgKeyRotation.swift
+++ b/ios/MullvadVPN/TunnelManager/WgKeyRotation.swift
@@ -18,7 +18,7 @@ import WireGuardKitTypes
 struct WgKeyRotation {
     /// Private key rotation interval counted from the time when the key was successfully pushed
     /// to the backend.
-    public static let rotationInterval: Duration = .days(14)
+    public static let rotationInterval: Duration = .days(30)
 
     /// Private key rotation retry interval counted from the time when the last rotation
     /// attempt took place.


### PR DESCRIPTION
We're updating the key rotation interval to 30 days across all clients now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6113)
<!-- Reviewable:end -->
