### PR TITLE
Implement daemon support for split tunneling for Android

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -15,7 +15,6 @@ mod geoip;
 pub mod logging;
 #[cfg(target_os = "macos")]
 mod macos;
-//#[cfg(not(target_os = "android"))]
 pub mod management_interface;
 mod migrations;
 mod relay_list;
@@ -43,6 +42,8 @@ use mullvad_relay_selector::{
 };
 #[cfg(target_os = "android")]
 use mullvad_types::account::{PlayPurchase, PlayPurchasePaymentToken};
+#[cfg(any(windows, target_os = "android"))]
+use mullvad_types::settings::SplitApp;
 #[cfg(target_os = "windows")]
 use mullvad_types::wireguard::DaitaSettings;
 use mullvad_types::{
@@ -63,10 +64,10 @@ use mullvad_types::{
 };
 use relay_list::{RelayListUpdater, RelayListUpdaterHandle, RELAYS_FILENAME};
 use settings::SettingsPersister;
+#[cfg(any(windows, target_os = "android"))]
+use std::collections::HashSet;
 #[cfg(target_os = "android")]
 use std::os::unix::io::RawFd;
-#[cfg(target_os = "windows")]
-use std::{collections::HashSet, ffi::OsString};
 use std::{
     marker::PhantomData,
     mem,
@@ -75,7 +76,7 @@ use std::{
     sync::{Arc, Weak},
     time::Duration,
 };
-#[cfg(any(target_os = "linux", windows))]
+#[cfg(any(target_os = "linux", windows, target_os = "android"))]
 use talpid_core::split_tunnel;
 use talpid_core::{
     mpsc::Sender,
@@ -147,7 +148,7 @@ pub enum Error {
     #[error("Unable to initialize split tunneling")]
     InitSplitTunneling(#[source] split_tunnel::Error),
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     #[error("Split tunneling error")]
     SplitTunnelError(#[source] split_tunnel::Error),
 
@@ -331,16 +332,16 @@ pub enum DaemonCommand {
     #[cfg(target_os = "linux")]
     ClearSplitTunnelProcesses(ResponseTx<(), split_tunnel::Error>),
     /// Exclude traffic of an application from the tunnel
-    #[cfg(windows)]
-    AddSplitTunnelApp(ResponseTx<(), Error>, PathBuf),
+    #[cfg(any(windows, target_os = "android"))]
+    AddSplitTunnelApp(ResponseTx<(), Error>, SplitApp),
     /// Remove application from list of apps to exclude from the tunnel
-    #[cfg(windows)]
-    RemoveSplitTunnelApp(ResponseTx<(), Error>, PathBuf),
+    #[cfg(any(windows, target_os = "android"))]
+    RemoveSplitTunnelApp(ResponseTx<(), Error>, SplitApp),
     /// Clear list of apps to exclude from the tunnel
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     ClearSplitTunnelApps(ResponseTx<(), Error>),
     /// Enable or disable split tunneling
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     SetSplitTunnelState(ResponseTx<(), Error>, bool),
     /// Returns all processes currently being excluded from the tunnel
     #[cfg(windows)]
@@ -392,14 +393,14 @@ pub(crate) enum InternalDaemonEvent {
     /// A geographical location has has been received from am.i.mullvad.net
     LocationEvent(LocationEventData),
     /// The split tunnel paths or state were updated.
-    #[cfg(target_os = "windows")]
+    #[cfg(any(windows, target_os = "android"))]
     ExcludedPathsEvent(ExcludedPathsUpdate, oneshot::Sender<Result<(), Error>>),
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(windows, target_os = "android"))]
 pub(crate) enum ExcludedPathsUpdate {
     SetState(bool),
-    SetPaths(HashSet<PathBuf>),
+    SetPaths(HashSet<SplitApp>),
 }
 
 impl From<TunnelStateTransition> for InternalDaemonEvent {
@@ -781,13 +782,14 @@ where
             PersistentTargetState::new(&cache_dir).await
         };
 
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "android"))]
         let exclude_paths = if settings.split_tunnel.enable_exclusions {
             settings
                 .split_tunnel
                 .apps
                 .iter()
-                .map(OsString::from)
+                .cloned()
+                .map(SplitApp::to_tunnel_command_repr)
                 .collect()
         } else {
             vec![]
@@ -824,7 +826,7 @@ where
                     .map_err(Error::ApiConnectionModeError)?
                     .endpoint,
                 reset_firewall: *target_state != TargetState::Secured,
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "android"))]
                 exclude_paths,
             },
             parameters_generator.clone(),
@@ -1009,7 +1011,7 @@ where
             } => self.handle_access_method_event(event, endpoint_active_tx),
             DeviceMigrationEvent(event) => self.handle_device_migration_event(event),
             LocationEvent(location_data) => self.handle_location_event(location_data),
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             ExcludedPathsEvent(update, tx) => self.handle_new_excluded_paths(update, tx).await,
         }
     }
@@ -1288,13 +1290,13 @@ where
             RemoveSplitTunnelProcess(tx, pid) => self.on_remove_split_tunnel_process(tx, pid),
             #[cfg(target_os = "linux")]
             ClearSplitTunnelProcesses(tx) => self.on_clear_split_tunnel_processes(tx),
-            #[cfg(windows)]
-            AddSplitTunnelApp(tx, path) => self.on_add_split_tunnel_app(tx, path),
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
+            AddSplitTunnelApp(tx, app) => self.on_add_split_tunnel_app(tx, app),
+            #[cfg(any(windows, target_os = "android"))]
             RemoveSplitTunnelApp(tx, path) => self.on_remove_split_tunnel_app(tx, path),
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             ClearSplitTunnelApps(tx) => self.on_clear_split_tunnel_apps(tx),
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             SetSplitTunnelState(tx, enabled) => self.on_set_split_tunnel_state(tx, enabled),
             #[cfg(windows)]
             GetSplitTunnelProcesses(tx) => self.on_get_split_tunnel_processes(tx),
