### PR TITLE
Bump wireguard-go submodule to wg-go-daita 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Line wrap the file at 100 chars.                                              Th
 - Add experimental support for Windows ARM64.
 
 ### Fixed
+- macOS and Linux: Fix potential crash when disconnecting with DAITA enabled.
+
 #### macOS
 - Exclude programs when executed using a relative path from a shell.
 - Reduce packet loss when using split tunneling.


### PR DESCRIPTION
Point to the latest tag which fixes a panic.

Fix DES-1154.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6657)
<!-- Reviewable:end -->
