### PR TITLE
Fix browser download script

### DIFF
--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -65,7 +65,7 @@ function main() {
     fi
 
     echo "[#] $PACKAGE_FILENAME has changed"
-    ln -f "$PACKAGE_FILENAME" $WORKDIR/
+    ln -f "$PACKAGE_FILENAME" "$WORKDIR/"
 }
 
 if [[ ${1:-} == "-h" ]] || [[ ${1:-} == "--help" ]]; then
@@ -81,7 +81,7 @@ fi
 
 if ! [[ -d $WORKDIR ]]; then
     echo "[#] Creating $WORKDIR"
-    mkdir -p $WORKDIR
+    mkdir -p "$WORKDIR"
 fi
 
 

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -31,13 +31,13 @@ function main() {
     SIGNATURE_URL=$PACKAGE_URL.asc
 
     echo "[#] Downloading $PACKAGE_FILENAME"
-    if ! wget --quiet --show-progress "$PACKAGE_URL"; then
+    if ! wget --quiet "$PACKAGE_URL"; then
         echo "[!] Failed to download $PACKAGE_URL"
         exit 1
     fi
 
     echo "[#] Downloading $PACKAGE_FILENAME.asc"
-    if ! wget --quiet --show-progress "$SIGNATURE_URL"; then
+    if ! wget --quiet "$SIGNATURE_URL"; then
         echo "[!] Failed to download $SIGNATURE_URL"
         exit 1
     fi

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -84,6 +84,11 @@ fi
 
 
 pushd "$TMP_DIR" > /dev/null
+function delete_tmp_dir {
+    echo "[#] Exiting and deleting $TMP_DIR"
+    rm -rf "$TMP_DIR"
+}
+trap 'delete_tmp_dir' EXIT
 
 
 echo "[#] Configured releases are: ${BROWSER_RELEASES[*]}"
@@ -108,6 +113,3 @@ for repository in "${REPOSITORIES[@]}"; do
     echo "[#] Notifying $repository_notify_file"
     echo "$REPOSITORY_TMP_ARTIFACT_DIR" > "$repository_notify_file"
 done
-
-# Remove our temporary working directory
-rm -r "$TMP_DIR"

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -6,8 +6,10 @@ set -eu
 # BROWSER_RELEASES=("alpha" "stable")
 BROWSER_RELEASES=("stable")
 REPOSITORIES=("stable" "beta")
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TMP_DIR=$(mktemp -qdt mullvad-browser-tmp-XXXXXXX)
-WORKDIR=/tmp/mullvad-browser-download
+WORKDIR="$SCRIPT_DIR/mullvad-browser-download"
 NOTIFY_DIR=/tmp/linux-repositories/production
 
 

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -63,7 +63,7 @@ function main() {
     fi
 
     echo "[#] $PACKAGE_FILENAME has changed"
-    ln "$PACKAGE_FILENAME" $WORKDIR/
+    ln -f "$PACKAGE_FILENAME" $WORKDIR/
 }
 
 if [[ ${1:-} == "-h" ]] || [[ ${1:-} == "--help" ]]; then


### PR DESCRIPTION
A missing `-f` made the `ln` command exit with a `File exists` error. I don't think this script was ever tested with upgrades when the destination already existed :sweat_smile:

Except from crippling the download script from actually publishing new browsers, this also left a ton of temporary downloads in `/tmp/mullvad-browser-tmp-.....`. I fixed this my moving the cleanup to a signal trap. This means the cleanup code always run on script exit, even if it exits prematurely due to a failing command.

I took the opportunity to do two other minor cleanups of the scripts here also:

1. Stop `wget` from printing very verbose progress. This filled up the systemd logs. The progress is not needed.
2. Store the latest known browser artifacts in the script dir instead of `/tmp`. This keeps the data closer to the script. This results in `/tmp` only being used for actual temporary files created and deleted during a single run of this script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6469)
<!-- Reviewable:end -->
