### PR TITLE
Match no OpenVPN relays when core privacy features are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Add experimental support for Windows ARM64.
 
+### Changed
+- Never use OpenVPN as a fallback protocol when any of the following features is enabled:
+  multihop, quantum-resistant tunnels, or DAITA.
+
 ### Fixed
 - macOS and Linux: Fix potential crash when disconnecting with DAITA enabled.
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2937,6 +2937,7 @@ fn new_selector_config(settings: &Settings) -> SelectorConfig {
             daita: settings.tunnel_options.wireguard.daita.enabled,
             #[cfg(not(daita))]
             daita: false,
+            quantum_resistant: settings.tunnel_options.wireguard.quantum_resistant,
         },
     };
 

--- a/mullvad-relay-selector/src/error.rs
+++ b/mullvad-relay-selector/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     #[error("Failed to write relay cache file to disk")]
     WriteRelayCache(#[source] std::io::Error),
 
+    #[error("The combination of relay constraints is invalid")]
+    InvalidConstraints,
+
     #[error("No relays matching current constraints")]
     NoRelay,
 

--- a/mullvad-relay-selector/src/relay_selector/matcher.rs
+++ b/mullvad-relay-selector/src/relay_selector/matcher.rs
@@ -26,22 +26,22 @@ pub fn filter_matching_relay_list(
 ) -> Vec<Relay> {
     let relays = relay_list.relays();
 
-    let locations = ResolvedLocationConstraint::from_constraint(&query.location, custom_lists);
+    let locations = ResolvedLocationConstraint::from_constraint(query.location(), custom_lists);
     let shortlist = relays
             // Filter on tunnel type
-            .filter(|relay| filter_tunnel_type(&query.tunnel_protocol, relay))
+            .filter(|relay| filter_tunnel_type(&query.tunnel_protocol(), relay))
             // Filter on active relays
             .filter(|relay| filter_on_active(relay))
             // Filter by location
             .filter(|relay| filter_on_location(&locations, relay))
             // Filter by ownership
-            .filter(|relay| filter_on_ownership(&query.ownership, relay))
+            .filter(|relay| filter_on_ownership(&query.ownership(), relay))
             // Filter by providers
-            .filter(|relay| filter_on_providers(&query.providers, relay))
+            .filter(|relay| filter_on_providers(query.providers(), relay))
             // Filter by DAITA support
-            .filter(|relay| filter_on_daita(&query.wireguard_constraints.daita, relay))
+            .filter(|relay| filter_on_daita(&query.wireguard_constraints().daita, relay))
             // Filter by obfuscation support
-            .filter(|relay| filter_on_obfuscation(&query.wireguard_constraints, relay_list, relay));
+            .filter(|relay| filter_on_obfuscation(query.wireguard_constraints(), relay_list, relay));
 
     // The last filtering to be done is on the `include_in_country` attribute found on each
     // relay. When the location constraint is based on country, a relay which has

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -28,6 +28,7 @@ use mullvad_types::{
     },
     relay_list::{Relay, RelayEndpointData, RelayList},
     settings::Settings,
+    wireguard::QuantumResistantState,
     CustomTunnelEndpoint, Intersection,
 };
 use talpid_types::{
@@ -123,6 +124,8 @@ pub struct AdditionalWireguardConstraints {
     /// If true, select WireGuard relays that support DAITA. If false, select any
     /// server.
     pub daita: bool,
+    /// If enabled, select relays that support PQ.
+    pub quantum_resistant: QuantumResistantState,
 }
 
 /// Values which affect the choice of relay but are only known at runtime.
@@ -137,7 +140,7 @@ impl RuntimeParameters {
     pub fn compatible(&self, query: &RelayQuery) -> bool {
         if !self.ipv6 {
             let must_use_ipv6 = matches!(
-                query.wireguard_constraints.ip_version,
+                query.wireguard_constraints().ip_version,
                 Constraint::Only(talpid_types::net::IpVersion::V6)
             );
             if must_use_ipv6 {
@@ -323,9 +326,11 @@ impl<'a> From<&'a SelectorConfig> for SpecializedSelectorConfig<'a> {
     }
 }
 
-impl<'a> From<NormalSelectorConfig<'a>> for RelayQuery {
+impl<'a> TryFrom<NormalSelectorConfig<'a>> for RelayQuery {
+    type Error = crate::Error;
+
     /// Map user settings to [`RelayQuery`].
-    fn from(value: NormalSelectorConfig<'a>) -> Self {
+    fn try_from(value: NormalSelectorConfig<'a>) -> Result<Self, Self::Error> {
         /// Map the Wireguard-specific bits of `value` to [`WireguradRelayQuery`]
         fn wireguard_constraints(
             wireguard_constraints: WireguardConstraints,
@@ -338,7 +343,10 @@ impl<'a> From<NormalSelectorConfig<'a>> for RelayQuery {
                 use_multihop,
                 entry_location,
             } = wireguard_constraints;
-            let AdditionalWireguardConstraints { daita } = additional_constraints;
+            let AdditionalWireguardConstraints {
+                daita,
+                quantum_resistant,
+            } = additional_constraints;
             WireguardRelayQuery {
                 port,
                 ip_version,
@@ -346,6 +354,7 @@ impl<'a> From<NormalSelectorConfig<'a>> for RelayQuery {
                 entry_location,
                 obfuscation: ObfuscationQuery::from(obfuscation_settings),
                 daita: Constraint::Only(daita),
+                quantum_resistant,
             }
         }
 
@@ -382,14 +391,14 @@ impl<'a> From<NormalSelectorConfig<'a>> for RelayQuery {
             *value.bridge_state,
             value.bridge_settings.clone(),
         );
-        RelayQuery {
-            location: value.user_preferences.location.clone(),
-            providers: value.user_preferences.providers.clone(),
-            ownership: value.user_preferences.ownership,
-            tunnel_protocol: value.user_preferences.tunnel_protocol,
+        RelayQuery::new(
+            value.user_preferences.location.clone(),
+            value.user_preferences.providers.clone(),
+            value.user_preferences.ownership,
+            value.user_preferences.tunnel_protocol,
             wireguard_constraints,
             openvpn_constraints,
-        }
+        )
     }
 }
 
@@ -473,10 +482,11 @@ impl RelaySelector {
         let specialized_config = SpecializedSelectorConfig::from(&*config);
 
         let near_location = match specialized_config {
-            SpecializedSelectorConfig::Normal(config) => {
-                let user_preferences = RelayQuery::from(config.clone());
-                Self::get_relay_midpoint(&user_preferences, parsed_relays, config.custom_lists)
-            }
+            SpecializedSelectorConfig::Normal(config) => RelayQuery::try_from(config.clone())
+                .ok()
+                .and_then(|user_preferences| {
+                    Self::get_relay_midpoint(&user_preferences, parsed_relays, config.custom_lists)
+                }),
             SpecializedSelectorConfig::Custom(_) => None,
         };
 
@@ -583,7 +593,7 @@ impl RelaySelector {
         user_config: &NormalSelectorConfig<'_>,
         parsed_relays: &ParsedRelays,
     ) -> Result<RelayQuery, Error> {
-        let user_query = RelayQuery::from(user_config.clone());
+        let user_query = RelayQuery::try_from(user_config.clone())?;
         log::trace!("Merging user preferences {user_query:?} with default retry strategy");
         retry_order
             .iter()
@@ -618,7 +628,7 @@ impl RelaySelector {
         parsed_relays: &ParsedRelays,
         custom_lists: &CustomListsSettings,
     ) -> Result<GetRelay, Error> {
-        match query.tunnel_protocol {
+        match query.tunnel_protocol() {
             Constraint::Only(TunnelType::Wireguard) => {
                 Self::get_wireguard_relay(query, custom_lists, parsed_relays)
             }
@@ -629,7 +639,9 @@ impl RelaySelector {
                 // Try Wireguard, then OpenVPN, then fail
                 for tunnel_type in [TunnelType::Wireguard, TunnelType::OpenVpn] {
                     let mut new_query = query.clone();
-                    new_query.tunnel_protocol = Constraint::Only(tunnel_type);
+                    new_query
+                        .set_tunnel_protocol(Constraint::Only(tunnel_type))
+                        .expect("unreachable since tunnel constraint is 'any', not wg");
                     // If a suitable relay is found, short-circuit and return it
                     if let Ok(relay) =
                         Self::get_relay_inner(&new_query, parsed_relays, custom_lists)
@@ -648,12 +660,12 @@ impl RelaySelector {
         parsed_relays: &ParsedRelays,
         custom_lists: &CustomListsSettings,
     ) -> Result<GetRelay, Error> {
-        // FIXME: A bit of defensive programming - calling `get_wiregurad_relay` with a query that
+        // FIXME: A bit of defensive programming - calling `get_wireguard_relay` with a query that
         // doesn't specify Wireguard as the desired tunnel type is not valid and will lead
         // to unwanted behavior. This should be seen as a workaround, and it would be nicer
         // to lift this invariant to be checked by the type system instead.
         let mut query = query.clone();
-        query.tunnel_protocol = Constraint::Only(TunnelType::Wireguard);
+        query.set_tunnel_protocol(Constraint::Only(TunnelType::Wireguard))?;
         Self::get_wireguard_relay(&query, custom_lists, parsed_relays)
     }
 
@@ -676,10 +688,10 @@ impl RelaySelector {
         parsed_relays: &ParsedRelays,
     ) -> Result<GetRelay, Error> {
         assert_eq!(
-            query.tunnel_protocol,
+            query.tunnel_protocol(),
             Constraint::Only(TunnelType::Wireguard)
         );
-        let inner = if !query.wireguard_constraints.multihop() {
+        let inner = if !query.wireguard_constraints().multihop() {
             Self::get_wireguard_singlehop_config(query, custom_lists, parsed_relays)?
         } else {
             Self::get_wireguard_multihop_config(query, custom_lists, parsed_relays)?
@@ -729,13 +741,17 @@ impl RelaySelector {
         // exception that the location is different. It is simply the location as dictated by
         // the query's multihop constraint.
         let mut entry_relay_query = query.clone();
-        entry_relay_query.location = query.wireguard_constraints.entry_location.clone();
+        entry_relay_query.set_location(query.wireguard_constraints().entry_location.clone())?;
         // After we have our two queries (one for the exit relay & one for the entry relay),
         // we can query for all exit & entry candidates! All candidates are needed for the next
         // step.
         let mut exit_relay_query = query.clone();
         // DAITA should only be enabled for the entry relay
-        exit_relay_query.wireguard_constraints.daita = Constraint::Only(false);
+
+        let mut wg_constraints = exit_relay_query.wireguard_constraints().clone();
+        wg_constraints.daita = Constraint::Only(false);
+        exit_relay_query.set_wireguard_constraints(wg_constraints)?;
+
         let exit_candidates =
             filter_matching_relay_list(&exit_relay_query, parsed_relays, custom_lists);
         let entry_candidates =
@@ -775,7 +791,7 @@ impl RelaySelector {
         relay: &WireguardConfig,
     ) -> Result<MullvadWireguardEndpoint, Error> {
         wireguard_endpoint(
-            &query.wireguard_constraints,
+            query.wireguard_constraints(),
             &parsed_relays.parsed_list().wireguard,
             relay,
         )
@@ -797,7 +813,7 @@ impl RelaySelector {
         };
         let box_obfsucation_error = |error: helpers::Error| Error::NoObfuscator(Box::new(error));
 
-        match &query.wireguard_constraints.obfuscation {
+        match &query.wireguard_constraints().obfuscation {
             ObfuscationQuery::Off | ObfuscationQuery::Auto => Ok(None),
             ObfuscationQuery::Udp2tcp(settings) => {
                 let udp2tcp_ports = &parsed_relays.parsed_list().wireguard.udp2tcp_ports;
@@ -843,7 +859,10 @@ impl RelaySelector {
         custom_lists: &CustomListsSettings,
         parsed_relays: &ParsedRelays,
     ) -> Result<GetRelay, Error> {
-        assert_eq!(query.tunnel_protocol, Constraint::Only(TunnelType::OpenVpn));
+        assert_eq!(
+            query.tunnel_protocol(),
+            Constraint::Only(TunnelType::OpenVpn)
+        );
         let exit =
             Self::choose_openvpn_relay(query, custom_lists, parsed_relays).ok_or(Error::NoRelay)?;
         let endpoint = Self::get_openvpn_endpoint(query, &exit, parsed_relays)?;
@@ -874,7 +893,7 @@ impl RelaySelector {
         parsed_relays: &ParsedRelays,
     ) -> Result<Endpoint, Error> {
         openvpn_endpoint(
-            &query.openvpn_constraints,
+            query.openvpn_constraints(),
             &parsed_relays.parsed_list().openvpn,
             relay,
         )
@@ -908,10 +927,10 @@ impl RelaySelector {
         parsed_relays: &ParsedRelays,
         custom_lists: &CustomListsSettings,
     ) -> Result<Option<SelectedBridge>, Error> {
-        if !BridgeQuery::should_use_bridge(&query.openvpn_constraints.bridge_settings) {
+        if !BridgeQuery::should_use_bridge(&query.openvpn_constraints().bridge_settings) {
             Ok(None)
         } else {
-            let bridge_query = &query.openvpn_constraints.bridge_settings.clone().unwrap();
+            let bridge_query = &query.openvpn_constraints().bridge_settings.clone().unwrap();
             let custom_lists = &custom_lists;
             match protocol {
                 TransportProtocol::Udp => {
@@ -1033,7 +1052,7 @@ impl RelaySelector {
         custom_lists: &CustomListsSettings,
     ) -> Option<Coordinates> {
         use std::ops::Not;
-        if query.location.is_any() {
+        if query.location().is_any() {
             return None;
         }
 

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -28,7 +28,7 @@
 //! queries and ensure that queries are built in a type-safe manner, reducing the risk
 //! of runtime errors and improving code readability.
 
-use crate::AdditionalWireguardConstraints;
+use crate::{AdditionalWireguardConstraints, Error};
 use mullvad_types::{
     constraints::Constraint,
     relay_constraints::{
@@ -36,6 +36,7 @@ use mullvad_types::{
         Providers, RelayConstraints, RelaySettings, SelectedObfuscation, ShadowsocksSettings,
         TransportPort, Udp2TcpObfuscationSettings, WireguardConstraints,
     },
+    wireguard::QuantumResistantState,
     Intersection,
 };
 use talpid_types::net::{proxy::CustomProxy, IpVersion, TunnelType};
@@ -74,30 +75,127 @@ use talpid_types::net::{proxy::CustomProxy, IpVersion, TunnelType};
 /// See [`builder`] for more info on how to construct queries.
 #[derive(Debug, Clone, Eq, PartialEq, Intersection)]
 pub struct RelayQuery {
-    pub location: Constraint<LocationConstraint>,
-    pub providers: Constraint<Providers>,
-    pub ownership: Constraint<Ownership>,
-    pub tunnel_protocol: Constraint<TunnelType>,
-    pub wireguard_constraints: WireguardRelayQuery,
-    pub openvpn_constraints: OpenVpnRelayQuery,
+    location: Constraint<LocationConstraint>,
+    providers: Constraint<Providers>,
+    ownership: Constraint<Ownership>,
+    tunnel_protocol: Constraint<TunnelType>,
+    wireguard_constraints: WireguardRelayQuery,
+    openvpn_constraints: OpenVpnRelayQuery,
 }
 
 impl RelayQuery {
+    /// Create a new [`RelayQuery`], and fail if the combination of constraints is invalid.
+    pub fn new(
+        location: Constraint<LocationConstraint>,
+        providers: Constraint<Providers>,
+        ownership: Constraint<Ownership>,
+        tunnel_protocol: Constraint<TunnelType>,
+        wireguard_constraints: WireguardRelayQuery,
+        openvpn_constraints: OpenVpnRelayQuery,
+    ) -> Result<RelayQuery, Error> {
+        let mut query = RelayQuery {
+            location,
+            providers,
+            ownership,
+            tunnel_protocol,
+            wireguard_constraints,
+            openvpn_constraints,
+        };
+        query.validate()?;
+        Ok(query)
+    }
+
+    fn validate(&mut self) -> Result<(), Error> {
+        if self.core_privacy_feature_enabled() {
+            if self.tunnel_protocol == Constraint::Only(TunnelType::OpenVpn) {
+                log::error!("Cannot use OpenVPN with a core privacy feature enabled (DAITA = {}, PQ = {}, or multihop = {})", self.wireguard_constraints.daita, self.wireguard_constraints.quantum_resistant, self.wireguard_constraints.multihop());
+                return Err(Error::InvalidConstraints);
+            }
+            self.tunnel_protocol = Constraint::Only(TunnelType::Wireguard);
+        }
+        Ok(())
+    }
+
+    fn core_privacy_feature_enabled(&self) -> bool {
+        self.wireguard_constraints.daita == Constraint::Only(true)
+            || self.wireguard_constraints.multihop()
+            || self.wireguard_constraints.quantum_resistant == QuantumResistantState::On
+    }
+
+    pub fn location(&self) -> &Constraint<LocationConstraint> {
+        &self.location
+    }
+
+    pub fn set_location(&mut self, location: Constraint<LocationConstraint>) -> Result<(), Error> {
+        self.set_if_valid(|query| query.location = location)
+    }
+
+    pub fn providers(&self) -> &Constraint<Providers> {
+        &self.providers
+    }
+
+    pub fn ownership(&self) -> Constraint<Ownership> {
+        self.ownership
+    }
+
+    pub fn tunnel_protocol(&self) -> Constraint<TunnelType> {
+        self.tunnel_protocol
+    }
+
+    pub fn set_tunnel_protocol(
+        &mut self,
+        tunnel_protocol: Constraint<TunnelType>,
+    ) -> Result<(), Error> {
+        self.set_if_valid(|query| query.tunnel_protocol = tunnel_protocol)
+    }
+
+    pub fn openvpn_constraints(&self) -> &OpenVpnRelayQuery {
+        &self.openvpn_constraints
+    }
+
+    pub fn set_openvpn_constraints(
+        &mut self,
+        openvpn_constraints: OpenVpnRelayQuery,
+    ) -> Result<(), Error> {
+        self.set_if_valid(|query| query.openvpn_constraints = openvpn_constraints)
+    }
+
+    pub fn wireguard_constraints(&self) -> &WireguardRelayQuery {
+        &self.wireguard_constraints
+    }
+
+    pub fn set_wireguard_constraints(
+        &mut self,
+        wireguard_constraints: WireguardRelayQuery,
+    ) -> Result<(), Error> {
+        self.set_if_valid(|query| query.wireguard_constraints = wireguard_constraints)
+    }
+
+    fn set_if_valid(&mut self, set_fn: impl FnOnce(&mut Self)) -> Result<(), Error> {
+        let mut new = self.clone();
+        (set_fn)(&mut new);
+        new.validate()?;
+        *self = new;
+
+        Ok(())
+    }
+}
+
+impl Default for RelayQuery {
     /// Create a new [`RelayQuery`] with no opinionated defaults. This query matches every relay
-    /// with any configuration by setting each of its fields to [`Constraint::Any`]. Should be the
-    /// const equivalent to [`Default::default`].
+    /// with any configuration by setting each of its fields to [`Constraint::Any`].
     ///
     /// Note that the following identity applies for any `other_query`:
     /// ```rust
     /// # use mullvad_relay_selector::query::RelayQuery;
     /// # use mullvad_types::Intersection;
     ///
-    /// # let other_query = RelayQuery::new();
-    /// assert_eq!(RelayQuery::new().intersection(other_query.clone()), Some(other_query));
-    /// # let other_query = RelayQuery::new();
-    /// assert_eq!(other_query.clone().intersection(RelayQuery::new()), Some(other_query));
+    /// # let other_query = RelayQuery::default();
+    /// assert_eq!(RelayQuery::default().intersection(other_query.clone()), Some(other_query));
+    /// # let other_query = RelayQuery::default();
+    /// assert_eq!(other_query.clone().intersection(RelayQuery::default()), Some(other_query));
     /// ```
-    pub const fn new() -> RelayQuery {
+    fn default() -> Self {
         RelayQuery {
             location: Constraint::Any,
             providers: Constraint::Any,
@@ -106,12 +204,6 @@ impl RelayQuery {
             wireguard_constraints: WireguardRelayQuery::new(),
             openvpn_constraints: OpenVpnRelayQuery::new(),
         }
-    }
-}
-
-impl Default for RelayQuery {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -152,6 +244,7 @@ pub struct WireguardRelayQuery {
     pub entry_location: Constraint<LocationConstraint>,
     pub obfuscation: ObfuscationQuery,
     pub daita: Constraint<bool>,
+    pub quantum_resistant: QuantumResistantState,
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -211,6 +304,7 @@ impl WireguardRelayQuery {
             entry_location: Constraint::Any,
             obfuscation: ObfuscationQuery::Auto,
             daita: Constraint::Any,
+            quantum_resistant: QuantumResistantState::Auto,
         }
     }
 }
@@ -240,6 +334,7 @@ impl From<WireguardRelayQuery> for AdditionalWireguardConstraints {
             daita: value
                 .daita
                 .unwrap_or(AdditionalWireguardConstraints::default().daita),
+            quantum_resistant: value.quantum_resistant,
         }
     }
 }
@@ -347,6 +442,7 @@ pub mod builder {
             BridgeConstraints, LocationConstraint, RelayConstraints, SelectedObfuscation,
             ShadowsocksSettings, TransportPort, Udp2TcpObfuscationSettings,
         },
+        wireguard::QuantumResistantState,
     };
     use talpid_types::net::TunnelType;
 
@@ -398,7 +494,8 @@ pub mod builder {
 
         /// Assemble the final [`RelayQuery`] that has been configured
         /// through `self`.
-        pub fn build(self) -> RelayQuery {
+        pub fn build(mut self) -> RelayQuery {
+            debug_assert!(self.query.validate().is_ok());
             self.query
         }
 
@@ -414,18 +511,19 @@ pub mod builder {
         /// which is used to guide the [`RelaySelector`]
         ///
         /// [`RelaySelector`]: crate::RelaySelector
-        pub const fn new() -> RelayQueryBuilder<Any> {
+        pub fn new() -> RelayQueryBuilder<Any> {
             RelayQueryBuilder {
-                query: RelayQuery::new(),
+                query: RelayQuery::default(),
                 protocol: Any,
             }
         }
         /// Set the VPN protocol for this [`RelayQueryBuilder`] to Wireguard.
-        pub fn wireguard(mut self) -> RelayQueryBuilder<Wireguard<Any, Any, Any>> {
+        pub fn wireguard(mut self) -> RelayQueryBuilder<Wireguard<Any, Any, Any, Any>> {
             let protocol = Wireguard {
                 multihop: Any,
                 obfuscation: Any,
                 daita: Any,
+                quantum_resistant: Any,
             };
             self.query.tunnel_protocol = Constraint::Only(TunnelType::Wireguard);
             // Update the type state
@@ -464,14 +562,17 @@ pub mod builder {
     ///   enabled, the builder should expose an option to select entry point.
     ///
     /// [`WireguardRelayQuery`]: super::WireguardRelayQuery
-    pub struct Wireguard<Multihop, Obfuscation, Daita> {
+    pub struct Wireguard<Multihop, Obfuscation, Daita, QuantumResistant> {
         multihop: Multihop,
         obfuscation: Obfuscation,
         daita: Daita,
+        quantum_resistant: QuantumResistant,
     }
 
     // This impl-block is quantified over all configurations
-    impl<Multihop, Obfuscation, Daita> RelayQueryBuilder<Wireguard<Multihop, Obfuscation, Daita>> {
+    impl<Multihop, Obfuscation, Daita, QuantumResistant>
+        RelayQueryBuilder<Wireguard<Multihop, Obfuscation, Daita, QuantumResistant>>
+    {
         /// Specify the port to ues when connecting to the selected
         /// Wireguard relay.
         pub const fn port(mut self, port: u16) -> Self {
@@ -487,9 +588,13 @@ pub mod builder {
         }
     }
 
-    impl<Multihop, Obfuscation> RelayQueryBuilder<Wireguard<Multihop, Obfuscation, Any>> {
+    impl<Multihop, Obfuscation, QuantumResistant>
+        RelayQueryBuilder<Wireguard<Multihop, Obfuscation, Any, QuantumResistant>>
+    {
         /// Enable DAITA support.
-        pub fn daita(mut self) -> RelayQueryBuilder<Wireguard<Multihop, Obfuscation, bool>> {
+        pub fn daita(
+            mut self,
+        ) -> RelayQueryBuilder<Wireguard<Multihop, Obfuscation, bool, QuantumResistant>> {
             self.query.wireguard_constraints.daita = Constraint::Only(true);
             // Update the type state
             RelayQueryBuilder {
@@ -498,16 +603,40 @@ pub mod builder {
                     multihop: self.protocol.multihop,
                     obfuscation: self.protocol.obfuscation,
                     daita: true,
+                    quantum_resistant: self.protocol.quantum_resistant,
                 },
             }
         }
     }
 
-    impl<Obfuscation, Daita> RelayQueryBuilder<Wireguard<Any, Obfuscation, Daita>> {
+    impl<Multihop, Obfuscation, Daita> RelayQueryBuilder<Wireguard<Multihop, Obfuscation, Daita, Any>> {
+        /// Enable PQ support.
+        pub fn quantum_resistant(
+            mut self,
+        ) -> RelayQueryBuilder<Wireguard<Multihop, Obfuscation, Daita, bool>> {
+            self.query.wireguard_constraints.quantum_resistant = QuantumResistantState::On;
+            // Update the type state
+            RelayQueryBuilder {
+                query: self.query,
+                protocol: Wireguard {
+                    multihop: self.protocol.multihop,
+                    obfuscation: self.protocol.obfuscation,
+                    daita: self.protocol.daita,
+                    quantum_resistant: true,
+                },
+            }
+        }
+    }
+
+    impl<Obfuscation, Daita, QuantumResistant>
+        RelayQueryBuilder<Wireguard<Any, Obfuscation, Daita, QuantumResistant>>
+    {
         /// Enable multihop.
         ///
         /// To configure the entry relay, see [`RelayQueryBuilder::entry`].
-        pub fn multihop(mut self) -> RelayQueryBuilder<Wireguard<bool, Obfuscation, Daita>> {
+        pub fn multihop(
+            mut self,
+        ) -> RelayQueryBuilder<Wireguard<bool, Obfuscation, Daita, QuantumResistant>> {
             self.query.wireguard_constraints.use_multihop = Constraint::Only(true);
             // Update the type state
             RelayQueryBuilder {
@@ -516,12 +645,15 @@ pub mod builder {
                     multihop: true,
                     obfuscation: self.protocol.obfuscation,
                     daita: self.protocol.daita,
+                    quantum_resistant: self.protocol.quantum_resistant,
                 },
             }
         }
     }
 
-    impl<Obfuscation, Daita> RelayQueryBuilder<Wireguard<bool, Obfuscation, Daita>> {
+    impl<Obfuscation, Daita, QuantumResistant>
+        RelayQueryBuilder<Wireguard<bool, Obfuscation, Daita, QuantumResistant>>
+    {
         /// Set the entry location in a multihop configuration. This requires
         /// multihop to be enabled.
         pub fn entry(mut self, location: GeographicLocationConstraint) -> Self {
@@ -531,12 +663,16 @@ pub mod builder {
         }
     }
 
-    impl<Multihop, Daita> RelayQueryBuilder<Wireguard<Multihop, Any, Daita>> {
+    impl<Multihop, Daita, QuantumResistant>
+        RelayQueryBuilder<Wireguard<Multihop, Any, Daita, QuantumResistant>>
+    {
         /// Enable `UDP2TCP` obufscation. This will in turn enable the option to configure the
         /// `UDP2TCP` port.
         pub fn udp2tcp(
             mut self,
-        ) -> RelayQueryBuilder<Wireguard<Multihop, Udp2TcpObfuscationSettings, Daita>> {
+        ) -> RelayQueryBuilder<
+            Wireguard<Multihop, Udp2TcpObfuscationSettings, Daita, QuantumResistant>,
+        > {
             let obfuscation = Udp2TcpObfuscationSettings {
                 port: Constraint::Any,
             };
@@ -544,6 +680,7 @@ pub mod builder {
                 multihop: self.protocol.multihop,
                 obfuscation: obfuscation.clone(),
                 daita: self.protocol.daita,
+                quantum_resistant: self.protocol.quantum_resistant,
             };
             self.query.wireguard_constraints.obfuscation = ObfuscationQuery::Udp2tcp(obfuscation);
             RelayQueryBuilder {
@@ -556,7 +693,8 @@ pub mod builder {
         /// port.
         pub fn shadowsocks(
             mut self,
-        ) -> RelayQueryBuilder<Wireguard<Multihop, ShadowsocksSettings, Daita>> {
+        ) -> RelayQueryBuilder<Wireguard<Multihop, ShadowsocksSettings, Daita, QuantumResistant>>
+        {
             let obfuscation = ShadowsocksSettings {
                 port: Constraint::Any,
             };
@@ -564,6 +702,7 @@ pub mod builder {
                 multihop: self.protocol.multihop,
                 obfuscation: obfuscation.clone(),
                 daita: self.protocol.daita,
+                quantum_resistant: self.protocol.quantum_resistant,
             };
             self.query.wireguard_constraints.obfuscation =
                 ObfuscationQuery::Shadowsocks(obfuscation);
@@ -574,7 +713,9 @@ pub mod builder {
         }
     }
 
-    impl<Multihop, Daita> RelayQueryBuilder<Wireguard<Multihop, Udp2TcpObfuscationSettings, Daita>> {
+    impl<Multihop, Daita, QuantumResistant>
+        RelayQueryBuilder<Wireguard<Multihop, Udp2TcpObfuscationSettings, Daita, QuantumResistant>>
+    {
         /// Set the `UDP2TCP` port. This is the TCP port which the `UDP2TCP` obfuscation
         /// protocol should use to connect to a relay.
         pub fn udp2tcp_port(mut self, port: u16) -> Self {
@@ -707,8 +848,9 @@ mod test {
         },
     };
     use proptest::prelude::*;
+    use talpid_types::net::TunnelType;
 
-    use super::{Intersection, ObfuscationQuery};
+    use super::{builder::RelayQueryBuilder, Intersection, ObfuscationQuery, RelayQuery};
 
     // Define proptest combinators for the `Constraint` type.
 
@@ -801,5 +943,83 @@ mod test {
             });
             assert_eq!(query, ObfuscationQuery::Auto);
         }
+    }
+
+    /// Test whether the default relay query is valid
+    #[test]
+    fn test_relay_query_default_valid() {
+        RelayQuery::default().validate().unwrap();
+    }
+
+    /// OpenVPN queries with DAITA enabled are invalid
+    /// DAITA is a core privacy feature.
+    #[test]
+    fn test_relay_query_daita_openvpn() {
+        let mut query = RelayQueryBuilder::new().wireguard().daita().build();
+        query
+            .set_tunnel_protocol(Constraint::Only(TunnelType::OpenVpn))
+            .expect_err("expected query to be invalid for OpenVPN");
+    }
+
+    /// OpenVPN queries with multihop enabled are invalid
+    /// Multihop is a core privacy feature.
+    #[test]
+    fn test_relay_query_multihop_openvpn() {
+        let mut query = RelayQueryBuilder::new().wireguard().multihop().build();
+        query
+            .set_tunnel_protocol(Constraint::Only(TunnelType::OpenVpn))
+            .expect_err("expected query to be invalid for OpenVPN");
+    }
+
+    /// OpenVPN queries with PQ enabled are invalid
+    /// PQ is a core privacy feature.
+    #[test]
+    fn test_relay_query_quantum_resistant_openvpn() {
+        let mut query = RelayQueryBuilder::new()
+            .wireguard()
+            .quantum_resistant()
+            .build();
+        query
+            .set_tunnel_protocol(Constraint::Only(TunnelType::OpenVpn))
+            .expect_err("expected query to be invalid for OpenVPN");
+    }
+
+    /// The tunnel protocol should be constrained to Wireguard when enabling DAITA
+    /// DAITA is a core privacy feature
+    #[test]
+    fn test_relay_query_daita_wireguard() {
+        let mut query = RelayQueryBuilder::new().wireguard().daita().build();
+        query.set_tunnel_protocol(Constraint::Any).unwrap();
+        assert_eq!(
+            query.tunnel_protocol(),
+            Constraint::Only(TunnelType::Wireguard)
+        );
+    }
+
+    /// The tunnel protocol should be constrained to Wireguard when enabling multihop
+    /// Multihop is a core privacy feature
+    #[test]
+    fn test_relay_query_multihop_wireguard() {
+        let mut query = RelayQueryBuilder::new().wireguard().multihop().build();
+        query.set_tunnel_protocol(Constraint::Any).unwrap();
+        assert_eq!(
+            query.tunnel_protocol(),
+            Constraint::Only(TunnelType::Wireguard)
+        );
+    }
+
+    /// The tunnel protocol should be constrained to Wireguard when enabling PQ
+    /// PQ is a core privacy feature
+    #[test]
+    fn test_relay_query_quantum_resistant_wireguard() {
+        let mut query = RelayQueryBuilder::new()
+            .wireguard()
+            .quantum_resistant()
+            .build();
+        query.set_tunnel_protocol(Constraint::Any).unwrap();
+        assert_eq!(
+            query.tunnel_protocol(),
+            Constraint::Only(TunnelType::Wireguard)
+        );
     }
 }

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -700,8 +700,12 @@ pub async fn constrain_to_relay(
                 let location = into_constraint(&exit)?;
                 let relay_constraints = RelayConstraints {
                     location,
-                    wireguard_constraints: WireguardConstraints::from(query.wireguard_constraints),
-                    openvpn_constraints: OpenVpnConstraints::from(query.openvpn_constraints),
+                    wireguard_constraints: WireguardConstraints::from(
+                        query.wireguard_constraints().clone(),
+                    ),
+                    openvpn_constraints: OpenVpnConstraints::from(
+                        query.openvpn_constraints().clone(),
+                    ),
                     ..Default::default()
                 };
                 Ok((exit, relay_constraints))


### PR DESCRIPTION
WireGuard will always be preferred, when any of these features is enabled, even when the tunnel protocol is set to auto.

Core privacy features include PQ, multihop, and DAITA.

Close DES-1066.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6668)
<!-- Reviewable:end -->
