### PR TITLE
Suggestion for spending less GitHub cloud minutes

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -2,6 +2,7 @@
 name: Android - Build and test
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '**'
       - '!.github/workflows/**'
@@ -49,6 +50,7 @@ on:
 jobs:
   prepare:
     name: Prepare
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -68,6 +70,7 @@ jobs:
 
   generate-debug-keystore:
     name: Generate debug keystore
+    if: github.event.pull_request.draft == false
     needs: prepare
     runs-on: ubuntu-latest
     steps:
@@ -93,6 +96,7 @@ jobs:
 
   generate-relay-list:
     name: Generate relay list
+    if: github.event.pull_request.draft == false
     needs: prepare
     runs-on: ubuntu-latest
     container:
@@ -137,6 +141,7 @@ jobs:
 
   build-native:
     name: Build native
+    if: github.event.pull_request.draft == false
     needs: prepare
     runs-on: ubuntu-latest
     container:
@@ -209,6 +214,7 @@ jobs:
 
   run-lint-and-tests:
     name: Run lint and test tasks
+    if: github.event.pull_request.draft == false
     needs: [prepare]
     runs-on: ubuntu-latest
     container:
@@ -248,6 +254,7 @@ jobs:
 
   build-app:
     name: Build app
+    if: github.event.pull_request.draft == false
     needs: [prepare, generate-debug-keystore]
     runs-on: ubuntu-latest
     container:
@@ -340,6 +347,7 @@ jobs:
 
   build-instrumented-tests:
     name: Build instrumented test packages
+    if: github.event.pull_request.draft == false
     needs: [prepare, generate-debug-keystore]
     runs-on: ubuntu-latest
     container:
@@ -393,6 +401,7 @@ jobs:
 
   instrumented-tests:
     name: Run instrumented tests
+    if: github.event.pull_request.draft == false
     runs-on: [self-hosted, android-device]
     timeout-minutes: 30
     needs: [build-app, build-instrumented-tests]
@@ -458,7 +467,9 @@ jobs:
   instrumented-e2e-tests:
     name: Run instrumented e2e tests
     runs-on: [self-hosted, android-device]
-    if: github.event_name == 'schedule' || github.event.inputs.run_e2e_tests == 'true'
+    if: >
+      github.event.pull_request.draft == false &&
+      (github.event_name == 'schedule' || github.event.inputs.run_e2e_tests == 'true')
     timeout-minutes: 30
     needs: [build-app, build-instrumented-tests]
     steps:

--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -2,6 +2,7 @@
 name: Android - Audit dependencies
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - .github/workflows/android-audit.yml
       - android/gradle/verification-metadata.xml
@@ -23,6 +24,7 @@ on:
 jobs:
   prepare:
     name: Prepare
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -42,6 +44,7 @@ jobs:
       container_image: ${{ env.inner_container_image }}
 
   owasp-dependency-check:
+    if: github.event.pull_request.draft == false
     needs: prepare
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/android-kotlin-format-check.yml
+++ b/.github/workflows/android-kotlin-format-check.yml
@@ -2,6 +2,7 @@
 name: Android - Check kotlin formatting
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths: [.github/workflows/android-kotlin-format-check.yml, android/**/*.kt]
   workflow_dispatch:
     inputs:
@@ -12,6 +13,7 @@ on:
 jobs:
   prepare:
     name: Prepare
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,6 +33,7 @@ jobs:
       container_image: ${{ env.inner_container_image }}
 
   check-formatting:
+    if: github.event.pull_request.draft == false
     needs: prepare
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,6 +2,7 @@
 name: Rust - Run Clippy to check lints
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - .github/workflows/clippy.yml
       - clippy.toml
@@ -10,6 +11,7 @@ on:
 jobs:
   prepare-android:
     name: Prepare Android container
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -30,6 +32,7 @@ jobs:
 
   clippy-check-desktop:
     name: Clippy linting, desktop
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -69,6 +72,7 @@ jobs:
 
   clippy-check-android:
     name: Clippy linting, Android
+    if: github.event.pull_request.draft == false
     needs: prepare-android
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -2,6 +2,7 @@
 name: Daemon+CLI - Build and test
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '**'
       - '!**/**.md'
@@ -31,6 +32,7 @@ on:
         required: false
 jobs:
   prepare-linux:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -50,6 +52,7 @@ jobs:
       container_image: ${{ env.inner_container_image }}
 
   build-linux:
+    if: github.event.pull_request.draft == false
     needs: prepare-linux
     runs-on: ubuntu-latest
     container:
