### PR TITLE
Add missed key into privacy manifest

### DIFF
--- a/ios/MullvadVPN/Supporting Files/PrivacyInfo.xcprivacy
+++ b/ios/MullvadVPN/Supporting Files/PrivacyInfo.xcprivacy
@@ -1,21 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSPrivacyTrackingDomains</key>
-	<array/>
-	<key>NSPrivacyTracking</key>
-	<false/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>CA92.1</string>
-			</array>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-		</dict>
-	</array>
-</dict>
+    <dict>
+        <key>NSPrivacyTrackingDomains</key>
+        <array/>
+        <key>NSPrivacyTracking</key>
+        <false/>
+        <key>NSPrivacyAccessedAPITypes</key>
+        <array>
+            <dict>
+                <key>NSPrivacyAccessedAPIType</key>
+                <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+                <key>NSPrivacyAccessedAPITypeReasons</key>
+                <array>
+                    <string>C617.1</string>
+                </array>
+            </dict>
+            <dict>
+                <key>NSPrivacyAccessedAPIType</key>
+                <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+                <key>NSPrivacyAccessedAPITypeReasons</key>
+                <array>
+                    <string>CA92.1</string>
+                </array>
+            </dict>
+        </array>
+    </dict>
 </plist>


### PR DESCRIPTION
Apple reported we missed NSPrivacyAccessedAPICategoryFileTimestamp in our privacy manifest. this PR introdues this functionality.