### PR TITLE
Fix typo issue in build-apk.sh

### DIFF
--- a/build-apk.sh
+++ b/build-apk.sh
@@ -68,7 +68,7 @@ elif which gradle > /dev/null; then
     GRADLE_CMD="gradle"
 else
     echo "ERROR: No gradle command found" >&2
-    echo "       Please either install gradle or restore the gradlew file" >&2
+    echo "       Please either install gradle or restore the gradle file" >&2
     exit 2
 fi
 


### PR DESCRIPTION
Fix wording from "gradlew" to "gradle".

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [x] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** Fix wording from "gradlew" to "gradle" in build-apk.sh
  * **Why** Correct the word.
  * If necessary, **how** it's implemented
  * How to **test** the change
