### PR TITLE
Upgrade ipnetwork to 0.20 and make it a workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -717,27 +717,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.9.3",
- "syn 1.0.109",
+ "strsim",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -808,27 +808,33 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.9.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
 dependencies = [
- "darling",
- "derive_builder_core",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.9.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1010,16 +1016,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
 ]
 
 [[package]]
@@ -1717,6 +1713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c429fffa658f288669529fc26565f728489a2e39bc7b24a428aaaf51355182e"
 
 [[package]]
+name = "ioctl-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd11f3a29434026f5ff98c730b668ba74b1033637b8817940b54d040696133c"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,9 +1738,9 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "ipnetwork"
-version = "0.16.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
 ]
@@ -2819,14 +2821,12 @@ dependencies = [
 
 [[package]]
 name = "pfctl"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27590368dee28aa01e3024b639818a6bf0ad31635d9eca000aad63021a59284d"
+checksum = "3eef3d868ab90cdd1a3814668982f248fbb8849922f2617142e398e7d037a81e"
 dependencies = [
  "derive_builder",
- "errno 0.2.8",
- "error-chain",
- "ioctl-sys",
+ "ioctl-sys 0.8.0",
  "ipnetwork",
  "libc",
 ]
@@ -3769,12 +3769,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4480,7 +4474,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures-core",
- "ioctl-sys",
+ "ioctl-sys 0.6.0",
  "libc",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,8 @@ chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4.4.18", features = ["cargo", "derive"] }
 once_cell = "1.13"
 
+ipnetwork = "0.20"
+
 # Test dependencies
 proptest = "1.4"
 

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = { workspace = true }
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "stream", "http1", "tcp" ] }
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 log = { workspace = true }
 serde = "1"
 serde_json = "1.0"

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true, features = ["rt"] }
 
 thiserror = { workspace = true }
 futures = "0.3"
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 jnix = { version = "0.5.1", features = ["derive"] }
 log = { workspace = true }
 log-panics = "2"

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 chrono = { workspace = true }
 thiserror = { workspace = true }
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 itertools = "0.12"
 log = { workspace = true }
 once_cell = { workspace = true }

--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 chrono = { workspace = true, features = ["clock", "serde"] }
 thiserror = { workspace = true }
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 once_cell = { workspace = true }
 log = { workspace = true }
 regex = "1"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 chrono = { workspace = true, features = ["clock"] }
 thiserror = { workspace = true }
 futures = "0.3.15"
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 libc = "0.2"
 log = { workspace = true }
 once_cell = { workspace = true }
@@ -48,7 +48,7 @@ duct = "0.13"
 [target.'cfg(target_os = "macos")'.dependencies]
 async-trait = "0.1"
 duct = "0.13"
-pfctl = "0.4.6"
+pfctl = "0.5.0"
 subslice = "0.2"
 system-configuration = "0.5.1"
 hickory-proto = "0.24.1"

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 thiserror = { workspace = true }
 futures = "0.3.15"
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "net", "io-util", "time"] }
 

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 thiserror = { workspace = true }
 cfg-if = "1.0"
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 talpid-routing = { path = "../talpid-routing" }
 talpid-types = { path = "../talpid-types" }
 futures = "0.3.15"

--- a/talpid-tunnel/src/tun_provider/android/ipnetwork_sub.rs
+++ b/talpid-tunnel/src/tun_provider/android/ipnetwork_sub.rs
@@ -40,15 +40,15 @@ impl AbstractIpNetwork for Ipv4Network {
     }
 
     fn mask(self) -> Self::Representation {
-        Ipv4Network::mask(&self).into()
+        Ipv4Network::mask(self).into()
     }
 
     fn network(self) -> Self::Representation {
-        Ipv4Network::network(&self).into()
+        Ipv4Network::network(self).into()
     }
 
     fn prefix(self) -> u8 {
-        Ipv4Network::prefix(&self)
+        Ipv4Network::prefix(self)
     }
 }
 

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 base64 = "0.22.0"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets", "zeroize", "getrandom"] }
 thiserror = { workspace = true }

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 thiserror = { workspace = true }
 futures = "0.3.15"
 hex = "0.4"
-ipnetwork = "0.16"
+ipnetwork = { workspace = true }
 once_cell = { workspace = true }
 libc = "0.2.150"
 log = { workspace = true }


### PR DESCRIPTION
Upgrade all our direct usage of `ipnetwork` to the latest version, and makes it a workspace dependency. Nothing new we need, but nice to have the latest version.

~We still have `ipnetwork 0.16` in our dependency tree until we cut a release of `pfctl`, but that can come later and does not need to block this upgrade of all direct upgrades.~.. pfctl 0.5.0 has been released! Fixing this blocker.

I manually reviewed the diff from 0.16 to 0.20 and it looks sane. A bunch of idiomatic improvements to the API, some constification and some other small stuff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6276)
<!-- Reviewable:end -->
