### PR TITLE
Structure error handling in `test_automatic_wireguard_rotation`

### DIFF
--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -25,7 +25,7 @@ use talpid_types::net::{obfuscation::ObfuscatorConfig, wireguard, TunnelParamete
 
 use talpid_types::{tunnel::ParameterGenerationError, ErrorExt};
 
-use crate::device::{AccountManagerHandle, PrivateAccountAndDevice};
+use crate::device::{AccountManagerHandle, Error as DeviceError, PrivateAccountAndDevice};
 
 /// The IP-addresses that the client uses when it connects to a server that supports the
 /// "Same IP" functionality. This means all clients have the same in-tunnel IP on these
@@ -49,6 +49,9 @@ pub enum Error {
 
     #[error("Failed to resolve hostname for custom relay")]
     ResolveCustomHostname,
+
+    #[error("Failed to get device data")]
+    Device(#[from] DeviceError),
 }
 
 #[derive(Clone)]
@@ -257,13 +260,8 @@ impl InnerParametersGenerator {
     }
 
     async fn device(&self) -> Result<PrivateAccountAndDevice, Error> {
-        self.account_manager
-            .data()
-            .await
-            .map(|s| s.into_device())
-            .ok()
-            .flatten()
-            .ok_or(Error::NoAuthDetails)
+        let device_state = self.account_manager.data().await?;
+        device_state.into_device().ok_or(Error::NoAuthDetails)
     }
 }
 
@@ -279,22 +277,30 @@ impl TunnelParametersGenerator for ParametersGenerator {
             inner
                 .generate(retry_attempt, ipv6)
                 .await
-                .map_err(|error| match error {
-                    Error::SelectRelay(mullvad_relay_selector::Error::NoBridge) => {
-                        ParameterGenerationError::NoMatchingBridgeRelay
-                    }
-                    Error::ResolveCustomHostname => {
-                        ParameterGenerationError::CustomTunnelHostResultionError
-                    }
-                    error => {
-                        log::error!(
-                            "{}",
-                            error.display_chain_with_msg("Failed to generate tunnel parameters")
-                        );
-                        ParameterGenerationError::NoMatchingRelay
-                    }
+                .inspect_err(|error| {
+                    log::error!(
+                        "{}",
+                        error.display_chain_with_msg("Failed to generate tunnel parameters")
+                    );
                 })
+                .map_err(ParameterGenerationError::from)
         })
+    }
+}
+
+impl From<Error> for ParameterGenerationError {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::SelectRelay(mullvad_relay_selector::Error::NoBridge) => {
+                ParameterGenerationError::NoMatchingBridgeRelay
+            }
+            Error::ResolveCustomHostname => {
+                ParameterGenerationError::CustomTunnelHostResultionError
+            }
+            Error::NoAuthDetails | Error::SelectRelay(_) | Error::Device(_) => {
+                ParameterGenerationError::NoMatchingRelay
+            }
+        }
     }
 }
 

--- a/mullvad-management-interface/src/types/conversions/device.rs
+++ b/mullvad-management-interface/src/types/conversions/device.rs
@@ -78,9 +78,9 @@ impl From<mullvad_types::device::DeviceState> for proto::DeviceState {
     fn from(state: mullvad_types::device::DeviceState) -> Self {
         proto::DeviceState {
             state: proto::device_state::State::from(&state) as i32,
-            device: state.into_device().map(|device| proto::AccountAndDevice {
-                account_token: device.account_token,
-                device: Some(proto::Device::from(device.device)),
+            device: state.logged_in().map(|client| proto::AccountAndDevice {
+                account_token: client.account_token,
+                device: Some(proto::Device::from(client.device)),
             }),
         }
     }

--- a/mullvad-types/src/device.rs
+++ b/mullvad-types/src/device.rs
@@ -50,22 +50,17 @@ pub enum DeviceState {
 }
 
 impl DeviceState {
-    pub fn into_device(self) -> Option<AccountAndDevice> {
+    /// Returns the active account and device if the device is currently logged in to a valid
+    /// account.
+    pub fn logged_in(self) -> Option<AccountAndDevice> {
         match self {
-            DeviceState::LoggedIn(dev) => Some(dev),
+            DeviceState::LoggedIn(client) => Some(client),
             _ => None,
         }
     }
 
-    pub fn is_logged_in(&self) -> bool {
+    pub const fn is_logged_in(&self) -> bool {
         matches!(self, Self::LoggedIn(_))
-    }
-
-    pub fn get_account(&self) -> Option<&AccountAndDevice> {
-        match self {
-            DeviceState::LoggedIn(ref account) => Some(account),
-            _ => None,
-        }
     }
 }
 

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -92,6 +92,7 @@ pub async fn run(
             logger.store_records(true);
         }
 
+        // TODO: Log how long each test took to run.
         let test_result = run_test(
             client.clone(),
             mullvad_client,

--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -209,8 +209,8 @@ pub async fn test_uninstall_app(
         .get_device()
         .await
         .context("failed to get device data")?
-        .into_device()
-        .context("failed to get device")?
+        .logged_in()
+        .context("Client is not logged in to a valid account")?
         .device
         .id;
 

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -80,7 +80,7 @@ pub async fn cleanup_after_test(
     rpc_provider: &RpcClientProvider,
 ) -> anyhow::Result<()> {
     log::debug!("Resetting daemon settings after test");
-    // Check if daemon should be restarted
+    // Check if daemon should be restarted.
     restart_daemon(rpc).await?;
     let mut mullvad_client = rpc_provider.new_client().await;
     mullvad_client


### PR DESCRIPTION
This PR overhauls `test_automatic_wireguard_rotation` to use `anyhow` to propagate error values instead of panicking, which is a commonly used strategy in other end-to-end tests. These are the fruits of some work investigating flakiness related to the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6490)
<!-- Reviewable:end -->
