### PR TITLE
Gracefully shutdown gRPC server

### DIFF
--- a/mullvad-daemon/src/access_method.rs
+++ b/mullvad-daemon/src/access_method.rs
@@ -1,4 +1,4 @@
-use crate::{api, settings, Daemon, EventListener};
+use crate::{api, settings, Daemon};
 use mullvad_api::{proxy::ApiConnectionMode, rest, ApiProxy};
 use mullvad_types::{
     access_method::{self, AccessMethod, AccessMethodSetting},
@@ -28,10 +28,7 @@ pub enum Error {
     Settings(#[from] settings::Error),
 }
 
-impl<L> Daemon<L>
-where
-    L: EventListener,
-{
+impl Daemon {
     /// Add a [`AccessMethod`] to the daemon's settings.
     ///
     /// If the daemon settings are successfully updated, the

--- a/mullvad-daemon/src/custom_list.rs
+++ b/mullvad-daemon/src/custom_list.rs
@@ -1,4 +1,4 @@
-use crate::{new_selector_config, Daemon, Error, EventListener};
+use crate::{new_selector_config, Daemon, Error};
 use mullvad_types::{
     constraints::Constraint,
     custom_list::{CustomList, Id},
@@ -6,10 +6,7 @@ use mullvad_types::{
 };
 use talpid_types::net::TunnelType;
 
-impl<L> Daemon<L>
-where
-    L: EventListener,
-{
+impl Daemon {
     /// Create a new custom list.
     ///
     /// Returns an error if the name is not unique.

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1,6 +1,4 @@
-use crate::{
-    account_history, device, version_check, DaemonCommand, DaemonCommandSender, EventListener,
-};
+use crate::{account_history, device, version_check, DaemonCommand, DaemonCommandSender};
 use futures::{
     channel::{mpsc, oneshot},
     StreamExt,
@@ -8,7 +6,7 @@ use futures::{
 use mullvad_api::{rest::Error as RestError, StatusCode};
 use mullvad_management_interface::{
     types::{self, daemon_event, management_service_server::ManagementService},
-    Code, Request, Response, Status,
+    Code, Request, Response, ServerJoinHandle, Status,
 };
 use mullvad_types::{
     account::AccountToken,
@@ -28,7 +26,10 @@ use std::{
     time::Duration,
 };
 use talpid_types::ErrorExt;
+use tokio::time::timeout;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+
+const RPC_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -1054,40 +1055,79 @@ impl ManagementServiceImpl {
     }
 }
 
-pub struct ManagementInterfaceServer(());
+/// The running management interface serving gRPC requests.
+pub struct ManagementInterfaceServer {
+    /// The rpc server spawned by [`Self::start`]. When the underlying join handle yields, the rpc
+    /// server has shutdown.
+    rpc_server_join_handle: ServerJoinHandle,
+    /// Channel used to signal the running gRPC server to shutdown. This needs to be done before
+    /// awaiting trying to join [`Self::rpc_server_join_handle`].
+    server_abort_tx: mpsc::Sender<()>,
+    /// A reference to the associated [`ManagementInterfaceEventBroadcaster`]. This may be used to
+    /// broadcast certain events to all subscribers of the management interface.
+    broadcast: ManagementInterfaceEventBroadcaster,
+}
 
 impl ManagementInterfaceServer {
     pub fn start(
-        tunnel_tx: DaemonCommandSender,
+        daemon_tx: DaemonCommandSender,
         rpc_socket_path: impl AsRef<Path>,
-    ) -> Result<ManagementInterfaceEventBroadcaster, Error> {
+    ) -> Result<ManagementInterfaceServer, Error> {
         let subscriptions = Arc::<Mutex<Vec<EventsListenerSender>>>::default();
-
+        // NOTE: It is important that the channel buffer size is kept at 0. When sending a signal
+        // to abort the gRPC server, the sender can be awaited to know when the gRPC server has
+        // received and started processing the shutdown signal.
         let (server_abort_tx, server_abort_rx) = mpsc::channel(0);
         let server = ManagementServiceImpl {
-            daemon_tx: tunnel_tx,
+            daemon_tx,
             subscriptions: subscriptions.clone(),
         };
-        let join_handle = mullvad_management_interface::spawn_rpc_server(
+        let rpc_server_join_handle = mullvad_management_interface::spawn_rpc_server(
             server,
             async move {
                 server_abort_rx.into_future().await;
             },
-            rpc_socket_path,
+            &rpc_socket_path,
         )
         .map_err(Error::SetupError)?;
 
-        tokio::spawn(async move {
-            if let Err(error) = join_handle.await {
-                log::error!("Management server panic: {}", error);
-            }
-            log::info!("Management interface shut down");
-        });
+        log::info!(
+            "Management interface listening on {}",
+            rpc_socket_path.as_ref().display()
+        );
 
-        Ok(ManagementInterfaceEventBroadcaster {
-            subscriptions,
-            _close_handle: server_abort_tx,
+        let broadcast = ManagementInterfaceEventBroadcaster { subscriptions };
+
+        Ok(ManagementInterfaceServer {
+            rpc_server_join_handle,
+            server_abort_tx,
+            broadcast,
         })
+    }
+
+    /// Wait for the server to shut down gracefully. If that does not happend within [`RPC_SERVER_SHUTDOWN_TIMEOUT`],
+    /// the gRPC server is aborted and we yield the async execution.
+    pub async fn stop(mut self) {
+        use futures::SinkExt;
+        // Send a singal to the underlying RPC server to shut down.
+        let _ = self.server_abort_tx.send(()).await;
+
+        match timeout(RPC_SERVER_SHUTDOWN_TIMEOUT, self.rpc_server_join_handle).await {
+            // Joining the rpc server handle timed out
+            Err(timeout) => {
+                log::error!("Timed out while shutting down management server: {timeout}");
+            }
+            Ok(join_result) => {
+                if let Err(_error) = join_result {
+                    log::error!("Management server task failed to execute until completion");
+                }
+            }
+        }
+    }
+
+    /// Obtain a reference to the associated [`ManagementInterfaceEventBroadcaster`].
+    pub const fn notifier(&self) -> &ManagementInterfaceEventBroadcaster {
+        &self.broadcast
     }
 }
 
@@ -1095,12 +1135,18 @@ impl ManagementInterfaceServer {
 #[derive(Clone)]
 pub struct ManagementInterfaceEventBroadcaster {
     subscriptions: Arc<Mutex<Vec<EventsListenerSender>>>,
-    _close_handle: mpsc::Sender<()>,
 }
 
-impl EventListener for ManagementInterfaceEventBroadcaster {
+impl ManagementInterfaceEventBroadcaster {
+    fn notify(&self, value: types::DaemonEvent) {
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+        subscriptions.retain(|tx| tx.send(Ok(value.clone())).is_ok());
+    }
+
+    /// Notify that the tunnel state changed.
+    ///
     /// Sends a new state update to all `new_state` subscribers of the management interface.
-    fn notify_new_state(&self, new_state: TunnelState) {
+    pub(crate) fn notify_new_state(&self, new_state: TunnelState) {
         self.notify(types::DaemonEvent {
             event: Some(daemon_event::Event::TunnelState(types::TunnelState::from(
                 new_state,
@@ -1108,8 +1154,10 @@ impl EventListener for ManagementInterfaceEventBroadcaster {
         })
     }
 
+    /// Notify that the settings changed.
+    ///
     /// Sends settings to all `settings` subscribers of the management interface.
-    fn notify_settings(&self, settings: Settings) {
+    pub(crate) fn notify_settings(&self, settings: Settings) {
         log::debug!("Broadcasting new settings");
         self.notify(types::DaemonEvent {
             event: Some(daemon_event::Event::Settings(types::Settings::from(
@@ -1118,8 +1166,10 @@ impl EventListener for ManagementInterfaceEventBroadcaster {
         })
     }
 
+    /// Notify that the relay list changed.
+    ///
     /// Sends relays to all subscribers of the management interface.
-    fn notify_relay_list(&self, relay_list: RelayList) {
+    pub(crate) fn notify_relay_list(&self, relay_list: RelayList) {
         log::debug!("Broadcasting new relay list");
         self.notify(types::DaemonEvent {
             event: Some(daemon_event::Event::RelayList(types::RelayList::from(
@@ -1128,7 +1178,9 @@ impl EventListener for ManagementInterfaceEventBroadcaster {
         })
     }
 
-    fn notify_app_version(&self, app_version_info: version::AppVersionInfo) {
+    /// Notify that info about the latest available app version changed.
+    /// Or some flag about the currently running version is changed.
+    pub(crate) fn notify_app_version(&self, app_version_info: version::AppVersionInfo) {
         log::debug!("Broadcasting new app version info");
         self.notify(types::DaemonEvent {
             event: Some(daemon_event::Event::VersionInfo(
@@ -1137,7 +1189,8 @@ impl EventListener for ManagementInterfaceEventBroadcaster {
         })
     }
 
-    fn notify_device_event(&self, device: mullvad_types::device::DeviceEvent) {
+    /// Notify that device changed (login, logout, or key rotation).
+    pub(crate) fn notify_device_event(&self, device: mullvad_types::device::DeviceEvent) {
         log::debug!("Broadcasting device event");
         self.notify(types::DaemonEvent {
             event: Some(daemon_event::Event::Device(types::DeviceEvent::from(
@@ -1146,7 +1199,11 @@ impl EventListener for ManagementInterfaceEventBroadcaster {
         })
     }
 
-    fn notify_remove_device_event(&self, remove_event: mullvad_types::device::RemoveDeviceEvent) {
+    /// Notify that a device was revoked using `RemoveDevice`.
+    pub(crate) fn notify_remove_device_event(
+        &self,
+        remove_event: mullvad_types::device::RemoveDeviceEvent,
+    ) {
         log::debug!("Broadcasting remove device event");
         self.notify(types::DaemonEvent {
             event: Some(daemon_event::Event::RemoveDevice(
@@ -1155,7 +1212,8 @@ impl EventListener for ManagementInterfaceEventBroadcaster {
         })
     }
 
-    fn notify_new_access_method_event(
+    /// Notify that the api access method changed.
+    pub(crate) fn notify_new_access_method_event(
         &self,
         new_access_method: mullvad_types::access_method::AccessMethodSetting,
     ) {
@@ -1165,13 +1223,6 @@ impl EventListener for ManagementInterfaceEventBroadcaster {
                 types::AccessMethodSetting::from(new_access_method),
             )),
         })
-    }
-}
-
-impl ManagementInterfaceEventBroadcaster {
-    fn notify(&self, value: types::DaemonEvent) {
-        let mut subscriptions = self.subscriptions.lock().unwrap();
-        subscriptions.retain(|tx| tx.send(Ok(value.clone())).is_ok());
     }
 }
 

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -13,8 +13,7 @@ use jnix::{
     FromJava, JnixEnv,
 };
 use mullvad_daemon::{
-    cleanup_old_rpc_socket, exception_logging, logging,
-    management_interface::ManagementInterfaceServer, runtime::new_multi_thread, version, Daemon,
+    cleanup_old_rpc_socket, exception_logging, logging, runtime::new_multi_thread, version, Daemon,
     DaemonCommandChannel, DaemonCommandSender,
 };
 use std::{
@@ -48,9 +47,6 @@ pub enum Error {
 
     #[error("Failed to init Tokio runtime")]
     InitTokio(#[source] io::Error),
-
-    #[error("Failed to spawn the management interface")]
-    SpawnManagementInterface(#[source] mullvad_daemon::management_interface::Error),
 }
 
 /// Throw a Java exception and return if `result` is an error
@@ -169,7 +165,6 @@ fn spawn_daemon(
         rpc_socket,
         files_dir,
         cache_dir,
-        daemon_command_channel,
         android_context,
     ))?;
 
@@ -184,23 +179,16 @@ async fn spawn_daemon_inner(
     rpc_socket: PathBuf,
     files_dir: PathBuf,
     cache_dir: PathBuf,
-    command_channel: DaemonCommandChannel,
     android_context: AndroidContext,
 ) -> Result<tokio::task::JoinHandle<()>, Error> {
     cleanup_old_rpc_socket(&rpc_socket).await;
-
-    let event_listener = ManagementInterfaceServer::start(command_channel.sender(), &rpc_socket)
-        .map_err(Error::SpawnManagementInterface)?;
-
-    log::info!("Management interface listening on {}", rpc_socket.display());
 
     let daemon = Daemon::start(
         Some(files_dir.clone()),
         files_dir.clone(),
         files_dir,
         cache_dir,
-        event_listener,
-        command_channel,
+        rpc_socket,
         android_context,
     )
     .await


### PR DESCRIPTION
This PR refactors the dameon a bit to properly shut down the management interface server. Previously, it would die when the tokio runtime was tore down due to the tokio task it was run on being dropped. Since we already spawn the `tonic` server with [`serve_with_incoming_shutdown`](https://docs.rs/tonic/latest/tonic/transport/server/struct.Router.html#method.serve_with_incoming_shutdown), it was just a matter of actually using the shutdown signal future that we already had before awaiting the management interface server future.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6559)
<!-- Reviewable:end -->
