### PR TITLE
Remove split tunnel interface if split tunneling is disabled

### DIFF
--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -359,10 +359,10 @@ impl ConnectedState {
             #[cfg(target_os = "macos")]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 match shared_values.set_exclude_paths(paths) {
-                    Ok(added_device) => {
+                    Ok(interface_changed) => {
                         let _ = result_tx.send(Ok(()));
 
-                        if added_device {
+                        if interface_changed {
                             if let Err(error) = self.set_firewall_policy(shared_values) {
                                 return self.disconnect(
                                     shared_values,

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -490,7 +490,7 @@ struct SharedTunnelStateValues {
 }
 
 impl SharedTunnelStateValues {
-    /// Return whether an split tunnel interface was created
+    /// Return whether a split tunnel interface was added or removed
     #[cfg(target_os = "macos")]
     pub fn set_exclude_paths(&mut self, paths: Vec<OsString>) -> Result<bool, split_tunnel::Error> {
         self.runtime.block_on(async {
@@ -506,7 +506,7 @@ impl SharedTunnelStateValues {
                     error
                 })?;
             let has_interface = self.split_tunnel.interface().await.is_some();
-            Ok(!had_interface && has_interface)
+            Ok(had_interface != has_interface)
         })
     }
 
@@ -537,7 +537,7 @@ impl SharedTunnelStateValues {
             v6_address,
         };
         self.runtime
-            .block_on(self.split_tunnel.set_tunnel(Some(vpn_interface)))
+            .block_on(self.split_tunnel.set_tunnel(vpn_interface))
             .inspect_err(|error| {
                 log::error!(
                     "{}",


### PR DESCRIPTION
In the current split tunnel design, the split tunnel interface is never destroyed once it has been created. This PR removes the split tunnel interface when split tunneling is disabled, since any potential issues with split tunneling should not affect anyone who disables the feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6666)
<!-- Reviewable:end -->
