### PR TITLE
Add GitHub actions permissions

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -3,9 +3,13 @@ name: Check changelog format
 on:
   pull_request:
     paths:
+      - .github/workflows/check-changelog.yml
       - 'CHANGELOG.md'
       - 'ios/CHANGELOG.md'
       - 'android/CHANGELOG.md'
+
+permissions: {}
+
 env:
   LINE_LIMIT: 100
 jobs:

--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -4,6 +4,8 @@ on:
   push:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-commit-message-style:
     name: Check commit message style

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/unicode-check.yml
+++ b/.github/workflows/unicode-check.yml
@@ -1,6 +1,9 @@
 ---
 name: Bidirectional Unicode scan
 on: [pull_request, workflow_dispatch]
+
+permissions: {}
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -26,6 +26,9 @@ on:
       - building/linux-container-image.txt
       - building/android-container-image.txt
       - building/sigstore/**
+
+permissions: {}
+
 jobs:
   verify-signatures:
     runs-on: ubuntu-latest

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -8,6 +8,9 @@ on:
       - '**/**.yml'
       - '**/**.yaml'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Locks down what permissions some of our Github actions has. Limits the risk of them doing something malicious against us. We don't build anything trusted in any of our actions. But with enough permissions set, the actions can write stuff back into the repository or cause other issues. So by default we should try to limit them as much as possible.

I wish Github defaulted to no permissions and explicitly required an action to specify if they needed more permissions than that.

This is in accordance with OpenSSF best practices: https://github.com/ossf/scorecard/blob/b48bdbf250dedadedb42934480bb885d756ead0c/docs/checks.md#token-permissions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6499)
<!-- Reviewable:end -->
