### PR TITLE
Document that it is round3 of the Kyber KEM we are using

### DIFF
--- a/talpid-tunnel-config-client/examples/tuncfg-server.rs
+++ b/talpid-tunnel-config-client/examples/tuncfg-server.rs
@@ -51,6 +51,7 @@ impl EphemeralPeer for EphemeralPeerImpl {
                             classic_mceliece_rust::encapsulate_boxed(&public_key, &mut rng);
                         (ciphertext.as_array().to_vec(), *shared_secret.as_array())
                     }
+                    // Kyber round3
                     "Kyber1024" => {
                         let public_key = kem_pubkey.key_data.as_slice();
                         let (ciphertext, shared_secret) =

--- a/talpid-tunnel-config-client/proto/ephemeralpeer.proto
+++ b/talpid-tunnel-config-client/proto/ephemeralpeer.proto
@@ -46,7 +46,7 @@ message EphemeralPeerRequestV1 {
 // The v1 request supports exactly two algorithms.
 // The algorithms can appear soletary or in mixed order:
 // - "Classic-McEliece-460896f", but explicitly identified as "Classic-McEliece-460896f-round3"
-// - "Kyber1024"
+// - "Kyber1024", this is round3 of the Kyber KEM
 message PostQuantumRequestV1 { repeated KemPubkeyV1 kem_pubkeys = 1; }
 
 message KemPubkeyV1 {

--- a/talpid-tunnel-config-client/src/kyber.rs
+++ b/talpid-tunnel-config-client/src/kyber.rs
@@ -1,3 +1,6 @@
+//! This module implements the Kyber round3 KEM as specified in:
+//! https://pq-crystals.org/kyber/data/kyber-specification-round3.pdf
+
 use pqc_kyber::KYBER_CIPHERTEXTBYTES;
 pub use pqc_kyber::{keypair, KyberError, SecretKey};
 


### PR DESCRIPTION
We had not stated what exact version of the Kyber KEM we were using for the quantum-resistant tunnels. The dependency we rely on for the implementation ([`pqc_kyber`](https://crates.io/crates/pqc_kyber)) is also very vague on this point. This makes it near impossible to figure out what protocol spec we use just by looking at the app code. I synchronized with the relay software team just to make sure I got it right. We use round3 of Kyber. I figured it's very valuable to have this documented in the app as well. Important when we evaluate potential replacements for `pqc_kyber` (a nearly dead create we should probably swap from in the near future?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6444)
<!-- Reviewable:end -->
