### PR TITLE
Align server IP override title with desktop

### DIFF
--- a/android/lib/resource/src/main/res/values-da/strings.xml
+++ b/android/lib/resource/src/main/res/values-da/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Sendt</string>
     <string name="sent_contact">Hvis det er nødvendigt, kontakter vi dig på %1$s</string>
     <string name="sent_thanks">Tak!</string>
+    <string name="server_ip_overrides">Server IP tilsidesættelse</string>
     <string name="server_ip_overrides_info_first_paragraph">På nogle netværk, hvor der bruges forskellige typer censur, er vores server IP-adresser nogle gange blokeret.</string>
     <string name="server_ip_overrides_info_second_paragraph">For at omgå dette kan du importere en fil eller en tekst, leveret af vores supportteam, med nye IP-adresser, der tilsidesætter standardadresserne på serverne i visningen Vælg placering.</string>
     <string name="server_ip_overrides_info_third_paragraph">Hvis du har problemer med at oprette forbindelse til VPN-servere, bedes du kontakte support.</string>

--- a/android/lib/resource/src/main/res/values-de/strings.xml
+++ b/android/lib/resource/src/main/res/values-de/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Gesendet</string>
     <string name="sent_contact">Bei Bedarf werden wir Sie über %1$s kontaktieren</string>
     <string name="sent_thanks">Danke!</string>
+    <string name="server_ip_overrides">Server-IP überschreiben</string>
     <string name="server_ip_overrides_info_first_paragraph">In einigen Netzwerken, in denen verschiedene Arten der Zensur eingesetzt werden, werden die IP-Adressen unserer Server manchmal blockiert.</string>
     <string name="server_ip_overrides_info_second_paragraph">Um dies zu umgehen, können Sie eine Datei oder einen von unserem Support-Team bereitgestellten Text mit neuen IP-Adressen importieren, die die Standardadressen der Server in der Ortsauswahl außer Kraft setzen.</string>
     <string name="server_ip_overrides_info_third_paragraph">Wenn Sie Probleme mit der Verbindung zu VPN-Servern haben, wenden Sie sich bitte an den Support.</string>

--- a/android/lib/resource/src/main/res/values-es/strings.xml
+++ b/android/lib/resource/src/main/res/values-es/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Enviado</string>
     <string name="sent_contact">Si es necesario, le enviaremos un correo electrónico a %1$s</string>
     <string name="sent_thanks">¡Gracias!</string>
+    <string name="server_ip_overrides">Anulación de IP de servidor</string>
     <string name="server_ip_overrides_info_first_paragraph">En algunas redes, donde se aplican diversos tipos de censura, a veces se bloquean las direcciones IP de nuestro servidor.</string>
     <string name="server_ip_overrides_info_second_paragraph">Para eludir esto, puede importar un archivo o texto, suministrado por nuestro equipo de asistencia, con nuevas direcciones IP que anulan las direcciones predeterminadas de los servidores en la vista Seleccionar ubicación.</string>
     <string name="server_ip_overrides_info_third_paragraph">Si tiene problemas para conectarse a los servidores VPN, póngase en contacto con el servicio de asistencia.</string>

--- a/android/lib/resource/src/main/res/values-fi/strings.xml
+++ b/android/lib/resource/src/main/res/values-fi/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Lähetetty</string>
     <string name="sent_contact">Tarvittaessa otamme sinuun yhteyttä osoitteeseen %1$s</string>
     <string name="sent_thanks">Kiitos!</string>
+    <string name="server_ip_overrides">Palvelimen IP-osoitteen ohitus</string>
     <string name="server_ip_overrides_info_first_paragraph">Palvelimiemme IP-osoitteet estetään toisinaan joissakin useita erityyppistä sensurointimenetelmiä käyttävissä verkoissa.</string>
     <string name="server_ip_overrides_info_second_paragraph">Voit kiertää estot tuomalla tukitiimimme toimittaman tiedoston tai tekstin, josta löytyy uusia, palvelimien oletusosoitteet sijainnin valintanäkymässä ohittavia IP-osoitteita.</string>
     <string name="server_ip_overrides_info_third_paragraph">Jos sinulla on ongelmia yhteyden muodostamisessa VPN-palvelimiin, ota yhteyttä tukeen.</string>

