### PR TITLE
Remove pointless firewall update

### DIFF
--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -157,11 +157,13 @@ impl Config {
     }
 
     /// Return the exit peer. `exit_peer` if it is set, otherwise `entry_peer`.
+    pub fn exit_peer(&self) -> &wireguard::PeerConfig {
+        self.exit_peer.as_ref().unwrap_or(&self.entry_peer)
+    }
+
+    /// Return the exit peer. `exit_peer` if it is set, otherwise `entry_peer`.
     pub fn exit_peer_mut(&mut self) -> &mut wireguard::PeerConfig {
-        if let Some(ref mut peer) = self.exit_peer {
-            return peer;
-        }
-        &mut self.entry_peer
+        self.exit_peer.as_mut().unwrap_or(&mut self.entry_peer)
     }
 
     /// Return an iterator over all peers.


### PR DESCRIPTION
When PQ or DAITA is enabled, the firewall state is updated twice to allow only traffic to `ipv4_gateway` inside the tunnel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6416)
<!-- Reviewable:end -->
