### PR TITLE
Re-enable screenshots for iPad

### DIFF
--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -20,7 +20,6 @@ jobs:
     env:
       SOURCE_PACKAGES_PATH: .spm
       TEST_ACCOUNT: ${{ secrets.IOS_TEST_ACCOUNT_NUMBER }}
-      PARTNER_API_TOKEN: ${{ secrets.STAGEMOLE_PARTNER_AUTH }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/ios/Configurations/UITests.xcconfig.template
+++ b/ios/Configurations/UITests.xcconfig.template
@@ -10,8 +10,7 @@ TEST_DEVICE_IDENTIFIER_UUID =
 // PARTNER_API_TOKEN = 
 
 // Mullvad accounts used by UI tests
-HAS_TIME_ACCOUNT_NUMBER[config=Debug] = 
-HAS_TIME_ACCOUNT_NUMBER[config=Staging] = 
+HAS_TIME_ACCOUNT_NUMBER = 
 
 // Ad serving domain used when testing ad blocking. Note that we are assuming there's an HTTP server running on the host.
 AD_SERVING_DOMAIN = vpnlist.to

--- a/ios/MullvadVPNUITests/Pages/Page.swift
+++ b/ios/MullvadVPNUITests/Pages/Page.swift
@@ -50,7 +50,8 @@ class Page {
     }
 
     @discardableResult func tapWhereStatusBarShouldBeToScrollToTopMostPosition() -> Self {
-        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0)).tap()
+        // Tapping but not at center x coordinate because on iPad there's an ellipsis button in the center of the status bar
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0)).tap()
         return self
     }
 }

--- a/ios/Snapfile
+++ b/ios/Snapfile
@@ -4,9 +4,9 @@ ios_version '17.2'
 devices([
   "iPhone SE (3rd generation)",
   "iPhone 15 Pro",
-  "iPhone 15 Pro Max"
-  #"iPad Pro (11-inch) (4th generation)",
-  #"iPad Pro (12.9-inch) (6th generation)"
+  "iPhone 15 Pro Max",
+  "iPad Pro (11-inch) (4th generation)",
+  "iPad Pro (12.9-inch) (6th generation)"
 ])
 
 languages([


### PR DESCRIPTION
Re-enable screenshots for iPad, since the iPad specific UI is now gone and screenshot tests should work on iPad again. The changes can be tested by running the iOS create screenshots workflow on this branch.

Also updated configuration so that `HAS_TIME_ACCOUNT_NUMBER` is properly set and partner API is not used.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6403)
<!-- Reviewable:end -->
