### PR TITLE
List only DAITA enabled entry locations in locations view

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -489,6 +489,8 @@
 		7A516C3C2B712F0B00BBD33D /* IPOverrideWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A516C3B2B712F0B00BBD33D /* IPOverrideWrapperTests.swift */; };
 		7A52F96A2C1735AE00B133B9 /* RelaySelectorStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FE25EF2AA77664003D1918 /* RelaySelectorStub.swift */; };
 		7A52F96C2C17450C00B133B9 /* RelaySelectorWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A52F96B2C17450C00B133B9 /* RelaySelectorWrapperTests.swift */; };
+		7A5468AC2C6A55B100590086 /* LocationRelays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5468AB2C6A55B100590086 /* LocationRelays.swift */; };
+		7A5468AD2C6B5E4B00590086 /* LocationRelays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5468AB2C6A55B100590086 /* LocationRelays.swift */; };
 		7A5869952B32E9C700640D27 /* LinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5869942B32E9C700640D27 /* LinkButton.swift */; };
 		7A5869972B32EA4500640D27 /* AppButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5869962B32EA4500640D27 /* AppButton.swift */; };
 		7A58699B2B482FE200640D27 /* UITableViewCell+Disable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A58699A2B482FE200640D27 /* UITableViewCell+Disable.swift */; };
@@ -1806,6 +1808,7 @@
 		7A516C392B7111A700BBD33D /* IPOverrideWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideWrapper.swift; sourceTree = "<group>"; };
 		7A516C3B2B712F0B00BBD33D /* IPOverrideWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideWrapperTests.swift; sourceTree = "<group>"; };
 		7A52F96B2C17450C00B133B9 /* RelaySelectorWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelectorWrapperTests.swift; sourceTree = "<group>"; };
+		7A5468AB2C6A55B100590086 /* LocationRelays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationRelays.swift; sourceTree = "<group>"; };
 		7A5869942B32E9C700640D27 /* LinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkButton.swift; sourceTree = "<group>"; };
 		7A5869962B32EA4500640D27 /* AppButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppButton.swift; sourceTree = "<group>"; };
 		7A58699A2B482FE200640D27 /* UITableViewCell+Disable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Disable.swift"; sourceTree = "<group>"; };
@@ -2756,6 +2759,7 @@
 				F050AE5D2B739A73003F4EDB /* LocationDataSourceProtocol.swift */,
 				7A6652B62BB44B120042D848 /* LocationDiffableDataSourceProtocol.swift */,
 				7A6389F72B864CDF008E77E1 /* LocationNode.swift */,
+				7A5468AB2C6A55B100590086 /* LocationRelays.swift */,
 				F050AE512B70DFC0003F4EDB /* LocationSection.swift */,
 				F0BE65362B9F136A005CC385 /* LocationSectionHeaderView.swift */,
 				5888AD86227B17950051EB06 /* LocationViewController.swift */,
@@ -5251,6 +5255,7 @@
 				A9A5FA422ACB05D90083449F /* DeviceStateAccessorProtocol.swift in Sources */,
 				7A5869C32B5820CE00640D27 /* IPOverrideRepositoryTests.swift in Sources */,
 				A9A5FA392ACB05910083449F /* UIColor+Palette.swift in Sources */,
+				7A5468AD2C6B5E4B00590086 /* LocationRelays.swift in Sources */,
 				A9A5FA3A2ACB05910083449F /* UIEdgeInsets+Extensions.swift in Sources */,
 				A9A5FA3B2ACB05910083449F /* UIMetrics.swift in Sources */,
 				58B07C182AEFDD6C00A09625 /* StoreTransactionLog.swift in Sources */,
@@ -5542,6 +5547,7 @@
 				7A9CCCC42A96302800DD6A34 /* TunnelCoordinator.swift in Sources */,
 				5827B0A42B0F38FD00CCBBA1 /* EditAccessMethodInteractorProtocol.swift in Sources */,
 				586C0D852B03D31E00E7CDD7 /* SocksSectionHandler.swift in Sources */,
