### PR TITLE
Add `--test-runner-dir` flag

### DIFF
--- a/test/test-manager/src/config.rs
+++ b/test/test-manager/src/config.rs
@@ -200,7 +200,7 @@ impl VmConfig {
         Some((self.ssh_user.as_ref()?, self.ssh_password.as_ref()?))
     }
 
-    pub fn get_runner_dir(&self) -> PathBuf {
+    pub fn get_default_runner_dir(&self) -> PathBuf {
         let target_dir = self.get_target_dir();
         let subdir = match self.architecture {
             None | Some(Architecture::X64) => self.get_x64_runner_subdir(),

--- a/test/test-manager/src/vm/mod.rs
+++ b/test/test-manager/src/vm/mod.rs
@@ -1,10 +1,7 @@
 use anyhow::{Context, Result};
 use std::net::IpAddr;
 
-use crate::{
-    config::{Config, ConfigFile, VmConfig, VmType},
-    package,
-};
+use crate::config::{Config, ConfigFile, VmConfig, VmType};
 
 mod logging;
 pub mod network;
@@ -61,17 +58,6 @@ pub async fn run(config: &Config, name: &str) -> Result<Box<dyn VmInstance>> {
     log::info!("Started instance of \"{name}\" vm");
 
     Ok(instance)
-}
-
-/// Returns the directory in the test runner where the test-runner binary is installed.
-pub async fn provision(
-    config: &Config,
-    name: &str,
-    instance: &dyn VmInstance,
-    app_manifest: &package::Manifest,
-) -> Result<String> {
-    let vm_config = get_vm_config(config, name)?;
-    provision::provision(vm_config, instance, app_manifest).await
 }
 
 pub async fn update_packages(

--- a/test/test-manager/src/vm/provision.rs
+++ b/test/test-manager/src/vm/provision.rs
@@ -16,6 +16,7 @@ pub async fn provision(
     config: &VmConfig,
     instance: &dyn super::VmInstance,
     app_manifest: &package::Manifest,
+    runner_dir: PathBuf,
 ) -> Result<String> {
     match config.provisioner {
         Provisioner::Ssh => {
@@ -25,7 +26,7 @@ pub async fn provision(
             provision_ssh(
                 instance,
                 config.os_type,
-                &config.get_runner_dir(),
+                &runner_dir,
                 app_manifest,
                 user,
                 password,


### PR DESCRIPTION
Add flag to explicitly specify the test runner dir. This is not used as of now, but is a preliminary step towards reusing the same `test-runner` for multiple VMs (e.g. all `x86_64-unknown-linux-gnu` targets).


<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6618)
<!-- Reviewable:end -->
