### PR TITLE
Fixes for firebase e2e still sometimes failing

### DIFF
--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -6,6 +6,7 @@ import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaime
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 import net.mullvad.mullvadvpn.test.e2e.misc.AccountTestRule
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -26,7 +27,7 @@ class LoginTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
     }
 
     @Test
-    @HighlyRateLimited
+    @Disabled("Failed login attempts are highly rate limited and cause test flakiness")
     fun testLoginWithInvalidCredentials() {
         // Given
         val invalidDummyAccountNumber = accountTestRule.invalidAccountNumber

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -5,7 +5,6 @@ import net.mullvad.mullvadvpn.test.common.constant.LOGIN_FAILURE_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
-import net.mullvad.mullvadvpn.test.e2e.annotations.HighlyRateLimited
 import net.mullvad.mullvadvpn.test.e2e.misc.AccountTestRule
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/SimpleMullvadHttpClient.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/SimpleMullvadHttpClient.kt
@@ -194,7 +194,14 @@ class SimpleMullvadHttpClient(context: Context) {
             "Unable to verify account due to invalid account or connectivity issues."
 
         private val onErrorResponse = { error: VolleyError ->
-            Logger.e("Response returned error status code: ${error.networkResponse.statusCode}")
+            if (error.networkResponse != null) {
+                Logger.e(
+                    "Response returned error message: ${error.message} " +
+                        "status code: ${error.networkResponse.statusCode}"
+                )
+            } else {
+                Logger.e("Response returned error: ${error.message}")
+            }
         }
     }
 }

--- a/android/test/firebase/e2e-play-stagemole.yml
+++ b/android/test/firebase/e2e-play-stagemole.yml
@@ -5,6 +5,7 @@ default:
   test: android/test/e2e/build/outputs/apk/playStagemole/debug/e2e-play-stagemole-debug.apk
   timeout: 10m
   use-orchestrator: true
+  num-flaky-test-attempts: 1
   device:
     - {model: shiba, version: 34, locale: en, orientation: portrait} # pixel 8
     - {model: felix, version: 34, locale: en, orientation: portrait} # pixel fold

--- a/android/test/firebase/mockapi-oss.yml
+++ b/android/test/firebase/mockapi-oss.yml
@@ -5,6 +5,7 @@ default:
   test: android/test/mockapi/build/outputs/apk/oss/debug/mockapi-oss-debug.apk
   timeout: 10m
   use-orchestrator: true
+  num-flaky-test-attempts: 1
   device:
     - {model: shiba, version: 34, locale: en, orientation: portrait}
     - {model: tangorpro, version: 33, locale: en, orientation: portrait}


### PR DESCRIPTION
e2e tests on Firebase are still sometimes failing due to rate limiting. This PR include some improvements related to failing tests in Firebase:
* Disable `testLoginWithInvalidCredentials` because the requests it generates are highly rate limited
* Logging broke in some bases because the response object was null
* Configure Firebase to re-run failing tests once

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6653)
<!-- Reviewable:end -->
