### PR TITLE
Allow relay selector to filter daita enabled relays

### DIFF
--- a/ios/MullvadMockData/MullvadREST/RelaySelectorStub.swift
+++ b/ios/MullvadMockData/MullvadREST/RelaySelectorStub.swift
@@ -58,7 +58,7 @@ extension RelaySelectorStub {
     /// Returns a relay selector that cannot satisfy constraints .
     public static func unsatisfied() -> RelaySelectorStub {
         return RelaySelectorStub { _ in
-            throw NoRelaysSatisfyingConstraintsError()
+            throw NoRelaysSatisfyingConstraintsError(.relayConstraintNotMatching)
         }
     }
 }

--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -34,6 +34,7 @@ extension REST {
         public let ipv4AddrIn: IPv4Address
         public let weight: UInt64
         public let includeInCountry: Bool
+        public var daita: Bool?
 
         public func override(ipv4AddrIn: IPv4Address?) -> Self {
             return BridgeRelay(
@@ -60,6 +61,7 @@ extension REST {
         public let ipv6AddrIn: IPv6Address
         public let publicKey: Data
         public let includeInCountry: Bool
+        public let daita: Bool?
 
         public func override(ipv4AddrIn: IPv4Address?, ipv6AddrIn: IPv6Address?) -> Self {
             return ServerRelay(
@@ -72,7 +74,8 @@ extension REST {
                 ipv4AddrIn: ipv4AddrIn ?? self.ipv4AddrIn,
                 ipv6AddrIn: ipv6AddrIn ?? self.ipv6AddrIn,
                 publicKey: publicKey,
-                includeInCountry: includeInCountry
+                includeInCountry: includeInCountry,
+                daita: daita
             )
         }
     }

--- a/ios/MullvadREST/Relay/AnyRelay.swift
+++ b/ios/MullvadREST/Relay/AnyRelay.swift
@@ -17,6 +17,7 @@ public protocol AnyRelay {
     var weight: UInt64 { get }
     var active: Bool { get }
     var includeInCountry: Bool { get }
+    var daita: Bool? { get }
 
     func override(ipv4AddrIn: IPv4Address?, ipv6AddrIn: IPv6Address?) -> Self
 }

--- a/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
+++ b/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
@@ -26,13 +26,13 @@ struct OneToOne: MultihopDecisionFlow {
     func pick(entryCandidates: [RelayCandidate], exitCandidates: [RelayCandidate]) throws -> SelectedRelays {
         guard canHandle(entryCandidates: entryCandidates, exitCandidates: exitCandidates) else {
             guard let next else {
-                throw NoRelaysSatisfyingConstraintsError()
+                throw NoRelaysSatisfyingConstraintsError(.multihopInvalidFlow)
             }
             return try next.pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates)
         }
 
         guard entryCandidates.first != exitCandidates.first else {
-            throw NoRelaysSatisfyingConstraintsError()
+            throw NoRelaysSatisfyingConstraintsError(.entryEqualsExit)
         }
 
         let entryMatch = try relayPicker.findBestMatch(from: entryCandidates)
@@ -61,7 +61,7 @@ struct OneToMany: MultihopDecisionFlow {
 
         guard canHandle(entryCandidates: entryCandidates, exitCandidates: exitCandidates) else {
             guard let next else {
-                throw NoRelaysSatisfyingConstraintsError()
+                throw NoRelaysSatisfyingConstraintsError(.multihopInvalidFlow)
             }
             return try next.pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates)
         }
@@ -100,7 +100,7 @@ struct ManyToMany: MultihopDecisionFlow {
 
         guard canHandle(entryCandidates: entryCandidates, exitCandidates: exitCandidates) else {
             guard let next else {
-                throw NoRelaysSatisfyingConstraintsError()
+                throw NoRelaysSatisfyingConstraintsError(.multihopInvalidFlow)
             }
             return try next.pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates)
         }

--- a/ios/MullvadREST/Relay/NoRelaysSatisfyingConstraintsError.swift
+++ b/ios/MullvadREST/Relay/NoRelaysSatisfyingConstraintsError.swift
@@ -8,10 +8,39 @@
 
 import Foundation
 
+public enum NoRelaysSatisfyingConstraintsReason {
+    case filterConstraintNotMatching
+    case invalidPort
+    case entryEqualsExit
+    case multihopInvalidFlow
+    case noActiveRelaysFound
+    case noDaitaRelaysFound
+    case relayConstraintNotMatching
+}
+
 public struct NoRelaysSatisfyingConstraintsError: LocalizedError {
-    public init() {}
+    public let reason: NoRelaysSatisfyingConstraintsReason
 
     public var errorDescription: String? {
-        "No relays satisfying constraints."
+        switch reason {
+        case .filterConstraintNotMatching:
+            "Filter yields no matching relays"
+        case .invalidPort:
+            "Invalid port selected by RelaySelector"
+        case .entryEqualsExit:
+            "Entry and exit relays are the same"
+        case .multihopInvalidFlow:
+            "Invalid multihop decision flow"
+        case .noActiveRelaysFound:
+            "No active relays found"
+        case .noDaitaRelaysFound:
+            "No DAITA relays found"
+        case .relayConstraintNotMatching:
+            "Invalid constraint created to pick a relay"
+        }
+    }
+
+    public init(_ reason: NoRelaysSatisfyingConstraintsReason) {
+        self.reason = reason
     }
 }

--- a/ios/MullvadREST/Relay/RelaySelector+Shadowsocks.swift
+++ b/ios/MullvadREST/Relay/RelaySelector+Shadowsocks.swift
@@ -43,11 +43,12 @@ extension RelaySelector {
             in relaysResponse: REST.ServerRelaysResponse
         ) -> REST.BridgeRelay? {
             let mappedBridges = mapRelays(relays: relaysResponse.bridge.relays, locations: relaysResponse.locations)
-            let filteredRelays = applyConstraints(
+            let filteredRelays = (try? applyConstraints(
                 location,
                 filterConstraint: filter,
+                daitaEnabled: false,
                 relays: mappedBridges
-            )
+            )) ?? []
             guard filteredRelays.isEmpty == false else { return relay(from: relaysResponse) }
 
             // Compute the midpoint location from all the filtered relays

--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -39,12 +39,14 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol {
         case .off:
             return try SinglehopPicker(
                 constraints: tunnelSettings.relayConstraints,
+                daitaSettings: tunnelSettings.daita,
                 relays: relays,
                 connectionAttemptCount: connectionAttemptCount
             ).pick()
         case .on:
             return try MultihopPicker(
                 constraints: tunnelSettings.relayConstraints,
+                daitaSettings: tunnelSettings.daita,
                 relays: relays,
                 connectionAttemptCount: connectionAttemptCount
             ).pick()

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -57,7 +57,7 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
         let locationViewControllerWrapper = LocationViewControllerWrapper(
             customListRepository: customListRepository,
             constraints: tunnelManager.settings.relayConstraints,
-            multihopEnabled: tunnelManager.settings.tunnelMultihopState == .on
+            multihopEnabled: tunnelManager.settings.tunnelMultihopState.isEnabled
         )
         locationViewControllerWrapper.delegate = self
 

--- a/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/TunnelStatusNotificationProvider.swift
@@ -236,6 +236,12 @@ final class TunnelStatusNotificationProvider: NotificationProvider, InAppNotific
         switch error {
         case .outdatedSchema:
             errorString = "Unable to start tunnel connection after update. Please disconnect and reconnect."
+        case .noRelaysSatisfyingFilterConstraints:
+            errorString = "No servers match your location filter. Try changing filter settings."
+        case .multihopEntryEqualsExit:
+            errorString = "The entry and exit servers cannot be the same. Try changing one to a new server or location."
+        case .noRelaysSatisfyingDaitaConstraints:
+            errorString = "No DAITA compatible servers match your location settings. Try changing location."
         case .noRelaysSatisfyingConstraints:
             errorString = "No servers match your settings, try changing server or other settings."
         case .invalidAccount:

--- a/ios/MullvadVPNTests/MullvadREST/ApiHandlers/ServerRelaysResponse+Stubs.swift
+++ b/ios/MullvadVPNTests/MullvadREST/ApiHandlers/ServerRelaysResponse+Stubs.swift
@@ -85,7 +85,8 @@ enum ServerRelaysResponseStubs {
                     ipv4AddrIn: .loopback,
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
-                    includeInCountry: true
+                    includeInCountry: true,
+                    daita: true
                 ),
                 REST.ServerRelay(
                     hostname: "se10-wireguard",
@@ -97,7 +98,8 @@ enum ServerRelaysResponseStubs {
                     ipv4AddrIn: .loopback,
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
-                    includeInCountry: true
+                    includeInCountry: true,
+                    daita: false
                 ),
                 REST.ServerRelay(
                     hostname: "se2-wireguard",
@@ -109,7 +111,8 @@ enum ServerRelaysResponseStubs {
                     ipv4AddrIn: .loopback,
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
-                    includeInCountry: true
+                    includeInCountry: true,
+                    daita: false
                 ),
                 REST.ServerRelay(
                     hostname: "se6-wireguard",
@@ -121,7 +124,8 @@ enum ServerRelaysResponseStubs {
                     ipv4AddrIn: .loopback,
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
-                    includeInCountry: true
+                    includeInCountry: true,
+                    daita: false
                 ),
                 REST.ServerRelay(
                     hostname: "us-dal-wg-001",
@@ -133,7 +137,8 @@ enum ServerRelaysResponseStubs {
                     ipv4AddrIn: .loopback,
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
-                    includeInCountry: true
+                    includeInCountry: true,
+                    daita: true
                 ),
                 REST.ServerRelay(
                     hostname: "us-nyc-wg-301",
@@ -145,7 +150,21 @@ enum ServerRelaysResponseStubs {
                     ipv4AddrIn: .loopback,
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
-                    includeInCountry: true
+                    includeInCountry: true,
+                    daita: true
+                ),
+                REST.ServerRelay(
+                    hostname: "us-nyc-wg-302",
+                    active: false,
+                    owned: true,
+                    location: "us-nyc",
+                    provider: "",
+                    weight: 100,
+                    ipv4AddrIn: .loopback,
+                    ipv6AddrIn: .loopback,
+                    publicKey: PrivateKey().publicKey.rawValue,
+                    includeInCountry: true,
+                    daita: true
                 ),
             ]
         ),

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import MullvadREST
+@testable import MullvadSettings
 @testable import MullvadTypes
 import XCTest
 
@@ -119,6 +120,7 @@ extension MultihopDecisionFlowTests {
 
         return MultihopPicker(
             constraints: constraints,
+            daitaSettings: DAITASettings(state: .off),
             relays: sampleRelays,
             connectionAttemptCount: 0
         )

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 @testable import MullvadREST
+@testable import MullvadSettings
 @testable import MullvadTypes
 import XCTest
 
@@ -23,6 +24,7 @@ class RelayPickingTests: XCTestCase {
 
         let picker = SinglehopPicker(
             constraints: constraints,
+            daitaSettings: DAITASettings(state: .off),
             relays: sampleRelays,
             connectionAttemptCount: 0
         )
@@ -41,6 +43,7 @@ class RelayPickingTests: XCTestCase {
 
         let picker = MultihopPicker(
             constraints: constraints,
+            daitaSettings: DAITASettings(state: .off),
             relays: sampleRelays,
             connectionAttemptCount: 0
         )
@@ -59,10 +62,16 @@ class RelayPickingTests: XCTestCase {
 
         let picker = MultihopPicker(
             constraints: constraints,
+            daitaSettings: DAITASettings(state: .off),
             relays: sampleRelays,
             connectionAttemptCount: 0
         )
 
-        XCTAssertThrowsError(try picker.pick())
+        XCTAssertThrowsError(
+            try picker.pick()
+        ) { error in
+            let error = error as? NoRelaysSatisfyingConstraintsError
+            XCTAssertEqual(error?.reason, .entryEqualsExit)
+        }
     }
 }

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorWrapperTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorWrapperTests.swift
@@ -52,4 +52,90 @@ class RelaySelectorWrapperTests: XCTestCase {
         let selectedRelays = try wrapper.selectRelays(connectionAttemptCount: 0)
         XCTAssertNotNil(selectedRelays.entry)
     }
+
+    func testCanSelectRelayWithMultihopOnAndDaitaOn() throws {
+        let wrapper = RelaySelectorWrapper(
+            relayCache: relayCache,
+            tunnelSettingsUpdater: settingsUpdater
+        )
+
+        let constraints = RelayConstraints(
+            entryLocations: .only(UserSelectedRelays(locations: [.country("es")])), // Relay with DAITA.
+            exitLocations: .only(UserSelectedRelays(locations: [.country("us")]))
+        )
+
+        let settings = LatestTunnelSettings(
+            relayConstraints: constraints,
+            tunnelMultihopState: .on,
+            daita: DAITASettings(state: .on)
+        )
+        settingsListener.onNewSettings?(settings)
+
+        XCTAssertNoThrow(try wrapper.selectRelays(connectionAttemptCount: 0))
+    }
+
+    func testCannotSelectRelayWithMultihopOnAndDaitaOn() throws {
+        let wrapper = RelaySelectorWrapper(
+            relayCache: relayCache,
+            tunnelSettingsUpdater: settingsUpdater
+        )
+
+        let constraints = RelayConstraints(
+            entryLocations: .only(UserSelectedRelays(locations: [.country("se")])), // Relay without DAITA.
+            exitLocations: .only(UserSelectedRelays(locations: [.country("us")]))
+        )
+
+        let settings = LatestTunnelSettings(
+            relayConstraints: constraints,
+            tunnelMultihopState: .on,
+            daita: DAITASettings(state: .on)
+        )
+        settingsListener.onNewSettings?(settings)
+
+        XCTAssertThrowsError(try wrapper.selectRelays(connectionAttemptCount: 0))
+    }
+
+    func testCanSelectRelayWithMultihopOffAndDaitaOn() throws {
+        let wrapper = RelaySelectorWrapper(
+            relayCache: relayCache,
+            tunnelSettingsUpdater: settingsUpdater
+        )
+
+        let constraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.country("es")])) // Relay with DAITA.
+        )
+
+        let settings = LatestTunnelSettings(
+            relayConstraints: constraints,
+            tunnelMultihopState: .off,
+            daita: DAITASettings(state: .on)
+        )
+        settingsListener.onNewSettings?(settings)
+
+        let selectedRelays = try wrapper.selectRelays(connectionAttemptCount: 0)
+        XCTAssertNil(selectedRelays.entry)
+    }
+
+    // If DAITA is enabled and no supported relays are found, we should try to find the nearest
+    // available relay that supports DAITA and use it as entry in a multihop selection.
+    func testCanSelectRelayWithMultihopOffAndDaitaOnThroughMultihop() throws {
+        let wrapper = RelaySelectorWrapper(
+            relayCache: relayCache,
+            tunnelSettingsUpdater: settingsUpdater
+        )
+
+        let constraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.country("se")])) // Relay without DAITA.
+        )
+
+        let settings = LatestTunnelSettings(
+            relayConstraints: constraints,
+            tunnelMultihopState: .off,
+            daita: DAITASettings(state: .on)
+        )
+        settingsListener.onNewSettings?(settings)
+
+        let selectedRelays = try wrapper.selectRelays(connectionAttemptCount: 0)
+        XCTAssertNotNil(selectedRelays.entry)
+    }
 }

--- a/ios/MullvadVPNTests/MullvadSettings/IPOverrideWrapperTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/IPOverrideWrapperTests.swift
@@ -83,7 +83,8 @@ extension IPOverrideWrapperTests {
             ipv4AddrIn: .any,
             ipv6AddrIn: .any,
             publicKey: Data(),
-            includeInCountry: true
+            includeInCountry: true,
+            daita: false
         )
     }
 

--- a/ios/PacketTunnel/PacketTunnelProvider/BlockedStateErrorMapper.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/BlockedStateErrorMapper.swift
@@ -47,9 +47,18 @@ public struct BlockedStateErrorMapper: BlockedStateErrorMapperProtocol {
                 return .readSettings
             }
 
-        case is NoRelaysSatisfyingConstraintsError:
-            // Returned by relay selector when there are no relays satisfying the given constraint.
-            return .noRelaysSatisfyingConstraints
+        case let error as NoRelaysSatisfyingConstraintsError:
+            // Returned by relay selector when there are no relays satisfying the given constraints.
+            return switch error.reason {
+            case .filterConstraintNotMatching:
+                .noRelaysSatisfyingFilterConstraints
+            case .entryEqualsExit:
+                .multihopEntryEqualsExit
+            case .noDaitaRelaysFound:
+                .noRelaysSatisfyingDaitaConstraints
+            default:
+                .noRelaysSatisfyingConstraints
+            }
 
         case is WireGuardAdapterError:
             // Any errors that originate from wireguard adapter including failure to set tunnel settings using

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -194,7 +194,9 @@ extension BlockedStateReason {
         case .deviceLocked:
             return true
 
-        case .noRelaysSatisfyingConstraints, .readSettings, .invalidAccount, .accountExpired, .deviceRevoked,
+        case .noRelaysSatisfyingConstraints, .noRelaysSatisfyingFilterConstraints,
+             .multihopEntryEqualsExit,
+             .noRelaysSatisfyingDaitaConstraints, .readSettings, .invalidAccount, .accountExpired, .deviceRevoked,
              .tunnelAdapter, .unknown, .deviceLoggedOut, .outdatedSchema, .invalidRelayPublicKey:
             return false
         }

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -192,8 +192,17 @@ public enum BlockedStateReason: String, Codable, Equatable {
     /// Settings schema is outdated.
     case outdatedSchema
 
-    /// No relay satisfying constraints.
+    /// General error for no relays satisfying constraints.
     case noRelaysSatisfyingConstraints
+
+    /// No relays satisfying filter constraints.
+    case noRelaysSatisfyingFilterConstraints
+
+    /// No relays satisfying multihop constraints.
+    case multihopEntryEqualsExit
+
+    /// No relays satisfying DAITA constraints.
+    case noRelaysSatisfyingDaitaConstraints
 
     /// Any other failure when reading settings.
     case readSettings

--- a/ios/PacketTunnelCoreTests/AppMessageHandlerTests.swift
+++ b/ios/PacketTunnelCoreTests/AppMessageHandlerTests.swift
@@ -85,7 +85,8 @@ final class AppMessageHandlerTests: XCTestCase {
         let candidates = try RelaySelector.WireGuard.findCandidates(
             by: relayConstraints.exitLocations,
             in: ServerRelaysResponseStubs.sampleRelays,
-            filterConstraint: relayConstraints.filter
+            filterConstraint: relayConstraints.filter,
+            daitaEnabled: false
         )
 
         let match = try RelaySelector.WireGuard.pickCandidate(

--- a/ios/PacketTunnelCoreTests/MultiHopPostQuantumKeyExchangingTests.swift
+++ b/ios/PacketTunnelCoreTests/MultiHopPostQuantumKeyExchangingTests.swift
@@ -27,7 +27,8 @@ final class MultiHopPostQuantumKeyExchangingTests: XCTestCase {
             from: try RelaySelector.WireGuard.findCandidates(
                 by: relayConstraints.exitLocations,
                 in: ServerRelaysResponseStubs.sampleRelays,
-                filterConstraint: relayConstraints.filter
+                filterConstraint: relayConstraints.filter,
+                daitaEnabled: false
             ),
             relays: ServerRelaysResponseStubs.sampleRelays,
             portConstraint: relayConstraints.port,
@@ -38,7 +39,8 @@ final class MultiHopPostQuantumKeyExchangingTests: XCTestCase {
             from: try RelaySelector.WireGuard.findCandidates(
                 by: relayConstraints.entryLocations,
                 in: ServerRelaysResponseStubs.sampleRelays,
-                filterConstraint: relayConstraints.filter
+                filterConstraint: relayConstraints.filter,
+                daitaEnabled: false
             ),
             relays: ServerRelaysResponseStubs.sampleRelays,
             portConstraint: relayConstraints.port,

--- a/ios/PacketTunnelCoreTests/PostQuantumKeyExchangingPipelineTests.swift
+++ b/ios/PacketTunnelCoreTests/PostQuantumKeyExchangingPipelineTests.swift
@@ -28,7 +28,8 @@ final class PostQuantumKeyExchangingPipelineTests: XCTestCase {
             from: try RelaySelector.WireGuard.findCandidates(
                 by: relayConstraints.exitLocations,
                 in: ServerRelaysResponseStubs.sampleRelays,
-                filterConstraint: relayConstraints.filter
+                filterConstraint: relayConstraints.filter,
+                daitaEnabled: false
             ),
             relays: ServerRelaysResponseStubs.sampleRelays,
             portConstraint: relayConstraints.port,
@@ -39,7 +40,8 @@ final class PostQuantumKeyExchangingPipelineTests: XCTestCase {
             from: try RelaySelector.WireGuard.findCandidates(
                 by: relayConstraints.entryLocations,
                 in: ServerRelaysResponseStubs.sampleRelays,
-                filterConstraint: relayConstraints.filter
+                filterConstraint: relayConstraints.filter,
+                daitaEnabled: false
             ),
             relays: ServerRelaysResponseStubs.sampleRelays,
             portConstraint: relayConstraints.port,

--- a/ios/PacketTunnelCoreTests/SingleHopPostQuantumKeyExchangingTests.swift
+++ b/ios/PacketTunnelCoreTests/SingleHopPostQuantumKeyExchangingTests.swift
@@ -24,7 +24,8 @@ final class SingleHopPostQuantumKeyExchangingTests: XCTestCase {
         let candidates = try RelaySelector.WireGuard.findCandidates(
             by: relayConstraints.exitLocations,
             in: ServerRelaysResponseStubs.sampleRelays,
-            filterConstraint: relayConstraints.filter
+            filterConstraint: relayConstraints.filter,
+            daitaEnabled: false
         )
 
         let match = try RelaySelector.WireGuard.pickCandidate(


### PR DESCRIPTION
When DAITA is enabled, the relay selector should only match DAITA enabled relays for the entry location when using multihop. If no DAITA relays can be matched, the packet tunnel should enter the blocked state - ideally with an error message displayed to the user that makes it obvious that no relays were matched due to none of the eligible ones allowing DAITA.

When using single-hop and DAITA is enabled only DAITA enabled relays should be considered first - the best suitable DAITA relay should be picked if at all possible. Otherwise, if the exit constraints do not match any DAITA enabled relay, the relay selector should use multihop to select a valid DAITA relay for the entry.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6590)
<!-- Reviewable:end -->
