### PR TITLE
Remove unused `libc` dependency in `talpid-routing`

### DIFF
--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -35,7 +35,6 @@ system-configuration = "0.5.1"
 
 
 [target.'cfg(windows)'.dependencies]
-libc = "0.2"
 talpid-windows = { path = "../talpid-windows" }
 widestring = "1.0"
 


### PR DESCRIPTION
This PR removes an unused dependency in `talpid-routing`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6407)
<!-- Reviewable:end -->
