### PR TITLE
Move all UDS cleanup to `main`

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -90,8 +90,6 @@ use talpid_types::{
     tunnel::{ErrorStateCause, TunnelStateTransition},
     ErrorExt,
 };
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-use tokio::fs;
 use tokio::io;
 
 /// Delay between generating a new WireGuard key and reconnecting
@@ -926,6 +924,8 @@ where
         Ok(())
     }
 
+    /// Destroy daemon safely, by dropping all objects in the correct order, waiting for them to
+    /// be destroyed, and executing shutdown tasks
     async fn finalize(self) {
         let (event_listener, shutdown_tasks, api_runtime, tunnel_state_machine_handle) =
             self.shutdown();
@@ -937,13 +937,6 @@ where
 
         drop(event_listener);
         drop(api_runtime);
-
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
-        if let Err(err) = fs::remove_file(mullvad_paths::get_rpc_socket_path()).await {
-            if err.kind() != std::io::ErrorKind::NotFound {
-                log::error!("Failed to remove old RPC socket: {}", err);
-            }
-        }
     }
 
     /// Shuts down the daemon without shutting down the underlying event listener and the shutdown
@@ -965,7 +958,6 @@ where
             account_manager,
             ..
         } = self;
-
         shutdown_tasks.push(Box::pin(target_state.finalize()));
         shutdown_tasks.push(Box::pin(account_manager.shutdown()));
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -188,6 +188,9 @@ async fn run_standalone(log_dir: Option<PathBuf>) -> Result<(), String> {
 
     daemon.run().await.map_err(|e| e.display_chain())?;
 
+    #[cfg(not(windows))]
+    cleanup_old_rpc_socket(mullvad_paths::get_rpc_socket_path()).await;
+
     log::info!("Mullvad daemon is quitting");
     thread::sleep(Duration::from_millis(500));
     Ok(())


### PR DESCRIPTION
The cleanup in `Daemon::finalize` is at the wrong abstraction level, since `Daemon` is agnostic about how `EventListener` is implemented. It technically doesn't have to rely a UDS at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6388)
<!-- Reviewable:end -->
