### PR TITLE
Add default settings when app is uninstalled

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -502,7 +502,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
 
                 SettingsManager.resetStore(completely: true)
+                try? SettingsManager.writeSettings(LatestTunnelSettings())
 
+                // Default access methods need to be repopulated again after settings wipe.
                 self.accessMethodRepository.reloadWithDefaultsAfterDataRemoval()
                 // At app startup, the relay cache tracker will get populated with a list of overriden IPs.
                 // The overriden IPs will get wiped, therefore, the cache needs to be pruned as well.


### PR DESCRIPTION
We wipe all settings when the app is deleted and then installed again. Currently no default settings are stored after that, which puts the tunnel into blocked state since it cannot read any settings. We should add the default settings right after the wipe to remedy this.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6123)
<!-- Reviewable:end -->