@@ -81,6 +84,7 @@ jobs:
         run: ./ci/check-rust.sh
 
   build-macos:
+    if: github.event.pull_request.draft == false
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -106,6 +110,7 @@ jobs:
         run: ./ci/check-rust.sh
 
   build-windows:
+    if: github.event.pull_request.draft == false
     runs-on: windows-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,6 +2,7 @@
 name: Desktop frontend
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - .github/workflows/frontend.yml
       - gui/**
@@ -10,6 +11,7 @@ on:
 
 jobs:
   check-frontend:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,6 +2,7 @@
 name: iOS app
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - .github/workflows/ios.yml
       - ios/build-rust-library.sh
@@ -12,6 +13,7 @@ on:
 jobs:
   check-formatting:
     name: Check formatting
+    if: github.event.pull_request.draft == false
     runs-on: macos-13
     steps:
       - name: Install SwiftFormat
@@ -30,6 +32,7 @@ jobs:
 
   swiftlint:
     name: Run swiftlint
+    if: github.event.pull_request.draft == false
     runs-on: macos-13
     steps:
       - name: Checkout repository
@@ -44,6 +47,7 @@ jobs:
 
   test:
     name: Unit tests
+    if: github.event.pull_request.draft == false
     runs-on: macos-13-xlarge
     env:
       SOURCE_PACKAGES_PATH: .spm

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -2,6 +2,7 @@
 name: Rust - Unused dependencies
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - .github/workflows/rust-unused-dependencies.yml
       - '**/*.rs'
@@ -13,6 +14,7 @@ env:
   RUST_NIGHTLY_TOOLCHAIN: nightly-2024-02-06
 jobs:
   prepare-containers:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,6 +29,7 @@ jobs:
       container_image_android: ${{ env.inner_container_image_android }}
 
   cargo-udeps-linux:
+    if: github.event.pull_request.draft == false
     needs: prepare-containers
     runs-on: ubuntu-latest
     container:
@@ -58,6 +61,7 @@ jobs:
         run: source env.sh && cargo udeps --workspace
 
   cargo-udeps-android:
+    if: github.event.pull_request.draft == false
     needs: prepare-containers
     runs-on: ubuntu-latest
     container:
@@ -85,6 +89,7 @@ jobs:
         run: cargo udeps --target aarch64-linux-android --package mullvad-jni
 
   cargo-udeps:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [macos-latest, windows-latest]

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -3,6 +3,7 @@
 name: DES Testframework - Clippy
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'test/**/*.rs'
       - .github/workflows/clippy-test.yml
@@ -11,6 +12,7 @@ on:
 jobs:
   clippy-check-test:
     name: Clippy linting of test workspace
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +50,7 @@ jobs:
 
   clippy-check-test-windows:
     name: Clippy linting of test workspace (Windows)
+    if: github.event.pull_request.draft == false
     runs-on: windows-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -3,6 +3,7 @@
 name: DES Testframework - Build
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '**'
       - '!**/**.md'
@@ -26,6 +27,7 @@ on:
   workflow_dispatch:
 jobs:
   prepare-build-test-framework-linux:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -46,6 +48,7 @@ jobs:
 
   # Build the test runner + test manager at once.
   build-test-framework-linux:
+    if: github.event.pull_request.draft == false
     needs: prepare-build-test-framework-linux
     runs-on: ubuntu-latest
     container:
@@ -69,6 +72,7 @@ jobs:
 
   # Build the test runner + test manager at once.
   build-test-framework-macos:
+    if: github.event.pull_request.draft == false
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -91,6 +95,7 @@ jobs:
 
   # Build only the test-runner binary on Windows. Windows is not a supported host for test-manager.
   build-test-runner-windows:
+    if: github.event.pull_request.draft == false
     # Cross-compile the test runner for Windows from Linux.
     needs: prepare-build-test-framework-linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
A suggestion for how less cloud minutes could be spent by not running time consuming jobs for draft PRs. With these changes runs triggered by `pull_request` will only trigger when the PR is not a draft, and when a draft PR is ready for review.

Looked over job execution time and made sure jobs taking over 1 minute aren't triggered for draft PRs.
<img width="728" alt="image" src="https://github.com/mullvad/mullvadvpn-app/assets/331986/e2ac8514-d180-4e94-aa06-2d42d318d0eb">


So when pushing commits to a draft PR branch actions triggered will look something like this:
![image](https://github.com/mullvad/mullvadvpn-app/assets/331986/f67c490f-ebe4-4f1d-ac3f-603077a08943)

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6279)
<!-- Reviewable:end -->
