### PR TITLE
Replace all maximum timeout values to 60 seconds

### DIFF
--- a/ios/MullvadMockData/Extensions/TimeInterval+Timeout.swift
+++ b/ios/MullvadMockData/Extensions/TimeInterval+Timeout.swift
@@ -1,0 +1,14 @@
+//
+//  TimeInterval+Timeout.swift
+//  MullvadMockData
+//
+//  Created by Jon Petersson on 2024-06-19.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+extension TimeInterval {
+    struct UnitTest {
+        static let timeout: TimeInterval = 60
+        static let invertedTimeout: TimeInterval = 0.5
+    }
+}

--- a/ios/MullvadPostQuantumTests/PostQuantumKeyExchangeActorTests.swift
+++ b/ios/MullvadPostQuantumTests/PostQuantumKeyExchangeActorTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 @testable import MullvadPostQuantum
 @testable import MullvadTypes
 import NetworkExtension
@@ -86,6 +87,6 @@ class MullvadPostQuantumTests: XCTestCase {
 
         keyExchangeActor.reset()
 
-        wait(for: [negotationCancelledExpectation, unexpectedNegotiationFailure], timeout: 0.5)
+        wait(for: [negotationCancelledExpectation, unexpectedNegotiationFailure], timeout: .UnitTest.invertedTimeout)
     }
 }

--- a/ios/MullvadRESTTests/HeadRequestTests.swift
+++ b/ios/MullvadRESTTests/HeadRequestTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 @testable import MullvadREST
 import XCTest
 
@@ -21,7 +22,7 @@ class HeadRequestTests: XCTestCase {
             }
         }
 
-        wait(for: [successfulRequestExpectation], timeout: 1)
+        wait(for: [successfulRequestExpectation], timeout: .UnitTest.timeout)
     }
 
     func testRequestWithErrors() throws {
@@ -35,6 +36,6 @@ class HeadRequestTests: XCTestCase {
             }
         }
 
-        wait(for: [failedRequestExpectation], timeout: 1)
+        wait(for: [failedRequestExpectation], timeout: .UnitTest.timeout)
     }
 }

--- a/ios/MullvadRESTTests/RequestExecutorTests.swift
+++ b/ios/MullvadRESTTests/RequestExecutorTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 @testable import MullvadREST
 @testable import MullvadTypes
 import XCTest
@@ -42,7 +43,7 @@ final class RequestExecutorTests: XCTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testCancelAsyncExecution() async throws {
@@ -70,6 +71,6 @@ final class RequestExecutorTests: XCTestCase {
 
         cancellationToken.cancel()
 
-        waitForExpectations(timeout: 2)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 }

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -604,6 +604,7 @@
 		7ADCB2DA2B6A730400C88F89 /* IPOverrideRepositoryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADCB2D92B6A730400C88F89 /* IPOverrideRepositoryStub.swift */; };
 		7AE044BB2A935726003915D8 /* Routing.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A88DCD02A8FABBE00D2FF0E /* Routing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AE2414A2C20682B0076CE33 /* FormsheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE241482C20682B0076CE33 /* FormsheetPresentationController.swift */; };
+		7AEBA52C2C22C65B0018BEC5 /* TimeInterval+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AEBA52B2C22C65B0018BEC5 /* TimeInterval+Timeout.swift */; };
 		7AED35CC2BD13F60002A67D1 /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
 		7AED35CD2BD13FC4002A67D1 /* ApplicationTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C76A072A33850E00100D75 /* ApplicationTarget.swift */; };
 		7AEF7F1A2AD00F52006FE45D /* AppMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AEF7F192AD00F52006FE45D /* AppMessageHandler.swift */; };
@@ -1173,6 +1174,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 58D223D4294C8E5E0029F5F8;
 			remoteInfo = MullvadTypes;
