### PR TITLE
Add niri as a supported wayland compositor

### DIFF
--- a/dist-assets/linux/mullvad-gui-launcher.sh
+++ b/dist-assets/linux/mullvad-gui-launcher.sh
@@ -8,7 +8,7 @@ else
     SANDBOX_FLAG=""
 fi
 
-SUPPORTED_COMPOSITORS="sway river Hyprland"
+SUPPORTED_COMPOSITORS="sway river Hyprland niri"
 if [ "${XDG_SESSION_TYPE:-""}"  = "wayland" ] && \
     echo " $SUPPORTED_COMPOSITORS " | \
     grep -qi -e " ${XDG_CURRENT_DESKTOP:-""} " -e " ${XDG_SESSION_DESKTOP:-""} "


### PR DESCRIPTION
https://github.com/YaLTeR/niri/

niri doesn't come with xwayland by default, so enabling wayland is required for the gui to work

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6282)
<!-- Reviewable:end -->
