### PR TITLE
Limit the size of custom list names to 30 graphemes

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -173,12 +173,8 @@ pub enum Error {
     TunnelError(#[source] tunnel_state_machine::Error),
 
     /// Custom list already exists
-    #[error("A list with that name already exists")]
-    CustomListExists,
-
-    /// Custom list does not exist
-    #[error("A list with that name does not exist")]
-    CustomListNotFound,
+    #[error("Custom list error: {0}")]
+    CustomListError(#[source] mullvad_types::custom_list::Error),
 
     #[error("Access method error")]
     AccessMethodError(#[source] access_method::Error),

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1115,16 +1115,6 @@ fn map_daemon_error(error: crate::Error) -> Status {
         DaemonError::NoAccountToken | DaemonError::NoAccountTokenHistory => {
             Status::unauthenticated(error.to_string())
         }
-        DaemonError::CustomListExists => Status::with_details(
-            Code::AlreadyExists,
-            error.to_string(),
-            mullvad_management_interface::CUSTOM_LIST_LIST_EXISTS_DETAILS.into(),
-        ),
-        DaemonError::CustomListNotFound => Status::with_details(
-            Code::NotFound,
-            error.to_string(),
-            mullvad_management_interface::CUSTOM_LIST_LIST_NOT_FOUND_DETAILS.into(),
-        ),
         error => Status::unknown(error.to_string()),
     }
 }

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(not(target_os = "android"))]
 use futures::TryFutureExt;
+#[cfg(not(target_os = "android"))]
+use mullvad_types::custom_list::Error as CustomListError;
 use mullvad_types::{
     relay_constraints::{RelayConstraints, RelaySettings, WireguardConstraints},
     settings::{DnsState, Settings},
@@ -47,15 +49,48 @@ pub enum Error {
 impl From<Error> for mullvad_management_interface::Status {
     fn from(error: Error) -> mullvad_management_interface::Status {
         use mullvad_management_interface::{Code, Status};
-
         match error {
             Error::DeleteError(..) | Error::WriteError(..) | Error::ReadError(..) => {
                 Status::new(Code::FailedPrecondition, error.to_string())
+            }
+            Error::UpdateFailed(err)
+                if err
+                    .downcast_ref::<mullvad_types::custom_list::Error>()
+                    .is_some() =>
+            {
+                let custom_list_err = *err.downcast::<CustomListError>().unwrap();
+                handle_custom_list_error(custom_list_err)
             }
             Error::SerializeError(..) | Error::ParseError(..) | Error::UpdateFailed(..) => {
                 Status::new(Code::Internal, error.to_string())
             }
         }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn handle_custom_list_error(
+    custom_list_err: CustomListError,
+) -> mullvad_management_interface::Status {
+    use mullvad_management_interface::{Code, Status};
+    match custom_list_err {
+        error @ CustomListError::ListExists | error @ CustomListError::DuplicateName => {
+            Status::with_details(
+                Code::AlreadyExists,
+                error.to_string(),
+                mullvad_management_interface::CUSTOM_LIST_LIST_EXISTS_DETAILS.into(),
+            )
+        }
+        error @ CustomListError::NameTooLong => Status::with_details(
+            Code::InvalidArgument,
+            error.to_string(),
+            mullvad_management_interface::CUSTOM_LIST_LIST_NAME_TOO_LONG_DETAILS.into(),
+        ),
+        error @ CustomListError::ListNotFound => Status::with_details(
+            Code::NotFound,
+            error.to_string(),
+            mullvad_management_interface::CUSTOM_LIST_LIST_NOT_FOUND_DETAILS.into(),
+        ),
     }
 }
 

--- a/mullvad-management-interface/src/lib.rs
+++ b/mullvad-management-interface/src/lib.rs
@@ -28,6 +28,7 @@ static MULLVAD_MANAGEMENT_SOCKET_GROUP: Lazy<Option<String>> =
 
 pub const CUSTOM_LIST_LIST_NOT_FOUND_DETAILS: &[u8] = b"custom_list_list_not_found";
 pub const CUSTOM_LIST_LIST_EXISTS_DETAILS: &[u8] = b"custom_list_list_exists";
+pub const CUSTOM_LIST_LIST_NAME_TOO_LONG_DETAILS: &[u8] = b"custom_list_list_name_too_long";
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/mullvad-types/src/custom_list.rs
+++ b/mullvad-types/src/custom_list.rs
@@ -11,6 +11,20 @@ use std::{
     str::FromStr,
 };
 
+const CUSTOM_LIST_NAME_MAX_SIZE: usize = 30;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Custom list name too long")]
+    NameTooLong,
+    #[error("Custom list with name already exists")]
+    DuplicateName,
+    #[error("Custom list not found")]
+    ListNotFound,
+    #[error("List with given ID already exists")]
+    ListExists,
+}
+
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id(uuid::Uuid);
 
@@ -91,17 +105,59 @@ impl From<Vec<CustomList>> for CustomListsSettings {
 }
 
 impl CustomListsSettings {
-    pub fn add(&mut self, list: CustomList) {
-        self.custom_lists.push(list);
+    pub fn add(&mut self, new_list: CustomList) -> Result<(), Error> {
+        self.check_if_id_is_unique(&new_list)?;
+        self.check_list_name_is_unique(&new_list)?;
+        self.custom_lists.push(new_list);
+        Ok(())
     }
 
-    pub fn remove(&mut self, index: usize) {
-        self.custom_lists.remove(index);
+    pub fn remove(&mut self, list_id: &Id) -> Result<(), Error> {
+        let Some(list_index) = self.find_list_index(list_id) else {
+            return Err(Error::ListNotFound);
+        };
+        self.custom_lists.remove(list_index);
+        Ok(())
     }
 
     /// Remove all custom lists
     pub fn clear(&mut self) {
         self.custom_lists.clear();
+    }
+
+    pub fn update(&mut self, new_list: CustomList) -> Result<(), Error> {
+        let list_index = self
+            .find_list_index(&new_list.id)
+            .ok_or(Error::ListNotFound)?;
+        self.check_list_name_is_unique(&new_list)?;
+        self.custom_lists[list_index] = new_list;
+        Ok(())
+    }
+
+    fn check_list_name_is_unique(&self, new_list: &CustomList) -> Result<(), Error> {
+        if self
+            .custom_lists
+            .iter()
+            .any(|list| list.name == new_list.name && list.id != new_list.id)
+        {
+            return Err(Error::DuplicateName);
+        }
+        Ok(())
+    }
+
+    fn check_if_id_is_unique(&self, new_list: &CustomList) -> Result<(), Error> {
+        if self.custom_lists.iter().any(|list| list.id == new_list.id) {
+            return Err(Error::ListExists);
+        }
+        Ok(())
+    }
+
+    fn find_list_index(&self, list_id: &Id) -> Option<usize> {
+        self.custom_lists
+            .iter()
+            .enumerate()
+            .find(|(_idx, list)| list.id == *list_id)
+            .map(|(idx, _list)| idx)
     }
 }
 
@@ -144,12 +200,16 @@ pub struct CustomList {
 }
 
 impl CustomList {
-    pub fn new(name: String) -> Self {
-        CustomList {
+    pub fn new(name: String) -> Result<Self, Error> {
+        if name.chars().count() > CUSTOM_LIST_NAME_MAX_SIZE {
+            return Err(Error::NameTooLong);
+        }
+
+        Ok(CustomList {
             id: Id(uuid::Uuid::new_v4()),
             name,
             locations: BTreeSet::new(),
-        }
+        })
     }
 }
 


### PR DESCRIPTION
I've gone and added a limitation on the length of the name of a custom list to 30 UTF-8 graphemes. And accidentally also reworked how custom lists are saved. Feel free to dismiss the changes in their entirety because of that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6141)
<!-- Reviewable:end -->
