### PR TITLE
Add postject dependency

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -63,6 +63,7 @@
         "gulp-typescript": "^6.0.0-alpha.1",
         "mocha": "^10.2.0",
         "playwright": "^1.41.1",
+        "postject": "^1.0.0-alpha.6",
         "prettier": "^2.2.1",
         "sinon": "^14.0.1",
         "ts-node": "^10.9.2",
@@ -9921,6 +9922,30 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -20999,6 +21024,23 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "requires": {
+        "commander": "^9.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+          "dev": true
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/gui/package.json
+++ b/gui/package.json
@@ -69,6 +69,7 @@
     "gulp-typescript": "^6.0.0-alpha.1",
     "mocha": "^10.2.0",
     "playwright": "^1.41.1",
+    "postject": "^1.0.0-alpha.6",
     "prettier": "^2.2.1",
     "sinon": "^14.0.1",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
When switching over to Node SEA for building the test executable (https://github.com/mullvad/mullvadvpn-app/pull/6242) we forgot to add `postject` as a dev dependency. This causes `buildserver-build.sh` to prompt and wait for the user to accept installing postject when running `npx postject ...`. This PR just adds postject as a dependency to resolve this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6262)
<!-- Reviewable:end -->
