### PR TITLE
Fix conncheck to work on staging environment

### DIFF
--- a/ios/Configurations/Api.xcconfig.template
+++ b/ios/Configurations/Api.xcconfig.template
@@ -1,7 +1,12 @@
-API_HOST_NAME[config=Debug] = api.mullvad.net
-API_HOST_NAME[config=Release] = api.mullvad.net
-API_HOST_NAME[config=MockRelease] = api.mullvad.net
-API_HOST_NAME[config=Staging] = api.stagemole.eu
+HOST_NAME[config=Debug] = mullvad.net
+HOST_NAME[config=Release] = mullvad.net
+HOST_NAME[config=MockRelease] = mullvad.net
+HOST_NAME[config=Staging] = stagemole.eu
+
+API_HOST_NAME[config=Debug] = api.$(HOST_NAME)
+API_HOST_NAME[config=Release] = api.$(HOST_NAME)
+API_HOST_NAME[config=MockRelease] = api.$(HOST_NAME)
+API_HOST_NAME[config=Staging] = api.$(HOST_NAME)
 
 API_ENDPOINT[config=Debug] = 45.83.223.196:443
 API_ENDPOINT[config=Release] = 45.83.223.196:443

--- a/ios/MullvadVPN/GeneralAPIs/OutgoingConnectionProxy.swift
+++ b/ios/MullvadVPN/GeneralAPIs/OutgoingConnectionProxy.swift
@@ -21,7 +21,7 @@ final class OutgoingConnectionProxy: OutgoingConnectionHandling {
         case v4 = "ipv4", v6 = "ipv6"
 
         var host: String {
-            "\(rawValue).am.i.mullvad.net"
+            "\(rawValue).am.i.\(ApplicationConfiguration.hostName)"
         }
     }
 

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -73,7 +73,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, SettingsMigrationUIHand
             devicesProxy: appDelegate.devicesProxy,
             accountsProxy: appDelegate.accountsProxy,
             outgoingConnectionService: OutgoingConnectionService(
-                outgoingConnectionProxy: OutgoingConnectionProxy(urlSession: URLSession(configuration: .ephemeral))
+                outgoingConnectionProxy: OutgoingConnectionProxy(
+                    urlSession: URLSession(configuration: .ephemeral),
+                    hostname: ApplicationConfiguration.hostName
+                )
             ),
             appPreferences: AppPreferences(),
             accessMethodRepository: accessMethodRepository,

--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>HostName</key>
+	<string>$(HOST_NAME)</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>The app needs this to connect and test a new method.</string>
 	<key>ApplicationSecurityGroupIdentifier</key>

--- a/ios/MullvadVPNTests/MullvadVPN/GeneralAPIs/OutgoingConnectionProxyTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/GeneralAPIs/OutgoingConnectionProxyTests.swift
@@ -11,6 +11,7 @@ import XCTest
 final class OutgoingConnectionProxyTests: XCTestCase {
     private var mockIPV6ConnectionData: Data!
     private var mockIPV4ConnectionData: Data!
+    private let hostname = "mullvad.net"
 
     private let encoder = JSONEncoder()
 
@@ -29,7 +30,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
 
         let outgoingConnectionProxy = OutgoingConnectionProxy(urlSession: URLSessionStub(
             response: (mockIPV4ConnectionData, createHTTPURLResponse(ip: .v4, statusCode: 200))
-        ))
+        ), hostname: hostname)
 
         let result = try await outgoingConnectionProxy.getIPV4(retryStrategy: .noRetry)
 
@@ -44,7 +45,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
 
         let outgoingConnectionProxy = OutgoingConnectionProxy(urlSession: URLSessionStub(
             response: (Data(), createHTTPURLResponse(ip: .v4, statusCode: 503))
-        ))
+        ), hostname: hostname)
 
         await XCTAssertThrowsErrorAsync(try await outgoingConnectionProxy.getIPV4(retryStrategy: .noRetry)) { _ in
             noIPv4Expectation.fulfill()
@@ -57,7 +58,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
 
         let outgoingConnectionProxy = OutgoingConnectionProxy(urlSession: URLSessionStub(
             response: (mockIPV6ConnectionData, createHTTPURLResponse(ip: .v6, statusCode: 200))
-        ))
+        ), hostname: hostname)
 
         let result = try await outgoingConnectionProxy.getIPV6(retryStrategy: .noRetry)
 
