### PR TITLE
Ensure log file sizes stay below a certain threshold

### DIFF
--- a/ios/MullvadLogging/CustomFormatLogHandler.swift
+++ b/ios/MullvadLogging/CustomFormatLogHandler.swift
@@ -16,14 +16,6 @@ public struct CustomFormatLogHandler: LogHandler {
     private let label: String
     private let streams: [TextOutputStream]
 
-    private let dateFormatter = Self.makeDateFormatter()
-
-    public static func makeDateFormatter() -> DateFormatter {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "YYYY-MM-dd HH:mm:ss.SSS"
-        return dateFormatter
-    }
-
     public init(label: String, streams: [TextOutputStream]) {
         self.label = label
         self.streams = streams
@@ -54,7 +46,7 @@ public struct CustomFormatLogHandler: LogHandler {
             }
         let prettyMetadata = Self.formatMetadata(mergedMetadata)
         let metadataOutput = prettyMetadata.isEmpty ? "" : " \(prettyMetadata)"
-        let timestamp = dateFormatter.string(from: Date())
+        let timestamp = Date().logFormatted
         let formattedMessage = "[\(timestamp)][\(label)][\(level)]\(metadataOutput) \(message)\n"
 
         for var stream in streams {

--- a/ios/MullvadLogging/Date+LogFormat.swift
+++ b/ios/MullvadLogging/Date+LogFormat.swift
@@ -9,16 +9,22 @@
 import Foundation
 
 extension Date {
-    public func logFormatDate() -> String {
+    public var logFormatted: String {
         let formatter = DateFormatter()
+
         formatter.dateFormat = "dd/MM/yyyy @ HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
 
         return formatter.string(from: self)
     }
 
-    public func logFormatFilename() -> String {
+    public var logFileFormatted: String {
         let formatter = DateFormatter()
+
         formatter.dateFormat = "dd-MM-yyyy'T'HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
 
         return formatter.string(from: self)
     }

--- a/ios/MullvadLogging/Logging.swift
+++ b/ios/MullvadLogging/Logging.swift
@@ -78,7 +78,7 @@ public struct LoggerBuilder {
             let rotationLogger = Logger(label: "LogRotation")
 
             for error in logRotationErrors {
-                rotationLogger.error(error: error, message: "Failed to rotate log")
+                rotationLogger.error(error: error, message: error.localizedDescription)
             }
         }
     }

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -603,6 +603,8 @@
 		7ADCB2D82B6A6EB300C88F89 /* AnyRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADCB2D72B6A6EB300C88F89 /* AnyRelay.swift */; };
 		7ADCB2DA2B6A730400C88F89 /* IPOverrideRepositoryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADCB2D92B6A730400C88F89 /* IPOverrideRepositoryStub.swift */; };
 		7AE044BB2A935726003915D8 /* Routing.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A88DCD02A8FABBE00D2FF0E /* Routing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AED35CC2BD13F60002A67D1 /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
+		7AED35CD2BD13FC4002A67D1 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
 		7AEF7F1A2AD00F52006FE45D /* AppMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AEF7F192AD00F52006FE45D /* AppMessageHandler.swift */; };
 		7AF10EB22ADE859200C090B9 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF10EB12ADE859200C090B9 /* AlertViewController.swift */; };
 		7AF10EB42ADE85BC00C090B9 /* RelayFilterCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF10EB32ADE85BC00C090B9 /* RelayFilterCoordinator.swift */; };
@@ -5732,6 +5734,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7AED35CC2BD13F60002A67D1 /* ApplicationConfiguration.swift in Sources */,
+				7AED35CD2BD13FC4002A67D1 /* ApplicationTarget.swift in Sources */,
 				58D22402294C90050029F5F8 /* Logger+Errors.swift in Sources */,
 				58D22404294C90050029F5F8 /* Date+LogFormat.swift in Sources */,
 				58D22403294C90050029F5F8 /* Logging.swift in Sources */,

--- a/ios/MullvadVPN/AddressCacheTracker/AddressCacheTracker.swift
+++ b/ios/MullvadVPN/AddressCacheTracker/AddressCacheTracker.swift
@@ -65,7 +65,7 @@ final class AddressCacheTracker {
 
         let scheduleDate = _nextScheduleDate()
 
-        logger.debug("Schedule address cache update at \(scheduleDate.logFormatDate()).")
+        logger.debug("Schedule address cache update at \(scheduleDate.logFormatted).")
 
         scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
     }
