### PR TITLE
Remove logs older than 7 days, instead all of them

### DIFF
--- a/ios/MullvadLogging/Logging.swift
+++ b/ios/MullvadLogging/Logging.swift
@@ -39,7 +39,7 @@ public struct LoggerBuilder {
         do {
             try LogRotation.rotateLogs(logDirectory: logsDirectoryURL, options: LogRotation.Options(
                 storageSizeLimit: 5_242_880, // 5 MB
-                oldestAllowedDate: Date(timeIntervalSinceNow: Duration.days(7).timeInterval)
+                oldestAllowedDate: Date(timeIntervalSinceNow: -Duration.days(7).timeInterval)
             ))
         } catch {
             logRotationErrors.append(error)


### PR DESCRIPTION
There's a small bug in the log rotation. We should fix this before the release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6143)
<!-- Reviewable:end -->
