### PR TITLE
Add `daita` as a custom config name

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -118,6 +118,8 @@ jobs:
       - name: Checkout repository
         if: steps.cache-relay-list.outputs.cache-hit != 'true'
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Generate
         if: steps.cache-relay-list.outputs.cache-hit != 'true'
@@ -164,6 +166,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Calculate native lib cache hash
         id: native-lib-cache-hash
@@ -195,7 +199,6 @@ jobs:
           UNSTRIPPED_LIB_PATH="$CARGO_TARGET_DIR/${{ matrix.target }}/$BUILD_TYPE/libmullvad_jni.so"
           STRIPPED_LIB_PATH="./android/app/build/extraJni/${{ matrix.abi }}/libmullvad_jni.so"
           NDK_TOOLCHAIN_STRIP_TOOL="$NDK_TOOLCHAIN_DIR/llvm-strip"
-          ./wireguard/build-wireguard-go.sh --android --no-docker
           cargo build --target ${{ matrix.target }} --verbose --package mullvad-jni --features api-override
           $NDK_TOOLCHAIN_STRIP_TOOL --strip-debug --strip-unneeded -o "$STRIPPED_LIB_PATH" "$UNSTRIPPED_LIB_PATH"
 
@@ -235,6 +238,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Run gradle task
         uses: burrunan/gradle-cache-action@v1
@@ -262,6 +267,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: actions/download-artifact@v4
         with:
@@ -366,6 +373,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cargo-vendor.yml
+++ b/.github/workflows/cargo-vendor.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1.0.6

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -43,8 +43,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout binaries submodule
-        run: git submodule update --init --depth=1 dist-assets/binaries
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --depth=1 dist-assets/binaries
+          git submodule update --init --recursive --depth=1 wireguard-go-rs
 
       - uses: actions-rs/toolchain@v1.0.6
         with:
@@ -57,6 +59,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libdbus-1-dev
+
+      - name: Install Go
+        if: matrix.os == 'linux-latest' || matrix.os == 'macos-latest'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.3
 
       - name: Clippy check
         shell: bash
@@ -82,6 +90,11 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Checkout wireguard-go submodule
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init --depth=1 wireguard-go-rs
 
       - name: Clippy check
         env:

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Checkout binaries submodule
+      - name: Checkout submodules
         run: |
           git config --global --add safe.directory '*'
           git submodule update --init --depth=1 dist-assets/binaries
-
+          git submodule update --init --recursive --depth=1 wireguard-go-rs
       # The container image already has rustup and Rust, but only the stable toolchain
       - name: Install Rust toolchain
         run: rustup default ${{ matrix.rust }}
@@ -85,6 +85,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Checkout wireguard-go submodule
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init --recursive --depth=1 wireguard-go-rs
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -103,10 +103,10 @@ jobs:
         run: echo "HOME=/root" >> $GITHUB_ENV
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Checkout binaries submodule
+      - name: Checkout submodules
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init --depth=1 dist-assets/binaries
+          git submodule update --init --depth=1 dist-assets/binaries wireguard-go-rs
       - name: Build app
         env:
           USE_MOLD: false
@@ -159,9 +159,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Checkout submodules
-        run: git submodule update --init --depth=1
+        uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -230,9 +230,9 @@ jobs:
     runs-on: [self-hosted, desktop-test, macOS] # app-test-macos-arm
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Checkout submodules
-        run: git submodule update --init --depth=1
+        uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Checkout wireguard-go submodule
+        run: git submodule update --init --depth=1 wireguard-go-rs
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1.0.6
         with:

--- a/.github/workflows/rust-supply-chain.yml
+++ b/.github/workflows/rust-supply-chain.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Checkout wireguard-go submodule
+        run: git submodule update --init --depth=1 wireguard-go-rs
+
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@v1
         with:

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 env:
   # Pinning nightly just to avoid random breakage. It's fine to bump this at any time
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-02-06
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-06-06
 jobs:
   prepare-containers:
     runs-on: ubuntu-latest
@@ -41,17 +41,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Checkout binaries submodule
+      - name: Checkout submodules
         run: |
           git config --global --add safe.directory '*'
           git submodule update --init --depth=1 dist-assets/binaries
+          git submodule update --init --recursive --depth=1 wireguard-go-rs
 
       - name: Install nightly Rust toolchain
         run: rustup default $RUST_NIGHTLY_TOOLCHAIN
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps
+          tool: cargo-udeps@0.1.48
 
       - name: Check for unused dependencies
         shell: bash
@@ -72,6 +73,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Checkout wireguard-go submodule
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init --depth=1 wireguard-go-rs
+
       - name: Install nightly Rust toolchain
         run: |
           rustup default $RUST_NIGHTLY_TOOLCHAIN
@@ -79,7 +85,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps
+          tool: cargo-udeps@0.1.48
 
       - name: Check for unused dependencies
         run: cargo udeps --target aarch64-linux-android --package mullvad-jni
@@ -87,12 +93,13 @@ jobs:
   cargo-udeps:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -108,7 +115,13 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps
+          tool: cargo-udeps@0.1.48
+
+      - name: Install Go
+        if: matrix.os == 'macos-latest'
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21.3
 
       - name: Check for unused dependencies
         shell: bash

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Checkout wireguard-go submodule
+        run: git submodule update --init --depth=1 wireguard-go-rs
+
       - name: Install nightly Rust
         uses: actions-rs/toolchain@v1.0.6
         with:

--- a/.github/workflows/unicode-check.yml
+++ b/.github/workflows/unicode-check.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Checkout submodules
-        run: git submodule update --init
+        run: git submodule update --init --depth=1 dist-assets/binaries wireguard-go-rs
 
       - name: Scan for code points
         run: ./ci/check-trojan-source.sh .

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ cd mullvadvpn-app
 git submodule update --init
 ```
 
+On Android, Linux and macOS you also want to checkout the wireguard-go submodule recursively:
+```bash
+git submodule update --init --recursive --depth=1 wireguard-go-rs
+```
+Further details on why this is necessary can be found in the [wireguard-go-rs crate](./wireguard-go-rs/README.md).
+
 We sign every commit on the `main` branch as well as our release tags. If you would like to verify
 your checkout, you can find our developer keys on [Mullvad's Open Source page].
 

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -8,7 +8,7 @@
 #     -v $GRADLE_CACHE_VOLUME_NAME:/root/.gradle:Z \
 #     -v $ANDROID_CREDENTIALS_DIR:/build/android/credentials:Z \
 #     -v /path/to/repository_root:/build:Z \
-#     mullvadvpn-app-build-android ./build-apk.sh --dev-build --no-docker
+#     mullvadvpn-app-build-android ./build-apk.sh --dev-build
 #
 # See the base image Dockerfile in the repository root (../../Dockerfile)
 # for more information.

--- a/android/docs/BuildInstructions.macos.md
+++ b/android/docs/BuildInstructions.macos.md
@@ -65,7 +65,7 @@ export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$NDK_TOOLCHAIN_DIR/x86_64-linux
 Run the build script in the root of the project to assemble all the native libraries and the app:
 
 ```bash
