### PR TITLE
Fix hardcoded tunnel interface name in test

### DIFF
--- a/test/test-manager/src/tests/cve_2019_14899.rs
+++ b/test/test-manager/src/tests/cve_2019_14899.rs
@@ -66,7 +66,9 @@ pub async fn test_cve_2019_14899_mitigation(
     helpers::connect_and_wait(&mut mullvad_client).await?;
 
     let host_interface = TAP_NAME;
-    let victim_tunnel_interface = "wg0-mullvad";
+    let victim_tunnel_interface = helpers::get_tunnel_interface(&mut mullvad_client)
+        .await
+        .context("Failed to find tunnel interface")?;
     let victim_gateway_ip = NON_TUN_GATEWAY;
 
     // Create a raw socket which let's us send custom ethernet packets


### PR DESCRIPTION
Another minor fix. Replaced code works most of the time, but occasionally the iface name can mismatch the constant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6551)
<!-- Reviewable:end -->
