### PR TITLE
Exclude relative paths properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### macOS
 - Fix intermittent failures to connect with PQ enabled.
+- Exclude programs when executed using a relative path from a shell.
 
 
 ## [2024.4] - 2024-07-23

--- a/talpid-core/src/split_tunnel/macos/process.rs
+++ b/talpid-core/src/split_tunnel/macos/process.rs
@@ -333,8 +333,15 @@ impl InnerProcessStates {
             log::error!("exec received for unknown pid {pid}");
             return;
         };
+        if msg.target.executable.path_truncated {
+            log::error!(
+                "Ignoring process {pid} with truncated path: {}",
+                msg.target.executable.path
+            );
+            return;
+        }
 
-        info.exec_path = PathBuf::from(msg.dyld_exec_path);
+        info.exec_path = PathBuf::from(msg.target.executable.path);
 
         // If the path is already excluded, no need to add it again
         if info.excluded_by_paths.contains(&info.exec_path) {
@@ -430,7 +437,22 @@ struct ESForkEvent {
 /// `exec` event returned by `eslogger`
 #[derive(Debug, Deserialize)]
 struct ESExecEvent {
-    dyld_exec_path: String,
+    target: EsExecTarget,
+}
+
+/// `target` field of the `exec` event returned by `eslogger`
+/// See `eslogger exec` output.
+#[derive(Debug, Deserialize)]
+struct EsExecTarget {
+    executable: EsExecTargetExecutable,
+}
+
+/// `executable` field of the `exec` `target` information
+/// See `eslogger exec` output.
+#[derive(Debug, Deserialize)]
+struct EsExecTargetExecutable {
+    path: String,
+    path_truncated: bool,
 }
 
 /// Event that triggered the message returned by `eslogger`.


### PR DESCRIPTION
Another split tunneling bug. The issue can be reproduced by excluding `test` and running `./test` from a shell with its directory as the working dir.

Fix DES-1152.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6644)
<!-- Reviewable:end -->