-./build-apk.sh --dev-build --no-docker
+./build-apk.sh --dev-build
 ```
 
 Once the build is complete you should receive a message looking similar to this:

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -16,7 +16,6 @@ GRADLE_BUILD_TYPE="release"
 GRADLE_TASKS=(createOssProdReleaseDistApk createPlayProdReleaseDistApk)
 BUNDLE_TASKS=(createPlayProdReleaseDistBundle)
 CARGO_ARGS=( "--release" )
-EXTRA_WGGO_ARGS=""
 BUILD_BUNDLE="no"
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-"target"}
 SKIP_STRIPPING=${SKIP_STRIPPING:-"no"}
@@ -32,11 +31,8 @@ while [ -n "${1:-""}" ]; do
         GRADLE_BUILD_TYPE="fdroid"
         GRADLE_TASKS=(createOssProdFdroidDistApk)
         BUNDLE_TASKS=(createOssProdFdroidDistBundle)
-        EXTRA_WGGO_ARGS="--no-docker"
     elif [[ "${1:-""}" == "--app-bundle" ]]; then
         BUILD_BUNDLE="yes"
-    elif [[ "${1:-""}" == "--no-docker" ]]; then
-        EXTRA_WGGO_ARGS="--no-docker"
     elif [[ "${1:-""}" == "--skip-stripping" ]]; then
         SKIP_STRIPPING="yes"
     fi
@@ -79,8 +75,6 @@ fi
 $GRADLE_CMD --console plain clean
 mkdir -p "app/build/extraJni"
 popd
-
-./wireguard/build-wireguard-go.sh --android $EXTRA_WGGO_ARGS
 
 for ARCHITECTURE in ${ARCHITECTURES:-aarch64 armv7 x86_64 i686}; do
     case "$ARCHITECTURE" in

--- a/building/containerized-build.sh
+++ b/building/containerized-build.sh
@@ -18,7 +18,7 @@ case $platform in
         shift 1
     ;;
     android)
-        build_command=("./build-apk.sh" "--no-docker")
+        build_command=("./build-apk.sh")
         shift 1
     ;;
     *)

--- a/ci/buildserver-build-android.sh
+++ b/ci/buildserver-build-android.sh
@@ -65,6 +65,7 @@ function checkout_ref {
     git reset --hard
     git checkout "$ref"
     git submodule update
+    git submodule update --init --recursive --depth=1 wireguard-go-rs || true
     git clean -df
 }
 

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -163,6 +163,7 @@ function checkout_ref {
     git reset --hard
     git checkout "$ref"
     git submodule update
+    git submodule update --init --recursive --depth=1 wireguard-go-rs || true
     git clean -df
 }
 

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -40,9 +40,12 @@ DAEMON_PLIST=$(cat <<-EOM
                 <key>Label</key>
                 <string>net.mullvad.daemon</string>
 
+                <key>WorkingDirectory</key>
+                <string>$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/</string>
+
                 <key>ProgramArguments</key>
                 <array>
-                        <string>$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-daemon</string>
+                        <string>./mullvad-daemon</string>
                         <string>-v</string>
                 </array>
 

--- a/mullvad-cli/build.rs
+++ b/mullvad-cli/build.rs
@@ -15,4 +15,11 @@ fn main() {
         ));
         res.compile().expect("Unable to generate windows resources");
     }
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+
+    // Enable Daita by default on Linux and Windows.
+    println!("cargo::rustc-check-cfg=cfg(daita)");
+    if let "linux" | "windows" = target_os.as_str() {
+        println!(r#"cargo::rustc-cfg=daita"#);
+    }
 }

--- a/mullvad-cli/src/cmds/relay.rs
+++ b/mullvad-cli/src/cmds/relay.rs
@@ -542,7 +542,7 @@ impl Relay {
                     allowed_ips: all_of_the_internet(),
                     endpoint: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
                     psk: None,
-                    #[cfg(any(target_os = "windows", target_os = "linux"))]
+                    #[cfg(daita)]
                     constant_packet_size: false,
                 },
                 exit_peer: None,

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Subcommand;
 use mullvad_management_interface::MullvadProxyClient;
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 use mullvad_types::wireguard::DaitaSettings;
 use mullvad_types::{
     constraints::Constraint,
@@ -41,7 +41,7 @@ pub enum TunnelOptions {
         #[arg(long)]
         quantum_resistant: Option<QuantumResistantState>,
         /// Configure whether to enable DAITA
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         #[arg(long)]
         daita: Option<BooleanOption>,
         /// The key rotation interval. Number of hours, or 'any'
@@ -101,7 +101,7 @@ impl Tunnel {
             tunnel_options.wireguard.quantum_resistant,
         );
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         print_option!("DAITA", tunnel_options.wireguard.daita.enabled);
 
         let key = rpc.get_wireguard_key().await?;
@@ -138,7 +138,7 @@ impl Tunnel {
             TunnelOptions::Wireguard {
                 mtu,
                 quantum_resistant,
-                #[cfg(any(target_os = "windows", target_os = "linux"))]
+                #[cfg(daita)]
                 daita,
                 rotation_interval,
                 rotate_key,
@@ -146,7 +146,7 @@ impl Tunnel {
                 Self::handle_wireguard(
                     mtu,
                     quantum_resistant,
-                    #[cfg(any(target_os = "windows", target_os = "linux"))]
+                    #[cfg(daita)]
                     daita,
                     rotation_interval,
                     rotate_key,
@@ -178,7 +178,7 @@ impl Tunnel {
     async fn handle_wireguard(
         mtu: Option<Constraint<u16>>,
         quantum_resistant: Option<QuantumResistantState>,
-        #[cfg(any(target_os = "windows", target_os = "linux"))] daita: Option<BooleanOption>,
+        #[cfg(daita)] daita: Option<BooleanOption>,
         rotation_interval: Option<Constraint<RotationInterval>>,
         rotate_key: Option<RotateKey>,
     ) -> Result<()> {
@@ -194,7 +194,7 @@ impl Tunnel {
             println!("Quantum resistant setting has been updated");
         }
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         if let Some(daita) = daita {
             rpc.set_daita_settings(DaitaSettings { enabled: *daita })
                 .await?;

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -174,7 +174,7 @@ fn format_relay_connection(
         "\nQuantum resistant tunnel: no"
     };
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     let daita = if !verbose {
         ""
     } else if endpoint.daita {
@@ -182,7 +182,7 @@ fn format_relay_connection(
     } else {
         "\nDAITA: no"
     };
-    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    #[cfg(not(daita))]
     let daita = "";
 
     let mut bridge_type = String::new();

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -18,16 +18,23 @@ fn main() {
             windows_sys::Win32::System::SystemServices::LANG_ENGLISH as u16,
             windows_sys::Win32::System::SystemServices::SUBLANG_ENGLISH_US as u16,
         ));
-        println!("cargo:rerun-if-env-changed=MULLVAD_ADD_MANIFEST");
+        println!("cargo::rerun-if-env-changed=MULLVAD_ADD_MANIFEST");
         if env::var("MULLVAD_ADD_MANIFEST")
             .map(|s| s != "0")
             .unwrap_or(false)
         {
             res.set_manifest_file("mullvad-daemon.manifest");
         } else {
-            println!("cargo:warning=Skipping mullvad-daemon manifest");
+            println!("cargo::warning=Skipping mullvad-daemon manifest");
         }
         res.compile().expect("Unable to generate windows resources");
+    }
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+
+    // Enable Daita by default on Linux and Windows.
+    println!("cargo::rustc-check-cfg=cfg(daita)");
+    if let "linux" | "windows" = target_os.as_str() {
+        println!(r#"cargo::rustc-cfg=daita"#);
     }
 }
 

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -1,4 +1,8 @@
-use std::{env, fs, path::PathBuf, process::Command};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 #[cfg(windows)]
 fn make_lang_id(p: u16, s: u16) -> u16 {
@@ -35,6 +39,19 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(daita)");
     if let "linux" | "windows" = target_os.as_str() {
         println!(r#"cargo::rustc-cfg=daita"#);
+    }
+
+    // For debug builds, configure rpath to facilitate linking with libwg.so
+    if matches!(target_os.as_str(), "linux" | "macos" | "android") && cfg!(debug_assertions) {
+        let target = env::var("TARGET").expect("TARGET not set");
+        let libwg_path = Path::new("../build/lib/")
+            .canonicalize()
+            .unwrap_or_else(|_| {
+                panic!("Could not resolve canonical path for relative path `build/lib/{target}`")
+            })
+            .join(target.clone());
+
+        println!("cargo::rustc-link-arg=-Wl,-rpath,{}", libwg_path.display());
     }
 }
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -44,7 +44,7 @@ use mullvad_relay_selector::{
 use mullvad_types::account::{PlayPurchase, PlayPurchasePaymentToken};
 #[cfg(any(windows, target_os = "android", target_os = "macos"))]
 use mullvad_types::settings::SplitApp;
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 use mullvad_types::wireguard::DaitaSettings;
 use mullvad_types::{
     access_method::{AccessMethod, AccessMethodSetting},
@@ -258,7 +258,7 @@ pub enum DaemonCommand {
     /// Set whether to enable PQ PSK exchange in the tunnel
     SetQuantumResistantTunnel(ResponseTx<(), settings::Error>, QuantumResistantState),
     /// Set DAITA settings for the tunnel
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     SetDaitaSettings(ResponseTx<(), settings::Error>, DaitaSettings),
     /// Set DNS options or servers to use
     SetDnsOptions(ResponseTx<(), settings::Error>, DnsOptions),
@@ -1230,7 +1230,7 @@ where
                 self.on_set_quantum_resistant_tunnel(tx, quantum_resistant_state)
                     .await
             }
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             SetDaitaSettings(tx, daita_settings) => {
                 self.on_set_daita_settings(tx, daita_settings).await
             }
@@ -2301,7 +2301,7 @@ where
         }
     }
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     async fn on_set_daita_settings(
         &mut self,
         tx: ResponseTx<(), settings::Error>,
@@ -2858,9 +2858,9 @@ impl DaemonShutdownHandle {
 fn new_selector_config(settings: &Settings) -> SelectorConfig {
     let additional_constraints = AdditionalRelayConstraints {
         wireguard: AdditionalWireguardConstraints {
-            #[cfg(target_os = "windows")]
+            #[cfg(daita)]
             daita: settings.tunnel_options.wireguard.daita.enabled,
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(not(daita))]
             daita: false,
         },
     };

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -322,7 +322,7 @@ impl ManagementService for ManagementServiceImpl {
         Ok(Response::new(()))
     }
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     async fn set_daita_settings(
         &self,
         request: Request<types::DaitaSettings>,
@@ -336,7 +336,7 @@ impl ManagementService for ManagementServiceImpl {
         Ok(Response::new(()))
     }
 
-    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    #[cfg(not(daita))]
     async fn set_daita_settings(&self, _: Request<types::DaitaSettings>) -> ServiceResult<()> {
         Ok(Response::new(()))
     }

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -2,7 +2,7 @@
 
 use crate::types;
 use futures::{Stream, StreamExt};
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 use mullvad_types::wireguard::DaitaSettings;
 use mullvad_types::{
     access_method::{self, AccessMethod, AccessMethodSetting},
@@ -346,7 +346,7 @@ impl MullvadProxyClient {
         Ok(())
     }
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     pub async fn set_daita_settings(&mut self, settings: DaitaSettings) -> Result<()> {
         let settings = types::DaitaSettings::from(settings);
         self.0

--- a/mullvad-management-interface/src/types/conversions/custom_tunnel.rs
+++ b/mullvad-management-interface/src/types/conversions/custom_tunnel.rs
@@ -91,7 +91,7 @@ impl TryFrom<proto::ConnectionConfig> for mullvad_types::ConnectionConfig {
                             allowed_ips,
                             endpoint,
                             psk: None,
-                            #[cfg(any(target_os = "windows", target_os = "linux"))]
+                            #[cfg(daita)]
                             constant_packet_size: false,
                         },
                         exit_peer: None,

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -40,9 +40,9 @@ impl From<talpid_types::net::TunnelEndpoint> for proto::TunnelEndpoint {
             tunnel_metadata: endpoint
                 .tunnel_interface
                 .map(|tunnel_interface| proto::TunnelMetadata { tunnel_interface }),
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             daita: endpoint.daita,
-            #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+            #[cfg(not(daita))]
             daita: false,
         }
     }
@@ -127,7 +127,7 @@ impl TryFrom<proto::TunnelEndpoint> for talpid_types::net::TunnelEndpoint {
             tunnel_interface: endpoint
                 .tunnel_metadata
                 .map(|tunnel_metadata| tunnel_metadata.tunnel_interface),
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             daita: endpoint.daita,
         })
     }

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -100,9 +100,9 @@ impl From<&mullvad_types::settings::TunnelOptions> for proto::TunnelOptions {
                         .expect("Failed to convert std::time::Duration to prost_types::Duration for tunnel_options.wireguard.rotation_interval")
                 }),
                 quantum_resistant: Some(proto::QuantumResistantState::from(options.wireguard.quantum_resistant)),
-                #[cfg(any(target_os = "windows", target_os = "linux"))]
+                #[cfg(daita)]
                 daita: Some(proto::DaitaSettings::from(options.wireguard.daita.clone())),
-                #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+                #[cfg(not(daita))]
                 daita: None,
             }),
             generic: Some(proto::tunnel_options::GenericOptions {
@@ -283,7 +283,7 @@ impl TryFrom<proto::TunnelOptions> for mullvad_types::settings::TunnelOptions {
                     .ok_or(FromProtobufTypeError::InvalidArgument(
                         "missing quantum resistant state",
                     ))??,
-                #[cfg(any(target_os = "windows", target_os = "linux"))]
+                #[cfg(daita)]
                 daita: wireguard_options
                     .daita
                     .map(mullvad_types::wireguard::DaitaSettings::from)

--- a/mullvad-management-interface/src/types/conversions/wireguard.rs
+++ b/mullvad-management-interface/src/types/conversions/wireguard.rs
@@ -73,7 +73,7 @@ impl TryFrom<proto::QuantumResistantState> for mullvad_types::wireguard::Quantum
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 impl From<mullvad_types::wireguard::DaitaSettings> for proto::DaitaSettings {
     fn from(settings: mullvad_types::wireguard::DaitaSettings) -> Self {
         proto::DaitaSettings {
@@ -82,7 +82,7 @@ impl From<mullvad_types::wireguard::DaitaSettings> for proto::DaitaSettings {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 impl From<proto::DaitaSettings> for mullvad_types::wireguard::DaitaSettings {
     fn from(settings: proto::DaitaSettings) -> Self {
         mullvad_types::wireguard::DaitaSettings {

--- a/mullvad-relay-selector/build.rs
+++ b/mullvad-relay-selector/build.rs
@@ -1,6 +1,4 @@
 fn main() {
-    tonic_build::compile_protos("proto/management_interface.proto").unwrap();
-
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
 
     // Enable Daita by default on Linux and Windows.

--- a/mullvad-relay-selector/src/relay_selector/detailer.rs
+++ b/mullvad-relay-selector/src/relay_selector/detailer.rs
@@ -85,7 +85,7 @@ fn wireguard_singlehop_endpoint(
         // This will be filled in later, not the relay selector's problem
         psk: None,
         // This will be filled in later
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         constant_packet_size: false,
     };
     Ok(MullvadWireguardEndpoint {
@@ -126,7 +126,7 @@ fn wireguard_multihop_endpoint(
         // This will be filled in later, not the relay selector's problem
         psk: None,
         // This will be filled in later
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         constant_packet_size: false,
     };
 
@@ -144,7 +144,7 @@ fn wireguard_multihop_endpoint(
         // This will be filled in later
         psk: None,
         // This will be filled in later
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         constant_packet_size: false,
     };
 

--- a/mullvad-types/build.rs
+++ b/mullvad-types/build.rs
@@ -1,6 +1,4 @@
 fn main() {
-    tonic_build::compile_protos("proto/management_interface.proto").unwrap();
-
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
 
     // Enable Daita by default on Linux and Windows.

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -51,7 +51,7 @@ impl FromStr for QuantumResistantState {
 #[error("Not a valid state")]
 pub struct QuantumResistantStateParseError;
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DaitaSettings {
     pub enabled: bool,
@@ -195,7 +195,7 @@ pub struct TunnelOptions {
     /// Obtain a PSK using the relay config client.
     pub quantum_resistant: QuantumResistantState,
     /// Configure DAITA
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     pub daita: DaitaSettings,
     /// Interval used for automatic key rotation
     pub rotation_interval: Option<RotationInterval>,
@@ -207,7 +207,7 @@ impl Default for TunnelOptions {
         TunnelOptions {
             mtu: None,
             quantum_resistant: QuantumResistantState::Auto,
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             daita: DaitaSettings::default(),
             rotation_interval: None,
         }
@@ -223,7 +223,7 @@ impl TunnelOptions {
                 QuantumResistantState::On => true,
                 QuantumResistantState::Off => false,
             },
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             daita: self.daita.enabled,
         }
     }

--- a/talpid-core/build.rs
+++ b/talpid-core/build.rs
@@ -29,12 +29,12 @@ mod win {
     }
 
     pub fn declare_library(env_var: &str, default_dir: &str, lib_name: &str) {
-        println!("cargo:rerun-if-env-changed={}", env_var);
+        println!("cargo::rerun-if-env-changed={}", env_var);
         let lib_dir = env::var_os(env_var)
             .map(PathBuf::from)
             .unwrap_or_else(|| default_windows_build_artifact_dir(default_dir));
-        println!("cargo:rustc-link-search={}", lib_dir.display());
-        println!("cargo:rustc-link-lib=dylib={}", lib_name);
+        println!("cargo::rustc-link-search={}", lib_dir.display());
+        println!("cargo::rustc-link-lib=dylib={}", lib_name);
     }
 
     pub fn manifest_dir() -> PathBuf {
@@ -53,7 +53,7 @@ fn main() {
     const WINFW_DIR_VAR: &str = "WINFW_LIB_DIR";
     declare_library(WINFW_DIR_VAR, WINFW_BUILD_DIR, "winfw");
     let lib_dir = manifest_dir().join("../build/lib/x86_64-pc-windows-msvc");
-    println!("cargo:rustc-link-search={}", &lib_dir.display());
+    println!("cargo::rustc-link-search={}", &lib_dir.display());
 }
 
 #[cfg(not(windows))]

--- a/talpid-types/build.rs
+++ b/talpid-types/build.rs
@@ -1,6 +1,4 @@
 fn main() {
-    tonic_build::compile_protos("proto/management_interface.proto").unwrap();
-
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
 
     // Enable Daita by default on Linux and Windows.

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -38,7 +38,7 @@ impl TunnelParameters {
                 obfuscation: None,
                 entry_endpoint: None,
                 tunnel_interface: None,
-                #[cfg(any(target_os = "windows", target_os = "linux"))]
+                #[cfg(daita)]
                 daita: false,
             },
             TunnelParameters::Wireguard(params) => TunnelEndpoint {
@@ -55,7 +55,7 @@ impl TunnelParameters {
                     .get_exit_endpoint()
                     .map(|_| params.connection.get_endpoint()),
                 tunnel_interface: None,
-                #[cfg(any(target_os = "windows", target_os = "linux"))]
+                #[cfg(daita)]
                 daita: params.options.daita,
             },
         }
@@ -179,7 +179,7 @@ pub struct TunnelEndpoint {
     pub obfuscation: Option<ObfuscationEndpoint>,
     pub entry_endpoint: Option<Endpoint>,
     pub tunnel_interface: Option<String>,
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     pub daita: bool,
 }
 

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -62,7 +62,7 @@ pub struct PeerConfig {
     #[serde(skip)]
     pub psk: Option<PresharedKey>,
     /// Enable constant packet sizes for `entry_peer``
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     #[serde(skip)]
     pub constant_packet_size: bool,
 }
