### PR TITLE
Add initial github CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Defining who has to review changes to what files.
+# Try to keep the entries sorted alphabetically, so they end up in the same order as
+# they would if you listed the entire repository as a tree.
+
+# Container images used for building the app are owned by respective team leads and tech lead
+/building/android-container-image.txt @faern @albin-mullvad
+/building/linux-container-image.txt @faern @raksooo
+
+# Developer signing keys must be approved by team/tech leads
+/ci/keys/ @faern @raksooo @pinkisemils @albin-mullvad
+
+# Desktop build server files owned by desktop leads
+/ci/buildserver* @faern @raksooo
+/ci/linux-repository-builder/ @faern @raksooo
+
+# Cargo deny config must be approved by tech lead or desktop team lead
+**/deny.toml @faern @raksooo
+
+# Changes to what CVEs are ignored must be approved by leads
+**/osv-scanner.toml @faern @raksooo @pinkisemils @albin-mullvad
+/.github/workflows/osv-scanner*.yml @faern @raksooo @pinkisemils @albin-mullvad
+
+# The CODEOWNERS itself must be protected from unauthorized changes,
+# otherwise the protection becomes quite moot.
+# Keep this entry last, so it is sure to override any existing previous wildcard match
+/.github/CODEOWNERS @faern @raksooo @pinkisemils @albin-mullvad

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -6,6 +6,7 @@ on:
       - '**'
       - '!.github/workflows/**'
       - '.github/workflows/android-app.yml'
+      - '!.github/CODEOWNERS'
       - '!audits/**'
       - '!ci/**'
       - '!dist-assets/**'

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -7,6 +7,7 @@ on:
       - '!**/**.md'
       - '!.github/workflows/**'
       - '.github/workflows/daemon.yml'
+      - '!.github/CODEOWNERS'
       - '!android/**'
       - '!audits/**'
       - '!build-apk.sh'

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/verify-locked-down-signatures.yml
+      - .github/CODEOWNERS
       - Cargo.toml
       - test/Cargo.toml
       - Cargo.lock


### PR DESCRIPTION
Limits a bit who has to approve changes to what files. This is far from complete, but rather testing out the system. Some of the more important files have been added for the sake of evaluating this in this repository.

You can read more about CODEOWNERS here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

The idea here is to use security features built into github for further protecting certain more important files. It can also help someone submitting a PR finding a suitable reviewer/automatically assigning a suitable reviewer.

Once we have this in place I intend to add to our branch protection rules that the CODEOWNERS must be respected in order to allow merges of PRs. By default it is not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6480)
<!-- Reviewable:end -->
