### PR TITLE
Add action to ensure clean lockfile

### DIFF
--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -7,6 +7,7 @@ on:
       - android/gradle/verification-metadata.xml
       - android/config/dependency-check-suppression.xml
       - android/test/test-suppression.xml
+      - android/scripts/update-lockfile.sh
   schedule:
     # At 06:20 UTC every day.
     # Notifications for scheduled workflows are sent to the user who last modified the cron
@@ -59,3 +60,33 @@ jobs:
 
       - name: Run gradle audit task
         run: android/gradlew -p android dependencyCheckAnalyze
+
+  ensure-clean-lockfile:
+    needs: prepare
+    name: Ensure clean lockfile
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.prepare.outputs.container_image }}
+    steps:
+      # Fix for HOME path overridden by GH runners when building in containers, see:
+      # https://github.com/actions/runner/issues/863
+      - name: Fix HOME path
+        run: echo "HOME=/root" >> $GITHUB_ENV
+
+      - name: Set locale
+        run: echo "LC_ALL=C.UTF-8" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+
+      - name: Fix git dir
+        run: git config --global --add safe.directory $(pwd)
+
+      # Needed until we improve the build system.
+      - name: Create dummy jni dir
+        run: mkdir -p android/app/build/extraJni
+
+      - name: Re-generate lockfile
+        run: android/scripts/update-lockfile.sh
+
+      - name: Ensure no changes
+        run: git diff --exit-code

--- a/android/scripts/update-lockfile.sh
+++ b/android/scripts/update-lockfile.sh
@@ -12,8 +12,4 @@ echo "Removing old components..."
 sed -i '/<components>/,/<\/components>/d' ../gradle/verification-metadata.xml
 
 echo "Generating new components..."
-android_container_image_name=$(cat "../../building/android-container-image.txt")
-podman run --rm -it \
-    -v ../..:/build:Z \
-    "$android_container_image_name" \
-    bash -c 'android/gradlew -q -p android -M sha256 assemble compileDebugUnitTestKotlin assembleAndroidTest lint'
+../gradlew -q -p .. -M sha256 assemble compileDebugUnitTestKotlin assembleAndroidTest lint


### PR DESCRIPTION
This PR aims to add an action which ensure that the lockfile is in a clean state. It also makes it possible to run the lockfile script without `podman`.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6361)
<!-- Reviewable:end -->
