### PR TITLE
Ignore micromatch CVE-2024-4067 and rexml CVE-2024-43398

### DIFF
--- a/ci/ios/upload-vm/osv-scanner.toml
+++ b/ci/ios/upload-vm/osv-scanner.toml
@@ -1,0 +1,8 @@
+# See repository root `osv-scanner.toml` for instructions and rules for this file.
+
+# rexml: The REXML gem before 3.3.6 has a DoS vulnerability when it parses an XML
+# that has many deep elements that have same local name attributes.
+[[IgnoredVulns]]
+id = "CVE-2024-43398" # GHSA-952p-6rrq-rcjv
+ignoreUntil = 2024-11-23
+reason = "rexml only parses trusted input (responses from Apple's APIs) in this code"

--- a/gui/osv-scanner.toml
+++ b/gui/osv-scanner.toml
@@ -42,3 +42,9 @@ reason = "We don't utilize the signing features in browserify"
 id = "CVE-2024-42459" # GHSA-f7q4-pwc6-w24p
 ignoreUntil = 2024-10-15
 reason = "We don't utilize the signing features in browserify"
+
+# micromatch (dev): Regular Expression Denial of Service (ReDoS) in micromatch
+[[IgnoredVulns]]
+id = "CVE-2024-4067" # GHSA-952p-6rrq-rcjv
+ignoreUntil = 2024-11-23
+reason = "This is just a dev dependency, and we don't have untrusted input to micromatch there"

--- a/ios/osv-scanner.toml
+++ b/ios/osv-scanner.toml
@@ -1,0 +1,8 @@
+# See repository root `osv-scanner.toml` for instructions and rules for this file.
+
+# rexml: The REXML gem before 3.3.6 has a DoS vulnerability when it parses an XML
+# that has many deep elements that have same local name attributes.
+[[IgnoredVulns]]
+id = "CVE-2024-43398" # GHSA-952p-6rrq-rcjv
+ignoreUntil = 2024-11-23
+reason = "rexml only parses trusted input (responses from Apple's APIs) in this code"


### PR DESCRIPTION
`osv-scanner` has started complaining about `micromatch` and `rexml` (one in desktop frontend, and one in iOS helper scripts). Both are regular expression DoS attacks which does not affect us, since we won't run untrusted input in it.

This is not the first time `rexml` has been having these silly[1] issues. It has proven to be problematic to just upgrade `rexml` (thank you ruby package management). So this time I opted for just ignoring it... For now :shrug: 


[1]: Silly as in they don't affect us, and basically all regular expression libraries have a metric ton of DoS all the time. So it's taxing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6669)
<!-- Reviewable:end -->
