### PR TITLE
Bump dates for all osv scanner ignored vulns and added reasons

### DIFF
--- a/android/gradle/osv-scanner.toml
+++ b/android/gradle/osv-scanner.toml
@@ -1,89 +1,84 @@
 # See repository root `osv-scanner.toml` for instructions and rules for this file.
 #
-# Temporarily ignoring all reported android vulnerabilites with a one month deadline
-# since we plan to examine the vulnerabilites and bootstrap this file with proper
-# ignore reasons (or address by bumping dependencies).
-#
-# Also worth mentioning that we're already using the OWASP Dependency-Check tool
-# for the android code base as of before.
+# The OWASP Dependency-Check tool is also used for vulnerability scanning.
 
 [[IgnoredVulns]]
 id = "CVE-2022-45868" # GHSA-22wj-vf5f-wrvj
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "Used by the dependency-check tool and not the app directly."
 
 [[IgnoredVulns]]
 id = "CVE-2023-3635" # GHSA-w33c-445m-f8w7
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "We do not use gzip when using okio."
 
 [[IgnoredVulns]]
 id = "CVE-2024-29025" # GHSA-5jpm-x58v-624v
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "We do not use netty for http communication."
 
 [[IgnoredVulns]]
 id = "CVE-2023-44487" # GHSA-xpw8-rcwv-8f8p
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "No impact on this app since it uses UDS rather than HTTP2."
 
 [[IgnoredVulns]]
 id = "CVE-2023-34462" # GHSA-6mjq-h674-j845
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "We do not use netty for http communication."
 
 [[IgnoredVulns]]
 id = "CVE-2024-26308" # GHSA-4265-ccf5-phj5
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "Apache commons compress is used by lint and not the app directly."
 
 [[IgnoredVulns]]
 id = "CVE-2024-25710" # GHSA-4g9r-vxhx-9pgx
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "Apache commons compress is used by lint and not the app directly."
 
 [[IgnoredVulns]]
 id = "CVE-2020-13956" # GHSA-7r82-7xv7-xcpj
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "Apache http client is used by lint and not the app directly."
 
 [[IgnoredVulns]]
 id = "CVE-2023-51775" # GHSA-6qvw-249j-h44c
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-09-02
+reason = "Used by the gradle bundler, will be fixed by upgrading the android gradle plugin."
 
 [[IgnoredVulns]]
 id = "CVE-2023-31582" # GHSA-7g24-qg88-p43q
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-09-02
+reason = "Used by the gradle bundler, will be fixed by upgrading the android gradle plugin."
 
 [[IgnoredVulns]]
 id = "GHSA-jgvc-jfgh-rjvv"
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-09-02
+reason = "Used by the gradle bundler, will be fixed by upgrading the android gradle plugin."
 
 [[IgnoredVulns]]
 id = "CVE-2022-24329" # GHSA-2qp4-g3q3-f92w
-ignoreUntil = 2024-08-02
-reason = "See top comment"
+ignoreUntil = 2024-11-02
+reason = "This CVE only affect Multiplatform Gradle Projects, which this project is not."
 
 [[PackageOverrides]]
 name = "org.bouncycastle:bcprov-jdk15on"
 ecosystem = "Maven"
 ignore = true
-effectiveUntil = 2024-08-02
-reason = "See top comment"
+effectiveUntil = 2024-11-02
+reason = "Used by lint and the dependency-check tool and not the app directly."
 
 [[PackageOverrides]]
 name = "org.bouncycastle:bcprov-jdk18on"
 ecosystem = "Maven"
 ignore = true
-effectiveUntil = 2024-08-02
-reason = "See top comment"
+effectiveUntil = 2024-11-02
+reason = "Used by lint and the dependency-check tool and not the app directly."
 
 [[PackageOverrides]]
 name = "org.bouncycastle:bcpkix-jdk18on"
 ecosystem = "Maven"
 ignore = true
-effectiveUntil = 2024-08-02
-reason = "See top comment"
+effectiveUntil = 2024-11-02
+reason = "Used by lint and the dependency-check tool and not the app directly."


### PR DESCRIPTION
Added a shorter deadline for `jose4j` since that one is hopefully fixed by upgrading the AGP plugin.

See this google issue:
https://issuetracker.google.com/issues/299134781

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6565)
<!-- Reviewable:end -->
