### PR TITLE
Use a wireguard commit that reduces multihop crashes

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9149,7 +9149,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = 758a8a22ccdc9fe37c2483f991141d1c750144db;
+				revision = e3fdc2e95ccd7a30284ec78f3bdf4f9a252a1ed2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "758a8a22ccdc9fe37c2483f991141d1c750144db"
+        "revision" : "e3fdc2e95ccd7a30284ec78f3bdf4f9a252a1ed2"
       }
     }
   ],


### PR DESCRIPTION
This PR bumps the wireguard dependency to commit `e3fdc2e95ccd7a30284ec78f3bdf4f9a252a1ed2` in our fork of `wireguard-apple` which fixes multihop related crashes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6566)
<!-- Reviewable:end -->
