### PR TITLE
Fix cell colors in location view

### DIFF
--- a/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
@@ -87,10 +87,10 @@ extension UIColor {
     // Cells
     enum Cell {
         enum Background {
-            static let indentationLevelZero = primaryColor
-            static let indentationLevelOne = UIColor(red: 0.15, green: 0.23, blue: 0.33, alpha: 1.0)
-            static let indentationLevelTwo = UIColor(red: 0.13, green: 0.20, blue: 0.30, alpha: 1.0)
-            static let indentationLevelThree = UIColor(red: 0.11, green: 0.17, blue: 0.27, alpha: 1.0)
+            static let indentationLevelZero = UIColor(red: 0.14, green: 0.25, blue: 0.38, alpha: 1.0)
+            static let indentationLevelOne = UIColor(red: 0.12, green: 0.23, blue: 0.34, alpha: 1.0)
+            static let indentationLevelTwo = UIColor(red: 0.11, green: 0.20, blue: 0.31, alpha: 1.0)
+            static let indentationLevelThree = UIColor(red: 0.11, green: 0.19, blue: 0.29, alpha: 1.0)
 
             static let normal = indentationLevelZero
             static let disabled = normal.darkened(by: 0.3)!

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -134,10 +134,7 @@ class LocationCell: UITableViewCell {
         contentView.backgroundColor = .clear
 
         backgroundView = UIView()
-        backgroundView?.backgroundColor = UIColor.Cell.Background.normal
-
         selectedBackgroundView = UIView()
-        selectedBackgroundView?.backgroundColor = UIColor.Cell.Background.selected
 
         checkboxButton.addTarget(self, action: #selector(toggleCheckboxButton(_:)), for: .touchUpInside)
         collapseButton.addTarget(self, action: #selector(handleCollapseButton(_:)), for: .touchUpInside)

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderView.swift
@@ -66,9 +66,9 @@ class LocationSectionHeaderView: UIView, UIContentView {
         nameLabel.text = configuration.name
         actionButton.isHidden = isActionHidden
         actionButton.accessibilityIdentifier = nil
-        actualConfiguration.primaryAction.flatMap { [weak self] action in
-            self?.actionButton.accessibilityIdentifier = .openCustomListsMenuButton
-            self?.actionButton.addAction(action, for: .touchUpInside)
+        actualConfiguration.primaryAction.flatMap { action in
+            actionButton.accessibilityIdentifier = .openCustomListsMenuButton
+            actionButton.addAction(action, for: .touchUpInside)
         }
     }
 


### PR DESCRIPTION
When we added custom lists we also added a title list item (All locations) which made the countries/cities/servers in the location view move down one step in the hierarchy. So we had to add a new color (Blue10%). This PR updates all related colors to their correct values.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6246)
<!-- Reviewable:end -->
