### PR TITLE
Use the new pageElement for setting accessibility identifiers

### DIFF
--- a/ios/MullvadVPNUITests/Pages/MultihopPromptAlert.swift
+++ b/ios/MullvadVPNUITests/Pages/MultihopPromptAlert.swift
@@ -13,7 +13,7 @@ class MultihopPromptAlert: Page {
     @discardableResult override init(_ app: XCUIApplication) {
         super.init(app)
 
-        self.pageAccessibilityIdentifier = .multihopPromptAlert
+        self.pageElement = app.otherElements[.multihopPromptAlert]
         waitForPageToBeShown()
     }
 


### PR DESCRIPTION
This PR fixes a small regression introduced in `57d678c5e` 
We now use the newly added `pageElement` for setting accessibility identifiers.