+		};
+		7A4BFF7F2C2AAB3900754DCB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 58CE5E58224146200008646E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F0ACE3072BE4E478006D5333;
+			remoteInfo = MullvadMockData;
+		};
+		7A4BFF802C2AB2B100754DCB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 58CE5E58224146200008646E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F0ACE3072BE4E478006D5333;
+			remoteInfo = MullvadMockData;
 		};
 		7A88DCD92A8FABBE00D2FF0E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1974,6 +1989,7 @@
 		7ADCB2D72B6A6EB300C88F89 /* AnyRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRelay.swift; sourceTree = "<group>"; };
 		7ADCB2D92B6A730400C88F89 /* IPOverrideRepositoryStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideRepositoryStub.swift; sourceTree = "<group>"; };
 		7AE241482C20682B0076CE33 /* FormsheetPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormsheetPresentationController.swift; sourceTree = "<group>"; };
+		7AEBA52B2C22C65B0018BEC5 /* TimeInterval+Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Timeout.swift"; sourceTree = "<group>"; };
 		7AEF7F192AD00F52006FE45D /* AppMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppMessageHandler.swift; sourceTree = "<group>"; };
 		7AF10EB12ADE859200C090B9 /* AlertViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		7AF10EB32ADE85BC00C090B9 /* RelayFilterCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelayFilterCoordinator.swift; sourceTree = "<group>"; };
@@ -3931,6 +3947,14 @@
 			path = "Presentation controllers";
 			sourceTree = "<group>";
 		};
+		7AEBA52D2C2310D20018BEC5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				7AEBA52B2C22C65B0018BEC5 /* TimeInterval+Timeout.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		7AF9BE912A39F47D00DBFEDB /* RelayFilter */ = {
 			isa = PBXGroup;
 			children = (
@@ -4137,6 +4161,7 @@
 			isa = PBXGroup;
 			children = (
 				F0ACE30A2BE4E478006D5333 /* MullvadMockData.h */,
+				7AEBA52D2C2310D20018BEC5 /* Extensions */,
 				F0ACE3172BE4E487006D5333 /* MullvadREST */,
 				F0ACE32B2BE4E748006D5333 /* MullvadTypes */,
 			);
@@ -4477,6 +4502,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				7A4BFF812C2AB2B100754DCB /* PBXTargetDependency */,
 			);
 			name = OperationsTests;
 			productName = OperationsTests;
@@ -4712,6 +4738,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				7AEBA5312C2981870018BEC5 /* PBXTargetDependency */,
 				58FBFBEC291622580020E046 /* PBXTargetDependency */,
 			);
 			name = MullvadRESTTests;
@@ -6247,6 +6274,7 @@
 				F0ACE31E2BE4E4F2006D5333 /* AccountsProxy+Stubs.swift in Sources */,
 				F0ACE3202BE4E4F2006D5333 /* AccessTokenManager+Stubs.swift in Sources */,
 				F0ACE32C2BE4E77E006D5333 /* DeviceMock.swift in Sources */,
+				7AEBA52C2C22C65B0018BEC5 /* TimeInterval+Timeout.swift in Sources */,
 				F0ACE3222BE4E4F2006D5333 /* APIProxy+Stubs.swift in Sources */,
 				F0ACE3332BE516F1006D5333 /* RESTRequestExecutor+Stubs.swift in Sources */,
 				F0ACE32D2BE4E784006D5333 /* AccountMock.swift in Sources */,
@@ -6414,6 +6442,11 @@
 			target = 58D223D4294C8E5E0029F5F8 /* MullvadTypes */;
 			targetProxy = 58FE65972AB1D90600E53CB5 /* PBXContainerItemProxy */;
 		};
+		7A4BFF812C2AB2B100754DCB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F0ACE3072BE4E478006D5333 /* MullvadMockData */;
+			targetProxy = 7A4BFF802C2AB2B100754DCB /* PBXContainerItemProxy */;
+		};
 		7A88DCDA2A8FABBE00D2FF0E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 7A88DCCD2A8FABBE00D2FF0E /* Routing */;
@@ -6433,6 +6466,11 @@
 			isa = PBXTargetDependency;
 			target = 7A88DCCD2A8FABBE00D2FF0E /* Routing */;
 			targetProxy = 7ABCA5B52A9349F20044A708 /* PBXContainerItemProxy */;
+		};
+		7AEBA5312C2981870018BEC5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F0ACE3072BE4E478006D5333 /* MullvadMockData */;
+			targetProxy = 7A4BFF7F2C2AAB3900754DCB /* PBXContainerItemProxy */;
 		};
 		8529692C2B4D9C1F007EAD4C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 @testable import MullvadREST
 @testable import MullvadSettings
 @testable import MullvadTypes
