### PR TITLE
Fix more browser download bugs

### DIFF
--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -47,6 +47,7 @@ function main() {
     echo "[#] Verifying $PACKAGE_FILENAME signature"
     if ! gpg --verify "$PACKAGE_FILENAME".asc; then
         echo "[!] Failed to verify signature"
+        rm "$PACKAGE_FILENAME" "$PACKAGE_FILENAME.asc"
         exit 1
     fi
     rm "$PACKAGE_FILENAME.asc"

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -65,7 +65,8 @@ function main() {
     fi
 
     echo "[#] $PACKAGE_FILENAME has changed"
-    ln -f "$PACKAGE_FILENAME" "$WORKDIR/"
+    cp "$PACKAGE_FILENAME" "$WORKDIR/"
+    # Leaving a file in `$TMP_DIR` is used as an indicator further down that something changed
 }
 
 if [[ ${1:-} == "-h" ]] || [[ ${1:-} == "--help" ]]; then

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -110,7 +110,7 @@ for repository in "${REPOSITORIES[@]}"; do
     inbox_dir="$NOTIFY_DIR/$repository"
 
     REPOSITORY_TMP_ARTIFACT_DIR=$(mktemp -qdt mullvad-browser-tmp-XXXXXXX)
-    cp "$TMP_DIR"/* "$REPOSITORY_TMP_ARTIFACT_DIR"
+    cp "$WORKDIR"/* "$REPOSITORY_TMP_ARTIFACT_DIR"
 
     repository_notify_file="$inbox_dir/browser.src"
     echo "[#] Notifying $repository_notify_file"


### PR DESCRIPTION
Follow up to #6469 from yesterday. I noticed further issues. The hard linking with `ln` stopped working when we moved the working directory off of `/tmp` as hard links do not work cross filesystems. So I tried to be less "smart" and just copy the file instead. This means we don't have the implicit requirement that workdirs and tmp dirs have to be on the same filesystem.

I also made it so we publish apps from the WORKDIR instead of the tmp dir. This ensures that all our "latest known browsers" are published at all times. For example with the old script. If it downloaded only the deb and not the rpm for some reason (this should not happen) then it would only publish the deb and remove the rpm from the repos. This is not desired. Instead if we always publish from WORKDIR we will be sure to include all types of artifacts even if only one happens to get an update.

Also some minor cleanup of files when signature verification fails. Not critical for the functionality, but makes sure we leave less stuff behind. Can be important since the existance of files in `TMP_DIR` is used as an indicator of whether or not there is anything new to publish.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6472)
<!-- Reviewable:end -->
