### PR TITLE
Increase start/boot timeout for testing VMs

### DIFF
--- a/test/test-manager/src/vm/qemu.rs
+++ b/test/test-manager/src/vm/qemu.rs
@@ -23,7 +23,7 @@ use super::{network, VmInstance};
 const LOG_PREFIX: &str = "[qemu] ";
 const STDERR_LOG_LEVEL: log::Level = log::Level::Error;
 const STDOUT_LOG_LEVEL: log::Level = log::Level::Debug;
-const OBTAIN_IP_TIMEOUT: Duration = Duration::from_secs(60);
+const OBTAIN_IP_TIMEOUT: Duration = Duration::from_secs(180);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {


### PR DESCRIPTION
Fix some timeouts seen recently on Windows 10.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6260)
<!-- Reviewable:end -->
