### PR TITLE
Add top level `permissions` to all Github Actions workflows

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -49,6 +49,9 @@ on:
   # Build if main is updated to ensure up-to-date caches are available
   push:
     branches: [main]
+
+permissions: {}
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -21,6 +21,9 @@ on:
         description: Override container image
         type: string
         required: false
+
+permissions: {}
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/android-kotlin-format-check.yml
+++ b/.github/workflows/android-kotlin-format-check.yml
@@ -9,6 +9,9 @@ on:
         description: Override container image
         type: string
         required: false
+
+permissions: {}
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/android-static-analysis.yml
+++ b/.github/workflows/android-static-analysis.yml
@@ -13,6 +13,9 @@ on:
     # Github Actions enabled, so these don't go unnoticed.
     # https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs
     - cron: '20 6 * * *'
+
+permissions: {}
+
 jobs:
   mobsfscan:
     name: Code scanning using mobsfscan

--- a/.github/workflows/android-xml-format-check.yml
+++ b/.github/workflows/android-xml-format-check.yml
@@ -6,6 +6,9 @@ on:
       - .github/workflows/android-xml-format-check.yml
       - android/**/*.xml
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -10,11 +10,13 @@ on:
     # At 06:20 UTC every day. Will create an issue if a CVE is found.
     - cron: '20 6 * * *'
   workflow_dispatch:
+
+permissions:
+  issues: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/cargo-vendor.yml
+++ b/.github/workflows/cargo-vendor.yml
@@ -11,6 +11,9 @@ on:
       - Cargo.lock
       - '**/Cargo.toml'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   cargo-vendor:
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,6 +7,9 @@ on:
       - clippy.toml
       - '**/*.rs'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   prepare-android:
     name: Prepare Android container

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -33,6 +33,9 @@ on:
         description: Override container image
         type: string
         required: false
+
+permissions: {}
+
 jobs:
   prepare-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -25,6 +25,9 @@ on:
         default: ''
         required: false
         type: string
+
+permissions: {}
+
 jobs:
   prepare-matrices:
     name: Prepare virtual machines

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,8 @@ on:
       - mullvad-management-interface/proto/**
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-frontend:
     strategy:

--- a/.github/workflows/ios-end-to-end-tests-api.yml
+++ b/.github/workflows/ios-end-to-end-tests-api.yml
@@ -2,12 +2,14 @@
 name: iOS end-to-end API tests
 on:
   workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   reuse-e2e-workflow:
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "api-tests"

--- a/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
+++ b/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
@@ -10,12 +10,14 @@ on:
     paths:
       - .github/workflows/ios-end-to-end-tests*.yml
       - ios/**
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   reuse-e2e-workflow:
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "pr-merge-to-main"

--- a/.github/workflows/ios-end-to-end-tests-nightly.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly.yml
@@ -9,6 +9,9 @@ on:
     # Github Actions enabled, so these don't go unnoticed.
     # https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs
     - cron: '0 0 * * *'
+
+permissions: {}
+
 jobs:
   reuse-e2e-workflow:
     permissions:

--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -9,6 +9,9 @@ on:
       - ios/Gemfile
       - ios/Gemfile.lock
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   test:
     name: Take screenshots

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -12,6 +12,9 @@ on:
       - ios/**/*.swift
       - ios/**/*.xctestplan
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   test:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ios-validate-build-schemas.yml
+++ b/.github/workflows/ios-validate-build-schemas.yml
@@ -14,6 +14,9 @@ on:
       - ios/**/*.xctestplan
       - Cargo.toml
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   test:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,6 +9,9 @@ on:
       - ios/**/*.swift
       - ios/**/*.xctestplan
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-formatting:
     name: Check formatting

--- a/.github/workflows/proto-format-check.yml
+++ b/.github/workflows/proto-format-check.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**/*.proto'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-supply-chain.yml
+++ b/.github/workflows/rust-supply-chain.yml
@@ -9,6 +9,9 @@ on:
       - Cargo.lock
       - '**/*.rs'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-supply-chain:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -11,6 +11,9 @@ on:
 env:
   # Pinning nightly just to avoid random breakage. It's fine to bump this at any time
   RUST_NIGHTLY_TOOLCHAIN: nightly-2024-06-06
+
+permissions: {}
+
 jobs:
   prepare-containers:
     runs-on: ubuntu-latest

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,6 +7,9 @@ on:
       - rustfmt.toml
       - '**/*.rs'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/clippy-test.yml
       - clippy.toml
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   clippy-check-test:
     name: Clippy linting of test workspace

--- a/.github/workflows/testframework-rust-supply-chain.yml
+++ b/.github/workflows/testframework-rust-supply-chain.yml
@@ -9,6 +9,9 @@ on:
       - 'test/**/Cargo.lock'
       - 'test/**/*.rs'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-test-framework-supply-chain:
     runs-on: ubuntu-latest

--- a/.github/workflows/testframework-rustfmt.yml
+++ b/.github/workflows/testframework-rustfmt.yml
@@ -8,6 +8,9 @@ on:
       - .github/workflows/rustfmt-test.yml
       - rustfmt.toml
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-formatting-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -26,6 +26,9 @@ on:
       - '!.yamllint'
       - '!**/osv-scanner.toml'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   prepare-build-test-framework-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/translations-converter.yml
+++ b/.github/workflows/translations-converter.yml
@@ -6,6 +6,9 @@ on:
       - .github/workflows/translations-converter.yml
       - android/translations-converter/**
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-translations:
     runs-on: ubuntu-latest

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -10,6 +10,9 @@ on:
       - gui/**
       - '!**/osv-scanner.toml'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   check-translations:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default permission on the repository is already set to read only. So in practice this makes no difference. But this makes that more explicit, and less relying on the repository being correctly configured.

This also makes security scanning tools such as OpenSSF scorecard happier about the overall security of our repository.

I think we should start *always* defining `permissions` on our actions. However, we currently don't have anything that enforces it, and given how little actual security it gives us right now it's definitely not worth automating. I just wanted to do this little manual sweep to "improve" the current state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6660)
<!-- Reviewable:end -->
