### PR TITLE
Link statically against libwg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2026,18 +2026,27 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "maybenot"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7fe205734d700937dabf0b8687e290f8574fac996f8a9d04bd7a62d7c2c1dad"
+checksum = "e308ea251c8fe965732a020db1aa182a1df0cfb551da0d422bf83016d0f10153"
 dependencies = [
  "byteorder",
  "hex",
  "libflate",
  "rand 0.8.5",
  "rand_distr",
- "ring 0.16.20",
+ "ring",
  "serde",
  "simple-error",
+]
+
+[[package]]
+name = "maybenot-ffi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a95dd874046b87f98b3a54e6beed8a63db6354088efd0ae7dc23c0f23931ce"
+dependencies = [
+ "maybenot",
 ]
 
 [[package]]
@@ -3278,21 +3287,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -3301,8 +3295,8 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.14",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3321,7 +3315,7 @@ dependencies = [
  "p384",
  "pkcs8",
  "rand_core 0.6.4",
- "ring 0.17.8",
+ "ring",
  "signature",
 ]
 
@@ -3387,7 +3381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -3407,8 +3401,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3456,8 +3450,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3591,7 +3585,7 @@ dependencies = [
  "serde_urlencoded",
  "shadowsocks-crypto",
  "socket2",
- "spin 0.9.8",
+ "spin",
  "thiserror",
  "tokio",
  "tokio-tfo",
@@ -3660,7 +3654,7 @@ dependencies = [
  "serde",
  "shadowsocks",
  "socket2",
- "spin 0.9.8",
+ "spin",
  "thiserror",
  "tokio",
  "windows-sys 0.52.0",
@@ -3746,12 +3740,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -4584,12 +4572,6 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -4721,16 +4703,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "web-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "which"
@@ -5083,6 +5055,7 @@ name = "wireguard-go-rs"
 version = "0.0.0"
 dependencies = [
  "log",
+ "maybenot-ffi",
  "thiserror",
  "zeroize",
 ]

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -105,7 +105,6 @@ const config = {
       { from: distAssets(path.join('binaries', '${env.TARGET_TRIPLE}', 'openvpn')), to: '.' },
       { from: distAssets(path.join('binaries', '${env.TARGET_TRIPLE}', 'apisocks5')), to: '.' },
       { from: distAssets('uninstall_macos.sh'), to: './uninstall.sh' },
-      { from: buildAssets(path.join('lib', '${env.TARGET_TRIPLE}', 'libwg.so')), to: '.' },
       { from: buildAssets('shell-completions/_mullvad'), to: '.' },
       { from: buildAssets('shell-completions/mullvad.fish'), to: '.' },
     ],
@@ -207,7 +206,6 @@ const config = {
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-daemon')) + '=/usr/bin/',
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-exclude')) + '=/usr/bin/',
       distAssets('linux/problem-report-link') + '=/usr/bin/mullvad-problem-report',
-      buildAssets(path.join('lib', `${hostTargetTriple}`, 'libwg.so')) + '=/lib/',
       buildAssets('shell-completions/mullvad.bash') +
         '=/usr/share/bash-completion/completions/mullvad',
       buildAssets('shell-completions/_mullvad') + '=/usr/local/share/zsh/site-functions/_mullvad',
@@ -241,7 +239,6 @@ const config = {
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-daemon')) + '=/usr/bin/',
       distAssets(path.join(getLinuxTargetSubdir(), 'mullvad-exclude')) + '=/usr/bin/',
       distAssets('linux/problem-report-link') + '=/usr/bin/mullvad-problem-report',
-      buildAssets(path.join('lib', `${hostTargetTriple}`, 'libwg.so')) + '=/lib/',
       buildAssets('shell-completions/mullvad.bash') +
         '=/usr/share/bash-completion/completions/mullvad',
       buildAssets('shell-completions/_mullvad') + '=/usr/share/zsh/site-functions/_mullvad',

--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -1,8 +1,4 @@
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{env, fs, path::PathBuf, process::Command};
 
 #[cfg(windows)]
 fn make_lang_id(p: u16, s: u16) -> u16 {
@@ -39,19 +35,6 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(daita)");
     if let "linux" | "windows" = target_os.as_str() {
         println!(r#"cargo::rustc-cfg=daita"#);
-    }
-
-    // For debug builds, configure rpath to facilitate linking with libwg.so
-    if matches!(target_os.as_str(), "linux" | "macos" | "android") && cfg!(debug_assertions) {
-        let target = env::var("TARGET").expect("TARGET not set");
-        let libwg_path = Path::new("../build/lib/")
-            .canonicalize()
-            .unwrap_or_else(|_| {
-                panic!("Could not resolve canonical path for relative path `build/lib/{target}`")
-            })
-            .join(target.clone());
-
-        println!("cargo::rustc-link-arg=-Wl,-rpath,{}", libwg_path.display());
     }
 }
 

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -57,7 +57,7 @@ talpid-dbus = { path = "../talpid-dbus" }
 bitflags = "1.2"
 talpid-windows = { path = "../talpid-windows" }
 widestring = "1.0"
-maybenot = "1.0"
+maybenot = "1.1.2"
 
 # TODO: Figure out which features are needed and which are not
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -8,3 +8,10 @@ license.workspace = true
 thiserror.workspace = true
 log.workspace = true
 zeroize = "1.8.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# The app does not depend on maybenot-ffi itself, but adds it as a dependency to expose FFI symbols to wireguard-go. 
+# This is done, instead of using the makefile in wireguard-go to build maybenot-ffi into its archive, to prevent
+# name clashes induced by link-time optimization.
+# NOTE: the version of maybenot-ffi below must be the same as the version checked into the wireguard-go submodule
+maybenot-ffi = "1.0.0"

--- a/wireguard-go-rs/build-wireguard-go.sh
+++ b/wireguard-go-rs/build-wireguard-go.sh
@@ -89,16 +89,13 @@ function build_unix {
     # Build wireguard-go as a library
     mkdir -p "$BUILD_DIR/lib/$TARGET"
     pushd libwg
+
     if [[ "$DAITA" == "true" ]]; then
-        pushd wireguard-go
-        CARGO_TARGET_DIR="$BUILD_DIR/tmp/" make libmaybenot.a LIBDEST="$BUILD_DIR/lib/$TARGET"
-        popd
-        CGO_LDFLAGS="-L$BUILD_DIR/lib/$TARGET" go build -v --tags daita -o "$BUILD_DIR/lib/$TARGET/libwg.so" -buildmode c-shared
+        go build -v --tags daita -o "$BUILD_DIR/lib/$TARGET"/libwg.a -buildmode c-archive
     else
-        go build -v -o "$BUILD_DIR/lib/$TARGET/libwg.so" -buildmode c-shared
+        go build -v -o "$BUILD_DIR/lib/$TARGET"/libwg.a -buildmode c-archive
     fi
-    # Copy libwg to `OUT_DIR` so that we may refer to it via `OUT_DIR` in `build.rs`, which might be handy.
-    cp "$BUILD_DIR/lib/$TARGET/libwg.so" "$OUT_DIR/libwg.so"
+
     popd
 }
 

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -26,6 +26,10 @@ pub type LoggingContext = u64;
 pub type LoggingCallback =
     unsafe extern "system" fn(level: WgLogLevel, msg: *const c_char, context: LoggingContext);
 
+// Make symbols from maybenot-ffi visible to wireguard-go
+#[cfg(daita)]
+use maybenot_ffi as _;
+
 /// A wireguard-go tunnel
 pub struct Tunnel {
     /// wireguard-go handle to the tunnel.


### PR DESCRIPTION
Use `Cargo.toml` to link against `maybenot-ffi` on desktop. This solves the issue of LTO breaking when using a separate archive file, as well as some issues of some scripts failing due to `libwg.so` not being found.

Fix DES-1038.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6374)
<!-- Reviewable:end -->
