### PR TITLE
Simplify cleanup of testing CI cache

### DIFF
--- a/test/ci-runtests.sh
+++ b/test/ci-runtests.sh
@@ -207,6 +207,8 @@ echo "**********************************"
 echo "* Downloading app packages"
 echo "**********************************"
 
+find "$PACKAGES_DIR" -type f -mtime +5 -delete || true
+
 mkdir -p "$PACKAGES_DIR"
 nice_time download_app_package "$OLD_APP_VERSION" "$TEST_OS"
 nice_time download_app_package "$NEW_APP_VERSION" "$TEST_OS"
@@ -215,9 +217,6 @@ nice_time download_e2e_executable "$NEW_APP_VERSION" "$TEST_OS"
 echo "**********************************"
 echo "* Building test runner"
 echo "**********************************"
-
-# Clean up packages. Try to keep ones that match the versions we're testing
-find "$PACKAGES_DIR/" -type f ! \( -name "*${OLD_APP_VERSION}_*" -o -name "*${OLD_APP_VERSION}.*" -o -name "*${commit}*" \) -delete || true
 
 function build_test_runner {
     if [[ "${TEST_OS}" =~ "debian"|"ubuntu"|"fedora" ]]; then


### PR DESCRIPTION
The previous code was trying to be too clever and incorrectly deleted packages in some cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6207)
<!-- Reviewable:end -->