--- a/android/lib/resource/src/main/res/values-fr/strings.xml
+++ b/android/lib/resource/src/main/res/values-fr/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Envoyé</string>
     <string name="sent_contact">Si nécessaire, nous vous contacterons à l\'adresse %1$s</string>
     <string name="sent_thanks">Merci !</string>
+    <string name="server_ip_overrides">Substitution d\'IP de serveur</string>
     <string name="server_ip_overrides_info_first_paragraph">Sur certains réseaux, où divers types de censure sont utilisés, les adresses IP de notre serveur sont parfois bloquées.</string>
     <string name="server_ip_overrides_info_second_paragraph">Pour contourner ce problème, vous pouvez importer un fichier ou du texte fourni par notre équipe d\'assistance, avec de nouvelles adresses IP qui remplacent les adresses par défaut des serveurs dans la vue Sélectionner un emplacement.</string>
     <string name="server_ip_overrides_info_third_paragraph">Si vous rencontrez des problèmes de connexion aux serveurs VPN, veuillez contacter l\'assistance.</string>

--- a/android/lib/resource/src/main/res/values-it/strings.xml
+++ b/android/lib/resource/src/main/res/values-it/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Inviato</string>
     <string name="sent_contact">Se necessario, ti contatteremo all\'indirizzo %1$s</string>
     <string name="sent_thanks">Grazie!</string>
+    <string name="server_ip_overrides">Sovrascritture IP server</string>
     <string name="server_ip_overrides_info_first_paragraph">Su alcune reti, dove vengono utilizzati vari tipi di censura, gli indirizzi IP dei nostri server vengono talvolta bloccati.</string>
     <string name="server_ip_overrides_info_second_paragraph">Per aggirare questo problema, puoi importare un file o un testo, fornito dal nostro team di supporto, con nuovi indirizzi IP che sovrascrivono gli indirizzi predefiniti dei server nella vista Seleziona posizione.</string>
     <string name="server_ip_overrides_info_third_paragraph">Se riscontri problemi di connessione ai server VPN, contatta l\'assistenza.</string>

--- a/android/lib/resource/src/main/res/values-ja/strings.xml
+++ b/android/lib/resource/src/main/res/values-ja/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">送信済み</string>
     <string name="sent_contact">必要に応じて %1$s 宛にご連絡します　</string>
     <string name="sent_thanks">ありがとうございます！</string>
+    <string name="server_ip_overrides">サーバーIPのオーバーライド</string>
     <string name="server_ip_overrides_info_first_paragraph">各種の検閲が使用されている一部のネットワークでは、サーバーIPアドレスがブロックされる場合があります。</string>
     <string name="server_ip_overrides_info_second_paragraph">これを回避するには、「場所を選択」ビューでサポートチームが提供したサーバーのデフォルトアドレスをオーバーライドする新しいIPアドレスを含むファイルまたはテキストをインポートできます。</string>
     <string name="server_ip_overrides_info_third_paragraph">VPNサーバーへの接続に問題が生じている場合は、サポートにお問い合わせください。</string>

--- a/android/lib/resource/src/main/res/values-ko/strings.xml
+++ b/android/lib/resource/src/main/res/values-ko/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">전송 완료</string>
     <string name="sent_contact">필요한 경우 %1$s(으)로 연락드리겠습니다.</string>
     <string name="sent_thanks">감사합니다!</string>
+    <string name="server_ip_overrides">서버 IP 재정의</string>
     <string name="server_ip_overrides_info_first_paragraph">다양한 유형의 검열이 사용되고 있는 일부 네트워크에서는 때때로 당사 서버 IP 주소가 차단됩니다.</string>
     <string name="server_ip_overrides_info_second_paragraph">이를 우회하려면 \'위치 선택\' 보기에서 서버의 기본 주소를 재정의하는 새 IP 주소를 사용하여 지원 팀에서 제공한 파일이나 텍스트를 가져올 수 있습니다.</string>
     <string name="server_ip_overrides_info_third_paragraph">VPN 서버 연결에 문제가 있는 경우 지원 팀에 문의하세요.</string>

--- a/android/lib/resource/src/main/res/values-my/strings.xml
+++ b/android/lib/resource/src/main/res/values-my/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">ပို့ပြီး</string>
     <string name="sent_contact">လိုအပ်ပါက %1$s မှတစ်ဆင့် ကျွန်ုပ်တို့ထံ ဆက်သွယ်ပါ</string>
     <string name="sent_thanks">ကျေးဇူးတင်ပါသည်။</string>
