### PR TITLE
Prevent SelectLocation view from reseting scroll position on back navigation

### DIFF
--- a/gui/src/renderer/components/select-location/ScrollPositionContext.tsx
+++ b/gui/src/renderer/components/select-location/ScrollPositionContext.tsx
@@ -1,5 +1,7 @@
+import { Action } from 'history';
 import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 
+import { useHistory } from '../../lib/history';
 import { useNormalRelaySettings, useStyledRef } from '../../lib/utilityHooks';
 import { CustomScrollbarsRef } from '../CustomScrollbars';
 import { LocationType } from './select-location-types';
@@ -36,6 +38,9 @@ interface ScrollPositionContextProps {
 export function ScrollPositionContextProvider(props: ScrollPositionContextProps) {
   const { locationType, searchTerm } = useSelectLocationContext();
   const relaySettings = useNormalRelaySettings();
+
+  const { action } = useHistory();
+  const recentNavigationAction = useRef<Action | null>(action);
 
   const scrollPositions = useRef<Partial<Record<LocationType, ScrollPosition>>>({});
   const scrollViewRef = useRef<CustomScrollbarsRef>(null);
@@ -82,6 +87,11 @@ export function ScrollPositionContextProvider(props: ScrollPositionContextProps)
 
   // Restore the scroll position when parameters change
   useEffect(() => {
+    if (recentNavigationAction.current === 'POP') {
+      recentNavigationAction.current = null;
+      return;
+    }
+
     const scrollPosition = scrollPositions.current?.[locationType];
     if (scrollPosition) {
       scrollViewRef.current?.scrollTo(...scrollPosition);


### PR DESCRIPTION
This PR enforces the stored scroll position when navigating back to the select location view. The behavior before this PR was that the select location view would scroll to the currently selected item when navigating back from either the filter view or the custom bridge view. This PR prevents that by suppressing that logic for `POP` navigations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6129)
<!-- Reviewable:end -->
