### PR TITLE
Bump linux container to `mullvadvpn-app-build:0186b645c`

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -19,7 +19,7 @@
 # patch for a given go version can be identified by checking the wireguard-android
 # repo: https://git.zx2c4.com/wireguard-android/tree/tunnel/tools/libwg-go.
 # It's also important to keep the go path in sync.
-FROM ghcr.io/mullvad/mullvadvpn-app-build:01a98bb5b
+FROM ghcr.io/mullvad/mullvadvpn-app-build:0186b645c
 
 # === Metadata ===
 LABEL org.opencontainers.image.source=https://github.com/mullvad/mullvadvpn-app

--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:c3c0a4bc1
+ghcr.io/mullvad/mullvadvpn-app-build:0186b645c


### PR DESCRIPTION
Bump both the container used for Linux builds, as well as the base used to build Android to the newly built container with Rust 1.80.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6662)
<!-- Reviewable:end -->
