### PR TITLE
Fix label alignment

### DIFF
--- a/gui/src/renderer/components/cell/Label.tsx
+++ b/gui/src/renderer/components/cell/Label.tsx
@@ -9,7 +9,6 @@ import { CellDisabledContext } from './Container';
 
 const StyledLabel = styled.div<{ disabled: boolean }>(buttonText, (props) => ({
   display: 'flex',
-  alignItems: 'center',
   margin: '10px 0',
   flex: 1,
   color: props.disabled ? colors.white40 : colors.white,


### PR DESCRIPTION
When adding the DAITA toggle, the alignment on cell labels were incorrectly set to centered. This PR fixes that by just removing the CSS rule.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6230)
<!-- Reviewable:end -->