+    <string name="server_ip_overrides">ဆာဗာ IP ကျော်လွန် ပယ်ဖျက်မှု</string>
     <string name="server_ip_overrides_info_first_paragraph">အမျိုးအမျိုးသော စိစစ်ဖြတ်တောက်မှု အမျိုးအစားများ အသုံးပြုသည့် ကွန်ရက်အချို့တွင် ကျွန်ုပ်တို့၏ ဆာဗာ IP လိပ်စာများကို တစ်ခါတစ်ရံ ပိတ်ဆို့ထားပါသည်။</string>
     <string name="server_ip_overrides_info_second_paragraph">ဤသည်ကို ရှောင်လွှဲရန် ကျွန်ုပ်တို့ အကူအညီပေးရေးအဖွဲ့မှ ပေးထားသော တည်နေရာ ရွေးရန် ပြသမှုအတွင်းရှိ ဆာဗာများ၏ ပုံသေ လိပ်စာများကို ကျော်လွန် ပယ်ဖျက်သည့် IP လိပ်စာအသစ်များဖြင့် ဖိုင် သို့မဟုတ် စာသားကို သင် ထည့်သွင်းနိုင်ပါသည်။</string>
     <string name="server_ip_overrides_info_third_paragraph">VPN ဆာဗာများကို ချိတ်ဆက်ရာတွင် ပြဿနာများရှိနေပါက အကူအညီပေးရေးအဖွဲ့ကို ဆက်သွယ်ပါ။</string>

--- a/android/lib/resource/src/main/res/values-nb/strings.xml
+++ b/android/lib/resource/src/main/res/values-nb/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Sendt</string>
     <string name="sent_contact">Vi vil kontakte deg på %1$s ved behov</string>
     <string name="sent_thanks">Takk!</string>
+    <string name="server_ip_overrides">Overstyring av server-IP</string>
     <string name="server_ip_overrides_info_first_paragraph">På enkelte nettverk der det brukes ulike typer sensur, kan server-IP-adressene av og til være blokkerte.</string>
     <string name="server_ip_overrides_info_second_paragraph">For å omgå dette kan du importere en fil eller tekst, som du har fått fra kundestøtteteamet, med nye IP-adresser som overstyrer standardadressene til serverne i «Velg plassering».</string>
     <string name="server_ip_overrides_info_third_paragraph">Hvis du har mistet tilkoblingen til VPN-serverne, kan du ta kontak med kundestøtten.</string>

--- a/android/lib/resource/src/main/res/values-nl/strings.xml
+++ b/android/lib/resource/src/main/res/values-nl/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Verzonden</string>
     <string name="sent_contact">Indien nodig nemen we u contact op via %1$s</string>
     <string name="sent_thanks">Bedankt!</string>
+    <string name="server_ip_overrides">Overschrijving van server-IP-adressen</string>
     <string name="server_ip_overrides_info_first_paragraph">Op sommige netwerken, waar verschillende soorten censuur worden gebruikt, worden onze server-IP-adressen soms geblokkeerd.</string>
     <string name="server_ip_overrides_info_second_paragraph">Om dit te omzeilen, kunt u een door ons ondersteuningsteam verstrekt bestand of tekst importeren, met nieuwe IP-adressen die de standaardadressen van de servers in de weergave Locatie selecteren overschrijven.</string>
     <string name="server_ip_overrides_info_third_paragraph">Als u problemen hebt met het verbinden met VPN-servers, neem dan contact op met de ondersteuning.</string>

--- a/android/lib/resource/src/main/res/values-pl/strings.xml
+++ b/android/lib/resource/src/main/res/values-pl/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Wysłano</string>
     <string name="sent_contact">W razie potrzeby skontaktujemy się z Tobą pod adresem %1$s</string>
     <string name="sent_thanks">Dziękujemy!</string>
