### PR TITLE
Use latest `cargo-udeps`

### DIFF
--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps@0.1.48
+          tool: cargo-udeps
 
       - name: Check for unused dependencies
         shell: bash
@@ -85,7 +85,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps@0.1.48
+          tool: cargo-udeps
 
       - name: Check for unused dependencies
         run: cargo udeps --target aarch64-linux-android --package mullvad-jni
@@ -119,7 +119,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-udeps@0.1.48
+          tool: cargo-udeps
 
       - name: Install Go
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
This PR reverts a workaround which pinned `cargo-udeps` to `0.1.48` due to missing binaries for macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6530)
<!-- Reviewable:end -->
