### PR TITLE
Add missing translations in Api Access views

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -129,6 +129,9 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
+msgid "Edit"
+msgstr ""
+
 msgid "Enable"
 msgstr ""
 
@@ -224,6 +227,9 @@ msgstr ""
 msgid "TCP"
 msgstr ""
 
+msgid "Test"
+msgstr ""
+
 #. Warning shown in dialog to users when they enable setting that increases
 #. network latency (decreases performance).
 #. Warning text in a dialog that is displayed after a setting is toggled.
@@ -246,6 +252,9 @@ msgid "Unblock"
 msgstr ""
 
 msgid "UNSECURED CONNECTION"
+msgstr ""
+
+msgid "Use"
 msgstr ""
 
 msgid "Username"
@@ -383,8 +392,9 @@ msgctxt "api-access-methods-view"
 msgid "Authentication"
 msgstr ""
 
+#. %(save)s - Will be replaced with the translation for the word "Save".
 msgctxt "api-access-methods-view"
-msgid "Clicking “Save” changes the in use method."
+msgid "Clicking “%(save)s” changes the in use method."
 msgstr ""
 
 msgctxt "api-access-methods-view"

--- a/gui/src/renderer/components/ApiAccessMethods.tsx
+++ b/gui/src/renderer/components/ApiAccessMethods.tsx
@@ -200,11 +200,15 @@ function ApiAccessMethod(props: ApiAccessMethodProps) {
     const items: Array<ContextMenuItem> = [
       {
         type: 'item' as const,
-        label: 'Use',
+        label: messages.gettext('Use'),
         disabled: props.inUse,
         onClick: setApiAccessMethod,
       },
-      { type: 'item' as const, label: 'Test', onClick: () => testApiAccessMethod(props.method.id) },
+      {
+        type: 'item' as const,
+        label: messages.gettext('Test'),
+        onClick: () => testApiAccessMethod(props.method.id),
+      },
     ];
 
     // Edit and Delete shouldn't be available for direct and bridges.
@@ -213,7 +217,7 @@ function ApiAccessMethod(props: ApiAccessMethodProps) {
         { type: 'separator' as const },
         {
           type: 'item' as const,
-          label: 'Edit',
+          label: messages.gettext('Edit'),
           onClick: () =>
             history.push(
               generateRoutePath(RoutePath.editApiAccessMethods, { id: props.method.id }),
@@ -221,7 +225,7 @@ function ApiAccessMethod(props: ApiAccessMethodProps) {
         },
         {
           type: 'item' as const,
-          label: 'Delete',
+          label: messages.gettext('Delete'),
           onClick: showRemoveConfirmation,
         },
       );

--- a/gui/src/renderer/components/EditApiAccessMethod.tsx
+++ b/gui/src/renderer/components/EditApiAccessMethod.tsx
@@ -198,9 +198,13 @@ function getTestingDialogSubTitle(type: ModalAlertType, newMethod: boolean, name
             ),
             { name },
           )
-        : messages.pgettext(
-            'api-access-methods-view',
-            'Clicking “Save” changes the in use method.',
+        : sprintf(
+            // TRANSLATORS: %(save)s - Will be replaced with the translation for the word "Save".
+            messages.pgettext(
+              'api-access-methods-view',
+              'Clicking “%(save)s” changes the in use method.',
+            ),
+            { save: messages.gettext('Save') },
           );
     default:
       return undefined;


### PR DESCRIPTION
This PR makes some strings translatable that weren't. "SOCKS5" and "Shadowsocks" has been marked in Crowdin as `translatable: false`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6115)
<!-- Reviewable:end -->
