### PR TITLE
Remove update available message

### DIFF
--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/ConnectScreenTest.kt
@@ -598,49 +598,10 @@ class ConnectScreenTest {
     }
 
     @Test
-    fun testOutdatedVersionNotification() {
-        composeExtension.use {
-            // Arrange
-            val versionInfo =
-                VersionInfo(
-                    currentVersion = "1.0",
-                    isSupported = true,
-                    suggestedUpgradeVersion = "1.1"
-                )
-            setContentWithTheme {
-                ConnectScreen(
-                    state =
-                        ConnectUiState(
-                            location = null,
-                            selectedRelayItemTitle = null,
-                            tunnelState = TunnelState.Connecting(null, null),
-                            inAddress = null,
-                            outAddress = "",
-                            showLocation = false,
-                            deviceName = "",
-                            daysLeftUntilExpiry = null,
-                            inAppNotification = InAppNotification.UpdateAvailable(versionInfo),
-                            isPlayBuild = false
-                        ),
-                )
-            }
-
-            // Assert
-            onNodeWithText("UPDATE AVAILABLE").assertExists()
-            onNodeWithText("Install Mullvad VPN (1.1) to stay up to date").assertExists()
-        }
-    }
-
-    @Test
     fun testUnsupportedVersionNotification() {
         composeExtension.use {
             // Arrange
-            val versionInfo =
-                VersionInfo(
-                    currentVersion = "1.0",
-                    isSupported = false,
-                    suggestedUpgradeVersion = "1.1"
-                )
+            val versionInfo = VersionInfo(currentVersion = "1.0", isSupported = false)
             setContentWithTheme {
                 ConnectScreen(
                     state =
@@ -702,12 +663,7 @@ class ConnectScreenTest {
         composeExtension.use {
             // Arrange
             val mockedClickHandler: () -> Unit = mockk(relaxed = true)
-            val versionInfo =
-                VersionInfo(
-                    isSupported = false,
-                    currentVersion = "",
-                    suggestedUpgradeVersion = "1.1"
-                )
+            val versionInfo = VersionInfo(isSupported = false, currentVersion = "")
             setContentWithTheme {
                 ConnectScreen(
                     onUpdateVersionClick = mockedClickHandler,

--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/SettingsScreenTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/compose/screen/SettingsScreenTest.kt
@@ -31,7 +31,7 @@ class SettingsScreenTest {
                         SettingsUiState(
                             appVersion = "",
                             isLoggedIn = true,
-                            isUpdateAvailable = true,
+                            isSupportedVersion = true,
                             isPlayBuild = false
                         ),
                 )
@@ -54,7 +54,7 @@ class SettingsScreenTest {
                         SettingsUiState(
                             appVersion = "",
                             isLoggedIn = false,
-                            isUpdateAvailable = true,
+                            isSupportedVersion = true,
                             isPlayBuild = false
                         ),
                 )

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/NavigationComposeCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/NavigationComposeCell.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import net.mullvad.mullvadvpn.R
@@ -95,7 +94,7 @@ internal fun NavigationTitleView(
         Image(
             painter = painterResource(id = R.drawable.icon_alert),
             modifier = Modifier.padding(end = Dimens.smallPadding),
-            contentDescription = stringResource(id = R.string.update_available)
+            contentDescription = null
         )
     }
     Text(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationBanner.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationBanner.kt
@@ -50,12 +50,7 @@ private fun PreviewNotificationBanner() {
             val bannerDataList =
                 listOf(
                         InAppNotification.UnsupportedVersion(
-                            versionInfo =
-                                VersionInfo(
-                                    currentVersion = "1.0",
-                                    isSupported = false,
-                                    suggestedUpgradeVersion = null
-                                ),
+                            versionInfo = VersionInfo(currentVersion = "1.0", isSupported = false),
                         ),
                         InAppNotification.AccountExpiry(expiry = DateTime.now()),
                         InAppNotification.TunnelStateBlocked,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationData.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationData.kt
@@ -93,19 +93,6 @@ fun InAppNotification.toNotificationData(
                     if (isPlayBuild) null
                     else NotificationAction(R.drawable.icon_extlink, onClickUpdateVersion)
             )
-        is InAppNotification.UpdateAvailable ->
-            NotificationData(
-                title = stringResource(id = R.string.update_available),
-                message =
-                    stringResource(
-                        id = R.string.update_available_description,
-                        versionInfo.suggestedUpgradeVersion ?: ""
-                    ),
-                statusLevel = StatusLevel.Warning,
-                action =
-                    if (isPlayBuild) null
-                    else NotificationAction(R.drawable.icon_extlink, onClickUpdateVersion)
-            )
     }
 
 @Composable

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SettingsScreen.kt
@@ -54,7 +54,7 @@ private fun PreviewSettings() {
                 SettingsUiState(
                     appVersion = "2222.22",
                     isLoggedIn = true,
-                    isUpdateAvailable = true,
+                    isSupportedVersion = true,
                     isPlayBuild = false
                 ),
         )
@@ -172,13 +172,13 @@ private fun AppVersion(context: Context, state: SettingsUiState) {
                     )
                 }
             },
-        showWarning = state.isUpdateAvailable,
+        showWarning = !state.isSupportedVersion,
         isRowEnabled = !state.isPlayBuild
     )
 
-    if (state.isUpdateAvailable) {
+    if (!state.isSupportedVersion) {
         Text(
-            text = stringResource(id = R.string.update_available_footer),
+            text = stringResource(id = R.string.unsupported_version_description),
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSecondary,
             modifier =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/SettingsUiState.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/state/SettingsUiState.kt
@@ -3,6 +3,6 @@ package net.mullvad.mullvadvpn.compose.state
 data class SettingsUiState(
     val appVersion: String,
     val isLoggedIn: Boolean,
-    val isUpdateAvailable: Boolean,
+    val isSupportedVersion: Boolean,
     val isPlayBuild: Boolean
 )

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/InAppNotificationController.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/repository/InAppNotificationController.kt
@@ -47,11 +47,6 @@ sealed class InAppNotification {
         override val statusLevel = StatusLevel.Info
         override val priority: Long = 1001
     }
-
-    data class UpdateAvailable(val versionInfo: VersionInfo) : InAppNotification() {
-        override val statusLevel = StatusLevel.Info
-        override val priority: Long = 1000
-    }
 }
 
 class InAppNotificationController(

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/VersionInfo.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/VersionInfo.kt
@@ -1,9 +1,3 @@
 package net.mullvad.mullvadvpn.ui
 
-data class VersionInfo(
-    val currentVersion: String,
-    val isSupported: Boolean,
-    val suggestedUpgradeVersion: String?
-) {
-    val isUpdateAvailable: Boolean = suggestedUpgradeVersion != null
-}
+data class VersionInfo(val currentVersion: String, val isSupported: Boolean)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoRepository.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/serviceconnection/AppVersionInfoRepository.kt
@@ -12,10 +12,6 @@ class AppVersionInfoRepository(
 ) {
     fun versionInfo(): Flow<VersionInfo> =
         managementService.versionInfo.map { appVersionInfo ->
-            VersionInfo(
-                currentVersion = buildVersion.name,
-                isSupported = appVersionInfo.supported,
-                suggestedUpgradeVersion = appVersionInfo.suggestedUpgrade,
-            )
+            VersionInfo(currentVersion = buildVersion.name, isSupported = appVersionInfo.supported)
         }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/usecase/VersionNotificationUseCase.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/usecase/VersionNotificationUseCase.kt
@@ -14,23 +14,8 @@ class VersionNotificationUseCase(
     operator fun invoke() =
         appVersionInfoRepository
             .versionInfo()
-            .map { versionInfo ->
-                listOfNotNull(
-                    unsupportedVersionNotification(versionInfo),
-                    updateAvailableNotification(versionInfo)
-                )
-            }
+            .map { versionInfo -> listOfNotNull(unsupportedVersionNotification(versionInfo)) }
             .distinctUntilChanged()
-
-    private fun updateAvailableNotification(versionInfo: VersionInfo): InAppNotification? {
-        if (!isVersionInfoNotificationEnabled) {
-            return null
-        }
-
-        return if (versionInfo.isUpdateAvailable) {
-            InAppNotification.UpdateAvailable(versionInfo)
-        } else null
-    }
 
     private fun unsupportedVersionNotification(versionInfo: VersionInfo): InAppNotification? {
         if (!isVersionInfoNotificationEnabled) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/SettingsViewModel.kt
@@ -24,8 +24,7 @@ class SettingsViewModel(
                 SettingsUiState(
                     isLoggedIn = deviceState is DeviceState.LoggedIn,
                     appVersion = versionInfo.currentVersion,
-                    isUpdateAvailable =
-                        versionInfo.let { it.isSupported.not() || it.isUpdateAvailable },
+                    isSupportedVersion = versionInfo.isSupported,
                     isPlayBuild = isPlayBuild
                 )
             }
@@ -35,7 +34,7 @@ class SettingsViewModel(
                 SettingsUiState(
                     appVersion = "",
                     isLoggedIn = false,
-                    isUpdateAvailable = false,
+                    isSupportedVersion = true,
                     isPlayBuild
                 )
             )
@@ -47,7 +46,7 @@ class SettingsViewModel(
             SettingsUiState(
                 appVersion = "",
                 isLoggedIn = false,
-                isUpdateAvailable = false,
+                isSupportedVersion = true,
                 isPlayBuild
             )
         )

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/InAppNotificationControllerTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/InAppNotificationControllerTest.kt
@@ -77,8 +77,7 @@ class InAppNotificationControllerTest {
         tunnelStateNotifications.value = listOf(tunnelStateBlocked, tunnelStateError)
 
         val unsupportedVersion = InAppNotification.UnsupportedVersion(mockk())
-        val updateAvailable = InAppNotification.UpdateAvailable(mockk())
-        versionNotifications.value = listOf(unsupportedVersion, updateAvailable)
+        versionNotifications.value = listOf(unsupportedVersion)
 
         val accountExpiry = InAppNotification.AccountExpiry(DateTime.now())
         accountExpiryNotifications.value = listOf(accountExpiry)
@@ -93,7 +92,6 @@ class InAppNotificationControllerTest {
                     unsupportedVersion,
                     accountExpiry,
                     newDevice,
-                    updateAvailable,
                 ),
                 notifications
             )

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/VersionNotificationUseCaseTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/VersionNotificationUseCaseTest.kt
@@ -23,10 +23,7 @@ class VersionNotificationUseCaseTest {
 
     private val mockAppVersionInfoRepository: AppVersionInfoRepository = mockk()
 
-    private val versionInfo =
-        MutableStateFlow(
-            VersionInfo(currentVersion = "", isSupported = true, suggestedUpgradeVersion = null)
-        )
+    private val versionInfo = MutableStateFlow(VersionInfo(currentVersion = "", isSupported = true))
     private lateinit var versionNotificationUseCase: VersionNotificationUseCase
 
     @BeforeEach
@@ -53,28 +50,6 @@ class VersionNotificationUseCaseTest {
     }
 
     @Test
-    fun `when a new version is available use case should emit UpdateAvailable with new version`() =
-        runTest {
-            versionNotificationUseCase().test {
-                // Arrange, Act
-                val upgradeVersionInfo =
-                    VersionInfo(
-                        currentVersion = "1.0",
-                        isSupported = true,
-                        suggestedUpgradeVersion = "1.1"
-                    )
-                awaitItem()
-                versionInfo.value = upgradeVersionInfo
-
-                // Assert
-                assertEquals(
-                    awaitItem(),
-                    listOf(InAppNotification.UpdateAvailable(upgradeVersionInfo))
-                )
-            }
-        }
-
-    @Test
     fun `when an unsupported version use case should emit UnsupportedVersion notification`() =
         runTest {
             versionNotificationUseCase().test {
@@ -83,7 +58,6 @@ class VersionNotificationUseCaseTest {
                     VersionInfo(
                         currentVersion = "1.0",
                         isSupported = false,
-                        suggestedUpgradeVersion = null
                     )
                 awaitItem()
                 versionInfo.value = upgradeVersionInfo

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SettingsViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/SettingsViewModelTest.kt
@@ -26,9 +26,7 @@ class SettingsViewModelTest {
     private val mockAppVersionInfoRepository: AppVersionInfoRepository = mockk()
 
     private val versionInfo =
-        MutableStateFlow(
-            VersionInfo(currentVersion = "", isSupported = false, suggestedUpgradeVersion = null)
-        )
+        MutableStateFlow(VersionInfo(currentVersion = "", isSupported = false))
 
     private lateinit var viewModel: SettingsViewModel
 
@@ -60,53 +58,30 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `when AppVersionInfoCache returns isOutdated false uiState should return isUpdateAvailable false`() =
+    fun `when AppVersionInfoRepository returns isSupported true uiState should return isSupportedVersion true`() =
         runTest {
             // Arrange
-            val versionInfoTestItem =
-                VersionInfo(
-                    currentVersion = "1.0",
-                    isSupported = true,
-                    suggestedUpgradeVersion = null
-                )
-
-            // Act, Assert
-            viewModel.uiState.test {
-                awaitItem() // Wait for initial value
-
-                versionInfo.value = versionInfoTestItem
-                val result = awaitItem()
-                assertEquals(false, result.isUpdateAvailable)
-            }
-        }
-
-    @Test
-    fun `when AppVersionInfoCache returns isSupported false uiState should return isUpdateAvailable true`() =
-        runTest {
-            // Arrange
-            val versionInfoTestItem =
-                VersionInfo(currentVersion = "", isSupported = false, suggestedUpgradeVersion = "")
+            val versionInfoTestItem = VersionInfo(currentVersion = "", isSupported = true)
             versionInfo.value = versionInfoTestItem
 
             // Act, Assert
             viewModel.uiState.test {
                 val result = awaitItem()
-                assertEquals(true, result.isUpdateAvailable)
+                assertEquals(true, result.isSupportedVersion)
             }
         }
 
     @Test
-    fun `when AppVersionInfoCache returns isOutdated true uiState should return isUpdateAvailable true`() =
+    fun `when AppVersionInfoRepository returns isSupported false uiState should return isSupportedVersion false`() =
         runTest {
             // Arrange
-            val versionInfoTestItem =
-                VersionInfo(currentVersion = "", isSupported = true, suggestedUpgradeVersion = "")
+            val versionInfoTestItem = VersionInfo(currentVersion = "", isSupported = false)
             versionInfo.value = versionInfoTestItem
 
             // Act, Assert
             viewModel.uiState.test {
                 val result = awaitItem()
-                assertEquals(true, result.isUpdateAvailable)
+                assertEquals(false, result.isSupportedVersion)
             }
         }
 }

--- a/android/lib/resource/src/main/res/values-da/strings.xml
+++ b/android/lib/resource/src/main/res/values-da/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">IKKE-UNDERSTØTTET VERSION</string>
     <string name="unsupported_version_description">Dit privatliv kan være i fare med denne ikke-understøttede appversion. Opdater den straks.</string>
     <string name="unsupported_version_without_upgrade">Du kører en ikke-understøttet appversion.</string>
-    <string name="update_available">OPDATERING TILGÆNGELIG</string>
-    <string name="update_available_description">Installer Mullvad VPN (%1$s) for at holde dig opdateret</string>
     <string name="update_available_footer">Opdatering tilgængelig, download den for at forblive sikker.</string>
     <string name="update_dns_server_dialog_title">Opdater DNS-server</string>
     <string name="update_list_name">Opdater listenavn</string>

--- a/android/lib/resource/src/main/res/values-de/strings.xml
+++ b/android/lib/resource/src/main/res/values-de/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">NICHT UNTERSTÜTZTE VERSION</string>
     <string name="unsupported_version_description">Ihre Privatsphäre könnte mit dieser nicht unterstützen Version der App gefährdet sein. Bitte aktualisieren Sie sie.</string>
     <string name="unsupported_version_without_upgrade">Sie verwenden eine nicht unterstützte Version der App. </string>
-    <string name="update_available">UPDATE VERFÜGBAR</string>
-    <string name="update_available_description">Installieren Sie Mullvad VPN (%1$s), um auf dem neuesten Stand zu bleiben</string>
     <string name="update_available_footer">Update verfügbar, laden Sie es herunter, um sicher zu bleiben.</string>
     <string name="update_dns_server_dialog_title">DNS-Server aktualisieren</string>
     <string name="update_list_name">Name der Liste ändern</string>

--- a/android/lib/resource/src/main/res/values-es/strings.xml
+++ b/android/lib/resource/src/main/res/values-es/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">VERSIÓN NO ADMITIDA</string>
     <string name="unsupported_version_description">Al usar esta versión obsoleta de la aplicación, es posible que su privacidad esté en riesgo. Actualice ahora.</string>
     <string name="unsupported_version_without_upgrade">Ejecuta una versión de la aplicación que no es compatible.</string>
-    <string name="update_available">ACTUALIZACIÓN DISPONIBLE</string>
-    <string name="update_available_description">Instale Mullvad VPN (%1$s) para seguir actualizado</string>
     <string name="update_available_footer">Hay una actualización disponible, descárguela para seguir protegido.</string>
     <string name="update_dns_server_dialog_title">Actualizar servidor DNS</string>
     <string name="update_list_name">Actualizar nombre de la lista</string>

--- a/android/lib/resource/src/main/res/values-fi/strings.xml
+++ b/android/lib/resource/src/main/res/values-fi/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">EI-TUETTU VERSIO</string>
     <string name="unsupported_version_description">Yksityisyytesi saattaa olla vaarassa tämän sovellusversion, jota ei tueta, vuoksi. Päivitä versio heti.</string>
     <string name="unsupported_version_without_upgrade">Sovellusversiotasi ei tueta.</string>
-    <string name="update_available">PÄIVITYS SAATAVILLA</string>
-    <string name="update_available_description">Asenna Mullvad VPN (%1$s) pysyäksesi ajan tasalla</string>
     <string name="update_available_footer">Päivitys saatavilla. Lataa se pysyäksesi suojattuna.</string>
     <string name="update_dns_server_dialog_title">Päivitä DNS-palvelin</string>
     <string name="update_list_name">Päivitä luettelon nimi</string>

--- a/android/lib/resource/src/main/res/values-fr/strings.xml
+++ b/android/lib/resource/src/main/res/values-fr/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">VERSION NON PRISE EN CHARGE</string>
     <string name="unsupported_version_description">Votre confidentialité peut être en danger avec cette version non prise en charge de l\'application. Veuillez la mettre à jour maintenant.</string>
     <string name="unsupported_version_without_upgrade">Vous utilisez une version de l\'application non prise en charge.</string>
-    <string name="update_available">MISE À JOUR DISPONIBLE</string>
-    <string name="update_available_description">Installez Mullvad VPN (%1$s) pour rester à jour</string>
     <string name="update_available_footer">Mise à jour disponible. Téléchargez-la pour rester en sécurité.</string>
     <string name="update_dns_server_dialog_title">Mettre à jour le serveur DNS</string>
     <string name="update_list_name">Mettre à jour le nom de la liste</string>

--- a/android/lib/resource/src/main/res/values-it/strings.xml
+++ b/android/lib/resource/src/main/res/values-it/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">VERSIONE NON SUPPORTATA</string>
     <string name="unsupported_version_description">La tua privacy potrebbe essere a rischio con questa versione dell\'app non supportata. Aggiornala subito.</string>
     <string name="unsupported_version_without_upgrade">Stai eseguendo una versione dell\'app non supportata.</string>
-    <string name="update_available">AGGIORNAMENTO DISPONIBILE</string>
-    <string name="update_available_description">Installa Mullvad VPN (%1$s) per rimanere aggiornato</string>
     <string name="update_available_footer">Aggiornamento disponibile; esegui il download per rimanere protetto.</string>
     <string name="update_dns_server_dialog_title">Aggiorna server DNS</string>
     <string name="update_list_name">Aggiorna nome elenco</string>

--- a/android/lib/resource/src/main/res/values-ja/strings.xml
+++ b/android/lib/resource/src/main/res/values-ja/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">未対応のバージョン</string>
     <string name="unsupported_version_description">このアプリバージョンはサポートされていないため、プライバシーが危険にさらされる可能性があります。今すぐアップデートしてください。</string>
     <string name="unsupported_version_without_upgrade">サポート対象外バージョンのアプリを実行しています。</string>
-    <string name="update_available">アップデート可</string>
-    <string name="update_available_description">Mullvad VPN (%1$s) をインストールして常に最新の状態を保ちましょう</string>
     <string name="update_available_footer">アップデートできます。セキュリティを維持するにはダウンロードしてしてください。</string>
     <string name="update_dns_server_dialog_title">DNS サーバーを更新</string>
     <string name="update_list_name">リスト名の更新</string>

--- a/android/lib/resource/src/main/res/values-ko/strings.xml
+++ b/android/lib/resource/src/main/res/values-ko/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">지원되지 않는 버전</string>
     <string name="unsupported_version_description">지원되지 않는 이 앱 버전으로 인해 개인 정보가 위험할 수 있습니다. 지금 업데이트하세요.</string>
     <string name="unsupported_version_without_upgrade">지원되지 않는 앱 버전을 실행 중입니다.</string>
-    <string name="update_available">업데이트 사용 가능</string>
-    <string name="update_available_description">Mullvad VPN(%1$s)을 설치하여 최신 상태로 유지하세요.</string>
     <string name="update_available_footer">업데이트를 사용할 수 있습니다. 안전을 유지하기 위해 다운로드하세요.</string>
     <string name="update_dns_server_dialog_title">DNS 서버 업데이트</string>
     <string name="update_list_name">목록 이름 업데이트</string>

--- a/android/lib/resource/src/main/res/values-my/strings.xml
+++ b/android/lib/resource/src/main/res/values-my/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">တွဲဖက်မလုပ်ဆောင်နိုင်သည့် ဗားရှင်း</string>
     <string name="unsupported_version_description">တွဲဖက်မလုပ်ဆောင်နိုင်သည့် ဤအက်ပ်ဗားရှင်းကြောင့် သင့်ကိုယ်ရေးအချက်အလက်များ အန္တရာယ် ရှိနိုင်ပါသည်။ ယခုပင် အပ်ဒိတ်လုပ်ပေးပါ။</string>
     <string name="unsupported_version_without_upgrade">တွဲဖက်မလုပ်ဆောင်နိုင်သည့် အက်ပ်ဗားရှင်းဖြင့် လုပ်ဆောင်နေပါသည်။</string>
-    <string name="update_available">အပ်ဒိတ် ရရှိနိုင်ပါပြီ</string>
-    <string name="update_available_description">အပ်ဒိတ် ဖြစ်နေစေရန် Mullvad VPN (%1$s) ကို ထည့်သွင်းပါ</string>
     <string name="update_available_footer">အပ်ဒိတ် ရရှိနိုင်ပါပြီ၊ ဆက်လက် လုံခြုံစေရန် ဒေါင်းလုဒ်လုပ်ပါ။</string>
     <string name="update_dns_server_dialog_title">DNS ဆာဗာကို အပ်ဒိတ်လုပ်ရန်</string>
     <string name="update_list_name">စာရင်း အမည်ကို အပ်ဒိတ်လုပ်ရန်</string>

--- a/android/lib/resource/src/main/res/values-nb/strings.xml
+++ b/android/lib/resource/src/main/res/values-nb/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">VERSJON UTEN STØTTE</string>
     <string name="unsupported_version_description">Personvernet ditt kan være i fare med denne appversjonen som ikke støttes. Oppdater nå.</string>
     <string name="unsupported_version_without_upgrade">Du kjører en appversjon som ikke støttes.</string>
-    <string name="update_available">OPPDATERING TILGJENGELIG</string>
-    <string name="update_available_description">Installer Mullvad VPN (%1$s) for å holde deg oppdatert</string>
     <string name="update_available_footer">Oppdatering tilgjengelig. Last ned for å oppdatere sikkerheten.</string>
     <string name="update_dns_server_dialog_title">Oppdater DNS-serveren</string>
     <string name="update_list_name">Oppdater listenavn</string>

--- a/android/lib/resource/src/main/res/values-nl/strings.xml
+++ b/android/lib/resource/src/main/res/values-nl/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">NIET-ONDERSTEUNDE VERSIE</string>
     <string name="unsupported_version_description">Uw privacy kan risico lopen met deze niet-ondersteunde appversie. Werk de app nu bij.</string>
     <string name="unsupported_version_without_upgrade">U gebruikt een niet-ondersteunde versie van de app.</string>
-    <string name="update_available">UPDATE BESCHIKBAAR</string>
-    <string name="update_available_description">Installeer Mullvad VPN (%1$s) om up-to-date te blijven</string>
     <string name="update_available_footer">Update beschikbaar, download deze om veilig te blijven.</string>
     <string name="update_dns_server_dialog_title">DNS-server bijwerken</string>
     <string name="update_list_name">Lijstnaam bijwerken</string>

--- a/android/lib/resource/src/main/res/values-pl/strings.xml
+++ b/android/lib/resource/src/main/res/values-pl/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">WERSJA NIEOBSŁUGIWANA</string>
     <string name="unsupported_version_description">W tej nieobsługiwanej wersji aplikacji prywatność może być zagrożona. Zaktualizuj już teraz.</string>
     <string name="unsupported_version_without_upgrade">Używasz nieobsługiwanej wersji aplikacji.</string>
-    <string name="update_available">DOSTĘPNA JEST AKTUALIZACJA</string>
-    <string name="update_available_description">Aby być na bieżąco, zainstaluj Mullvad VPN (%1$s)</string>
     <string name="update_available_footer">Dostępna jest aktualizacja. Aby zachować bezpieczeństwo, pobierz ją.</string>
     <string name="update_dns_server_dialog_title">Zaktualizuj serwer DNS</string>
     <string name="update_list_name">Zaktualizuj nazwę listy</string>

--- a/android/lib/resource/src/main/res/values-pt/strings.xml
+++ b/android/lib/resource/src/main/res/values-pt/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">VERSÃO NÃO SUPORTADA</string>
     <string name="unsupported_version_description">A sua privacidade pode estar comprometida com uma versão não suportada da aplicação. Por favor efetue a atualização agora.</string>
     <string name="unsupported_version_without_upgrade">Está a executar uma versão da aplicação não suportada.</string>
-    <string name="update_available">ESTÁ DISPONÍVEL UMA ATUALIZAÇÃO</string>
-    <string name="update_available_description">Instalar o Mullvad VPN (%1$s) para ficar atualizado</string>
     <string name="update_available_footer">Atualização disponível, transfira-a para ficar seguro.</string>
     <string name="update_dns_server_dialog_title">Atualizar servidor DNS</string>
     <string name="update_list_name">Atualizar nome da lista</string>

--- a/android/lib/resource/src/main/res/values-ru/strings.xml
+++ b/android/lib/resource/src/main/res/values-ru/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">НЕПОДДЕРЖИВАЕМАЯ ВЕРСИЯ</string>
     <string name="unsupported_version_description">Эта версия приложения не поддерживается, что может угрожать неприкосновенности ваших данных. Обновите приложение.</string>
     <string name="unsupported_version_without_upgrade">Версия приложения, с которой вы работаете, не поддерживается.</string>
-    <string name="update_available">ЕСТЬ ОБНОВЛЕНИЕ</string>
-    <string name="update_available_description">Пользуйтесь актуальной версией — установите Mullvad VPN (%1$s)</string>
     <string name="update_available_footer">Вышло обновление. Установите его, чтобы защитить подключения.</string>
     <string name="update_dns_server_dialog_title">Обновить DNS-сервер</string>
     <string name="update_list_name">Обновление названия списка</string>

--- a/android/lib/resource/src/main/res/values-sv/strings.xml
+++ b/android/lib/resource/src/main/res/values-sv/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">VERSION UTAN STÖD</string>
     <string name="unsupported_version_description">Din sekretess kan vara utsatt för risk med den här appversionen som inte stöds. Uppdatera nu.</string>
     <string name="unsupported_version_without_upgrade">Du kör en appversion som inte stöds.</string>
-    <string name="update_available">UPPDATERING TILLGÄNGLIG</string>
-    <string name="update_available_description">Installera Mullvad VPN (%1$s) för att hålla dig uppdaterad</string>
     <string name="update_available_footer">Uppdatering tillgänglig. Ladda ned för att vara säker.</string>
     <string name="update_dns_server_dialog_title">Uppdatera DNS-server</string>
     <string name="update_list_name">Uppdatera listnamn</string>

--- a/android/lib/resource/src/main/res/values-th/strings.xml
+++ b/android/lib/resource/src/main/res/values-th/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">เวอร์ชันที่ไม่รองรับ</string>
     <string name="unsupported_version_description">ความเป็นส่วนตัวของคุณอาจมีความเสี่ยง ในขณะที่ใช้งานเวอร์ชันแอปที่ไม่ได้รับการสนับสนุนนี้ โปรดอัปเดตตอนนี้เลย</string>
     <string name="unsupported_version_without_upgrade">คุณกำลังใช้งานเวอร์ชันแอปที่ไม่ได้รับการสนับสนุน</string>
-    <string name="update_available">มีการอัปเดตให้ใช้งาน</string>
-    <string name="update_available_description">ติดตั้ง Mullvad VPN (%1$s) เพื่อรับอัปเดตล่าสุดอยู่เสมอ</string>
     <string name="update_available_footer">มีอัปเดตพร้อมใช้งาน ดาวน์โหลดเพื่อคงความปลอดภัยไว้</string>
     <string name="update_dns_server_dialog_title">อัปเดตเซิร์ฟเวอร์ DNS</string>
     <string name="update_list_name">อัปเดตชื่อรายการ</string>

--- a/android/lib/resource/src/main/res/values-tr/strings.xml
+++ b/android/lib/resource/src/main/res/values-tr/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">DESTEKLENMEYEN SÜRÜM</string>
     <string name="unsupported_version_description">Bu desteklenmeyen uygulama sürümüyle gizliliğiniz risk altında olabilir. Lütfen hemen güncelleyin.</string>
     <string name="unsupported_version_without_upgrade">Desteklenmeyen bir uygulama sürümünü kullanıyorsunuz.</string>
-    <string name="update_available">GÜNCELLEME MEVCUT</string>
-    <string name="update_available_description">Güncel kalmak için Mullvad VPN (%1$s) yükleyin</string>
     <string name="update_available_footer">Güncelleme mevcut, güvende kalmak için güncellemeyi indirin.</string>
     <string name="update_dns_server_dialog_title">DNS sunucusunu güncelle</string>
     <string name="update_list_name">Liste adını güncelle</string>

--- a/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">不受支持的版本</string>
     <string name="unsupported_version_description">此应用版本不受支持，因此您的隐私可能存在风险。请立即更新。</string>
     <string name="unsupported_version_without_upgrade">您正在运行不受支持的应用版本。</string>
-    <string name="update_available">有可用更新</string>
-    <string name="update_available_description">安装 Mullvad VPN (%1$s) 以保持最新状态</string>
     <string name="update_available_footer">有可用更新，请下载以保持安全。</string>
     <string name="update_dns_server_dialog_title">更新 DNS 服务器</string>
     <string name="update_list_name">更新列表名称</string>

--- a/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
@@ -333,8 +333,6 @@
     <string name="unsupported_version">不支援的版本</string>
     <string name="unsupported_version_description">此應用程式版本不受支援，因此您的隱私可能存在風險。請立即更新。</string>
     <string name="unsupported_version_without_upgrade">您所執行的應用程式版本不受支援。</string>
-    <string name="update_available">可用的更新</string>
-    <string name="update_available_description">安裝 Mullvad VPN (%1$s) 以維持最新狀態</string>
     <string name="update_available_footer">更新可用，請下載以維持安全。</string>
     <string name="update_dns_server_dialog_title">更新 DNS 伺服器</string>
     <string name="update_list_name">更新清單名稱</string>

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -145,8 +145,6 @@
     <string name="custom_tunnel_host_resolution_error">Unable to resolve host of custom tunnel. Try changing your settings.</string>
     <string name="is_offline">Your device is offline. The tunnel will automatically connect once your device is back online.</string>
     <string name="virtual_adapter_problem">Virtual adapter error</string>
-    <string name="update_available">UPDATE AVAILABLE</string>
-    <string name="update_available_description">Install Mullvad VPN (%1$s) to stay up to date</string>
     <string name="unsupported_version">UNSUPPORTED VERSION</string>
     <string name="unsupported_version_description">Your privacy might be at risk with this unsupported app version. Please update now.</string>
     <string name="unsupported_version_without_upgrade">You are running an unsupported app version.</string>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2315,9 +2315,6 @@ msgstr ""
 msgid "Importing new overrides might replace some previously imported overrides."
 msgstr ""
 
-msgid "Install Mullvad VPN (%s) to stay up to date"
-msgstr ""
-
 msgid "Invalid or missing value \"%s\""
 msgstr ""
 


### PR DESCRIPTION
This PR aims to remove the update available message from the in-app notification and settings. Instead of showing it in settings we'll instead just show the unsupported message.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6428)
<!-- Reviewable:end -->
