### PR TITLE
Fix feature indicators missing during connecting state

### DIFF
--- a/mullvad-types/src/features.rs
+++ b/mullvad-types/src/features.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
+use crate::settings::{DnsState, Settings};
 use serde::{Deserialize, Serialize};
+use talpid_types::net::{ObfuscationType, TunnelEndpoint, TunnelType};
 
 /// Feature indicators are active settings that should be shown to the user to make them aware of
 /// what is affecting their connection at any given time.
@@ -61,4 +63,86 @@ impl std::fmt::Display for FeatureIndicator {
         };
         write!(f, "{feature}")
     }
+}
+
+/// Calculate active [`FeatureIndicators`] from setting and endpoint information.
+///
+/// Note that [`FeatureIndicators`] are only applicable for the connected and connecting states, and
+/// this function should not be called with arguments from different tunnel states.
+pub fn compute_feature_indicators(
+    settings: &Settings,
+    endpoint: &TunnelEndpoint,
+) -> FeatureIndicators {
+    #[cfg(any(windows, target_os = "android", target_os = "macos"))]
+    let split_tunneling = settings.split_tunnel.enable_exclusions;
+    #[cfg(not(any(windows, target_os = "android", target_os = "macos")))]
+    let split_tunneling = false;
+
+    let lockdown_mode = settings.block_when_disconnected;
+    let lan_sharing = settings.allow_lan;
+    let dns_content_blockers = settings
+        .tunnel_options
+        .dns_options
+        .default_options
+        .any_blockers_enabled();
+    let custom_dns = settings.tunnel_options.dns_options.state == DnsState::Custom;
+    let server_ip_override = !settings.relay_overrides.is_empty();
+
+    let generic_features = [
+        (split_tunneling, FeatureIndicator::SplitTunneling),
+        (lockdown_mode, FeatureIndicator::LockdownMode),
+        (lan_sharing, FeatureIndicator::LanSharing),
+        (dns_content_blockers, FeatureIndicator::DnsContentBlockers),
+        (custom_dns, FeatureIndicator::CustomDns),
+        (server_ip_override, FeatureIndicator::ServerIpOverride),
+    ];
+
+    // Pick protocol-specific features and whether they are currently enabled.
+    let protocol_features = match endpoint.tunnel_type {
+        TunnelType::OpenVpn => {
+            let bridge_mode = endpoint.proxy.is_some();
+            let mss_fix = settings.tunnel_options.openvpn.mssfix.is_some();
+
+            vec![
+                (bridge_mode, FeatureIndicator::BridgeMode),
+                (mss_fix, FeatureIndicator::CustomMssFix),
+            ]
+        }
+        TunnelType::Wireguard => {
+            let quantum_resistant = endpoint.quantum_resistant;
+            let multihop = endpoint.entry_endpoint.is_some();
+            let udp_tcp = endpoint
+                .obfuscation
+                .as_ref()
+                .filter(|obfuscation| obfuscation.obfuscation_type == ObfuscationType::Udp2Tcp)
+                .is_some();
+            let shadowsocks = endpoint
+                .obfuscation
+                .as_ref()
+                .filter(|obfuscation| obfuscation.obfuscation_type == ObfuscationType::Shadowsocks)
+                .is_some();
+
+            let mtu = settings.tunnel_options.wireguard.mtu.is_some();
+
+            #[cfg(daita)]
+            let daita = endpoint.daita;
+
+            vec![
+                (quantum_resistant, FeatureIndicator::QuantumResistance),
+                (multihop, FeatureIndicator::Multihop),
+                (udp_tcp, FeatureIndicator::Udp2Tcp),
+                (shadowsocks, FeatureIndicator::Shadowsocks),
+                (mtu, FeatureIndicator::CustomMtu),
+                #[cfg(daita)]
+                (daita, FeatureIndicator::Daita),
+            ]
+        }
+    };
+
+    // use the booleans to filter into a list of only the active features
+    generic_features
+        .into_iter()
+        .chain(protocol_features)
+        .filter_map(|(active, feature)| active.then_some(feature))
+        .collect()
 }

--- a/mullvad-types/src/states.rs
+++ b/mullvad-types/src/states.rs
@@ -123,32 +123,4 @@ impl TunnelState {
             None => None,
         }
     }
-
-    /// Returns the current feature indicators for an active connection.
-    /// This value exists in the connecting and connected states.
-    pub const fn get_feature_indicators(&self) -> Option<&FeatureIndicators> {
-        match self {
-            TunnelState::Connecting {
-                feature_indicators, ..
-            }
-            | TunnelState::Connected {
-                feature_indicators, ..
-            } => Some(feature_indicators),
-            _ => None,
-        }
-    }
-
-    /// Update the set of feature indicators for this [`TunnelState`]. This is only applicable in
-    /// the connecting and connected states.
-    pub fn set_feature_indicators(&mut self, new_feature_indicators: FeatureIndicators) {
-        if let TunnelState::Connecting {
-            feature_indicators, ..
-        }
-        | TunnelState::Connected {
-            feature_indicators, ..
-        } = self
-        {
-            *feature_indicators = new_feature_indicators;
-        }
-    }
 }


### PR DESCRIPTION
Feature indicators were missing during the connecting state. This was
because they were calculated using the endpoint of the previous tunnel
state.

This commit fixes the bug and restructures the access to feature
indicators to be more readable.

Fixes DES-1140
<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6643)
<!-- Reviewable:end -->
