### PR TITLE
Spawn `connection-checker` as an unprivileged user

### DIFF
--- a/test/test-manager/src/vm/provision.rs
+++ b/test/test-manager/src/vm/provision.rs
@@ -10,6 +10,7 @@ use std::{
     net::{IpAddr, SocketAddr, TcpStream},
     path::{Path, PathBuf},
 };
+use test_rpc::UNPRIVILEGED_USER;
 
 /// Returns the directory in the test runner where the test-runner binary is installed.
 pub async fn provision(
@@ -156,7 +157,7 @@ fn blocking_ssh(
 
     // Run the setup script in the test runner
     let cmd = format!(
-        r#"sudo {} {remote_dir} "{app_package_path}" "{app_package_to_upgrade_from_path}" "{gui_package_path}""#,
+        r#"sudo {} {remote_dir} "{app_package_path}" "{app_package_to_upgrade_from_path}" "{gui_package_path}" "{UNPRIVILEGED_USER}""#,
         bootstrap_script_dest.display(),
     );
     log::debug!("Running setup script on remote, cmd: {cmd}");

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -13,6 +13,10 @@ pub mod net;
 pub mod package;
 pub mod transport;
 
+/// Unprivileged user. This is used for things like spawning processes.
+/// This is also used as the password for the same user, as is common practice.
+pub const UNPRIVILEGED_USER: &str = "mole";
+
 #[derive(thiserror::Error, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Error {
     #[error("Test runner RPC failed")]

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -58,7 +58,7 @@ features = ["codec"]
 default-features = false
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true }
+nix = { workspace = true, features = ["user"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rs-release = "0.1.7"

--- a/test/test-runner/src/util.rs
+++ b/test/test-runner/src/util.rs
@@ -21,3 +21,72 @@ impl<F: FnOnce() + Send> OnDrop<F> {
         }
     }
 }
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct Error {
+    inner: InnerError,
+}
+
+#[cfg(unix)]
+#[derive(thiserror::Error, Debug)]
+enum InnerError {
+    #[error("Failed to get the specified user")]
+    GetUser(#[source] nix::Error),
+    #[error("The specified user was not found")]
+    MissingUser,
+    #[error("Failed to set uid")]
+    SetUid(#[source] nix::Error),
+    #[error("Failed to set gid")]
+    SetGid(#[source] nix::Error),
+}
+
+#[cfg(target_os = "windows")]
+#[derive(thiserror::Error, Debug)]
+enum InnerError {}
+
+impl From<InnerError> for Error {
+    fn from(inner: InnerError) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn as_unprivileged_user<T>(unpriv_user: &str, func: impl FnOnce() -> T) -> Result<T, Error> {
+    // NOTE: no-op
+    let _ = unpriv_user;
+    Ok(func())
+}
+
+#[cfg(unix)]
+pub fn as_unprivileged_user<T>(unpriv_user: &str, func: impl FnOnce() -> T) -> Result<T, Error> {
+    let original_uid = nix::unistd::getuid();
+    let original_gid = nix::unistd::getgid();
+
+    let user = nix::unistd::User::from_name(unpriv_user)
+        .map_err(InnerError::GetUser)?
+        .ok_or(InnerError::MissingUser)?;
+    let uid = user.uid;
+    let gid = user.gid;
+
+    nix::unistd::setegid(gid).map_err(InnerError::SetGid)?;
+    let restore_gid = OnDrop::new(|| {
+        if let Err(error) = nix::unistd::setegid(original_gid) {
+            log::error!("Failed to restore gid: {error}");
+        }
+    });
+
+    nix::unistd::seteuid(uid).map_err(InnerError::SetUid)?;
+    let restore_uid = OnDrop::new(|| {
+        if let Err(error) = nix::unistd::seteuid(original_uid) {
+            log::error!("Failed to restore uid: {error}");
+        }
+    });
+
+    let result = Ok(func());
+
+    drop(restore_uid);
+    drop(restore_gid);
+
+    result
+}


### PR DESCRIPTION
`test-runner` now spawns all processes as an unprivileged user.

Fix DES-1131
Fix DES-1129

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6656)
<!-- Reviewable:end -->
