### PR TITLE
Enable constant packet size for entry peer

### DIFF
--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -558,7 +558,7 @@ impl WireguardMonitor {
         }
 
         config.exit_peer_mut().psk = exit_psk;
-        #[cfg(target_os = "windows")]
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
         if config.daita {
             log::trace!("Enabling constant packet size for entry peer");
             config.entry_peer.constant_packet_size = true;

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -70,7 +70,6 @@ type WireGuardGetConfigurationFn = unsafe extern "stdcall" fn(
 type WireGuardSetStateFn =
     unsafe extern "stdcall" fn(adapter: RawHandle, state: WgAdapterState) -> BOOL;
 
-#[cfg(windows)]
 #[repr(C)]
 #[allow(dead_code)]
 enum LogLevel {
@@ -79,7 +78,6 @@ enum LogLevel {
     Err = 2,
 }
 
-#[cfg(windows)]
 impl From<LogLevel> for logging::LogLevel {
     fn from(level: LogLevel) -> Self {
         match level {
@@ -1145,7 +1143,6 @@ mod tests {
             allowed_ips: vec!["1.3.3.0/24".parse().unwrap()],
             endpoint: "1.2.3.4:1234".parse().unwrap(),
             psk: None,
-            #[cfg(target_os = "windows")]
             constant_packet_size: false,
         },
         exit_peer: None,
@@ -1181,7 +1178,6 @@ mod tests {
             rx_bytes: 0,
             last_handshake: 0,
             allowed_ips_count: 1,
-            #[cfg(target_os = "windows")]
             constant_packet_size: 0,
         },
         p0_allowed_ip_0: WgAllowedIp {

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-
+[target.'cfg(unix)'.dependencies]
 # NOTE: remember to update libwg/go.mod if you change this:
 cmaybenot = { git = "https://github.com/mullvad/wireguard-go", rev = "7cf6da8e40b37770d911eb2b4b5469f77fdd8aa2" }

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 pub type Fd = std::os::unix::io::RawFd;
 use std::ffi::{c_char, c_void};
 pub type WgLogLevel = u32;


### PR DESCRIPTION
This PR also drive-by fixes the `wireguard-go-rs` crate messing up compilation of the app on Windows :sweat_smile:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6200)
<!-- Reviewable:end -->
