### PR TITLE
Add `make` to container image

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -42,6 +42,7 @@ ARG PROTOBUF_COMMIT_REF=ee1355459c9ce7ffe264bc40cfdc7b7623d37e99
 RUN dpkg --add-architecture arm64 && apt-get update -y && apt-get install -y \
     git \
     curl \
+    make \
     gcc gcc-aarch64-linux-gnu \
     libdbus-1-dev libdbus-1-dev:arm64 \
     rpm \


### PR DESCRIPTION
This PR adds the `make` tool to the Linux container image, which will be used when building `libmaybenot.a`, which in turn will be used to build `wireguard-go` with DAITA support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6256)
<!-- Reviewable:end -->
