### PR TITLE
Enable permissions when calling sub workflow

### DIFF
--- a/.github/workflows/ios-end-to-end-tests-api.yml
+++ b/.github/workflows/ios-end-to-end-tests-api.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
 jobs:
   reuse-e2e-workflow:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "api-tests"

--- a/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
+++ b/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
@@ -12,6 +12,10 @@ on:
       - ios/**
 jobs:
   reuse-e2e-workflow:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "pr-merge-to-main"

--- a/.github/workflows/ios-end-to-end-tests-nightly.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly.yml
@@ -11,6 +11,10 @@ on:
     - cron: '0 0 * * *'
 jobs:
   reuse-e2e-workflow:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "nightly"


### PR DESCRIPTION
This PR adds the following permissions
```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```
to actions calling into `ios-end-to-end-tests`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6588)
<!-- Reviewable:end -->
