### PR TITLE
Add possibility to use openvpn binary without the --route-noexec option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add custom bridge settings in GUI.
+- Add possibility to use openvpn binary without the --route-noexec option
 
 ### Fixed
 #### macOS

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -263,6 +263,7 @@ impl TryFrom<proto::TunnelOptions> for mullvad_types::settings::TunnelOptions {
         Ok(Self {
             openvpn: net::openvpn::TunnelOptions {
                 mssfix: openvpn_options.mssfix.map(|mssfix| mssfix as u16),
+                allow_route_push: false,
             },
             wireguard: mullvad_types::wireguard::TunnelOptions {
                 mtu: wireguard_options.mtu.map(|mtu| mtu as u16),

--- a/talpid-openvpn/src/process/openvpn.rs
+++ b/talpid-openvpn/src/process/openvpn.rs
@@ -254,6 +254,11 @@ impl OpenVpnCommand {
             args.extend(["--mark", &mark.to_string()].iter().map(OsString::from));
         }
 
+        #[cfg(target_os = "linux")]
+        if !self.tunnel_options.allow_route_push {
+            args.retain(|x| *x != OsString::from("--route-noexec"));
+        }
+
         args
     }
 

--- a/talpid-types/src/net/openvpn.rs
+++ b/talpid-types/src/net/openvpn.rs
@@ -42,4 +42,5 @@ pub struct TunnelOptions {
     /// Optional argument for openvpn to try and limit TCP packet size,
     /// as discussed [here](https://openvpn.net/archive/openvpn-users/2003-11/msg00154.html)
     pub mssfix: Option<u16>,
+    pub allow_route_push: bool,
 }


### PR DESCRIPTION
This PR introduce way to push routes to the openvpnbinary when using it through talpid-openvpn. It add a option in the  openvpn::tunnelOptions structure (allow_route_push) that can be set to true in order to allow the capability.
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6197)
<!-- Reviewable:end -->
