### PR TITLE
Fix crash in request vpn permission

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/RequestVpnPermission.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/util/RequestVpnPermission.kt
@@ -8,13 +8,21 @@ import androidx.activity.result.contract.ActivityResultContract
 
 class RequestVpnPermission : ActivityResultContract<Unit, Boolean>() {
     override fun createIntent(context: Context, input: Unit): Intent {
-        // We expect this permission to only be requested when the permission is missing, however,
-        // if it for some reason is called incorrectly we should return an empty intent so we avoid
-        // a crash.
-        return VpnService.prepare(context) ?: Intent()
+        return VpnService.prepare(context)
     }
 
     override fun parseResult(resultCode: Int, intent: Intent?): Boolean {
         return resultCode == Activity.RESULT_OK
+    }
+
+    // We expect this permission to only be requested when the permission is missing, however,
+    // if it for some reason is called incorrectly we will skip the call to create intent
+    // to avoid crashing. The app will then proceed as the user accepted permission.
+    override fun getSynchronousResult(context: Context, input: Unit): SynchronousResult<Boolean>? {
+        return if (VpnService.prepare(context) == null) {
+            SynchronousResult(true)
+        } else {
+            null
+        }
     }
 }


### PR DESCRIPTION
This crash could occur if create intent in request vpn permission was called while vpn permission was already approved

Fixed by returning true immediately in those cases

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
