### PR TITLE
Fix screenshot tests failing

### DIFF
--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -38,17 +38,20 @@ jobs:
 
       - name: Configure Xcode project
         run: |
-          cp Base.xcconfig.template Base.xcconfig
-          cp App.xcconfig.template App.xcconfig
-          cp PacketTunnel.xcconfig.template PacketTunnel.xcconfig
-          cp Screenshots.xcconfig.template Screenshots.xcconfig
-          cp Api.xcconfig.template Api.xcconfig
-          sed -i "" "s/MULLVAD_ACCOUNT_TOKEN = /MULLVAD_ACCOUNT_TOKEN = $TEST_ACCOUNT/g" Screenshots.xcconfig
+          for file in *.xcconfig.template ; do cp $file ${file//.template/} ; done
+          sed -i "" \
+            "/HAS_TIME_ACCOUNT_NUMBER =/ s#= .*#= 1234123412341234#" \
+            UITests.xcconfig
         working-directory: ios/Configurations
 
       - name: Bundle
         run: bundle install
         working-directory: ios
+
+      - name: Install protobuf
+        run: |
+          brew update
+          brew install protobuf
 
       - name: Create screenshots
         run: bundle exec fastlane snapshot --cloned_source_packages_path "$SOURCE_PACKAGES_PATH"

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -14,12 +14,13 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    if: github.event.pull_request.merged
+    if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     name: Screenshot tests
     runs-on: macos-13-xlarge
     env:
       SOURCE_PACKAGES_PATH: .spm
       TEST_ACCOUNT: ${{ secrets.IOS_TEST_ACCOUNT_NUMBER }}
+      PARTNER_API_TOKEN: ${{ secrets.STAGEMOLE_PARTNER_AUTH }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -54,14 +55,16 @@ jobs:
 
       - name: Configure Xcode project
         run: |
-          cp Base.xcconfig.template Base.xcconfig
-          cp App.xcconfig.template App.xcconfig
-          cp PacketTunnel.xcconfig.template PacketTunnel.xcconfig
-          cp Screenshots.xcconfig.template Screenshots.xcconfig
-          cp Api.xcconfig.template Api.xcconfig
-          cp UITests.xcconfig.template UITests.xcconfig
-          sed -i "" "s/MULLVAD_ACCOUNT_TOKEN = /MULLVAD_ACCOUNT_TOKEN = $TEST_ACCOUNT/g" Screenshots.xcconfig
+          for file in *.xcconfig.template ; do cp $file ${file//.template/} ; done
+          sed -i "" \
+            "/HAS_TIME_ACCOUNT_NUMBER =/ s#= .*#= 1234123412341234#" \
+            UITests.xcconfig
         working-directory: ios/Configurations
+
+      - name: Install zip
+        run: |
+          brew update
+          brew install zip
 
       - name: Install xcbeautify
         run: |
@@ -82,5 +85,16 @@ jobs:
             -destination "platform=iOS Simulator,name=iPhone 15" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
             -disableAutomaticPackageResolution \
+            -resultBundlePath xcode-test-report \
             test 2>&1 | xcbeautify
         working-directory: ios/
+
+      - name: Archive test report
+        run: zip -r test-report.zip ios/xcode-test-report.xcresult
+
+      - name: Store test report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: test-report.zip

--- a/ios/Configurations/Screenshots.xcconfig.template
+++ b/ios/Configurations/Screenshots.xcconfig.template
@@ -5,6 +5,3 @@
 PROVISIONING_PROFILE_SPECIFIER[config=Debug][sdk=*][arch=*] = Screenshots Development
 PROVISIONING_PROFILE_SPECIFIER[config=Staging][sdk=*][arch=*] = Screenshots Development
 PROVISIONING_PROFILE_SPECIFIER[config=MockRelease][sdk=*][arch=*] = Screenshots Development
-
-// Mullvad account number used when taking screenshots
-MULLVAD_ACCOUNT_TOKEN = 

--- a/ios/Configurations/UITests.xcconfig.template
+++ b/ios/Configurations/UITests.xcconfig.template
@@ -7,7 +7,7 @@ IOS_DEVICE_PIN_CODE =
 TEST_DEVICE_IDENTIFIER_UUID = 
 
 // Base64 encoded token for the partner API. Will only be used if account numbers are not configured.
-PARTNER_API_TOKEN = 
+// PARTNER_API_TOKEN = 
 
 // Mullvad accounts used by UI tests
 HAS_TIME_ACCOUNT_NUMBER[config=Debug] = 

--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -32,6 +32,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>HasTimeAccountNumber</key>
+	<string>$(HAS_TIME_ACCOUNT_NUMBER)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/MullvadVPNUITests/Networking/PartnerAPIClient.swift
+++ b/ios/MullvadVPNUITests/Networking/PartnerAPIClient.swift
@@ -107,7 +107,7 @@ class PartnerAPIClient {
                     XCTFail("Failed to deserialize JSON response")
                 }
             } else {
-                XCTFail("Request failed")
+                XCTFail("Request failed with status code \(response.statusCode)")
             }
 
             completionHandlerInvokedExpectation.fulfill()

--- a/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
+++ b/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
@@ -68,6 +68,9 @@ class SelectLocationPage: Page {
     }
 
     @discardableResult func tapCustomListEllipsisButton() -> Self {
+        // This wait should not be needed, but is due to the issues we are having with the ellipsis button
+        _ = app.buttons[.openCustomListsMenuButton].waitForExistence(timeout: BaseUITestCase.shortTimeout)
+
         let customListEllipsisButtons = app.buttons
             .matching(identifier: AccessibilityIdentifier.openCustomListsMenuButton.rawValue).allElementsBoundByIndex
 

--- a/ios/Snapfile
+++ b/ios/Snapfile
@@ -1,10 +1,12 @@
+ios_version '17.2'
+
 # A list of devices you want to take the screenshots from
 devices([
   "iPhone SE (3rd generation)",
   "iPhone 15 Pro",
-  "iPhone 15 Pro Max",
-  "iPad Pro (11-inch) (4th generation)",
-  "iPad Pro (12.9-inch) (6th generation)"
+  "iPhone 15 Pro Max"
+  #"iPad Pro (11-inch) (4th generation)",
+  #"iPad Pro (12.9-inch) (6th generation)"
 ])
 
 languages([
@@ -14,8 +16,8 @@ languages([
   # ["pt", "pt_BR"] # Portuguese with Brazilian locale
 ])
 
-# The name of the scheme which contains the UI Tests
-scheme("MullvadVPNUITests")
+# The name of the scheme which contains the screenshot UI Tests
+scheme("MullvadVPN")
 
 # The name of the test plan which contains the UI Tests
 testplan("MullvadVPNScreenshots")


### PR DESCRIPTION
This PR addresses screenshot tests failing, especially after the staging PR was merged to main but they were also failing prior to that.

* Removed usage of partner API client for creating accounts
* Issue with ellipsis button again. There's a race condition even though there shouldn't be. Added a wait for the ellipsis button to show before tapping it.
* Removed `MULLVAD_ACCOUNT_TOKEN` which is no longer used
* Made screenshot tests workflow store Xcode test report as artefact,similar to end to end tests
* Specified simulator iOS version. Fastlane was defaulting to 17.0 without specifying a version, and the runner image have very few 17.0 simulators.
* Not producing screenshots for iPad as the tests do not support the iPad UI

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6336)
<!-- Reviewable:end -->
