### PR TITLE
Fix `cargo udeps`

### DIFF
--- a/talpid-time/Cargo.toml
+++ b/talpid-time/Cargo.toml
@@ -17,4 +17,6 @@ test = []
 
 [dependencies]
 tokio = { workspace = true, features = ["time"] }
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
This PR fixes `cargo udeps` which started to detect some unused dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6334)
<!-- Reviewable:end -->
