### PR TITLE
Fix daemon not starting with IPv6 disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Add support for split tunneling (beta).
 
+### Changed
+- Don't fail to start daemon when the offline monitor fails to be initialized.
+
 ### Fixed
 #### Linux
 - Fix GUI not working on Ubuntu 24.04 by adding an AppArmor profile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 #### Linux
 - Fix GUI not working on Ubuntu 24.04 by adding an AppArmor profile.
+- Service failed to start when IPv6 was disabled in the kernel.
 
 
 ## [2024.2] - 2024-04-29

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -55,10 +55,6 @@ const TUNNEL_STATE_MACHINE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Errors that can happen when setting up or using the state machine.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    /// Unable to spawn offline state monitor
-    #[error("Unable to spawn offline state monitor")]
-    OfflineMonitorError(#[from] crate::offline::Error),
-
     /// Unable to set up split tunneling
     #[cfg(any(target_os = "windows", target_os = "macos"))]
     #[error("Failed to initialize split tunneling")]
@@ -339,8 +335,7 @@ impl TunnelStateMachine {
             #[cfg(target_os = "android")]
             android_context,
         )
-        .await
-        .map_err(Error::OfflineMonitorError)?;
+        .await;
         let connectivity = offline_monitor.connectivity().await;
         let _ = initial_offline_state_tx.unbounded_send(connectivity);
 


### PR DESCRIPTION
Moreover, the daemon will no longer refuse to start when the offline monitor cannot be initialized.

Fix DES-948.
Fix #6198.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6210)
<!-- Reviewable:end -->
