### PR TITLE
Add missing feature in `talpid-wireguard`

### DIFF
--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -86,3 +86,4 @@ features = [
 
 [dev-dependencies]
 proptest = { workspace = true }
+tokio = { workspace = true, features = [ "test-util" ] }


### PR DESCRIPTION
Fix `cargo test -p talpid-wireguard` by adding missing `test-util` feature for `tokio`. `cargo test` would not compile the crate otherwise.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6497)
<!-- Reviewable:end -->
