### PR TITLE
IOS-699: fix crash on deletion of access method

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodViewController.swift
@@ -180,7 +180,9 @@ class ListAccessMethodViewController: UIViewController, UITableViewDelegate {
         itemIdentifier: ListAccessMethodItemIdentifier
     ) -> UITableViewCell {
         let cell = tableView.dequeueReusableView(withIdentifier: CellReuseIdentifier.default, for: indexPath)
-        let item = fetchedItems[indexPath.row]
+        guard let item = fetchedItems.first(where: { $0.id == itemIdentifier.id }) else {
+            fatalError("Unable to find item in fetchedItems")
+        }
 
         var contentConfiguration = ListCellContentConfiguration()
         contentConfiguration.text = item.name

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodViewController.swift
@@ -158,6 +158,7 @@ class ListAccessMethodViewController: UIViewController, UITableViewDelegate {
     }
 
     private func updateDataSource(animated: Bool = true) {
+        guard let dataSource else { return }
         fetchedItems = interactor.fetch()
 
         var snapshot = NSDiffableDataSourceSnapshot<ListAccessMethodSectionIdentifier, ListAccessMethodItemIdentifier>()
@@ -168,11 +169,13 @@ class ListAccessMethodViewController: UIViewController, UITableViewDelegate {
         }
         snapshot.appendItems(itemIdentifiers, toSection: .primary)
 
-        for item in fetchedItems {
-            snapshot.reloadItems([ListAccessMethodItemIdentifier(id: item.id)])
+        if dataSource.snapshot().numberOfItems == fetchedItems.count {
+            for item in fetchedItems {
+                snapshot.reloadItems([ListAccessMethodItemIdentifier(id: item.id)])
+            }
         }
 
-        dataSource?.apply(snapshot, animatingDifferences: animated)
+        dataSource.apply(snapshot, animatingDifferences: animated)
     }
 
     private func dequeueCell(
@@ -180,9 +183,7 @@ class ListAccessMethodViewController: UIViewController, UITableViewDelegate {
         itemIdentifier: ListAccessMethodItemIdentifier
     ) -> UITableViewCell {
         let cell = tableView.dequeueReusableView(withIdentifier: CellReuseIdentifier.default, for: indexPath)
-        guard let item = fetchedItems.first(where: { $0.id == itemIdentifier.id }) else {
-            fatalError("Unable to find item in fetchedItems")
-        }
+        let item = fetchedItems[indexPath.row]
 
         var contentConfiguration = ListCellContentConfiguration()
         contentConfiguration.text = item.name


### PR DESCRIPTION
`ListAccessMethodViewController`'s data source was getting out of sync with `fetchedItems`, which was caused by reloading items (useful when existing items have changed, catastrophic for when items have been removed from the middle of the list). Only reloading if the number of items is the same fixes the issue.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6287)
<!-- Reviewable:end -->
