### PR TITLE
Refactor test manager cleanup logic

### DIFF
--- a/test/scripts/ssh-setup.sh
+++ b/test/scripts/ssh-setup.sh
@@ -17,7 +17,7 @@ echo "Copying test-runner to $RUNNER_DIR"
 mkdir -p "$RUNNER_DIR"
 
 for file in test-runner connection-checker $APP_PACKAGE $PREVIOUS_APP $UI_RUNNER; do
-    echo "Moving $file to $RUNNER_DIR"
+    echo "Moving $SCRIPT_DIR/$file to $RUNNER_DIR"
     cp -f "$SCRIPT_DIR/$file" "$RUNNER_DIR"
 done
 
@@ -106,6 +106,7 @@ fi
 setup_systemd
 
 function install_packages_apt {
+    echo "Installing required apt packages"
     apt update
     apt install -yf xvfb wireguard-tools curl
     curl -fsSL https://get.docker.com | sh

--- a/test/scripts/test-utils.sh
+++ b/test/scripts/test-utils.sh
@@ -50,7 +50,7 @@ function get_package_dir {
     local package_dir
     if [[ -n "${PACKAGE_DIR+x}" ]]; then
         # Resolve the package dir to an absolute path since cargo must be invoked from the test directory
-        package_dir=$(cd "$PACKAGE_DIR" > /dev/null && pwd)
+        package_dir=$(realpath "$PACKAGE_DIR")
     elif [[ ("$(uname -s)" == "Darwin") ]]; then
         package_dir="$HOME/Library/Caches/mullvad-test/packages"
     elif [[ ("$(uname -s)" == "Linux") ]]; then

--- a/test/test-manager/src/logging.rs
+++ b/test/test-manager/src/logging.rs
@@ -3,6 +3,8 @@ use colored::Colorize;
 use std::sync::{Arc, Mutex};
 use test_rpc::logging::{LogOutput, Output};
 
+use crate::summary;
+
 /// Logger that optionally supports logging records to a buffer
 #[derive(Clone)]
 pub struct Logger {
@@ -109,25 +111,94 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
+/// Encapsulate caught unwound panics, such that we can catch tests that panic and differentiate
+/// them from tests that just fail.
 #[derive(Debug, thiserror::Error)]
-#[error("Test panic: {0}")]
-pub struct PanicMessage(String);
+#[error("Test panic: {}", self.as_string())]
+pub struct Panic(Box<dyn std::any::Any + Send + 'static>);
+
+impl Panic {
+    /// Create a new [`Panic`] from a caught unwound panic.
+    pub fn new(result: Box<dyn std::any::Any + Send + 'static>) -> Self {
+        Self(result)
+    }
+
+    /// Convert this panic to a [`String`] representation.
+    pub fn as_string(&self) -> String {
+        if let Some(result) = self.0.downcast_ref::<String>() {
+            return result.clone();
+        }
+        match self.0.downcast_ref::<&str>() {
+            Some(s) => String::from(*s),
+            None => String::from("unknown message"),
+        }
+    }
+}
 
 pub struct TestOutput {
     pub error_messages: Vec<Output>,
     pub test_name: &'static str,
-    pub result: Result<Result<(), Error>, PanicMessage>,
+    pub result: TestResult,
     pub log_output: Option<LogOutput>,
+}
+
+// Convert this unwieldy return type to a workable `TestResult`.
+// What we are converting from is the acutal return type of the test execution.
+impl From<Result<Result<(), Error>, Panic>> for TestResult {
+    fn from(value: Result<Result<(), Error>, Panic>) -> Self {
+        match value {
+            Ok(Ok(())) => TestResult::Pass,
+            Ok(Err(e)) => TestResult::Fail(e),
+            Err(e) => TestResult::Panic(e),
+        }
+    }
+}
+
+/// Result from a test execution. This may carry information in case the test failed during
+/// execution.
+pub enum TestResult {
+    /// Test passed.
+    Pass,
+    /// Test failed during execution. Contains the source error which caused the test to fail.
+    Fail(Error),
+    /// Test panicked during execution. Contains the caught unwound panic.
+    Panic(Panic),
+}
+
+impl TestResult {
+    /// Returns `true` if test failed or panicked, i.e. when `TestResult` is `Fail` or `Panic`.
+    pub const fn failure(&self) -> bool {
+        matches!(self, TestResult::Fail(_) | TestResult::Panic(_))
+    }
+
+    /// Convert `self` to a [`summary::TestResult`], which is used for creating fancy exports of
+    /// the results for a test run.
+    pub const fn summary(&self) -> summary::TestResult {
+        match self {
+            TestResult::Pass => summary::TestResult::Pass,
+            TestResult::Fail(_) | TestResult::Panic(_) => summary::TestResult::Fail,
+        }
+    }
+
+    /// Consume `self` and convert into a [`Result`] where [`TestResult::Pass`] is mapped to [`Ok`]
+    /// while [`TestResult::Fail`] & [`TestResult::Panic`] is mapped to [`Err`].
+    pub fn anyhow(self) -> anyhow::Result<()> {
+        match self {
+            TestResult::Pass => Ok(()),
+            TestResult::Fail(error) => anyhow::bail!(error),
+            TestResult::Panic(error) => anyhow::bail!(error.to_string()),
+        }
+    }
 }
 
 impl TestOutput {
     pub fn print(&self) {
         match &self.result {
-            Ok(Ok(_)) => {
+            TestResult::Pass => {
                 println!("{}", format!("TEST {} SUCCEEDED!", self.test_name).green());
                 return;
             }
-            Ok(Err(e)) => {
+            TestResult::Fail(e) => {
                 println!(
                     "{}",
                     format!(
@@ -138,13 +209,13 @@ impl TestOutput {
                     .red()
                 );
             }
-            Err(panic_msg) => {
+            TestResult::Panic(panic_msg) => {
                 println!(
                     "{}",
                     format!(
                         "TEST {} PANICKED WITH MESSAGE: {}",
                         self.test_name,
-                        panic_msg.0.bold()
+                        panic_msg.as_string().bold()
                     )
                     .red()
                 );
@@ -189,15 +260,5 @@ impl TestOutput {
         }
 
         println!("{}", format!("TEST {} END OF OUTPUT", self.test_name).red());
-    }
-}
-
-pub fn panic_as_string(error: Box<dyn std::any::Any + Send + 'static>) -> PanicMessage {
-    if let Some(result) = error.downcast_ref::<String>() {
-        return PanicMessage(result.clone());
-    }
-    match error.downcast_ref::<&str>() {
-        Some(s) => PanicMessage(String::from(*s)),
-        None => PanicMessage(String::from("unknown message")),
     }
 }

--- a/test/test-manager/src/main.rs
+++ b/test/test-manager/src/main.rs
@@ -92,8 +92,9 @@ enum Commands {
         #[arg(long)]
         app_package: String,
 
-        /// App package to upgrade from when running `test_install_previous_app`, can be left empty
-        /// if this test is not ran. Parsed the same way as `--app-package`.
+        /// Given this argument, the `test_upgrade_app` test will run, which installs the previous
+        /// version then upgrades to the version specified in by `--app-package`. If left empty,
+        /// the test will be skipped. Parsed the same way as `--app-package`.
         ///
         /// # Note
         ///
@@ -336,7 +337,8 @@ async fn main() -> Result<()> {
                 instance.wait().await;
             }
             socks.close();
-            result
+            // Propagate any error from the test run if applicable
+            result?.anyhow()
         }
         Commands::FormatTestReports { reports } => {
             summary::print_summary_table(&reports).await;

--- a/test/test-manager/src/main.rs
+++ b/test/test-manager/src/main.rs
@@ -13,6 +13,7 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use tests::{config::TEST_CONFIG, get_filtered_tests};
 use vm::provision;
 
 use crate::tests::config::OpenVPNCertificate;
@@ -118,7 +119,8 @@ enum Commands {
         #[arg(long)]
         openvpn_certificate: Option<PathBuf>,
 
-        /// Only run tests matching substrings
+        /// Names of tests to run. The order given will be respected. If not set, all tests will be
+        /// run.
         test_filters: Vec<String>,
 
         /// Print results live
@@ -294,6 +296,28 @@ async fn main() -> Result<()> {
                 .await
                 .context("Failed to run provisioning for VM")?;
 
+            TEST_CONFIG.init(tests::config::TestConfig::new(
+                account,
+                artifacts_dir,
+                manifest
+                    .app_package_path
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned(),
+                manifest
+                    .app_package_to_upgrade_from_path
+                    .map(|path| path.file_name().unwrap().to_string_lossy().into_owned()),
+                manifest
+                    .gui_package_path
+                    .map(|path| path.file_name().unwrap().to_string_lossy().into_owned()),
+                mullvad_host,
+                vm::network::bridge()?,
+                test_rpc::meta::Os::from(vm_config.os_type),
+                openvpn_certificate,
+            ));
+            let tests = get_filtered_tests(&test_filters)?;
+
             // For convenience, spawn a SOCKS5 server that is reachable for tests that need it
             let socks = socks_server::spawn(SocketAddr::new(
                 crate::vm::network::NON_TUN_GATEWAY.into(),
@@ -303,35 +327,9 @@ async fn main() -> Result<()> {
 
             let skip_wait = vm_config.provisioner != config::Provisioner::Noop;
 
-            let result = run_tests::run(
-                tests::config::TestConfig::new(
-                    account,
-                    artifacts_dir,
-                    manifest
-                        .app_package_path
-                        .file_name()
-                        .unwrap()
-                        .to_string_lossy()
-                        .into_owned(),
-                    manifest
-                        .app_package_to_upgrade_from_path
-                        .map(|path| path.file_name().unwrap().to_string_lossy().into_owned()),
-                    manifest
-                        .gui_package_path
-                        .map(|path| path.file_name().unwrap().to_string_lossy().into_owned()),
-                    mullvad_host,
-                    vm::network::bridge()?,
-                    test_rpc::meta::Os::from(vm_config.os_type),
-                    openvpn_certificate,
-                ),
-                &*instance,
-                &test_filters,
-                skip_wait,
-                !verbose,
-                summary_logger,
-            )
-            .await
-            .context("Tests failed");
+            let result = run_tests::run(&*instance, tests, skip_wait, !verbose, summary_logger)
+                .await
+                .context("Tests failed");
 
             if display {
                 instance.wait().await;

--- a/test/test-manager/src/network_monitor.rs
+++ b/test/test-manager/src/network_monitor.rs
@@ -98,7 +98,7 @@ impl Codec {
                 payload = seg.payload().to_vec();
             }
             IpHeaderProtocols::Icmp => {}
-            proto => log::debug!("ignoring v4 packet, transport/protocol type {proto}"),
+            proto => log::warn!("ignoring v4 packet, transport/protocol type {proto}"),
         }
 
         Some(ParsedPacket {
@@ -140,7 +140,7 @@ impl Codec {
                 payload = seg.payload().to_vec();
             }
             IpHeaderProtocols::Icmpv6 => {}
-            proto => log::debug!("ignoring v6 packet, transport/protocol type {proto}"),
+            proto => log::warn!("ignoring v6 packet, transport/protocol type {proto}"),
         }
 
         Some(ParsedPacket {

--- a/test/test-manager/src/package.rs
+++ b/test/test-manager/src/package.rs
@@ -69,7 +69,7 @@ pub fn get_app_manifest(
     })
 }
 
-fn get_version_from_path(app_package_path: &Path) -> Result<String, anyhow::Error> {
+pub fn get_version_from_path(app_package_path: &Path) -> Result<String, anyhow::Error> {
     static VERSION_REGEX: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"\d{4}\.\d+((-beta\d+)?(-dev)?-([0-9a-z])+)?").unwrap());
 

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -147,9 +147,6 @@ pub async fn run(
 
     if !test_filters.is_empty() {
         tests.retain(|test| {
-            if test.always_run {
-                return true;
-            }
             for command in test_filters {
                 let command = command.to_lowercase();
                 if test.command.to_lowercase().contains(&command) {

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -30,7 +30,7 @@ pub async fn run(
 
     let pty_path = instance.get_pty();
 
-    log::info!("Connecting to {pty_path}");
+    log::debug!("Connecting to {pty_path}");
 
     let serial_stream =
         tokio_serial::SerialStream::open(&tokio_serial::new(pty_path, BAUD)).unwrap();

--- a/test/test-manager/src/run_tests.rs
+++ b/test/test-manager/src/run_tests.rs
@@ -1,14 +1,14 @@
 use crate::{
-    logging::{panic_as_string, TestOutput},
-    mullvad_daemon::{self, MullvadClientArgument},
-    summary::{self, maybe_log_test_result},
+    logging::{Logger, Panic, TestOutput, TestResult},
+    mullvad_daemon::{self, MullvadClientArgument, RpcClientProvider},
+    summary::SummaryLogger,
     tests::{self, config::TEST_CONFIG, get_tests, TestContext},
     vm,
 };
 use anyhow::{Context, Result};
 use futures::FutureExt;
 use std::{future::Future, panic, time::Duration};
-use test_rpc::{logging::Output, mullvad_daemon::MullvadClientVersion, ServiceClient};
+use test_rpc::{logging::Output, ServiceClient};
 
 /// The baud rate of the serial connection between the test manager and the test runner.
 /// There is a known issue with setting a baud rate at all or macOS, and the workaround
@@ -17,14 +17,97 @@ use test_rpc::{logging::Output, mullvad_daemon::MullvadClientVersion, ServiceCli
 /// Keep this constant in sync with `test-runner/src/main.rs`
 const BAUD: u32 = if cfg!(target_os = "macos") { 0 } else { 115200 };
 
+struct TestHandler<'a> {
+    rpc_provider: &'a RpcClientProvider,
+    test_runner_client: &'a ServiceClient,
+    failed_tests: Vec<&'static str>,
+    successful_tests: Vec<&'static str>,
+    summary_logger: Option<SummaryLogger>,
+    print_failed_tests_only: bool,
+    logger: Logger,
+}
+
+impl TestHandler<'_> {
+    /// Run `tests::test_upgrade_app` and register the result
+    async fn run_test<R, F>(
+        &mut self,
+        test: &F,
+        test_name: &'static str,
+        mullvad_client: MullvadClientArgument,
+    ) -> Result<(), anyhow::Error>
+    where
+        F: Fn(super::tests::TestContext, ServiceClient, MullvadClientArgument) -> R,
+        R: Future<Output = anyhow::Result<()>>,
+    {
+        log::info!("Running {test_name}");
+
+        if self.print_failed_tests_only {
+            // Stop live record
+            self.logger.store_records(true);
+        }
+
+        let test_output = run_test_function(
+            self.test_runner_client.clone(),
+            mullvad_client,
+            &test,
+            test_name,
+            TestContext {
+                rpc_provider: self.rpc_provider.clone(),
+            },
+        )
+        .await;
+
+        if self.print_failed_tests_only {
+            // Print results of failed test
+            if test_output.result.failure() {
+                self.logger.print_stored_records();
+            } else {
+                self.logger.flush_records();
+            }
+            self.logger.store_records(false);
+        }
+
+        test_output.print();
+
+        register_test_result(
+            test_output.result,
+            &mut self.failed_tests,
+            test_name,
+            &mut self.successful_tests,
+            self.summary_logger.as_mut(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    fn gather_results(self) -> TestResult {
+        log::info!("TESTS THAT SUCCEEDED:");
+        for test in self.successful_tests {
+            log::info!("{test}");
+        }
+
+        log::info!("TESTS THAT FAILED:");
+        for test in &self.failed_tests {
+            log::info!("{test}");
+        }
+
+        if self.failed_tests.is_empty() {
+            TestResult::Pass
+        } else {
+            TestResult::Fail(anyhow::anyhow!("Some tests failed"))
+        }
+    }
+}
+
 pub async fn run(
     config: tests::config::TestConfig,
     instance: &dyn vm::VmInstance,
     test_filters: &[String],
     skip_wait: bool,
     print_failed_tests_only: bool,
-    mut summary_logger: Option<summary::SummaryLogger>,
-) -> Result<()> {
+    summary_logger: Option<SummaryLogger>,
+) -> Result<TestResult> {
     log::trace!("Setting test constants");
     TEST_CONFIG.init(config);
 
@@ -43,11 +126,20 @@ pub async fn run(
 
     log::info!("Running client");
 
-    let client = ServiceClient::new(connection_handle.clone(), runner_transport);
-    let mullvad_client =
-        mullvad_daemon::new_rpc_client(connection_handle, mullvad_daemon_transport);
+    let test_runner_client = ServiceClient::new(connection_handle.clone(), runner_transport);
+    let rpc_provider = mullvad_daemon::new_rpc_client(connection_handle, mullvad_daemon_transport);
 
-    print_os_version(&client).await;
+    print_os_version(&test_runner_client).await;
+
+    let mut test_handler = TestHandler {
+        rpc_provider: &rpc_provider,
+        test_runner_client: &test_runner_client,
+        failed_tests: vec![],
+        successful_tests: vec![],
+        summary_logger,
+        print_failed_tests_only,
+        logger: Logger::get_or_init(),
+    };
 
     let mut tests = get_tests();
 
@@ -68,116 +160,65 @@ pub async fn run(
         });
     }
 
-    let mut final_result = Ok(());
-
-    let test_context = TestContext {
-        rpc_provider: mullvad_client,
+    if TEST_CONFIG.app_package_to_upgrade_from_filename.is_some() {
+        test_handler
+            .run_test(
+                &tests::test_upgrade_app,
+                "test_upgrade_app",
+                MullvadClientArgument::None,
+            )
+            .await?;
+    } else {
+        log::warn!("No previous app to upgrade from, skipping upgrade test");
     };
 
-    let mut successful_tests = vec![];
-    let mut failed_tests = vec![];
-
-    let logger = super::logging::Logger::get_or_init();
-
     for test in tests {
-        let mullvad_client = test_context
-            .rpc_provider
+        tests::prepare_daemon(&test_runner_client, &rpc_provider)
+            .await
+            .context("Failed to reset daemon before test")?;
+
+        let mullvad_client = rpc_provider
             .mullvad_client(test.mullvad_client_version)
             .await;
-
-        log::info!("Running {}", test.name);
-
-        if print_failed_tests_only {
-            // Stop live record
-            logger.store_records(true);
-        }
-
-        // TODO: Log how long each test took to run.
-        let test_result = run_test(
-            client.clone(),
-            mullvad_client,
-            &test.func,
-            test.name,
-            test_context.clone(),
-        )
-        .await;
-
-        if test.mullvad_client_version == MullvadClientVersion::New {
-            // Try to reset the daemon state if the test failed OR if the test doesn't explicitly
-            // disabled cleanup.
-            if test.cleanup || matches!(test_result.result, Err(_) | Ok(Err(_))) {
-                crate::tests::cleanup_after_test(client.clone(), &test_context.rpc_provider)
-                    .await?;
-            }
-        }
-
-        if print_failed_tests_only {
-            // Print results of failed test
-            if matches!(test_result.result, Err(_) | Ok(Err(_))) {
-                logger.print_stored_records();
-            } else {
-                logger.flush_records();
-            }
-            logger.store_records(false);
-        }
-
-        test_result.print();
-
-        let test_succeeded = matches!(test_result.result, Ok(Ok(_)));
-
-        maybe_log_test_result(
-            summary_logger.as_mut(),
-            test.name,
-            if test_succeeded {
-                summary::TestResult::Pass
-            } else {
-                summary::TestResult::Fail
-            },
-        )
-        .await
-        .context("Failed to log test result")?;
-
-        match test_result.result {
-            Err(panic) => {
-                failed_tests.push(test.name);
-                final_result = Err(panic).context("test panicked");
-                if test.must_succeed {
-                    break;
-                }
-            }
-            Ok(Err(failure)) => {
-                failed_tests.push(test.name);
-                final_result = Err(failure).context("test failed");
-                if test.must_succeed {
-                    break;
-                }
-            }
-            Ok(Ok(result)) => {
-                successful_tests.push(test.name);
-                final_result = final_result.and(Ok(result));
-            }
-        }
+        test_handler
+            .run_test(&test.func, test.name, mullvad_client)
+            .await?;
     }
 
-    log::info!("TESTS THAT SUCCEEDED:");
-    for test in successful_tests {
-        log::info!("{test}");
-    }
-
-    log::info!("TESTS THAT FAILED:");
-    for test in failed_tests {
-        log::info!("{test}");
-    }
+    let result = test_handler.gather_results();
 
     // wait for cleanup
-    drop(client);
-    drop(test_context);
+    drop(test_runner_client);
+    drop(rpc_provider);
     let _ = tokio::time::timeout(Duration::from_secs(5), completion_handle).await;
 
-    final_result
+    Ok(result)
 }
 
-pub async fn run_test<F, R>(
+async fn register_test_result(
+    test_result: TestResult,
+    failed_tests: &mut Vec<&str>,
+    test_name: &'static str,
+    successful_tests: &mut Vec<&str>,
+    summary_logger: Option<&mut SummaryLogger>,
+) -> anyhow::Result<()> {
+    if let Some(logger) = summary_logger {
+        logger
+            .log_test_result(test_name, test_result.summary())
+            .await
+            .context("Failed to log test result")?
+    };
+
+    if test_result.failure() {
+        failed_tests.push(test_name);
+    } else {
+        successful_tests.push(test_name);
+    }
+
+    Ok(())
+}
+
+pub async fn run_test_function<F, R>(
     runner_rpc: ServiceClient,
     mullvad_rpc: MullvadClientArgument,
     test: &F,
@@ -194,13 +235,15 @@ where
     // assertion being incorrect can not lead to memory unsafety however it could theoretically
     // lead to logic bugs. The problem of forcing the test to be unwind safe is that it causes a
     // large amount of unergonomic design.
-    let result = panic::AssertUnwindSafe(test(test_context, runner_rpc.clone(), mullvad_rpc))
-        .catch_unwind()
-        .await
-        .map_err(panic_as_string);
+    let result: TestResult =
+        panic::AssertUnwindSafe(test(test_context, runner_rpc.clone(), mullvad_rpc))
+            .catch_unwind()
+            .await
+            .map_err(Panic::new)
+            .into();
 
     let mut output = vec![];
-    if matches!(result, Ok(Err(_)) | Err(_)) {
+    if result.failure() {
         let output_after_test = runner_rpc.try_poll_output().await;
         match output_after_test {
             Ok(mut output_after_test) => {

--- a/test/test-manager/src/summary.rs
+++ b/test/test-manager/src/summary.rs
@@ -250,11 +250,7 @@ pub async fn print_summary_table<P: AsRef<Path>>(summary_files: &[P]) {
     for test in &tests {
         println!("<tr>");
 
-        println!(
-            "<td>{}{}</td>",
-            test.name,
-            if test.must_succeed { " *" } else { "" }
-        );
+        println!("<td>{}</td>", test.name,);
 
         let mut failed_platforms = vec![];
         for summary in &summaries {

--- a/test/test-manager/src/summary.rs
+++ b/test/test-manager/src/summary.rs
@@ -107,19 +107,6 @@ impl SummaryLogger {
     }
 }
 
-/// Convenience function that logs when there's a value, and is a no-op otherwise.
-// y u no trait async fn
-pub async fn maybe_log_test_result(
-    summary_logger: Option<&mut SummaryLogger>,
-    test_name: &str,
-    test_result: TestResult,
-) -> Result<(), Error> {
-    match summary_logger {
-        Some(logger) => logger.log_test_result(test_name, test_result).await,
-        None => Ok(()),
-    }
-}
-
 /// Parsed summary results
 pub struct Summary {
     /// Name of the configuration

--- a/test/test-manager/src/tests/account.rs
+++ b/test/test-manager/src/tests/account.rs
@@ -289,7 +289,7 @@ async fn get_current_wireguard_key(
 
 /// Remove all devices on the current account
 pub async fn clear_devices(device_client: &DevicesProxy) -> anyhow::Result<()> {
-    log::info!("Removing all devices for account");
+    log::debug!("Removing all devices for account");
 
     for dev in list_devices_with_retries(device_client).await?.into_iter() {
         if let Err(error) = device_client

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -306,6 +306,7 @@ pub fn get_interface_index(interface: &str) -> anyhow::Result<std::ffi::c_uint> 
 pub async fn login_with_retries(
     mullvad_client: &mut MullvadProxyClient,
 ) -> Result<(), mullvad_management_interface::Error> {
+    log::debug!("Logging in/generating device");
     loop {
         match mullvad_client
             .login_account(TEST_CONFIG.account_number.clone())
@@ -339,6 +340,7 @@ pub async fn ensure_logged_in(
     if mullvad_client.get_device().await?.is_logged_in() {
         return Ok(());
     }
+    log::info!("Current device not logged in. Clearing devices and logging in.");
     // We are apparently not logged in already.. Try to log in.
     login_with_retries(mullvad_client).await
 }
@@ -375,7 +377,7 @@ pub async fn connect_and_wait(
 }
 
 pub async fn disconnect_and_wait(mullvad_client: &mut MullvadProxyClient) -> Result<(), Error> {
-    log::info!("Disconnecting");
+    log::debug!("Disconnecting");
     mullvad_client.disconnect_tunnel().await?;
 
     wait_for_tunnel_state(mullvad_client.clone(), |state| {
@@ -383,7 +385,7 @@ pub async fn disconnect_and_wait(mullvad_client: &mut MullvadProxyClient) -> Res
     })
     .await?;
 
-    log::info!("Disconnected");
+    log::debug!("Disconnected");
 
     Ok(())
 }

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -1,6 +1,13 @@
 use super::{config::TEST_CONFIG, Error, TestContext, WAIT_FOR_TUNNEL_STATE_TIMEOUT};
-use crate::network_monitor::{
-    self, start_packet_monitor, MonitorOptions, MonitorUnexpectedlyStopped, PacketMonitor,
+use crate::{
+    mullvad_daemon::RpcClientProvider,
+    network_monitor::{
+        self, start_packet_monitor, MonitorOptions, MonitorUnexpectedlyStopped, PacketMonitor,
+    },
+    tests::{
+        account::{clear_devices, new_device_client},
+        helpers,
+    },
 };
 use anyhow::{anyhow, bail, ensure, Context};
 use futures::StreamExt;
@@ -27,7 +34,9 @@ use std::{
     time::Duration,
 };
 use talpid_types::net::wireguard::{PeerConfig, PrivateKey, TunnelConfig};
-use test_rpc::{meta::Os, package::Package, AmIMullvad, ServiceClient, SpawnOpts};
+use test_rpc::{
+    meta::Os, mullvad_daemon::ServiceStatus, package::Package, AmIMullvad, ServiceClient, SpawnOpts,
+};
 use tokio::time::sleep;
 
 pub const THROTTLE_RETRY_DELAY: Duration = Duration::from_secs(120);
@@ -54,10 +63,64 @@ macro_rules! assert_tunnel_state {
     }};
 }
 
-pub fn get_package_desc(name: &str) -> Result<Package, Error> {
-    Ok(Package {
+/// Install the app cleanly, failing if the installer doesn't succeed
+/// or if the VPN service is not running afterwards.
+pub async fn install_app(
+    rpc: &ServiceClient,
+    app_filename: &str,
+    rpc_provider: &RpcClientProvider,
+) -> anyhow::Result<MullvadProxyClient> {
+    // install package
+    log::info!("Installing app '{}'", app_filename);
+    rpc.install_app(get_package_desc(app_filename)).await?;
+
+    // verify that daemon is running
+    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
+        bail!(Error::DaemonNotRunning);
+    }
+
+    // Set the log level to trace
+    rpc.set_daemon_log_level(test_rpc::mullvad_daemon::Verbosity::Trace)
+        .await?;
+
+    replace_openvpn_certificate(rpc).await?;
+
+    // Override env vars
+    rpc.set_daemon_environment(get_app_env().await?).await?;
+
+    // Wait for the relay list to be updated
+    let mut mullvad_client = rpc_provider.new_client().await;
+    helpers::ensure_updated_relay_list(&mut mullvad_client)
+        .await
+        .context("Failed to update relay list")?;
+    Ok(mullvad_client)
+}
+
+/// Replace the OpenVPN CA certificate which is currently used by the installed Mullvad App.
+/// This needs to be invoked after reach (re)installation to use the custom OpenVPN certificate.
+async fn replace_openvpn_certificate(rpc: &ServiceClient) -> Result<(), Error> {
+    const DEST_CERT_FILENAME: &str = "ca.crt";
+
+    let dest_dir = match TEST_CONFIG.os {
+        Os::Windows => "C:\\Program Files\\Mullvad VPN\\resources",
+        Os::Linux => "/opt/Mullvad VPN/resources",
+        Os::Macos => "/Applications/Mullvad VPN.app/Contents/Resources",
+    };
+
+    let dest = Path::new(dest_dir)
+        .join(DEST_CERT_FILENAME)
+        .as_os_str()
+        .to_string_lossy()
+        .into_owned();
+    rpc.write_file(dest, TEST_CONFIG.openvpn_certificate.to_vec())
+        .await
+        .map_err(Error::Rpc)
+}
+
+pub fn get_package_desc(name: &str) -> Package {
+    Package {
         path: Path::new(&TEST_CONFIG.artifacts_dir).join(name),
-    })
+    }
 }
 
 /// Reboot the guest virtual machine.
@@ -334,15 +397,28 @@ pub async fn login_with_retries(
 /// This will first check whether we are logged in. If not, it will also try to login
 /// on your behalf. If this function returns without any errors, we are logged in to a valid
 /// account.
-pub async fn ensure_logged_in(
-    mullvad_client: &mut MullvadProxyClient,
-) -> Result<(), mullvad_management_interface::Error> {
-    if mullvad_client.get_device().await?.is_logged_in() {
+pub async fn ensure_logged_in(mullvad_client: &mut MullvadProxyClient) -> anyhow::Result<()> {
+    if !matches!(
+        mullvad_client.update_device().await,
+        Err(mullvad_management_interface::Error::DeviceNotFound)
+    ) && mullvad_client.get_device().await?.is_logged_in()
+    {
         return Ok(());
     }
     log::info!("Current device not logged in. Clearing devices and logging in.");
     // We are apparently not logged in already.. Try to log in.
-    login_with_retries(mullvad_client).await
+    clear_devices(
+        &new_device_client()
+            .await
+            .context("Failed to create device client")?,
+    )
+    .await
+    .context("failed to clear devices")?;
+
+    login_with_retries(mullvad_client)
+        .await
+        .context("Failed to log in")?;
+    Ok(())
 }
 
 /// Try to connect to a Mullvad Tunnel.

--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -1,47 +1,20 @@
-use anyhow::{bail, Context};
-use std::{path::Path, time::Duration};
+use anyhow::{bail, ensure, Context};
+use std::time::Duration;
 
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::{constraints::Constraint, relay_constraints};
 use test_macro::test_function;
-use test_rpc::{meta::Os, mullvad_daemon::ServiceStatus, ServiceClient};
+use test_rpc::{mullvad_daemon::ServiceStatus, ServiceClient};
+
+use crate::{mullvad_daemon::MullvadClientArgument, tests::helpers};
 
 use super::{
     config::TEST_CONFIG,
-    helpers::{connect_and_wait, get_app_env, get_package_desc, wait_for_tunnel_state, Pinger},
+    helpers::{
+        connect_and_wait, get_app_env, get_package_desc, install_app, wait_for_tunnel_state, Pinger,
+    },
     Error, TestContext,
 };
-
-/// Install the last stable version of the app and verify that it is running.
-#[test_function(priority = -200)]
-pub async fn test_install_previous_app(_: TestContext, rpc: ServiceClient) -> anyhow::Result<()> {
-    // verify that daemon is not already running
-    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::NotRunning {
-        bail!(Error::DaemonRunning);
-    }
-
-    // install package
-    log::debug!("Installing old app");
-    rpc.install_app(get_package_desc(
-        TEST_CONFIG
-            .app_package_to_upgrade_from_filename
-            .as_ref()
-            .context("Missing previous app version")?,
-    )?)
-    .await?;
-    log::debug!("Replacing the OpenVPN CA certificate");
-    replace_openvpn_certificate(&rpc).await?;
-
-    // verify that daemon is running
-    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
-        bail!(Error::DaemonNotRunning);
-    }
-
-    // Override env vars
-    rpc.set_daemon_environment(get_app_env().await?).await?;
-
-    Ok(())
-}
 
 /// Upgrade to the "version under test". This test fails if:
 ///
@@ -49,8 +22,23 @@ pub async fn test_install_previous_app(_: TestContext, rpc: ServiceClient) -> an
 ///   upgrade.
 /// * The installer does not successfully complete.
 /// * The VPN service is not running after the upgrade.
-#[test_function(priority = -190)]
-pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> anyhow::Result<()> {
+pub async fn test_upgrade_app(
+    ctx: TestContext,
+    rpc: ServiceClient,
+    _mullvad_client: MullvadClientArgument,
+) -> anyhow::Result<()> {
+    // Install the older version of the app and verify that it is running.
+    install_app(
+        &rpc,
+        TEST_CONFIG
+            .app_package_to_upgrade_from_filename
+            .as_ref()
+            .unwrap(),
+        &ctx.rpc_provider,
+    )
+    .await
+    .context("Failed to install previous app version")?;
+
     // Verify that daemon is running
     if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
         bail!(Error::DaemonNotRunning);
@@ -68,7 +56,7 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> anyhow::R
     // mullvad_client
     //    .login_account(TEST_CONFIG.account_number.clone())
     //    .await
-    //    .expect("login failed");
+    //    .context("login failed")?;
 
     // Start blocking
     //
@@ -107,8 +95,9 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> anyhow::R
     let pinger = Pinger::start(&rpc).await;
 
     // install new package
+
     log::debug!("Installing new app");
-    rpc.install_app(get_package_desc(&TEST_CONFIG.app_package_filename)?)
+    rpc.install_app(helpers::get_package_desc(&TEST_CONFIG.app_package_filename))
         .await?;
 
     // Give it some time to start
@@ -118,14 +107,12 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> anyhow::R
     if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
         bail!(Error::DaemonNotRunning);
     }
-
     // Check if any traffic was observed
     //
     let guest_ip = pinger.guest_ip;
-    let monitor_result = pinger.stop().await.unwrap();
-    assert_eq!(
-        monitor_result.packets.len(),
-        0,
+    let monitor_result = pinger.stop().await.context("Failed to stop pinger")?;
+    ensure!(
+        monitor_result.packets.is_empty(),
         "observed unexpected packets from {guest_ip}"
     );
 
@@ -154,7 +141,7 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> anyhow::R
         _ => false,
     };
 
-    assert!(
+    ensure!(
         relay_location_was_preserved,
         "relay location was not preserved after upgrade. new settings: {:?}",
         settings,
@@ -163,13 +150,12 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> anyhow::R
     // check if account history was preserved
     // TODO: Cannot check account history because overriding the API is impossible for releases
     // let history = mullvad_client
-    // .get_account_history(())
-    // .await
-    // .expect("failed to obtain account history");
-    // assert_eq!(
-    // history.into_inner().token,
-    // Some(TEST_CONFIG.account_number.clone()),
-    // "lost account history"
+    //     .get_account_history()
+    //     .await
+    //     .context("failed to obtain account history")?;
+    // ensure!(
+    //     history.into_inner().token == Some(TEST_CONFIG.account_number.clone()),
+    //     "lost account history"
     // );
 
     Ok(())
@@ -186,23 +172,12 @@ pub async fn test_upgrade_app(ctx: TestContext, rpc: ServiceClient) -> anyhow::R
 /// Files due to Electron, temporary files, registry
 /// values/keys, and device drivers are not guaranteed
 /// to be deleted.
-#[test_function(priority = -170, cleanup = false)]
+#[test_function(priority = -160)]
 pub async fn test_uninstall_app(
-    _: TestContext,
+    _ctx: TestContext,
     rpc: ServiceClient,
     mut mullvad_client: MullvadProxyClient,
 ) -> anyhow::Result<()> {
-    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
-        bail!(Error::DaemonNotRunning);
-    }
-
-    // Login to test preservation of device/account
-    // TODO: Remove once we can login before upgrade above
-    mullvad_client
-        .login_account(TEST_CONFIG.account_number.clone())
-        .await
-        .context("login failed")?;
-
     // save device to verify that uninstalling removes the device
     // we should still be logged in after upgrading
     let uninstalled_device = mullvad_client
@@ -247,37 +222,6 @@ pub async fn test_uninstall_app(
     Ok(())
 }
 
-/// Install the app cleanly, failing if the installer doesn't succeed
-/// or if the VPN service is not running afterwards.
-#[test_function(always_run = true, must_succeed = true, priority = -160)]
-pub async fn test_install_new_app(_: TestContext, rpc: ServiceClient) -> anyhow::Result<()> {
-    // verify that daemon is not already running
-    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::NotRunning {
-        bail!(Error::DaemonRunning);
-    }
-
-    // install package
-    log::debug!("Installing new app");
-    rpc.install_app(get_package_desc(&TEST_CONFIG.app_package_filename)?)
-        .await?;
-
-    // verify that daemon is running
-    if rpc.mullvad_daemon_get_status().await? != ServiceStatus::Running {
-        bail!(Error::DaemonNotRunning);
-    }
-
-    // Set the log level to trace
-    rpc.set_daemon_log_level(test_rpc::mullvad_daemon::Verbosity::Trace)
-        .await?;
-
-    replace_openvpn_certificate(&rpc).await?;
-
-    // Override env vars
-    rpc.set_daemon_environment(get_app_env().await?).await?;
-
-    Ok(())
-}
-
 /// Install the multiple times starting from a connected state with auto-connect
 /// disabled, failing if the app starts in a disconnected state.
 ///
@@ -306,14 +250,14 @@ pub async fn test_installation_idempotency(
 
     // Check for traffic leaks during the installation processes.
     //
-    // Start continously pinging while monitoring the network traffic. No
+    // Start continuously pinging while monitoring the network traffic. No
     // traffic should be observed going outside of the tunnel during either
     // installation process.
     let pinger = Pinger::start(&rpc).await;
     for _ in 0..2 {
         // Install the app
         log::info!("Installing new app");
-        let app_package = get_package_desc(&TEST_CONFIG.app_package_filename)?;
+        let app_package = get_package_desc(&TEST_CONFIG.app_package_filename);
         rpc.install_app(app_package).await?;
         log::info!("App was successfully installed!");
 
@@ -346,25 +290,4 @@ pub async fn test_installation_idempotency(
     );
 
     Ok(())
-}
-
-/// Replace the OpenVPN CA certificate which is currently used by the installed Mullvad App.
-/// This needs to be invoked after reach (re)installation to use the custom OpenVPN certificate.
-async fn replace_openvpn_certificate(rpc: &ServiceClient) -> Result<(), Error> {
-    const DEST_CERT_FILENAME: &str = "ca.crt";
-
-    let dest_dir = match TEST_CONFIG.os {
-        Os::Windows => "C:\\Program Files\\Mullvad VPN\\resources",
-        Os::Linux => "/opt/Mullvad VPN/resources",
-        Os::Macos => "/Applications/Mullvad VPN.app/Contents/Resources",
-    };
-
-    let dest = Path::new(dest_dir)
-        .join(DEST_CERT_FILENAME)
-        .as_os_str()
-        .to_string_lossy()
-        .into_owned();
-    rpc.write_file(dest, TEST_CONFIG.openvpn_certificate.to_vec())
-        .await
-        .map_err(Error::Rpc)
 }

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -22,8 +22,12 @@ use std::time::Duration;
 
 use crate::{
     mullvad_daemon::{MullvadClientArgument, RpcClientProvider},
-    tests::helpers::get_app_env,
+    package::get_version_from_path,
 };
+use config::TEST_CONFIG;
+use helpers::{get_app_env, install_app};
+pub use install::test_upgrade_app;
+use mullvad_management_interface::MullvadProxyClient;
 use test_rpc::ServiceClient;
 
 const WAIT_FOR_TUNNEL_STATE_TIMEOUT: Duration = Duration::from_secs(40);
@@ -74,21 +78,51 @@ pub fn get_tests() -> Vec<&'static TestMetadata> {
     tests
 }
 
-/// Restore settings to the defaults.
-pub async fn cleanup_after_test(
-    rpc: ServiceClient,
+/// Make sure the daemon is installed and logged in and restore settings to the defaults.
+pub async fn prepare_daemon(
+    rpc: &ServiceClient,
     rpc_provider: &RpcClientProvider,
 ) -> anyhow::Result<()> {
-    log::debug!("Resetting daemon settings after test");
-    // Check if daemon should be restarted.
-    restart_daemon(rpc).await?;
-    let mut mullvad_client = rpc_provider.new_client().await;
+    // Check if daemon should be restarted
+    let mut mullvad_client = ensure_daemon_version(rpc, rpc_provider)
+        .await
+        .context("Failed to restart daemon")?;
+
+    log::debug!("Resetting daemon settings before test");
     mullvad_client
         .reset_settings()
         .await
         .context("Failed to reset settings")?;
-    helpers::disconnect_and_wait(&mut mullvad_client).await?;
+    helpers::disconnect_and_wait(&mut mullvad_client)
+        .await
+        .context("Failed to disconnect daemon after test")?;
+    helpers::ensure_logged_in(&mut mullvad_client).await?;
+
     Ok(())
+}
+
+/// Reset the daemons environment.
+///
+/// Will and restart or reinstall it if necessary.
+async fn ensure_daemon_version(
+    rpc: &ServiceClient,
+    rpc_provider: &RpcClientProvider,
+) -> anyhow::Result<MullvadProxyClient> {
+    let app_package_filename = &TEST_CONFIG.app_package_filename;
+
+    let mullvad_client = if correct_daemon_version_is_running(rpc_provider.new_client().await).await
+    {
+        ensure_daemon_environment(rpc)
+            .await
+            .context("Failed to reset daemon environment")?;
+        rpc_provider.new_client().await
+    } else {
+        // NOTE: Reinstalling the app resets the daemon environment
+        install_app(rpc, app_package_filename, rpc_provider)
+            .await
+            .with_context(|| format!("Failed to install app '{app_package_filename}'"))?
+    };
+    Ok(mullvad_client)
 }
 
 /// Conditionally restart the running daemon
@@ -96,12 +130,41 @@ pub async fn cleanup_after_test(
 /// If the daemon was started with non-standard environment variables, subsequent tests may break
 /// due to assuming a default configuration. In that case, reset the environment variables and
 /// restart.
-async fn restart_daemon(rpc: ServiceClient) -> anyhow::Result<()> {
-    let current_env = rpc.get_daemon_environment().await?;
-    let default_env = get_app_env().await?;
+pub async fn ensure_daemon_environment(rpc: &ServiceClient) -> Result<(), anyhow::Error> {
+    let current_env = rpc
+        .get_daemon_environment()
+        .await
+        .context("Failed to get daemon env variables")?;
+    let default_env = get_app_env()
+        .await
+        .context("Failed to get daemon default env variables")?;
     if current_env != default_env {
         log::debug!("Restarting daemon due changed environment variables. Values since last test {current_env:?}");
-        rpc.set_daemon_environment(default_env).await?;
-    }
+        rpc.set_daemon_environment(default_env)
+            .await
+            .context("Failed to restart daemon")?;
+    };
     Ok(())
+}
+
+/// Checks if daemon is installed with the version specified by `TEST_CONFIG.app_package_filename`
+async fn correct_daemon_version_is_running(mut mullvad_client: MullvadProxyClient) -> bool {
+    let app_package_filename = &TEST_CONFIG.app_package_filename;
+    let expected_version = get_version_from_path(std::path::Path::new(app_package_filename))
+        .unwrap_or_else(|_| panic!("Invalid app version: {app_package_filename}"));
+
+    use mullvad_management_interface::Error::*;
+    match mullvad_client.get_current_version().await {
+        // Failing to reach the daemon is a sign that it is not installed
+        Err(Rpc(..)) => {
+            log::debug!("Could not reach active daemon before test, it is not running");
+            false
+        }
+        Err(e) => panic!("Failed to get app version: {e}"),
+        Ok(version) if version == expected_version => true,
+        _ => {
+            log::debug!("Daemon version mismatch");
+            false
+        }
+    }
 }

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -78,6 +78,26 @@ pub fn get_tests() -> Vec<&'static TestMetadata> {
     tests
 }
 
+pub fn get_filtered_tests(specified_tests: &[String]) -> Result<Vec<&TestMetadata>, anyhow::Error> {
+    let mut tests = get_tests();
+    tests.retain(|test| test.should_run_on_os(TEST_CONFIG.os));
+    if !specified_tests.is_empty() {
+        specified_tests
+            .iter()
+            .map(|f| {
+                tests
+                    .iter()
+                    .find(|t| t.command.eq_ignore_ascii_case(f))
+                    .cloned()
+                    .ok_or(anyhow::anyhow!("Test '{f}' not found"))
+            })
+            .collect()
+    } else {
+        // Keep all tests
+        Ok(tests)
+    }
+}
+
 /// Make sure the daemon is installed and logged in and restore settings to the defaults.
 pub async fn prepare_daemon(
     rpc: &ServiceClient,

--- a/test/test-manager/src/tests/test_metadata.rs
+++ b/test/test-manager/src/tests/test_metadata.rs
@@ -8,7 +8,6 @@ pub struct TestMetadata {
     pub mullvad_client_version: MullvadClientVersion,
     pub func: TestWrapperFunction,
     pub priority: Option<i32>,
-    pub always_run: bool,
 }
 
 impl TestMetadata {

--- a/test/test-manager/src/tests/test_metadata.rs
+++ b/test/test-manager/src/tests/test_metadata.rs
@@ -9,7 +9,6 @@ pub struct TestMetadata {
     pub func: TestWrapperFunction,
     pub priority: Option<i32>,
     pub always_run: bool,
-    pub must_succeed: bool,
 }
 
 impl TestMetadata {

--- a/test/test-manager/src/tests/test_metadata.rs
+++ b/test/test-manager/src/tests/test_metadata.rs
@@ -10,7 +10,6 @@ pub struct TestMetadata {
     pub priority: Option<i32>,
     pub always_run: bool,
     pub must_succeed: bool,
-    pub cleanup: bool,
 }
 
 impl TestMetadata {

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -1,8 +1,4 @@
-use super::{
-    config::TEST_CONFIG,
-    helpers::{self, ensure_logged_in},
-    Error, TestContext,
-};
+use super::{config::TEST_CONFIG, helpers, Error, TestContext};
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_relay_selector::query::builder::RelayQueryBuilder;
 use std::{
@@ -124,7 +120,12 @@ pub async fn test_ui_tunnel_settings(
 
 /// Test whether logging in and logging out work in the GUI
 #[test_function(priority = 500)]
-pub async fn test_ui_login(_: TestContext, rpc: ServiceClient) -> Result<(), Error> {
+pub async fn test_ui_login(
+    _: TestContext,
+    rpc: ServiceClient,
+    mut mullvad_client: MullvadProxyClient,
+) -> Result<(), Error> {
+    mullvad_client.logout_account().await?;
     let ui_result = run_test_env(
         &rpc,
         &["login.spec"],
@@ -229,13 +230,6 @@ async fn test_custom_bridge_gui(
     // See `gui/test/e2e/installed/state-dependent/custom-bridge.spec.ts`
     // for details. The setup should be the same as in
     // `test_manager::tests::access_methods::test_shadowsocks`.
-    //
-    // # Note
-    // The test requires the app to already be logged in.
-
-    ensure_logged_in(&mut mullvad_client)
-        .await
-        .expect("ensure_logged_in failed");
 
     let gui_test = "custom-bridge.spec";
     let relay_list = mullvad_client.get_relay_locations().await.unwrap();
@@ -276,9 +270,6 @@ async fn test_custom_bridge_gui(
 }
 
 /// Test settings import / IP overrides in the GUI
-///
-/// # Note
-/// This test expects the daemon to be logged in
 #[test_function]
 pub async fn test_import_settings_ui(_: TestContext, rpc: ServiceClient) -> Result<(), Error> {
     let ui_result = run_test(&rpc, &["settings-import.spec"]).await?;

--- a/test/test-manager/src/vm/mod.rs
+++ b/test/test-manager/src/vm/mod.rs
@@ -37,7 +37,7 @@ pub async fn set_config(config: &mut ConfigFile, vm_name: &str, vm_config: VmCon
 pub async fn run(config: &Config, name: &str) -> Result<Box<dyn VmInstance>> {
     let vm_conf = get_vm_config(config, name)?;
 
-    log::info!("Starting \"{name}\"");
+    log::info!("Starting VM \"{name}\"");
 
     let instance = match vm_conf.vm_type {
         VmType::Qemu => Box::new(
@@ -55,7 +55,7 @@ pub async fn run(config: &Config, name: &str) -> Result<Box<dyn VmInstance>> {
         VmType::Tart => return Err(anyhow::anyhow!("Failed to run Tart VM on a non-macOS host")),
     };
 
-    log::info!("Started instance of \"{name}\" vm");
+    log::debug!("Started instance of \"{name}\" vm");
 
     Ok(instance)
 }

--- a/test/test-manager/src/vm/provision.rs
+++ b/test/test-manager/src/vm/provision.rs
@@ -107,27 +107,28 @@ fn blocking_ssh(
 
     // Transfer a test runner
     let source = local_runner_dir.join("test-runner");
-    ssh_send_file(&session, &source, temp_dir).context("Failed to send test runner to remote")?;
+    ssh_send_file(&session, &source, temp_dir)
+        .with_context(|| format!("Failed to send '{source:?}' to remote"))?;
 
     // Transfer connection-checker
     let source = local_runner_dir.join("connection-checker");
     ssh_send_file(&session, &source, temp_dir)
-        .context("Failed to send connection-checker to remote")?;
+        .with_context(|| format!("Failed to send '{source:?}' to remote"))?;
 
     // Transfer app packages
-    ssh_send_file(&session, &local_app_manifest.app_package_path, temp_dir)
-        .context("Failed to send current app package to remote")?;
-    if let Some(app_package_to_upgrade_from_path) =
-        &local_app_manifest.app_package_to_upgrade_from_path
-    {
-        ssh_send_file(&session, app_package_to_upgrade_from_path, temp_dir)
-            .context("Failed to send previous app package to remote")?;
+    let source = &local_app_manifest.app_package_path;
+    ssh_send_file(&session, source, temp_dir)
+        .with_context(|| format!("Failed to send '{source:?}' to remote"))?;
+
+    if let Some(source) = &local_app_manifest.app_package_to_upgrade_from_path {
+        ssh_send_file(&session, source, temp_dir)
+            .with_context(|| format!("Failed to send '{source:?}' to remote"))?;
     } else {
-        log::warn!("No previous app to send to remote")
+        log::warn!("No previous app package to upgrade from to send to remote")
     }
-    if let Some(gui_package_path) = &local_app_manifest.gui_package_path {
-        ssh_send_file(&session, gui_package_path, temp_dir)
-            .context("Failed to send gui_package_path to remote")?;
+    if let Some(source) = &local_app_manifest.gui_package_path {
+        ssh_send_file(&session, source, temp_dir)
+            .with_context(|| format!("Failed to send '{source:?}' to remote"))?;
     } else {
         log::warn!("No UI e2e test to send to remote")
     }

--- a/test/test-manager/test_macro/src/lib.rs
+++ b/test/test-manager/test_macro/src/lib.rs
@@ -23,9 +23,6 @@ use test_rpc::meta::Os;
 /// * `priority` - The order in which tests will be run where low numbers run before high numbers
 ///   and tests with the same number run in undefined order. `priority` defaults to 0.
 ///
-/// * `must_succeed` - If the testing suite stops running if this test fails. `must_succeed`
-///   defaults to false.
-///
 /// * `always_run` - If the test should always run regardless of what test filters are provided by
 ///   the user. `always_run` defaults to false.
 ///
@@ -51,10 +48,10 @@ use test_rpc::meta::Os;
 ///
 /// ## Create a test with custom parameters
 ///
-/// This test will run early in the test loop and must succeed and will always run.
+/// This test will run early in the test loop and will always run.
 ///
 /// ```ignore
-/// #[test_function(priority = -1337, must_succeed = true, always_run = true)]
+/// #[test_function(priority = -1337, always_run = true)]
 /// pub async fn test_function(
 ///     rpc: ServiceClient,
 ///     mut mullvad_client: mullvad_management_interface::MullvadProxyClient,
@@ -109,7 +106,6 @@ fn parse_marked_test_function(
 fn get_test_macro_parameters(attributes: &syn::AttributeArgs) -> Result<MacroParameters> {
     let mut priority = None;
     let mut always_run = false;
-    let mut must_succeed = false;
     let mut targets = vec![];
 
     for attribute in attributes {
@@ -128,11 +124,6 @@ fn get_test_macro_parameters(attributes: &syn::AttributeArgs) -> Result<MacroPar
             match lit {
                 Lit::Bool(lit_bool) => always_run = lit_bool.value(),
                 _ => bail!(nv, "'always_run' should have a bool value"),
-            }
-        } else if nv.path.is_ident("must_succeed") {
-            match lit {
-                Lit::Bool(lit_bool) => must_succeed = lit_bool.value(),
-                _ => bail!(nv, "'must_succeed' should have a bool value"),
             }
         } else if nv.path.is_ident("target_os") {
             let Lit::Str(lit_str) = lit else {
@@ -157,7 +148,6 @@ fn get_test_macro_parameters(attributes: &syn::AttributeArgs) -> Result<MacroPar
     Ok(MacroParameters {
         priority,
         always_run,
-        must_succeed,
         targets,
     })
 }
@@ -176,7 +166,6 @@ fn create_test(test_function: TestFunction) -> proc_macro2::TokenStream {
         .collect();
 
     let always_run = test_function.macro_parameters.always_run;
-    let must_succeed = test_function.macro_parameters.must_succeed;
 
     let func_name = test_function.name;
     let function_mullvad_version = test_function.function_parameters.mullvad_client.version();
@@ -219,7 +208,6 @@ fn create_test(test_function: TestFunction) -> proc_macro2::TokenStream {
             func: #wrapper_closure,
             priority: #test_function_priority,
             always_run: #always_run,
-            must_succeed: #must_succeed,
         });
     }
 }
@@ -233,7 +221,6 @@ struct TestFunction {
 struct MacroParameters {
     priority: Option<i32>,
     always_run: bool,
-    must_succeed: bool,
     targets: Vec<Os>,
 }
 

--- a/test/test-manager/test_macro/src/lib.rs
+++ b/test/test-manager/test_macro/src/lib.rs
@@ -23,9 +23,6 @@ use test_rpc::meta::Os;
 /// * `priority` - The order in which tests will be run where low numbers run before high numbers
 ///   and tests with the same number run in undefined order. `priority` defaults to 0.
 ///
-/// * `always_run` - If the test should always run regardless of what test filters are provided by
-///   the user. `always_run` defaults to false.
-///
 /// * `target_os` - The test should only run on the specified OS. This can currently be set to
 ///   `linux`, `windows`, or `macos`.
 ///
@@ -48,10 +45,10 @@ use test_rpc::meta::Os;
 ///
 /// ## Create a test with custom parameters
 ///
-/// This test will run early in the test loop and will always run.
+/// This test will run early in the test loop.
 ///
 /// ```ignore
-/// #[test_function(priority = -1337, always_run = true)]
+/// #[test_function(priority = -1337)]
 /// pub async fn test_function(
 ///     rpc: ServiceClient,
 ///     mut mullvad_client: mullvad_management_interface::MullvadProxyClient,
@@ -105,7 +102,6 @@ fn parse_marked_test_function(
 
 fn get_test_macro_parameters(attributes: &syn::AttributeArgs) -> Result<MacroParameters> {
     let mut priority = None;
-    let mut always_run = false;
     let mut targets = vec![];
 
     for attribute in attributes {
@@ -119,11 +115,6 @@ fn get_test_macro_parameters(attributes: &syn::AttributeArgs) -> Result<MacroPar
             match lit {
                 Lit::Int(lit_int) => priority = Some(lit_int.base10_parse().unwrap()),
                 _ => bail!(nv, "'priority' should have an integer value"),
-            }
-        } else if nv.path.is_ident("always_run") {
-            match lit {
-                Lit::Bool(lit_bool) => always_run = lit_bool.value(),
-                _ => bail!(nv, "'always_run' should have a bool value"),
             }
         } else if nv.path.is_ident("target_os") {
             let Lit::Str(lit_str) = lit else {
@@ -145,11 +136,7 @@ fn get_test_macro_parameters(attributes: &syn::AttributeArgs) -> Result<MacroPar
         }
     }
 
-    Ok(MacroParameters {
-        priority,
-        always_run,
-        targets,
-    })
+    Ok(MacroParameters { priority, targets })
 }
 
 fn create_test(test_function: TestFunction) -> proc_macro2::TokenStream {
@@ -164,8 +151,6 @@ fn create_test(test_function: TestFunction) -> proc_macro2::TokenStream {
             Os::Windows => quote! { ::test_rpc::meta::Os::Windows, },
         })
         .collect();
-
-    let always_run = test_function.macro_parameters.always_run;
 
     let func_name = test_function.name;
     let function_mullvad_version = test_function.function_parameters.mullvad_client.version();
@@ -207,7 +192,6 @@ fn create_test(test_function: TestFunction) -> proc_macro2::TokenStream {
             mullvad_client_version: #function_mullvad_version,
             func: #wrapper_closure,
             priority: #test_function_priority,
-            always_run: #always_run,
         });
     }
 }
@@ -220,7 +204,6 @@ struct TestFunction {
 
 struct MacroParameters {
     priority: Option<i32>,
-    always_run: bool,
     targets: Vec<Os>,
 }
 


### PR DESCRIPTION
Currently, the cleanup code only resets a small subset of the daemon state, and many tests implicitly rely on being left in a certain state by the previous. This is inherently flaky, as one test failing may cause the following ones to also fail. It is also very inflexible, as it doesn't allow testing arbitrary single tests, or changing the order of tests.

- Refactor the cleanup to completely and deterministically make sure the correct daemon version is installed, logged in and disconnected with all setting cleared before each test
- Allow reordering tests

Fixes DES-1137

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6493)
<!-- Reviewable:end -->
