### PR TITLE
Add Zlib to allowed licences

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -50,7 +50,8 @@ allow = [
     "CC0-1.0",
     # https://github.com/briansmith/ring/issues/902
     "LicenseRef-ring",
-    "Unicode-DFS-2016"
+    "Unicode-DFS-2016",
+    "Zlib"
 ]
 
 [[licenses.clarify]]

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -40,7 +40,8 @@ allow = [
     "CC0-1.0",
     # https://github.com/briansmith/ring/issues/902
     "LicenseRef-ring",
-    "Unicode-DFS-2016"
+    "Unicode-DFS-2016",
+    "Zlib"
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
This PR adds Zlib to the list of allowed licenses in `deny.toml`, since it is compatible with GPL-3.

Reference:
https://www.gnu.org/licenses/license-list.html#ZLib

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6124)
<!-- Reviewable:end -->