@@ -82,7 +82,7 @@ pub struct TunnelOptions {
     /// Perform PQ-safe PSK exchange when connecting
     pub quantum_resistant: bool,
     /// Enable DAITA during tunnel config
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     pub daita: bool,
 }
 

--- a/talpid-wireguard/build.rs
+++ b/talpid-wireguard/build.rs
@@ -9,17 +9,23 @@ fn main() {
 }
 
 fn add_wireguard_go_cfg(target_os: &str) {
-    println!("cargo:rustc-check-cfg=cfg(wireguard_go)");
+    println!("cargo::rustc-check-cfg=cfg(wireguard_go)");
     if matches!(target_os, "linux" | "macos" | "android") {
-        println!("cargo:rustc-cfg=wireguard_go");
+        println!("cargo::rustc-cfg=wireguard_go");
+    }
+
+    // Enable Daita by default on Linux and Windows.
+    println!("cargo::rustc-check-cfg=cfg(daita)");
+    if matches!(target_os, "linux" | "windows") {
+        println!(r#"cargo::rustc-cfg=daita"#);
     }
 }
 
 fn declare_libs_dir(base: &str) {
     let target_triplet = env::var("TARGET").expect("TARGET is not set");
     let lib_dir = manifest_dir().join(base).join(target_triplet);
-    println!("cargo:rerun-if-changed={}", lib_dir.display());
-    println!("cargo:rustc-link-search={}", lib_dir.display());
+    println!("cargo::rerun-if-changed={}", lib_dir.display());
+    println!("cargo::rustc-link-search={}", lib_dir.display());
 }
 
 fn manifest_dir() -> PathBuf {

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -97,9 +97,9 @@ impl Config {
             enable_ipv6: generic_options.enable_ipv6,
             obfuscator_config: obfuscator_config.to_owned(),
             quantum_resistant: wg_options.quantum_resistant,
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             daita: wg_options.daita,
-            #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+            #[cfg(not(daita))]
             daita: false,
         };
 

--- a/talpid-wireguard/src/connectivity_check.rs
+++ b/talpid-wireguard/src/connectivity_check.rs
@@ -403,6 +403,7 @@ mod test {
     use crate::{
         config::Config,
         stats::{self, Stats},
+        Tunnel,
     };
     use std::{
         pin::Pin,
@@ -615,7 +616,7 @@ mod test {
             Box::pin(async { Ok(()) })
         }
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         fn start_daita(&mut self) -> std::result::Result<(), TunnelError> {
             Ok(())
         }

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -385,7 +385,7 @@ impl WireguardMonitor {
                 let config = config.clone();
                 let iface_name = iface_name.clone();
                 tokio::task::spawn(async move {
-                    #[cfg(target_os = "windows")]
+                    #[cfg(daita)]
                     if config.daita {
                         // TODO: For now, we assume the MTU during the tunnel lifetime.
                         // We could instead poke maybenot whenever we detect changes to it.
@@ -558,7 +558,7 @@ impl WireguardMonitor {
         }
 
         config.exit_peer_mut().psk = exit_psk;
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         if config.daita {
             log::trace!("Enabling constant packet size for entry peer");
             config.entry_peer.constant_packet_size = true;
@@ -576,7 +576,7 @@ impl WireguardMonitor {
         )
         .await?;
 
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         if config.daita {
             // Start local DAITA machines
             let mut tunnel = tunnel.lock().await;
@@ -833,7 +833,7 @@ impl WireguardMonitor {
     fn open_wireguard_go_tunnel(
         config: &Config,
         log_path: Option<&Path>,
-        #[cfg(any(target_os = "windows", target_os = "linux"))] resource_dir: &Path,
+        #[cfg(daita)] resource_dir: &Path,
         tun_provider: Arc<Mutex<TunProvider>>,
         #[cfg(target_os = "android")] gateway_only: bool,
     ) -> Result<WgGoTunnel> {
@@ -848,7 +848,7 @@ impl WireguardMonitor {
             log_path,
             tun_provider,
             routes,
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             resource_dir,
         )
         .map_err(Error::TunnelError)?;
@@ -1065,7 +1065,7 @@ pub(crate) trait Tunnel: Send {
         &'a mut self,
         _config: Config,
     ) -> Pin<Box<dyn Future<Output = std::result::Result<(), TunnelError>> + Send + 'a>>;
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     /// A [`Tunnel`] capable of using DAITA.
     fn start_daita(&mut self) -> std::result::Result<(), TunnelError>;
 }
@@ -1143,17 +1143,18 @@ pub enum TunnelError {
     LoggingError(#[source] logging::Error),
 
     /// Failed to receive DAITA event
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     #[error("Failed to start DAITA")]
     StartDaita(#[source] Box<dyn std::error::Error + Send>),
 
     /// This tunnel does not support DAITA.
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     #[error("Failed to start DAITA - tunnel implemenation does not support DAITA")]
     DaitaNotSupported,
 }
 
 #[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn will_nm_manage_dns() -> bool {
     use talpid_dbus::network_manager::NetworkManager;
 

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -1,7 +1,7 @@
 use ipnetwork::IpNetwork;
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 use once_cell::sync::OnceCell;
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 use std::{ffi::CString, fs, path::PathBuf};
 use std::{
     future::Future,
@@ -25,11 +25,11 @@ use crate::logging::{clean_up_logging, initialize_logging};
 const MAX_PREPARE_TUN_ATTEMPTS: usize = 4;
 
 /// Maximum number of events that can be stored in the underlying buffer
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 const DAITA_EVENTS_CAPACITY: u32 = 1000;
 
 /// Maximum number of actions that can be stored in the underlying buffer
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(daita)]
 const DAITA_ACTIONS_CAPACITY: u32 = 1000;
 
 type Result<T> = std::result::Result<T, TunnelError>;
@@ -52,9 +52,9 @@ pub struct WgGoTunnel {
     _logging_context: LoggingContext,
     #[cfg(target_os = "android")]
     tun_provider: Arc<Mutex<TunProvider>>,
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     resource_dir: PathBuf,
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     config: Config,
 }
 
@@ -64,7 +64,7 @@ impl WgGoTunnel {
         log_path: Option<&Path>,
         tun_provider: Arc<Mutex<TunProvider>>,
         routes: impl Iterator<Item = IpNetwork>,
-        #[cfg(any(target_os = "windows", target_os = "linux"))] resource_dir: &Path,
+        #[cfg(daita)] resource_dir: &Path,
     ) -> Result<Self> {
         #[cfg(target_os = "android")]
         let tun_provider_clone = tun_provider.clone();
@@ -101,9 +101,9 @@ impl WgGoTunnel {
             _logging_context: logging_context,
             #[cfg(target_os = "android")]
             tun_provider: tun_provider_clone,
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             resource_dir: resource_dir.to_owned(),
-            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            #[cfg(daita)]
             config: config.clone(),
         })
     }
@@ -242,7 +242,7 @@ impl Tunnel for WgGoTunnel {
         })
     }
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     fn start_daita(&mut self) -> Result<()> {
         static MAYBENOT_MACHINES: OnceCell<CString> = OnceCell::new();
         let machines = MAYBENOT_MACHINES.get_or_try_init(|| {

--- a/talpid-wireguard/src/wireguard_kernel/netlink_tunnel.rs
+++ b/talpid-wireguard/src/wireguard_kernel/netlink_tunnel.rs
@@ -128,8 +128,8 @@ impl Tunnel for NetlinkTunnel {
         })
     }
 
-    // TODO: We shouldn't force `NetlinkTunnel` to implement `start_daita`
+    /// Outright fail to start - this tunnel type does not support DAITA.
     fn start_daita(&mut self) -> std::result::Result<(), TunnelError> {
-        unreachable!("Netlink tunnel does not support DAITA")
+        Err(TunnelError::DaitaNotSupported)
     }
 }

--- a/talpid-wireguard/src/wireguard_kernel/nm_tunnel.rs
+++ b/talpid-wireguard/src/wireguard_kernel/nm_tunnel.rs
@@ -111,9 +111,9 @@ impl Tunnel for NetworkManagerTunnel {
         })
     }
 
-    // TODO: We shouldn't force `NetworkManagerTunnel` tunnel to implement `start_daita`
+    /// Outright fail to start - this tunnel type does not support DAITA.
     fn start_daita(&mut self) -> std::result::Result<(), TunnelError> {
-        unreachable!("NetworkManager tunnel does not support DAITA")
+        Err(TunnelError::DaitaNotSupported)
     }
 }
 

--- a/talpid-wireguard/src/wireguard_nt/daita.rs
+++ b/talpid-wireguard/src/wireguard_nt/daita.rs
@@ -1,3 +1,4 @@
+#![cfg(daita)]
 use super::WIREGUARD_KEY_LENGTH;
 use maybenot::framework::MachineId;
 use once_cell::sync::OnceCell;

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -8,15 +8,17 @@ use bitflags::bitflags;
 use futures::SinkExt;
 use ipnetwork::IpNetwork;
 use once_cell::sync::{Lazy, OnceCell};
+#[cfg(daita)]
+use std::{ffi::c_uchar, path::PathBuf};
 use std::{
-    ffi::{c_uchar, CStr},
+    ffi::CStr,
     fmt,
     future::Future,
     io,
     mem::{self, MaybeUninit},
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     os::windows::io::RawHandle,
-    path::{Path, PathBuf},
+    path::Path,
     pin::Pin,
     ptr,
     sync::{Arc, Mutex},
@@ -36,6 +38,7 @@ use windows_sys::{
     },
 };
 
+#[cfg(daita)]
 mod daita;
 
 static WG_NT_DLL: OnceCell<WgNtDll> = OnceCell::new();
@@ -159,20 +162,24 @@ pub enum Error {
     InvalidConfigData,
 
     /// DAITA machinist failed
+    #[cfg(daita)]
     #[error("Failed to enable DAITA on tunnel device")]
     EnableTunnelDaita(#[source] io::Error),
 
     /// DAITA machinist failed
+    #[cfg(daita)]
     #[error("Failed to initialize DAITA machinist")]
     InitializeMachinist(#[source] daita::Error),
 }
 
 pub struct WgNtTunnel {
+    #[cfg(daita)]
     resource_dir: PathBuf,
     config: Arc<Mutex<Config>>,
     device: Option<Arc<WgNtAdapter>>,
     interface_name: String,
     setup_handle: tokio::task::JoinHandle<()>,
+    #[cfg(daita)]
     daita_handle: Option<daita::MachinistHandle>,
     _logger_handle: LoggerHandle,
 }
@@ -314,6 +321,7 @@ bitflags! {
         const REPLACE_ALLOWED_IPS = 0b00100000;
         const REMOVE = 0b01000000;
         const UPDATE = 0b10000000;
+        #[cfg(daita)]
         const HAS_CONSTANT_PACKET_SIZE = 0b100000000;
     }
 }
@@ -332,6 +340,7 @@ struct WgPeer {
     rx_bytes: u64,
     last_handshake: u64,
     allowed_ips_count: u32,
+    #[cfg(daita)]
     constant_packet_size: c_uchar,
 }
 
@@ -468,11 +477,13 @@ impl WgNtTunnel {
         });
 
         Ok(WgNtTunnel {
+            #[cfg(daita)]
             resource_dir: resource_dir.to_owned(),
             config: Arc::new(Mutex::new(config.clone())),
             device,
             interface_name,
             setup_handle,
+            #[cfg(daita)]
             daita_handle: None,
             _logger_handle: logger_handle,
         })
@@ -480,12 +491,14 @@ impl WgNtTunnel {
 
     fn stop_tunnel(&mut self) {
         self.setup_handle.abort();
+        #[cfg(daita)]
         if let Some(daita_handle) = self.daita_handle.take() {
             let _ = daita_handle.close();
         }
         let _ = self.device.take();
     }
 
+    #[cfg(daita)]
     fn spawn_machinist(&mut self) -> Result<()> {
         if let Some(handle) = self.daita_handle.take() {
             log::info!("Stopping previous DAITA machines");
@@ -666,10 +679,13 @@ struct WgNtDll {
     func_set_adapter_state: WireGuardSetStateFn,
     func_set_logger: WireGuardSetLoggerFn,
     func_set_adapter_logging: WireGuardSetAdapterLoggingFn,
-
+    #[cfg(daita)]
     func_daita_activate: daita::bindings::WireGuardDaitaActivateFn,
+    #[cfg(daita)]
     func_daita_event_data_available_event: daita::bindings::WireGuardDaitaEventDataAvailableEventFn,
+    #[cfg(daita)]
     func_daita_receive_events: daita::bindings::WireGuardDaitaReceiveEventsFn,
+    #[cfg(daita)]
     func_daita_send_action: daita::bindings::WireGuardDaitaSendActionFn,
 }
 
@@ -743,24 +759,28 @@ impl WgNtDll {
                     CStr::from_bytes_with_nul(b"WireGuardSetAdapterLogging\0").unwrap(),
                 )?) as *const _ as *const _)
             },
+            #[cfg(daita)]
             func_daita_activate: unsafe {
                 *((&get_proc_fn(
                     handle,
                     CStr::from_bytes_with_nul(b"WireGuardDaitaActivate\0").unwrap(),
                 )?) as *const _ as *const _)
             },
+            #[cfg(daita)]
             func_daita_event_data_available_event: unsafe {
                 *((&get_proc_fn(
                     handle,
                     CStr::from_bytes_with_nul(b"WireGuardDaitaEventDataAvailableEvent\0").unwrap(),
                 )?) as *const _ as *const _)
             },
+            #[cfg(daita)]
             func_daita_receive_events: unsafe {
                 *((&get_proc_fn(
                     handle,
                     CStr::from_bytes_with_nul(b"WireGuardDaitaReceiveEvents\0").unwrap(),
                 )?) as *const _ as *const _)
             },
+            #[cfg(daita)]
             func_daita_send_action: unsafe {
                 *((&get_proc_fn(
                     handle,
@@ -864,6 +884,7 @@ impl WgNtDll {
         Ok(())
     }
 
+    #[cfg(daita)]
     pub unsafe fn daita_activate(
         &self,
         adapter: RawHandle,
@@ -876,6 +897,7 @@ impl WgNtDll {
         Ok(())
     }
 
+    #[cfg(daita)]
     pub unsafe fn daita_event_data_available_event(
         &self,
         adapter: RawHandle,
@@ -887,6 +909,7 @@ impl WgNtDll {
         Ok(ready_event)
     }
 
+    #[cfg(daita)]
     pub unsafe fn daita_receive_events(
         &self,
         adapter: RawHandle,
@@ -899,6 +922,7 @@ impl WgNtDll {
         Ok(num_events)
     }
 
+    #[cfg(daita)]
     pub unsafe fn daita_send_action(
         &self,
         adapter: RawHandle,
@@ -935,12 +959,16 @@ fn serialize_config(config: &Config) -> Result<Vec<MaybeUninit<u8>>> {
     buffer.extend(as_uninit_byte_slice(&header));
 
     for peer in config.peers() {
+        #[cfg(not(daita))]
+        let mut flags = WgPeerFlag::HAS_PUBLIC_KEY | WgPeerFlag::HAS_ENDPOINT;
+        #[cfg(daita)]
         let mut flags = WgPeerFlag::HAS_PUBLIC_KEY
             | WgPeerFlag::HAS_ENDPOINT
             | WgPeerFlag::HAS_CONSTANT_PACKET_SIZE;
         if peer.psk.is_some() {
             flags |= WgPeerFlag::HAS_PRESHARED_KEY;
         }
+        #[cfg(daita)]
         let constant_packet_size = if peer.constant_packet_size { 1 } else { 0 };
         let wg_peer = WgPeer {
             flags,
@@ -957,6 +985,7 @@ fn serialize_config(config: &Config) -> Result<Vec<MaybeUninit<u8>>> {
             rx_bytes: 0,
             last_handshake: 0,
             allowed_ips_count: u32::try_from(peer.allowed_ips.len()).unwrap(),
+            #[cfg(daita)]
             constant_packet_size,
         };
 
@@ -1101,6 +1130,7 @@ impl Tunnel for WgNtTunnel {
         })
     }
 
+    #[cfg(daita)]
     fn start_daita(&mut self) -> std::result::Result<(), crate::TunnelError> {
         self.spawn_machinist().map_err(|error| {
             log::error!(
@@ -1150,6 +1180,7 @@ mod tests {
         ipv6_gateway: None,
         mtu: 0,
         obfuscator_config: None,
+        #[cfg(daita)]
         daita: false,
         quantum_resistant: false,
     });

--- a/test/test-manager/build.rs
+++ b/test/test-manager/build.rs
@@ -1,4 +1,4 @@
 fn main() {
     // Rebuild if SSH provision script changes
-    println!("cargo:rerun-if-changed=../scripts/ssh-setup.sh");
+    println!("cargo::rerun-if-changed=../scripts/ssh-setup.sh");
 }

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -4,7 +4,7 @@ description = "Rust bindings to wireguard-go with DAITA support"
 edition = "2021"
 license.workspace = true
 
-[dependencies]
+[target.'cfg(unix)'.dependencies]
 thiserror.workspace = true
 log.workspace = true
 zeroize = "1.8.1"

--- a/wireguard-go-rs/README.md
+++ b/wireguard-go-rs/README.md
@@ -1,10 +1,11 @@
 # `wireguard-go-rs`
-This crate wraps `libwg`, which in turn wraps [Mullvad VPN's fork of wireguard-go](https://github.com/mullvad/wireguard-go) which extends `wireguard-go` with [DAITA](https://mullvad.net/en/blog/introducing-defense-against-ai-guided-traffic-analysis-daita).
+This crate is a Rust-friendly wrapper around `wireguard-go`.
+It wraps `libwg`, which in turn wraps [Mullvad VPN's fork of wireguard-go](https://github.com/mullvad/wireguard-go) that extends `wireguard-go` with [DAITA](https://mullvad.net/en/blog/introducing-defense-against-ai-guided-traffic-analysis-daita).
 
 ## Known limitation
-To extend `wireguard-go` with DAITA capabilities, it statically links against [maybenot](https://github.com/maybenot-io/maybenot/), which at the time of writing will cause issues if it in turn is statically linked from another Rust crate: https://github.com/rust-lang/rust/issues/104707.
-As such, `libwg` is built as a shared object which you have to link to dynamically.
-To get rid of this limitation, you could compile `wireguard-go` without DAITA support. See [build-wireguard-go.sh](./build-wireguard-go.sh) for details.
+To extend `wireguard-go` with DAITA capabilities, `wireguard-go` links against [maybenot](https://github.com/maybenot-io/maybenot/). This is done statically, which at the time of writing will cause issues if `wireguard-go` in turn is statically linked from another Rust crate: https://github.com/rust-lang/rust/issues/104707.
+As such `libwg` is built as a shared object which you can link to dynamically, which circumvents this issue.
+To get rid of this limitation, you can compile `wireguard-go` without DAITA support. See [build-wireguard-go.sh](./build-wireguard-go.sh) for details on how to do that.
 
 ## Upgrading `wireguard-go`
 Upgrading `wireguard-go` involves updating the git submodule found in `libwg/wireguard-go`. This module uses [Mullvad VPN's fork of wireguard-go](https://github.com/mullvad/wireguard-go).

--- a/wireguard-go-rs/build-wireguard-go.sh
+++ b/wireguard-go-rs/build-wireguard-go.sh
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
-
-# This script is used to build wireguard-go libraries for all the platforms.
 #
-# If "DAITA" support should be enabled, pass the `--daita` flag when invoking this script.
+# This script is used to build libwg (wireguard-go as an FFI-friendly library) for different platforms.
+#
+# Supported arguments:
+# * --android
+#   If libwg should be built for an Android target.
+# * --daita
+#   Build libwg with "DAITA" support.
+#
 
 set -eu
 
+# If the target OS is Android.
+ANDROID="false"
 # If Wireguard-go should be built with DAITA-support.
 DAITA="false"
-# If the target OS is Adnroid.
-ANDROID="false"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_DIR="$SCRIPT_DIR/../build"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --android) ANDROID="true";;
         --daita)   DAITA="true";;
         *)
-            log_error "Unknown parameter: $1"
+            echo "Unknown parameter: $1"
             exit 1
             ;;
     esac
@@ -45,7 +53,6 @@ function unix_target_triple {
 
 
 function build_unix {
-    # TODO: consider using `log_header` here
     echo "Building wireguard-go for $1"
 
     # Flags for cross compiling
@@ -79,16 +86,19 @@ function build_unix {
     fi
 
 
-    # Build wiregaurd-go as a library
+    # Build wireguard-go as a library
+    mkdir -p "$BUILD_DIR/lib/$TARGET"
     pushd libwg
     if [[ "$DAITA" == "true" ]]; then
         pushd wireguard-go
-        make libmaybenot.a LIBDEST="$OUT_DIR"
+        CARGO_TARGET_DIR="$BUILD_DIR/tmp/" make libmaybenot.a LIBDEST="$BUILD_DIR/lib/$TARGET"
         popd
-        go build -v --tags daita -o "$OUT_DIR"/libwg.a -buildmode c-archive
+        CGO_LDFLAGS="-L$BUILD_DIR/lib/$TARGET" go build -v --tags daita -o "$BUILD_DIR/lib/$TARGET/libwg.so" -buildmode c-shared
     else
-        go build -v -o "$OUT_DIR"/libwg.a -buildmode c-archive
+        go build -v -o "$BUILD_DIR/lib/$TARGET/libwg.so" -buildmode c-shared
     fi
+    # Copy libwg to `OUT_DIR` so that we may refer to it via `OUT_DIR` in `build.rs`, which might be handy.
+    cp "$BUILD_DIR/lib/$TARGET/libwg.so" "$OUT_DIR/libwg.so"
     popd
 }
 
@@ -107,7 +117,7 @@ function build_wireguard_go {
     local platform
     platform="$(uname -s)";
     case "$platform" in
-        Linux*|Darwin*) build_unix "${1:-$(unix_target_triple)}";;
+        Linux*|Darwin*) build_unix "${TARGET:-$(unix_target_triple)}";;
         *)
             echo "Unsupported platform"
             return 1

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -4,6 +4,8 @@ use std::{env, path::PathBuf};
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("Missing OUT_DIR");
     eprintln!("OUT_DIR: {out_dir}");
+    // Add DAITA as a conditional configuration
+    println!("cargo::rustc-check-cfg=cfg(daita)");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("Missing 'CARGO_CFG_TARGET_OS");
     let mut cmd = std::process::Command::new("bash");
@@ -12,7 +14,7 @@ fn main() {
     match target_os.as_str() {
         "linux" => {
             // Enable DAITA & Tell rustc to link libmaybenot
-            println!("cargo::rustc-link-lib=static=maybenot");
+            println!(r#"cargo::rustc-cfg=daita"#);
             // Tell the build script to build wireguard-go with DAITA support
             cmd.arg("--daita");
         }

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -3,6 +3,7 @@ use std::{env, path::PathBuf};
 
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("Missing OUT_DIR");
+
     eprintln!("OUT_DIR: {out_dir}");
     // Add DAITA as a conditional configuration
     println!("cargo::rustc-check-cfg=cfg(daita)");
@@ -36,19 +37,26 @@ fn main() {
         panic!();
     }
 
-    if target_os == "android" {
-        // NOTE: Go programs does not support being statically linked on android
-        // so we need to dynamically link to libwg
-        println!("cargo::rustc-link-lib=wg");
-        declare_libs_dir("../build/lib");
-    } else {
-        // other platforms can statically link to libwg just fine
-        // TODO: consider doing dynamic linking everywhere, to keep things simpler
-        println!("cargo::rustc-link-lib=static=wg");
-        println!("cargo::rustc-link-search={out_dir}");
-    }
+    // NOTE: Link dynamically to libwg on all platforms.
+    //
+    // LTO breaks when statically linking to libwg due to its dependency
+    // libmaybenot already statically links against the Rust standard library,
+    // which will cause the linker to see duplicate symbols once we try to
+    // statically link any other Rust program (e.g. mullvad-daemon) against
+    // libwg. This is not an issue if we stick to dynamic linking.
+    //
+    // Also, Go programs does not support being statically linked on android so
+    // we need to dynamically link to libwg.
+    println!("cargo::rustc-link-lib=wg");
+    declare_libs_dir("../build/lib");
 
     println!("cargo::rerun-if-changed=libwg");
+
+    // Add `OUT_DIR` to the library search path to facilitate linking of libwg for debug artifacts,
+    // such as test binaries.
+    if cfg!(debug_assertions) {
+        println!("cargo::rustc-link-search={out_dir}");
+    }
 }
 
 /// Tell linker to check `base`/$TARGET for shared libraries.

--- a/wireguard-go-rs/libwg/build-android.sh
+++ b/wireguard-go-rs/libwg/build-android.sh
@@ -57,8 +57,6 @@ for arch in ${ARCHITECTURES:-armv7 aarch64 x86_64 i686}; do
 
     # Set permissions so that the build server can clean the outputs afterwards
     chmod 777 "$STRIPPED_LIB_PATH"
-
-    rm -rf build
 done
 
 # ensure `git clean -fd` does not require root permissions

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -149,7 +149,7 @@ impl Tunnel {
     /// Activate DAITA for the specified peer.
     ///
     /// `machines` is a string containing LF-separated maybenot machines.
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(daita)]
     pub fn activate_daita(
         &self,
         peer_public_key: &[u8; 32],
@@ -262,7 +262,7 @@ mod ffi {
         /// - `peer_public_key` must point to a 32 byte array.
         /// - `machines` must point to a null-terminated UTF-8 string.
         /// - Neither pointer will be read from after `wgActivateDaita` has returned.
-        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        #[cfg(daita)]
         pub fn wgActivateDaita(
             tunnel_handle: i32,
             peer_public_key: *const u8,


### PR DESCRIPTION
This PR adds support for gating DAITA behind a cfg option. This makes it _way_ easier to track what code is strictly DAITA-related, as well as enabling DAITA support on other platforms down the line.

This PR also changes the build chain of the app on Android, Linux and macOS. 
* On Linux and macOS, `libwg` is now distributed as a shared library, which is how wireguard-go currently is built for Android.
* On all of the above platforms, wireguard-go is now a submodule in the app repository. This means that it has to be checkout out in order to build the app on these platforms. This has been detailed in [the general build instructions](https://github.com/mullvad/mullvadvpn-app/blob/add-daita-cfg-flag/README.md#checking-out-the-code).

This fixes DES-937.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6202)
<!-- Reviewable:end -->