@@ -1450,7 +1452,7 @@ where
         });
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     async fn handle_new_excluded_paths(
         &mut self,
         update: ExcludedPathsUpdate,
@@ -1823,7 +1825,7 @@ where
     }
 
     /// Update the split app paths in both the settings and tunnel
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     fn set_split_tunnel_paths(
         &mut self,
         tx: ResponseTx<(), Error>,
@@ -1852,9 +1854,13 @@ where
             }
         };
 
+        // Update the tunnel state
         if new_state || new_state != settings.split_tunnel.enable_exclusions {
             let tunnel_list = if new_state {
-                new_list.map(OsString::from).collect()
+                new_list
+                    .cloned()
+                    .map(SplitApp::to_tunnel_command_repr)
+                    .collect()
             } else {
                 vec![]
             };
@@ -1889,37 +1895,43 @@ where
         }
     }
 
-    #[cfg(windows)]
-    fn on_add_split_tunnel_app(&mut self, tx: ResponseTx<(), Error>, path: PathBuf) {
+    #[cfg(any(windows, target_os = "android"))]
+    fn on_add_split_tunnel_app(&mut self, tx: ResponseTx<(), Error>, app: impl Into<SplitApp>) {
         let settings = self.settings.to_settings();
 
-        let mut new_list = settings.split_tunnel.apps.clone();
-        new_list.insert(path);
+        let excluded_apps = {
+            let mut apps = settings.split_tunnel.apps.clone();
+            apps.insert(app.into());
+            apps
+        };
 
         self.set_split_tunnel_paths(
             tx,
             "add_split_tunnel_app response",
             settings,
-            ExcludedPathsUpdate::SetPaths(new_list),
+            ExcludedPathsUpdate::SetPaths(excluded_apps),
         );
     }
 
-    #[cfg(windows)]
-    fn on_remove_split_tunnel_app(&mut self, tx: ResponseTx<(), Error>, path: PathBuf) {
+    #[cfg(any(windows, target_os = "android"))]
+    fn on_remove_split_tunnel_app(&mut self, tx: ResponseTx<(), Error>, app: impl Into<SplitApp>) {
         let settings = self.settings.to_settings();
 
-        let mut new_list = settings.split_tunnel.apps.clone();
-        new_list.remove(&path);
+        let excluded_apps = {
+            let mut apps = settings.split_tunnel.apps.clone();
+            apps.remove(&app.into());
+            apps
+        };
 
         self.set_split_tunnel_paths(
             tx,
             "remove_split_tunnel_app response",
             settings,
-            ExcludedPathsUpdate::SetPaths(new_list),
+            ExcludedPathsUpdate::SetPaths(excluded_apps),
         );
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     fn on_clear_split_tunnel_apps(&mut self, tx: ResponseTx<(), Error>) {
         let settings = self.settings.to_settings();
         let new_list = HashSet::new();
@@ -1931,7 +1943,7 @@ where
         );
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     fn on_set_split_tunnel_state(&mut self, tx: ResponseTx<(), Error>, state: bool) {
         let settings = self.settings.to_settings();
         self.set_split_tunnel_paths(

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2846,9 +2846,8 @@ fn oneshot_map<T1: Send + 'static, T2: Send + 'static>(
     new_tx
 }
 
-/// TODO: Change name
-/// TODO: Document
-#[cfg(not(target_os = "windows"))]
+/// Remove any old RPC socket (if it exists).
+#[cfg(not(windows))]
 pub async fn cleanup_old_rpc_socket() {
     if let Err(err) = tokio::fs::remove_file(mullvad_paths::get_rpc_socket_path()).await {
         if err.kind() != std::io::ErrorKind::NotFound {
@@ -2856,8 +2855,3 @@ pub async fn cleanup_old_rpc_socket() {
         }
     }
 }
-
-/// NOP on Windows
-#[cfg(target_os = "windows")]
-#[allow(clippy::unused_async)]
-async fn cleanup_old_rpc_socket() {}

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -1,5 +1,7 @@
+#[cfg(not(windows))]
+use mullvad_daemon::cleanup_old_rpc_socket;
 use mullvad_daemon::{
-    cleanup_old_rpc_socket, logging,
+    logging,
     management_interface::{ManagementInterfaceEventBroadcaster, ManagementInterfaceServer},
     rpc_uniqueness_check, runtime, version, Daemon, DaemonCommandChannel, DaemonCommandSender,
 };
@@ -160,6 +162,7 @@ fn get_log_dir(config: &cli::Config) -> Result<Option<PathBuf>, String> {
 }
 
 async fn run_standalone(log_dir: Option<PathBuf>) -> Result<(), String> {
+    #[cfg(not(windows))]
     cleanup_old_rpc_socket().await;
 
     if !running_as_admin() {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -20,8 +20,6 @@ use mullvad_types::{
     version,
     wireguard::{RotationInterval, RotationIntervalError},
 };
-#[cfg(windows)]
-use std::path::PathBuf;
 use std::{
     str::FromStr,
     sync::{Arc, Mutex},
@@ -824,10 +822,11 @@ impl ManagementService for ManagementServiceImpl {
         }
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     async fn add_split_tunnel_app(&self, request: Request<String>) -> ServiceResult<()> {
+        use mullvad_types::settings::SplitApp;
         log::debug!("add_split_tunnel_app");
-        let path = PathBuf::from(request.into_inner());
+        let path = SplitApp::from(request.into_inner());
         let (tx, rx) = oneshot::channel();
         self.send_command_to_daemon(DaemonCommand::AddSplitTunnelApp(tx, path))?;
         self.wait_for_result(rx)
@@ -835,15 +834,17 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
             .map(Response::new)
     }
-    #[cfg(not(windows))]
+
+    #[cfg(not(any(windows, target_os = "android")))]
     async fn add_split_tunnel_app(&self, _: Request<String>) -> ServiceResult<()> {
         Ok(Response::new(()))
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     async fn remove_split_tunnel_app(&self, request: Request<String>) -> ServiceResult<()> {
+        use mullvad_types::settings::SplitApp;
         log::debug!("remove_split_tunnel_app");
-        let path = PathBuf::from(request.into_inner());
+        let path = SplitApp::from(request.into_inner());
         let (tx, rx) = oneshot::channel();
         self.send_command_to_daemon(DaemonCommand::RemoveSplitTunnelApp(tx, path))?;
         self.wait_for_result(rx)
@@ -851,12 +852,13 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
             .map(Response::new)
     }
-    #[cfg(not(windows))]
+
+    #[cfg(not(any(windows, target_os = "android")))]
     async fn remove_split_tunnel_app(&self, _: Request<String>) -> ServiceResult<()> {
         Ok(Response::new(()))
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     async fn clear_split_tunnel_apps(&self, _: Request<()>) -> ServiceResult<()> {
         log::debug!("clear_split_tunnel_apps");
         let (tx, rx) = oneshot::channel();
@@ -866,12 +868,13 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
             .map(Response::new)
     }
-    #[cfg(not(windows))]
+
+    #[cfg(not(any(windows, target_os = "android")))]
     async fn clear_split_tunnel_apps(&self, _: Request<()>) -> ServiceResult<()> {
         Ok(Response::new(()))
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     async fn set_split_tunnel_state(&self, request: Request<bool>) -> ServiceResult<()> {
         log::debug!("set_split_tunnel_state");
         let enabled = request.into_inner();
@@ -882,7 +885,8 @@ impl ManagementService for ManagementServiceImpl {
             .map_err(map_daemon_error)
             .map(Response::new)
     }
-    #[cfg(not(windows))]
+
+    #[cfg(not(any(windows, target_os = "android")))]
     async fn set_split_tunnel_state(&self, _: Request<bool>) -> ServiceResult<()> {
         Ok(Response::new(()))
     }

--- a/mullvad-daemon/src/migrations/v9.rs
+++ b/mullvad-daemon/src/migrations/v9.rs
@@ -1,0 +1,672 @@
+#[cfg(target_os = "android")]
+use serde_json::json;
+#[cfg(target_os = "android")]
+use std::{
+    fs::{read_to_string, remove_file},
+    path::Path,
+};
+
+use mullvad_types::settings::SettingsVersion;
+
+use super::{Error, Result};
+
+// ======================================================
+// Section for vendoring types and values that
+// this settings version depend on. See `mod.rs`.
+type JsonSettings = serde_json::Map<String, serde_json::Value>;
+
+/// Directories which the migration may want to touch.
+#[cfg(target_os = "android")]
+pub struct Directories<'path> {
+    /// The path to the directory where `settings.json` is stored.
+    pub settings: &'path Path,
+}
+
+/// The file where all currently split-tunnelled apps are stored.
+#[cfg(target_os = "android")]
+const SPLIT_TUNNELING_APPS: &str = "split-tunnelling.txt";
+/// The file where the split-tunnelling state (enabled / disabled) is stored.
+#[cfg(target_os = "android")]
+const SPLIT_TUNNELING_STATE: &str = "split-tunnelling-enabled.txt";
+
+// ======================================================
+
+/// This is an open migration
+///
+/// This migration onboards the Android app's split tunnel settings into the daemon's settings.
+///
+/// Until now, split tunneling has been completely handled client side by the Android app. This
+/// includes keeping track of the setting itself (enabled / disabled) as well as all apps whose
+/// traffic is supposed to be routed outside of any active tunnel. This migration reads all split
+/// apps which has been stored by the Android client and writes them to the daemon's settings,
+/// adding the 'split_tunnel' key to the settings object in the process.
+///
+/// # Note
+/// This `migrate` function needs to get passed a `settings_dir` to work on Android. This is
+/// because the Android client will pass the settings directory when initializing the daemon,
+/// which means that we can not know ahead of time where the settings are stored.
+#[allow(unused_variables)]
+pub fn migrate(
+    settings: &mut serde_json::Value,
+    #[cfg(target_os = "android")] directories: Option<Directories<'_>>,
+) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to V10");
+
+    let json_blob = to_settings_object(settings)?;
+
+    // TODO: Remove this comment when closing the migration:
+    // While this is an open migration, we check to see if the split tunnel apps have been migrated
+    // already. If so, we don't want to run the migration code again. The call to `split_tunnel_subkey_exists`
+    // can safely be removed when closing this migration.
+    #[cfg(target_os = "android")]
+    if !android::split_tunnel_subkey_exists(json_blob) {
+        if let Some(directories) = directories {
+            android::migrate_split_tunnel_settings(json_blob, directories)?;
+        } else {
+            log::warn!(
+                "Did not migrate old split tunnelled apps due to missing settings directory"
+            );
+        }
+    }
+
+    // TODO: Uncomment this when closing the migration:
+    // json_blob["settings_version"] = serde_json::json!(SettingsVersion::V10);
+
+    Ok(())
+}
+
+fn version_matches(settings: &serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V9 as u64)
+        .unwrap_or(false)
+}
+
+/// Represent the settings blob for what it is: A JSON-object.
+fn to_settings_object(settings: &mut serde_json::Value) -> Result<&mut JsonSettings> {
+    settings
+        .as_object_mut()
+        .ok_or(Error::InvalidSettingsContent)
+}
+
+// TODO: Document
+#[cfg(target_os = "android")]
+mod android {
+    use super::*;
+
+    /// Check if the "split_tunnel" subkey already exists on the settings blob.
+    /// On Android, this key *should not* exist before this migration.
+    pub fn split_tunnel_subkey_exists(settings: &mut JsonSettings) -> bool {
+        settings.get("split_tunnel").is_some()
+    }
+
+    /// Read the existing split-tunneling settings which the Android client has kept track off and
+    /// write them to the settings object.
+    pub fn migrate_split_tunnel_settings(
+        settings: &mut JsonSettings,
+        directories: Directories<'_>,
+    ) -> Result<()> {
+        // Read the split tunnel state (enabled / disabled) & all split apps
+        // If both files can not be read for whatever reason we should not migrate any actual data.
+        // Instead, we fill in conservative default values instead.
+        let (enabled, split_apps) = match (
+            read_split_tunnel_state(&directories),
+            read_split_apps(&directories),
+        ) {
+            (Some(enabled), Some(apps)) => (enabled, apps),
+            _ => (false, vec![]),
+        };
+
+        // Write the split tunnel settings to the settings object.
+        add_split_tunneling_settings(settings, enabled, split_apps);
+
+        // Remove the old leftover settings files.
+        remove_old_split_tunneling_directories(&directories);
+
+        Ok(())
+    }
+
+    /// Add the "split_tunnel" subkey to the settings object while setting it's own subkeys to
+    /// `enabled` and `apps`.
+    pub fn add_split_tunneling_settings(
+        settings: &mut JsonSettings,
+        enabled: bool,
+        apps: Vec<String>,
+    ) {
+        // Create the "split_tunnel" key in the settings object and store the read split tunnel state in the daemon's settings
+        settings.insert(
+            "split_tunnel".to_string(),
+            json!({ "enable_exclusions": enabled, "apps": apps }),
+        );
+    }
+
+    /// Read the target file and parse the stored split tunneling state. If split tunneling was
+    /// previously enabled in the android app, the return value of this function will be `Some(true)`,
+    /// otherwise `Some(false)`.
+    ///
+    /// If the file could not be found or read, some logging will occur and `None` will be returned.
+    pub fn read_split_tunnel_state(directories: &Directories<'_>) -> Option<bool> {
+        let path = directories.settings.join(SPLIT_TUNNELING_STATE);
+        log::trace!("Reading split tunnel state from {}", path.display());
+        let enabled = read_to_string(path.clone())
+            .inspect_err(|_| {
+                log::error!("Could not read split tunnel state from {}", path.display())
+            })
+            .ok()?
+            .trim()
+            .eq("true");
+        Some(enabled)
+    }
+
+    /// Read the target file and parse the stored split tunneled apps.
+    ///
+    /// If the file could not be found or read, some logging will occur and `None` will be returned.
+    pub fn read_split_apps(directories: &Directories<'_>) -> Option<Vec<String>> {
+        let path = directories.settings.join(SPLIT_TUNNELING_APPS);
+        log::trace!("Reading split tunnel apps from {}", path.display());
+        let split_apps = read_to_string(path.clone())
+            .inspect_err(|_| {
+                log::error!("Could not read split tunnel apps from {}", path.display())
+            })
+            .ok()?
+            .lines()
+            .map(str::to_owned)
+            .collect();
+        Some(split_apps)
+    }
+
+    /// Remove the lingering, old files split tunnelling related files. They should have been
+    /// completely migrated to the daemon settings at this point, so they won't be needed any longer.
+    ///
+    /// Note: We don't really care if these operations fail - they won't ever be read again, and new
+    /// app installations shall not create them.
+    pub fn remove_old_split_tunneling_directories(directories: &Directories<'_>) {
+        remove_file(directories.settings.join(SPLIT_TUNNELING_STATE))
+            .inspect_err(|error| log::error!("Failed to remove {SPLIT_TUNNELING_STATE}: {error}"))
+            .ok();
+        remove_file(directories.settings.join(SPLIT_TUNNELING_APPS))
+            .inspect_err(|error| log::error!("Failed to remove {SPLIT_TUNNELING_APPS}: {error}"))
+            .ok();
+    }
+}
+
+#[cfg(test)]
+#[cfg(allow_unused)]
+mod test {
+    use mullvad_types::settings::SettingsVersion;
+
+    use super::{migrate, version_matches};
+    use crate::migrations::v9::test::constants::V9_SETTINGS;
+
+    /// The most basic assertion: Make sure that the settings version was bumped post-migration.
+    #[test]
+    fn test_v9_to_v10_migration_version_number() {
+        let mut settings = serde_json::from_str(V9_SETTINGS).unwrap();
+        assert!(version_matches(&settings));
+        migrate(
+            &mut settings,
+            #[cfg(target_os = "android")]
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            serde_json::from_value::<SettingsVersion>(settings["settings_version"].clone())
+                .unwrap(),
+            SettingsVersion::V10
+        );
+    }
+
+    /// Assert that split-tunneling settings has been added to the android settings post-migration.
+    #[test]
+    #[cfg(target_os = "android")]
+    fn test_v9_to_v10_migration() {
+        use crate::migrations::v9::{
+            add_split_tunneling_settings,
+            test::constants::{V10_ANDROID_SETTINGS, V9_ANDROID_SETTINGS},
+        };
+
+        let enabled = true;
+        let apps = ["com.android.chrome", "net.mullvad.mullvadvpn"];
+
+        let mut settings = serde_json::from_str(V9_ANDROID_SETTINGS).unwrap();
+        // Perform the actual settings migration while skipping the I/O performed in
+        // `migrate_split_tunnel_settings`.
+        add_split_tunneling_settings(settings, enabled, apps);
+        let new_settings = serde_json::from_str(V10_ANDROID_SETTINGS).unwrap();
+        assert_eq!(settings, new_settings);
+    }
+
+    mod constants {
+        pub const V9_SETTINGS: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "92135711-534d-4950-963d-93e446a792e4",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "settings_version": 9
+}
+"#;
+
+        pub const V10_SETTINGS: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "92135711-534d-4950-963d-93e446a792e4",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "settings_version": 10
+}
+"#;
+
+        /// This settings blob does not contain the "split_tunnel" option.
+        #[cfg(target_os = "android")]
+        pub const V9_ANDROID_SETTINGS: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "92135711-534d-4950-963d-93e446a792e4",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "settings_version": 9
+}
+"#;
+
+        /// This settings blob *should* contain the "split_tunnel" option.
+        #[cfg(target_os = "android")]
+        pub const V10_ANDROID_SETTINGS: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "se"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "92135711-534d-4950-963d-93e446a792e4",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "split_tunnel": {
+    "enable_exclusions": true,
+    "apps": ["com.android.chrome", "net.mullvad.mullvadvpn"]
+  }
+  "settings_version": 10
+}
+"#;
+    }
+}

--- a/mullvad-jni/src/daemon_interface.rs
+++ b/mullvad-jni/src/daemon_interface.rs
@@ -1,70 +1,13 @@
-use futures::{channel::oneshot, executor::block_on};
-use mullvad_daemon::{device, DaemonCommand, DaemonCommandSender};
-use mullvad_types::{
-    account::{AccountData, AccountToken, VoucherSubmission},
-    custom_list::CustomList,
-    device::{Device, DeviceState},
-    relay_constraints::{ObfuscationSettings, RelaySettings},
-    relay_list::RelayList,
-    settings::{DnsOptions, Settings},
-    states::{TargetState, TunnelState},
-    version::AppVersionInfo,
-    wireguard,
-    wireguard::QuantumResistantState,
-};
+use mullvad_daemon::{DaemonCommandSender, Error};
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Can't send command to daemon because it is not running")]
-    NoDaemon(#[source] mullvad_daemon::Error),
-
-    #[error("No response received from daemon")]
-    NoResponse,
-
-    #[error("Attempt to use daemon command sender before it was configured")]
-    NoSender,
-
-    #[error("Error performing RPC with the remote API")]
-    Api(#[source] mullvad_api::rest::Error),
-
-    #[error("Failed to update settings")]
-    UpdateSettings,
-
-    #[error("Daemon returned an error")]
-    Other(#[source] mullvad_daemon::Error),
-}
-
-impl From<mullvad_daemon::Error> for Error {
-    fn from(error: mullvad_daemon::Error) -> Error {
-        match error {
-            mullvad_daemon::Error::RestError(error) => Error::Api(error),
-            mullvad_daemon::Error::LoginError(device::Error::OtherRestError(error)) => {
-                Error::Api(error)
-            }
-            mullvad_daemon::Error::ListDevicesError(device::Error::OtherRestError(error)) => {
-                Error::Api(error)
-            }
-            error => Error::Other(error),
-        }
-    }
-}
-
-type Result<T> = std::result::Result<T, Error>;
-
-pub struct DaemonInterface {
-    command_sender: DaemonCommandSender,
-}
+pub struct DaemonInterface(DaemonCommandSender);
 
 impl DaemonInterface {
     pub fn new(command_sender: DaemonCommandSender) -> Self {
-        DaemonInterface { command_sender }
+        DaemonInterface(command_sender)
     }
 
-    pub fn shutdown(&self) -> Result<()> {
-        self.command_sender.shutdown().map_err(Error::NoDaemon)
-    }
-
-    fn send_command(&self, command: DaemonCommand) -> Result<()> {
-        self.command_sender.send(command).map_err(Error::NoDaemon)
+    pub fn shutdown(&self) -> Result<(), Error> {
+        self.0.shutdown()
     }
 }

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -9,22 +9,16 @@ mod talpid_vpn_service;
 use crate::daemon_interface::DaemonInterface;
 use jnix::{
     jni::{
-        objects::{GlobalRef, JObject, JString, JValue},
+        objects::{GlobalRef, JObject, JValue},
         signature::{JavaType, Primitive},
-        sys::{jboolean, jlong},
+        sys::jlong,
         JNIEnv, JavaVM,
     },
-    FromJava, IntoJava, JnixEnv,
+    FromJava, JnixEnv,
 };
-use mullvad_api::{rest::Error as RestError, StatusCode};
 use mullvad_daemon::{
-    cleanup_old_rpc_socket, device, exception_logging, logging, runtime::new_multi_thread, version,
-    Daemon, DaemonCommandChannel,
-};
-use mullvad_types::{
-    account::{AccountData, VoucherSubmission},
-    custom_list::CustomList,
-    settings::DnsOptions,
+    cleanup_old_rpc_socket, exception_logging, logging, runtime::new_multi_thread, version, Daemon,
+    DaemonCommandChannel,
 };
 use std::{
     io,
@@ -493,20 +487,6 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_shutdow
             log::error!(
                 "{}",
                 error.display_chain_with_msg("Failed to shutdown daemon thread")
-            );
-        }
-    }
-}
-
-fn log_request_error(request: &str, error: &daemon_interface::Error) {
-    match error {
-        daemon_interface::Error::Api(RestError::Aborted) => {
-            log::debug!("Request to {} cancelled", request);
-        }
-        error => {
-            log::error!(
-                "{}",
-                error.display_chain_with_msg(&format!("Failed to {}", request))
             );
         }
     }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -92,11 +92,13 @@ service ManagementService {
   rpc RemoveSplitTunnelProcess(google.protobuf.Int32Value) returns (google.protobuf.Empty) {}
   rpc ClearSplitTunnelProcesses(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
-  // Split tunneling (Windows)
+  // Split tunneling (Windows, Android)
   rpc AddSplitTunnelApp(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
   rpc RemoveSplitTunnelApp(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
-  rpc ClearSplitTunnelApps(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc SetSplitTunnelState(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
+
+  // Split tunneling (Windows)
+  rpc ClearSplitTunnelApps(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc GetExcludedProcesses(google.protobuf.Empty) returns (ExcludedProcessList) {}
 
   // Play payment (Android)
@@ -420,6 +422,9 @@ message SplitTunnelSettings {
   bool enable_exclusions = 1;
   repeated string apps = 2;
 }
+
+// A list of apps which should be excluded from the tunnel.
+message ExcludedApps { repeated string apps = 1; }
 
 message RelaySettings {
   oneof endpoint {

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -4,24 +4,27 @@ use talpid_types::ErrorExt;
 
 impl From<&mullvad_types::settings::Settings> for proto::Settings {
     fn from(settings: &mullvad_types::settings::Settings) -> Self {
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "android"))]
         let split_tunnel = {
-            let mut converted_list = vec![];
-            for path in settings.split_tunnel.apps.clone().iter() {
-                match path.as_path().as_os_str().to_str() {
-                    Some(path) => converted_list.push(path.to_string()),
+            let apps = settings
+                .split_tunnel
+                .apps
+                .iter()
+                .filter_map(|app| match app.clone().to_string() {
                     None => {
-                        log::error!("failed to convert OS string: {:?}", path);
+                        log::error!("Failed to convert application to string: {:?}", app);
+                        None
                     }
-                }
-            }
+                    string => string,
+                })
+                .collect();
 
             Some(proto::SplitTunnelSettings {
                 enable_exclusions: settings.split_tunnel.enable_exclusions,
-                apps: converted_list,
+                apps,
             })
         };
-        #[cfg(not(windows))]
+        #[cfg(not(any(windows, target_os = "android")))]
         let split_tunnel = None;
 
         Self {
@@ -156,7 +159,7 @@ impl TryFrom<proto::Settings> for mullvad_types::settings::Settings {
                 .ok_or(FromProtobufTypeError::InvalidArgument(
                     "missing api access methods settings",
                 ))?;
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "android"))]
         let split_tunnel = settings
             .split_tunnel
             .ok_or(FromProtobufTypeError::InvalidArgument(
@@ -181,7 +184,7 @@ impl TryFrom<proto::Settings> for mullvad_types::settings::Settings {
                 .map(mullvad_types::relay_constraints::RelayOverride::try_from)
                 .collect::<Result<Vec<_>, _>>()?,
             show_beta_releases: settings.show_beta_releases,
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             split_tunnel: mullvad_types::settings::SplitTunnelSettings::from(split_tunnel),
             obfuscation_settings: mullvad_types::relay_constraints::ObfuscationSettings::try_from(
                 obfuscation_settings,
@@ -216,16 +219,13 @@ pub fn try_bridge_state_from_i32(
     }
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "android"))]
 impl From<proto::SplitTunnelSettings> for mullvad_types::settings::SplitTunnelSettings {
     fn from(value: proto::SplitTunnelSettings) -> Self {
-        mullvad_types::settings::SplitTunnelSettings {
+        use mullvad_types::settings::{SplitApp, SplitTunnelSettings};
+        SplitTunnelSettings {
             enable_exclusions: value.enable_exclusions,
-            apps: value
-                .apps
-                .into_iter()
-                .map(std::path::PathBuf::from)
-                .collect(),
+            apps: value.apps.into_iter().map(SplitApp::from).collect(),
         }
     }
 }

--- a/mullvad-paths/src/rpc_socket.rs
+++ b/mullvad-paths/src/rpc_socket.rs
@@ -7,18 +7,17 @@ pub fn get_rpc_socket_path() -> PathBuf {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn get_default_rpc_socket_path() -> PathBuf {
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    {
-        PathBuf::from("/var/run/mullvad-vpn")
-    }
-    #[cfg(windows)]
-    {
-        PathBuf::from("//./pipe/Mullvad VPN")
-    }
-    #[cfg(target_os = "android")]
-    {
-        log::warn!("HELLO? ");
-        PathBuf::from(format!("{}/rpc-socket", crate::APP_PATH))
-    }
+    PathBuf::from("/var/run/mullvad-vpn")
+}
+
+#[cfg(windows)]
+pub fn get_default_rpc_socket_path() -> PathBuf {
+    PathBuf::from("//./pipe/Mullvad VPN")
+}
+
+#[cfg(target_os = "android")]
+pub fn get_default_rpc_socket_path() -> PathBuf {
+    PathBuf::from(format!("{}/rpc-socket", crate::APP_PATH))
 }

--- a/mullvad-paths/src/settings.rs
+++ b/mullvad-paths/src/settings.rs
@@ -22,25 +22,24 @@ fn get_settings_dir() -> Result<PathBuf> {
     }
 }
 
+#[cfg(not(target_os = "android"))]
 pub fn get_default_settings_dir() -> Result<PathBuf> {
-    #[cfg(not(target_os = "android"))]
+    let dir;
+    #[cfg(unix)]
     {
-        let dir;
-        #[cfg(unix)]
-        {
-            dir = Ok(PathBuf::from("/etc"));
-        }
-        #[cfg(windows)]
-        {
-            dir = crate::windows::get_system_service_appdata().map_err(|error| {
-                log::error!("Failed to obtain system app data path: {error}");
-                crate::Error::FindDirError
-            })
-        }
-        dir.map(|dir| dir.join(crate::PRODUCT_NAME))
+        dir = Ok(PathBuf::from("/etc"));
     }
-    #[cfg(target_os = "android")]
+    #[cfg(windows)]
     {
-        Ok(PathBuf::from(crate::APP_PATH))
+        dir = crate::windows::get_system_service_appdata().map_err(|error| {
+            log::error!("Failed to obtain system app data path: {error}");
+            crate::Error::FindDirError
+        })
     }
+    dir.map(|dir| dir.join(crate::PRODUCT_NAME))
+}
+
+#[cfg(target_os = "android")]
+pub fn get_default_settings_dir() -> Result<PathBuf> {
+    Ok(PathBuf::from(crate::APP_PATH))
 }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -22,7 +22,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V9;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V10;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -35,6 +35,7 @@ pub enum SettingsVersion {
     V7 = 7,
     V8 = 8,
     V9 = 9,
+    V10 = 10,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -51,6 +52,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V7 as u32 => Ok(SettingsVersion::V7),
             v if v == SettingsVersion::V8 as u32 => Ok(SettingsVersion::V8),
             v if v == SettingsVersion::V9 as u32 => Ok(SettingsVersion::V9),
+            v if v == SettingsVersion::V10 as u32 => Ok(SettingsVersion::V10),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -12,8 +12,8 @@ use crate::{
 #[cfg(target_os = "android")]
 use jnix::IntoJava;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(target_os = "windows")]
-use std::{collections::HashSet, path::PathBuf};
+#[cfg(any(windows, target_os = "android"))]
+use std::collections::HashSet;
 use talpid_types::net::{openvpn, GenericTunnelOptions};
 
 mod dns;
@@ -70,25 +70,19 @@ impl Serialize for SettingsVersion {
 /// Mullvad daemon settings.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
-#[cfg_attr(target_os = "android", derive(IntoJava))]
-#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct Settings {
     pub relay_settings: RelaySettings,
-    #[cfg_attr(target_os = "android", jnix(skip))]
     pub bridge_settings: BridgeSettings,
     pub obfuscation_settings: ObfuscationSettings,
-    #[cfg_attr(target_os = "android", jnix(skip))]
     pub bridge_state: BridgeState,
     /// All of the custom relay lists
     pub custom_lists: CustomListsSettings,
     /// API access methods
-    #[cfg_attr(target_os = "android", jnix(skip))]
     pub api_access_methods: access_method::Settings,
     /// If the daemon should allow communication with private (LAN) networks.
     pub allow_lan: bool,
     /// Extra level of kill switch. When this setting is on, the disconnected state will block
     /// the firewall to not allow any traffic in or out.
-    #[cfg_attr(target_os = "android", jnix(skip))]
     pub block_when_disconnected: bool,
     /// If the daemon should connect the VPN tunnel directly on start or not.
     pub auto_connect: bool,
@@ -100,20 +94,84 @@ pub struct Settings {
     /// Whether to notify users of beta updates.
     pub show_beta_releases: bool,
     /// Split tunneling settings
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "android"))]
     pub split_tunnel: SplitTunnelSettings,
     /// Specifies settings schema version
-    #[cfg_attr(target_os = "android", jnix(skip))]
     pub settings_version: SettingsVersion,
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "android"))]
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 pub struct SplitTunnelSettings {
     /// Toggles split tunneling on or off
     pub enable_exclusions: bool,
-    /// List of applications to exclude from the tunnel.
-    pub apps: HashSet<PathBuf>,
+    /// Set of applications to exclude from the tunnel.
+    pub apps: HashSet<SplitApp>,
+}
+
+/// An application whose traffic should be excluded from any active tunnel.
+#[cfg(windows)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SplitApp(std::path::PathBuf);
+
+/// An application whose traffic should be excluded from any active tunnel.
+#[cfg(target_os = "android")]
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SplitApp(String);
+
+#[cfg(windows)]
+impl SplitApp {
+    /// Convert the underlying path to a [`String`].
+    /// This function will fail if the underlying path string is not valid UTF-8. See [`std::ffi::OsStr::to_str`] for details.
+    pub fn to_string(self) -> Option<String> {
+        self.0.as_os_str().to_str().map(str::to_string)
+    }
+
+    /// This is the String-representation as expected by [`SetExcludedApps`].
+    pub fn to_tunnel_command_repr(self) -> std::ffi::OsString {
+        self.0.as_os_str().to_owned()
+    }
+
+    pub fn display(&self) -> std::path::Display<'_> {
+        self.0.display()
+    }
+}
+
+#[cfg(target_os = "android")]
+impl SplitApp {
+    /// Convert the underlying app name to a [`String`].
+    ///
+    /// # Note
+    /// This function is fallible due to the Window's dito being fallible, and it is convenient to have the same API across all platforms.
+    pub fn to_string(self) -> Option<String> {
+        Some(self.0)
+    }
+
+    /// This is the String-representation as expected by [`SetExcludedApps`].
+    pub fn to_tunnel_command_repr(self) -> String {
+        self.0
+    }
+}
+
+#[cfg(windows)]
+impl From<String> for SplitApp {
+    fn from(value: String) -> Self {
+        SplitApp::from(std::path::PathBuf::from(value))
+    }
+}
+
+#[cfg(windows)]
+impl From<std::path::PathBuf> for SplitApp {
+    fn from(value: std::path::PathBuf) -> Self {
+        SplitApp(value)
+    }
+}
+
+#[cfg(target_os = "android")]
+impl From<String> for SplitApp {
+    fn from(value: String) -> Self {
+        SplitApp(value)
+    }
 }
 
 impl Default for Settings {
@@ -145,7 +203,7 @@ impl Default for Settings {
             tunnel_options: TunnelOptions::default(),
             relay_overrides: vec![],
             show_beta_releases: false,
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             split_tunnel: SplitTunnelSettings::default(),
             settings_version: CURRENT_SETTINGS_VERSION,
         }

--- a/mullvad-version/Cargo.toml
+++ b/mullvad-version/Cargo.toml
@@ -16,5 +16,5 @@ rust-version.workspace = true
 workspace = true
 
 
-[target.'cfg(not(target_os="android"))'.dependencies]
+[dependencies]
 regex = "1.6.0"

--- a/talpid-core/src/split_tunnel/android.rs
+++ b/talpid-core/src/split_tunnel/android.rs
@@ -1,0 +1,8 @@
+/// Errors related to split tunneling.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Failed to update the set of excluded apps. This implies that the current
+    /// tunnel was not recreated.
+    #[error("Failed to update the set of excluded apps")]
+    SetExcludedApps(#[source] talpid_tunnel::tun_provider::Error),
+}

--- a/talpid-core/src/split_tunnel/mod.rs
+++ b/talpid-core/src/split_tunnel/mod.rs
@@ -2,12 +2,13 @@
 #[path = "linux.rs"]
 mod imp;
 
-#[cfg(target_os = "linux")]
-pub use imp::*;
-
 #[cfg(windows)]
 #[path = "windows/mod.rs"]
 mod imp;
 
-#[cfg(windows)]
+#[cfg(target_os = "android")]
+#[path = "android.rs"]
+mod imp;
+
+#[cfg(any(target_os = "android", target_os = "linux", windows))]
 pub use imp::*;

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -323,9 +323,9 @@ impl ConnectedState {
                 shared_values.bypass_socket(fd, done_tx);
                 SameState(self)
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                shared_values.split_tunnel.set_paths(&paths, result_tx);
+                shared_values.exclude_paths(paths, result_tx);
                 SameState(self)
             }
         }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -463,9 +463,9 @@ impl ConnectingState {
                 shared_values.bypass_socket(fd, done_tx);
                 SameState(self)
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                shared_values.split_tunnel.set_paths(&paths, result_tx);
+                shared_values.exclude_paths(paths, result_tx);
                 SameState(self)
             }
         }

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -211,9 +211,9 @@ impl TunnelState for DisconnectedState {
                 shared_values.bypass_socket(fd, done_tx);
                 SameState(self)
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                shared_values.split_tunnel.set_paths(&paths, result_tx);
+                shared_values.exclude_paths(paths, result_tx);
                 SameState(self)
             }
             None => {

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -76,9 +76,9 @@ impl DisconnectingState {
                     shared_values.bypass_socket(fd, done_tx);
                     AfterDisconnect::Nothing
                 }
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "android"))]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                    shared_values.split_tunnel.set_paths(&paths, result_tx);
+                    shared_values.exclude_paths(paths, result_tx);
                     AfterDisconnect::Nothing
                 }
             },
@@ -122,9 +122,9 @@ impl DisconnectingState {
                     shared_values.bypass_socket(fd, done_tx);
                     AfterDisconnect::Block(reason)
                 }
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "android"))]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                    shared_values.split_tunnel.set_paths(&paths, result_tx);
+                    shared_values.exclude_paths(paths, result_tx);
                     AfterDisconnect::Block(reason)
                 }
                 None => AfterDisconnect::Block(reason),
@@ -169,9 +169,9 @@ impl DisconnectingState {
                     shared_values.bypass_socket(fd, done_tx);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "android"))]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                    shared_values.split_tunnel.set_paths(&paths, result_tx);
+                    shared_values.exclude_paths(paths, result_tx);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
             },

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -211,9 +211,9 @@ impl TunnelState for ErrorState {
                 shared_values.bypass_socket(fd, done_tx);
                 SameState(self)
             }
-            #[cfg(windows)]
+            #[cfg(any(windows, target_os = "android"))]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
-                shared_values.split_tunnel.set_paths(&paths, result_tx);
+                shared_values.exclude_paths(paths, result_tx);
                 SameState(self)
             }
         }

