### PR TITLE
Update package dependency to include all routes in network settings

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9311,7 +9311,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = 11a00c20dc03f2751db47e94f585c0778c7bde82;
+				revision = 15242e1698fc45261285d7417ed2cd5130d7332e;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "11a00c20dc03f2751db47e94f585c0778c7bde82"
+        "revision" : "15242e1698fc45261285d7417ed2cd5130d7332e"
       }
     }
   ],


### PR DESCRIPTION
This PR updates the checked package dependency to commit `15242e1698fc45261285d7417ed2cd5130d7332e` on mullvad's wireguard fork.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6321)
<!-- Reviewable:end -->
