### PR TITLE
Fix missing device refresh

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModel.kt
@@ -118,6 +118,7 @@ class ConnectViewModel(
                 viewModelScope.launch { accountRepository.getAccountData() }
             }
         }
+        viewModelScope.launch { deviceRepository.updateDevice() }
     }
 
     fun onDisconnectClick() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/OutOfTimeViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/OutOfTimeViewModel.kt
@@ -59,6 +59,7 @@ class OutOfTimeViewModel(
         }
         verifyPurchases()
         fetchPaymentAvailability()
+        viewModelScope.launch { deviceRepository.updateDevice() }
     }
 
     fun onSitePaymentClick() {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModel.kt
@@ -59,6 +59,7 @@ class WelcomeViewModel(
         }
         verifyPurchases()
         fetchPaymentAvailability()
+        viewModelScope.launch { deviceRepository.updateDevice() }
     }
 
     private fun hasAddedTimeEffect() =

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/ConnectViewModelTest.kt
@@ -3,9 +3,11 @@ package net.mullvad.mullvadvpn.viewmodel
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import arrow.core.right
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
@@ -101,6 +103,8 @@ class ConnectViewModelTest {
         every { mockAccountRepository.accountData } returns accountExpiryState
 
         every { mockDeviceRepository.deviceState } returns device
+
+        coEvery { mockDeviceRepository.updateDevice() } just Runs
 
         every { mockInAppNotificationController.notifications } returns notifications
 

--- a/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/ManagementService.kt
+++ b/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/ManagementService.kt
@@ -210,6 +210,10 @@ class ManagementService(
             .map { it.toDomain() }
             .mapLeft { GetDeviceStateError.Unknown(it) }
 
+    suspend fun updateDevice() {
+        grpc.updateDevice(Empty.getDefaultInstance())
+    }
+
     suspend fun getDeviceList(token: AccountNumber): Either<GetDeviceListError, List<Device>> =
         Either.catch { grpc.listDevices(StringValue.of(token.value)) }
             .map { it.devicesList.map(ManagementInterface.Device::toDomain) }

--- a/android/lib/shared/src/main/kotlin/net/mullvad/mullvadvpn/lib/shared/DeviceRepository.kt
+++ b/android/lib/shared/src/main/kotlin/net/mullvad/mullvadvpn/lib/shared/DeviceRepository.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.lib.shared
 
+import android.util.Log
 import arrow.core.Either
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -33,4 +34,9 @@ class DeviceRepository(
 
     suspend fun deviceList(accountNumber: AccountNumber): Either<GetDeviceListError, List<Device>> =
         managementService.getDeviceList(accountNumber)
+
+    suspend fun updateDevice() {
+        Log.d("mullvad", "Update device")
+        managementService.updateDevice()
+    }
 }


### PR DESCRIPTION
This PR aims to fix an issue where the UI doesn't trigger automatic device updates/refresh. Instead, the app would rely on other mechanisms such as the tunnel connection or purchase flows to update/refresh the device. The consequence of this is that users could end up in strange scenarios such as a device being revoked immediately after purchasing time.

The new behavior is that we update/refresh the device similar to how we handle purchase verification as part of a few screens. This is a bit similar to how it's handled on desktop where they are even more aggressive on updating/refresh the device. On desktop it's done every time a gRPC connection is established.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6344)
<!-- Reviewable:end -->
