### PR TITLE
Fix Auto connect lockdown mode title

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/TopBar.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/TopBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Surface
@@ -38,6 +39,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -276,7 +278,14 @@ fun MullvadLargeTopBar(
     scrollBehavior: TopAppBarScrollBehavior? = null
 ) {
     LargeTopAppBar(
-        title = { Text(text = title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
+        title = {
+            Text(
+                text = title,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                style = LocalTextStyle.current.copy(lineBreak = LineBreak.Heading)
+            )
+        },
         navigationIcon = navigationIcon,
         scrollBehavior = scrollBehavior,
         colors =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AutoConnectAndLockdownModeScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AutoConnectAndLockdownModeScreen.kt
@@ -84,7 +84,7 @@ fun AutoConnectAndLockdownMode(navigator: DestinationsNavigator) {
 fun AutoConnectAndLockdownModeScreen(onBackClick: () -> Unit = {}) {
     val context = LocalContext.current
     ScaffoldWithLargeTopBarAndButton(
-        appBarTitle = stringResource(id = R.string.auto_connect_and_lockdown_mode_two_lines),
+        appBarTitle = stringResource(id = R.string.auto_connect_and_lockdown_mode),
         navigationIcon = { NavigateBackIconButton(onNavigateBack = onBackClick) },
         buttonTitle = stringResource(id = R.string.go_to_vpn_settings),
         onButtonClick = { context.openVpnSettings() },

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -74,7 +74,6 @@
     <string name="allow_lan_footer">Allows access to other devices on the same network for sharing, printing etc.</string>
     <string name="auto_connect">Auto-connect</string>
     <string name="auto_connect_and_lockdown_mode">Auto-connect &amp; Lockdown mode</string>
-    <string name="auto_connect_and_lockdown_mode_two_lines">Auto-connect &amp; \nLockdown mode</string>
     <string name="auto_connect_and_lockdown_mode_footer">Makes sure the device is always on the VPN tunnel.</string>
     <string name="go_to_vpn_settings">Go to VPN settings</string>
     <string name="vpn_settings_not_found">There is no VPN settings on your device</string>

--- a/android/lib/theme/src/main/kotlin/net/mullvad/mullvadvpn/lib/theme/Theme.kt
+++ b/android/lib/theme/src/main/kotlin/net/mullvad/mullvadvpn/lib/theme/Theme.kt
@@ -48,6 +48,12 @@ import net.mullvad.mullvadvpn.lib.theme.typeface.TypeScale
 private val MullvadTypography =
     Typography(
         headlineLarge = TextStyle(fontSize = TypeScale.TextHuge, fontWeight = FontWeight.Bold),
+        headlineMedium =
+            TextStyle(
+                fontWeight = FontWeight.Bold,
+                fontSize = TypeScale.TextHeadline,
+                lineHeight = TypeScale.HeadlineMediumLineHeight,
+            ),
         headlineSmall = TextStyle(fontSize = TypeScale.TextBig, fontWeight = FontWeight.Bold),
         bodySmall = TextStyle(fontSize = TypeScale.TextSmall),
         titleSmall = TextStyle(fontSize = TypeScale.TextMedium, fontWeight = FontWeight.SemiBold),

--- a/android/lib/theme/src/main/kotlin/net/mullvad/mullvadvpn/lib/theme/typeface/TypeScale.kt
+++ b/android/lib/theme/src/main/kotlin/net/mullvad/mullvadvpn/lib/theme/typeface/TypeScale.kt
@@ -12,9 +12,12 @@ import androidx.compose.ui.unit.sp
  */
 internal object TypeScale {
     val TextHuge = 30.sp
+    val TextHeadline = 28.sp
     val TextBig = 24.sp
     val TextMediumPlus = 18.sp
     val TextMedium = 16.sp
     val TextSmall = 13.sp
     val TitleLarge = 22.sp
+
+    val HeadlineMediumLineHeight = 36.0.sp
 }

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2192,9 +2192,6 @@ msgstr ""
 msgid "Auto-connect & Lockdown mode"
 msgstr ""
 
-msgid "Auto-connect & \\nLockdown mode"
-msgstr ""
-
 msgid "Auto-connect (legacy)"
 msgstr ""
 


### PR DESCRIPTION
- Remove string with newline in it since it was not treated properly by the translation script
- Change the line break strategy so that the title looks better in the Auto-connect screen.
- Make the title bold as other titles.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6630)
<!-- Reviewable:end -->
