### PR TITLE
Add the word obfuscate to the list of allowed verbs

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -32,4 +32,4 @@ jobs:
           # This action defaults to 50 char subjects, but 72 is fine.
           max-subject-line-length: '72'
           # The action's wordlist is a bit short. Add more accepted verbs
-          additional-verbs: 'tidy, wrap'
+          additional-verbs: 'tidy, wrap, obfuscate'


### PR DESCRIPTION
This PR adds the word "obfuscate" to the list of allowed verbs in commit messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6298)
<!-- Reviewable:end -->
