### PR TITLE
Fix hostname line for custom bridge

### DIFF
--- a/gui/src/renderer/components/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/ConnectionPanel.tsx
@@ -166,10 +166,6 @@ export default class ConnectionPanel extends React.Component<IProps> {
           entry: this.props.entryHostname,
         },
       );
-    } else if (this.props.bridgeInfo?.ip) {
-      hostname = sprintf(messages.pgettext('connection-info', '%(relay)s via %(entry)s'), {
-        relay: this.props.hostname,
-      });
     } else if (this.props.bridgeInfo !== undefined) {
       hostname = sprintf(messages.pgettext('connection-info', '%(relay)s via Custom bridge'), {
         relay: this.props.hostname,


### PR DESCRIPTION
Due to an error the hostname line shows as "<exit> via undefined" when using a custom bridge. This is now fixed by removing old code that shouldn't be needed anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6183)
<!-- Reviewable:end -->
