### PR TITLE
Update view model when switching between entry and exit location

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 		7A3353912AAA014400F0A71C /* SimulatorVPNConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3353902AAA014400F0A71C /* SimulatorVPNConnection.swift */; };
 		7A3353932AAA089000F0A71C /* SimulatorTunnelInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3353922AAA089000F0A71C /* SimulatorTunnelInfo.swift */; };
 		7A3353972AAA0F8600F0A71C /* OperationBlockObserverSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3353962AAA0F8600F0A71C /* OperationBlockObserverSupport.swift */; };
+		7A3EFAAB2BDFDAE800318736 /* RelaySelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3EFAAA2BDFDAE800318736 /* RelaySelection.swift */; };
 		7A3FD1B52AD4465A0042BEA6 /* AppMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3FD1B42AD4465A0042BEA6 /* AppMessageHandlerTests.swift */; };
 		7A3FD1B72AD54ABD0042BEA6 /* AnyTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDEB982A98F4ED00F578F2 /* AnyTransport.swift */; };
 		7A3FD1B82AD54AE60042BEA6 /* TimeServerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDEB9A2A98F58600F578F2 /* TimeServerProxy.swift */; };
@@ -1873,6 +1874,7 @@
 		7A3353902AAA014400F0A71C /* SimulatorVPNConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorVPNConnection.swift; sourceTree = "<group>"; };
 		7A3353922AAA089000F0A71C /* SimulatorTunnelInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorTunnelInfo.swift; sourceTree = "<group>"; };
 		7A3353962AAA0F8600F0A71C /* OperationBlockObserverSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationBlockObserverSupport.swift; sourceTree = "<group>"; };
+		7A3EFAAA2BDFDAE800318736 /* RelaySelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelection.swift; sourceTree = "<group>"; };
 		7A3FD1B42AD4465A0042BEA6 /* AppMessageHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppMessageHandlerTests.swift; sourceTree = "<group>"; };
 		7A42DEC82A05164100B209BE /* SettingsInputCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsInputCell.swift; sourceTree = "<group>"; };
 		7A45CFC22C05FF2F00D80B21 /* ScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTests.swift; sourceTree = "<group>"; };
@@ -2820,6 +2822,7 @@
 				F0BE65362B9F136A005CC385 /* LocationSectionHeaderView.swift */,
 				5888AD86227B17950051EB06 /* LocationViewController.swift */,
 				7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */,
+				7A3EFAAA2BDFDAE800318736 /* RelaySelection.swift */,
 			);
 			path = SelectLocation;
 			sourceTree = "<group>";
@@ -5878,6 +5881,7 @@
 				5878F50029CDA742003D4BE2 /* UIView+AutoLayoutBuilder.swift in Sources */,
 				7A28826D2BAAC9DE00FD9F20 /* IPOverrideHeaderView.swift in Sources */,
 				A98502032B627B120061901E /* LocalNetworkProbe.swift in Sources */,
+				7A3EFAAB2BDFDAE800318736 /* RelaySelection.swift in Sources */,
 				7A6F2FA92AFD0842006D0856 /* CustomDNSDataSource.swift in Sources */,
 				58EF580B25D69D7A00AEBA94 /* ProblemReportSubmissionOverlayView.swift in Sources */,
 				5892A45E265FABFF00890742 /* EmptyTableViewHeaderFooterView.swift in Sources */,

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsDataSource.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsDataSource.swift
@@ -53,16 +53,6 @@ class AddLocationsDataSource:
         reloadWithSelectedLocations()
     }
 
-    // Called from `LocationDiffableDataSourceProtocol`.
-    func nodeShowsChildren(_ node: LocationNode) -> Bool {
-        isLocationInCustomList(node: node)
-    }
-
-    // Called from `LocationDiffableDataSourceProtocol`.
-    func nodeShouldBeSelected(_ node: LocationNode) -> Bool {
-        customListLocationNode.children.contains(node)
-    }
-
     private func reloadWithSelectedLocations() {
         var locationsList: [LocationCellViewModel] = []
         nodes.forEach { node in
@@ -158,6 +148,22 @@ extension AddLocationsDataSource: LocationCellDelegate {
             }
             self.subject.value.locations = locations
         })
