### PR TITLE
Suppress elliptic CVEs

### DIFF
--- a/gui/osv-scanner.toml
+++ b/gui/osv-scanner.toml
@@ -24,3 +24,21 @@ reason = "This project does not use PostCSS to parse untrusted CSS"
 id = "CVE-2024-4068" # GHSA-grv7-fg5c-xmjg
 ignoreUntil = 2024-09-05
 reason = "This package is only used to match paths from either us or trusted libraries"
+
+# elliptic: Elliptic allows BER-encoded signatures
+[[IgnoredVulns]]
+id = "CVE-2024-42461" # GHSA-49q7-c7j4-3p7m
+ignoreUntil = 2024-10-15
+reason = "We don't utilize the signing features in browserify"
+
+# elliptic: Elliptic's ECDSA missing check for whether leading bit of r and s is zero
+[[IgnoredVulns]]
+id = "CVE-2024-42460" # GHSA-977x-g7h5-7qgw
+ignoreUntil = 2024-10-15
+reason = "We don't utilize the signing features in browserify"
+
+# elliptic: Elliptic's EDDSA missing signature length check
+[[IgnoredVulns]]
+id = "CVE-2024-42459" # GHSA-f7q4-pwc6-w24p
+ignoreUntil = 2024-10-15
+reason = "We don't utilize the signing features in browserify"


### PR DESCRIPTION
We're not affected by the elliptic CVEs. This PR suppresses the warnings in OSV scanner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6626)
<!-- Reviewable:end -->
