### PR TITLE
Enable quantum-resistant tunnels by default on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add DAITA (Defence against AI-guided Traffic Analysis) setting for Linux and macOS.
 
+### Changed
+#### macOS
+- Enable quantum resistant tunnels by default (when set to `auto`).
+
 ### Fixed
 - Fix mullvad cli bug causing `mullvad status listen` command to miss events if they occurred
   too quickly.

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -9,9 +9,9 @@ pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(30 * 24 * 60 * 6
 pub const DEFAULT_ROTATION_INTERVAL: Duration = MAX_ROTATION_INTERVAL;
 
 /// Whether to enable or disable quantum resistant tunnels when the setting is set to
-/// `QuantumResistantState::Auto`. It is currently enabled by default on Linux but disabled on all
-/// other platforms.
-const QUANTUM_RESISTANT_AUTO_STATE: bool = cfg!(target_os = "linux");
+/// `QuantumResistantState::Auto`. It is currently enabled by default on Linux and macOS,
+/// but disabled on all other platforms.
+const QUANTUM_RESISTANT_AUTO_STATE: bool = cfg!(any(target_os = "linux", target_os = "macos"));
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
Fix DES-557.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6501)
<!-- Reviewable:end -->
