### PR TITLE
Add a new container view to wrap the whole location selection

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -587,6 +587,7 @@
 		7AA513862BC91C6B00D081A4 /* LogRotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */; };
 		7AB2B6702BA1EB8C00B03E3B /* ListCustomListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB2B66E2BA1EB8C00B03E3B /* ListCustomListViewController.swift */; };
 		7AB2B6712BA1EB8C00B03E3B /* ListCustomListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB2B66F2BA1EB8C00B03E3B /* ListCustomListCoordinator.swift */; };
+		7AB3BEB52BD7A6CB00E34384 /* LocationViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */; };
 		7AB4CCB92B69097E006037F5 /* IPOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4CCB82B69097E006037F5 /* IPOverrideTests.swift */; };
 		7AB4CCBB2B691BBB006037F5 /* IPOverrideInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4CCBA2B691BBB006037F5 /* IPOverrideInteractor.swift */; };
 		7ABCA5B32A9349F20044A708 /* Routing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A88DCCE2A8FABBE00D2FF0E /* Routing.framework */; };
@@ -1855,6 +1856,7 @@
 		7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRotationTests.swift; sourceTree = "<group>"; };
 		7AB2B66E2BA1EB8C00B03E3B /* ListCustomListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListCustomListViewController.swift; sourceTree = "<group>"; };
 		7AB2B66F2BA1EB8C00B03E3B /* ListCustomListCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListCustomListCoordinator.swift; sourceTree = "<group>"; };
+		7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationViewControllerWrapper.swift; sourceTree = "<group>"; };
 		7AB4CCB82B69097E006037F5 /* IPOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideTests.swift; sourceTree = "<group>"; };
 		7AB4CCBA2B691BBB006037F5 /* IPOverrideInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideInteractor.swift; sourceTree = "<group>"; };
 		7ABE318C2A1CDD4500DF4963 /* UIFont+Weight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Weight.swift"; sourceTree = "<group>"; };
@@ -2646,6 +2648,7 @@
 				F050AE512B70DFC0003F4EDB /* LocationSection.swift */,
 				F0BE65362B9F136A005CC385 /* LocationSectionHeaderView.swift */,
 				5888AD86227B17950051EB06 /* LocationViewController.swift */,
+				7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */,
 			);
 			path = SelectLocation;
 			sourceTree = "<group>";
@@ -5582,6 +5585,7 @@
 				063687BA28EB234F00BE7161 /* PacketTunnelTransport.swift in Sources */,
 				A9C342C12ACC37E30045F00E /* TunnelStatusBlockObserver.swift in Sources */,
 				587425C12299833500CA2045 /* RootContainerViewController.swift in Sources */,
