### PR TITLE
Prevent user from selecting same entry and exit relay for multihop

### DIFF
--- a/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsDataSource.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsDataSource.swift
@@ -161,10 +161,6 @@ extension AddLocationsDataSource {
     func nodeShouldBeSelected(_ node: LocationNode) -> Bool {
         customListLocationNode.children.contains(node)
     }
-
-    func excludedRelayTitle(_ node: LocationNode) -> String? {
-        nil // N/A
-    }
 }
 
 // MARK: - Toggle selection in table view

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -209,7 +209,6 @@ class LocationCell: UITableViewCell {
 
     private func updateDisabled(_ isDisabled: Bool) {
         locationLabel.alpha = isDisabled ? 0.2 : 1
-        collapseButton.alpha = isDisabled ? 0.2 : 1
 
         if isDisabled {
             accessibilityTraits.insert(.notEnabled)
@@ -339,14 +338,14 @@ extension LocationCell {
             }
         }
 
-        setExcludedRelayTitle(item.excludedRelayTitle)
         setBehavior(behavior)
     }
 
-    private func setExcludedRelayTitle(_ title: String?) {
-        if let title {
-            locationLabel.text! += " (\(title))"
-            updateDisabled(true)
+    func setExcluded(relayTitle: String? = nil) {
+        updateDisabled(true)
+
+        if let relayTitle {
+            locationLabel.text! += " (\(relayTitle))"
         }
     }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDiffableDataSourceProtocol.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDiffableDataSourceProtocol.swift
@@ -14,7 +14,6 @@ protocol LocationDiffableDataSourceProtocol: UITableViewDiffableDataSource<Locat
     var sections: [LocationSection] { get }
     func nodeShowsChildren(_ node: LocationNode) -> Bool
     func nodeShouldBeSelected(_ node: LocationNode) -> Bool
-    func excludedRelayTitle(_ node: LocationNode) -> String?
 }
 
 extension LocationDiffableDataSourceProtocol {
@@ -40,10 +39,7 @@ extension LocationDiffableDataSourceProtocol {
         }
     }
 
-    func toggledItems(
-        for cell: LocationCell,
-        excludedRelayTitleCallback: ((LocationNode) -> String?)? = nil
-    ) -> [[LocationCellViewModel]] {
+    func toggledItems(for cell: LocationCell) -> [[LocationCellViewModel]] {
         guard let indexPath = tableView.indexPath(for: cell),
               let item = itemIdentifier(for: indexPath) else { return [[]] }
 
@@ -54,7 +50,7 @@ extension LocationDiffableDataSourceProtocol {
         item.node.showsChildren = !isExpanded
 
         if !isExpanded {
-            locationList.addSubNodes(from: item, at: indexPath, excludedRelayTitleCallback: excludedRelayTitleCallback)
+            locationList.addSubNodes(from: item, at: indexPath)
         } else {
             locationList.removeSubNodes(from: item.node)
         }
@@ -103,8 +99,7 @@ extension LocationDiffableDataSourceProtocol {
                     section: section,
                     node: childNode,
                     indentationLevel: indentationLevel,
-                    isSelected: nodeShouldBeSelected(childNode),
-                    excludedRelayTitle: excludedRelayTitle(childNode)
+                    isSelected: nodeShouldBeSelected(childNode)
                 )
             )
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/RelaySelection.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/RelaySelection.swift
@@ -12,11 +12,4 @@ struct RelaySelection {
     var selected: UserSelectedRelays?
     var excluded: UserSelectedRelays?
     var excludedTitle: String?
-
-    var hasExcludedRelay: Bool {
-        if excluded?.locations.count == 1, case .hostname = excluded?.locations.first {
-            return true
-        }
-        return false
-    }
 }


### PR DESCRIPTION
When displaying either the entry or exit location lists, any location (country, city or relay) shouldn't be selectable if, after apply all other constraints, the location item resolves to a single candidate that is already selected by the entry.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6455)
<!-- Reviewable:end -->
