### PR TITLE
Save executable path instead of application bundle path for manually added macOS split tunneling applications

### DIFF
--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -807,8 +807,8 @@ class ApplicationMain
       // If the applications is a string (path) it's an application picked with the file picker
       // that we want to add to the list of additional applications.
       if (typeof application === 'string') {
-        this.settings.gui.addBrowsedForSplitTunnelingApplications(application);
         const executablePath = await splitTunneling!.resolveExecutablePath(application);
+        this.settings.gui.addBrowsedForSplitTunnelingApplications(executablePath);
         await splitTunneling!.addApplicationPathToCache(application);
         await this.daemonRpc.addSplitTunnelingApplication(executablePath);
       } else {


### PR DESCRIPTION
I noticed that it is not possible to remove manually added applications in macOS split tunneling. This is because the path that is saved to `gui_settings.json` is the application bundle path and when we remove it we try to remove the executable path. This PR changes the behavior to save the executable path in `gui_settings.json` instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6316)
<!-- Reviewable:end -->
