### PR TITLE
Fix nightly Rust build

### DIFF
--- a/talpid-wireguard/build.rs
+++ b/talpid-wireguard/build.rs
@@ -21,7 +21,12 @@ fn main() {
 
     println!("cargo:rustc-link-lib{link_type}=wg");
 
-    if let "linux" | "macos" | "android" = target_os.as_str() {
+    add_wireguard_go_cfg(&target_os);
+}
+
+fn add_wireguard_go_cfg(target_os: &str) {
+    println!("cargo:rustc-check-cfg=cfg(wireguard_go)");
+    if matches!(target_os, "linux" | "macos" | "android") {
         println!("cargo:rustc-cfg=wireguard_go");
     }
 }


### PR DESCRIPTION
This fixes builds failing on nightly rustc due to [`unexpected_cfgs`](https://blog.rust-lang.org/2024/05/06/check-cfg.html). See, for example, https://github.com/mullvad/mullvadvpn-app/actions/runs/8970591493/job/24634481519

Fix DES-952.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6228)
<!-- Reviewable:end -->
