### PR TITLE
Change checkboxes in location cells to the correct ones

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -40,9 +40,13 @@ class LocationCell: UITableViewCell {
 
     private let checkboxButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(systemName: "checkmark.square.fill"), for: .selected)
-        button.setImage(UIImage(systemName: "square"), for: .normal)
-        button.tintColor = .white
+        let checkboxView = CheckboxView()
+
+        checkboxView.isUserInteractionEnabled = false
+        button.addConstrainedSubviews([checkboxView]) {
+            checkboxView.pinEdgesToSuperviewMargins(PinnableEdges([.top(8), .bottom(8), .leading(16), .trailing(16)]))
+        }
+
         return button
     }()
 
@@ -314,8 +318,11 @@ extension LocationCell {
         showsCollapseControl = !item.node.children.isEmpty
         isExpanded = item.node.showsChildren
         checkboxButton.accessibilityIdentifier = .customListLocationCheckmarkButton
-        checkboxButton.isSelected = item.isSelected
-        checkboxButton.tintColor = item.isSelected ? .successColor : .white
+
+        for view in checkboxButton.subviews where view is CheckboxView {
+            let checkboxView = view as? CheckboxView
+            checkboxView?.isChecked = item.isSelected
+        }
 
         if item.node is CountryLocationNode {
             accessibilityIdentifier = .countryLocationCell


### PR DESCRIPTION
The checkboxes in custom lists should be white with a green checkmark, as this is how it looks in the rest of the app. For instance in filter by provider.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
