### PR TITLE
Add test filters field to E2E workflow_dispatch

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -20,6 +20,11 @@ on:
         default: ''
         required: false
         type: string
+      tests:
+        description: "Tests to run (defaults to all if empty)"
+        default: ''
+        required: false
+        type: string
 jobs:
   prepare-matrices:
     name: Prepare virtual machines
@@ -151,6 +156,7 @@ jobs:
         shell: bash -ieo pipefail {0}
         run: |
           git fetch --tags --force
+          export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
         if: '!cancelled()'
@@ -226,6 +232,7 @@ jobs:
         shell: bash -ieo pipefail {0}
         run: |
           git fetch --tags --force
+          export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
         if: '!cancelled()'
@@ -297,6 +304,7 @@ jobs:
         shell: bash -ieo pipefail {0}
         run: |
           git fetch --tags --force
+          export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
         if: '!cancelled()'

--- a/test/scripts/test-utils.sh
+++ b/test/scripts/test-utils.sh
@@ -254,6 +254,7 @@ function run_tests_for_os {
     package_dir=$(get_package_dir)
     local test_dir
     test_dir=$(get_test_utls_dir)/..
+    read -ra test_filters_arg <<<"${TEST_FILTERS:-}" # Split the string by words into an array
     pushd "$test_dir"
         if ! RUST_LOG_STYLE=always cargo run --bin test-manager \
             run-tests \
@@ -263,7 +264,7 @@ function run_tests_for_os {
             "${test_report_arg[@]}" \
             --package-dir "${package_dir}" \
             --vm "$vm" \
-            "${TEST_FILTERS:-}" \
+            "${test_filters_arg[@]}" \
             2>&1 | sed -r "s/${ACCOUNT_TOKEN}/\{ACCOUNT_TOKEN\}/g"; then
             echo "Test run failed"
             exit 1


### PR DESCRIPTION
This makes it possible to run only a subset of all tests during a manually triggered test run.

Fix DES-825.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6625)
<!-- Reviewable:end -->
