### PR TITLE
Fix clippy error for `rust_2018_idioms`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 non_ascii_idents = "forbid"
 
 # Deny old style Rust
-rust_2018_idioms = "deny"
+rust_2018_idioms = { level = "deny", priority = -1 }
 macro_use_extern_crate = "deny"
 absolute_paths_not_starting_with_crate = "deny"
 


### PR DESCRIPTION
`clippy` complains about `rust_2018_idioms` having the same priority as other lints, being a lint group, since the list of lints is unordered: https://rust-lang.github.io/rust-clippy/master/index.html#/lint_groups_priority

This fixes the issue by giving the group a lower priority.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6502)
<!-- Reviewable:end -->