@@ -72,7 +73,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
 
         let outgoingConnectionProxy = OutgoingConnectionProxy(urlSession: URLSessionStub(
             response: (mockIPV6ConnectionData, createHTTPURLResponse(ip: .v6, statusCode: 404))
-        ))
+        ), hostname: hostname)
 
         await XCTAssertThrowsErrorAsync(try await outgoingConnectionProxy.getIPV6(retryStrategy: .noRetry)) { _ in
             noIPv6Expectation.fulfill()
@@ -84,7 +85,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
 extension OutgoingConnectionProxyTests {
     private func createHTTPURLResponse(ip: OutgoingConnectionProxy.ExitIPVersion, statusCode: Int) -> HTTPURLResponse {
         return HTTPURLResponse(
-            url: URL(string: "https://\(ip.host)/json")!,
+            url: URL(string: "https://\(ip.host(hostname: hostname))/json")!,
             statusCode: statusCode,
             httpVersion: nil,
             headerFields: ["Content-Type": "application/json"]

--- a/ios/PacketTunnel/Info.plist
+++ b/ios/PacketTunnel/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>HostName</key>
+	<string>$(HOST_NAME)</string>
 	<key>ApplicationSecurityGroupIdentifier</key>
 	<string>$(SECURITY_GROUP_IDENTIFIER)</string>
 	<key>MainApplicationIdentifier</key>

--- a/ios/Shared/ApplicationConfiguration.swift
+++ b/ios/Shared/ApplicationConfiguration.swift
@@ -9,10 +9,14 @@
 import Foundation
 import Network
 
+// swiftlint:disable force_cast
 enum ApplicationConfiguration {
+    static var hostName: String {
+        Bundle.main.object(forInfoDictionaryKey: "HostName") as! String
+    }
+
     /// Shared container security group identifier.
     static var securityGroupIdentifier: String {
-        // swiftlint:disable:next force_cast
         Bundle.main.object(forInfoDictionaryKey: "ApplicationSecurityGroupIdentifier") as! String
     }
 
@@ -59,14 +63,16 @@ enum ApplicationConfiguration {
     static let logMaximumFileSize: UInt64 = 131_072 // 128 kB.
 
     /// Privacy policy URL.
-    static let privacyPolicyURL = URL(string: "https://mullvad.net/help/privacy-policy/")!
+    static let privacyPolicyURL = URL(string: "https://\(Self.hostName)/help/privacy-policy/")!
 
     /// Make a start regarding  policy URL.
-    static let privacyGuidesURL = URL(string: "https://mullvad.net/help/first-steps-towards-online-privacy/")!
+    static let privacyGuidesURL = URL(string: "https://\(Self.hostName)/help/first-steps-towards-online-privacy/")!
 
     /// FAQ & Guides URL.
-    static let faqAndGuidesURL = URL(string: "https://mullvad.net/help/tag/mullvad-app/")!
+    static let faqAndGuidesURL = URL(string: "https://\(Self.hostName)/help/tag/mullvad-app/")!
 
     /// Maximum number of devices per account.
     static let maxAllowedDevices = 5
 }
+
+// swiftlint:enable force_cast

--- a/ios/Shared/ApplicationConfiguration.swift
+++ b/ios/Shared/ApplicationConfiguration.swift
@@ -9,14 +9,15 @@
 import Foundation
 import Network
 
-// swiftlint:disable force_cast
 enum ApplicationConfiguration {
     static var hostName: String {
+        // swiftlint:disable:next force_cast
         Bundle.main.object(forInfoDictionaryKey: "HostName") as! String
     }
 
     /// Shared container security group identifier.
     static var securityGroupIdentifier: String {
+        // swiftlint:disable:next force_cast
         Bundle.main.object(forInfoDictionaryKey: "ApplicationSecurityGroupIdentifier") as! String
     }
 
@@ -74,5 +75,3 @@ enum ApplicationConfiguration {
     /// Maximum number of devices per account.
     static let maxAllowedDevices = 5
 }
-
-// swiftlint:enable force_cast


### PR DESCRIPTION
This PR removes hard coded mentions of `mullvad.net` to replace them by a hostname defined in `Api.xcconfig` instead.
This enables conncheck (`am.i.mullvad.net`) working on both debug and staging environments.

@niklasberglund : I've tagged you because I explicitly didn't touch the `mullvad.net` mentions in the UITests (`Networking.swift`). 
Let's discuss this to see if we want to make changes there as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6302)
<!-- Reviewable:end -->
