### PR TITLE
Fix IP-override feature indicator

### DIFF
--- a/mullvad-api/src/relay_list.rs
+++ b/mullvad-api/src/relay_list.rs
@@ -154,6 +154,8 @@ fn into_mullvad_relay(
         hostname: relay.hostname,
         ipv4_addr_in: relay.ipv4_addr_in,
         ipv6_addr_in: relay.ipv6_addr_in,
+        overridden_ipv4: false,
+        overridden_ipv6: false,
         include_in_country: relay.include_in_country,
         active: relay.active,
         owned: relay.owned,

--- a/mullvad-management-interface/src/types/conversions/relay_list.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_list.rs
@@ -291,6 +291,8 @@ impl TryFrom<proto::Relay> for mullvad_types::relay_list::Relay {
                 FromProtobufTypeError::InvalidArgument("invalid relay IPv4 address")
             })?,
             ipv6_addr_in,
+            overridden_ipv4: false,
+            overridden_ipv6: false,
             include_in_country: relay.include_in_country,
             active: relay.active,
             owned: relay.owned,

--- a/mullvad-relay-selector/src/relay_selector/matcher.rs
+++ b/mullvad-relay-selector/src/relay_selector/matcher.rs
@@ -163,8 +163,9 @@ fn filter_on_shadowsocks(
     let ip_version = super::detailer::resolve_ip_version(*ip_version);
 
     match (settings, &relay.endpoint_data) {
-        // If Shadowsocks is specifically asked for, we must check if the specific relay supports our port.
-        // If there are extra addresses, then all ports are available, so we do not need to do this.
+        // If Shadowsocks is specifically asked for, we must check if the specific relay supports
+        // our port. If there are extra addresses, then all ports are available, so we do
+        // not need to do this.
         (
             ShadowsocksSettings {
                 port: Constraint::Only(desired_port),

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -804,9 +804,11 @@ fn test_selecting_wireguard_over_shadowsocks_extra_ips() {
     match relay {
         GetRelay::Wireguard {
             obfuscator: Some(SelectedObfuscator { config: ObfuscatorConfig::Shadowsocks { endpoint }, .. }),
-            inner: WireguardConfig::Singlehop { .. },
+            inner: WireguardConfig::Singlehop { exit },
             ..
         } => {
+            assert!(!exit.overridden_ipv4);
+            assert!(!exit.overridden_ipv6);
             assert!(SHADOWSOCKS_RELAY_EXTRA_ADDRS.contains(&endpoint.ip()), "{} is not an additional IP", endpoint);
         }
         wrong_relay => panic!(
@@ -849,6 +851,7 @@ fn test_selecting_wireguard_ignore_extra_ips_override_v4() {
             ..
         } => {
             assert!(exit.overridden_ipv4);
+            assert!(!exit.overridden_ipv6);
             assert_eq!(endpoint.ip(), IpAddr::from(OVERRIDE_IPV4));
         }
         wrong_relay => panic!(
@@ -887,9 +890,11 @@ fn test_selecting_wireguard_ignore_extra_ips_override_v6() {
     match relay {
         GetRelay::Wireguard {
             obfuscator: Some(SelectedObfuscator { config: ObfuscatorConfig::Shadowsocks { endpoint }, .. }),
-            inner: WireguardConfig::Singlehop { .. },
+            inner: WireguardConfig::Singlehop { exit },
             ..
         } => {
+            assert!(exit.overridden_ipv6);
+            assert!(!exit.overridden_ipv4);
             assert_eq!(endpoint.ip(), IpAddr::from(OVERRIDE_IPV6));
         }
         wrong_relay => panic!(

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -47,6 +47,8 @@ static RELAYS: Lazy<RelayList> = Lazy::new(|| RelayList {
                     hostname: "se9-wireguard".to_string(),
                     ipv4_addr_in: "185.213.154.68".parse().unwrap(),
                     ipv6_addr_in: Some("2a03:1b20:5:f011::a09f".parse().unwrap()),
+                    overridden_ipv4: false,
+                    overridden_ipv6: false,
                     include_in_country: true,
                     active: true,
                     owned: true,
@@ -66,6 +68,8 @@ static RELAYS: Lazy<RelayList> = Lazy::new(|| RelayList {
                     hostname: "se10-wireguard".to_string(),
                     ipv4_addr_in: "185.213.154.69".parse().unwrap(),
                     ipv6_addr_in: Some("2a03:1b20:5:f011::a10f".parse().unwrap()),
+                    overridden_ipv4: false,
+                    overridden_ipv6: false,
                     include_in_country: true,
                     active: true,
                     owned: false,
@@ -85,6 +89,8 @@ static RELAYS: Lazy<RelayList> = Lazy::new(|| RelayList {
                     hostname: "se-got-001".to_string(),
                     ipv4_addr_in: "185.213.154.131".parse().unwrap(),
                     ipv6_addr_in: None,
+                    overridden_ipv4: false,
+                    overridden_ipv6: false,
                     include_in_country: true,
                     active: true,
                     owned: true,
@@ -97,6 +103,8 @@ static RELAYS: Lazy<RelayList> = Lazy::new(|| RelayList {
                     hostname: "se-got-002".to_string(),
                     ipv4_addr_in: "1.2.3.4".parse().unwrap(),
                     ipv6_addr_in: None,
+                    overridden_ipv4: false,
+                    overridden_ipv6: false,
                     include_in_country: true,
                     active: true,
                     owned: true,
@@ -109,6 +117,8 @@ static RELAYS: Lazy<RelayList> = Lazy::new(|| RelayList {
                     hostname: "se-got-br-001".to_string(),
                     ipv4_addr_in: "1.3.3.7".parse().unwrap(),
                     ipv6_addr_in: None,
+                    overridden_ipv4: false,
+                    overridden_ipv6: false,
                     include_in_country: true,
                     active: true,
                     owned: true,
@@ -182,6 +192,8 @@ static SHADOWSOCKS_RELAY: Lazy<Relay> = Lazy::new(|| Relay {
         .to_owned(),
     ipv4_addr_in: SHADOWSOCKS_RELAY_IPV4,
     ipv6_addr_in: Some(SHADOWSOCKS_RELAY_IPV6),
+    overridden_ipv4: false,
+    overridden_ipv6: false,
     include_in_country: true,
     active: true,
     owned: true,
@@ -463,6 +475,8 @@ fn test_wireguard_entry() {
                         hostname: "se9-wireguard".to_string(),
                         ipv4_addr_in: "185.213.154.68".parse().unwrap(),
                         ipv6_addr_in: Some("2a03:1b20:5:f011::a09f".parse().unwrap()),
+                        overridden_ipv4: false,
+                        overridden_ipv6: false,
                         include_in_country: true,
                         active: true,
                         owned: true,
@@ -482,6 +496,8 @@ fn test_wireguard_entry() {
                         hostname: "se10-wireguard".to_string(),
                         ipv4_addr_in: "185.213.154.69".parse().unwrap(),
                         ipv6_addr_in: Some("2a03:1b20:5:f011::a10f".parse().unwrap()),
+                        overridden_ipv4: false,
+                        overridden_ipv6: false,
                         include_in_country: true,
                         active: true,
                         owned: false,
@@ -746,7 +762,8 @@ fn test_selecting_any_relay_will_consider_multihop() {
     }
 }
 
-/// Test whether Shadowsocks is always selected as the obfuscation protocol when Shadowsocks is selected.
+/// Test whether Shadowsocks is always selected as the obfuscation protocol when Shadowsocks is
+/// selected.
 #[test]
 fn test_selecting_wireguard_over_shadowsocks() {
     let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
@@ -828,9 +845,10 @@ fn test_selecting_wireguard_ignore_extra_ips_override_v4() {
     match relay {
         GetRelay::Wireguard {
             obfuscator: Some(SelectedObfuscator { config: ObfuscatorConfig::Shadowsocks { endpoint }, .. }),
-            inner: WireguardConfig::Singlehop { .. },
+            inner: WireguardConfig::Singlehop { exit },
             ..
         } => {
+            assert!(exit.overridden_ipv4);
             assert_eq!(endpoint.ip(), IpAddr::from(OVERRIDE_IPV4));
         }
         wrong_relay => panic!(
@@ -1118,6 +1136,8 @@ fn test_include_in_country() {
                         hostname: "se9-wireguard".to_string(),
                         ipv4_addr_in: "185.213.154.68".parse().unwrap(),
                         ipv6_addr_in: Some("2a03:1b20:5:f011::a09f".parse().unwrap()),
+                        overridden_ipv4: false,
+                        overridden_ipv6: false,
                         include_in_country: false,
                         active: true,
                         owned: true,
@@ -1137,6 +1157,8 @@ fn test_include_in_country() {
                         hostname: "se10-wireguard".to_string(),
                         ipv4_addr_in: "185.213.154.69".parse().unwrap(),
                         ipv6_addr_in: Some("2a03:1b20:5:f011::a10f".parse().unwrap()),
+                        overridden_ipv4: false,
+                        overridden_ipv6: false,
                         include_in_country: false,
                         active: true,
                         owned: false,
@@ -1339,6 +1361,8 @@ fn test_daita() {
                         hostname: "se9-wireguard".to_string(),
                         ipv4_addr_in: "185.213.154.68".parse().unwrap(),
                         ipv6_addr_in: Some("2a03:1b20:5:f011::a09f".parse().unwrap()),
+                        overridden_ipv4: false,
+                        overridden_ipv6: false,
                         include_in_country: true,
                         active: true,
                         owned: true,
@@ -1358,6 +1382,8 @@ fn test_daita() {
                         hostname: "se10-wireguard".to_string(),
                         ipv4_addr_in: "185.213.154.69".parse().unwrap(),
                         ipv6_addr_in: Some("2a03:1b20:5:f011::a10f".parse().unwrap()),
+                        overridden_ipv4: false,
+                        overridden_ipv6: false,
                         include_in_country: true,
                         active: true,
                         owned: false,

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -658,14 +658,14 @@ impl RelayOverride {
                 "Overriding ipv4_addr_in for {}: {ipv4_addr_in}",
                 relay.hostname
             );
-            relay.ipv4_addr_in = ipv4_addr_in;
+            relay.override_ipv4(ipv4_addr_in);
         }
         if let Some(ipv6_addr_in) = self.ipv6_addr_in {
             log::debug!(
                 "Overriding ipv6_addr_in for {}: {ipv6_addr_in}",
                 relay.hostname
             );
-            relay.ipv6_addr_in = Some(ipv6_addr_in);
+            relay.override_ipv6(ipv6_addr_in);
         }
 
         // Additional IPs should be ignored when overrides are present

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -80,6 +80,10 @@ pub struct Relay {
     pub hostname: String,
     pub ipv4_addr_in: Ipv4Addr,
     pub ipv6_addr_in: Option<Ipv6Addr>,
+    // NOTE: Probably a better design choice would be to store the overridden IP addresses
+    // instead of a boolean override flags. This would allow us to access the original IPs.
+    pub overridden_ipv4: bool,
+    pub overridden_ipv6: bool,
     pub include_in_country: bool,
     pub active: bool,
     pub owned: bool,
@@ -87,6 +91,18 @@ pub struct Relay {
     pub weight: u64,
     pub endpoint_data: RelayEndpointData,
     pub location: Option<Location>,
+}
+
+impl Relay {
+    pub fn override_ipv4(&mut self, new_ipv4: Ipv4Addr) {
+        self.ipv4_addr_in = new_ipv4;
+        self.overridden_ipv4 = true;
+    }
+
+    pub fn override_ipv6(&mut self, new_ipv6: Ipv6Addr) {
+        self.ipv6_addr_in = Some(new_ipv6);
+        self.overridden_ipv6 = true;
+    }
 }
 
 impl PartialEq for Relay {
@@ -103,6 +119,8 @@ impl PartialEq for Relay {
     ///     hostname: "se9-wireguard".to_string(),
     ///     ipv4_addr_in: "185.213.154.68".parse().unwrap(),
     ///     # ipv6_addr_in: None,
+    ///     # overridden_ipv4: false,
+    ///     # overridden_ipv6: false,
     ///     # include_in_country: true,
     ///     # active: true,
     ///     # owned: true,


### PR DESCRIPTION
It was trigger by any overrides existing in the settings, not by the current endpoint being overridden.

Add flag to `Relay` to specify if its IPv4 and/or IPv6 has been overridden and use that in combination with the endpoint IP version to derive if the current connection is overridden.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6654)
<!-- Reviewable:end -->