--- a/talpid-tunnel/src/tun_provider/mod.rs
+++ b/talpid-tunnel/src/tun_provider/mod.rs
@@ -33,10 +33,7 @@ cfg_if! {
 /// Configuration for creating a tunnel device.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(target_os = "android", derive(IntoJava))]
-#[cfg_attr(
-    target_os = "android",
-    jnix(package = "net.mullvad.mullvadvpn.model")
-)]
+#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.mullvadvpn.model"))]
 pub struct TunConfig {
     /// IP addresses for the tunnel interface.
     pub addresses: Vec<IpAddr>,
@@ -55,6 +52,10 @@ pub struct TunConfig {
     #[cfg(target_os = "android")]
     #[jnix(skip)]
     pub required_routes: Vec<IpNetwork>,
+
+    /// App packages that should be excluded from the tunnel.
+    #[cfg(target_os = "android")]
+    pub excluded_packages: Vec<String>,
 
     /// Maximum Transmission Unit in the tunnel.
     #[cfg_attr(target_os = "android", jnix(map = "|mtu| mtu as i32"))]


### PR DESCRIPTION
This PR implements daemon support for split tunneling on Android.

The list of excluded apps is now handled by the daemon. The list of excluded apps is provided to the Android client via `TunConfig`, which has been updated slightly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6182)
<!-- Reviewable:end -->
