### PR TITLE
Improve the `psk-exchange-example`

### DIFF
--- a/talpid-tunnel-config-client/examples/psk-exchange.rs
+++ b/talpid-tunnel-config-client/examples/psk-exchange.rs
@@ -25,8 +25,8 @@ async fn main() {
         true,
         false,
     )
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     println!("private key: {private_key:?}");
     println!("psk: {:?}", ephemeral_peer.psk);

--- a/talpid-tunnel-config-client/examples/psk-exchange.rs
+++ b/talpid-tunnel-config-client/examples/psk-exchange.rs
@@ -29,5 +29,5 @@ async fn main() {
         .unwrap();
 
     println!("private key: {private_key:?}");
-    println!("psk: {:?}", ephemeral_peer.psk);
+    println!("psk: {:?}", ephemeral_peer.psk.unwrap());
 }

--- a/talpid-tunnel-config-client/examples/psk-exchange.rs
+++ b/talpid-tunnel-config-client/examples/psk-exchange.rs
@@ -11,23 +11,26 @@ async fn main() {
         .next()
         .expect("Give tuncfg server IP as first argument")
         .parse()
-        .expect("tuncfg ip argument not a valid IP");
-    let pubkey_string = args
+        .expect("tuncfg ip argument not a valid IPv4");
+    let public_key_string = args
         .next()
         .expect("Give WireGuard public key as second argument");
-    let pubkey = PublicKey::from_base64(pubkey_string.trim()).expect("Invalid public key");
-    let private_key = PrivateKey::new_from_random();
+    let public_key = PublicKey::from_base64(&public_key_string).expect("Invalid public key");
+    // The ephemeral peer requires an ephemeral public WireGuard key,
+    // which can also be provided by other means.
+    let ephemeral_private_key = PrivateKey::new_from_random();
 
     let ephemeral_peer = talpid_tunnel_config_client::request_ephemeral_peer(
         tuncfg_server_ip,
-        pubkey,
-        private_key.public_key(),
-        true,
-        false,
+        public_key, // Parent connection's public key.
+        ephemeral_private_key.public_key(),
+        true, // Whether to negotiate a "PQ-safe" PSK
+        false, // Whether to use DAITA. (Does not work with Linux kernel WireGuard.)
     )
         .await
         .unwrap();
 
-    println!("private key: {private_key:?}");
+    println!("private key: {ephemeral_private_key}");
+    // Use fmt::Debug since Serialize is not implemented for PresharedKey.
     println!("psk: {:?}", ephemeral_peer.psk.unwrap());
 }


### PR DESCRIPTION
I recently played around with the PSK exchange example in order to get my tunnels using upstream WireGuard to also support the "quantum resistant PSK" and there were some things upon which I stumbled, so I decided to improve them.

I tried to run the program with the service's IPv6 (`fc00:bbbb:bbbb:bb01::1`) which failed since `request_ephemeral_peer` only supports IPv4. It was also weird that the PSK got output as a wrapped value instead of a mere Base64 string and it seemed peculiar to me that both keys were output in debug mode.
I also made it clearer that one of the expected keys is the public key of the parent connection and the other is an ephemeral key which is discarded after configuring the interface.

The PSK is now output as an unwrapped value. There are comments explaining that any ephemeral public key will suffice for the peer negotiation and why the PSK is printed in debug mode. The error message specifies that an IPv4 is expected. And after reading up on DAITA another comment explains that it does not work with the upstream WireGuard.

I think with these changes the example is also very suitable for third parties.

The change can be tested in whatever way you tested the program before. I personally would have preferred "Private key:" and "PSK:" for the output, but did not change it in case any of your tests rely on parsing exactly that output.
The only change in behaviour is that the PSK is output as `psk: [32 byte as base64]` instead of the wrapped `psk: Some([32 byte as base64])` which I can't imagine to have been intentional. I could not find anything referring to `psk-exchange` so you have at least no public test relying on it, but if you have any tests that use it, make sure to adjust them.
Manually it can be tested by compiling it and then running `./psk-exchange 10.64.0.1 <public_key>` through a Mullvad WireGuard tunnel while providing the public key of that tunnel.

I would have preferred to let the user optionally also provide the ephemeral public key as argument, but my Rust knowledge is not extensive enough to do so in a succinct manner. What I tried caused the example to become too bloated and therefore unsuitable as an example, so I dropped it. For my own usage I have a binary which only takes the public keys and does not generate a key itself, which is also succinct. So maybe just adding a second example for that case would be the right choice.