### PR TITLE
Update wireguard-apple

### DIFF
--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.20.14
 
       - name: Set up yeetd to workaround XCode being slow in CI
         run: |

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.20.14
 
       - name: Set up yeetd to workaround XCode being slow in CI
         run: |

--- a/.github/workflows/ios-validate-build-schemas.yml
+++ b/.github/workflows/ios-validate-build-schemas.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.20.14
 
       - name: Set up yeetd to workaround XCode being slow in CI
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.20.14
 
       - name: Set up yeetd to workaround XCode being slow in CI
         run: |

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9111,7 +9111,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = 15242e1698fc45261285d7417ed2cd5130d7332e;
+				revision = 5f24cdf1aa7fc1802f1695473aab95b4451e4ba0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "15242e1698fc45261285d7417ed2cd5130d7332e"
+        "revision" : "5f24cdf1aa7fc1802f1695473aab95b4451e4ba0"
       }
     }
   ],

--- a/ios/PacketTunnel/WireGuardAdapter/WireGuardAdapterError+Localization.swift
+++ b/ios/PacketTunnel/WireGuardAdapter/WireGuardAdapterError+Localization.swift
@@ -35,6 +35,8 @@ extension WireGuardAdapterError: LocalizedError {
 
         case let .startWireGuardBackend(code):
             return "Failure to start WireGuard backend (error code: \(code))."
+        case .noInterfaceIp:
+            return "Interface has no IP address specified."
         }
     }
 }

--- a/ios/build-wireguard-go.sh
+++ b/ios/build-wireguard-go.sh
@@ -37,6 +37,8 @@ fi
 WIREGUARD_KIT_GO_PATH="$RESOLVED_SOURCE_PACKAGES_PATH/checkouts/wireguard-apple/Sources/WireGuardKitGo"
 echo "WireGuardKitGo path resolved to $WIREGUARD_KIT_GO_PATH"
 
+export PATH=/opt/homebrew/opt/go@1.20/bin:$PATH
+
 # Run make
 # shellcheck disable=SC2086
 /usr/bin/make -C "$WIREGUARD_KIT_GO_PATH" $ACTION


### PR DESCRIPTION
This updates the commit hash to the current [`mullvad-master` of `wireguard-apple`](https://github.com/mullvad/wireguard-apple/commit/5f24cdf1aa7fc1802f1695473aab95b4451e4ba0). Along with these changes, we have to handle one more wg-go error and the WireGuard-go buildscript has been changed to rely on go 1.20, as installed via `brew install go@1.20`. This is so that multiple installations can remain active in case we need to revert this commit without making changes to our buildserver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6473)
<!-- Reviewable:end -->
