### PR TITLE
Use narrower type to fix possible panic with IPv6 address argument

### DIFF
--- a/talpid-tunnel-config-client/examples/psk-exchange.rs
+++ b/talpid-tunnel-config-client/examples/psk-exchange.rs
@@ -4,7 +4,6 @@
 // Usage: ./psk-exchange <tuncfg_server_ip> <wireguard_public_key>
 // e. g. ./psk-exchange 10.64.0.1 NkECLsf+VbZUjve7RVN6sE3NYUcYUmUn8qpFugqbXFk=
 
-use std::net::IpAddr;
 use talpid_types::net::wireguard::{PrivateKey, PublicKey};
 
 #[tokio::main]
@@ -24,7 +23,7 @@ async fn main() {
     let ephemeral_private_key = PrivateKey::new_from_random();
 
     let ephemeral_peer = talpid_tunnel_config_client::request_ephemeral_peer(
-        IpAddr::V4(tuncfg_server_ip),
+        tuncfg_server_ip,
         public_key, // Parent connection's public key.
         ephemeral_private_key.public_key(),
         true,  // Whether to negotiate a "PQ-safe" PSK.

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -1,9 +1,9 @@
 use proto::PostQuantumRequestV1;
 use std::fmt;
 #[cfg(not(target_os = "ios"))]
-use std::net::IpAddr;
-#[cfg(not(target_os = "ios"))]
 use std::net::SocketAddr;
+#[cfg(not(target_os = "ios"))]
+use std::net::{IpAddr, Ipv4Addr};
 use talpid_types::net::wireguard::{PresharedKey, PublicKey};
 #[cfg(not(target_os = "ios"))]
 use tokio::net::TcpSocket;
@@ -189,7 +189,7 @@ pub async fn request_ephemeral_peer_with(
 /// Negotiate a short-lived peer with a PQ-safe PSK or with DAITA enabled.
 #[cfg(not(target_os = "ios"))]
 pub async fn request_ephemeral_peer(
-    service_address: IpAddr,
+    service_address: Ipv4Addr,
     parent_pubkey: PublicKey,
     ephemeral_pubkey: PublicKey,
     enable_post_quantum: bool,
@@ -245,8 +245,9 @@ fn xor_assign(dst: &mut [u8; 32], src: &[u8; 32]) {
 }
 
 #[cfg(not(target_os = "ios"))]
-async fn new_client(addr: IpAddr) -> Result<RelayConfigService, Error> {
+async fn new_client(addr: Ipv4Addr) -> Result<RelayConfigService, Error> {
     let endpoint = Endpoint::from_static("tcp://0.0.0.0:0");
+    let addr = IpAddr::V4(addr);
 
     let conn = endpoint
         .connect_with_connector(service_fn(move |_| async move {

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -728,7 +728,7 @@ impl WireguardMonitor {
         let ephemeral = tokio::time::timeout(
             timeout,
             talpid_tunnel_config_client::request_ephemeral_peer(
-                IpAddr::from(config.ipv4_gateway),
+                config.ipv4_gateway,
                 config.tunnel.private_key.public_key(),
                 wg_psk_pubkey,
                 enable_pq,


### PR DESCRIPTION
This is a further cleanup following some discoveries I made when working with your PSK exchange.

As already written during PR #6477, calling `psk-exchange` or more specifically `talpid_tunnel_config_client::request_ephemeral_peer` with an IPv6 resulted in an `EAFNOSUPPORT` error.
With the current program it never makes sense to pass an `Ipv6Addr` to `request_ephemeral_peer`, since it can't handle an IPv6 connection even if the tunnel configuration service was listening to an IPv6.

There are two locations where `request_ephemeral_peer` is called. One of them is in `talpid-wireguard/src/lib.rs`, the other one is in the `psk-exchange` example.
Since the address is statically set to the IPv4 gateway in the former case, presently the only possible case for problems to happen was if someone entered an IPv6 when using the example.
I already disabled the possibility to enter such an address as part of the linked PR, but it still is a wart and it would not feel right to leave it in this faulty way.

So I had to decide whether to fix the IPv6 connectivity or to disable it.
I modified `talpid-tunnel-config-client/src/lib.rs` and `talpid-tunnel-config-client/examples/psk-exchange` to work with an IPv6 and then called `psk-exchange` with `fc00:bbbb:bbbb:bb01::1` (the IPv6 gateway address) which failed with `ECONNREFUSED`. This seems to suggest that the tunnel configuration service is not listening to an IPv6 (at least not on that address and on port 1337, which would be the expected location.)

I tested `psk-exchange` just as described in my other PR and I did not know how to dedicatedly test `talpid-wireguard/src/lib.rs` but it compiles and the test suite (`cargo test -p talpid-wireguard` [it turns out that I did not properly call the tests at first, but I did now and with the patch from #6497 applied]) also finishes successfully. Since the input is static, I don't see any possible problem here.

If at some later point you decide to refactor this to support IPv6 it would probably be easiest to look at the passed `IpAddr`, check whether it is IPv4 or IPv6 and create an according socket.
Theoretically you could use an IPv6 socket to make IPv4 connections but the socket option `IPV6_V6ONLY` has to be disabled and this would turn into a portability nightmare and also has some security implications, so I'd recommend against it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6498)
<!-- Reviewable:end -->
