### PR TITLE
Repeat option for e2e tests and incrementing timeout

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -32,17 +32,18 @@ on:
         description: Override container image
         type: string
         required: false
-      run_e2e_tests:
-        description: Run e2e tests
-        type: boolean
-        required: false
       run_firebase_tests:
         description: Run firebase tests
         type: boolean
         required: false
       mockapi_test_repeat:
-        description: Mockapi test repeat
+        description: Mockapi test repeat(self hosted)
         default: '1'
+        required: true
+        type: string
+      e2e_test_repeat:
+        description: e2e test repeat(self hosted)
+        default: '0'
         required: true
         type: string
   # Build if main is updated to ensure up-to-date caches are available
@@ -407,7 +408,6 @@ jobs:
   instrumented-tests:
     name: Run instrumented tests
     runs-on: [self-hosted, android-device]
-    timeout-minutes: 30
     needs: [build-app, build-instrumented-tests]
     strategy:
       fail-fast: false
@@ -423,6 +423,7 @@ jobs:
       - name: Prepare report dir
         if: ${{ matrix.test-repeat != 0 }}
         id: prepare-report-dir
+        timeout-minutes: 5
         env:
           INNER_REPORT_DIR: /tmp/${{ matrix.test-type }}-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
@@ -471,11 +472,15 @@ jobs:
     name: Run instrumented e2e tests
     # Temporary workaround for targeting the runner android-runner-v1
     runs-on: [self-hosted, android-device, android-emulator]
-    if: github.event_name == 'schedule' || github.event.inputs.run_e2e_tests == 'true'
-    timeout-minutes: 30
+    if: github.event_name == 'schedule' || ${{ github.event.inputs.e2e_test_repeat }} != '0'
     needs: [build-app, build-instrumented-tests]
+    strategy:
+      matrix:
+        include:
+          - test-repeat: ${{ github.event.inputs.e2e_test_repeat || 1 }}
     steps:
       - name: Prepare report dir
+        if: ${{ matrix.test-repeat != 0 }}
         id: prepare-report-dir
         env:
           INNER_REPORT_DIR: /tmp/${{ github.run_id }}-${{ github.run_attempt }}
@@ -484,21 +489,25 @@ jobs:
           echo "report_dir=$INNER_REPORT_DIR" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
+        if: ${{ matrix.test-repeat != 0 }}
         uses: actions/checkout@v4
 
       # Using v3 due to v4 being very slow for this artifact.
       - uses: actions/download-artifact@v3
+        if: ${{ matrix.test-repeat != 0 }}
         with:
           name: apks
           path: android/app/build/outputs/apk
 
       # Using v3 due to v4 being very slow for this artifact.
       - uses: actions/download-artifact@v3
+        if: ${{ matrix.test-repeat != 0 }}
         with:
           name: e2e-instrumentation-apks
           path: android/test/e2e/build/outputs/apk
 
       - name: Run instrumented test script
+        if: ${{ matrix.test-repeat != 0 }}
         shell: bash -ieo pipefail {0}
         env:
           AUTO_FETCH_TEST_HELPER_APKS: true
@@ -509,7 +518,7 @@ jobs:
           INVALID_TEST_ACCOUNT_NUMBER: '0000000000000000'
           ENABLE_HIGHLY_RATE_LIMITED_TESTS: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
           REPORT_DIR: ${{ steps.prepare-report-dir.outputs.report_dir }}
-        run: ./android/scripts/run-instrumented-tests.sh
+        run: ./android/scripts/run-instrumented-tests-repeat.sh ${{ matrix.test-repeat }}
 
   firebase-tests:
     name: Run firebase tests

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -423,7 +423,6 @@ jobs:
       - name: Prepare report dir
         if: ${{ matrix.test-repeat != 0 }}
         id: prepare-report-dir
-        timeout-minutes: 5
         env:
           INNER_REPORT_DIR: /tmp/${{ matrix.test-type }}-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
@@ -448,8 +447,14 @@ jobs:
           name: ${{ matrix.test-type }}-instrumentation-apks
           path: ${{ matrix.path }}
 
+      - name: Calculate timeout
+        id: calculate-timeout
+        run: echo "timeout=$(( ${{ matrix.test-repeat }} * 10 ))" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Run instrumented test script
         if: ${{ matrix.test-repeat != 0 }}
+        timeout-minutes: ${{ fromJSON(steps.calculate-timeout.outputs.timeout) }} 
         shell: bash -ieo pipefail {0}
         env:
           AUTO_FETCH_TEST_HELPER_APKS: true
@@ -506,8 +511,14 @@ jobs:
           name: e2e-instrumentation-apks
           path: android/test/e2e/build/outputs/apk
 
+      - name: Calculate timeout
+        id: calculate-timeout
+        run: echo "timeout=$(( ${{ matrix.test-repeat }} * 10 ))" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Run instrumented test script
         if: ${{ matrix.test-repeat != 0 }}
+        timeout-minutes: ${{ fromJSON(steps.calculate-timeout.outputs.timeout) }}
         shell: bash -ieo pipefail {0}
         env:
           AUTO_FETCH_TEST_HELPER_APKS: true


### PR DESCRIPTION
This PR introduces an option for specifying how many times e2e tests should run on our office runner(s), similar to the option mockapi already have. The timeout for mockapi and e2e tests is now also based on the number of test runs to avoid a high number of runs resulting in reaching timeout.

The changes can be tested by running the *Android - Build and test* workflow on this branch.

<img width="354" alt="image" src="https://github.com/user-attachments/assets/f211598f-1490-4c3f-98a9-d7f880d0051c">


<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