+    }
+}
+
+// MARK: - Called from LocationDiffableDataSourceProtocol
+
+extension AddLocationsDataSource {
+    func nodeShowsChildren(_ node: LocationNode) -> Bool {
+        isLocationInCustomList(node: node)
+    }
+
+    func nodeShouldBeSelected(_ node: LocationNode) -> Bool {
+        customListLocationNode.children.contains(node)
+    }
+
+    func excludedRelayTitle(_ node: LocationNode) -> String? {
+        nil // N/A
     }
 }
 

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -54,10 +54,10 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
     }
 
     func start() {
-        // TODO: - the location should be defined whether it's Entry or Exit location
         let locationViewControllerWrapper = LocationViewControllerWrapper(
             customListRepository: customListRepository,
-            selectedRelays: tunnelManager.settings.relayConstraints.exitLocations.value
+            constraints: tunnelManager.settings.relayConstraints,
+            multihopEnabled: tunnelManager.settings.tunnelMultihopState == .on
         )
         locationViewControllerWrapper.delegate = self
 
@@ -155,18 +155,25 @@ extension LocationCoordinator: RelayCacheTrackerObserver {
 }
 
 extension LocationCoordinator: LocationViewControllerWrapperDelegate {
-    func didSelectRelays(relays: UserSelectedRelays) {
+    func didSelectEntryRelays(_ relays: UserSelectedRelays) {
+        var relayConstraints = tunnelManager.settings.relayConstraints
+        relayConstraints.entryLocations = .only(relays)
+
+        tunnelManager.updateSettings([.relayConstraints(relayConstraints)]) {
+            self.tunnelManager.startTunnel()
+        }
+    }
+
+    func didSelectExitRelays(_ relays: UserSelectedRelays) {
         var relayConstraints = tunnelManager.settings.relayConstraints
         relayConstraints.exitLocations = .only(relays)
 
         tunnelManager.updateSettings([.relayConstraints(relayConstraints)]) {
             self.tunnelManager.startTunnel()
         }
-
-        didFinish?(self)
     }
 
-    func didUpdateFilter(filter: RelayFilter) {
+    func didUpdateFilter(_ filter: RelayFilter) {
         var relayConstraints = tunnelManager.settings.relayConstraints
         relayConstraints.filter = .only(filter)
 

--- a/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
@@ -137,7 +137,7 @@ extension UIColor {
     }
 
     enum SegmentedControl {
-        static let backgroundColor = UIColor(red: 0.18, green: 0.33, blue: 0.49, alpha: 1.0)
+        static let backgroundColor = UIColor(red: 0.14, green: 0.25, blue: 0.38, alpha: 1.0)
         static let selectedColor = successColor
     }
 

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
@@ -94,7 +94,7 @@ class RelayFilterView: UIView {
         contentContainer.spacing = UIMetrics.FilterView.labelSpacing
 
         addConstrainedSubviews([contentContainer]) {
-            contentContainer.pinEdges(.init([.top(4), .bottom(0)]), to: self)
+            contentContainer.pinEdges(.init([.top(7), .bottom(0)]), to: self)
             contentContainer.pinEdges(.init([.leading(4), .trailing(4)]), to: layoutMarginsGuide)
         }
     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -72,7 +72,7 @@ class LocationCell: UITableViewCell {
 
     var isDisabled = false {
         didSet {
-            updateDisabled()
+            updateDisabled(isDisabled)
             updateBackgroundColor()
             updateStatusIndicatorColor()
         }
@@ -150,7 +150,7 @@ class LocationCell: UITableViewCell {
 
         updateCollapseImage()
         updateAccessibilityCustomActions()
-        updateDisabled()
+        updateDisabled(isDisabled)
         updateBackgroundColor()
         setLayoutMargins()
 
@@ -207,7 +207,7 @@ class LocationCell: UITableViewCell {
         statusIndicator.backgroundColor = statusIndicatorColor()
     }
 
-    private func updateDisabled() {
+    private func updateDisabled(_ isDisabled: Bool) {
         locationLabel.alpha = isDisabled ? 0.2 : 1
         collapseButton.alpha = isDisabled ? 0.2 : 1
 
@@ -339,7 +339,15 @@ extension LocationCell {
             }
         }
 
+        setExcludedRelayTitle(item.excludedRelayTitle)
         setBehavior(behavior)
+    }
+
+    private func setExcludedRelayTitle(_ title: String?) {
+        if let title {
+            locationLabel.text! += " (\(title))"
+            updateDisabled(true)
+        }
     }
 
     private func setBehavior(_ newBehavior: LocationCellBehavior) {

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
@@ -13,26 +13,29 @@ struct LocationCellViewModel: Hashable {
     let node: LocationNode
     var indentationLevel = 0
     var isSelected = false
+    var excludedRelayTitle: String?
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(node)
         hasher.combine(node.children.count)
         hasher.combine(section)
         hasher.combine(isSelected)
-        hasher.combine(indentationLevel)
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.node == rhs.node &&
             lhs.node.children.count == rhs.node.children.count &&
             lhs.section == rhs.section &&
-            lhs.isSelected == rhs.isSelected &&
-            lhs.indentationLevel == rhs.indentationLevel
+            lhs.isSelected == rhs.isSelected
     }
 }
 
 extension [LocationCellViewModel] {
-    mutating func addSubNodes(from item: LocationCellViewModel, at indexPath: IndexPath) {
+    mutating func addSubNodes(
+        from item: LocationCellViewModel,
+        at indexPath: IndexPath,
+        excludedRelayTitleCallback: ((LocationNode) -> String?)?
+    ) {
         let section = LocationSection.allCases[indexPath.section]
         let row = indexPath.row + 1
 
@@ -41,7 +44,8 @@ extension [LocationCellViewModel] {
                 section: section,
                 node: $0,
                 indentationLevel: item.indentationLevel + 1,
-                isSelected: item.isSelected
+                isSelected: false,
+                excludedRelayTitle: excludedRelayTitleCallback?($0)
             )
         }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
@@ -17,7 +17,11 @@ final class LocationDataSource:
     LocationDiffableDataSourceProtocol {
     private var currentSearchString = ""
     private var dataSources: [LocationDataSourceProtocol] = []
-    private var selectedItem: LocationCellViewModel?
+    // The selected location.
+    private var selectedLocation: LocationCellViewModel?
+    // When multihop is enabled, this is the "inverted" selected location, ie. entry
+    // if in exit mode and exit if in entry mode.
+    private var excludedLocation: LocationCellViewModel?
     let tableView: UITableView
     let sections: [LocationSection]
 
@@ -50,7 +54,7 @@ final class LocationDataSource:
         defaultRowAnimation = .fade
     }
 
-    func setRelays(_ response: REST.ServerRelaysResponse, selectedRelays: UserSelectedRelays?, filter: RelayFilter) {
+    func setRelays(_ response: REST.ServerRelaysResponse, selectedRelays: RelaySelection, filter: RelayFilter) {
         let allLocationsDataSource =
             dataSources.first(where: { $0 is AllLocationDataSource }) as? AllLocationDataSource
 
@@ -64,7 +68,7 @@ final class LocationDataSource:
         allLocationsDataSource?.reload(response, relays: relays)
         customListsDataSource?.reload(allLocationNodes: allLocationsDataSource?.nodes ?? [])
 
-        mapSelectedItem(from: selectedRelays)
+        setSelectedRelays(selectedRelays)
         filterRelays(by: currentSearchString)
     }
 
@@ -81,8 +85,10 @@ final class LocationDataSource:
         }
 
         updateDataSnapshot(with: list, reloadExisting: !searchString.isEmpty) {
+            self.tableView.reloadData()
+
             if searchString.isEmpty {
-                self.setSelectedItem(self.selectedItem, animated: false, completion: {
+                self.updateSelection(self.selectedLocation, animated: false, completion: {
                     self.scrollToSelectedRelay()
                 })
             } else {
@@ -92,7 +98,7 @@ final class LocationDataSource:
     }
 
     /// Refreshes the custom list section and keeps all modifications intact (selection and expanded states).
-    func refreshCustomLists(selectedRelays: UserSelectedRelays?) {
+    func refreshCustomLists(selectedRelays: RelaySelection) {
         guard let allLocationsDataSource =
             dataSources.first(where: { $0 is AllLocationDataSource }) as? AllLocationDataSource,
             let customListsDataSource =
@@ -110,7 +116,7 @@ final class LocationDataSource:
         customListsDataSource.reload(allLocationNodes: allLocationsDataSource.nodes)
 
         // Reapply current selection.
-        mapSelectedItem(from: selectedRelays)
+        setSelectedRelays(selectedRelays)
 
         // Reapply current search filter.
         let searchResultNodes = dataSources[0].search(by: currentSearchString)
@@ -133,27 +139,28 @@ final class LocationDataSource:
         ], reloadExisting: true)
     }
 
+    func setSelectedRelays(_ selectedRelays: RelaySelection) {
+        selectedLocation = mapSelection(from: selectedRelays.selected)
+
+        if selectedRelays.hasExcludedRelay {
+            excludedLocation = mapSelection(from: selectedRelays.excluded)
+            excludedLocation?.excludedRelayTitle = selectedRelays.excludedTitle
+        }
+
+        tableView.reloadData()
+    }
+
     func scrollToSelectedRelay() {
         indexPathForSelectedRelay().flatMap {
             tableView.scrollToRow(at: $0, at: .middle, animated: false)
         }
     }
 
-    // Called from `LocationDiffableDataSourceProtocol`.
-    func nodeShowsChildren(_ node: LocationNode) -> Bool {
-        node.showsChildren
-    }
-
-    // Called from `LocationDiffableDataSourceProtocol`.
-    func nodeShouldBeSelected(_ node: LocationNode) -> Bool {
-        false
-    }
-
     private func indexPathForSelectedRelay() -> IndexPath? {
-        selectedItem.flatMap { indexPath(for: $0) }
+        selectedLocation.flatMap { indexPath(for: $0) }
     }
 
-    private func mapSelectedItem(from selectedRelays: UserSelectedRelays?) {
+    private func mapSelection(from selectedRelays: UserSelectedRelays?) -> LocationCellViewModel? {
         let allLocationsDataSource =
             dataSources.first(where: { $0 is AllLocationDataSource }) as? AllLocationDataSource
 
@@ -165,7 +172,7 @@ final class LocationDataSource:
             if let customListSelection = selectedRelays.customListSelection,
                let customList = customListsDataSource?.customList(by: customListSelection.listId),
                let selectedNode = customListsDataSource?.node(by: selectedRelays, for: customList) {
-                selectedItem = LocationCellViewModel(
+                return LocationCellViewModel(
                     section: .customLists,
                     node: selectedNode,
                     indentationLevel: selectedNode.hierarchyLevel
@@ -173,47 +180,49 @@ final class LocationDataSource:
                 // Look for a matching all locations node.
             } else if let location = selectedRelays.locations.first,
                       let selectedNode = allLocationsDataSource?.node(by: location) {
-                selectedItem = LocationCellViewModel(
+                return LocationCellViewModel(
                     section: .allLocations,
                     node: selectedNode,
                     indentationLevel: selectedNode.hierarchyLevel
                 )
             }
         }
+
+        return nil
     }
 
-    private func setSelectedItem(_ item: LocationCellViewModel?, animated: Bool, completion: (() -> Void)? = nil) {
-        selectedItem = item
-        guard let selectedItem else { return }
+    private func updateSelection(_ item: LocationCellViewModel?, animated: Bool, completion: (() -> Void)? = nil) {
+        selectedLocation = item
+        guard let selectedLocation else { return }
 
-        let rootNode = selectedItem.node.root
+        let rootNode = selectedLocation.node.root
 
         // Exit early if no changes to the node tree should be made.
-        guard selectedItem.node != rootNode else {
+        guard selectedLocation.node != rootNode else {
             completion?()
             return
         }
 
         // Make sure we have an index path for the selected item.
         guard let indexPath = indexPath(for: LocationCellViewModel(
-            section: selectedItem.section,
+            section: selectedLocation.section,
             node: rootNode
         )) else { return }
 
         // Walk tree backwards to determine which nodes should be expanded.
-        selectedItem.node.forEachAncestor { node in
+        selectedLocation.node.forEachAncestor { node in
             node.showsChildren = true
         }
 
         // Construct node tree.
         let nodesToAdd = recursivelyCreateCellViewModelTree(
             for: rootNode,
-            in: selectedItem.section,
+            in: selectedLocation.section,
             indentationLevel: 1
         )
 
         // Insert the new node tree below the selected item.
-        var snapshotItems = snapshot().itemIdentifiers(inSection: selectedItem.section)
+        var snapshotItems = snapshot().itemIdentifiers(inSection: selectedLocation.section)
         snapshotItems.insert(contentsOf: nodesToAdd, at: indexPath.row + 1)
 
         let list = sections.enumerated().map { index, section in
@@ -230,11 +239,37 @@ final class LocationDataSource:
         )
     }
 
+    private func nodeMatchesExcludedLocation(_ node: LocationNode) -> Bool {
+        // Compare nodes on name rather than whole node in order to match all items in both .customLists
+        // and .allLocations.
+        node.name == excludedLocation?.node.name
+    }
+
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         // swiftlint:disable:next force_cast
         let cell = super.tableView(tableView, cellForRowAt: indexPath) as! LocationCell
         cell.delegate = self
         return cell
+    }
+}
+
+// MARK: - Called from LocationDiffableDataSourceProtocol
+
+extension LocationDataSource {
+    func nodeShowsChildren(_ node: LocationNode) -> Bool {
+        node.showsChildren
+    }
+
+    func nodeShouldBeSelected(_ node: LocationNode) -> Bool {
+        false // N/A
+    }
+
+    func excludedRelayTitle(_ node: LocationNode) -> String? {
+        if nodeMatchesExcludedLocation(node) {
+            excludedLocation?.excludedRelayTitle
+        } else {
+            nil
+        }
     }
 }
 
@@ -271,7 +306,8 @@ extension LocationDataSource: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
-        itemIdentifier(for: indexPath)?.node.isActive ?? false
+        guard let item = itemIdentifier(for: indexPath) else { return false }
+        return !nodeMatchesExcludedLocation(item.node) && item.node.isActive
     }
 
     func tableView(_ tableView: UITableView, indentationLevelForRowAt indexPath: IndexPath) -> Int {
@@ -279,15 +315,16 @@ extension LocationDataSource: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if let item = itemIdentifier(for: indexPath), item == selectedItem {
-            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+        if let item = itemIdentifier(for: indexPath), item == selectedLocation {
+            cell.setSelected(true, animated: false)
         }
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         if let indexPath = indexPathForSelectedRelay() {
-            tableView.deselectRow(at: indexPath, animated: false)
-            selectedItem = nil
+            if let cell = tableView.cellForRow(at: indexPath) {
+                cell.setSelected(false, animated: false)
+            }
         }
 
         return indexPath
@@ -295,7 +332,7 @@ extension LocationDataSource: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let item = itemIdentifier(for: indexPath) else { return }
-        selectedItem = item
+        selectedLocation = item
 
         var customListSelection: UserSelectedRelays.CustomListSelection?
         if let topmostNode = item.node.root as? CustomListLocationNode {
@@ -323,7 +360,9 @@ extension LocationDataSource: LocationCellDelegate {
         guard let indexPath = tableView.indexPath(for: cell),
               let item = itemIdentifier(for: indexPath) else { return }
 
-        let items = toggledItems(for: cell)
+        let items = toggledItems(for: cell, excludedRelayTitleCallback: { node in
+            self.excludedRelayTitle(node)
+        })
 
         updateDataSnapshot(with: items, reloadExisting: true, completion: {
             self.scroll(to: item, animated: true)

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDiffableDataSourceProtocol.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDiffableDataSourceProtocol.swift
@@ -14,6 +14,7 @@ protocol LocationDiffableDataSourceProtocol: UITableViewDiffableDataSource<Locat
     var sections: [LocationSection] { get }
     func nodeShowsChildren(_ node: LocationNode) -> Bool
     func nodeShouldBeSelected(_ node: LocationNode) -> Bool
+    func excludedRelayTitle(_ node: LocationNode) -> String?
 }
 
 extension LocationDiffableDataSourceProtocol {
@@ -39,7 +40,10 @@ extension LocationDiffableDataSourceProtocol {
         }
     }
 
-    func toggledItems(for cell: LocationCell) -> [[LocationCellViewModel]] {
+    func toggledItems(
+        for cell: LocationCell,
+        excludedRelayTitleCallback: ((LocationNode) -> String?)? = nil
+    ) -> [[LocationCellViewModel]] {
         guard let indexPath = tableView.indexPath(for: cell),
               let item = itemIdentifier(for: indexPath) else { return [[]] }
 
@@ -50,7 +54,7 @@ extension LocationDiffableDataSourceProtocol {
         item.node.showsChildren = !isExpanded
 
         if !isExpanded {
-            locationList.addSubNodes(from: item, at: indexPath)
+            locationList.addSubNodes(from: item, at: indexPath, excludedRelayTitleCallback: excludedRelayTitleCallback)
         } else {
             locationList.removeSubNodes(from: item.node)
         }
@@ -99,7 +103,8 @@ extension LocationDiffableDataSourceProtocol {
                     section: section,
                     node: childNode,
                     indentationLevel: indentationLevel,
-                    isSelected: nodeShouldBeSelected(childNode)
+                    isSelected: nodeShouldBeSelected(childNode),
+                    excludedRelayTitle: excludedRelayTitle(childNode)
                 )
             )
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -25,7 +25,7 @@ final class LocationViewController: UIViewController {
     private var dataSource: LocationDataSource?
     private var cachedRelays: CachedRelays?
     private var filter = RelayFilter()
-    private var selectedRelays: UserSelectedRelays?
+    private var selectedRelays: RelaySelection
     weak var delegate: LocationViewControllerDelegate?
     var customListRepository: CustomListRepositoryProtocol
 
@@ -37,9 +37,10 @@ final class LocationViewController: UIViewController {
         return (filter.ownership == .any) && (filter.providers == .any)
     }
 
-    init(customListRepository: CustomListRepositoryProtocol, selectedRelays: UserSelectedRelays?) {
+    init(customListRepository: CustomListRepositoryProtocol, selectedRelays: RelaySelection) {
         self.customListRepository = customListRepository
         self.selectedRelays = selectedRelays
+
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -55,7 +56,7 @@ final class LocationViewController: UIViewController {
         view.accessibilityIdentifier = .selectLocationView
         view.backgroundColor = .secondaryColor
 
-        setUpDataSources()
+        setUpDataSource()
         setUpTableView()
         setUpTopContent()
 
@@ -97,17 +98,22 @@ final class LocationViewController: UIViewController {
         dataSource?.refreshCustomLists(selectedRelays: selectedRelays)
     }
 
+    func setSelectedRelays(_ selectedRelays: RelaySelection) {
+        self.selectedRelays = selectedRelays
+        dataSource?.setSelectedRelays(selectedRelays)
+    }
+
     // MARK: - Private
 
-    private func setUpDataSources() {
+    private func setUpDataSource() {
         dataSource = LocationDataSource(
             tableView: tableView,
             allLocations: AllLocationDataSource(),
             customLists: CustomListsDataSource(repository: customListRepository)
         )
 
-        dataSource?.didSelectRelayLocations = { [weak self] locations in
-            self?.delegate?.didSelectRelays(relays: locations)
+        dataSource?.didSelectRelayLocations = { [weak self] relays in
+            self?.delegate?.didSelectRelays(relays: relays)
         }
 
         dataSource?.didTapEditCustomLists = { [weak self] in

--- a/ios/MullvadVPN/View controllers/SelectLocation/RelaySelection.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/RelaySelection.swift
@@ -1,0 +1,22 @@
+//
+//  RelaySelection.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2024-04-29.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadTypes
+
+struct RelaySelection {
+    var selected: UserSelectedRelays?
+    var excluded: UserSelectedRelays?
+    var excludedTitle: String?
+
+    var hasExcludedRelay: Bool {
+        if excluded?.locations.count == 1, case .hostname = excluded?.locations.first {
+            return true
+        }
+        return false
+    }
+}

--- a/ios/MullvadVPNTests/MullvadLogging/LogRotationTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LogRotationTests.swift
@@ -11,11 +11,13 @@ import XCTest
 
 final class LogRotationTests: XCTestCase {
     let fileManager = FileManager.default
-    let directoryPath = FileManager.default.temporaryDirectory
-        .appendingPathComponent("LogRotationTests", isDirectory: true)
+    var directoryPath: URL!
 
     override func setUpWithError() throws {
-        try? fileManager.createDirectory(
+        directoryPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LogRotationTests", isDirectory: true)
+
+        try fileManager.createDirectory(
             at: directoryPath,
             withIntermediateDirectories: true
         )


### PR DESCRIPTION
This PR contains two closely related issues:

1. https://linear.app/mullvad/issue/IOS-631/update-view-model-when-switching-between-entry-and-exit-location

The view location selection view must be able to work with both entry and exit locations. If a user has selected a single relay as an entry, the user should not be able to select the same relay as an exit, and vice versa. Edge cases around countries/cities containing a single relay don't have to be accounted for.

2. https://linear.app/mullvad/issue/IOS-610/allow-selecting-entry-location

The user must be able to specify what locations should be used for the entry relay when multi-hop is enabled. The UI for this should follow the design from [IOS-504](https://linear.app/mullvad/issue/IOS-504/design-ui-for-toggling-multihop). 

The first time you enter the location view after enabling multi-hop, the user should be directed to the entry view so to onboard the user. Afterwards, entering the location view would direct the user to the exit view.

When showing the exit tab, the selected entry location should be marked as (Entry) and if it's a relay it should be greyed out. Same goes for the selected Exit point if you're in the entry view. Furthermore you should be able to click an already selected list item in order to get to the next step of the flow (Entry to Exit, Exit to Main view).

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6224)
<!-- Reviewable:end -->
