### PR TITLE
Fixed yanked dependency in test workspace

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -4391,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]


### PR DESCRIPTION
Seems like this version has been yanked. Apparently, downgrading helps. I chose to do that since that's the same version that's used in the app repo.

See https://github.com/mullvad/mullvadvpn-app/actions/runs/8894943512/job/24424260453?pr=5844

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6201)
<!-- Reviewable:end -->