+    <string name="server_ip_overrides">Zastąpienie adresu IP serwera</string>
     <string name="server_ip_overrides_info_first_paragraph">W niektórych sieciach, w których stosowane są różnego rodzaju cenzury, adresy IP naszych serwerów są czasami blokowane.</string>
     <string name="server_ip_overrides_info_second_paragraph">Aby obejść ten problem, można zaimportować plik lub tekst dostarczony przez nasz zespół pomocy technicznej, zawierający nowe adresy IP, które zastępują domyślne adresy serwerów w widoku Wybierz lokalizację.</string>
     <string name="server_ip_overrides_info_third_paragraph">Jeśli masz problemy z łączeniem się z serwerami VPN, skontaktuj się z pomocą techniczną.</string>

--- a/android/lib/resource/src/main/res/values-pt/strings.xml
+++ b/android/lib/resource/src/main/res/values-pt/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Enviado</string>
     <string name="sent_contact">Se necessário, iremos contactá-lo através de %1$s</string>
     <string name="sent_thanks">Obrigado!</string>
+    <string name="server_ip_overrides">Substituição de IP de servidor</string>
     <string name="server_ip_overrides_info_first_paragraph">Em algumas redes, onde são utilizados vários tipos de censura, os endereços IP dos nossos servidores são por vezes bloqueados.</string>
     <string name="server_ip_overrides_info_second_paragraph">Para contornar esta situação, pode importar um ficheiro ou texto, fornecido pela nossa equipa de apoio, com novos endereços IP que substituem os endereços padrão dos servidores na vista Selecionar local.</string>
     <string name="server_ip_overrides_info_third_paragraph">Se tiver problemas em ligar-se aos servidores VPN, contacte o apoio.</string>

--- a/android/lib/resource/src/main/res/values-ru/strings.xml
+++ b/android/lib/resource/src/main/res/values-ru/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Отправлено</string>
     <string name="sent_contact">При необходимости мы свяжемся с вами по адресу %1$s</string>
     <string name="sent_thanks">Спасибо!</string>
+    <string name="server_ip_overrides">Переопределение IP-адреса сервера</string>
     <string name="server_ip_overrides_info_first_paragraph">В некоторых сетях, где используются различные виды цензуры, IP-адреса наших серверов иногда блокируются.</string>
     <string name="server_ip_overrides_info_second_paragraph">Чтобы обойти эту проблему, можно импортировать файл или текст, предоставленный нашей службой поддержки, с новыми IP-адресами, которые заменяют адреса серверов по умолчанию в представлении «Выбор местоположения».</string>
     <string name="server_ip_overrides_info_third_paragraph">Если у вас возникли проблемы с подключением к VPN-серверам, обратитесь в службу поддержки.</string>

--- a/android/lib/resource/src/main/res/values-sv/strings.xml
+++ b/android/lib/resource/src/main/res/values-sv/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Skickat</string>
     <string name="sent_contact">Om det behövs kontaktar vi dig på %1$s</string>
     <string name="sent_thanks">Tack!</string>
+    <string name="server_ip_overrides">Åsidosättning av server-IP</string>
     <string name="server_ip_overrides_info_first_paragraph">På vissa nätverk där olika typer av censureringar används blockeras blir ibland vår servers IP-adresser blockerade.</string>
     <string name="server_ip_overrides_info_second_paragraph">För att kringgå detta kan du importera en fil eller text, som tillhandahålls av vårt supportteam, med nya IP-adresser som åsidosätter servrarnas standardadresser i Välj platsvy.</string>
     <string name="server_ip_overrides_info_third_paragraph">Kontakta supporten om du har problem med att ansluta till VPN-servrar.</string>

--- a/android/lib/resource/src/main/res/values-th/strings.xml
+++ b/android/lib/resource/src/main/res/values-th/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">ส่ง</string>
     <string name="sent_contact">เราจะติดต่อคุณไปทาง %1$s ในกรณีจำเป็น</string>
     <string name="sent_thanks">ขอบคุณ!</string>
+    <string name="server_ip_overrides">โอเวอร์ไรด์เซิร์ฟเวอร์ IP</string>
     <string name="server_ip_overrides_info_first_paragraph">บางครั้งที่อยู่ IP เซิร์ฟเวอร์ของเราอาจถูกบล็อก ในบางเครือข่ายที่มีการใช้งานเซ็นเซอร์หลายประเภท</string>
     <string name="server_ip_overrides_info_second_paragraph">ในการหลีกเลี่ยงปัญหานี้ คุณสามารถนำเข้าไฟล์หรือข้อความที่ได้รับจากทีมสนับสนุนของเรา พร้อมด้วยที่อยู่ IP ใหม่ที่โอเวอร์ไรด์ที่อยู่เริ่มต้นของเซิร์ฟเวอร์ในมุมมองเลือกตำแหน่งที่ตั้ง</string>
     <string name="server_ip_overrides_info_third_paragraph">หากคุณประสบปัญหาในการเชื่อมต่อกับเซิร์ฟเวอร์ VPN โปรดติดต่อฝ่ายสนับสนุน</string>

