### PR TITLE
Limit the name of a custom list to 30 characters

### DIFF
--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListCellConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListCellConfiguration.swift
@@ -75,6 +75,7 @@ struct CustomListCellConfiguration {
         contentConfiguration.setPlaceholder(type: .required)
         contentConfiguration.textFieldProperties = .withSmartFeaturesDisabled()
         contentConfiguration.inputText = subject.value.name
+        contentConfiguration.maxLength = 30
         contentConfiguration.editingEvents.onChange = subject.bindTextAction(to: \.name)
 
         cell.contentConfiguration = contentConfiguration

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -20,9 +20,8 @@ class LocationCell: UITableViewCell {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 16)
         label.textColor = .white
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
-        label.lineBreakStrategy = []
+        label.lineBreakMode = .byTruncatingTail
+        label.numberOfLines = 1
         return label
     }()
 


### PR DESCRIPTION
We must limit the name of the name of a custom list to 30 UTF-8 characters.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6131)
<!-- Reviewable:end -->
