### PR TITLE
Bump wireguard-apple to use latest changes.

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9121,7 +9121,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = 5f24cdf1aa7fc1802f1695473aab95b4451e4ba0;
+				revision = 758a8a22ccdc9fe37c2483f991141d1c750144db;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "5f24cdf1aa7fc1802f1695473aab95b4451e4ba0"
+        "revision" : "758a8a22ccdc9fe37c2483f991141d1c750144db"
       }
     }
   ],


### PR DESCRIPTION
Effectively, these changes imply we're not using any of the IAN code so it'll work just as good as it did in the last release for singlehop - that should be the only difference between the previous commit and this one. This

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6513)
<!-- Reviewable:end -->
