### PR TITLE
Upgrade winapi related deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,9 +1442,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1457,7 +1457,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1604,7 +1604,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.3",
+ "socket2",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -3445,7 +3445,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "shadowsocks-crypto",
- "socket2 0.5.3",
+ "socket2",
  "spin 0.9.8",
  "thiserror",
  "tokio",
@@ -3513,7 +3513,7 @@ dependencies = [
  "regex",
  "serde",
  "shadowsocks",
- "socket2 0.5.3",
+ "socket2",
  "spin 0.9.8",
  "thiserror",
  "tokio",
@@ -3594,16 +3594,6 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
@@ -3674,7 +3664,7 @@ dependencies = [
  "parking_lot",
  "pnet_packet",
  "rand 0.8.5",
- "socket2 0.5.3",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -3954,7 +3944,7 @@ name = "talpid-windows"
 version = "0.0.0"
 dependencies = [
  "futures",
- "socket2 0.5.3",
+ "socket2",
  "talpid-types",
  "thiserror",
  "windows-sys 0.48.0",
@@ -3986,7 +3976,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rtnetlink",
- "socket2 0.5.3",
+ "socket2",
  "surge-ping",
  "talpid-dbus",
  "talpid-routing",
@@ -4091,7 +4081,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4162,7 +4152,7 @@ dependencies = [
  "log",
  "once_cell",
  "pin-project",
- "socket2 0.5.3",
+ "socket2",
  "tokio",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,11 +4651,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
I just saw that `winapi-util` just released a version finally migrating from `winapi` to `windows-sys` (https://github.com/BurntSushi/winapi-util/pull/13#issuecomment-2072513938). So I created this branch to bump the dependency. Not that it gets rid of `winapi` from our dependency tree, but one step in that direction.

I then looked at `cargo tree --all-targets` and identified another place where we could actually shrink our dependency tree a tiny bit. Bumping `hyper` removes the last dependency on `socket2 0.4` which gets rid of that completely, and in turn removes another link to `winapi` in the meantime.

So this is just a small dependency tree maintenance PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6178)
<!-- Reviewable:end -->
