### PR TITLE
Update rexml to 3.3.2 for fastlane

### DIFF
--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - ios/*
+  pull_request:
+    paths:
+      - ios/Gemfile
+      - ios/Gemfile.lock
   workflow_dispatch:
 jobs:
   test:

--- a/ci/ios/upload-vm/Gemfile.lock
+++ b/ci/ios/upload-vm/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.9)
+    rexml (3.3.2)
       strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.9)
+    rexml (3.3.2)
       strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)


### PR DESCRIPTION
Updating `rexml` dependency to `3.3.2` due to [[CVE-2024-39908](https://osv.dev/vulnerability/CVE-2024-39908)](https://osv.dev/vulnerability/GHSA-4xqq-m2hx-25v8).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6478)
<!-- Reviewable:end -->
