### PR TITLE
Reset all settings between tests

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2256,18 +2256,10 @@ where
         {
             Ok(settings_changed) => {
                 Self::oneshot_send(tx, Ok(()), "set_daita_settings response");
-                if settings_changed {
-                    self.parameters_generator
-                        .set_tunnel_options(&self.settings.tunnel_options)
-                        .await;
-                    self.event_listener
-                        .notify_settings(self.settings.to_settings());
-                    self.relay_selector
-                        .set_config(new_selector_config(&self.settings));
-                    if self.get_target_tunnel_type() == Some(TunnelType::Wireguard) {
-                        log::info!("Reconnecting because DAITA settings changed");
-                        self.reconnect_tunnel();
-                    }
+                if settings_changed && self.get_target_tunnel_type() == Some(TunnelType::Wireguard)
+                {
+                    log::info!("Reconnecting because DAITA settings changed");
+                    self.reconnect_tunnel();
                 }
             }
             Err(e) => {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -246,6 +246,14 @@ impl ManagementService for ManagementServiceImpl {
             .map(|settings| Response::new(types::Settings::from(&settings)))
     }
 
+    async fn reset_settings(&self, _: Request<()>) -> ServiceResult<()> {
+        log::debug!("reset_settings");
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::ResetSettings(tx))?;
+        self.wait_for_result(rx).await??;
+        Ok(Response::new(()))
+    }
+
     async fn set_allow_lan(&self, request: Request<bool>) -> ServiceResult<()> {
         let allow_lan = request.into_inner();
         log::debug!("set_allow_lan({})", allow_lan);

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(not(target_os = "android"))]
 use futures::TryFutureExt;
 use mullvad_types::{
     custom_list::Error as CustomListError,
@@ -220,7 +219,6 @@ impl SettingsPersister {
     }
 
     /// Resets default settings
-    #[cfg(not(target_os = "android"))]
     pub async fn reset(&mut self) -> Result<(), Error> {
         self.settings = Self::default_settings();
         let path = self.path.clone();

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -39,6 +39,7 @@ service ManagementService {
 
   // Settings
   rpc GetSettings(google.protobuf.Empty) returns (Settings) {}
+  rpc ResetSettings(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc SetAllowLan(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
   rpc SetShowBetaReleases(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}
   rpc SetBlockWhenDisconnected(google.protobuf.BoolValue) returns (google.protobuf.Empty) {}

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -313,6 +313,11 @@ impl MullvadProxyClient {
         Settings::try_from(settings).map_err(Error::InvalidResponse)
     }
 
+    pub async fn reset_settings(&mut self) -> Result<()> {
+        self.0.reset_settings(()).await.map_err(Error::Rpc)?;
+        Ok(())
+    }
+
     pub async fn set_allow_lan(&mut self, state: bool) -> Result<()> {
         self.0.set_allow_lan(state).await.map_err(Error::Rpc)?;
         Ok(())

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -79,115 +79,15 @@ pub async fn cleanup_after_test(
     rpc: ServiceClient,
     rpc_provider: &RpcClientProvider,
 ) -> anyhow::Result<()> {
-    log::debug!("Cleaning up daemon in test cleanup");
+    log::debug!("Resetting daemon settings after test");
     // Check if daemon should be restarted
     restart_daemon(rpc).await?;
     let mut mullvad_client = rpc_provider.new_client().await;
-
+    mullvad_client
+        .reset_settings()
+        .await
+        .context("Failed to reset settings")?;
     helpers::disconnect_and_wait(&mut mullvad_client).await?;
-
-    // Bring all the settings into scope so we remember to reset them.
-    let mullvad_types::settings::Settings {
-        relay_settings,
-        bridge_settings,
-        obfuscation_settings,
-        bridge_state,
-        custom_lists,
-        api_access_methods,
-        allow_lan,
-        block_when_disconnected,
-        auto_connect,
-        tunnel_options,
-        relay_overrides,
-        show_beta_releases,
-        #[cfg(target_os = "macos")]
-            split_tunnel: _,
-        settings_version: _, // N/A
-    } = Default::default();
-
-    mullvad_client
-        .clear_custom_access_methods()
-        .await
-        .context("Could not clear custom api access methods")?;
-    for access_method in api_access_methods.iter() {
-        mullvad_client
-            .update_access_method(access_method.clone())
-            .await
-            .context("Could not reset default access method")?;
-    }
-
-    mullvad_client
-        .set_relay_settings(relay_settings)
-        .await
-        .context("Could not set relay settings")?;
-
-    let _ = relay_overrides;
-    mullvad_client
-        .clear_all_relay_overrides()
-        .await
-        .context("Could not set relay overrides")?;
-
-    mullvad_client
-        .set_auto_connect(auto_connect)
-        .await
-        .context("Could not set auto connect in cleanup")?;
-
-    mullvad_client
-        .set_allow_lan(allow_lan)
-        .await
-        .context("Could not set allow lan in cleanup")?;
-
-    mullvad_client
-        .set_show_beta_releases(show_beta_releases)
-        .await
-        .context("Could not set show beta releases in cleanup")?;
-
-    mullvad_client
-        .set_bridge_state(bridge_state)
-        .await
-        .context("Could not set bridge state in cleanup")?;
-
-    mullvad_client
-        .set_bridge_settings(bridge_settings.clone())
-        .await
-        .context("Could not set bridge settings in cleanup")?;
-
-    mullvad_client
-        .set_obfuscation_settings(obfuscation_settings.clone())
-        .await
-        .context("Could set obfuscation settings in cleanup")?;
-
-    mullvad_client
-        .set_block_when_disconnected(block_when_disconnected)
-        .await
-        .context("Could not set block when disconnected setting in cleanup")?;
-
-    mullvad_client
-        .clear_split_tunnel_apps()
-        .await
-        .context("Could not clear split tunnel apps in cleanup")?;
-
-    mullvad_client
-        .clear_split_tunnel_processes()
-        .await
-        .context("Could not clear split tunnel processes in cleanup")?;
-
-    mullvad_client
-        .set_dns_options(tunnel_options.dns_options.clone())
-        .await
-        .context("Could not clear dns options in cleanup")?;
-
-    mullvad_client
-        .set_quantum_resistant_tunnel(tunnel_options.wireguard.quantum_resistant)
-        .await
-        .context("Could not clear PQ options in cleanup")?;
-
-    let _ = custom_lists;
-    mullvad_client
-        .clear_custom_lists()
-        .await
-        .context("Could not remove custom list")?;
-
     Ok(())
 }
 


### PR DESCRIPTION
The DAITA setting was not being reset during cleanup. The PR fixes this by adding an RPC that resets all settings without logging out.

Fix DES-1108.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6553)
<!-- Reviewable:end -->
