### PR TITLE
Fix desktop e2e GitHub action false negatives

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -22,6 +22,7 @@ on:
         type: string
 jobs:
   prepare-matrices:
+    name: Prepare virtual machines
     runs-on: ubuntu-latest
     steps:
       - name: Generate matrix for Linux builds
@@ -72,6 +73,7 @@ jobs:
       macos_matrix: ${{ env.macos_matrix }}
 
   prepare-linux:
+    name: Prepare Linux build container
     needs: prepare-matrices
     if: |
       needs.prepare-matrices.outputs.linux_matrix != '[]' &&
@@ -91,6 +93,7 @@ jobs:
     outputs:
       container_image: ${{ env.inner_container_image }}
   build-linux:
+    name: Build Linux
     needs: prepare-linux
     runs-on: ubuntu-latest
     container:
@@ -156,6 +159,7 @@ jobs:
           path: ./test/.ci-logs/${{ matrix.os }}_report
 
   build-windows:
+    name: Build Windows
     needs: prepare-matrices
     if: |
       needs.prepare-matrices.outputs.windows_matrix != '[]' &&
@@ -230,6 +234,7 @@ jobs:
           path: ./test/.ci-logs/${{ matrix.os }}_report
 
   build-macos:
+    name: Build macOS
     needs: prepare-matrices
     if: |
       needs.prepare-matrices.outputs.macos_matrix != '[]' &&

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -126,7 +126,10 @@ jobs:
   e2e-test-linux:
     name: Linux end-to-end tests
     needs: [prepare-matrices, build-linux]
-    if: '!cancelled()'
+    if: |
+      !cancelled() &&
+      needs.prepare-matrices.outputs.linux_matrix != '[]' &&
+      needs.prepare-matrices.outputs.linux_matrix != ''
     runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
     timeout-minutes: 240
     strategy:
@@ -196,7 +199,10 @@ jobs:
 
   e2e-test-windows:
     needs: [prepare-matrices, build-windows]
-    if: '!cancelled()'
+    if: |
+      !cancelled() &&
+      needs.prepare-matrices.outputs.windows_matrix != '[]' &&
+      needs.prepare-matrices.outputs.windows_matrix != ''
     name: Windows end-to-end tests
     runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
     timeout-minutes: 240
@@ -263,7 +269,10 @@ jobs:
 
   e2e-test-macos:
     needs: [prepare-matrices, build-macos]
-    if: '!cancelled()'
+    if: |
+      !cancelled() &&
+      needs.prepare-matrices.outputs.macos_matrix != '[]' &&
+      needs.prepare-matrices.outputs.macos_matrix != ''
     name: macOS end-to-end tests
     runs-on: [self-hosted, desktop-test, macOS] # app-test-macos-arm
     timeout-minutes: 240


### PR DESCRIPTION
Add a precondition which checks if there are any VMs to test for the given OS. Without this check, the parsing of the VM names assumed that there would exist at least one, causing the parsing to fail if there were none. This would show up in the GitHub summary view as a failure.

Also, add some more descriptive names to other steps

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6491)
<!-- Reviewable:end -->