@@ -38,7 +39,7 @@ final class MigrationManagerTests: XCTestCase {
                 nothingToMigrateExpectation.fulfill()
             }
         }
-        wait(for: [nothingToMigrateExpectation], timeout: 1)
+        wait(for: [nothingToMigrateExpectation], timeout: .UnitTest.timeout)
     }
 
     func testNothingToMigrateWhenSettingsAreNotFound() throws {
@@ -51,7 +52,7 @@ final class MigrationManagerTests: XCTestCase {
                 nothingToMigrateExpectation.fulfill()
             }
         }
-        wait(for: [nothingToMigrateExpectation], timeout: 1)
+        wait(for: [nothingToMigrateExpectation], timeout: .UnitTest.timeout)
 
         // Reset the `SettingsManager` unit test store to avoid affecting other tests
         // since it's a globally shared instance
@@ -66,7 +67,7 @@ final class MigrationManagerTests: XCTestCase {
                 failedMigrationExpectation.fulfill()
             }
         }
-        wait(for: [failedMigrationExpectation], timeout: 1)
+        wait(for: [failedMigrationExpectation], timeout: .UnitTest.timeout)
     }
 
     func testFailedMigrationResetsSettings() throws {
@@ -116,7 +117,7 @@ final class MigrationManagerTests: XCTestCase {
                 failedMigrationExpectation.fulfill()
             }
         }
-        wait(for: [failedMigrationExpectation], timeout: 1)
+        wait(for: [failedMigrationExpectation], timeout: .UnitTest.timeout)
     }
 
     func testSuccessfulMigrationFromV4ToLatest() throws {
@@ -198,7 +199,7 @@ final class MigrationManagerTests: XCTestCase {
                 successfulMigrationExpectation.fulfill()
             }
         }
-        wait(for: [successfulMigrationExpectation], timeout: 1)
+        wait(for: [successfulMigrationExpectation], timeout: .UnitTest.timeout)
     }
 
     private func write(settings: any TunnelSettings, version: Int, in store: SettingsStore) throws {

--- a/ios/MullvadVPNTests/MullvadVPN/GeneralAPIs/OutgoingConnectionProxyTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/GeneralAPIs/OutgoingConnectionProxyTests.swift
@@ -5,6 +5,8 @@
 //  Created by Mojgan on 2023-10-25.
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
+
+@testable import MullvadMockData
 import MullvadREST
 import XCTest
 
@@ -37,7 +39,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
         if result.ip == IPV4ConnectionData.mock.ip {
             iPv4Expectation.fulfill()
         }
-        await fulfillment(of: [iPv4Expectation], timeout: 1)
+        await fulfillment(of: [iPv4Expectation], timeout: .UnitTest.timeout)
     }
 
     func testFailureGettingIPV4() async throws {
@@ -50,7 +52,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
         await XCTAssertThrowsErrorAsync(try await outgoingConnectionProxy.getIPV4(retryStrategy: .noRetry)) { _ in
             noIPv4Expectation.fulfill()
         }
-        await fulfillment(of: [noIPv4Expectation], timeout: 1)
+        await fulfillment(of: [noIPv4Expectation], timeout: .UnitTest.timeout)
     }
 
     func testSuccessGettingIPV6() async throws {
@@ -65,7 +67,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
         if result.ip == IPV6ConnectionData.mock.ip {
             ipv6Expectation.fulfill()
         }
-        await fulfillment(of: [ipv6Expectation], timeout: 1.0)
+        await fulfillment(of: [ipv6Expectation], timeout: .UnitTest.timeout)
     }
 
     func testFailureGettingIPV6() async throws {
@@ -78,7 +80,7 @@ final class OutgoingConnectionProxyTests: XCTestCase {
         await XCTAssertThrowsErrorAsync(try await outgoingConnectionProxy.getIPV6(retryStrategy: .noRetry)) { _ in
             noIPv6Expectation.fulfill()
         }
-        await fulfillment(of: [noIPv6Expectation], timeout: 1)
+        await fulfillment(of: [noIPv6Expectation], timeout: .UnitTest.timeout)
     }
 }
 

