### PR TITLE
Packet Tunnel stuck in blocked state after Airplane mode is toggled.

### DIFF
--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -104,6 +104,7 @@ extension PacketTunnelActor {
             currentKey: connState.currentKey,
             keyPolicy: connState.keyPolicy,
             networkReachability: connState.networkReachability,
+            recoveryTask: startRecoveryTaskIfNeeded(reason: reason),
             priorState: priorState
         )
     }

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -188,16 +188,16 @@ extension BlockedStateReason {
      - Keychain and filesystem are locked on boot until user unlocks device in the very first time.
      - App update that requires settings schema migration. Packet tunnel will be automatically restarted after update but it would not be able to read settings until
        user opens the app which performs migration.
+     - Packet tunnel will be automatically restarted when there is a tunnel adapter error.
      */
     var shouldRestartAutomatically: Bool {
         switch self {
-        case .deviceLocked:
+        case .deviceLocked, .tunnelAdapter:
             return true
-
         case .noRelaysSatisfyingConstraints, .noRelaysSatisfyingFilterConstraints,
              .multihopEntryEqualsExit,
              .noRelaysSatisfyingDaitaConstraints, .readSettings, .invalidAccount, .accountExpired, .deviceRevoked,
-             .tunnelAdapter, .unknown, .deviceLoggedOut, .outdatedSchema, .invalidRelayPublicKey:
+             .unknown, .deviceLoggedOut, .outdatedSchema, .invalidRelayPublicKey:
             return false
         }
     }

--- a/ios/PacketTunnelCore/Actor/Timings.swift
+++ b/ios/PacketTunnelCore/Actor/Timings.swift
@@ -11,7 +11,7 @@ import MullvadTypes
 
 /// Struct holding all timings used by tunnel actor.
 public struct PacketTunnelActorTimings {
-    /// Periodicity at which actor will attempt to restart when an error occurred on system boot when filesystem is locked until device is unlocked.
+    /// Periodicity at which actor will attempt to restart when an error occurred on system boot when filesystem is locked until device is unlocked or tunnel adapter error.
     public var bootRecoveryPeriodicity: Duration
 
     /// Time that takes for new WireGuard key to propagate across relays.
@@ -19,7 +19,7 @@ public struct PacketTunnelActorTimings {
 
     /// Designated initializer.
     public init(
-        bootRecoveryPeriodicity: Duration = .seconds(10),
+        bootRecoveryPeriodicity: Duration = .seconds(5),
         wgKeyPropagationDelay: Duration = .seconds(120)
     ) {
         self.bootRecoveryPeriodicity = bootRecoveryPeriodicity


### PR DESCRIPTION
When the reason for the blocked state is a tunnel adapter error, we need to automatically recover the connection to attempt reconnection to the current relay, keeping the tunnel up to date. This PR introduces that functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6647)
<!-- Reviewable:end -->
