### PR TITLE
[docs] Fix Typo issue from `passprase` to `passphrase`

### DIFF
--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -89,7 +89,7 @@ as intended.
   export CSC_LINK=/path/to/macos_signing_application.p12
   export CSC_INSTALLER_LINK=/path/to/macos_signing_installer.p12
   ```
-* The passprase for the `.p12` files must be assigned to `CSC_KEY_PASSWORD` and
+* The passphrase for the `.p12` files must be assigned to `CSC_KEY_PASSWORD` and
   `CSC_INSTALLER_KEY_PASSWORD` respectively. But our `buildserver-build.sh` script will
   automatically ask for those, so no need to export them manually.
 


### PR DESCRIPTION
* [x] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [x] The PR description should describe:
 Fix Typo issue from `passprase` to `passphrase` at `docs/macos-signing.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6670)
<!-- Reviewable:end -->
