### PR TITLE
Reconnect if split tunnel state changed

### DIFF
--- a/mullvad-management-interface/src/types/conversions/states.rs
+++ b/mullvad-management-interface/src/types/conversions/states.rs
@@ -107,7 +107,11 @@ impl From<mullvad_types::states::TunnelState> for proto::TunnelState {
                             talpid_tunnel::ErrorStateCause::InvalidDnsServers(_) => {
                                 i32::from(Cause::SetDnsError)
                             }
-                            #[cfg(any(target_os = "windows", target_os = "macos"))]
+                            #[cfg(any(
+                                target_os = "windows",
+                                target_os = "macos",
+                                target_os = "android"
+                            ))]
                             talpid_tunnel::ErrorStateCause::SplitTunnelError => {
                                 i32::from(Cause::SplitTunnelError)
                             }

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -211,9 +211,14 @@ impl TunnelState for DisconnectedState {
                 shared_values.bypass_socket(fd, done_tx);
                 SameState(self)
             }
-            #[cfg(any(windows, target_os = "android"))]
+            #[cfg(windows)]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 shared_values.exclude_paths(paths, result_tx);
+                SameState(self)
+            }
+            #[cfg(target_os = "android")]
+            Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
+                let _ = result_tx.send(shared_values.exclude_paths(paths).map(|_| ()));
                 SameState(self)
             }
             #[cfg(target_os = "macos")]

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -76,9 +76,14 @@ impl DisconnectingState {
                     shared_values.bypass_socket(fd, done_tx);
                     AfterDisconnect::Nothing
                 }
-                #[cfg(any(windows, target_os = "android"))]
+                #[cfg(windows)]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                     shared_values.exclude_paths(paths, result_tx);
+                    AfterDisconnect::Nothing
+                }
+                #[cfg(target_os = "android")]
+                Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
+                    let _ = result_tx.send(shared_values.exclude_paths(paths).map(|_| ()));
                     AfterDisconnect::Nothing
                 }
                 #[cfg(target_os = "macos")]
@@ -127,9 +132,14 @@ impl DisconnectingState {
                     shared_values.bypass_socket(fd, done_tx);
                     AfterDisconnect::Block(reason)
                 }
-                #[cfg(any(windows, target_os = "android"))]
+                #[cfg(windows)]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                     shared_values.exclude_paths(paths, result_tx);
+                    AfterDisconnect::Block(reason)
+                }
+                #[cfg(target_os = "android")]
+                Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
+                    let _ = result_tx.send(shared_values.exclude_paths(paths).map(|_| ()));
                     AfterDisconnect::Block(reason)
                 }
                 #[cfg(target_os = "macos")]
@@ -179,9 +189,14 @@ impl DisconnectingState {
                     shared_values.bypass_socket(fd, done_tx);
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
-                #[cfg(any(windows, target_os = "android"))]
+                #[cfg(windows)]
                 Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                     shared_values.exclude_paths(paths, result_tx);
+                    AfterDisconnect::Reconnect(retry_attempt)
+                }
+                #[cfg(target_os = "android")]
+                Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
+                    let _ = result_tx.send(shared_values.exclude_paths(paths).map(|_| ()));
                     AfterDisconnect::Reconnect(retry_attempt)
                 }
                 #[cfg(target_os = "macos")]

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -211,7 +211,12 @@ impl TunnelState for ErrorState {
                 shared_values.bypass_socket(fd, done_tx);
                 SameState(self)
             }
-            #[cfg(any(windows, target_os = "android"))]
+            #[cfg(target_os = "android")]
+            Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
+                let _ = result_tx.send(shared_values.exclude_paths(paths).map(|_| ()));
+                SameState(self)
+            }
+            #[cfg(windows)]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 shared_values.exclude_paths(paths, result_tx);
                 SameState(self)

--- a/talpid-tunnel/src/tun_provider/android/mod.rs
+++ b/talpid-tunnel/src/tun_provider/android/mod.rs
@@ -299,7 +299,7 @@ impl AndroidTunProvider {
     }
 
     fn prepare_tun_config_for_excluded_apps(&self, config: &mut TunConfig) {
-        config.excluded_packages = self.excluded_apps.clone();
+        config.excluded_packages.clone_from(&self.excluded_apps);
     }
 
     /// Allow a socket to bypass the tunnel.

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -96,7 +96,7 @@ pub enum ErrorStateCause {
     #[cfg(target_os = "android")]
     VpnPermissionDenied,
     /// Error reported by split tunnel module.
-    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "android"))]
     SplitTunnelError,
     /// Missing permissions required by macOS split tunneling.
     #[cfg(target_os = "macos")]
@@ -202,7 +202,7 @@ impl fmt::Display for ErrorStateCause {
             IsOffline => "This device is offline, no tunnels can be established",
             #[cfg(target_os = "android")]
             VpnPermissionDenied => "The Android VPN permission was denied when creating the tunnel",
-            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            #[cfg(any(target_os = "windows", target_os = "macos", target_os = "android"))]
             SplitTunnelError => "The split tunneling module reported an error",
             #[cfg(target_os = "macos")]
             NeedFullDiskPermissions => "Need full disk access to enable split tunneling",


### PR DESCRIPTION
This PR fixes a bug in the Android split tunnel implementation where the daemon would fail to reconnect when the split tunnel settings changed. This could case the tunnel to become stale, blocking internet traffic for some apps in the process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6540)
<!-- Reviewable:end -->