--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
@@ -45,7 +45,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldNotRotateKeyForInvalidAccount() {
@@ -76,7 +76,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldNotRotateKeyForRevokedDevice() {
@@ -107,7 +107,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldRotateKeyOnMismatchImmediately() {
@@ -136,7 +136,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldRespectCooldownWhenAttemptingToRotateImmediately() {
@@ -165,7 +165,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldNotRotateDeviceKeyWhenServerKeyIsIdentical() {
@@ -188,7 +188,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldNotRotateKeyBeforeRetryIntervalPassed() {
@@ -213,7 +213,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldRotateKeyOnceInTwentyFourHours() {
@@ -238,7 +238,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldReportFailedKeyRotataionAttempt() {
@@ -268,7 +268,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testShouldFailOnKeyRotationRace() {
@@ -305,7 +305,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     private func startDeviceCheck(

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 import MullvadSettings
 import Network
 import Operations
@@ -63,7 +64,7 @@ class StartTunnelOperationTests: XCTestCase {
         }
 
         operationQueue.addOperation(operation)
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: .UnitTest.timeout)
     }
 
     func testSetsReconnectIfDisconnecting() {
@@ -80,7 +81,7 @@ class StartTunnelOperationTests: XCTestCase {
             expectation.fulfill()
         }
         operationQueue.addOperation(operation)
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: .UnitTest.timeout)
     }
 
     func testStartsTunnelIfDisconnected() {
@@ -95,6 +96,6 @@ class StartTunnelOperationTests: XCTestCase {
             expectation.fulfill()
         }
         operationQueue.addOperation(operation)
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: .UnitTest.timeout)
     }
 }

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/OutgoingConnectionServiceTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/OutgoingConnectionServiceTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+@testable import MullvadMockData
 import XCTest
 
 final class OutgoingConnectionServiceTests: XCTestCase {
@@ -23,7 +24,7 @@ final class OutgoingConnectionServiceTests: XCTestCase {
            result.ipv6 == .mock {
             successExpectation.fulfill()
         }
-        await fulfillment(of: [successExpectation], timeout: 1.0)
+        await fulfillment(of: [successExpectation], timeout: .UnitTest.timeout)
     }
 
     func testFailureGetOutgoingConnectionInfo() async throws {
@@ -40,7 +41,7 @@ final class OutgoingConnectionServiceTests: XCTestCase {
         } catch {
             failExpectation.fulfill()
         }
-        await fulfillment(of: [failExpectation], timeout: 1.0)
+        await fulfillment(of: [failExpectation], timeout: .UnitTest.timeout)
     }
 }
 

--- a/ios/MullvadVPNUITests/Screenshots/SnapshotHelper.swift
+++ b/ios/MullvadVPNUITests/Screenshots/SnapshotHelper.swift
@@ -210,7 +210,7 @@ open class Snapshot: NSObject {
             let format = UIGraphicsImageRendererFormat()
             format.scale = image.scale
             let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-            return renderer.image { context in
+            return renderer.image { _ in
                 image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
             }
         } else {

--- a/ios/OperationsTests/AsyncBlockOperationTests.swift
+++ b/ios/OperationsTests/AsyncBlockOperationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 import MullvadTypes
 import Operations
 import XCTest
@@ -28,7 +29,7 @@ final class AsyncBlockOperationTests: XCTestCase {
 
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testSynchronousBlockOperation() {
@@ -45,7 +46,7 @@ final class AsyncBlockOperationTests: XCTestCase {
 
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testCancellableTaskBlockOperation() {
@@ -72,7 +73,7 @@ final class AsyncBlockOperationTests: XCTestCase {
 
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testCancellationShouldNotFireBeforeOperationIsEnqueued() throws {
@@ -83,7 +84,7 @@ final class AsyncBlockOperationTests: XCTestCase {
         operation.onCancel { _ in expect.fulfill() }
         operation.cancel()
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.invertedTimeout)
     }
 
     func testCancellationShouldFireAfterCancelledOperationIsEnqueued() throws {
@@ -94,6 +95,6 @@ final class AsyncBlockOperationTests: XCTestCase {
         operation.cancel()
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 }

--- a/ios/OperationsTests/AsyncResultBlockOperationTests.swift
+++ b/ios/OperationsTests/AsyncResultBlockOperationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 import MullvadTypes
 import Operations
 import XCTest
@@ -27,7 +28,7 @@ final class AsyncResultBlockOperationTests: XCTestCase {
 
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testThrowingBlockOperation() {
@@ -46,7 +47,7 @@ final class AsyncResultBlockOperationTests: XCTestCase {
 
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testCancellableTaskOperation() {
@@ -70,6 +71,6 @@ final class AsyncResultBlockOperationTests: XCTestCase {
 
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 }

--- a/ios/OperationsTests/OperationConditionTests.swift
+++ b/ios/OperationsTests/OperationConditionTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 import Operations
 import XCTest
 
@@ -28,7 +29,7 @@ class OperationConditionTests: XCTestCase {
         let operationQueue = AsyncOperationQueue()
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testFalseCondition() {
@@ -52,7 +53,8 @@ class OperationConditionTests: XCTestCase {
         let operationQueue = AsyncOperationQueue()
         operationQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 1)
+        wait(for: [expectOperationToNeverExecute], timeout: .UnitTest.invertedTimeout)
+        wait(for: [expectConditionEvaluation], timeout: .UnitTest.timeout)
     }
 
     func testNoCancelledDependenciesCondition() {
@@ -71,7 +73,7 @@ class OperationConditionTests: XCTestCase {
         let operationQueue = AsyncOperationQueue()
         operationQueue.addOperations([parent, child], waitUntilFinished: false)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.invertedTimeout)
     }
 
     func testNoFailedDependenciesCondition() {
@@ -91,7 +93,7 @@ class OperationConditionTests: XCTestCase {
         let operationQueue = AsyncOperationQueue()
         operationQueue.addOperations([parent, child], waitUntilFinished: false)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.invertedTimeout)
     }
 
     func testNoFailedDependenciesIgnoringCancellationsCondition() {
@@ -109,7 +111,7 @@ class OperationConditionTests: XCTestCase {
         let operationQueue = AsyncOperationQueue()
         operationQueue.addOperations([parent, child], waitUntilFinished: false)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 
     func testMutuallyExclusiveCondition() {
@@ -139,6 +141,6 @@ class OperationConditionTests: XCTestCase {
         operationQueue.addOperations([firstOperation, secondOperation], waitUntilFinished: false)
 
         let expectations = [expectFirstOperationExecution, expectSecondOperationExecution]
-        wait(for: expectations, timeout: 2, enforceOrder: true)
+        wait(for: expectations, timeout: .UnitTest.timeout, enforceOrder: true)
     }
 }

--- a/ios/OperationsTests/OperationObserverTests.swift
+++ b/ios/OperationsTests/OperationObserverTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 import Operations
 import XCTest
 
@@ -33,8 +34,8 @@ class OperationObserverTests: XCTestCase {
         let operationQueue = AsyncOperationQueue()
         operationQueue.addOperation(operation)
 
-        let expectations = [expectDidCancel, expectDidAttach, expectDidStart, expectDidFinish]
-        wait(for: expectations, timeout: 1, enforceOrder: true)
+        wait(for: [expectDidCancel], timeout: .UnitTest.invertedTimeout)
+        wait(for: [expectDidAttach, expectDidStart, expectDidFinish], timeout: .UnitTest.timeout, enforceOrder: true)
     }
 
     func testBlockObserverWithCancelledOperation() {
@@ -61,7 +62,7 @@ class OperationObserverTests: XCTestCase {
         let operationQueue = AsyncOperationQueue()
         operationQueue.addOperation(operation)
 
-        let expectations = [expectDidAttach, expectDidCancel, expectDidStart, expectDidFinish]
-        wait(for: expectations, timeout: 1, enforceOrder: true)
+        wait(for: [expectDidStart], timeout: .UnitTest.invertedTimeout)
+        wait(for: [expectDidAttach, expectDidCancel, expectDidFinish], timeout: .UnitTest.timeout, enforceOrder: true)
     }
 }

--- a/ios/PacketTunnelCoreTests/AppMessageHandlerTests.swift
+++ b/ios/PacketTunnelCoreTests/AppMessageHandlerTests.swift
@@ -30,7 +30,7 @@ final class AppMessageHandlerTests: XCTestCase {
             TunnelProviderMessage.sendURLRequest(urlRequest).encode()
         )
 
-        await fulfillment(of: [sendRequestExpectation], timeout: 1)
+        await fulfillment(of: [sendRequestExpectation], timeout: .UnitTest.timeout)
     }
 
     func testHandleAppMessageForCancelURLRequest() async throws {
@@ -43,7 +43,7 @@ final class AppMessageHandlerTests: XCTestCase {
             TunnelProviderMessage.cancelURLRequest(UUID()).encode()
         )
 
-        await fulfillment(of: [cancelRequestExpectation], timeout: 1)
+        await fulfillment(of: [cancelRequestExpectation], timeout: .UnitTest.timeout)
     }
 
     func testHandleAppMessageForTunnelStatus() async throws {
@@ -56,7 +56,7 @@ final class AppMessageHandlerTests: XCTestCase {
             TunnelProviderMessage.getTunnelStatus.encode()
         )
 
-        await fulfillment(of: [stateExpectation], timeout: 1)
+        await fulfillment(of: [stateExpectation], timeout: .UnitTest.timeout)
     }
 
     func testHandleAppMessageForKeyRotation() async throws {
@@ -69,7 +69,7 @@ final class AppMessageHandlerTests: XCTestCase {
             TunnelProviderMessage.privateKeyRotation.encode()
         )
 
-        await fulfillment(of: [keyRotationExpectation], timeout: 1)
+        await fulfillment(of: [keyRotationExpectation], timeout: .UnitTest.timeout)
     }
 
     func testHandleAppMessageForReconnectTunnel() async throws {
@@ -98,7 +98,7 @@ final class AppMessageHandlerTests: XCTestCase {
             TunnelProviderMessage.reconnectTunnel(.preSelected(selectedRelay)).encode()
         )
 
-        await fulfillment(of: [reconnectExpectation], timeout: 1)
+        await fulfillment(of: [reconnectExpectation], timeout: .UnitTest.timeout)
     }
 }
 

--- a/ios/PacketTunnelCoreTests/EventChannelTests.swift
+++ b/ios/PacketTunnelCoreTests/EventChannelTests.swift
@@ -7,6 +7,7 @@
 //  Formerly known as CommandChannelTests
 //
 
+@testable import MullvadMockData
 @testable import PacketTunnelCore
 import XCTest
 
@@ -77,7 +78,7 @@ final class EventChannelTests: XCTestCase {
             channel.finish()
         }
 
-        await fulfillment(of: [expectFinish, expectEndIteration], timeout: 100, enforceOrder: true)
+        await fulfillment(of: [expectFinish, expectEndIteration], timeout: .UnitTest.timeout, enforceOrder: true)
     }
 }
 

--- a/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
+++ b/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+@testable import MullvadMockData
 @testable import MullvadREST
 @testable import MullvadSettings
 import MullvadTypes
@@ -56,7 +57,7 @@ final class PacketTunnelActorTests: XCTestCase {
 
         actor.start(options: launchOptions)
 
-        await fulfillment(of: allExpectations, timeout: 1, enforceOrder: true)
+        await fulfillment(of: allExpectations, timeout: .UnitTest.timeout, enforceOrder: true)
     }
 
     func testStartIgnoresSubsequentStarts() async throws {
@@ -88,7 +89,7 @@ final class PacketTunnelActorTests: XCTestCase {
         actor.start(options: launchOptions)
         actor.start(options: launchOptions)
 
-        await fulfillment(of: allExpectations, timeout: 1, enforceOrder: true)
+        await fulfillment(of: allExpectations, timeout: .UnitTest.timeout, enforceOrder: true)
     }
 
     /**
@@ -120,7 +121,7 @@ final class PacketTunnelActorTests: XCTestCase {
             }
 
         actor.start(options: StartOptions(launchSource: .app))
-        await fulfillment(of: [connectingStateExpectation], timeout: 1)
+        await fulfillment(of: [connectingStateExpectation], timeout: .UnitTest.timeout)
     }
 
     func testPostQuantumReconnectionTransition() async throws {
@@ -151,7 +152,7 @@ final class PacketTunnelActorTests: XCTestCase {
             }
 
         actor.start(options: StartOptions(launchSource: .app))
-        await fulfillment(of: [negotiatingPostQuantumKeyStateExpectation], timeout: 1)
+        await fulfillment(of: [negotiatingPostQuantumKeyStateExpectation], timeout: .UnitTest.timeout)
     }
 
     /**
@@ -193,7 +194,7 @@ final class PacketTunnelActorTests: XCTestCase {
         actor.start(options: StartOptions(launchSource: .app))
         await fulfillment(
             of: [connectingStateExpectation, connectedStateExpectation, reconnectingStateExpectation],
-            timeout: 1,
+            timeout: .UnitTest.timeout,
             enforceOrder: true
         )
     }
@@ -207,7 +208,7 @@ final class PacketTunnelActorTests: XCTestCase {
      3. The issue goes away on the second attempt to read settings.
      4. An actor should transition through `.connecting` towards`.connected` state.
      */
-    func testLockedDeviceErrorOnBoot() async throws {
+    func testLockedDeviceErrorOnBoot() async throws { // swiftlint:disable:this function_body_length
         let initialStateExpectation = expectation(description: "Expect initial state")
         let errorStateExpectation = expectation(description: "Expect error state")
         let connectingStateExpectation = expectation(description: "Expect connecting state")
@@ -265,7 +266,7 @@ final class PacketTunnelActorTests: XCTestCase {
 
         actor.start(options: launchOptions)
 
-        await fulfillment(of: allExpectations, timeout: 1, enforceOrder: true)
+        await fulfillment(of: allExpectations, timeout: .UnitTest.timeout, enforceOrder: true)
     }
 
     func testStopGoesToDisconnected() async throws {
@@ -281,13 +282,13 @@ final class PacketTunnelActorTests: XCTestCase {
 
         // Wait for the connected state to happen so it doesn't get coalesced immediately after the call to `actor.stop`
         actor.start(options: launchOptions)
-        await fulfillment(of: [connectedStateExpectation], timeout: 1)
+        await fulfillment(of: [connectedStateExpectation], timeout: .UnitTest.timeout)
 
         await expect(.disconnected, on: actor) {
             disconnectedStateExpectation.fulfill()
         }
         actor.stop()
-        await fulfillment(of: [disconnectedStateExpectation], timeout: 1)
+        await fulfillment(of: [disconnectedStateExpectation], timeout: .UnitTest.timeout)
     }
 
     func testStopIsNoopBeforeStart() async throws {
@@ -304,7 +305,7 @@ final class PacketTunnelActorTests: XCTestCase {
         actor.stop()
         actor.stop()
 
-        await fulfillment(of: [disconnectedExpectation], timeout: Duration.milliseconds(100).timeInterval)
+        await fulfillment(of: [disconnectedExpectation], timeout: .UnitTest.invertedTimeout)
     }
 
     func testStopCancelsDefaultPathObserver() async throws {
@@ -323,7 +324,7 @@ final class PacketTunnelActorTests: XCTestCase {
         }
 
         actor.start(options: launchOptions)
-        await fulfillment(of: [connectedStateExpectation], timeout: 1)
+        await fulfillment(of: [connectedStateExpectation], timeout: .UnitTest.timeout)
 
         let disconnectedStateExpectation = expectation(description: "Disconnected state")
 
@@ -331,7 +332,7 @@ final class PacketTunnelActorTests: XCTestCase {
             disconnectedStateExpectation.fulfill()
         }
         actor.stop()
-        await fulfillment(of: [disconnectedStateExpectation, didStopObserverExpectation], timeout: 1)
+        await fulfillment(of: [disconnectedStateExpectation, didStopObserverExpectation], timeout: .UnitTest.timeout)
     }
 
     func testCannotEnterErrorStateWhenStopping() async throws {
@@ -350,7 +351,7 @@ final class PacketTunnelActorTests: XCTestCase {
             connectingStateExpectation.fulfill()
         }
         actor.start(options: launchOptions)
-        await fulfillment(of: [connectingStateExpectation], timeout: 1)
+        await fulfillment(of: [connectingStateExpectation], timeout: .UnitTest.timeout)
 
         stateSink = await actor.$observedState
             .receive(on: DispatchQueue.main)
@@ -368,8 +369,8 @@ final class PacketTunnelActorTests: XCTestCase {
         actor.stop()
         actor.setErrorState(reason: .readSettings)
 
-        await fulfillment(of: [disconnectedStateExpectation], timeout: 1)
-        await fulfillment(of: [errorStateExpectation], timeout: Duration.milliseconds(100).timeInterval)
+        await fulfillment(of: [disconnectedStateExpectation], timeout: .UnitTest.timeout)
+        await fulfillment(of: [errorStateExpectation], timeout: .UnitTest.invertedTimeout)
     }
 
     func testReconnectIsNoopBeforeConnecting() async throws {
@@ -387,7 +388,7 @@ final class PacketTunnelActorTests: XCTestCase {
 
         await fulfillment(
             of: [reconnectingStateExpectation],
-            timeout: Duration.milliseconds(100).timeInterval
+            timeout: .UnitTest.invertedTimeout
         )
     }
 
@@ -402,12 +403,12 @@ final class PacketTunnelActorTests: XCTestCase {
 
         actor.start(options: launchOptions)
         // Wait for the connected state to happen so it doesn't get coalesced immediately after the call to `actor.stop`
-        await fulfillment(of: [connectedStateExpectation], timeout: 1)
+        await fulfillment(of: [connectedStateExpectation], timeout: .UnitTest.timeout)
 
         let disconnectedStateExpectation = expectation(description: "Expect disconnected state")
         await expect(.disconnected, on: actor) { disconnectedStateExpectation.fulfill() }
         actor.stop()
-        await fulfillment(of: [disconnectedStateExpectation], timeout: 1)
+        await fulfillment(of: [disconnectedStateExpectation], timeout: .UnitTest.timeout)
 
         let reconnectingStateExpectation = expectation(description: "Expect reconnecting state")
         reconnectingStateExpectation.isInverted = true
@@ -417,7 +418,7 @@ final class PacketTunnelActorTests: XCTestCase {
         actor.reconnect(to: .random, reconnectReason: .userInitiated)
         await fulfillment(
             of: [reconnectingStateExpectation],
-            timeout: Duration.milliseconds(100).timeInterval
+            timeout: .UnitTest.invertedTimeout
         )
     }
 
@@ -440,13 +441,13 @@ final class PacketTunnelActorTests: XCTestCase {
             connectedExpectation.fulfill()
         }
         actor.start(options: launchOptions)
-        await fulfillment(of: [connectedExpectation], timeout: 1)
+        await fulfillment(of: [connectedExpectation], timeout: .UnitTest.timeout)
 
         // Cancel the state sink to avoid overfulfilling the connected expectation
         stateSink?.cancel()
 
         actor.reconnect(to: .random, reconnectReason: .userInitiated)
-        await fulfillment(of: [stopMonitorExpectation], timeout: 1)
+        await fulfillment(of: [stopMonitorExpectation], timeout: .UnitTest.timeout)
     }
 }
 

--- a/ios/PacketTunnelCoreTests/PingerTests.swift
+++ b/ios/PacketTunnelCoreTests/PingerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 import Network
 import PacketTunnelCore
 import XCTest
@@ -27,6 +28,6 @@ final class PingerTests: XCTestCase {
         try pinger.openSocket(bindTo: "lo0")
         sendResult = try pinger.send(to: .loopback)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.timeout)
     }
 }

--- a/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
+++ b/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
 
+@testable import MullvadMockData
 import MullvadTypes
 import Network
 @testable import PacketTunnelCore
@@ -37,7 +38,7 @@ final class TunnelMonitorTests: XCTestCase {
 
         tunnelMonitor.start(probeAddress: .loopback)
 
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: .UnitTest.invertedTimeout)
     }
 
     func testInitialConnectionTimings() {

--- a/ios/PacketTunnelCoreTests/TunnelSettingsManagerTests.swift
+++ b/ios/PacketTunnelCoreTests/TunnelSettingsManagerTests.swift
@@ -13,7 +13,7 @@ import PacketTunnelCore
 import XCTest
 
 class TunnelSettingsManagerTests: XCTestCase {
-    func notifyWhenSettingsLoadedTest() throws {
+    func testNotifyWhenSettingsLoaded() throws {
         var loadedConfiguration: Settings?
         let tunnelSettingsManager = TunnelSettingsManager(
             settingsReader: SettingsReaderStub.staticConfiguration(),


### PR DESCRIPTION
After a discussion we came to the conclusion that 1 second timeout would not help us see if the unit tests ever enter a dead lock situation.

Having a 60 seconds timeout would point that out by having tests fail after 1 minute.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6398)
<!-- Reviewable:end -->