+				7AB3BEB52BD7A6CB00E34384 /* LocationViewControllerWrapper.swift in Sources */,
 				F09D04BD2AEBB7C5003D4F89 /* OutgoingConnectionService.swift in Sources */,
 				58FF9FF42B07C61B00E4C97D /* AccessMethodValidationError.swift in Sources */,
 				5896AE84246D5889005B36CB /* CustomDateComponentsFormatting.swift in Sources */,

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -102,6 +102,7 @@ public enum AccessibilityIdentifier: String {
     case outOfTimeView
     case termsOfServiceView
     case selectLocationView
+    case selectLocationViewWrapper
     case selectLocationTableView
     case settingsTableView
     case vpnSettingsTableView

--- a/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
@@ -136,6 +136,11 @@ extension UIColor {
         static let actionButtonColor = UIColor(white: 1.0, alpha: 0.8)
     }
 
+    enum SegmentedControl {
+        static let backgroundColor = UIColor(red: 0.18, green: 0.33, blue: 0.49, alpha: 1.0)
+        static let selectedColor = successColor
+    }
+
     // Common colors
     static let primaryColor = UIColor(red: 0.16, green: 0.30, blue: 0.45, alpha: 1.0)
     static let secondaryColor = UIColor(red: 0.10, green: 0.18, blue: 0.27, alpha: 1.0)

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
@@ -94,8 +94,8 @@ class RelayFilterView: UIView {
         contentContainer.spacing = UIMetrics.FilterView.labelSpacing
 
         addConstrainedSubviews([contentContainer]) {
-            contentContainer.pinEdges(.init([.top(0), .bottom(0)]), to: self)
-            contentContainer.pinEdges(.init([.leading(0), .trailing(0)]), to: layoutMarginsGuide)
+            contentContainer.pinEdges(.init([.top(4), .bottom(0)]), to: self)
+            contentContainer.pinEdges(.init([.leading(4), .trailing(4)]), to: layoutMarginsGuide)
         }
     }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
@@ -1,0 +1,156 @@
+//
+//  LocationViewControllerWrapper.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2024-04-23.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadREST
+import MullvadSettings
+import MullvadTypes
+import UIKit
+
+protocol LocationViewControllerWrapperDelegate: AnyObject {
+    func navigateToCustomLists(nodes: [LocationNode])
+    func navigateToFilter()
+    func didSelectRelays(relays: UserSelectedRelays)
+    func didUpdateFilter(filter: RelayFilter)
+}
+
+final class LocationViewControllerWrapper: UIViewController {
+    private let locationViewController: LocationViewController
+    private let segmentedControl = UISegmentedControl()
+
+    weak var delegate: LocationViewControllerWrapperDelegate?
+
+    init(customListRepository: CustomListRepositoryProtocol, selectedRelays: UserSelectedRelays?) {
+        locationViewController = LocationViewController(
+            customListRepository: customListRepository,
+            selectedRelays: selectedRelays
+        )
+
+        super.init(nibName: nil, bundle: nil)
+
+        locationViewController.delegate = self
+    }
+
+    var didFinish: (() -> Void)?
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.accessibilityIdentifier = .selectLocationViewWrapper
+        view.backgroundColor = .secondaryColor
+
+        setUpNavigation()
+        setUpSegmentedControl()
+        addSubviews()
+    }
+
+    func setCachedRelays(_ cachedRelays: CachedRelays, filter: RelayFilter) {
+        locationViewController.setCachedRelays(cachedRelays, filter: filter)
+    }
+
+    func refreshCustomLists() {
+        locationViewController.refreshCustomLists()
+    }
+
+    private func setUpNavigation() {
+        navigationItem.largeTitleDisplayMode = .never
+
+        navigationItem.title = NSLocalizedString(
+            "NAVIGATION_TITLE",
+            tableName: "SelectLocation",
+            value: "Select location",
+            comment: ""
+        )
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            title: NSLocalizedString(
+                "NAVIGATION_FILTER",
+                tableName: "SelectLocation",
+                value: "Filter",
+                comment: ""
+            ),
+            primaryAction: UIAction(handler: { [weak self] _ in
+                self?.delegate?.navigateToFilter()
+            })
+        )
+        navigationItem.leftBarButtonItem?.accessibilityIdentifier = .selectLocationFilterButton
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            systemItem: .done,
+            primaryAction: UIAction(handler: { [weak self] _ in
+                self?.didFinish?()
+            })
+        )
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = .closeSelectLocationButton
+    }
+
+    private func setUpSegmentedControl() {
+        segmentedControl.backgroundColor = .SegmentedControl.backgroundColor
+        segmentedControl.selectedSegmentTintColor = .SegmentedControl.selectedColor
+        segmentedControl.setTitleTextAttributes([
+            .foregroundColor: UIColor.white,
+            .font: UIFont.systemFont(ofSize: 17, weight: .medium),
+        ], for: .normal)
+
+        segmentedControl.insertSegment(withTitle: NSLocalizedString(
+            "MULTIHOP_TAB_ENTRY",
+            tableName: "SelectLocation",
+            value: "Entry",
+            comment: ""
+        ), at: 0, animated: false)
+        segmentedControl.insertSegment(withTitle: NSLocalizedString(
+            "MULTIHOP_TAB_EXIT",
+            tableName: "SelectLocation",
+            value: "Exit",
+            comment: ""
+        ), at: 1, animated: false)
+
+        segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.addTarget(self, action: #selector(segmentedControlDidChange), for: .valueChanged)
+    }
+
+    private func addSubviews() {
+        addChild(locationViewController)
+        locationViewController.didMove(toParent: self)
+
+        view.addConstrainedSubviews([segmentedControl, locationViewController.view]) {
+            segmentedControl.heightAnchor.constraint(equalToConstant: 44)
+            segmentedControl.pinEdgesToSuperviewMargins(PinnableEdges([.top(0), .leading(8), .trailing(8)]))
+
+            locationViewController.view.pinEdgesToSuperview(.all().excluding(.top))
+
+            #if DEBUG
+            locationViewController.view.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor, constant: 4)
+            #else
+            locationViewController.view.pinEdgeToSuperviewMargin(.top(0))
+            #endif
+        }
+    }
+
+    @objc
+    private func segmentedControlDidChange(sender: UISegmentedControl) {
+        refreshCustomLists()
+    }
+}
+
+extension LocationViewControllerWrapper: LocationViewControllerDelegate {
+    func navigateToCustomLists(nodes: [LocationNode]) {
+        delegate?.navigateToCustomLists(nodes: nodes)
+    }
+
+    func didSelectRelays(relays: UserSelectedRelays) {
+        delegate?.didSelectRelays(relays: relays)
+    }
+
+    func didUpdateFilter(filter: RelayFilter) {
+        delegate?.didUpdateFilter(filter: filter)
+    }
+}


### PR DESCRIPTION
The wrapper should have a segmented control. The child will be updated through the wrapper, keeping most of the previous implementation intact.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6181)
<!-- Reviewable:end -->
