### PR TITLE
Update protocol usage to include 'any' keyword

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -6480,6 +6480,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -6501,6 +6502,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -7148,6 +7150,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Mullvad VPN Development";
@@ -7761,6 +7764,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "-enable-upcoming-feature ExistentialAny";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Mullvad VPN Development";

--- a/ios/MullvadVPN/AccessMethodRepository/ProxyConfigurationTester.swift
+++ b/ios/MullvadVPN/AccessMethodRepository/ProxyConfigurationTester.swift
@@ -14,7 +14,7 @@ import MullvadTypes
 
 /// A concrete implementation of an access method proxy configuration.
 class ProxyConfigurationTester: ProxyConfigurationTesterProtocol {
-    private var cancellable: MullvadTypes.Cancellable?
+    private var cancellable: (any MullvadTypes.Cancellable)?
     private let transportProvider: ProxyConfigurationTransportProvider
     private var headRequest: REST.APIAvailabilityTestRequest?
 
@@ -22,7 +22,7 @@ class ProxyConfigurationTester: ProxyConfigurationTesterProtocol {
         self.transportProvider = transportProvider
     }
 
-    func start(configuration: PersistentProxyConfiguration, completion: @escaping (Error?) -> Void) {
+    func start(configuration: PersistentProxyConfiguration, completion: @escaping ((any Error)?) -> Void) {
         do {
             let transport = try transportProvider.makeTransport(with: configuration)
             let request = REST.APIAvailabilityTestRequest(transport: transport)

--- a/ios/MullvadVPN/AccessMethodRepository/ProxyConfigurationTesterProtocol.swift
+++ b/ios/MullvadVPN/AccessMethodRepository/ProxyConfigurationTesterProtocol.swift
@@ -15,7 +15,7 @@ protocol ProxyConfigurationTesterProtocol {
     /// - Parameters:
     ///   - configuration: a proxy configuration.
     ///   - completion: a completion handler that receives `nil` upon success, otherwise the underlying error.
-    func start(configuration: PersistentProxyConfiguration, completion: @escaping (Error?) -> Void)
+    func start(configuration: PersistentProxyConfiguration, completion: @escaping ((any Error)?) -> Void)
 
     /// Cancel testing proxy configuration.
     func cancel()

--- a/ios/MullvadVPN/AddressCacheTracker/AddressCacheTracker.swift
+++ b/ios/MullvadVPN/AddressCacheTracker/AddressCacheTracker.swift
@@ -24,7 +24,7 @@ final class AddressCacheTracker {
     private let application: UIApplication
 
     /// REST API proxy.
-    private let apiProxy: APIQuerying
+    private let apiProxy: any APIQuerying
 
     /// Address cache.
     private let store: REST.AddressCache
@@ -36,7 +36,7 @@ final class AddressCacheTracker {
     private var lastFailureAttemptDate: Date?
 
     /// Timer used for scheduling periodic updates.
-    private var timer: DispatchSourceTimer?
+    private var timer: (any DispatchSourceTimer)?
 
     /// Operation queue.
     private let operationQueue = AsyncOperationQueue.makeSerial()
@@ -45,7 +45,7 @@ final class AddressCacheTracker {
     private let nslock = NSLock()
 
     /// Designated initializer
-    init(application: UIApplication, apiProxy: APIQuerying, store: REST.AddressCache) {
+    init(application: UIApplication, apiProxy: any APIQuerying, store: REST.AddressCache) {
         self.application = application
         self.apiProxy = apiProxy
         self.store = store
@@ -84,8 +84,8 @@ final class AddressCacheTracker {
         timer = nil
     }
 
-    func updateEndpoints(completionHandler: ((Result<Bool, Error>) -> Void)? = nil) -> Cancellable {
-        let operation = ResultBlockOperation<Bool> { finish -> Cancellable in
+    func updateEndpoints(completionHandler: ((Result<Bool, any Error>) -> Void)? = nil) -> any Cancellable {
+        let operation = ResultBlockOperation<Bool> { finish -> any Cancellable in
             guard self.nextScheduleDate() <= Date() else {
                 finish(.success(false))
                 return AnyCancellable()
@@ -121,7 +121,7 @@ final class AddressCacheTracker {
         return _nextScheduleDate()
     }
 
-    private func setEndpoints(from result: Result<[AnyIPEndpoint], Error>) {
+    private func setEndpoints(from result: Result<[AnyIPEndpoint], any Error>) {
         nslock.lock()
         defer { nslock.unlock() }
 

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -31,9 +31,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private(set) var addressCache: REST.AddressCache!
 
     private var proxyFactory: REST.ProxyFactory!
-    private(set) var apiProxy: APIQuerying!
-    private(set) var accountsProxy: RESTAccountHandling!
-    private(set) var devicesProxy: DeviceHandling!
+    private(set) var apiProxy: (any APIQuerying)!
+    private(set) var accountsProxy: (any RESTAccountHandling)!
+    private(set) var devicesProxy: (any DeviceHandling)!
 
     private(set) var addressCacheTracker: AddressCacheTracker!
     private(set) var relayCacheTracker: RelayCacheTracker!
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private let migrationManager = MigrationManager()
 
     private(set) var accessMethodRepository = AccessMethodRepository()
-    private(set) var shadowsocksLoader: ShadowsocksLoaderProtocol!
+    private(set) var shadowsocksLoader: (any ShadowsocksLoaderProtocol)!
     private(set) var configuredTransportProvider: ProxyConfigurationTransportProvider!
     private(set) var ipOverrideRepository = IPOverrideRepository()
 
@@ -450,7 +450,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
                     case let .failure(error):
                         let migrationUIHandler = application.connectedScenes
-                            .first { $0 is SettingsMigrationUIHandler } as? SettingsMigrationUIHandler
+                            .first { $0 is (any SettingsMigrationUIHandler) } as? any SettingsMigrationUIHandler
 
                         if let migrationUIHandler {
                             migrationUIHandler.showMigrationError(error) {

--- a/ios/MullvadVPN/Classes/AutomaticKeyboardResponder.swift
+++ b/ios/MullvadVPN/Classes/AutomaticKeyboardResponder.swift
@@ -80,7 +80,7 @@ class AutomaticKeyboardResponder {
             let fromCoordinateSpace = screen.coordinateSpace
 
             // Get your view's coordinate space.
-            let toCoordinateSpace: UICoordinateSpace = targetView
+            let toCoordinateSpace: any UICoordinateSpace = targetView
 
             // Convert the keyboard's frame from the screen's coordinate space to your view's coordinate space.
             let convertedKeyboardFrameEnd = fromCoordinateSpace.convert(keyboardFrameEnd, to: toCoordinateSpace)

--- a/ios/MullvadVPN/Classes/InputTextFormatter.swift
+++ b/ios/MullvadVPN/Classes/InputTextFormatter.swift
@@ -186,7 +186,7 @@ class InputTextFormatter: NSObject, UITextFieldDelegate, UITextPasteDelegate {
     // MARK: - UITextPasteDelegate
 
     func textPasteConfigurationSupporting(
-        _ textPasteConfigurationSupporting: UITextPasteConfigurationSupporting,
+        _ textPasteConfigurationSupporting: any UITextPasteConfigurationSupporting,
         performPasteOf attributedString: NSAttributedString,
         to textRange: UITextRange
     ) -> UITextRange {

--- a/ios/MullvadVPN/Containers/CustomSplitViewController.swift
+++ b/ios/MullvadVPN/Containers/CustomSplitViewController.swift
@@ -10,14 +10,14 @@ import UIKit
 
 class CustomSplitViewController: UISplitViewController, RootContainment {
     var preferredHeaderBarPresentation: HeaderBarPresentation {
-        for case let viewController as RootContainment in viewControllers {
+        for case let viewController as any RootContainment in viewControllers {
             return viewController.preferredHeaderBarPresentation
         }
         return .default
     }
 
     var prefersHeaderBarHidden: Bool {
-        for case let viewController as RootContainment in viewControllers {
+        for case let viewController as any RootContainment in viewControllers {
             return viewController.prefersHeaderBarHidden
         }
         return false

--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -115,7 +115,7 @@ class RootContainerViewController: UIViewController {
         viewControllers.last
     }
 
-    weak var delegate: RootContainerViewControllerDelegate?
+    weak var delegate: (any RootContainerViewControllerDelegate)?
 
     override var childForStatusBarStyle: UIViewController? {
         topViewController
@@ -487,7 +487,7 @@ class RootContainerViewController: UIViewController {
         let viewControllersToRemove = viewControllers.filter { !newViewControllers.contains($0) }
 
         // hide in-App notificationBanner when the container decides to keep it invisible
-        isNavigationBarHidden = (targetViewController as? RootContainment)?.prefersNotificationBarHidden ?? false
+        isNavigationBarHidden = (targetViewController as? any RootContainment)?.prefersNotificationBarHidden ?? false
 
         configureViewControllers(
             viewControllersToAdd: viewControllersToAdd,
@@ -741,20 +741,20 @@ class RootContainerViewController: UIViewController {
     }
 
     private func updateHeaderBarStyleFromChildPreferences(animated: Bool) {
-        if let conforming = topViewController as? RootContainment {
+        if let conforming = topViewController as? any RootContainment {
             setHeaderBarPresentation(conforming.preferredHeaderBarPresentation, animated: animated)
         }
     }
 
     private func updateDeviceInfoBarHiddenFromChildPreferences() {
-        if let conforming = topViewController as? RootContainment {
+        if let conforming = topViewController as? any RootContainment {
             headerBarView.isDeviceInfoHidden = conforming.prefersDeviceInfoBarHidden
         }
     }
 
     private func updateNotificationBarHiddenFromChildPreferences() {
         if let notificationController,
-           let conforming = topViewController as? RootContainment {
+           let conforming = topViewController as? any RootContainment {
             if conforming.prefersNotificationBarHidden {
                 removeNotificationController(notificationController)
             } else {
@@ -766,7 +766,7 @@ class RootContainerViewController: UIViewController {
     private func updateHeaderBarHiddenFromChildPreferences(animated: Bool) {
         guard overrideHeaderBarHidden == nil else { return }
 
-        if let conforming = topViewController as? RootContainment {
+        if let conforming = topViewController as? any RootContainment {
             setHeaderBarHidden(conforming.prefersHeaderBarHidden, animated: animated)
         }
     }

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -71,13 +71,13 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
     private let storePaymentManager: StorePaymentManager
     private let relayCacheTracker: RelayCacheTracker
 
-    private let apiProxy: APIQuerying
-    private let devicesProxy: DeviceHandling
-    private let accountsProxy: RESTAccountHandling
-    private var tunnelObserver: TunnelObserver?
-    private var appPreferences: AppPreferencesDataSource
-    private var outgoingConnectionService: OutgoingConnectionServiceHandling
-    private var accessMethodRepository: AccessMethodRepositoryProtocol
+    private let apiProxy: any APIQuerying
+    private let devicesProxy: any DeviceHandling
+    private let accountsProxy: any RESTAccountHandling
+    private var tunnelObserver: (any TunnelObserver)?
+    private var appPreferences: any AppPreferencesDataSource
+    private var outgoingConnectionService: any OutgoingConnectionServiceHandling
+    private var accessMethodRepository: any AccessMethodRepositoryProtocol
     private let configuredTransportProvider: ProxyConfigurationTransportProvider
     private let ipOverrideRepository: IPOverrideRepository
 
@@ -91,12 +91,12 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         tunnelManager: TunnelManager,
         storePaymentManager: StorePaymentManager,
         relayCacheTracker: RelayCacheTracker,
-        apiProxy: APIQuerying,
-        devicesProxy: DeviceHandling,
-        accountsProxy: RESTAccountHandling,
-        outgoingConnectionService: OutgoingConnectionServiceHandling,
-        appPreferences: AppPreferencesDataSource,
-        accessMethodRepository: AccessMethodRepositoryProtocol,
+        apiProxy: any APIQuerying,
+        devicesProxy: any DeviceHandling,
+        accountsProxy: any RESTAccountHandling,
+        outgoingConnectionService: any OutgoingConnectionServiceHandling,
+        appPreferences: any AppPreferencesDataSource,
+        accessMethodRepository: any AccessMethodRepositoryProtocol,
         transportProvider: ProxyConfigurationTransportProvider,
         ipOverrideRepository: IPOverrideRepository
 
@@ -193,7 +193,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
                 context.dismissedRoutes.forEach { $0.coordinator.removeFromParent() }
 
             case .selectLocation, .account, .settings, .changelog, .alert:
-                guard let coordinator = dismissedRoute.coordinator as? Presentable else {
+                guard let coordinator = dismissedRoute.coordinator as? any Presentable else {
                     completion()
                     return assertionFailure("Expected presentable coordinator for \(dismissedRoute.route)")
                 }
@@ -205,7 +205,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
 
             switch dismissedRoute.route {
             case .outOfTime, .welcome:
-                guard let coordinator = dismissedRoute.coordinator as? Poppable else {
+                guard let coordinator = dismissedRoute.coordinator as? any Poppable else {
                     completion()
                     return assertionFailure("Expected presentable coordinator for \(dismissedRoute.route)")
                 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddCustomListCoordinator.swift
@@ -13,7 +13,7 @@ import UIKit
 
 class AddCustomListCoordinator: Coordinator, Presentable, Presenting {
     let navigationController: UINavigationController
-    let interactor: CustomListInteractorProtocol
+    let interactor: any CustomListInteractorProtocol
     let nodes: [LocationNode]
     let subject = CurrentValueSubject<CustomListViewModel, Never>(
         CustomListViewModel(id: UUID(), name: "", locations: [], tableSections: [.name, .addLocations])
@@ -27,7 +27,7 @@ class AddCustomListCoordinator: Coordinator, Presentable, Presenting {
 
     init(
         navigationController: UINavigationController,
-        interactor: CustomListInteractorProtocol,
+        interactor: any CustomListInteractorProtocol,
         nodes: [LocationNode]
     ) {
         self.navigationController = navigationController

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsViewController.swift
@@ -20,7 +20,7 @@ class AddLocationsViewController: UIViewController {
     private let nodes: [LocationNode]
     private let customList: CustomList
 
-    weak var delegate: AddLocationsViewControllerDelegate?
+    weak var delegate: (any AddLocationsViewControllerDelegate)?
     private let tableView: UITableView = {
         let tableView = UITableView()
         tableView.separatorColor = .secondaryColor

--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListCellConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListCellConfiguration.swift
@@ -47,7 +47,7 @@ struct CustomListCellConfiguration {
             contentValidationErrors: validationErrors
         )
 
-        guard let cell = cell as? DynamicBackgroundConfiguration else { return }
+        guard let cell = cell as? any DynamicBackgroundConfiguration else { return }
 
         cell.setAutoAdaptingBackgroundConfiguration(.mullvadListGroupedCell(), selectionType: .dimmed)
     }
@@ -86,7 +86,7 @@ struct CustomListCellConfiguration {
         contentConfiguration.text = itemIdentifier.text
         cell.contentConfiguration = contentConfiguration
 
-        if let cell = cell as? CustomCellDisclosureHandling {
+        if let cell = cell as? any CustomCellDisclosureHandling {
             cell.disclosureType = .chevron
         }
     }

--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListInteractor.swift
@@ -15,7 +15,7 @@ protocol CustomListInteractorProtocol {
 }
 
 struct CustomListInteractor: CustomListInteractorProtocol {
-    let repository: CustomListRepositoryProtocol
+    let repository: any CustomListRepositoryProtocol
 
     func fetchAll() -> [CustomList] {
         repository.fetchAll()

--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewController.swift
@@ -19,7 +19,7 @@ protocol CustomListViewControllerDelegate: AnyObject {
 class CustomListViewController: UIViewController {
     typealias DataSource = UITableViewDiffableDataSource<CustomListSectionIdentifier, CustomListItemIdentifier>
 
-    private let interactor: CustomListInteractorProtocol
+    private let interactor: any CustomListInteractorProtocol
     private let tableView = UITableView(frame: .zero, style: .insetGrouped)
     private let subject: CurrentValueSubject<CustomListViewModel, Never>
     private var cancellables = Set<AnyCancellable>()
@@ -54,10 +54,10 @@ class CustomListViewController: UIViewController {
         return barButtonItem
     }()
 
-    weak var delegate: CustomListViewControllerDelegate?
+    weak var delegate: (any CustomListViewControllerDelegate)?
 
     init(
-        interactor: CustomListInteractorProtocol,
+        interactor: any CustomListInteractorProtocol,
         subject: CurrentValueSubject<CustomListViewModel, Never>,
         alertPresenter: AlertPresenter
     ) {

--- a/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/EditCustomListCoordinator.swift
@@ -17,7 +17,7 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
     }
 
     let navigationController: UINavigationController
-    let customListInteractor: CustomListInteractorProtocol
+    let customListInteractor: any CustomListInteractorProtocol
     let customList: CustomList
     let nodes: [LocationNode]
     let subject: CurrentValueSubject<CustomListViewModel, Never>
@@ -30,7 +30,7 @@ class EditCustomListCoordinator: Coordinator, Presentable, Presenting {
 
     init(
         navigationController: UINavigationController,
-        customListInteractor: CustomListInteractorProtocol,
+        customListInteractor: any CustomListInteractorProtocol,
         customList: CustomList,
         nodes: [LocationNode]
     ) {

--- a/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
@@ -15,7 +15,7 @@ import UIKit
 
 final class LoginCoordinator: Coordinator, Presenting, DeviceManagementViewControllerDelegate {
     private let tunnelManager: TunnelManager
-    private let devicesProxy: DeviceHandling
+    private let devicesProxy: any DeviceHandling
 
     private var loginController: LoginViewController?
     private var lastLoginAction: LoginAction?
@@ -34,7 +34,7 @@ final class LoginCoordinator: Coordinator, Presenting, DeviceManagementViewContr
     init(
         navigationController: RootContainerViewController,
         tunnelManager: TunnelManager,
-        devicesProxy: DeviceHandling
+        devicesProxy: any DeviceHandling
     ) {
         self.navigationController = navigationController
         self.tunnelManager = tunnelManager
@@ -75,7 +75,7 @@ final class LoginCoordinator: Coordinator, Presenting, DeviceManagementViewContr
 
     // MARK: - Private
 
-    private func didFinishLogin(action: LoginAction, error: Error?) -> EndLoginAction {
+    private func didFinishLogin(action: LoginAction, error: (any Error)?) -> EndLoginAction {
         guard let error else {
             callDidFinishAfterDelay()
             return .nothing
@@ -115,7 +115,7 @@ final class LoginCoordinator: Coordinator, Presenting, DeviceManagementViewContr
         }
     }
 
-    private func showDeviceList(for accountNumber: String, completion: @escaping (Error?) -> Void) {
+    private func showDeviceList(for accountNumber: String, completion: @escaping ((any Error)?) -> Void) {
         let interactor = DeviceManagementInteractor(
             accountNumber: accountNumber,
             devicesProxy: devicesProxy

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Add/AddAccessMethodCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Add/AddAccessMethodCoordinator.swift
@@ -15,8 +15,8 @@ class AddAccessMethodCoordinator: Coordinator, Presentable, Presenting {
     private let subject: CurrentValueSubject<AccessMethodViewModel, Never> = .init(AccessMethodViewModel())
 
     let navigationController: UINavigationController
-    let accessMethodRepository: AccessMethodRepositoryProtocol
-    let proxyConfigurationTester: ProxyConfigurationTesterProtocol
+    let accessMethodRepository: any AccessMethodRepositoryProtocol
+    let proxyConfigurationTester: any ProxyConfigurationTesterProtocol
 
     var presentedViewController: UIViewController {
         navigationController
@@ -24,8 +24,8 @@ class AddAccessMethodCoordinator: Coordinator, Presentable, Presenting {
 
     init(
         navigationController: UINavigationController,
-        accessMethodRepo: AccessMethodRepositoryProtocol,
-        proxyConfigurationTester: ProxyConfigurationTesterProtocol
+        accessMethodRepo: any AccessMethodRepositoryProtocol,
+        proxyConfigurationTester: any ProxyConfigurationTesterProtocol
     ) {
         self.navigationController = navigationController
         self.accessMethodRepository = accessMethodRepo

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ButtonCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ButtonCellContentConfiguration.swift
@@ -25,11 +25,11 @@ struct ButtonCellContentConfiguration: UIContentConfiguration, Equatable {
     /// The button content edge insets.
     var directionalContentEdgeInsets: NSDirectionalEdgeInsets = UIMetrics.SettingsCell.insetLayoutMargins
 
-    func makeContentView() -> UIView & UIContentView {
+    func makeContentView() -> any UIView & UIContentView {
         return ButtonCellContentView(configuration: self)
     }
 
-    func updated(for state: UIConfigurationState) -> Self {
+    func updated(for state: any UIConfigurationState) -> Self {
         return self
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ButtonCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ButtonCellContentView.swift
@@ -15,7 +15,7 @@ class ButtonCellContentView: UIView, UIContentView {
     /// Default cell corner radius in inset grouped table view
     private let tableViewCellCornerRadius: CGFloat = 10
 
-    var configuration: UIContentConfiguration {
+    var configuration: any UIContentConfiguration {
         get {
             actualConfiguration
         }
@@ -32,7 +32,7 @@ class ButtonCellContentView: UIView, UIContentView {
 
     private var actualConfiguration: ButtonCellContentConfiguration
 
-    func supports(_ configuration: UIContentConfiguration) -> Bool {
+    func supports(_ configuration: any UIContentConfiguration) -> Bool {
         configuration is ButtonCellContentConfiguration
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ListCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ListCellContentView.swift
@@ -14,7 +14,7 @@ class ListCellContentView: UIView, UIContentView, UITextFieldDelegate {
     private var secondaryTextLabel = UILabel()
     private var tertiaryTextLabel = UILabel()
 
-    var configuration: UIContentConfiguration {
+    var configuration: any UIContentConfiguration {
         get {
             actualConfiguration
         }
@@ -31,7 +31,7 @@ class ListCellContentView: UIView, UIContentView, UITextFieldDelegate {
 
     private var actualConfiguration: ListCellContentConfiguration
 
-    func supports(_ configuration: UIContentConfiguration) -> Bool {
+    func supports(_ configuration: any UIContentConfiguration) -> Bool {
         configuration is ListCellContentConfiguration
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentConfiguration.swift
@@ -30,11 +30,11 @@ struct SwitchCellContentConfiguration: UIContentConfiguration, Equatable {
     /// Content view layout margins.
     var directionalLayoutMargins: NSDirectionalEdgeInsets = UIMetrics.SettingsCell.apiAccessInsetLayoutMargins
 
-    func makeContentView() -> UIView & UIContentView {
+    func makeContentView() -> any UIView & UIContentView {
         return SwitchCellContentView(configuration: self)
     }
 
-    func updated(for state: UIConfigurationState) -> Self {
+    func updated(for state: any UIConfigurationState) -> Self {
         return self
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentConfiguration.swift
@@ -37,11 +37,11 @@ struct TextCellContentConfiguration: UIContentConfiguration, Equatable {
     /// The content view layout margins.
     var directionalLayoutMargins: NSDirectionalEdgeInsets = UIMetrics.SettingsCell.apiAccessInsetLayoutMargins
 
-    func makeContentView() -> UIView & UIContentView {
+    func makeContentView() -> any UIView & UIContentView {
         return TextCellContentView(configuration: self)
     }
 
-    func updated(for state: UIConfigurationState) -> Self {
+    func updated(for state: any UIConfigurationState) -> Self {
         return self
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentView.swift
@@ -13,7 +13,7 @@ class TextCellContentView: UIView, UIContentView, UIGestureRecognizerDelegate {
     private var textLabel = UILabel()
     private var textField = CustomTextField()
 
-    var configuration: UIContentConfiguration {
+    var configuration: any UIContentConfiguration {
         get {
             actualConfiguration
         }
@@ -30,7 +30,7 @@ class TextCellContentView: UIView, UIContentView, UIGestureRecognizerDelegate {
 
     private var actualConfiguration: TextCellContentConfiguration
 
-    func supports(_ configuration: UIContentConfiguration) -> Bool {
+    func supports(_ configuration: any UIContentConfiguration) -> Bool {
         configuration is TextCellContentConfiguration
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Common/ShadowsocksSectionHandler.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Common/ShadowsocksSectionHandler.swift
@@ -72,7 +72,7 @@ struct ShadowsocksSectionHandler {
         contentConfiguration.secondaryText = subject.value.shadowsocks.cipher.rawValue.description
         cell.contentConfiguration = contentConfiguration
 
-        if let cell = cell as? CustomCellDisclosureHandling {
+        if let cell = cell as? any CustomCellDisclosureHandling {
             cell.disclosureType = .chevron
         }
     }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodInteractor.swift
@@ -12,8 +12,8 @@ import MullvadSettings
 
 struct EditAccessMethodInteractor: EditAccessMethodInteractorProtocol {
     let subject: CurrentValueSubject<AccessMethodViewModel, Never>
-    let repository: AccessMethodRepositoryProtocol
-    let proxyConfigurationTester: ProxyConfigurationTesterProtocol
+    let repository: any AccessMethodRepositoryProtocol
+    let proxyConfigurationTester: any ProxyConfigurationTesterProtocol
 
     func saveAccessMethod() {
         guard let persistentMethod = try? subject.value.intoPersistentAccessMethod() else { return }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
@@ -17,16 +17,16 @@ class EditAccessMethodViewController: UITableViewController {
     >
 
     private let subject: CurrentValueSubject<AccessMethodViewModel, Never>
-    private let interactor: EditAccessMethodInteractorProtocol
+    private let interactor: any EditAccessMethodInteractorProtocol
     private var alertPresenter: AlertPresenter
     private var cancellables = Set<AnyCancellable>()
     private var dataSource: EditAccessMethodDataSource?
 
-    weak var delegate: EditAccessMethodViewControllerDelegate?
+    weak var delegate: (any EditAccessMethodViewControllerDelegate)?
 
     init(
         subject: CurrentValueSubject<AccessMethodViewModel, Never>,
-        interactor: EditAccessMethodInteractorProtocol,
+        interactor: any EditAccessMethodInteractorProtocol,
         alertPresenter: AlertPresenter
     ) {
         self.subject = subject
@@ -159,7 +159,7 @@ class EditAccessMethodViewController: UITableViewController {
     }
 
     private func configureBackground(cell: UITableViewCell, itemIdentifier: EditAccessMethodItemIdentifier) {
-        guard let cell = cell as? DynamicBackgroundConfiguration else { return }
+        guard let cell = cell as? any DynamicBackgroundConfiguration else { return }
 
         guard !itemIdentifier.isClearBackground else {
             cell.setAutoAdaptingClearBackgroundConfiguration()
@@ -213,7 +213,7 @@ class EditAccessMethodViewController: UITableViewController {
         contentConfiguration.text = itemIdentifier.text
         cell.contentConfiguration = contentConfiguration
 
-        if let cell = cell as? CustomCellDisclosureHandling {
+        if let cell = cell as? any CustomCellDisclosureHandling {
             cell.disclosureType = .chevron
         }
     }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsCellConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsCellConfiguration.swift
@@ -70,7 +70,7 @@ class MethodSettingsCellConfiguration {
             contentValidationErrors: contentValidationErrors
         )
 
-        guard let cell = cell as? DynamicBackgroundConfiguration else { return }
+        guard let cell = cell as? any DynamicBackgroundConfiguration else { return }
 
         guard !itemIdentifier.isClearBackground else {
             cell.setAutoAdaptingClearBackgroundConfiguration()
@@ -149,7 +149,7 @@ class MethodSettingsCellConfiguration {
         contentConfiguration.secondaryText = subject.value.method.localizedDescription
         cell.contentConfiguration = contentConfiguration
 
-        if let cell = cell as? CustomCellDisclosureHandling {
+        if let cell = cell as? any CustomCellDisclosureHandling {
             cell.disclosureType = .chevron
         }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodTestingStatusCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodTestingStatusCellContentConfiguration.swift
@@ -31,11 +31,11 @@ struct MethodTestingStatusCellContentConfiguration: UIContentConfiguration, Equa
     /// Layout margins.
     var directionalLayoutMargins: NSDirectionalEdgeInsets = UIMetrics.SettingsCell.apiAccessInsetLayoutMargins
 
-    func makeContentView() -> UIView & UIContentView {
+    func makeContentView() -> any UIView & UIContentView {
         return MethodTestingStatusCellContentView(configuration: self)
     }
 
-    func updated(for state: UIConfigurationState) -> Self {
+    func updated(for state: any UIConfigurationState) -> Self {
         return self
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodTestingStatusCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodTestingStatusCellContentView.swift
@@ -53,7 +53,7 @@ class MethodTestingStatusCellContentView: UIView, UIContentView {
         return stackView
     }()
 
-    var configuration: UIContentConfiguration {
+    var configuration: any UIContentConfiguration {
         get {
             actualConfiguration
         }
@@ -69,7 +69,7 @@ class MethodTestingStatusCellContentView: UIView, UIContentView {
 
     private var actualConfiguration: MethodTestingStatusCellContentConfiguration
 
-    func supports(_ configuration: UIContentConfiguration) -> Bool {
+    func supports(_ configuration: any UIContentConfiguration) -> Bool {
         configuration is MethodTestingStatusCellContentConfiguration
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodCoordinator.swift
@@ -12,8 +12,8 @@ import UIKit
 
 class ListAccessMethodCoordinator: Coordinator, Presenting, SettingsChildCoordinator {
     let navigationController: UINavigationController
-    let accessMethodRepository: AccessMethodRepositoryProtocol
-    let proxyConfigurationTester: ProxyConfigurationTesterProtocol
+    let accessMethodRepository: any AccessMethodRepositoryProtocol
+    let proxyConfigurationTester: any ProxyConfigurationTesterProtocol
 
     var presentationContext: UIViewController {
         navigationController
@@ -21,8 +21,8 @@ class ListAccessMethodCoordinator: Coordinator, Presenting, SettingsChildCoordin
 
     init(
         navigationController: UINavigationController,
-        accessMethodRepository: AccessMethodRepositoryProtocol,
-        proxyConfigurationTester: ProxyConfigurationTesterProtocol
+        accessMethodRepository: any AccessMethodRepositoryProtocol,
+        proxyConfigurationTester: any ProxyConfigurationTesterProtocol
     ) {
         self.navigationController = navigationController
         self.accessMethodRepository = accessMethodRepository

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodInteractor.swift
@@ -11,9 +11,9 @@ import MullvadSettings
 
 /// A concrete implementation of an API access list interactor.
 struct ListAccessMethodInteractor: ListAccessMethodInteractorProtocol {
-    let repository: AccessMethodRepositoryProtocol
+    let repository: any AccessMethodRepositoryProtocol
 
-    init(repository: AccessMethodRepositoryProtocol) {
+    init(repository: any AccessMethodRepositoryProtocol) {
         self.repository = repository
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Pickers/ListItemPickerViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Pickers/ListItemPickerViewController.swift
@@ -93,11 +93,11 @@ class ListItemPickerViewController<DataSource: ListItemDataSourceProtocol>: UITa
         let cell = tableView.dequeueReusableView(withIdentifier: CellIdentifier.default, for: indexPath)
         cell.contentConfiguration = configuration
 
-        if let cell = cell as? CustomCellDisclosureHandling {
+        if let cell = cell as? any CustomCellDisclosureHandling {
             cell.disclosureType = item.id == selectedItemID ? .tick : .none
         }
 
-        if let cell = cell as? DynamicBackgroundConfiguration {
+        if let cell = cell as? any DynamicBackgroundConfiguration {
             cell.setAutoAdaptingBackgroundConfiguration(.mullvadListPlainCell(), selectionType: .dimmed)
         }
 

--- a/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideCoordinator.swift
@@ -21,7 +21,7 @@ class IPOverrideCoordinator: Coordinator, Presenting, SettingsChildCoordinator {
 
     init(
         navigationController: UINavigationController,
-        repository: IPOverrideRepositoryProtocol,
+        repository: any IPOverrideRepositoryProtocol,
         tunnelManager: TunnelManager
     ) {
         self.navigationController = navigationController

--- a/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideInteractor.swift
@@ -13,7 +13,7 @@ import MullvadTypes
 
 final class IPOverrideInteractor {
     private let logger = Logger(label: "IPOverrideInteractor")
-    private let repository: IPOverrideRepositoryProtocol
+    private let repository: any IPOverrideRepositoryProtocol
     private let tunnelManager: TunnelManager
     private var statusWorkItem: DispatchWorkItem?
 
@@ -30,7 +30,7 @@ final class IPOverrideInteractor {
         }
     }
 
-    init(repository: IPOverrideRepositoryProtocol, tunnelManager: TunnelManager) {
+    init(repository: any IPOverrideRepositoryProtocol, tunnelManager: TunnelManager) {
         self.repository = repository
         self.tunnelManager = tunnelManager
 

--- a/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideViewController.swift
@@ -15,7 +15,7 @@ class IPOverrideViewController: UIViewController {
     private let alertPresenter: AlertPresenter
     private let headerView = IPOverrideHeaderView()
 
-    weak var delegate: IPOverrideViewControllerDelegate?
+    weak var delegate: (any IPOverrideViewControllerDelegate)?
 
     private lazy var containerView: UIStackView = {
         let view = UIStackView()

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
@@ -38,8 +38,8 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
     private let interactorFactory: SettingsInteractorFactory
     private var currentRoute: SettingsNavigationRoute?
     private var modalRoute: SettingsNavigationRoute?
-    private let accessMethodRepository: AccessMethodRepositoryProtocol
-    private let proxyConfigurationTester: ProxyConfigurationTesterProtocol
+    private let accessMethodRepository: any AccessMethodRepositoryProtocol
+    private let proxyConfigurationTester: any ProxyConfigurationTesterProtocol
     private let ipOverrideRepository: IPOverrideRepository
 
     let navigationController: UINavigationController
@@ -65,8 +65,8 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
     init(
         navigationController: UINavigationController,
         interactorFactory: SettingsInteractorFactory,
-        accessMethodRepository: AccessMethodRepositoryProtocol,
-        proxyConfigurationTester: ProxyConfigurationTesterProtocol,
+        accessMethodRepository: any AccessMethodRepositoryProtocol,
+        proxyConfigurationTester: any ProxyConfigurationTesterProtocol,
         ipOverrideRepository: IPOverrideRepository
     ) {
         self.navigationController = navigationController
@@ -210,7 +210,7 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
     /// Release all child coordinators conforming to ``SettingsChildCoordinator`` protocol.
     private func releaseChildren() {
         childCoordinators.forEach { coordinator in
-            if coordinator is SettingsChildCoordinator {
+            if coordinator is any SettingsChildCoordinator {
                 coordinator.removeFromParent()
             }
         }
@@ -225,7 +225,7 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
 
         /// Child coordinator that should be added to the children hierarchy.
         /// The child is responsile for presenting itself.
-        case childCoordinator(SettingsChildCoordinator)
+        case childCoordinator(any SettingsChildCoordinator)
 
         /// Failure to produce a child.
         case failed

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsFieldValidationErrorConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsFieldValidationErrorConfiguration.swift
@@ -16,11 +16,11 @@ struct SettingsFieldValidationErrorConfiguration: UIContentConfiguration, Equata
     var errors: [SettingsFieldValidationError] = []
     var directionalLayoutMargins: NSDirectionalEdgeInsets = UIMetrics.SettingsCell.settingsValidationErrorLayoutMargins
 
-    func makeContentView() -> UIView & UIContentView {
+    func makeContentView() -> any UIView & UIContentView {
         return SettingsFieldValidationErrorContentView(configuration: self)
     }
 
-    func updated(for state: UIConfigurationState) -> Self {
+    func updated(for state: any UIConfigurationState) -> Self {
         return self
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsFieldValidationErrorContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsFieldValidationErrorContentView.swift
@@ -18,7 +18,7 @@ class SettingsFieldValidationErrorContentView: UIView, UIContentView {
         return view
     }
 
-    var configuration: UIContentConfiguration {
+    var configuration: any UIContentConfiguration {
         get {
             actualConfiguration
         }
@@ -34,7 +34,7 @@ class SettingsFieldValidationErrorContentView: UIView, UIContentView {
 
     private var actualConfiguration: SettingsFieldValidationErrorConfiguration
 
-    func supports(_ configuration: UIContentConfiguration) -> Bool {
+    func supports(_ configuration: any UIContentConfiguration) -> Bool {
         configuration is SettingsFieldValidationErrorConfiguration
     }
 

--- a/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
@@ -13,7 +13,7 @@ class TunnelCoordinator: Coordinator, Presenting {
     private let tunnelManager: TunnelManager
     private let controller: TunnelViewController
 
-    private var tunnelObserver: TunnelObserver?
+    private var tunnelObserver: (any TunnelObserver)?
 
     var presentationContext: UIViewController {
         controller
@@ -27,7 +27,7 @@ class TunnelCoordinator: Coordinator, Presenting {
 
     init(
         tunnelManager: TunnelManager,
-        outgoingConnectionService: OutgoingConnectionServiceHandling
+        outgoingConnectionService: any OutgoingConnectionServiceHandling
     ) {
         self.tunnelManager = tunnelManager
 

--- a/ios/MullvadVPN/Extensions/StorePaymentManagerError+Display.swift
+++ b/ios/MullvadVPN/Extensions/StorePaymentManagerError+Display.swift
@@ -22,7 +22,7 @@ extension StorePaymentManagerError: DisplayError {
             )
 
         case let .validateAccount(error):
-            let reason = (error as? DisplayError)?.displayErrorDescription ?? ""
+            let reason = (error as? any DisplayError)?.displayErrorDescription ?? ""
 
             return String(
                 format: NSLocalizedString(
@@ -61,7 +61,7 @@ extension StorePaymentManagerError: DisplayError {
             }
 
         case let .sendReceipt(error):
-            let reason = (error as? DisplayError)?.displayErrorDescription ?? ""
+            let reason = (error as? any DisplayError)?.displayErrorDescription ?? ""
             let errorFormat = NSLocalizedString(
                 "SEND_RECEIPT_ERROR",
                 tableName: "StorePaymentManager",

--- a/ios/MullvadVPN/Extensions/UIView+AutoLayoutBuilder.swift
+++ b/ios/MullvadVPN/Extensions/UIView+AutoLayoutBuilder.swift
@@ -26,14 +26,14 @@ extension UIView {
     /**
      Pin all edges to edges of other view.
      */
-    func pinEdgesTo(_ other: AutoLayoutAnchorsProtocol) -> [NSLayoutConstraint] {
+    func pinEdgesTo(_ other: any AutoLayoutAnchorsProtocol) -> [NSLayoutConstraint] {
         pinEdges(.all(), to: other)
     }
 
     /**
      Pin edges to edges of other view.
      */
-    func pinEdges(_ edges: PinnableEdges, to other: AutoLayoutAnchorsProtocol) -> [NSLayoutConstraint] {
+    func pinEdges(_ edges: PinnableEdges, to other: any AutoLayoutAnchorsProtocol) -> [NSLayoutConstraint] {
         edges.makeConstraints(firstView: self, secondView: other)
     }
 
@@ -202,8 +202,8 @@ struct PinnableEdges {
         }
 
         func makeConstraint(
-            firstView: AutoLayoutAnchorsProtocol,
-            secondView: AutoLayoutAnchorsProtocol
+            firstView: any AutoLayoutAnchorsProtocol,
+            secondView: any AutoLayoutAnchorsProtocol
         ) -> NSLayoutConstraint {
             switch self {
             case let .top(inset):
@@ -257,8 +257,8 @@ struct PinnableEdges {
      Returns new constraints pinning edges of the corresponding views.
      */
     func makeConstraints(
-        firstView: AutoLayoutAnchorsProtocol,
-        secondView: AutoLayoutAnchorsProtocol
+        firstView: any AutoLayoutAnchorsProtocol,
+        secondView: any AutoLayoutAnchorsProtocol
     ) -> [NSLayoutConstraint] {
         inner.map { $0.makeConstraint(firstView: firstView, secondView: secondView) }
     }

--- a/ios/MullvadVPN/GeneralAPIs/OutgoingConnectionProxy.swift
+++ b/ios/MullvadVPN/GeneralAPIs/OutgoingConnectionProxy.swift
@@ -25,9 +25,9 @@ final class OutgoingConnectionProxy: OutgoingConnectionHandling {
         }
     }
 
-    let urlSession: URLSessionProtocol
+    let urlSession: any URLSessionProtocol
 
-    init(urlSession: URLSessionProtocol) {
+    init(urlSession: any URLSessionProtocol) {
         self.urlSession = urlSession
     }
 

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiryInAppNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiryInAppNotificationProvider.swift
@@ -13,7 +13,7 @@ import MullvadTypes
 final class AccountExpiryInAppNotificationProvider: NotificationProvider, InAppNotificationProvider {
     private var accountExpiry = AccountExpiry()
     private var tunnelObserver: TunnelBlockObserver?
-    private var timer: DispatchSourceTimer?
+    private var timer: (any DispatchSourceTimer)?
 
     init(tunnelManager: TunnelManager) {
         super.init()

--- a/ios/MullvadVPN/Notifications/NotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/NotificationProvider.swift
@@ -17,7 +17,7 @@ protocol NotificationProviderDelegate: AnyObject {
 
 /// Base class for all notification providers.
 class NotificationProvider: NotificationProviderProtocol {
-    weak var delegate: NotificationProviderDelegate?
+    weak var delegate: (any NotificationProviderDelegate)?
 
     /**
      Provider identifier.

--- a/ios/MullvadVPN/Operations/ProductsRequestOperation.swift
+++ b/ios/MullvadVPN/Operations/ProductsRequestOperation.swift
@@ -18,7 +18,7 @@ final class ProductsRequestOperation: ResultOperation<SKProductsResponse>,
     private let retryDelay: Duration = .seconds(2)
 
     private var retryCount = 0
-    private var retryTimer: DispatchSourceTimer?
+    private var retryTimer: (any DispatchSourceTimer)?
     private var request: SKProductsRequest?
 
     init(productIdentifiers: Set<String>, completionHandler: @escaping CompletionHandler) {
@@ -46,7 +46,7 @@ final class ProductsRequestOperation: ResultOperation<SKProductsResponse>,
         // no-op
     }
 
-    func request(_ request: SKRequest, didFailWithError error: Error) {
+    func request(_ request: SKRequest, didFailWithError error: any Error) {
         dispatchQueue.async {
             if self.retryCount < self.maxRetryCount, !self.isCancelled {
                 self.retryCount += 1
@@ -72,7 +72,7 @@ final class ProductsRequestOperation: ResultOperation<SKProductsResponse>,
         request?.start()
     }
 
-    private func retry(error: Error) {
+    private func retry(error: any Error) {
         retryTimer = DispatchSource.makeTimerSource(flags: [], queue: .main)
 
         retryTimer?.setEventHandler { [weak self] in

--- a/ios/MullvadVPN/Presentation controllers/FormsheetPresentationController.swift
+++ b/ios/MullvadVPN/Presentation controllers/FormsheetPresentationController.swift
@@ -207,12 +207,12 @@ class FormSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDel
         forPresented presented: UIViewController,
         presenting: UIViewController,
         source: UIViewController
-    ) -> UIViewControllerAnimatedTransitioning? {
+    ) -> (any UIViewControllerAnimatedTransitioning)? {
         FormSheetPresentationAnimator()
     }
 
     func animationController(forDismissed dismissed: UIViewController)
-        -> UIViewControllerAnimatedTransitioning? {
+        -> (any UIViewControllerAnimatedTransitioning)? {
         FormSheetPresentationAnimator()
     }
 
@@ -230,12 +230,12 @@ class FormSheetTransitioningDelegate: NSObject, UIViewControllerTransitioningDel
 }
 
 class FormSheetPresentationAnimator: NSObject, UIViewControllerAnimatedTransitioning {
-    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?)
+    func transitionDuration(using transitionContext: (any UIViewControllerContextTransitioning)?)
         -> TimeInterval {
         (transitionContext?.isAnimated ?? true) ? UIMetrics.FormSheetTransition.duration.timeInterval : 0
     }
 
-    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    func animateTransition(using transitionContext: any UIViewControllerContextTransitioning) {
         let destination = transitionContext.viewController(forKey: .to)
 
         if destination?.isBeingPresented ?? false {
@@ -245,7 +245,7 @@ class FormSheetPresentationAnimator: NSObject, UIViewControllerAnimatedTransitio
         }
     }
 
-    private func animatePresentation(_ transitionContext: UIViewControllerContextTransitioning) {
+    private func animatePresentation(_ transitionContext: any UIViewControllerContextTransitioning) {
         let duration = transitionDuration(using: transitionContext)
         let containerView = transitionContext.containerView
         let destinationView = transitionContext.view(forKey: .to)!
@@ -274,7 +274,7 @@ class FormSheetPresentationAnimator: NSObject, UIViewControllerAnimatedTransitio
         }
     }
 
-    private func animateDismissal(_ transitionContext: UIViewControllerContextTransitioning) {
+    private func animateDismissal(_ transitionContext: any UIViewControllerContextTransitioning) {
         let duration = transitionDuration(using: transitionContext)
         let containerView = transitionContext.containerView
         let sourceView = transitionContext.view(forKey: .from)!

--- a/ios/MullvadVPN/Protocols/SettingsMigrationUIHandler.swift
+++ b/ios/MullvadVPN/Protocols/SettingsMigrationUIHandler.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol SettingsMigrationUIHandler {
-    func showMigrationError(_ error: Error, completionHandler: @escaping () -> Void)
+    func showMigrationError(_ error: any Error, completionHandler: @escaping () -> Void)
 }

--- a/ios/MullvadVPN/StorePaymentManager/StorePaymentManagerError.swift
+++ b/ios/MullvadVPN/StorePaymentManager/StorePaymentManagerError.swift
@@ -16,16 +16,16 @@ enum StorePaymentManagerError: LocalizedError, WrappingError {
     case noAccountSet
 
     /// Failure to validate the account token.
-    case validateAccount(Error)
+    case validateAccount(any Error)
 
     /// Failure to handle payment transaction. Contains error returned by StoreKit.
-    case storePayment(Error)
+    case storePayment(any Error)
 
     /// Failure to read the AppStore receipt.
-    case readReceipt(Error)
+    case readReceipt(any Error)
 
     /// Failure to send the AppStore receipt to backend.
-    case sendReceipt(Error)
+    case sendReceipt(any Error)
 
     var errorDescription: String? {
         switch self {
@@ -42,7 +42,7 @@ enum StorePaymentManagerError: LocalizedError, WrappingError {
         }
     }
 
-    var underlyingError: Error? {
+    var underlyingError: (any Error)? {
         switch self {
         case .noAccountSet:
             return nil

--- a/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
@@ -14,9 +14,9 @@ import Operations
 
 class LoadTunnelConfigurationOperation: ResultOperation<Void> {
     private let logger = Logger(label: "LoadTunnelConfigurationOperation")
-    private let interactor: TunnelInteractor
+    private let interactor: any TunnelInteractor
 
-    init(dispatchQueue: DispatchQueue, interactor: TunnelInteractor) {
+    init(dispatchQueue: DispatchQueue, interactor: any TunnelInteractor) {
         self.interactor = interactor
 
         super.init(dispatchQueue: dispatchQueue)
@@ -58,7 +58,7 @@ class LoadTunnelConfigurationOperation: ResultOperation<Void> {
         finish(result: .success(()))
     }
 
-    private func readSettings() -> Result<LatestTunnelSettings?, Error> {
+    private func readSettings() -> Result<LatestTunnelSettings?, any Error> {
         Result { try SettingsManager.readSettings() }
             .flatMapError { error in
                 if let error = error as? ReadSettingsVersionError,
@@ -77,7 +77,7 @@ class LoadTunnelConfigurationOperation: ResultOperation<Void> {
             }
     }
 
-    private func readDeviceState() -> Result<DeviceState?, Error> {
+    private func readDeviceState() -> Result<DeviceState?, any Error> {
         Result { try SettingsManager.readDeviceState() }
             .flatMapError { error in
                 if let error = error as? KeychainError, error == .itemNotFound {

--- a/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/RotateKeyOperation.swift
@@ -16,11 +16,11 @@ import WireGuardKitTypes
 
 class RotateKeyOperation: ResultOperation<Void> {
     private let logger = Logger(label: "RotateKeyOperation")
-    private let interactor: TunnelInteractor
-    private let devicesProxy: DeviceHandling
-    private var task: Cancellable?
+    private let interactor: any TunnelInteractor
+    private let devicesProxy: any DeviceHandling
+    private var task: (any Cancellable)?
 
-    init(dispatchQueue: DispatchQueue, interactor: TunnelInteractor, devicesProxy: DeviceHandling) {
+    init(dispatchQueue: DispatchQueue, interactor: any TunnelInteractor, devicesProxy: any DeviceHandling) {
         self.interactor = interactor
         self.devicesProxy = devicesProxy
 
@@ -98,7 +98,7 @@ class RotateKeyOperation: ResultOperation<Void> {
         }
     }
 
-    private func handleError(_ error: Error) {
+    private func handleError(_ error: any Error) {
         if !error.isOperationCancellationError {
             logger.error(error: error, message: "Failed to rotate device key.")
         }

--- a/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
@@ -10,11 +10,11 @@ import Foundation
 import Operations
 
 class StopTunnelOperation: ResultOperation<Void> {
-    private let interactor: TunnelInteractor
+    private let interactor: any TunnelInteractor
 
     init(
         dispatchQueue: DispatchQueue,
-        interactor: TunnelInteractor,
+        interactor: any TunnelInteractor,
         completionHandler: @escaping CompletionHandler
     ) {
         self.interactor = interactor

--- a/ios/MullvadVPN/TunnelManager/Tunnel.swift
+++ b/ios/MullvadVPN/TunnelManager/Tunnel.swift
@@ -37,8 +37,8 @@ protocol TunnelProtocol: AnyObject {
 
     func logFormat() -> String
 
-    func saveToPreferences(_ completion: @escaping (Error?) -> Void)
-    func removeFromPreferences(completion: @escaping (Error?) -> Void)
+    func saveToPreferences(_ completion: @escaping ((any Error)?) -> Void)
+    func removeFromPreferences(completion: @escaping ((any Error)?) -> Void)
 
     func setConfiguration(_ configuration: TunnelConfiguration)
     func start(options: [String: NSObject]?) throws
@@ -134,7 +134,7 @@ final class Tunnel: TunnelProtocol, Equatable {
     }
 
     func sendProviderMessage(_ messageData: Data, responseHandler: ((Data?) -> Void)?) throws {
-        let session = tunnelProvider.connection as? VPNTunnelProviderSessionProtocol
+        let session = tunnelProvider.connection as? any VPNTunnelProviderSessionProtocol
 
         try session?.sendProviderMessage(messageData, responseHandler: responseHandler)
     }
@@ -143,7 +143,7 @@ final class Tunnel: TunnelProtocol, Equatable {
         configuration.apply(to: tunnelProvider)
     }
 
-    func saveToPreferences(_ completion: @escaping (Error?) -> Void) {
+    func saveToPreferences(_ completion: @escaping ((any Error)?) -> Void) {
         tunnelProvider.saveToPreferences { error in
             if let error {
                 completion(error)
@@ -157,7 +157,7 @@ final class Tunnel: TunnelProtocol, Equatable {
         }
     }
 
-    func removeFromPreferences(completion: @escaping (Error?) -> Void) {
+    func removeFromPreferences(completion: @escaping ((any Error)?) -> Void) {
         tunnelProvider.removeFromPreferences(completionHandler: completion)
     }
 
@@ -181,7 +181,7 @@ final class Tunnel: TunnelProtocol, Equatable {
     }
 
     @objc private func handleVPNStatusChangeNotification(_ notification: Notification) {
-        guard let connection = notification.object as? VPNConnectionProtocol else { return }
+        guard let connection = notification.object as? any VPNConnectionProtocol else { return }
 
         let newStatus = connection.status
 

--- a/ios/MullvadVPN/TunnelManager/TunnelBlockObserver.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelBlockObserver.swift
@@ -18,7 +18,7 @@ final class TunnelBlockObserver: TunnelObserver {
         _ previousDeviceState: DeviceState
     ) -> Void
     typealias DidUpdateTunnelSettingsHandler = (TunnelManager, LatestTunnelSettings) -> Void
-    typealias DidFailWithErrorHandler = (TunnelManager, Error) -> Void
+    typealias DidFailWithErrorHandler = (TunnelManager, any Error) -> Void
 
     private let didLoadConfiguration: DidLoadConfigurationHandler?
     private let didUpdateTunnelStatus: DidUpdateTunnelStatusHandler?
@@ -60,7 +60,7 @@ final class TunnelBlockObserver: TunnelObserver {
         didUpdateTunnelSettings?(manager, tunnelSettings)
     }
 
-    func tunnelManager(_ manager: TunnelManager, didFailWithError error: Error) {
+    func tunnelManager(_ manager: TunnelManager, didFailWithError error: any Error) {
         didFailWithError?(manager, error)
     }
 }

--- a/ios/MullvadVPN/TunnelManager/TunnelObserver.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelObserver.swift
@@ -18,5 +18,5 @@ protocol TunnelObserver: AnyObject {
         previousDeviceState: DeviceState
     )
     func tunnelManager(_ manager: TunnelManager, didUpdateTunnelSettings tunnelSettings: LatestTunnelSettings)
-    func tunnelManager(_ manager: TunnelManager, didFailWithError error: Error)
+    func tunnelManager(_ manager: TunnelManager, didFailWithError error: any Error)
 }

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -45,7 +45,7 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver {
         return persistentTunnels
     }
 
-    func loadPersistentTunnels(completion: @escaping (Error?) -> Void) {
+    func loadPersistentTunnels(completion: @escaping ((any Error)?) -> Void) {
         TunnelProviderManagerType.loadAllFromPreferences { managers, error in
             self.lock.lock()
             defer {

--- a/ios/MullvadVPN/TunnelManager/UpdateDeviceDataOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/UpdateDeviceDataOperation.swift
@@ -15,15 +15,15 @@ import Operations
 import WireGuardKitTypes
 
 class UpdateDeviceDataOperation: ResultOperation<StoredDeviceData> {
-    private let interactor: TunnelInteractor
-    private let devicesProxy: DeviceHandling
+    private let interactor: any TunnelInteractor
+    private let devicesProxy: any DeviceHandling
 
-    private var task: Cancellable?
+    private var task: (any Cancellable)?
 
     init(
         dispatchQueue: DispatchQueue,
-        interactor: TunnelInteractor,
-        devicesProxy: DeviceHandling
+        interactor: any TunnelInteractor,
+        devicesProxy: any DeviceHandling
     ) {
         self.interactor = interactor
         self.devicesProxy = devicesProxy
@@ -54,7 +54,7 @@ class UpdateDeviceDataOperation: ResultOperation<StoredDeviceData> {
         task = nil
     }
 
-    private func didReceiveDeviceResponse(result: Result<Device, Error>) {
+    private func didReceiveDeviceResponse(result: Result<Device, any Error>) {
         let result = result.tryMap { device -> StoredDeviceData in
             switch interactor.deviceState {
             case .loggedIn(let storedAccount, var storedDevice):

--- a/ios/MullvadVPN/TunnelManager/VPNConnectionProtocol.swift
+++ b/ios/MullvadVPN/TunnelManager/VPNConnectionProtocol.swift
@@ -20,11 +20,11 @@ protocol VPNTunnelProviderManagerProtocol: Equatable {
 
     init()
 
-    func loadFromPreferences(completionHandler: @escaping (Error?) -> Void)
-    func saveToPreferences(completionHandler: ((Error?) -> Void)?)
-    func removeFromPreferences(completionHandler: ((Error?) -> Void)?)
+    func loadFromPreferences(completionHandler: @escaping ((any Error)?) -> Void)
+    func saveToPreferences(completionHandler: (((any Error)?) -> Void)?)
+    func removeFromPreferences(completionHandler: (((any Error)?) -> Void)?)
 
-    static func loadAllFromPreferences(completionHandler: @escaping ([SelfType]?, Error?) -> Void)
+    static func loadAllFromPreferences(completionHandler: @escaping ([SelfType]?, (any Error)?) -> Void)
 }
 
 protocol VPNConnectionProtocol: NSObject {

--- a/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
@@ -16,18 +16,18 @@ import StoreKit
 final class AccountInteractor {
     private let storePaymentManager: StorePaymentManager
     let tunnelManager: TunnelManager
-    let accountsProxy: RESTAccountHandling
+    let accountsProxy: any RESTAccountHandling
 
     var didReceivePaymentEvent: ((StorePaymentEvent) -> Void)?
     var didReceiveDeviceState: ((DeviceState) -> Void)?
 
-    private var tunnelObserver: TunnelObserver?
-    private var paymentObserver: StorePaymentObserver?
+    private var tunnelObserver: (any TunnelObserver)?
+    private var paymentObserver: (any StorePaymentObserver)?
 
     init(
         storePaymentManager: StorePaymentManager,
         tunnelManager: TunnelManager,
-        accountsProxy: RESTAccountHandling
+        accountsProxy: any RESTAccountHandling
     ) {
         self.storePaymentManager = storePaymentManager
         self.tunnelManager = tunnelManager
@@ -63,8 +63,8 @@ final class AccountInteractor {
 
     func restorePurchases(
         for accountNumber: String,
-        completionHandler: @escaping (Result<REST.CreateApplePaymentResponse, Error>) -> Void
-    ) -> Cancellable {
+        completionHandler: @escaping (Result<REST.CreateApplePaymentResponse, any Error>) -> Void
+    ) -> any Cancellable {
         storePaymentManager.restorePurchases(
             for: accountNumber,
             completionHandler: completionHandler
@@ -73,8 +73,8 @@ final class AccountInteractor {
 
     func requestProducts(
         with productIdentifiers: Set<StoreSubscription>,
-        completionHandler: @escaping (Result<SKProductsResponse, Error>) -> Void
-    ) -> Cancellable {
+        completionHandler: @escaping (Result<SKProductsResponse, any Error>) -> Void
+    ) -> any Cancellable {
         storePaymentManager.requestProducts(
             with: productIdentifiers,
             completionHandler: completionHandler

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
@@ -18,7 +18,7 @@ class AccountDeletionContentView: UIView {
     enum State {
         case initial
         case loading
-        case failure(Error)
+        case failure(any Error)
     }
 
     private let scrollView: UIScrollView = {
@@ -265,7 +265,7 @@ class AccountDeletionContentView: UIView {
         return inputLengthIsValid && inputMatchesAccountNumber
     }
 
-    weak var delegate: AccountDeletionContentViewDelegate?
+    weak var delegate: (any AccountDeletionContentViewDelegate)?
 
     override init(frame: CGRect) {
         super.init(frame: .zero)

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewController.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewController.swift
@@ -21,7 +21,7 @@ class AccountDeletionViewController: UIViewController {
         return view
     }()
 
-    weak var delegate: AccountDeletionViewControllerDelegate?
+    weak var delegate: (any AccountDeletionViewControllerDelegate)?
     var interactor: AccountDeletionInteractor
 
     init(interactor: AccountDeletionInteractor) {
@@ -49,7 +49,7 @@ class AccountDeletionViewController: UIViewController {
         contentView.isEditing = false
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
         contentView.isEditing = false
         super.viewWillTransition(to: size, with: coordinator)
     }

--- a/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
@@ -90,7 +90,7 @@ class SetupAccountCompletedContentView: UIView {
         return stackView
     }()
 
-    weak var delegate: SetupAccountCompletedContentViewDelegate?
+    weak var delegate: (any SetupAccountCompletedContentViewDelegate)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedController.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedController.swift
@@ -36,7 +36,7 @@ class SetupAccountCompletedController: UIViewController, RootContainment {
         true
     }
 
-    weak var delegate: SetupAccountCompletedControllerDelegate?
+    weak var delegate: (any SetupAccountCompletedControllerDelegate)?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
@@ -158,7 +158,7 @@ final class WelcomeContentView: UIView {
         return stackView
     }()
 
-    weak var delegate: WelcomeContentViewDelegate?
+    weak var delegate: (any WelcomeContentViewDelegate)?
     var viewModel: WelcomeViewModel? {
         didSet {
             accountNumberLabel.text = viewModel?.accountNumber

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeInteractor.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeInteractor.swift
@@ -17,10 +17,10 @@ final class WelcomeInteractor {
 
     /// Interval used for periodic polling account updates.
     private let accountUpdateTimerInterval: Duration = .minutes(1)
-    private var accountUpdateTimer: DispatchSourceTimer?
+    private var accountUpdateTimer: (any DispatchSourceTimer)?
 
     private let logger = Logger(label: "\(WelcomeInteractor.self)")
-    private var tunnelObserver: TunnelObserver?
+    private var tunnelObserver: (any TunnelObserver)?
     private(set) var product: SKProduct?
 
     var didChangeInAppPurchaseState: ((ProductState) -> Void)?

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeViewController.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeViewController.swift
@@ -24,7 +24,7 @@ class WelcomeViewController: UIViewController, RootContainment {
 
     private let interactor: WelcomeInteractor
 
-    weak var delegate: WelcomeViewControllerDelegate?
+    weak var delegate: (any WelcomeViewControllerDelegate)?
 
     var preferredHeaderBarPresentation: HeaderBarPresentation {
         HeaderBarPresentation(style: .default, showsDivider: true)

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
@@ -18,7 +18,7 @@ protocol DeviceManagementViewControllerDelegate: AnyObject {
 }
 
 class DeviceManagementViewController: UIViewController, RootContainment {
-    weak var delegate: DeviceManagementViewControllerDelegate?
+    weak var delegate: (any DeviceManagementViewControllerDelegate)?
 
     var preferredHeaderBarPresentation: HeaderBarPresentation {
         .default
@@ -86,7 +86,7 @@ class DeviceManagementViewController: UIViewController, RootContainment {
 
     func fetchDevices(
         animateUpdates: Bool,
-        completionHandler: ((Result<Void, Error>) -> Void)? = nil
+        completionHandler: ((Result<Void, any Error>) -> Void)? = nil
     ) {
         interactor.getDevices { [weak self] result in
             guard let self = self else { return }
@@ -150,7 +150,7 @@ class DeviceManagementViewController: UIViewController, RootContainment {
         }
     }
 
-    private func getErrorDescription(_ error: Error) -> String {
+    private func getErrorDescription(_ error: any Error) -> String {
         if case let .network(urlError) = error as? REST.Error {
             return urlError.localizedDescription
         } else {
@@ -158,7 +158,7 @@ class DeviceManagementViewController: UIViewController, RootContainment {
         }
     }
 
-    private func showErrorAlert(title: String, error: Error) {
+    private func showErrorAlert(title: String, error: any Error) {
         let presentation = AlertPresentation(
             id: "delete-device-error-alert",
             title: title,
@@ -234,7 +234,7 @@ class DeviceManagementViewController: UIViewController, RootContainment {
         alertPresenter.showAlert(presentation: presentation, animated: true)
     }
 
-    private func deleteDevice(identifier: String, completionHandler: @escaping (Error?) -> Void) {
+    private func deleteDevice(identifier: String, completionHandler: @escaping ((any Error)?) -> Void) {
         interactor.deleteDevice(identifier) { [weak self] completion in
             guard let self = self else { return }
 

--- a/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
@@ -543,7 +543,7 @@ final class AccountInputGroupView: UIView {
 }
 
 private class AccountInputBorderLayer: CAShapeLayer {
-    override class func defaultAction(forKey event: String) -> CAAction? {
+    override class func defaultAction(forKey event: String) -> (any CAAction)? {
         if event == "path" {
             let action = CABasicAnimation(keyPath: event)
             action.duration = animationDuration.timeInterval

--- a/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
@@ -13,7 +13,7 @@ import MullvadSettings
 final class LoginInteractor {
     private let tunnelManager: TunnelManager
     private let logger = Logger(label: "LoginInteractor")
-    private var tunnelObserver: TunnelObserver?
+    private var tunnelObserver: (any TunnelObserver)?
     var didCreateAccount: (() -> Void)?
     var suggestPreferredAccountNumber: ((String) -> Void)?
 

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeInteractor.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeInteractor.swift
@@ -18,13 +18,13 @@ final class OutOfTimeInteractor {
     private let storePaymentManager: StorePaymentManager
     private let tunnelManager: TunnelManager
 
-    private var tunnelObserver: TunnelObserver?
-    private var paymentObserver: StorePaymentObserver?
+    private var tunnelObserver: (any TunnelObserver)?
+    private var paymentObserver: (any StorePaymentObserver)?
 
     private let logger = Logger(label: "OutOfTimeInteractor")
 
     private let accountUpdateTimerInterval: Duration = .minutes(1)
-    private var accountUpdateTimer: DispatchSourceTimer?
+    private var accountUpdateTimer: (any DispatchSourceTimer)?
 
     var didReceivePaymentEvent: ((StorePaymentEvent) -> Void)?
     var didReceiveTunnelStatus: ((TunnelStatus) -> Void)?
@@ -78,9 +78,9 @@ final class OutOfTimeInteractor {
         for accountNumber: String,
         completionHandler: @escaping (Result<
             REST.CreateApplePaymentResponse,
-            Error
+            any Error
         >) -> Void
-    ) -> Cancellable {
+    ) -> any Cancellable {
         storePaymentManager.restorePurchases(
             for: accountNumber,
             completionHandler: completionHandler
@@ -89,8 +89,8 @@ final class OutOfTimeInteractor {
 
     func requestProducts(
         with productIdentifiers: Set<StoreSubscription>,
-        completionHandler: @escaping (Result<SKProductsResponse, Error>) -> Void
-    ) -> Cancellable {
+        completionHandler: @escaping (Result<SKProductsResponse, any Error>) -> Void
+    ) -> any Cancellable {
         storePaymentManager.requestProducts(
             with: productIdentifiers,
             completionHandler: completionHandler

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
@@ -18,7 +18,7 @@ protocol OutOfTimeViewControllerDelegate: AnyObject {
 }
 
 class OutOfTimeViewController: UIViewController, RootContainment {
-    weak var delegate: OutOfTimeViewControllerDelegate?
+    weak var delegate: (any OutOfTimeViewControllerDelegate)?
 
     private let interactor: OutOfTimeInteractor
     private let errorPresenter: PaymentAlertPresenter

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
@@ -12,7 +12,7 @@ import MullvadTypes
 import Operations
 
 final class ProblemReportInteractor {
-    private let apiProxy: APIQuerying
+    private let apiProxy: any APIQuerying
     private let tunnelManager: TunnelManager
 
     private lazy var consolidatedLog: ConsolidatedApplicationLog = {
@@ -31,7 +31,7 @@ final class ProblemReportInteractor {
         return report
     }()
 
-    init(apiProxy: APIQuerying, tunnelManager: TunnelManager) {
+    init(apiProxy: any APIQuerying, tunnelManager: TunnelManager) {
         self.apiProxy = apiProxy
         self.tunnelManager = tunnelManager
     }
@@ -39,8 +39,8 @@ final class ProblemReportInteractor {
     func sendReport(
         email: String,
         message: String,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) -> Cancellable {
+        completion: @escaping (Result<Void, any Error>) -> Void
+    ) -> any Cancellable {
         let request = REST.ProblemReportRequest(
             address: email,
             message: message,

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherInteractor.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherInteractor.swift
@@ -12,10 +12,10 @@ import MullvadTypes
 
 final class RedeemVoucherInteractor {
     private let tunnelManager: TunnelManager
-    private let accountsProxy: RESTAccountHandling
+    private let accountsProxy: any RESTAccountHandling
     private let shouldVerifyVoucherAsAccount: Bool
 
-    private var tasks: [Cancellable] = []
+    private var tasks: [any Cancellable] = []
     private var preferredAccountNumber: String?
 
     var showLogoutDialog: (() -> Void)?
@@ -23,7 +23,7 @@ final class RedeemVoucherInteractor {
 
     init(
         tunnelManager: TunnelManager,
-        accountsProxy: RESTAccountHandling,
+        accountsProxy: any RESTAccountHandling,
         verifyVoucherAsAccount: Bool
     ) {
         self.tunnelManager = tunnelManager
@@ -33,7 +33,7 @@ final class RedeemVoucherInteractor {
 
     func redeemVoucher(
         code: String,
-        completion: @escaping ((Result<REST.SubmitVoucherResponse, Error>) -> Void)
+        completion: @escaping ((Result<REST.SubmitVoucherResponse, any Error>) -> Void)
     ) {
         tasks.append(tunnelManager.redeemVoucher(code) { [weak self] result in
             guard let self else { return }

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
@@ -22,7 +22,7 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
     private let contentView: RedeemVoucherContentView
     private var interactor: RedeemVoucherInteractor
 
-    weak var delegate: RedeemVoucherViewControllerDelegate?
+    weak var delegate: (any RedeemVoucherViewControllerDelegate)?
 
     init(
         configuration: RedeemVoucherViewConfiguration,
@@ -79,7 +79,7 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
         contentView.isEditing = false
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
         contentView.isEditing = false
         super.viewWillTransition(to: size, with: coordinator)
     }

--- a/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceInteractor.swift
+++ b/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceInteractor.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class RevokedDeviceInteractor {
     private let tunnelManager: TunnelManager
-    private var tunnelObserver: TunnelObserver?
+    private var tunnelObserver: (any TunnelObserver)?
 
     var didUpdateTunnelStatus: ((TunnelStatus) -> Void)?
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/CustomListsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/CustomListsDataSource.swift
@@ -13,9 +13,9 @@ import MullvadTypes
 
 class CustomListsDataSource: LocationDataSourceProtocol {
     private(set) var nodes = [LocationNode]()
-    private(set) var repository: CustomListRepositoryProtocol
+    private(set) var repository: any CustomListRepositoryProtocol
 
-    init(repository: CustomListRepositoryProtocol) {
+    init(repository: any CustomListRepositoryProtocol) {
         self.repository = repository
     }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -14,7 +14,7 @@ protocol LocationCellDelegate: AnyObject {
 }
 
 class LocationCell: UITableViewCell {
-    weak var delegate: LocationCellDelegate?
+    weak var delegate: (any LocationCellDelegate)?
 
     private let locationLabel: UILabel = {
         let label = UILabel()

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -25,8 +25,8 @@ final class LocationViewController: UIViewController {
     private var cachedRelays: CachedRelays?
     private var filter = RelayFilter()
     var relayLocations: UserSelectedRelays?
-    weak var delegate: LocationViewControllerDelegate?
-    var customListRepository: CustomListRepositoryProtocol
+    weak var delegate: (any LocationViewControllerDelegate)?
+    var customListRepository: any CustomListRepositoryProtocol
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         .lightContent
@@ -41,7 +41,7 @@ final class LocationViewController: UIViewController {
     var didUpdateFilter: ((RelayFilter) -> Void)?
     var didFinish: (() -> Void)?
 
-    init(customListRepository: CustomListRepositoryProtocol) {
+    init(customListRepository: any CustomListRepositoryProtocol) {
         self.customListRepository = customListRepository
         super.init(nibName: nil, bundle: nil)
     }

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
@@ -65,7 +65,7 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
     private var storedAccountData: StoredAccountData?
     private weak var tableView: UITableView?
 
-    weak var delegate: SettingsDataSourceDelegate?
+    weak var delegate: (any SettingsDataSourceDelegate)?
 
     init(tableView: UITableView, interactor: SettingsInteractor) {
         self.tableView = tableView

--- a/ios/MullvadVPN/View controllers/Settings/SettingsInteractorFactory.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsInteractorFactory.swift
@@ -11,18 +11,18 @@ import MullvadSettings
 
 final class SettingsInteractorFactory {
     private let storePaymentManager: StorePaymentManager
-    private let apiProxy: APIQuerying
+    private let apiProxy: any APIQuerying
     private let relayCacheTracker: RelayCacheTracker
-    private let ipOverrideRepository: IPOverrideRepositoryProtocol
+    private let ipOverrideRepository: any IPOverrideRepositoryProtocol
 
     let tunnelManager: TunnelManager
 
     init(
         storePaymentManager: StorePaymentManager,
         tunnelManager: TunnelManager,
-        apiProxy: APIQuerying,
+        apiProxy: any APIQuerying,
         relayCacheTracker: RelayCacheTracker,
-        ipOverrideRepository: IPOverrideRepositoryProtocol
+        ipOverrideRepository: any IPOverrideRepositoryProtocol
     ) {
         self.storePaymentManager = storePaymentManager
         self.tunnelManager = tunnelManager

--- a/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
@@ -19,7 +19,7 @@ protocol SettingsViewControllerDelegate: AnyObject {
 }
 
 class SettingsViewController: UITableViewController, SettingsDataSourceDelegate {
-    weak var delegate: SettingsViewControllerDelegate?
+    weak var delegate: (any SettingsViewControllerDelegate)?
     private var dataSource: SettingsDataSource?
     private let interactor: SettingsInteractor
 

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -115,7 +115,7 @@ class TunnelViewController: UIViewController, RootContainment {
 
     override func viewWillTransition(
         to size: CGSize,
-        with coordinator: UIViewControllerTransitionCoordinator
+        with coordinator: any UIViewControllerTransitionCoordinator
     ) {
         super.viewWillTransition(to: size, with: coordinator)
 

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewControllerInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewControllerInteractor.swift
@@ -12,9 +12,9 @@ import MullvadTypes
 
 final class TunnelViewControllerInteractor {
     private let tunnelManager: TunnelManager
-    private let outgoingConnectionService: OutgoingConnectionServiceHandling
-    private var tunnelObserver: TunnelObserver?
-    private var outgoingConnectionTask: Task<Void, Error>?
+    private let outgoingConnectionService: any OutgoingConnectionServiceHandling
+    private var tunnelObserver: (any TunnelObserver)?
+    private var outgoingConnectionTask: Task<Void, any Error>?
 
     var didUpdateTunnelStatus: ((TunnelStatus) -> Void)?
     var didUpdateDeviceState: ((_ deviceState: DeviceState, _ previousDeviceState: DeviceState) -> Void)?
@@ -34,7 +34,7 @@ final class TunnelViewControllerInteractor {
 
     init(
         tunnelManager: TunnelManager,
-        outgoingConnectionService: OutgoingConnectionServiceHandling
+        outgoingConnectionService: any OutgoingConnectionServiceHandling
     ) {
         self.tunnelManager = tunnelManager
         self.outgoingConnectionService = outgoingConnectionService

--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
@@ -19,7 +19,7 @@ protocol CustomDNSCellEventHandler {
 final class CustomDNSCellFactory: CellFactoryProtocol {
     let tableView: UITableView
     var viewModel: VPNSettingsViewModel
-    var delegate: CustomDNSCellEventHandler?
+    var delegate: (any CustomDNSCellEventHandler)?
     var isEditing = false
 
     init(tableView: UITableView, viewModel: VPNSettingsViewModel) {

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -155,7 +155,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
     private let vpnSettingsCellFactory: VPNSettingsCellFactory
     private weak var tableView: UITableView?
 
-    weak var delegate: VPNSettingsDataSourceDelegate?
+    weak var delegate: (any VPNSettingsDataSourceDelegate)?
 
     var selectedIndexPaths: [IndexPath] {
         let wireGuardPortItem: Item = viewModel.customWireGuardPort == nil

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInteractor.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInteractor.swift
@@ -12,7 +12,7 @@ import MullvadSettings
 
 final class VPNSettingsInteractor {
     let tunnelManager: TunnelManager
-    private var tunnelObserver: TunnelObserver?
+    private var tunnelObserver: (any TunnelObserver)?
     private let relayCacheTracker: RelayCacheTracker
 
     var tunnelSettingsDidChange: ((LatestTunnelSettings) -> Void)?


### PR DESCRIPTION
We need to add the keyword 'any' whenever we're using protocols. In Swift 6 this will be enforced. To test, enable the ExistentialAny feature flag to force the correct usage.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6125)
<!-- Reviewable:end -->
