### PR TITLE
Adapt to new never type fallback by explicitly stating unit types

### DIFF
--- a/talpid-dbus/src/network_manager.rs
+++ b/talpid-dbus/src/network_manager.rs
@@ -574,8 +574,11 @@ impl NetworkManager {
         settings: Settings,
         version_id: u64,
     ) -> Result<()> {
-        self.as_path(device)
-            .method_call(NM_DEVICE, "Reapply", (settings, version_id, 0u32))?;
+        self.as_path(device).method_call::<(), _, _, _>(
+            NM_DEVICE,
+            "Reapply",
+            (settings, version_id, 0u32),
+        )?;
         Ok(())
     }
 

--- a/talpid-dbus/src/systemd_resolved.rs
+++ b/talpid-dbus/src/systemd_resolved.rs
@@ -322,7 +322,7 @@ impl SystemdResolved {
             // replaced in systemd-resolved.
             // v248.3
             link_object
-                .method_call(
+                .method_call::<(), _, _, _>(
                     LINK_INTERFACE,
                     SET_DNS_METHOD,
                     (Vec::<(i32, Vec<u8>)>::new(),),


### PR DESCRIPTION
The aim is for the never type to be stabilized in Rust 2024 (:partying_face: YAY, finally!). But for that to happen some of the current automatic fallback from never (`!`) to unit (`()`) must be changed. And as a result any code relying on the current fallback to unit behavior must be changed to not rely on this automatic fallback, but rather be explicit unit type.

This PR fixes the two instances we had of this automatic fallback, as pointed out by the latest nightly compiler.

The tracking issue for never types: https://github.com/rust-lang/rust/issues/123748

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6352)
<!-- Reviewable:end -->