--- a/android/lib/resource/src/main/res/values-tr/strings.xml
+++ b/android/lib/resource/src/main/res/values-tr/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">Gönderildi</string>
     <string name="sent_contact">Gerektiğinde sizinle %1$s adresinden iletişime geçeceğiz</string>
     <string name="sent_thanks">Teşekkürler!</string>
+    <string name="server_ip_overrides">Sunucu IP\'sini geçersiz kılma</string>
     <string name="server_ip_overrides_info_first_paragraph">Farklı sansür türlerinin kullanıldığı bazı ağlarda sunucu IP adreslerimiz zaman zaman engellenir.</string>
     <string name="server_ip_overrides_info_second_paragraph">Bu sınırlamadan kaçınmak için Konum Seç görünümündeki varsayılan sunucu adreslerini geçersiz kılan yeni IP adreslerine sahip bir dosyayı veya metni (destek ekibimiz tarafından sağlanır) içe aktarabilirsiniz.</string>
     <string name="server_ip_overrides_info_third_paragraph">VPN sunucularına bağlanırken sorun yaşıyorsanız lütfen destek ekibiyle iletişime geçin.</string>

--- a/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">已发送</string>
     <string name="sent_contact">如果需要，我们将通过 %1$s 与您联系</string>
     <string name="sent_thanks">谢谢！</string>
+    <string name="server_ip_overrides">服务器 IP 覆盖</string>
     <string name="server_ip_overrides_info_first_paragraph">在某些使用各类审查的网络上，我们的服务器 IP 地址有时会被阻止。</string>
     <string name="server_ip_overrides_info_second_paragraph">为了避免这种情况，您可以导入由我们的支持团队提供的文件或文本，其中的新 IP 地址会覆盖“选择位置”视图中服务器的默认地址。</string>
     <string name="server_ip_overrides_info_third_paragraph">如果您在连接到 VPN 服务器时遇到问题，请联系支持团队。</string>

--- a/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
@@ -215,6 +215,7 @@
     <string name="sent">已傳送</string>
     <string name="sent_contact">如有需要，我們將透過 %1$s 與您聯絡</string>
     <string name="sent_thanks">謝謝！</string>
+    <string name="server_ip_overrides">伺服器 IP 覆寫</string>
     <string name="server_ip_overrides_info_first_paragraph">在某些採用了各類審查功能的網路上，我們的伺服器 IP 位址有時會遭到封鎖。</string>
     <string name="server_ip_overrides_info_second_paragraph">為了避免這種情況，您可以匯入由我們支援團隊所提供的檔案或文字，其中的新 IP 位址會覆蓋「選取位置」視圖中伺服器的預設位址。</string>
     <string name="server_ip_overrides_info_third_paragraph">如果您在連線至 VPN 伺服器時遇到問題，請聯絡支援人員。</string>

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -318,7 +318,7 @@
     <string name="locations_were_changed_for">Locations were changed for \"%s\"</string>
     <string name="not_found">Not found</string>
     <string name="server_ip_overrides_import_button">Import</string>
-    <string name="server_ip_overrides">Server Ip overrides</string>
+    <string name="server_ip_overrides">Server IP override</string>
     <string name="server_ip_overrides_active">Overrides active</string>
     <string name="server_ip_overrides_inactive">Overrides inactive</string>
     <string name="server_ip_overrides_info_first_paragraph">On some networks, where various types of censorship are being used, our server IP addresses are sometimes blocked.</string>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2353,9 +2353,6 @@ msgstr ""
 msgid "Secured"
 msgstr ""
 
-msgid "Server Ip overrides"
-msgstr ""
-
 msgid "Set WireGuard MTU value. Valid range: %d - %d."
 msgstr ""
 


### PR DESCRIPTION
This PR aims to align the server IP override title with the desktop app.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6140)
<!-- Reviewable:end -->
