### PR TITLE
Fix iPad location selection entries not being unmarked as selected

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
@@ -136,6 +136,12 @@ final class LocationDataSource:
         ], reloadExisting: true)
     }
 
+    func scrollToSelectedRelay() {
+        indexPathForSelectedRelay().flatMap {
+            tableView.scrollToRow(at: $0, at: .middle, animated: false)
+        }
+    }
+
     // Called from `LocationDiffableDataSourceProtocol`.
     func nodeShowsChildren(_ node: LocationNode) -> Bool {
         node.showsChildren
@@ -277,12 +283,22 @@ extension LocationDataSource: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         if let item = itemIdentifier(for: indexPath), item == selectedItem {
-            cell.setSelected(true, animated: false)
+            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
         }
+    }
+
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        if let indexPath = indexPathForSelectedRelay() {
+            tableView.deselectRow(at: indexPath, animated: false)
+            selectedItem = nil
+        }
+
+        return indexPath
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let item = itemIdentifier(for: indexPath) else { return }
+        selectedItem = item
 
         var customListSelection: UserSelectedRelays.CustomListSelection?
         if let topmostNode = item.node.root as? CustomListLocationNode {
@@ -302,12 +318,6 @@ extension LocationDataSource: UITableViewDelegate {
 
     private func scrollToTop(animated: Bool) {
         tableView.setContentOffset(.zero, animated: animated)
-    }
-
-    private func scrollToSelectedRelay() {
-        indexPathForSelectedRelay().flatMap {
-            tableView.scrollToRow(at: $0, at: .middle, animated: false)
-        }
     }
 }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -96,9 +96,13 @@ final class LocationViewController: UIViewController {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        dataSource?.scrollToSelectedRelay()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
         tableView.flashScrollIndicators()
     }
 


### PR DESCRIPTION
Currently, the iPad location selection view doesn't unmark previously selected locations when a user selects a new location.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6174)
<!-- Reviewable:end -->
