### PR TITLE
Unify account number naming

### DIFF
--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/WelcomeScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/WelcomeScreenTest.kt
@@ -13,7 +13,7 @@ import net.mullvad.mullvadvpn.compose.setContentWithTheme
 import net.mullvad.mullvadvpn.compose.state.PaymentState
 import net.mullvad.mullvadvpn.compose.state.WelcomeUiState
 import net.mullvad.mullvadvpn.compose.test.PLAY_PAYMENT_INFO_ICON_TEST_TAG
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.payment.model.PaymentProduct
 import net.mullvad.mullvadvpn.lib.payment.model.PaymentStatus
 import net.mullvad.mullvadvpn.lib.payment.model.ProductId
@@ -83,7 +83,7 @@ class WelcomeScreenTest {
     fun testShowAccountNumber() =
         composeExtension.use {
             // Arrange
-            val rawAccountNumber = AccountToken("1111222233334444")
+            val rawAccountNumber = AccountNumber("1111222233334444")
             val expectedAccountNumber = "1111 2222 3333 4444"
             setContentWithTheme {
                 WelcomeScreen(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceListScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/DeviceListScreen.kt
@@ -54,7 +54,7 @@ import net.mullvad.mullvadvpn.compose.state.DeviceListUiState
 import net.mullvad.mullvadvpn.compose.transitions.DefaultTransition
 import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.compose.util.showSnackbarImmediately
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.Device
 import net.mullvad.mullvadvpn.lib.model.DeviceId
 import net.mullvad.mullvadvpn.lib.model.GetDeviceListError
@@ -105,13 +105,13 @@ private fun PreviewDeviceListError() {
 @Composable
 fun DeviceList(
     navigator: DestinationsNavigator,
-    accountToken: String,
+    accountNumber: String,
     confirmRemoveResultRecipient:
         ResultRecipient<RemoveDeviceConfirmationDialogDestination, DeviceId>
 ) {
     val viewModel =
         koinViewModel<DeviceListViewModel>(
-            parameters = { parametersOf(AccountToken(accountToken)) }
+            parameters = { parametersOf(AccountNumber(accountNumber)) }
         )
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -148,7 +148,7 @@ fun DeviceList(
         snackbarHostState = snackbarHostState,
         onBackClick = navigator::navigateUp,
         onContinueWithLogin = {
-            navigator.navigate(LoginDestination(accountToken)) {
+            navigator.navigate(LoginDestination(accountNumber)) {
                 launchSingleTop = true
                 popUpTo(LoginDestination) { inclusive = true }
             }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/LoginScreen.kt
@@ -76,7 +76,7 @@ import net.mullvad.mullvadvpn.compose.test.LOGIN_TITLE_TEST_TAG
 import net.mullvad.mullvadvpn.compose.textfield.mullvadWhiteTextFieldColors
 import net.mullvad.mullvadvpn.compose.transitions.LoginTransition
 import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
-import net.mullvad.mullvadvpn.compose.util.accountTokenVisualTransformation
+import net.mullvad.mullvadvpn.compose.util.accountNumberVisualTransformation
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaTopBar
@@ -118,16 +118,16 @@ private fun PreviewLoginSuccess() {
 @Composable
 fun Login(
     navigator: DestinationsNavigator,
-    accountToken: String? = null,
+    accountNumber: String? = null,
     vm: LoginViewModel = koinViewModel()
 ) {
     val state by vm.uiState.collectAsStateWithLifecycle()
 
     // Login with argument, e.g when user comes from Too Many Devices screen
-    LaunchedEffect(accountToken) {
-        if (accountToken != null) {
-            vm.onAccountNumberChange(accountToken)
-            vm.login(accountToken)
+    LaunchedEffect(accountNumber) {
+        if (accountNumber != null) {
+            vm.onAccountNumberChange(accountNumber)
+            vm.login(accountNumber)
         }
     }
 
@@ -144,7 +144,7 @@ fun Login(
                     popUpTo(NavGraphs.root) { inclusive = true }
                 }
             is LoginUiSideEffect.TooManyDevices ->
-                navigator.navigate(DeviceListDestination(it.accountToken.value)) {
+                navigator.navigate(DeviceListDestination(it.accountNumber.value)) {
                     launchSingleTop = true
                 }
             LoginUiSideEffect.NavigateToOutOfTime ->
@@ -291,7 +291,7 @@ private fun ColumnScope.LoginInput(
         onValueChange = onAccountNumberChange,
         singleLine = true,
         maxLines = 1,
-        visualTransformation = accountTokenVisualTransformation(),
+        visualTransformation = accountNumberVisualTransformation(),
         enabled = state.loginState is Idle,
         colors = mullvadWhiteTextFieldColors(),
         isError = state.loginState.isError(),
@@ -299,13 +299,13 @@ private fun ColumnScope.LoginInput(
 
     AnimatedVisibility(visible = state.lastUsedAccount != null && expandedDropdown) {
         val token = state.lastUsedAccount?.value.orEmpty()
-        val accountTransformation = remember { accountTokenVisualTransformation() }
+        val accountTransformation = remember { accountNumberVisualTransformation() }
         val transformedText =
             remember(token) { accountTransformation.filter(AnnotatedString(token)).text }
 
         AccountDropDownItem(
             modifier = Modifier.onFocusChanged { ddFocusState = it },
-            accountToken = transformedText.toString(),
+            accountNumber = transformedText.toString(),
             onClick = {
                 state.lastUsedAccount?.let {
                     onAccountNumberChange(it.value)
@@ -379,7 +379,7 @@ private fun LoginState.supportingText(): String? {
 @Composable
 private fun AccountDropDownItem(
     modifier: Modifier = Modifier,
-    accountToken: String,
+    accountNumber: String,
     onClick: () -> Unit,
     onDeleteClick: () -> Unit
 ) {
@@ -404,7 +404,7 @@ private fun AccountDropDownItem(
                     .padding(horizontal = Dimens.mediumPadding, vertical = Dimens.smallPadding),
             contentAlignment = Alignment.CenterStart
         ) {
-            Text(text = accountToken, overflow = TextOverflow.Clip)
+            Text(text = accountNumber, overflow = TextOverflow.Clip)
         }
         IconButton(onClick = onDeleteClick) {
             Icon(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/WelcomeScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/WelcomeScreen.kt
@@ -54,7 +54,7 @@ import net.mullvad.mullvadvpn.compose.transitions.HomeTransition
 import net.mullvad.mullvadvpn.compose.util.CollectSideEffectWithLifecycle
 import net.mullvad.mullvadvpn.compose.util.createCopyToClipboardHandle
 import net.mullvad.mullvadvpn.lib.common.util.groupWithSpaces
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.payment.model.PaymentProduct
 import net.mullvad.mullvadvpn.lib.payment.model.ProductId
 import net.mullvad.mullvadvpn.lib.payment.model.ProductPrice
@@ -72,7 +72,7 @@ private fun PreviewWelcomeScreen() {
         WelcomeScreen(
             state =
                 WelcomeUiState(
-                    accountNumber = AccountToken("4444555566667777"),
+                    accountNumber = AccountNumber("4444555566667777"),
                     deviceName = "Happy Mole",
                     billingPaymentState =
                         PaymentState.PaymentAvailable(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/LoginUiState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/LoginUiState.kt
@@ -1,12 +1,12 @@
 package net.mullvad.mullvadvpn.compose.state
 
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 
 const val MIN_ACCOUNT_LOGIN_LENGTH = 8
 
 data class LoginUiState(
     val accountNumberInput: String = "",
-    val lastUsedAccount: AccountToken? = null,
+    val lastUsedAccount: AccountNumber? = null,
     val loginState: LoginState = LoginState.Idle(null)
 ) {
     val loginButtonEnabled =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/WelcomeUiState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/WelcomeUiState.kt
@@ -1,11 +1,11 @@
 package net.mullvad.mullvadvpn.compose.state
 
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.TunnelState
 
 data class WelcomeUiState(
     val tunnelState: TunnelState = TunnelState.Disconnected(),
-    val accountNumber: AccountToken? = null,
+    val accountNumber: AccountNumber? = null,
     val deviceName: String? = null,
     val showSitePayment: Boolean = false,
     val billingPaymentState: PaymentState? = null,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/AccountNumberVisualTransformation.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/AccountNumberVisualTransformation.kt
@@ -5,22 +5,22 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 
-const val ACCOUNT_TOKEN_SEPARATOR = " "
-const val ACCOUNT_TOKEN_CHUNK_SIZE = 4
+const val ACCOUNT_NUMBER_SEPARATOR = " "
+const val ACCOUNT_NUMBER_CHUNK_SIZE = 4
 
-fun accountTokenVisualTransformation() = VisualTransformation {
+fun accountNumberVisualTransformation() = VisualTransformation {
     val transformedString =
-        it.chunked(ACCOUNT_TOKEN_CHUNK_SIZE).joinToString(ACCOUNT_TOKEN_SEPARATOR)
+        it.chunked(ACCOUNT_NUMBER_CHUNK_SIZE).joinToString(ACCOUNT_NUMBER_SEPARATOR)
     val transformedAnnotatedString = AnnotatedString(transformedString)
 
     TransformedText(
         transformedAnnotatedString,
         object : OffsetMapping {
             override fun originalToTransformed(offset: Int): Int =
-                offset + (offset - 1) / ACCOUNT_TOKEN_CHUNK_SIZE
+                offset + (offset - 1) / ACCOUNT_NUMBER_CHUNK_SIZE
 
             override fun transformedToOriginal(offset: Int): Int =
-                offset - (offset - 1) / (ACCOUNT_TOKEN_CHUNK_SIZE + 1)
+                offset - (offset - 1) / (ACCOUNT_NUMBER_CHUNK_SIZE + 1)
         }
     )
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/VoucherVisualTransformation.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/VoucherVisualTransformation.kt
@@ -23,16 +23,16 @@ fun vouchersVisualTransformation() = VisualTransformation { text ->
         AnnotatedString(out),
         object : OffsetMapping {
             override fun originalToTransformed(offset: Int): Int {
-                val res = offset + offset / ACCOUNT_TOKEN_CHUNK_SIZE
+                val res = offset + offset / ACCOUNT_NUMBER_CHUNK_SIZE
                 // Limit max input to 19 characters (16 voucher - 3 dividers)
                 return min(
                     res,
-                    MAX_VOUCHER_LENGTH + MAX_VOUCHER_LENGTH / ACCOUNT_TOKEN_CHUNK_SIZE - 1
+                    MAX_VOUCHER_LENGTH + MAX_VOUCHER_LENGTH / ACCOUNT_NUMBER_CHUNK_SIZE - 1
                 )
             }
 
             override fun transformedToOriginal(offset: Int): Int =
-                offset - offset / (ACCOUNT_TOKEN_CHUNK_SIZE + 1)
+                offset - offset / (ACCOUNT_NUMBER_CHUNK_SIZE + 1)
         }
     )
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceListViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/DeviceListViewModel.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import net.mullvad.mullvadvpn.compose.state.DeviceItemUiState
 import net.mullvad.mullvadvpn.compose.state.DeviceListUiState
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.Device
 import net.mullvad.mullvadvpn.lib.model.DeviceId
 import net.mullvad.mullvadvpn.lib.model.GetDeviceListError
@@ -25,7 +25,7 @@ import net.mullvad.mullvadvpn.lib.shared.DeviceRepository
 
 class DeviceListViewModel(
     private val deviceRepository: DeviceRepository,
-    private val token: AccountToken,
+    private val token: AccountNumber,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
     private val loadingDevices = MutableStateFlow<Set<DeviceId>>(emptySet())

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/NewDeviceUseNotificationCaseTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/NewDeviceUseNotificationCaseTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import net.mullvad.mullvadvpn.lib.common.test.TestCoroutineRule
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.Device
 import net.mullvad.mullvadvpn.lib.model.DeviceId
 import net.mullvad.mullvadvpn.lib.model.DeviceState
@@ -29,7 +29,7 @@ class NewDeviceUseNotificationCaseTest {
     private val deviceState =
         MutableStateFlow<DeviceState?>(
             DeviceState.LoggedIn(
-                AccountToken("1234123412341234"),
+                AccountNumber("1234123412341234"),
                 Device(
                     id = DeviceId.fromString(UUID),
                     name = deviceName,

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/AccountViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/AccountViewModelTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 import net.mullvad.mullvadvpn.compose.state.PaymentState
 import net.mullvad.mullvadvpn.lib.common.test.TestCoroutineRule
 import net.mullvad.mullvadvpn.lib.common.test.assertLists
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.Device
 import net.mullvad.mullvadvpn.lib.model.DeviceId
 import net.mullvad.mullvadvpn.lib.model.DeviceState
@@ -46,8 +46,8 @@ class AccountViewModelTest {
 
     private val dummyDevice =
         Device(id = DeviceId.fromString(UUID), name = "fake_name", creationDate = DateTime.now())
-    private val dummyAccountToken: AccountToken =
-        AccountToken(
+    private val dummyAccountNumber: AccountNumber =
+        AccountNumber(
             DUMMY_DEVICE_NAME,
         )
 
@@ -82,7 +82,7 @@ class AccountViewModelTest {
         viewModel.uiState.test {
             awaitItem() // Default state
             deviceState.value =
-                DeviceState.LoggedIn(accountToken = dummyAccountToken, device = dummyDevice)
+                DeviceState.LoggedIn(accountNumber = dummyAccountNumber, device = dummyDevice)
             val result = awaitItem()
             assertEquals(DUMMY_DEVICE_NAME, result.accountNumber)
         }

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
@@ -24,7 +24,7 @@ import net.mullvad.mullvadvpn.compose.state.LoginState.Success
 import net.mullvad.mullvadvpn.compose.state.LoginUiState
 import net.mullvad.mullvadvpn.lib.common.test.TestCoroutineRule
 import net.mullvad.mullvadvpn.lib.model.AccountData
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.LoginAccountError
 import net.mullvad.mullvadvpn.lib.shared.AccountRepository
 import net.mullvad.mullvadvpn.usecase.ConnectivityUseCase
@@ -93,7 +93,7 @@ class LoginViewModelTest {
             // Arrange
             val uiStates = loginViewModel.uiState.testIn(backgroundScope)
             val sideEffects = loginViewModel.uiSideEffect.testIn(backgroundScope)
-            coEvery { mockedAccountRepository.createAccount() } returns DUMMY_ACCOUNT_TOKEN.right()
+            coEvery { mockedAccountRepository.createAccount() } returns DUMMY_ACCOUNT_NUMBER.right()
 
             // Act, Assert
             uiStates.skipDefaultItem()
@@ -115,7 +115,7 @@ class LoginViewModelTest {
 
             // Act, Assert
             uiStates.skipDefaultItem()
-            loginViewModel.login(DUMMY_ACCOUNT_TOKEN.value)
+            loginViewModel.login(DUMMY_ACCOUNT_NUMBER.value)
             assertEquals(Loading.LoggingIn, uiStates.awaitItem().loginState)
             assertEquals(Success, uiStates.awaitItem().loginState)
             assertEquals(LoginUiSideEffect.NavigateToConnect, sideEffects.awaitItem())
@@ -131,7 +131,7 @@ class LoginViewModelTest {
 
             // Act, Assert
             skipDefaultItem()
-            loginViewModel.login(DUMMY_ACCOUNT_TOKEN.value)
+            loginViewModel.login(DUMMY_ACCOUNT_NUMBER.value)
             assertEquals(Loading.LoggingIn, awaitItem().loginState)
             assertEquals(Idle(loginError = LoginError.InvalidCredentials), awaitItem().loginState)
         }
@@ -145,14 +145,14 @@ class LoginViewModelTest {
                 val uiStates = loginViewModel.uiState.testIn(backgroundScope)
                 val sideEffects = loginViewModel.uiSideEffect.testIn(backgroundScope)
                 coEvery { mockedAccountRepository.login(any()) } returns
-                    LoginAccountError.MaxDevicesReached(DUMMY_ACCOUNT_TOKEN).left()
+                    LoginAccountError.MaxDevicesReached(DUMMY_ACCOUNT_NUMBER).left()
 
                 // Act, Assert
                 uiStates.skipDefaultItem()
-                loginViewModel.login(DUMMY_ACCOUNT_TOKEN.value)
+                loginViewModel.login(DUMMY_ACCOUNT_NUMBER.value)
                 assertEquals(Loading.LoggingIn, uiStates.awaitItem().loginState)
                 assertEquals(
-                    LoginUiSideEffect.TooManyDevices(DUMMY_ACCOUNT_TOKEN),
+                    LoginUiSideEffect.TooManyDevices(DUMMY_ACCOUNT_NUMBER),
                     sideEffects.awaitItem()
                 )
             }
@@ -167,7 +167,7 @@ class LoginViewModelTest {
 
             // Act, Assert
             skipDefaultItem()
-            loginViewModel.login(DUMMY_ACCOUNT_TOKEN.value)
+            loginViewModel.login(DUMMY_ACCOUNT_NUMBER.value)
             assertEquals(Loading.LoggingIn, awaitItem().loginState)
             assertEquals(
                 Idle(LoginError.Unknown(EXPECTED_RPC_ERROR_MESSAGE)),
@@ -185,7 +185,7 @@ class LoginViewModelTest {
 
             // Act, Assert
             skipDefaultItem()
-            loginViewModel.login(DUMMY_ACCOUNT_TOKEN.value)
+            loginViewModel.login(DUMMY_ACCOUNT_NUMBER.value)
             assertEquals(Loading.LoggingIn, awaitItem().loginState)
             val loginState = awaitItem().loginState
             assertIs<Idle>(loginState)
@@ -197,12 +197,12 @@ class LoginViewModelTest {
     fun `on new accountHistory emission uiState should include lastUsedAccount matching accountHistory`() =
         runTest {
             // Arrange
-            coEvery { mockedAccountRepository.fetchAccountHistory() } returns DUMMY_ACCOUNT_TOKEN
+            coEvery { mockedAccountRepository.fetchAccountHistory() } returns DUMMY_ACCOUNT_NUMBER
 
             // Act, Assert
             loginViewModel.uiState.test {
                 assertEquals(
-                    LoginUiState.INITIAL.copy(lastUsedAccount = DUMMY_ACCOUNT_TOKEN),
+                    LoginUiState.INITIAL.copy(lastUsedAccount = DUMMY_ACCOUNT_NUMBER),
                     awaitItem()
                 )
             }
@@ -220,7 +220,7 @@ class LoginViewModelTest {
     }
 
     companion object {
-        private val DUMMY_ACCOUNT_TOKEN = AccountToken("DUMMY")
+        private val DUMMY_ACCOUNT_NUMBER = AccountNumber("DUMMY")
         private const val EXPECTED_RPC_ERROR_MESSAGE = "RpcError"
     }
 }

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
@@ -16,7 +16,7 @@ import net.mullvad.mullvadvpn.compose.state.PaymentState
 import net.mullvad.mullvadvpn.lib.common.test.TestCoroutineRule
 import net.mullvad.mullvadvpn.lib.common.test.assertLists
 import net.mullvad.mullvadvpn.lib.model.AccountData
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.Device
 import net.mullvad.mullvadvpn.lib.model.DeviceState
 import net.mullvad.mullvadvpn.lib.model.TunnelState
@@ -126,7 +126,7 @@ class WelcomeViewModelTest {
     fun `when DeviceRepository returns LoggedIn uiState should include new accountNumber`() =
         runTest {
             // Arrange
-            val expectedAccountNumber = AccountToken("4444555566667777")
+            val expectedAccountNumber = AccountNumber("4444555566667777")
             val device: Device = mockk()
             every { device.displayName() } returns ""
 
@@ -136,7 +136,7 @@ class WelcomeViewModelTest {
                 awaitItem()
                 paymentAvailabilityFlow.value = null
                 deviceStateFlow.value =
-                    DeviceState.LoggedIn(accountToken = expectedAccountNumber, device = device)
+                    DeviceState.LoggedIn(accountNumber = expectedAccountNumber, device = device)
                 assertEquals(expectedAccountNumber, awaitItem().accountNumber)
             }
         }

--- a/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/mapper/ToDomain.kt
+++ b/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/mapper/ToDomain.kt
@@ -11,7 +11,7 @@ import net.mullvad.mullvadvpn.lib.daemon.grpc.GrpcConnectivityState
 import net.mullvad.mullvadvpn.lib.daemon.grpc.RelayNameComparator
 import net.mullvad.mullvadvpn.lib.model.AccountData
 import net.mullvad.mullvadvpn.lib.model.AccountId
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.ActionAfterDisconnect
 import net.mullvad.mullvadvpn.lib.model.AppId
 import net.mullvad.mullvadvpn.lib.model.AppVersionInfo
@@ -491,7 +491,7 @@ internal fun ManagementInterface.Device.toDomain(): Device =
 internal fun ManagementInterface.DeviceState.toDomain(): DeviceState =
     when (state) {
         ManagementInterface.DeviceState.State.LOGGED_IN ->
-            DeviceState.LoggedIn(AccountToken(device.accountToken), device.device.toDomain())
+            DeviceState.LoggedIn(AccountNumber(device.accountToken), device.device.toDomain())
         ManagementInterface.DeviceState.State.LOGGED_OUT -> DeviceState.LoggedOut
         ManagementInterface.DeviceState.State.REVOKED -> DeviceState.Revoked
         ManagementInterface.DeviceState.State.UNRECOGNIZED ->

--- a/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/AccountNumber.kt
+++ b/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/AccountNumber.kt
@@ -3,4 +3,4 @@ package net.mullvad.mullvadvpn.lib.model
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
-@JvmInline @Parcelize value class AccountToken(val value: String) : Parcelable
+@JvmInline @Parcelize value class AccountNumber(val value: String) : Parcelable

--- a/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/DeviceState.kt
+++ b/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/DeviceState.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 sealed class DeviceState : Parcelable {
     @Parcelize
-    data class LoggedIn(val accountToken: AccountToken, val device: Device) : DeviceState()
+    data class LoggedIn(val accountNumber: AccountNumber, val device: Device) : DeviceState()
 
     @Parcelize data object LoggedOut : DeviceState()
 
@@ -15,7 +15,7 @@ sealed class DeviceState : Parcelable {
         return (this as? LoggedIn)?.device?.displayName()
     }
 
-    fun token(): AccountToken? {
-        return (this as? LoggedIn)?.accountToken
+    fun token(): AccountNumber? {
+        return (this as? LoggedIn)?.accountNumber
     }
 }

--- a/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/LoginAccountError.kt
+++ b/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/LoginAccountError.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
 sealed class LoginAccountError : Parcelable {
     data object InvalidAccount : LoginAccountError()
 
-    data class MaxDevicesReached(val accountToken: AccountToken) : LoginAccountError()
+    data class MaxDevicesReached(val accountNumber: AccountNumber) : LoginAccountError()
 
     data object RpcError : LoginAccountError()
 

--- a/android/lib/shared/src/main/kotlin/net/mullvad/mullvadvpn/lib/shared/DeviceRepository.kt
+++ b/android/lib/shared/src/main/kotlin/net/mullvad/mullvadvpn/lib/shared/DeviceRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import net.mullvad.mullvadvpn.lib.daemon.grpc.ManagementService
-import net.mullvad.mullvadvpn.lib.model.AccountToken
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
 import net.mullvad.mullvadvpn.lib.model.DeleteDeviceError
 import net.mullvad.mullvadvpn.lib.model.Device
 import net.mullvad.mullvadvpn.lib.model.DeviceId
@@ -27,10 +27,10 @@ class DeviceRepository(
         )
 
     suspend fun removeDevice(
-        accountToken: AccountToken,
+        accountNumber: AccountNumber,
         deviceId: DeviceId
-    ): Either<DeleteDeviceError, Unit> = managementService.removeDevice(accountToken, deviceId)
+    ): Either<DeleteDeviceError, Unit> = managementService.removeDevice(accountNumber, deviceId)
 
-    suspend fun deviceList(accountToken: AccountToken): Either<GetDeviceListError, List<Device>> =
-        managementService.getDeviceList(accountToken)
+    suspend fun deviceList(accountNumber: AccountNumber): Either<GetDeviceListError, List<Device>> =
+        managementService.getDeviceList(accountNumber)
 }

--- a/android/scripts/run-instrumented-tests.sh
+++ b/android/scripts/run-instrumented-tests.sh
@@ -14,8 +14,8 @@ ORCHESTRATOR_URL=https://dl.google.com/android/maven2/androidx/test/orchestrator
 TEST_SERVICES_URL=https://dl.google.com/android/maven2/androidx/test/services/test-services/1.4.2/test-services-1.4.2.apk
 
 PARTNER_AUTH="${PARTNER_AUTH:-}"
-VALID_TEST_ACCOUNT_TOKEN="${VALID_TEST_ACCOUNT_TOKEN:-}"
-INVALID_TEST_ACCOUNT_TOKEN="${INVALID_TEST_ACCOUNT_TOKEN:-}"
+VALID_TEST_ACCOUNT_NUMBER="${VALID_TEST_ACCOUNT_NUMBER:-}"
+INVALID_TEST_ACCOUNT_NUMBER="${INVALID_TEST_ACCOUNT_NUMBER:-}"
 REPORT_DIR="${REPORT_DIR:-}"
 
 while [[ "$#" -gt 0 ]]; do
@@ -113,21 +113,21 @@ case "$TEST_TYPE" in
         exit 1
     fi
     OPTIONAL_TEST_ARGUMENTS=""
-    if [[ -n ${INVALID_TEST_ACCOUNT_TOKEN-} ]]; then
-        OPTIONAL_TEST_ARGUMENTS+=" -e invalid_test_account_token $INVALID_TEST_ACCOUNT_TOKEN"
+    if [[ -n ${INVALID_TEST_ACCOUNT_NUMBER-} ]]; then
+        OPTIONAL_TEST_ARGUMENTS+=" -e invalid_test_account_number $INVALID_TEST_ACCOUNT_NUMBER"
     else
-        echo "Error: The variable INVALID_TEST_ACCOUNT_TOKEN must be set."
+        echo "Error: The variable INVALID_TEST_ACCOUNT_NUMBER must be set."
         exit 1
     fi
     if [[ -n ${PARTNER_AUTH} ]]; then
         echo "Test account used for e2e test (provided/partner): partner"
         OPTIONAL_TEST_ARGUMENTS+=" -e partner_auth $PARTNER_AUTH"
-    elif [[ -n ${VALID_TEST_ACCOUNT_TOKEN} ]]; then
+    elif [[ -n ${VALID_TEST_ACCOUNT_NUMBER} ]]; then
         echo "Test account used for e2e test (provided/partner): provided"
-        OPTIONAL_TEST_ARGUMENTS+=" -e valid_test_account_token $VALID_TEST_ACCOUNT_TOKEN"
+        OPTIONAL_TEST_ARGUMENTS+=" -e valid_test_account_number $VALID_TEST_ACCOUNT_NUMBER"
     else
         echo ""
-        echo "Error: The variable PARTNER_AUTH or VALID_TEST_ACCOUNT_TOKEN must be set."
+        echo "Error: The variable PARTNER_AUTH or VALID_TEST_ACCOUNT_NUMBER must be set."
         exit 1
     fi
     USE_ORCHESTRATOR="true"

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/NameTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/NameTest.kt
@@ -1,0 +1,33 @@
+package net.mullvad.mullvadvpn.test.arch
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.parameters
+import com.lemonappdev.konsist.api.provider.KoNameProvider
+import com.lemonappdev.konsist.api.verify.assertFalse
+import java.util.stream.Stream
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+
+class NameTest {
+    @TestFactory
+    fun `ensure no disallowed declaration or parameter names`(): Stream<DynamicTest> =
+        DISALLOWED_DECLARATION_OR_PARAMETER_NAMES.stream().map { disallowedName ->
+            val testName = "ensure no declarations or parameters include: $disallowedName"
+            dynamicTest(testName) {
+                Konsist.scopeFromProject()
+                    .let { it.declarations() + it.functions().parameters }
+                    .filterIsInstance<KoNameProvider>()
+                    .assertFalse(testName = testName) { it.hasNameContaining(disallowedName) }
+            }
+        }
+
+    companion object {
+        private val DISALLOWED_DECLARATION_OR_PARAMETER_NAMES =
+            listOf(
+                "accountToken",
+                "AccountToken",
+                "ACCOUNT_TOKEN",
+            )
+    }
+}

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -43,12 +43,12 @@ class AppInteractor(
         device.wait(Until.hasObject(By.pkg(targetPackageName).depth(0)), APP_LAUNCH_TIMEOUT)
     }
 
-    fun launchAndEnsureLoggedIn(accountToken: String) {
+    fun launchAndEnsureLoggedIn(accountNumber: String) {
         launch()
         device.clickAgreeOnPrivacyDisclaimer()
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         waitForLoginPrompt()
-        attemptLogin(accountToken)
+        attemptLogin(accountNumber)
         ensureLoggedIn()
     }
 
@@ -61,10 +61,10 @@ class AppInteractor(
         ensureAccountCreated()
     }
 
-    fun attemptLogin(accountToken: String) {
+    fun attemptLogin(accountNumber: String) {
         val loginObject =
             device.findObjectWithTimeout(By.clazz("android.widget.EditText")).apply {
-                text = accountToken
+                text = accountNumber
             }
         loginObject.parent.findObject(By.clazz(Button::class.java)).click()
     }
@@ -73,10 +73,10 @@ class AppInteractor(
         device.findObjectWithTimeout(By.text("Create account")).click()
     }
 
-    fun ensureAccountCreated(accountToken: String? = null) {
+    fun ensureAccountCreated(accountNumber: String? = null) {
         device.findObjectWithTimeout(By.text("Congrats!"), LOGIN_TIMEOUT)
-        accountToken?.let {
-            device.findObjectWithTimeout(By.text(accountToken), DEFAULT_INTERACTION_TIMEOUT)
+        accountNumber?.let {
+            device.findObjectWithTimeout(By.text(accountNumber), DEFAULT_INTERACTION_TIMEOUT)
         }
     }
 

--- a/android/test/e2e/README.md
+++ b/android/test/e2e/README.md
@@ -7,14 +7,14 @@ The tests in this module are end-to-end tests that rely on the publicly accessib
 Set tokens in the below command and then execute the command in the `android` directory to run the tests on a local device:
 ```
 ./gradlew :test:e2e:connectedDebugAndroidTest \
-    -Pvalid_test_account_token=XXXX \
-    -Pinvalid_test_account_token=XXXX
+    -Pvalid_test_account_number=XXXX \
+    -Pinvalid_test_account_number=XXXX
 ```
 
 For convenience, the tokens can also be set in `<REPO-ROOT>/android/local.properties` in the following way:
 ```
-valid_test_account_token=XXXX
-invalid_test_account_token=XXXX
+valid_test_account_number=XXXX
+invalid_test_account_number=XXXX
 ```
 
 It's also possible to provide the tokens to the test runner during test execution. However note that this requires [the APKs to be installed manually](https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner#architecture).
@@ -22,8 +22,8 @@ It's also possible to provide the tokens to the test runner during test executio
 adb shell 'CLASSPATH=$(pm path androidx.test.services) app_process / \
     androidx.test.services.shellexecutor.ShellMain am instrument -w \
     -e clearPackageData true \
-    -e valid_test_account_token XXXX \
-    -e invalid_test_account_token XXXX \
+    -e valid_test_account_number XXXX \
+    -e invalid_test_account_number XXXX \
     -e targetInstrumentation net.mullvad.mullvadvpn.test.e2e/androidx.test.runner.AndroidJUnitRunner \
     androidx.test.orchestrator/.AndroidTestOrchestrator'
 ```
@@ -41,7 +41,7 @@ gcloud firebase test android run \
     --test ./android/test/e2e/build/outputs/apk/debug/e2e-debug.apk \
     --device model=redfin,version=30,locale=en,orientation=portrait \
     --use-orchestrator \
-    --environment-variables clearPackageData=true,valid_test_account_token=XXXX,invalid_test_account_token=XXXX
+    --environment-variables clearPackageData=true,valid_test_account_number=XXXX,invalid_test_account_number=XXXX
 ```
 
 If using gcloud via the docker image, the following can be executed in the `android` directory to run the tests (on a Pixel 5e):
@@ -52,5 +52,5 @@ docker run --rm --volumes-from gcloud-config -v ${PWD}:/android gcr.io/google.co
     --test ./android/test/e2e/build/outputs/apk/debug/e2e-debug.apk \
     --device model=redfin,version=30,locale=en,orientation=portrait \
     --use-orchestrator \
-    --environment-variables clearPackageData=true,valid_test_account_token=XXXX,invalid_test_account_token=XXXX
+    --environment-variables clearPackageData=true,valid_test_account_number=XXXX,invalid_test_account_number=XXXX
 ```

--- a/android/test/e2e/build.gradle.kts
+++ b/android/test/e2e/build.gradle.kts
@@ -43,8 +43,8 @@ android {
         testInstrumentationRunnerArguments +=
             mutableMapOf<String, String>().apply {
                 put("clearPackageData", "true")
-                addOptionalPropertyAsArgument("valid_test_account_token")
-                addOptionalPropertyAsArgument("invalid_test_account_token")
+                addOptionalPropertyAsArgument("valid_test_account_number")
+                addOptionalPropertyAsArgument("invalid_test_account_number")
             }
     }
 

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -17,10 +17,10 @@ class LoginTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
     @Test
     fun testLoginWithValidCredentials() {
         // Given
-        val validTestAccountToken = accountTestRule.validAccountNumber
+        val validTestAccountNumber = accountTestRule.validAccountNumber
 
         // When
-        app.launchAndEnsureLoggedIn(validTestAccountToken)
+        app.launchAndEnsureLoggedIn(validTestAccountNumber)
 
         // Then
         app.ensureLoggedIn()
@@ -30,14 +30,14 @@ class LoginTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
     @Disabled("Disabled to avoid getting rate-limited.")
     fun testLoginWithInvalidCredentials() {
         // Given
-        val invalidDummyAccountToken = accountTestRule.invalidAccountNumber
+        val invalidDummyAccountNumber = accountTestRule.invalidAccountNumber
 
         // When
         app.launch()
         device.clickAgreeOnPrivacyDisclaimer()
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         app.waitForLoginPrompt()
-        app.attemptLogin(invalidDummyAccountToken)
+        app.attemptLogin(invalidDummyAccountNumber)
 
         // Then
         device.findObjectWithTimeout(By.text("Invalid account number"), LOGIN_FAILURE_TIMEOUT)

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/constant/Constants.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/constant/Constants.kt
@@ -2,5 +2,5 @@ package net.mullvad.mullvadvpn.test.e2e.constant
 
 const val LOG_TAG = "mullvad-e2e"
 const val PARTNER_AUTH = "partner_auth"
-const val VALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY = "valid_test_account_token"
-const val INVALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY = "invalid_test_account_token"
+const val VALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY = "valid_test_account_number"
+const val INVALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY = "invalid_test_account_number"

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/interactor/MullvadAccountInteractor.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/interactor/MullvadAccountInteractor.kt
@@ -4,9 +4,9 @@ import net.mullvad.mullvadvpn.test.e2e.misc.SimpleMullvadHttpClient
 
 class MullvadAccountInteractor(
     private val httpClient: SimpleMullvadHttpClient,
-    private val testAccountToken: String
+    private val testAccountNumber: String
 ) {
     fun cleanupAccount() {
-        httpClient.removeAllDevices(testAccountToken)
+        httpClient.removeAllDevices(testAccountNumber)
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/AccountTestRule.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/AccountTestRule.kt
@@ -1,9 +1,9 @@
 package net.mullvad.mullvadvpn.test.e2e.misc
 
 import androidx.test.platform.app.InstrumentationRegistry
-import net.mullvad.mullvadvpn.test.e2e.constant.INVALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY
+import net.mullvad.mullvadvpn.test.e2e.constant.INVALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY
 import net.mullvad.mullvadvpn.test.e2e.constant.PARTNER_AUTH
-import net.mullvad.mullvadvpn.test.e2e.constant.VALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY
+import net.mullvad.mullvadvpn.test.e2e.constant.VALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY
 import net.mullvad.mullvadvpn.test.e2e.extension.getRequiredArgument
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -30,12 +30,12 @@ class AccountTestRule : BeforeEachCallback {
                 )
             } else {
                 validAccountNumber =
-                    bundle.getRequiredArgument(VALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY)
+                    bundle.getRequiredArgument(VALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY)
                 client.removeAllDevices(validAccountNumber)
             }
 
             invalidAccountNumber =
-                bundle.getRequiredArgument(INVALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY)
+                bundle.getRequiredArgument(INVALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY)
         }
     }
 

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/CleanupAccountTestRule.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/CleanupAccountTestRule.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.test.e2e.misc
 import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
 import net.mullvad.mullvadvpn.test.e2e.constant.LOG_TAG
-import net.mullvad.mullvadvpn.test.e2e.constant.VALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY
+import net.mullvad.mullvadvpn.test.e2e.constant.VALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY
 import net.mullvad.mullvadvpn.test.e2e.extension.getRequiredArgument
 import net.mullvad.mullvadvpn.test.e2e.interactor.MullvadAccountInteractor
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -14,10 +14,10 @@ class CleanupAccountTestRule : BeforeEachCallback {
     override fun beforeEach(context: ExtensionContext) {
         Log.d(LOG_TAG, "Cleaning up account before test: ${context.requiredTestMethod.name}")
         val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val validTestAccountToken =
+        val validTestAccountNumber =
             InstrumentationRegistry.getArguments()
-                .getRequiredArgument(VALID_TEST_ACCOUNT_TOKEN_ARGUMENT_KEY)
-        MullvadAccountInteractor(SimpleMullvadHttpClient(targetContext), validTestAccountToken)
+                .getRequiredArgument(VALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY)
+        MullvadAccountInteractor(SimpleMullvadHttpClient(targetContext), validTestAccountNumber)
             .cleanupAccount()
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/SimpleMullvadHttpClient.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/SimpleMullvadHttpClient.kt
@@ -22,17 +22,17 @@ class SimpleMullvadHttpClient(context: Context) {
 
     private val queue = Volley.newRequestQueue(context)
 
-    fun removeAllDevices(accountToken: String) {
+    fun removeAllDevices(accountNumber: String) {
         Log.v(LOG_TAG, "Remove all devices")
-        val token = login(accountToken)
+        val token = login(accountNumber)
         val devices = getDeviceList(token)
         devices.forEach { removeDevice(token, it) }
         Log.v(LOG_TAG, "All devices removed")
     }
 
-    fun login(accountToken: String): String {
-        Log.v(LOG_TAG, "Attempt login with account token: $accountToken")
-        val json = JSONObject().apply { put("account_number", accountToken) }
+    fun login(accountNumber: String): String {
+        Log.v(LOG_TAG, "Attempt login with account token: $accountNumber")
+        val json = JSONObject().apply { put("account_number", accountNumber) }
         return sendSimpleSynchronousRequest(Request.Method.POST, AUTH_URL, json)!!.let { response ->
             response.getString("access_token").also { accessToken ->
                 Log.v(LOG_TAG, "Successfully logged in and received access token: $accessToken")

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountExpiryMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountExpiryMockApiTest.kt
@@ -17,10 +17,10 @@ class AccountExpiryMockApiTest : MockApiTest() {
     @Test
     fun testAccountExpiryDateUpdated() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         val oldAccountExpiry = currentUtcTimeWithOffsetZero().plusMonths(1)
         apiDispatcher.apply {
-            expectedAccountToken = validAccountToken
+            expectedAccountNumber = validAccountNumber
             accountExpiry = oldAccountExpiry
             devices = DEFAULT_DEVICE_LIST.toMutableMap()
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
@@ -32,7 +32,7 @@ class AccountExpiryMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
 
         // Assert logged in
         app.ensureLoggedIn()
@@ -51,10 +51,10 @@ class AccountExpiryMockApiTest : MockApiTest() {
     @Test
     fun testAccountTimeExpiredWhileUsingTheAppShouldShowOutOfTimeScreen() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         val oldAccountExpiry = currentUtcTimeWithOffsetZero().plusMonths(1)
         apiDispatcher.apply {
-            expectedAccountToken = validAccountToken
+            expectedAccountNumber = validAccountNumber
             accountExpiry = oldAccountExpiry
             devices = DEFAULT_DEVICE_LIST.toMutableMap()
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
@@ -66,7 +66,7 @@ class AccountExpiryMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
 
         // Assert logged in
         app.ensureLoggedIn()

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountHistoryMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountHistoryMockApiTest.kt
@@ -18,9 +18,9 @@ class AccountHistoryMockApiTest : MockApiTest() {
     @Test
     fun testShowAccountHistory() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
-            expectedAccountToken = validAccountToken
+            expectedAccountNumber = validAccountNumber
             accountExpiry = currentUtcTimeWithOffsetZero().plusMonths(1)
             devices = DEFAULT_DEVICE_LIST.toMutableMap()
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
@@ -32,7 +32,7 @@ class AccountHistoryMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
         app.ensureLoggedIn()
         app.clickAccountCog()
         app.clickActionButtonByText("Log out")

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/CreateAccountMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/CreateAccountMockApiTest.kt
@@ -11,9 +11,9 @@ class CreateAccountMockApiTest : MockApiTest() {
     @Test
     fun testCreateAccountSuccessful() {
         // Arrange
-        val createdAccountToken = "1234123412341234"
+        val createdAccountNumber = "1234123412341234"
         apiDispatcher.apply {
-            expectedAccountToken = createdAccountToken
+            expectedAccountNumber = createdAccountNumber
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
         }
         app.launch(endpoint)

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/Extensions.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/Extensions.kt
@@ -11,7 +11,7 @@ fun MockResponse.addJsonHeader(): MockResponse {
     return addHeader("Content-Type", "application/json")
 }
 
-fun Buffer.getAccountToken(): String? {
+fun Buffer.getAccountNumber(): String? {
     return try {
         JSONObject(readUtf8()).getString("account_number")
     } catch (ex: JSONException) {

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
@@ -18,9 +18,9 @@ class LoginMockApiTest : MockApiTest() {
     @Test
     fun testLoginWithInvalidCredentials() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
-            expectedAccountToken = null
+            expectedAccountNumber = null
             accountExpiry = currentUtcTimeWithOffsetZero().plusDays(1)
         }
         app.launch(endpoint)
@@ -30,7 +30,7 @@ class LoginMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
 
         // Assert
         val result =
@@ -44,9 +44,9 @@ class LoginMockApiTest : MockApiTest() {
     @Test
     fun testLoginWithValidCredentialsToUnexpiredAccount() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
-            expectedAccountToken = validAccountToken
+            expectedAccountNumber = validAccountNumber
             accountExpiry = currentUtcTimeWithOffsetZero().plusDays(1)
             devices = DEFAULT_DEVICE_LIST.toMutableMap()
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
@@ -58,7 +58,7 @@ class LoginMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
 
         // Assert
         app.ensureLoggedIn()
@@ -67,9 +67,9 @@ class LoginMockApiTest : MockApiTest() {
     @Test
     fun testLoginWithValidCredentialsToExpiredAccount() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
-            expectedAccountToken = validAccountToken
+            expectedAccountNumber = validAccountNumber
             accountExpiry = currentUtcTimeWithOffsetZero().minusDays(1)
             devices = DEFAULT_DEVICE_LIST.toMutableMap()
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
@@ -81,7 +81,7 @@ class LoginMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
 
         // Assert
         app.ensureOutOfTime()

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LogoutMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LogoutMockApiTest.kt
@@ -17,9 +17,9 @@ class LogoutMockApiTest : MockApiTest() {
     @Test
     fun testLoginWithValidCredentialsToUnexpiredAccountAndLogout() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
-            expectedAccountToken = validAccountToken
+            expectedAccountNumber = validAccountNumber
             accountExpiry = currentUtcTimeWithOffsetZero().plusMonths(1)
             devices = DEFAULT_DEVICE_LIST.toMutableMap()
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
@@ -31,7 +31,7 @@ class LogoutMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
         app.ensureLoggedIn()
         app.clickAccountCog()
         app.clickActionButtonByText("Log out")

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiDispatcher.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiDispatcher.kt
@@ -23,7 +23,7 @@ import org.json.JSONArray
 
 class MockApiDispatcher : Dispatcher() {
 
-    var expectedAccountToken: String? = null
+    var expectedAccountNumber: String? = null
     var accountExpiry: DateTime? = null
     var devices: MutableMap<String, String>? = null
     private val canAddDevices: Boolean
@@ -75,9 +75,9 @@ class MockApiDispatcher : Dispatcher() {
     }
 
     private fun handleLoginRequest(requestBody: Buffer): MockResponse {
-        val accountToken = requestBody.getAccountToken()
+        val accountNumber = requestBody.getAccountNumber()
 
-        return if (accountToken != null && accountToken == expectedAccountToken) {
+        return if (accountNumber != null && accountNumber == expectedAccountNumber) {
             MockResponse()
                 .setResponseCode(200)
                 .addJsonHeader()
@@ -91,7 +91,7 @@ class MockApiDispatcher : Dispatcher() {
         } else {
             Log.e(
                 LOG_TAG,
-                "Unexpected account token (expected=$expectedAccountToken was=$accountToken)"
+                "Unexpected account number (expected=$expectedAccountNumber was=$accountNumber)"
             )
             MockResponse().setResponseCode(400)
         }
@@ -168,7 +168,7 @@ class MockApiDispatcher : Dispatcher() {
     }
 
     private fun handleAccountCreationRequest(): MockResponse {
-        return expectedAccountToken?.let { expectedAccountToken ->
+        return expectedAccountNumber?.let { expectedAccountNumber ->
             MockResponse()
                 .setResponseCode(201)
                 .addJsonHeader()
@@ -176,7 +176,7 @@ class MockApiDispatcher : Dispatcher() {
                     accountCreationJson(
                             id = DUMMY_ID_1,
                             expiry = DateTime(),
-                            accountToken = expectedAccountToken
+                            accountNumber = expectedAccountNumber
                         )
                         .toString()
                 )

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
@@ -24,9 +24,9 @@ class TooManyDevicesMockApiTest : MockApiTest() {
     @Test
     fun testRemoveDeviceSuccessfulAndLogin() {
         // Arrange
-        val validAccountToken = "1234123412341234"
+        val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
-            expectedAccountToken = validAccountToken
+            expectedAccountNumber = validAccountNumber
             accountExpiry = currentUtcTimeWithOffsetZero().plusMonths(1)
             devices =
                 mutableMapOf(
@@ -45,7 +45,7 @@ class TooManyDevicesMockApiTest : MockApiTest() {
         device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         device.dismissChangelogDialogIfShown()
         app.waitForLoginPrompt()
-        app.attemptLogin(validAccountToken)
+        app.attemptLogin(validAccountNumber)
 
         // Assert that we have too many devices
         device.findObjectWithTimeout(By.text("Too many devices"))

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/util/JsonUtils.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/util/JsonUtils.kt
@@ -11,8 +11,8 @@ fun accountInfoJson(id: String, expiry: DateTime) =
         put("can_add_devices", true)
     }
 
-fun accountCreationJson(id: String, accountToken: String, expiry: DateTime) =
-    accountInfoJson(id, expiry).apply { put("number", accountToken) }
+fun accountCreationJson(id: String, accountNumber: String, expiry: DateTime) =
+    accountInfoJson(id, expiry).apply { put("number", accountNumber) }
 
 fun deviceJson(id: String, name: String, publicKey: String, creationDate: DateTime) =
     JSONObject().apply {


### PR DESCRIPTION
This PR aims to unify the "account number" naming within the code base. Rather than using a mix of "account number" and "account token" throughout the Android code base, this PR aims to make sure we **konsist**ently use  "account number". It also includes a test to ensure this convention is followed.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6333)
<!-- Reviewable:end -->
