### PR TITLE
Change crate_type into crate-type since the first is deprecated

### DIFF
--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 api-override = ["mullvad-api/api-override"]
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 thiserror = { workspace = true }

--- a/mullvad-nsis/Cargo.toml
+++ b/mullvad-nsis/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [lib]
-crate_type = ["staticlib"]
+crate-type = ["staticlib"]
 
 [target.i686-pc-windows-msvc.dependencies]
 mullvad-paths = { path = "../mullvad-paths" }


### PR DESCRIPTION
`cargo` is warning that `crate_type` is deprecated. It's trivial to fix since it just has to be changed to `crate-type`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6353)
<!-- Reviewable:end -->
