### PR TITLE
Remove unsupported distros from e2e tests

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -16,7 +16,7 @@ on:
         description: "Space-delimited list of targets to run tests on, e.g. `debian11 debian12`. \
           Available images are:\n
           `debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 ubuntu2310 ubuntu2404 fedora40 \
-          fedora39 fedora38 fedora37 fedora36 windows10 windows11 macos12 macos13 macos14`."
+          fedora39 windows10 windows11 macos12 macos13 macos14`."
         default: ''
         required: false
         type: string
@@ -30,7 +30,7 @@ jobs:
         run: |
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
-          all='["debian11","debian12","ubuntu2004","ubuntu2204","ubuntu2304","ubuntu2310","ubuntu2404","fedora40","fedora39","fedora38","fedora37","fedora36"]'
+          all='["debian11","debian12","ubuntu2004","ubuntu2204","ubuntu2304","ubuntu2310","ubuntu2404","fedora40","fedora39"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -15,7 +15,7 @@ on:
       oses:
         description: "Space-delimited list of targets to run tests on, e.g. `debian11 debian12`. \
           Available images are:\n
-          `debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2304 ubuntu2310 ubuntu2404 fedora40 \
+          `debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2404 fedora40 \
           fedora39 windows10 windows11 macos12 macos13 macos14`."
         default: ''
         required: false
@@ -30,7 +30,7 @@ jobs:
         run: |
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
-          all='["debian11","debian12","ubuntu2004","ubuntu2204","ubuntu2304","ubuntu2310","ubuntu2404","fedora40","fedora39"]'
+          all='["debian11","debian12","ubuntu2004","ubuntu2204","ubuntu2404","fedora40","fedora39"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then


### PR DESCRIPTION
Only the last two major Fedora versions are supported. See https://docs.fedoraproject.org/en-US/releases/eol/

Same for Ubuntu 23.10 and 23.04: https://ubuntu.com/about/release-cycle, https://fridge.ubuntu.com/2023/12/15/ubuntu-23-04-lunar-lobster-reaches-end-of-life-on-january-25-2024/

This should speed things up a bit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6616)
<!-- Reviewable:end -->
