### PR TITLE
Disable ATS entirely

### DIFF
--- a/ios/MullvadREST/ApiHandlers/SSLPinningURLSessionDelegate.swift
+++ b/ios/MullvadREST/ApiHandlers/SSLPinningURLSessionDelegate.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MullvadLogging
+import Network
 import Security
 
 final class SSLPinningURLSessionDelegate: NSObject, URLSessionDelegate {
@@ -29,17 +30,32 @@ final class SSLPinningURLSessionDelegate: NSObject, URLSessionDelegate {
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-           let serverTrust = challenge.protectionSpace.serverTrust,
-           verifyServerTrust(serverTrust) {
-            completionHandler(.useCredential, URLCredential(trust: serverTrust))
-        } else {
-            completionHandler(.rejectProtectionSpace, nil)
+           let serverTrust = challenge.protectionSpace.serverTrust {
+            /// If a request is going through a local shadowsocks proxy, the host would be a localhost address,`
+            /// which would not appear in the list of valid host names in the root certificate.
+            /// The same goes for direct connections to the API, the host would be the IP address of the endpoint.
+            /// Certificates, cannot be signed for IP addresses, in such case, specify that the host name is `defaultAPIHostname`
+            var hostName = challenge.protectionSpace.host
+            let overridenHostnames = [
+                "\(IPv4Address.loopback)",
+                "\(IPv6Address.loopback)",
+                "\(REST.defaultAPIEndpoint.ip)",
+            ]
+            if overridenHostnames.contains(hostName) {
+                hostName = sslHostname
+            }
+
+            if verifyServerTrust(serverTrust, for: hostName) {
+                completionHandler(.useCredential, URLCredential(trust: serverTrust))
+                return
+            }
         }
+        completionHandler(.rejectProtectionSpace, nil)
     }
 
     // MARK: - Private
 
-    private func verifyServerTrust(_ serverTrust: SecTrust) -> Bool {
+    private func verifyServerTrust(_ serverTrust: SecTrust, for sslHostname: String) -> Bool {
         var secResult: OSStatus
 
         // Set SSL policy

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -74,7 +74,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, SettingsMigrationUIHand
             accountsProxy: appDelegate.accountsProxy,
             outgoingConnectionService: OutgoingConnectionService(
                 outgoingConnectionProxy: OutgoingConnectionProxy(
-                    urlSession: URLSession(configuration: .ephemeral),
+                    urlSession: REST.makeURLSession(),
                     hostname: ApplicationConfiguration.hostName
                 )
             ),

--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -44,39 +44,6 @@
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>185.217.116.129</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>127.0.0.1</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>45.83.223.196</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
-		<key>NSPinnedDomains</key>
-		<dict>
-			<key>am.i.mullvad.net</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSPinnedCAIdentities</key>
-				<array>
-					<dict>
-						<key>SPKI-SHA256-BASE64</key>
-						<string>C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=</string>
-					</dict>
-				</array>
-			</dict>
-		</dict>
 	</dict>
 	<key>NSUserActivityTypes</key>
 	<array>


### PR DESCRIPTION
This PR disables ATS entirely from our application. 
This requires justifying to apple why we do this, and we feel we have a good explanation in hand : 

- We do not trust DNS systems
- We do SSL pinning so we cannot do insecure connections to our API (we already validate the TLS connection ourselves)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6642)
<!-- Reviewable:end -->
