### PR TITLE
Fix connecting issue on macOS

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -32,4 +32,4 @@ jobs:
           # This action defaults to 50 char subjects, but 72 is fine.
           max-subject-line-length: '72'
           # The action's wordlist is a bit short. Add more accepted verbs
-          additional-verbs: 'tidy, wrap, obfuscate'
+          additional-verbs: 'tidy, wrap, obfuscate, bias'

--- a/talpid-core/src/split_tunnel/macos/tun.rs
+++ b/talpid-core/src/split_tunnel/macos/tun.rs
@@ -286,6 +286,9 @@ fn open_default_bpf(
     default_dev
         .set_see_sent(false)
         .map_err(Error::ConfigDefaultBpf)?;
+    default_dev
+        .set_nonblocking(true)
+        .map_err(Error::ConfigDefaultBpf)?;
 
     // Split the default device BPF handle into a read and write half
     let (default_read, default_write) = default_dev.split().map_err(Error::ConfigDefaultBpf)?;
@@ -412,6 +415,7 @@ fn open_vpn_bpf(vpn_interface: &VpnInterface) -> Result<bpf::Bpf, Error> {
         .map_err(Error::ConfigVpnBpf)?;
     vpn_dev.set_immediate(true).map_err(Error::ConfigVpnBpf)?;
     vpn_dev.set_see_sent(false).map_err(Error::ConfigVpnBpf)?;
+    vpn_dev.set_nonblocking(true).map_err(Error::ConfigVpnBpf)?;
     Ok(vpn_dev)
 }
 


### PR DESCRIPTION
Fix issues related to split tunneling, primarily these:
* Use of blocking I/O in async context.
* Race condition involving an abort channel. This could cause the tunnel monitor to get stuck.

This does not affect any released version of the app.

Close DES-1036.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6359)
<!-- Reviewable:end -->
