### PR TITLE
Fix e2e tests failing on Firebase due to rate limiting

### DIFF
--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/AccountTestRule.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/AccountTestRule.kt
@@ -9,24 +9,21 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
 class AccountTestRule : BeforeEachCallback {
-
-    private val partnerAccount: String?
     private val client =
         SimpleMullvadHttpClient(InstrumentationRegistry.getInstrumentation().targetContext)
+    private val partnerAuth: String? =
+        InstrumentationRegistry.getArguments().getString(PARTNER_AUTH, null)
+    lateinit var validAccountNumber: String
+    lateinit var invalidAccountNumber: String
 
-    val validAccountNumber: String
-    val invalidAccountNumber: String
-
-    init {
+    override fun beforeEach(context: ExtensionContext) {
         InstrumentationRegistry.getArguments().also { bundle ->
-            partnerAccount = bundle.getString(PARTNER_AUTH)
-
-            if (partnerAccount != null) {
+            if (partnerAuth != null) {
                 validAccountNumber = client.createAccount()
                 client.addTimeToAccountUsingPartnerAuth(
                     accountNumber = validAccountNumber,
                     daysToAdd = 1,
-                    partnerAuth = partnerAccount
+                    partnerAuth = partnerAuth
                 )
             } else {
                 validAccountNumber =
@@ -38,6 +35,4 @@ class AccountTestRule : BeforeEachCallback {
                 bundle.getRequiredArgument(INVALID_TEST_ACCOUNT_NUMBER_ARGUMENT_KEY)
         }
     }
-
-    override fun beforeEach(context: ExtensionContext) {}
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/SimpleMullvadHttpClient.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/SimpleMullvadHttpClient.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.services.events.TestEventException
 import co.touchlab.kermit.Logger
 import com.android.volley.Request
+import com.android.volley.VolleyError
 import com.android.volley.toolbox.JsonArrayRequest
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.RequestFuture
@@ -106,8 +107,9 @@ class SimpleMullvadHttpClient(context: Context) {
         authorizationHeader: String? = null
     ): JSONObject? {
         val future = RequestFuture.newFuture<JSONObject>()
+
         val request =
-            object : JsonObjectRequest(method, url, body, future, future) {
+            object : JsonObjectRequest(method, url, body, future, onErrorResponse) {
                 override fun getHeaders(): MutableMap<String, String> {
                     val headers = HashMap<String, String>()
                     if (body != null) {
@@ -136,7 +138,7 @@ class SimpleMullvadHttpClient(context: Context) {
     ): String? {
         val future = RequestFuture.newFuture<String>()
         val request =
-            object : StringRequest(method, url, future, future) {
+            object : StringRequest(method, url, future, onErrorResponse) {
                 override fun getHeaders(): MutableMap<String, String> {
                     val headers = HashMap<String, String>()
                     if (body != null) {
@@ -165,7 +167,7 @@ class SimpleMullvadHttpClient(context: Context) {
     ): JSONArray? {
         val future = RequestFuture.newFuture<JSONArray>()
         val request =
-            object : JsonArrayRequest(method, url, null, future, future) {
+            object : JsonArrayRequest(method, url, null, future, onErrorResponse) {
                 override fun getHeaders(): MutableMap<String, String> {
                     val headers = HashMap<String, String>()
                     headers.put("Content-Type", "application/json")
@@ -190,5 +192,9 @@ class SimpleMullvadHttpClient(context: Context) {
     companion object {
         private const val REQUEST_ERROR_MESSAGE =
             "Unable to verify account due to invalid account or connectivity issues."
+
+        private val onErrorResponse = { error: VolleyError ->
+            Logger.e("Response returned error status code: ${error.networkResponse.statusCode}")
+        }
     }
 }


### PR DESCRIPTION
Firebase tests are failing because of rate limiting, the issue is that `AccountTestRule`'s setup code runs for all tests even ignored ones. Moving code from `init` to `beforeEach` solves this.

Also added logging of response status code when `SimpleMullvadHttpClient` receives error response.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6645)
<!-- Reviewable:end -->
