### PR TITLE
Show spinner when consolidating logs for problem reports

### DIFF
--- a/ios/MullvadVPN/View controllers/Alert/AlertViewController.swift
+++ b/ios/MullvadVPN/View controllers/Alert/AlertViewController.swift
@@ -135,8 +135,9 @@ class AlertViewController: UIViewController {
             )
         }
 
-        // Icon only alerts should have equal top and bottom margin.
-        if presentation.icon != nil, contentView.arrangedSubviews.count == 1 {
+        // Icon only spinner alerts should have no background and equal top and bottom margins.
+        if presentation.icon == .spinner, contentView.arrangedSubviews.count == 1 {
+            viewContainer.backgroundColor = .clear
             contentView.directionalLayoutMargins.bottom = UIMetrics.CustomAlert.containerMargins.top
         }
     }

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
@@ -10,10 +10,10 @@ import UIKit
 
 class ProblemReportReviewViewController: UIViewController {
     private var textView = UITextView()
-    private let reportString: String
+    private let interactor: ProblemReportInteractor
 
-    init(reportString: String) {
-        self.reportString = reportString
+    init(interactor: ProblemReportInteractor) {
+        self.interactor = interactor
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -48,7 +48,6 @@ class ProblemReportReviewViewController: UIViewController {
         #endif
 
         textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.text = reportString
         textView.isEditable = false
         textView.font = UIFont.monospacedSystemFont(
             ofSize: UIFont.systemFontSize,
@@ -68,16 +67,33 @@ class ProblemReportReviewViewController: UIViewController {
         // Used to layout constraints so that navigation controller could properly adjust the text
         // view insets.
         view.layoutIfNeeded()
+
+        loadLogs()
     }
 
     override func selectAll(_ sender: Any?) {
         textView.selectAll(sender)
     }
 
+    private func loadLogs() {
+        let presentation = AlertPresentation(
+            id: "problem-report-load",
+            icon: .spinner,
+            buttons: []
+        )
+
+        let alertController = AlertViewController(presentation: presentation)
+
+        present(alertController, animated: true) {
+            self.textView.text = self.interactor.reportString
+            self.dismiss(animated: true)
+        }
+    }
+
     #if DEBUG
     private func share() {
         let activityController = UIActivityViewController(
-            activityItems: [reportString],
+            activityItems: [interactor.reportString],
             applicationActivities: nil
         )
 

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
@@ -130,9 +130,7 @@ final class ProblemReportViewController: UIViewController, UITextFieldDelegate {
     }
 
     @objc func handleViewLogsButtonTap() {
-        let reviewController = ProblemReportReviewViewController(
-            reportString: interactor.reportString
-        )
+        let reviewController = ProblemReportReviewViewController(interactor: interactor)
         let navigationController = UINavigationController(rootViewController: reviewController)
 
         present(navigationController, animated: true)


### PR DESCRIPTION
The problem report view freezes when pressing the "view app logs" button, if many logs need to be consolidated. We should add a spinner to let the user know that everything's alright.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6255)
<!-- Reviewable:end -->
