### PR TITLE
Fix Windows compile errors due to missing features

### DIFF
--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -39,6 +39,7 @@ talpid-windows = { path = "../talpid-windows" }
 workspace = true
 features = [
     "Win32_Foundation",
+    "Win32_System_Com",
     "Win32_System_LibraryLoader",
     "Win32_System_Registry",
     "Win32_NetworkManagement_Ndis",

--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Globalization",
+    "Win32_Security",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_IO",
     "Win32_Networking_WinSock",


### PR DESCRIPTION
While investigating issues with Wintun, I stumbled upon 2 cases where `talpid-*` crates would not compile correctly on Windows due to missing Cargo features.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6127)
<!-- Reviewable:end -->
