### PR TITLE
Restart `mullvad-daemon` after user grants Full Disk Access (macOS)

### DIFF
--- a/gui/src/main/daemon-rpc.ts
+++ b/gui/src/main/daemon-rpc.ts
@@ -568,6 +568,10 @@ export class DaemonRpc {
     await this.callEmpty(this.client.updateDevice);
   }
 
+  public async prepareRestart(quit: boolean) {
+    await this.callBool(this.client.prepareRestartV2, quit);
+  }
+
   public async setDaitaSettings(daitaSettings: IDaitaSettings): Promise<void> {
     const grpcDaitaSettings = new grpcTypes.DaitaSettings();
     grpcDaitaSettings.setEnabled(daitaSettings.enabled);

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -321,7 +321,11 @@ class ApplicationMain
     }
   };
 
-  private onBeforeQuit = (event: Electron.Event) => {
+  private onBeforeQuit = async (event: Electron.Event) => {
+    if (this.tunnelState.hasReceivedFullDiskAccessError) {
+      await this.daemonRpc.prepareRestart(true);
+    }
+
     log.info('before-quit received');
     if (this.quitInitiated) {
       event.preventDefault();

--- a/gui/src/main/tunnel-state.ts
+++ b/gui/src/main/tunnel-state.ts
@@ -1,5 +1,5 @@
 import { connectEnabled, disconnectEnabled, reconnectEnabled } from '../shared/connect-helper';
-import { ILocation, TunnelState } from '../shared/daemon-rpc-types';
+import { ErrorStateCause, ILocation, TunnelState } from '../shared/daemon-rpc-types';
 import { Scheduler } from '../shared/scheduler';
 
 export interface TunnelStateProvider {
@@ -20,10 +20,15 @@ export default class TunnelStateHandler {
   // Scheduler for discarding the assumed next state.
   private tunnelStateFallbackScheduler = new Scheduler();
 
+  private receivedFullDiskAccessError = false;
+
   private lastKnownDisconnectedLocation: Partial<ILocation> | undefined;
 
   public constructor(private delegate: TunnelStateHandlerDelegate) {}
 
+  public get hasReceivedFullDiskAccessError() {
+    return this.receivedFullDiskAccessError;
+  }
   public get tunnelState() {
     return this.tunnelStateValue;
   }
@@ -53,6 +58,12 @@ export default class TunnelStateHandler {
   }
 
   public handleNewTunnelState(newState: TunnelState) {
+    if (newState.state === 'error' && newState.details) {
+      if (newState.details.cause === ErrorStateCause.needFullDiskPermissions) {
+        this.receivedFullDiskAccessError = true;
+      }
+    }
+
     // If there's a fallback state set then the app is in an assumed next state and need to check
     // if it's now reached or if the current state should be ignored and set as the fallback state.
     if (this.tunnelStateFallback) {

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -225,6 +225,21 @@ fn print_error_state(error_state: &ErrorState) {
             println!("Blocked: {cause}");
             println!("Your kernel might be terribly out of date or missing nftables");
         }
+        #[cfg(target_os = "macos")]
+        cause @ talpid_types::tunnel::ErrorStateCause::NeedFullDiskPermissions => {
+            println!("Blocked: {cause}");
+            println!();
+            println!(
+                r#"Enable "Full Disk Access" for "Mullvad VPN" in the macOS system settings:"#
+            );
+            println!(
+                r#"open "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles""#
+            );
+            println!();
+            println!("Restart the Mullvad daemon for the change to take effect:");
+            println!("launchctl unload -w /Library/LaunchDaemons/net.mullvad.daemon.plist");
+            println!("launchctl load -w /Library/LaunchDaemons/net.mullvad.daemon.plist");
+        }
         talpid_types::tunnel::ErrorStateCause::AuthFailed(Some(auth_failed)) => {
             println!(
                 "Blocked: Authentication with remote server failed: {}",

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -17,7 +17,11 @@ service ManagementService {
 
   // Control the daemon and receive events
   rpc EventsListen(google.protobuf.Empty) returns (stream DaemonEvent) {}
+  // DEPRECATED: Prefer PrepareRestartV2.
   rpc PrepareRestart(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+  // Takes a a boolean argument which says whether the daemon should stop after
+  // it is done preparing for a restart.
+  rpc PrepareRestartV2(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
   rpc FactoryReset(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 
   rpc GetCurrentVersion(google.protobuf.Empty) returns (google.protobuf.StringValue) {}

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -149,8 +149,22 @@ impl MullvadProxyClient {
         }))
     }
 
+    /// DEPRECATED: Prefer to use `prepare_restart_v2`.
     pub async fn prepare_restart(&mut self) -> Result<()> {
         self.0.prepare_restart(()).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
+    /// Tell the daemon to get ready for a restart by securing a user, i.e. putting firewall rules
+    /// in place.
+    ///
+    /// - `shutdown`: Whether the daemon should shutdown immediately after its prepare-for-restart
+    /// routine.
+    pub async fn prepare_restart_v2(&mut self, shutdown: bool) -> Result<()> {
+        self.0
+            .prepare_restart_v2(shutdown)
+            .await
+            .map_err(Error::Rpc)?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR fixes an issue where the `mullvad-daemon` would not automatically restart after the user had granted "Mullvad VPN" application Full Disk Access. This is needed to make split tunneling work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6381)
<!-- Reviewable:end -->
