### PR TITLE
Reuse the connection attempts count logic for PQ PSK negotiation

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -307,6 +307,6 @@ extension PacketTunnelProvider: PostQuantumKeyReceiving {
         postQuantumActor.endCurrentNegotiation()
         // Do not try reconnecting to the `.current` relay, else the actor's `State` equality check will fail
         // and it will not try to reconnect
-        actor.reconnect(to: .random)
+        actor.reconnect(to: .random, reconnectReason: .connectionLoss)
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+PostQuantum.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+PostQuantum.swift
@@ -17,10 +17,10 @@ extension PacketTunnelActor {
     internal func tryStartPostQuantumNegotiation(
         withSettings settings: Settings,
         nextRelay: NextRelay,
-        reason: ReconnectReason
+        reason: ActorReconnectReason
     ) async throws {
-        if let connectionState = try makeConnectionState(nextRelay: nextRelay, settings: settings, reason: reason) {
-            let selectedEndpoint = connectionState.selectedRelay.endpoint
+        if let connectionState = try obfuscateConnection(nextRelay: nextRelay, settings: settings, reason: reason) {
+            let selectedEndpoint = connectionState.connectedEndpoint
             let activeKey = activeKey(from: connectionState, in: settings)
 
             let configurationBuilder = ConfigurationBuilder(

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+Public.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+Public.swift
@@ -38,8 +38,8 @@ extension PacketTunnelActor {
 
      - Parameter nextRelay: next relay to connect to.
      */
-    public nonisolated func reconnect(to nextRelay: NextRelay) {
-        eventChannel.send(.reconnect(nextRelay))
+    public nonisolated func reconnect(to nextRelay: NextRelay, reconnectReason: ActorReconnectReason = .userInitiated) {
+        eventChannel.send(.reconnect(nextRelay, reason: reconnectReason))
     }
 
     /**

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActorCommand.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActorCommand.swift
@@ -19,7 +19,7 @@ extension PacketTunnelActor {
         case stop
 
         /// Reconnect tunnel.
-        case reconnect(NextRelay, reason: ReconnectReason = .userInitiated)
+        case reconnect(NextRelay, reason: ActorReconnectReason = .userInitiated)
 
         /// Enter blocked state.
         case error(BlockedStateReason)

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActorProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActorProtocol.swift
@@ -11,6 +11,6 @@ import Foundation
 public protocol PacketTunnelActorProtocol {
     var observedState: ObservedState { get async }
 
-    func reconnect(to nextRelay: NextRelay)
+    func reconnect(to nextRelay: NextRelay, reconnectReason: ActorReconnectReason)
     func notifyKeyRotation(date: Date?)
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActorReducer.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActorReducer.swift
@@ -18,7 +18,7 @@ extension PacketTunnelActor {
         case stopTunnelMonitor
         case updateTunnelMonitorPath(NetworkPath)
         case startConnection(NextRelay)
-        case restartConnection(NextRelay, ReconnectReason)
+        case restartConnection(NextRelay, ActorReconnectReason)
         // trigger a reconnect, which becomes several effects depending on the state
         case reconnect(NextRelay)
         case stopTunnelAdapter
@@ -123,7 +123,7 @@ extension PacketTunnelActor {
 
         fileprivate static func subreducerForReconnect(
             _ state: State,
-            _ reason: PacketTunnelActor.ReconnectReason,
+            _ reason: ActorReconnectReason,
             _ nextRelay: NextRelay
         ) -> [PacketTunnelActor.Effect] {
             switch state {

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -238,3 +238,13 @@ public enum NextRelay: Equatable, Codable {
     /// Use pre-selected relay.
     case preSelected(SelectedRelay)
 }
+
+/// Describes the reason for reconnection request.
+public enum ActorReconnectReason: Equatable {
+    /// Initiated by user.
+    case userInitiated
+
+    /// Initiated by tunnel monitor due to loss of connectivity, or if post quantum key negotiation times out.
+    /// Actor will increment the connection attempt counter before picking next relay.
+    case connectionLoss
+}

--- a/ios/PacketTunnelCore/IPC/AppMessageHandler.swift
+++ b/ios/PacketTunnelCore/IPC/AppMessageHandler.swift
@@ -54,7 +54,7 @@ public struct AppMessageHandler {
             return nil
 
         case let .reconnectTunnel(nextRelay):
-            packetTunnelActor.reconnect(to: nextRelay)
+            packetTunnelActor.reconnect(to: nextRelay, reconnectReason: ActorReconnectReason.userInitiated)
             return nil
         }
     }

--- a/ios/PacketTunnelCoreTests/Mocks/PacketTunnelActorStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/PacketTunnelActorStub.swift
@@ -23,7 +23,7 @@ struct PacketTunnelActorStub: PacketTunnelActorProtocol {
         }
     }
 
-    func reconnect(to nextRelay: NextRelay) {
+    func reconnect(to nextRelay: PacketTunnelCore.NextRelay, reconnectReason: ActorReconnectReason) {
         reconnectExpectation?.fulfill()
     }
 

--- a/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
@@ -37,4 +37,18 @@ extension SettingsReaderStub {
             return staticSettings
         }
     }
+
+    static func postQuantumConfiguration() -> SettingsReaderStub {
+        let staticSettings = Settings(
+            privateKey: PrivateKey(),
+            interfaceAddresses: [IPAddressRange(from: "127.0.0.1/32")!],
+            relayConstraints: RelayConstraints(),
+            dnsServers: .gateway,
+            obfuscation: WireGuardObfuscationSettings(state: .off, port: .automatic),
+            quantumResistance: .on
+        )
+        return SettingsReaderStub {
+            return staticSettings
+        }
+    }
 }


### PR DESCRIPTION
This PR does the following things :
- Use the obfuscation logic when making a post quantum connection
- Rename the `ReconnectReason` to `ActorReconnectReason` and move it to the public interface
- When doing PQ PSK negotiation, send a reconnect message to the actor with a `connectionLoss` reason 
- Make the PQ PSK negotiation logic reuse the connection attempt counts when using the obfuscation logic algorithm