@@ -165,7 +165,7 @@ final class AddressCacheTracker {
             let scheduleDate = self._nextScheduleDate()
 
             self.logger
-                .debug("Schedule next address cache update at \(scheduleDate.logFormatDate()).")
+                .debug("Schedule next address cache update at \(scheduleDate.logFormatted).")
 
             self.scheduleEndpointsUpdate(startTime: .now() + scheduleDate.timeIntervalSinceNow)
         }

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -307,7 +307,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             let request = BGAppRefreshTaskRequest(identifier: BackgroundTask.appRefresh.identifier)
             request.earliestBeginDate = date
 
-            logger.debug("Schedule app refresh task at \(date.logFormatDate()).")
+            logger.debug("Schedule app refresh task at \(date.logFormatted).")
 
             try BGTaskScheduler.shared.submit(request)
         } catch {
@@ -325,7 +325,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             request.requiresNetworkConnectivity = true
             request.earliestBeginDate = date
 
-            logger.debug("Schedule key rotation task at \(date.logFormatDate()).")
+            logger.debug("Schedule key rotation task at \(date.logFormatted).")
 
             try BGTaskScheduler.shared.submit(request)
         } catch {
@@ -341,7 +341,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             request.requiresNetworkConnectivity = true
             request.earliestBeginDate = date
 
-            logger.debug("Schedule address cache update task at \(date.logFormatDate()).")
+            logger.debug("Schedule address cache update task at \(date.logFormatted).")
 
             try BGTaskScheduler.shared.submit(request)
         } catch {

--- a/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
+++ b/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-private let kLogMaxReadBytes: UInt64 = 128 * 1024
 private let kLogDelimiter = "===================="
 private let kRedactedPlaceholder = "[REDACTED]"
 private let kRedactedAccountPlaceholder = "[REDACTED ACCOUNT NUMBER]"
@@ -93,7 +92,7 @@ class ConsolidatedApplicationLog: TextOutputStreamable {
         let path = fileURL.path
         let redactedPath = redact(string: path)
 
-        if let lossyString = Self.readFileLossy(path: path, maxBytes: kLogMaxReadBytes) {
+        if let lossyString = Self.readFileLossy(path: path, maxBytes: ApplicationConfiguration.logMaximumFileSize) {
             let redactedString = redact(string: lossyString)
 
             logs.append(LogAttachment(label: redactedPath, content: redactedString))
@@ -126,7 +125,7 @@ class ConsolidatedApplicationLog: TextOutputStreamable {
             fileHandle.seek(toFileOffset: 0)
         }
 
-        let data = fileHandle.readData(ofLength: Int(kLogMaxReadBytes))
+        let data = fileHandle.readData(ofLength: Int(ApplicationConfiguration.logMaximumFileSize))
         let replacementCharacter = Character(UTF8.decode(UTF8.encodedReplacementCharacter))
         let lossyString = String(
             String(decoding: data, as: UTF8.self)

--- a/ios/MullvadVPN/StorePaymentManager/SendStoreReceiptOperation.swift
+++ b/ios/MullvadVPN/StorePaymentManager/SendStoreReceiptOperation.swift
@@ -140,7 +140,7 @@ class SendStoreReceiptOperation: ResultOperation<REST.CreateApplePaymentResponse
                     """
                     AppStore receipt was processed. \
                     Time added: \(response.timeAdded), \
-                    New expiry: \(response.newExpiry.logFormatDate())
+                    New expiry: \(response.newExpiry.logFormatted)
                     """
                 )
                 self.finish(result: .success(response))

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -172,7 +172,7 @@ final class TunnelManager: StorePaymentObserver {
 
         privateKeyRotationTimer = timer
 
-        logger.debug("Schedule next private key rotation at \(scheduleDate.logFormatDate()).")
+        logger.debug("Schedule next private key rotation at \(scheduleDate.logFormatted).")
     }
 
     // MARK: - Public methods

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
@@ -30,6 +30,10 @@ final class ProblemReportInteractor {
         return report
     }()
 
+    var reportString: String {
+        consolidatedLog.string
+    }
+
     init(apiProxy: APIQuerying, tunnelManager: TunnelManager) {
         self.apiProxy = apiProxy
         self.tunnelManager = tunnelManager
@@ -54,9 +58,5 @@ final class ProblemReportInteractor {
             retryStrategy: .default,
             completionHandler: completion
         )
-    }
-
-    var reportString: String {
-        consolidatedLog.string
     }
 }

--- a/ios/MullvadVPNTests/MullvadLogging/LogRotationTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LogRotationTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
-import MullvadLogging
+@testable import MullvadLogging
 import XCTest
 
 final class LogRotationTests: XCTestCase {
@@ -22,6 +22,45 @@ final class LogRotationTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try fileManager.removeItem(atPath: directoryPath.relativePath)
+    }
+
+    func testRotatingActiveLogWhenSizeLimitIsExceeded() throws {
+        let logName = "test.log"
+        let logPath = directoryPath.appendingPathComponent(logName)
+
+        let totalLogSizeLimit = 200
+        let totalLogTestSize = 645
+        let logChunkSize = 20
+
+        let expectedLogCount = Int(ceil(Double(totalLogTestSize) / Double(totalLogSizeLimit)))
+        let writeOperationCount = Int(ceil(Double(totalLogTestSize) / Double(logChunkSize)))
+
+        let stream = LogFileOutputStream(fileURL: logPath, header: "", fileSizeLimit: UInt64(totalLogSizeLimit))
+        for _ in 0 ..< writeOperationCount {
+            stream.write(stringOfSize(logChunkSize))
+
+            // Without sync between every write the test fails on Github.
+            sync()
+        }
+
+        let actualLogCount = try fileManager.contentsOfDirectory(atPath: directoryPath.relativePath).count
+        XCTAssertEqual(expectedLogCount, actualLogCount)
+
+        for index in 0 ..< actualLogCount {
+            var expectedFileName = logName
+
+            if index != 0 {
+                // Rotated log filenames start at "_2".
+                expectedFileName = expectedFileName.replacingOccurrences(of: ".log", with: "_\(index + 1).log")
+            }
+
+            let logExists = fileManager.fileExists(
+                atPath: directoryPath
+                    .appendingPathComponent(expectedFileName)
+                    .relativePath
+            )
+            XCTAssertTrue(logExists)
+        }
     }
 
     func testRotateLogsByStorageSizeLimit() throws {
@@ -97,6 +136,10 @@ final class LogRotationTests: XCTestCase {
 }
 
 extension LogRotationTests {
+    private func stringOfSize(_ size: Int) -> String {
+        (0 ..< size).map { "\($0 % 10)" }.joined(separator: "")
+    }
+
     private func writeDataToDisk(path: URL, fileSize: Int) throws {
         let data = Data((0 ..< fileSize).map { UInt8($0 & 0xff) })
         try data.write(to: path)

--- a/ios/MullvadVPNTests/MullvadLogging/LoggingTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LoggingTests.swift
@@ -26,7 +26,7 @@ class MullvadLoggingTests: XCTestCase {
         return fileURL
     }
 
-    func testLogFileOutputStreamWritesHeader() {
+    func testLogFileOutputStreamWritesHeader() throws {
         let headerText = "This is a header"
         let logMessage = "And this is a log message\n"
         let fileURL = temporaryFileURL()
@@ -34,11 +34,11 @@ class MullvadLoggingTests: XCTestCase {
         stream.write(logMessage)
         sync()
 
-        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
+        let contents = try XCTUnwrap(String(contentsOf: fileURL))
         XCTAssertEqual(contents, "\(headerText)\n\(logMessage)")
     }
 
-    func testLogHeader() {
+    func testLogHeader() throws {
         let expectedHeader = "Header of a log file"
 
         var builder = LoggerBuilder(header: expectedHeader)
@@ -51,7 +51,7 @@ class MullvadLoggingTests: XCTestCase {
 
         sync()
 
-        let contents = String(decoding: try! Data(contentsOf: fileURL), as: UTF8.self)
+        let contents = try XCTUnwrap(String(contentsOf: fileURL))
 
         XCTAssert(contents.hasPrefix(expectedHeader))
     }

--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -196,7 +196,9 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .enterText("4001")
             .dismissKeyboard()
             .swipeDownToDismissModal()
-            .swipeDownToDismissModal() // After editing text field the table is first responder for the first swipe so we need to swipe twice to swipe the modal
+
+            // After editing text field the table is first responder for the first swipe so we need to swipe twice to swipe the modal
+            .swipeDownToDismissModal()
 
         TunnelControlPage(app)
             .tapSecureConnectionButton()


### PR DESCRIPTION
We should limit log files to not be larger than a certain threshold (currently 16kB) when writing to disk. If limit is exceeded, create a new file with a "_<partial count>" suffix and keep writing to it instead. Repeat if necessary.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6151)
<!-- Reviewable:end -->
