### PR TITLE
Disable obfuscation in WireGuard port GUI test

### DIFF
--- a/gui/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -62,6 +62,7 @@ test('App should show correct WireGuard port', async () => {
 
   await expect(inData).toContainText(new RegExp(':[0-9]+'));
 
+  await exec('mullvad obfuscation set mode off');
   await exec('mullvad relay set tunnel wireguard --port=53');
   await expectConnected(page);
   await expect(inData).toContainText(new RegExp(':53'));
@@ -71,6 +72,7 @@ test('App should show correct WireGuard port', async () => {
   await expect(inData).toContainText(new RegExp(':51820'));
 
   await exec('mullvad relay set tunnel wireguard --port=any');
+  await exec('mullvad obfuscation set mode auto');
 });
 
 test('App should show correct WireGuard transport protocol', async () => {


### PR DESCRIPTION
After changing the default obfuscation value to "Auto", the `tunnel-state` test has started failing occasionally due to trying udp2tcp when failing to connect on the first try. This PR disables obfuscation during that test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6402)
<!-- Reviewable:end -->
