### PR TITLE
Fix shutdown issue on Android

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -589,19 +589,18 @@ impl Daemon {
         settings_dir: PathBuf,
         cache_dir: PathBuf,
         rpc_socket_path: PathBuf,
+        daemon_command_channel: DaemonCommandChannel,
         #[cfg(target_os = "android")] android_context: AndroidContext,
     ) -> Result<Self, Error> {
         #[cfg(target_os = "macos")]
         macos::bump_filehandle_limit();
 
-        let command_channel = DaemonCommandChannel::new();
-        let command_sender = command_channel.sender();
-
+        let command_sender = daemon_command_channel.sender();
         let management_interface =
             ManagementInterfaceServer::start(command_sender, rpc_socket_path)
                 .map_err(Error::ManagementInterfaceError)?;
 
-        let (internal_event_tx, internal_event_rx) = command_channel.destructure();
+        let (internal_event_tx, internal_event_rx) = daemon_command_channel.destructure();
 
         mullvad_api::proxy::ApiConnectionMode::try_delete_cache(&cache_dir).await;
         let api_runtime = mullvad_api::Runtime::with_cache(

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -582,7 +582,6 @@ pub struct Daemon {
 }
 
 impl Daemon {
-    #[allow(clippy::too_many_arguments)]
     pub async fn start(
         log_dir: Option<PathBuf>,
         resource_dir: PathBuf,

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -2,7 +2,9 @@ use std::{path::PathBuf, thread, time::Duration};
 
 #[cfg(not(windows))]
 use mullvad_daemon::cleanup_old_rpc_socket;
-use mullvad_daemon::{logging, rpc_uniqueness_check, runtime, version, Daemon};
+use mullvad_daemon::{
+    logging, rpc_uniqueness_check, runtime, version, Daemon, DaemonCommandChannel,
+};
 use talpid_types::ErrorExt;
 
 mod cli;
@@ -197,12 +199,15 @@ async fn create_daemon(log_dir: Option<PathBuf>) -> Result<Daemon, String> {
     let cache_dir = mullvad_paths::cache_dir()
         .map_err(|e| e.display_chain_with_msg("Unable to get cache dir"))?;
 
+    let daemon_command_channel = DaemonCommandChannel::new();
+
     Daemon::start(
         log_dir,
         resource_dir,
         settings_dir,
         cache_dir,
         rpc_socket_path,
+        daemon_command_channel,
     )
     .await
     .map_err(|e| e.display_chain_with_msg("Unable to initialize daemon"))

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -165,6 +165,7 @@ fn spawn_daemon(
         rpc_socket,
         files_dir,
         cache_dir,
+        daemon_command_channel,
         android_context,
     ))?;
 
@@ -179,6 +180,7 @@ async fn spawn_daemon_inner(
     rpc_socket: PathBuf,
     files_dir: PathBuf,
     cache_dir: PathBuf,
+    daemon_command_channel: DaemonCommandChannel,
     android_context: AndroidContext,
 ) -> Result<tokio::task::JoinHandle<()>, Error> {
     cleanup_old_rpc_socket(&rpc_socket).await;
@@ -189,6 +191,7 @@ async fn spawn_daemon_inner(
         files_dir,
         cache_dir,
         rpc_socket,
+        daemon_command_channel,
         android_context,
     )
     .await


### PR DESCRIPTION
This PR fixes an issue encountered when shutting down the Android app. The daemon never received the shutdown event, causing it to never actually triggering a shutdown. This was fixed by actually using the correct `DaemonCommandChannel` to send the shutdown event.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6577)
<!-- Reviewable:end -->
