### PR TITLE
Fix burst daemon events being missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Line wrap the file at 100 chars.                                              Th
 - Update Electron from 28.1.3 to 30.0.4.
 
 ### Fixed
+- Fix mullvad cli bug causing `mullvad status listen` command to miss events if they occurred
+  too quickly.
+
 #### Windows
 - Fix race condition that could result in crashes when DAITA was enabled during disconnects.
 

--- a/mullvad-cli/src/cmds/status.rs
+++ b/mullvad-cli/src/cmds/status.rs
@@ -27,7 +27,8 @@ impl Status {
     pub async fn listen(mut rpc: MullvadProxyClient, args: StatusArgs) -> Result<()> {
         let mut previous_tunnel_state = None;
 
-        while let Some(event) = rpc.events_listen().await?.next().await {
+        let mut event_stream = rpc.events_listen().await?;
+        while let Some(event) = event_stream.next().await {
             match event? {
                 DaemonEvent::TunnelState(new_state) => {
                     if args.debug {


### PR DESCRIPTION
The daemon event stream was reset between every item, which caused events to be missed if they arrive while the previous item was being handled.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6479)
<!-- Reviewable:end -->
