### PR TITLE
Add `network-manager` feature to `talpid-platform-metadata`

### DIFF
--- a/talpid-platform-metadata/Cargo.toml
+++ b/talpid-platform-metadata/Cargo.toml
@@ -10,10 +10,13 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = ["network-manager"]
+network-manager = ["talpid-dbus"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rs-release = "0.1.7"
-talpid-dbus = { path = "../talpid-dbus" }
+talpid-dbus = { path = "../talpid-dbus", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/talpid-platform-metadata/src/linux.rs
+++ b/talpid-platform-metadata/src/linux.rs
@@ -80,9 +80,12 @@ fn parse_lsb_release() -> Option<String> {
 }
 
 pub fn extra_metadata() -> impl Iterator<Item = (String, String)> {
-    [kernel_version, nm_version, wg_version, systemd_version]
-        .iter()
-        .filter_map(|f| f())
+    #[cfg(not(feature = "network-manager"))]
+    let version_cmds = [kernel_version, wg_version, systemd_version];
+    #[cfg(feature = "network-manager")]
+    let version_cmds = [kernel_version, nm_version, wg_version, systemd_version];
+
+    version_cmds.into_iter().filter_map(|f| f())
 }
 
 /// `uname -r` outputs a single line containing only the kernel version:
@@ -94,6 +97,7 @@ fn kernel_version() -> Option<(String, String)> {
 
 /// NetworkManager's version is returned as a numeric version string
 /// > 1.26.0
+#[cfg(feature = "network-manager")]
 fn nm_version() -> Option<(String, String)> {
     let nm = talpid_dbus::network_manager::NetworkManager::new().ok()?;
     Some(("nm".to_string(), nm.version_string().ok()?))

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -691,17 +691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
-dependencies = [
- "libc",
- "libdbus-sys",
- "winapi",
-]
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,15 +1630,6 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "libloading"
@@ -3218,23 +3198,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "talpid-dbus"
-version = "0.0.0"
-dependencies = [
- "dbus",
- "libc",
- "log",
- "once_cell",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "talpid-platform-metadata"
 version = "0.0.0"
 dependencies = [
  "rs-release",
- "talpid-dbus",
  "windows-sys 0.52.0",
 ]
 

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -31,7 +31,7 @@ chrono = { workspace = true, features = ["serde"] }
 
 test-rpc = { path = "../test-rpc" }
 mullvad-paths = { path = "../../mullvad-paths" }
-talpid-platform-metadata = { path = "../../talpid-platform-metadata" }
+talpid-platform-metadata = { path = "../../talpid-platform-metadata", default-features = false }
 
 socket2 = { version = "0.5.4", features = ["all"] }
 


### PR DESCRIPTION
Add `network-manager` as a feature so that `talpid-platform-metadata` does not have to depend on `talpid-dbus`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6614)
<!-- Reviewable:end -->
