### PR TITLE
Exclude ci/ directory from triggering heavy Rust CI jobs

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -11,6 +11,8 @@ on:
       - '!audits/**'
       - '!build-apk.sh'
       - '!build.sh'
+      - '!ci/**'
+      - 'ci/check-rust.sh'
       - '!clippy.toml'
       - '!deny.toml'
       - '!docs/**'

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -12,6 +12,7 @@ on:
       - '!audits/**'
       - '!build-apk.sh'
       - '!build.sh'
+      - '!ci/**'
       - '!clippy.toml'
       - '!deny.toml'
       - '!docs/**'


### PR DESCRIPTION
I noticed in #6469 that it triggered heavy Rust CI jobs. These should not be needed. So I went ahead and excluded the `ci/` dir from the list of files that trigger those jobs. However `ci/check-rust.sh`, is a dependency on the main CI job, so that is included again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6470)
<!-- Reviewable:end -->
