### PR TITLE
Re-enable and fix testConnectAndVerifyWithConnectionCheck

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -91,7 +91,8 @@ class AppInteractor(
         device.findObjectWithTimeout(By.res("location_info_test_tag")).click()
         return device
             .findObjectWithTimeout(
-                By.res("location_info_connection_out_test_tag"),
+                // Text exist and contains IP address
+                By.res("location_info_connection_out_test_tag").textContains("."),
                 CONNECTION_TIMEOUT
             )
             .text

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -57,7 +57,9 @@ class AppInteractor(
             device.findObjectWithTimeout(By.clazz("android.widget.EditText")).apply {
                 text = accountNumber
             }
-        loginObject.parent.findObject(By.clazz(Button::class.java)).click()
+        val loginButton = loginObject.parent.findObject(By.clazz(Button::class.java))
+        loginButton.wait(Until.enabled(true), DEFAULT_INTERACTION_TIMEOUT)
+        loginButton.click()
     }
 
     fun attemptCreateAccount() {

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/rule/ForgetAllVpnAppsInSettingsTestRule.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/rule/ForgetAllVpnAppsInSettingsTestRule.kt
@@ -23,14 +23,22 @@ class ForgetAllVpnAppsInSettingsTestRule : BeforeTestExecutionCallback {
             device.findObjects(By.res(SETTINGS_PACKAGE, VPN_SETTINGS_BUTTON_ID))
         vpnSettingsButtons.forEach { button ->
             button.click()
-            device.findObjectWithTimeout(By.text(FORGET_VPN_VPN_BUTTON_TEXT)).click()
-            device.findObjectByCaseInsensitiveText(FORGET_VPN_VPN_CONFIRM_BUTTON_TEXT).click()
+
+            try {
+                device.findObjectWithTimeout(By.text(FORGET_VPN_VPN_BUTTON_TEXT)).click()
+                device.findObjectByCaseInsensitiveText(FORGET_VPN_VPN_CONFIRM_BUTTON_TEXT).click()
+            } catch (_: Exception) {
+                device.findObjectWithTimeout(By.text(DELETE_VPN_PROFILE_TEXT)).click()
+                device.findObjectWithTimeout(By.text(DELETE_VPN_CONFIRM_BUTTON_TEXT)).click()
+            }
         }
     }
 
     companion object {
         private const val FORGET_VPN_VPN_BUTTON_TEXT = "Forget VPN"
+        private const val DELETE_VPN_PROFILE_TEXT = "Delete VPN profile"
         private const val FORGET_VPN_VPN_CONFIRM_BUTTON_TEXT = "Forget"
+        private const val DELETE_VPN_CONFIRM_BUTTON_TEXT = "DELETE"
         private const val SETTINGS_PACKAGE = "com.android.settings"
         private const val VPN_SETTINGS_BUTTON_ID = "settings_button"
     }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
@@ -9,7 +9,6 @@ import net.mullvad.mullvadvpn.test.e2e.misc.AccountTestRule
 import net.mullvad.mullvadvpn.test.e2e.misc.ConnCheckState
 import net.mullvad.mullvadvpn.test.e2e.misc.SimpleMullvadHttpClient
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -35,7 +34,6 @@ class ConnectionTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
     }
 
     @Test
-    @Disabled("Disabled since the connection check isn't reliable in the stagemole infrastructure.")
     fun testConnectAndVerifyWithConnectionCheck() {
         // Given
         app.launchAndEnsureLoggedIn(accountTestRule.validAccountNumber)


### PR DESCRIPTION
This PR enables `testConnectAndVerifyWithConnectionCheck` and adds a wait for the out IP address to show before attempting to extract it. It is valid that it in some cases take a while for it to show.

There is also a small fix for login button sometimes being pressed before it has been enabled.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6663)
<!-- Reviewable:end -->