+				7A5468AC2C6A55B100590086 /* LocationRelays.swift in Sources */,
 				58BFA5CC22A7CE1F00A6173D /* ApplicationConfiguration.swift in Sources */,
 				5891BF5125E66B1E006D6FB0 /* UIBarButtonItem+KeyboardNavigation.swift in Sources */,
 				58E511E628DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift in Sources */,

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterChipView.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterChipView.swift
@@ -18,6 +18,16 @@ class RelayFilterChipView: UIView {
         return label
     }()
 
+    let closeButton: IncreasedHitButton = {
+        let button = IncreasedHitButton()
+        button.setImage(
+            UIImage(resource: .iconCloseSml).withTintColor(.white.withAlphaComponent(0.6)),
+            for: .normal
+        )
+        button.accessibilityIdentifier = .relayFilterChipCloseButton
+        return button
+    }()
+
     var didTapButton: (() -> Void)?
 
     init() {
@@ -25,12 +35,6 @@ class RelayFilterChipView: UIView {
 
         self.accessibilityIdentifier = .relayFilterChipView
 
-        let closeButton = IncreasedHitButton()
-        closeButton.setImage(
-            UIImage(named: "IconCloseSml")?.withTintColor(.white.withAlphaComponent(0.6)),
-            for: .normal
-        )
-        closeButton.accessibilityIdentifier = .relayFilterChipCloseButton
         closeButton.addTarget(self, action: #selector(didTapButton(_:)), for: .touchUpInside)
 
         let container = UIStackView(arrangedSubviews: [titleLabel, closeButton])

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
@@ -34,6 +34,7 @@ class RelayFilterView: UIView {
 
     private let ownershipView = RelayFilterChipView()
     private let providersView = RelayFilterChipView()
+    private let daitaView = RelayFilterChipView()
     private var filter: RelayFilter?
 
     var didUpdateFilter: ((RelayFilter) -> Void)?
@@ -71,7 +72,16 @@ class RelayFilterView: UIView {
         }
     }
 
+    func setDaita(_ enabled: Bool) {
+        daitaView.isHidden = !enabled
+    }
+
     private func setUpViews() {
+        daitaView.setTitle(localizedDaitaText())
+        daitaView.isHidden = true
+        daitaView.closeButton.isHidden = true
+
+        ownershipView.isHidden = true
         ownershipView.didTapButton = { [weak self] in
             guard var filter = self?.filter else { return }
 
@@ -79,6 +89,7 @@ class RelayFilterView: UIView {
             self?.didUpdateFilter?(filter)
         }
 
+        providersView.isHidden = true
         providersView.didTapButton = { [weak self] in
             guard var filter = self?.filter else { return }
 
@@ -87,7 +98,7 @@ class RelayFilterView: UIView {
         }
 
         // Add a dummy view at the end to push content to the left.
-        let filterContainer = UIStackView(arrangedSubviews: [ownershipView, providersView, UIView()])
+        let filterContainer = UIStackView(arrangedSubviews: [daitaView, ownershipView, providersView, UIView()])
         filterContainer.spacing = UIMetrics.FilterView.interChipViewSpacing
 
         let contentContainer = UIStackView(arrangedSubviews: [titleLabel, filterContainer])
@@ -97,6 +108,15 @@ class RelayFilterView: UIView {
             contentContainer.pinEdges(.init([.top(7), .bottom(0)]), to: self)
             contentContainer.pinEdges(.init([.leading(4), .trailing(4)]), to: layoutMarginsGuide)
         }
+    }
+
+    private func localizedDaitaText() -> String {
+        return NSLocalizedString(
+            "RELAY_FILTER_APPLIED_DAITA",
+            tableName: "RelayFilter",
+            value: "Setting: DAITA",
+            comment: ""
+        )
     }
 
     private func localizedOwnershipText(for string: String) -> String {

--- a/ios/MullvadVPN/View controllers/SelectLocation/AllLocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/AllLocationDataSource.swift
@@ -20,13 +20,13 @@ class AllLocationDataSource: LocationDataSourceProtocol {
     /// Constructs a collection of node trees from relays fetched from the API.
     /// ``RelayLocation.city`` is of special import since we use it to get country
     /// and city names.
-    func reload(_ response: REST.ServerRelaysResponse, relays: [REST.ServerRelay]) {
+    func reload(_ relays: LocationRelays) {
         let rootNode = RootLocationNode()
 
-        for relay in relays {
+        for relay in relays.relays {
             guard case
                 let .city(countryCode, cityCode) = RelayLocation(dashSeparatedString: relay.location),
-                let serverLocation = response.locations[relay.location]
+                let serverLocation = relays.locations[relay.location]
             else { continue }
 
             let relayLocation = RelayLocation.hostname(countryCode, cityCode, relay.hostname)

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCellViewModel.swift
@@ -62,17 +62,17 @@ extension [LocationCellViewModel] {
 }
 
 extension LocationCellViewModel {
-    /* Exclusion of other locations in the same node tree as the currently excluded location
+    /* Exclusion of other locations in the same node tree (as the currently excluded location)
      happens when there are no more hosts in that tree that can be selected.
      We check this by doing the following, in order:
 
-     1. Count host names in the tree. More than one means that there are other locations than
+     1. Count hostnames in the tree. More than one means that there are other locations than
      the excluded one for the relay selector to choose from. No exlusion.
 
-     2. Count host names in the excluded node. More than one means that there are multiple
-     locations for the relay selector to choose from. No exlusion.
+     2. Count hostnames in the excluded node. More than one means that there are multiple
+     locations for the relay selector to choose from. No exclusion.
 
-     3. Check existance of a location in the tree that match the currently excluded location.
+     3. Check existance of a location in the tree that matches the currently excluded location.
      No match means no exclusion.
      */
     func shouldExcludeLocation(_ excludedLocation: LocationCellViewModel?) -> Bool {
@@ -86,8 +86,8 @@ extension LocationCellViewModel {
             if case .hostname = location { true } else { false }
         }.count
 
-        // If the there are more than one selectable relay in the current node we don't need
-        // show this in the location tree and can return early.
+        // If the there's more than one selectable relay in the current node we don't need
+        // to show this in the location tree and can return early.
         guard hostCount == 1 else { return false }
 
         let proxyExcludedNode = RootLocationNode(children: [excludedLocation.node])
@@ -96,8 +96,8 @@ extension LocationCellViewModel {
             if case .hostname = location { true } else { false }
         }.count
 
-        // If the there are more than one selectable relay in the excluded node we don't need
-        // show this in the location tree and can return early.
+        // If the there's more than one selectable relay in the excluded node we don't need
+        // to show this in the location tree and can return early.
         guard excludedHostCount == 1 else { return false }
 
         var containsExcludedLocation = false

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationDataSource.swift
@@ -54,18 +54,14 @@ final class LocationDataSource:
         defaultRowAnimation = .fade
     }
 
-    func setRelays(_ response: REST.ServerRelaysResponse, selectedRelays: RelaySelection, filter: RelayFilter) {
+    func setRelays(_ cachedRelays: LocationRelays, selectedRelays: RelaySelection) {
         let allLocationsDataSource =
             dataSources.first(where: { $0 is AllLocationDataSource }) as? AllLocationDataSource
 
         let customListsDataSource =
             dataSources.first(where: { $0 is CustomListsDataSource }) as? CustomListsDataSource
 
-        let relays = response.wireguard.relays.filter { relay in
-            RelaySelector.relayMatchesFilter(relay, filter: filter)
-        }
-
-        allLocationsDataSource?.reload(response, relays: relays)
+        allLocationsDataSource?.reload(cachedRelays)
         customListsDataSource?.reload(allLocationNodes: allLocationsDataSource?.nodes ?? [])
 
         setSelectedRelays(selectedRelays)
@@ -235,12 +231,6 @@ final class LocationDataSource:
             animated: animated,
             completion: completion
         )
-    }
-
-    private func nodeMatchesExcludedLocation(_ node: LocationNode) -> Bool {
-        // Compare nodes on name rather than whole node in order to match all items in both .customLists
-        // and .allLocations.
-        node.name == excludedLocation?.node.name
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationRelays.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationRelays.swift
@@ -1,0 +1,14 @@
+//
+//  LocationRelays.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2024-08-12.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadREST
+
+struct LocationRelays {
+    var relays: [REST.ServerRelay]
+    var locations: [String: REST.ServerLocation]
+}

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
@@ -52,27 +52,34 @@ final class LocationViewControllerWrapper: UIViewController {
     private var selectedExit: UserSelectedRelays?
     private let multihopEnabled: Bool
     private var multihopContext: MultihopContext = .exit
+    private let daitaEnabled: Bool
 
     weak var delegate: LocationViewControllerWrapperDelegate?
 
     init(
         customListRepository: CustomListRepositoryProtocol,
         constraints: RelayConstraints,
-        multihopEnabled: Bool
+        multihopEnabled: Bool,
+        daitaEnabled: Bool,
+        startContext: MultihopContext
     ) {
         self.multihopEnabled = multihopEnabled
+        self.daitaEnabled = daitaEnabled
+        multihopContext = startContext
 
         selectedEntry = constraints.entryLocations.value
         selectedExit = constraints.exitLocations.value
 
         entryLocationViewController = LocationViewController(
             customListRepository: customListRepository,
-            selectedRelays: RelaySelection()
+            selectedRelays: RelaySelection(),
+            daitaEnabled: multihopEnabled && daitaEnabled
         )
 
         exitLocationViewController = LocationViewController(
             customListRepository: customListRepository,
-            selectedRelays: RelaySelection()
+            selectedRelays: RelaySelection(),
+            daitaEnabled: !multihopEnabled && daitaEnabled
         )
 
         super.init(nibName: nil, bundle: nil)
@@ -100,9 +107,19 @@ final class LocationViewControllerWrapper: UIViewController {
         swapViewController()
     }
 
-    func setCachedRelays(_ cachedRelays: CachedRelays, filter: RelayFilter) {
-        updateViewControllers {
-            $0.setCachedRelays(cachedRelays, filter: filter)
+    func setCachedRelays(_ cachedRelays: LocationRelays, filter: RelayFilter) {
+        var daitaFilteredRelays = cachedRelays
+        if daitaEnabled {
+            daitaFilteredRelays.relays = cachedRelays.relays.filter { relay in
+                relay.daita == true
+            }
+        }
+
+        if multihopEnabled {
+            entryLocationViewController.setCachedRelays(daitaFilteredRelays, filter: filter)
+            exitLocationViewController.setCachedRelays(cachedRelays, filter: filter)
+        } else {
+            exitLocationViewController.setCachedRelays(daitaFilteredRelays, filter: filter)
         }
     }
 

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
@@ -91,7 +91,7 @@ class RelaySelectorTests: XCTestCase {
         )
     }
 
-    func testNoMatchingRelayConstraintError() throws {
+    func testNoMatchingRelayConstraint() throws {
         let constraints = RelayConstraints(
             exitLocations: .only(UserSelectedRelays(locations: [.country("-")]))
         )

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/AllLocationsDataSourceTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/AllLocationsDataSourceTests.swift
@@ -58,9 +58,9 @@ class AllLocationsDataSourceTests: XCTestCase {
 extension AllLocationsDataSourceTests {
     private func setUpDataSource() {
         let response = ServerRelaysResponseStubs.sampleRelays
-        let relays = response.wireguard.relays
+        let relays = LocationRelays(relays: response.wireguard.relays, locations: response.locations)
 
         dataSource = AllLocationDataSource()
-        dataSource.reload(response, relays: relays)
+        dataSource.reload(relays)
     }
 }

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/CustomListsDataSourceTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/CustomListsDataSourceTests.swift
@@ -80,10 +80,10 @@ extension CustomListsDataSourceTests {
 
     private func createAllLocationNodes() {
         let response = ServerRelaysResponseStubs.sampleRelays
-        let relays = response.wireguard.relays
+        let relays = LocationRelays(relays: response.wireguard.relays, locations: response.locations)
 
         let dataSource = AllLocationDataSource()
-        dataSource.reload(response, relays: relays)
+        dataSource.reload(relays)
 
         allLocationNodes = dataSource.nodes
     }


### PR DESCRIPTION
When DAITA is enabled, the app should only list DAITA enabled entry locations in the locations view.

If the user has enabled both DAITA & multihop and the relay selector fails to match an entry, when the location view is opened, it should default to showing the entry location view.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6609)
<!-- Reviewable:end -->
