### PR TITLE
Update `test/Cargo.lock`

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -1934,7 +1934,6 @@ dependencies = [
  "chrono",
  "intersection-derive",
  "ipnetwork 0.16.0",
- "jnix",
  "log",
  "once_cell",
  "regex",


### PR DESCRIPTION
It seems like the `Cargo.lock` file in the test workspace was not updated before merging the humongous Android-gRPC PR.  

```
$ cargo c &> /dev/null && git diff
diff --git a/test/Cargo.lock b/test/Cargo.lock
index 5c6719c82..4bd2b4796 100644
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -1934,7 +1934,6 @@ dependencies = [
  "chrono",
  "intersection-derive",
  "ipnetwork 0.16.0",
- "jnix",
  "log",
  "once_cell",
  "regex",
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6313)
<!-- Reviewable:end -->
