### PR TITLE
Add the UITests xcconfig file when running screenshot tests

### DIFF
--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -59,6 +59,7 @@ jobs:
           cp PacketTunnel.xcconfig.template PacketTunnel.xcconfig
           cp Screenshots.xcconfig.template Screenshots.xcconfig
           cp Api.xcconfig.template Api.xcconfig
+          cp UITests.xcconfig.template UITests.xcconfig
           sed -i "" "s/MULLVAD_ACCOUNT_TOKEN = /MULLVAD_ACCOUNT_TOKEN = $TEST_ACCOUNT/g" Screenshots.xcconfig
         working-directory: ios/Configurations
 


### PR DESCRIPTION
When we changed the screenshot test to run in a different target, we forgot to update the screenshot tests to use the configuration used by said target. 

This PR fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6327)
<!-- Reviewable:end -->
