### PR TITLE
Don't rebuild daemon every time new git refs are fetched

### DIFF
--- a/mullvad-version/build.rs
+++ b/mullvad-version/build.rs
@@ -101,14 +101,17 @@ fn get_dev_suffix(release_tag: &str) -> Option<String> {
 fn rerun_if_git_ref_changed(release_tag: &str) -> std::io::Result<()> {
     let git_dir = Path::new("..").join(".git");
 
-    // If we build our output on information about HEAD we need to re-run if HEAD moves
+    // The `.git/HEAD` file contains the position of the current head. If in 'detached HEAD' state,
+    // this will be the ref of the current commit. If on a branch it will just point to it, e.g.
+    // `ref: refs/heads/main`. Tracking changes to this file will tell us if we change branch, or
+    // modify the current detached HEAD state (e.g. committing or rebasing).
     let head_path = git_dir.join("HEAD");
     if head_path.exists() {
         println!("cargo:rerun-if-changed={}", head_path.display());
     }
 
-    // If we build our output on information about the ref of the current branch, we need to re-run
-    // on changes to it
+    // The above check will not cause a rebuild when modifying commits on a currently checked out
+    // branch. To catch this, we need to track the `.git/refs/heads/$current_branch` file.
     let output = Command::new("git")
         .arg("branch")
         .arg("--show-current")
@@ -135,7 +138,15 @@ fn rerun_if_git_ref_changed(release_tag: &str) -> std::io::Result<()> {
     if git_release_tag_ref.exists() {
         println!("cargo:rerun-if-changed={}", git_release_tag_ref.display());
     };
-    Some(())
+
+    // NOTE: As the repository has gotten quite large, you may find the contents of the
+    // `.git/refs/heads` and `.git/refs/tags` empty. This happens because `git pack-refs` compresses
+    // and moves the information into the `.git/packed-refs` file to save storage. We do not have to
+    // track this file, however, as any changes to the current branch, 'detached HEAD' state
+    // or tags will update the corresponding `.git/refs` file we are tracking, even if it had
+    // previously been pruned.
+
+    Ok(())
 }
 
 /// Returns the commit hash for the commit that `git_ref` is pointing to.

--- a/mullvad-version/build.rs
+++ b/mullvad-version/build.rs
@@ -52,15 +52,26 @@ fn get_product_version(target: Target) -> String {
         Target::Desktop => DESKTOP_VERSION_FILE_PATH,
     };
     println!("cargo:rerun-if-changed={version_file_path}");
-    let version = fs::read_to_string(version_file_path)
+    let product_version = fs::read_to_string(version_file_path)
         .unwrap_or_else(|_| panic!("Failed to read {version_file_path}"))
         .trim()
         .to_owned();
 
-    if let Some(dev_suffix) = get_dev_suffix(target, &version) {
-        format!("{version}{dev_suffix}")
+    // Compute the expected tag name for the release named `product_version`
+    let release_tag = match target {
+        Target::Android => format!("android/{product_version}"),
+        Target::Desktop => product_version.to_owned(),
+    };
+
+    // Rerun this build script on changes to the git ref that affects the build version.
+    // NOTE: This must be kept up to date with the behavior of `git_rev_parse_commit_hash`.
+    rerun_if_git_ref_changed(&release_tag)
+        .expect("Failed to set 'cargo:rerun-if-changed' on git ref changes");
+
+    if let Some(dev_suffix) = get_dev_suffix(&product_version) {
+        format!("{product_version}{dev_suffix}")
     } else {
-        version
+        product_version
     }
 }
 
@@ -68,51 +79,11 @@ fn get_product_version(target: Target) -> String {
 /// suffix if the build is not done on a git tag named `product_version`.
 /// This also returns `None` if the `git` command can't run, or the code does
 /// not live in a git repository.
-fn get_dev_suffix(target: Target, product_version: &str) -> Option<String> {
-    // Compute the expected tag name for the release named `product_version`
-    let release_tag = match target {
-        Target::Android => format!("android/{product_version}"),
-        Target::Desktop => product_version.to_owned(),
-    };
-
-    let git_dir = Path::new("..").join(".git");
-
-    // If we build our output on information about HEAD we need to re-run if HEAD moves
-    let head_path = git_dir.join("HEAD");
-    if head_path.exists() {
-        println!("cargo:rerun-if-changed={}", head_path.display());
-    }
-
-    let output = Command::new("git")
-        .arg("branch")
-        .arg("--show-current")
-        .output()
-        .ok()?;
-    let current_branch = String::from_utf8(output.stdout).unwrap();
-    // If we build our output on information about a git reference, we need to re-run
-    // if it moves. Instead of trying to be smart, just re-run if any git reference moves.
-    let git_current_branch_ref = git_dir
-        .join("refs")
-        .join("heads")
-        .join(current_branch.trim());
-    if git_current_branch_ref.exists() {
-        println!(
-            "cargo:rerun-if-changed={}",
-            git_current_branch_ref.display()
-        );
-    }
-    let git_current_branch_ref = git_dir.join("refs").join("tags").join(&release_tag);
-    if git_current_branch_ref.exists() {
-        println!(
-            "cargo:rerun-if-changed={}",
-            git_current_branch_ref.display()
-        );
-    }
-
+fn get_dev_suffix(release_tag: &str) -> Option<String> {
     // Get the git commit hashes for the latest release and current HEAD
     // Return `None` if unable to find the hash for HEAD.
     let head_commit_hash = git_rev_parse_commit_hash("HEAD")?;
-    let product_version_commit_hash = git_rev_parse_commit_hash(&release_tag);
+    let product_version_commit_hash = git_rev_parse_commit_hash(release_tag);
 
     // If we are currently building the release tag, there is no dev suffix
     if Some(&head_commit_hash) == product_version_commit_hash.as_ref() {
@@ -122,6 +93,49 @@ fn get_dev_suffix(target: Target, product_version: &str) -> Option<String> {
         "-dev-{}",
         &head_commit_hash[..GIT_HASH_DEV_SUFFIX_LEN]
     ))
+}
+
+/// Trigger rebuild of `mullvad-version` on changing branch (`.git/HEAD`), on changes to the ref of
+/// the current branch (`.git/refs/heads/$current_branch`) and on changes to the ref of the current
+/// release tag (`.git/refs/tags/$current_release_tag`).
+fn rerun_if_git_ref_changed(release_tag: &str) -> std::io::Result<()> {
+    let git_dir = Path::new("..").join(".git");
+
+    // If we build our output on information about HEAD we need to re-run if HEAD moves
+    let head_path = git_dir.join("HEAD");
+    if head_path.exists() {
+        println!("cargo:rerun-if-changed={}", head_path.display());
+    }
+
+    // If we build our output on information about the ref of the current branch, we need to re-run
+    // on changes to it
+    let output = Command::new("git")
+        .arg("branch")
+        .arg("--show-current")
+        .output()?;
+
+    let current_branch = String::from_utf8(output.stdout).unwrap();
+    let current_branch = current_branch.trim();
+
+    // When in 'detached HEAD' state, the output will be empty. However, in that case we already get
+    // the ref from `.git/HEAD`, so we can safely skip this part.
+    if !current_branch.is_empty() {
+        let git_current_branch_ref = git_dir.join("refs").join("heads").join(current_branch);
+        if git_current_branch_ref.exists() {
+            println!(
+                "cargo:rerun-if-changed={}",
+                git_current_branch_ref.display()
+            );
+        }
+    }
+
+    // Since the product version depends on if the build is done on the commit with the
+    // corresponding release tag or not, we must track creation of/changes to said tag
+    let git_release_tag_ref = git_dir.join("refs").join("tags").join(release_tag);
+    if git_release_tag_ref.exists() {
+        println!("cargo:rerun-if-changed={}", git_release_tag_ref.display());
+    };
+    Some(())
 }
 
 /// Returns the commit hash for the commit that `git_ref` is pointing to.

--- a/mullvad-version/build.rs
+++ b/mullvad-version/build.rs
@@ -44,8 +44,9 @@ fn main() {
     .unwrap();
 }
 
-/// Returns the Mullvad product version from the corresponding metadata files,
-/// depending on target platform.
+/// Computes the Mullvad product version using the latest release on the given platform and the git
+/// hash pointed to by `HEAD`. Also triggers a rebuild of this crate when the information becomes
+/// outdated.
 fn get_product_version(target: Target) -> String {
     let version_file_path = match target {
         Target::Android => ANDROID_VERSION_FILE_PATH,


### PR DESCRIPTION
Fixes DES-950

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6211)
<!-- Reviewable:end -->
