### PR TITLE
Allow multihop in release and update changelog ios 769

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -22,8 +22,10 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
-
-
+### Added
+- Add multihop, a feature that routes traffic through two
+  of our relays before it reaches the internet.
+ 
 ## [2024.4 - 2024-06-25]
 ### Added
 - Add Post-Quantum secure tunnels.

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -412,9 +412,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         snapshot.appendItems([.dnsSettings], toSection: .dnsSettings)
         snapshot.appendItems([.ipOverrides], toSection: .ipOverrides)
 
-        #if DEBUG
         snapshot.appendItems([.multihop], toSection: .multiHop)
-        #endif
 
         applySnapshot(snapshot, animated: animated, completion: completion)
     }


### PR DESCRIPTION
This PR enables multihop in release mode, and updates the changelog file accordingly.