### PR TITLE
Fix out-of-time notifications

### DIFF
--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiry.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiry.swift
@@ -7,37 +7,86 @@
 //
 
 import Foundation
+import MullvadTypes
 
 struct AccountExpiry {
-    var expiryDate: Date?
+    enum Trigger {
+        case system, inApp
 
-    var triggerDate: Date? {
-        guard let expiryDate else { return nil }
-
-        return Calendar.current.date(
-            byAdding: .day,
-            value: -NotificationConfiguration.closeToExpiryTriggerInterval,
-            to: expiryDate
-        )
+        var dateIntervals: [Int] {
+            switch self {
+            case .system:
+                NotificationConfiguration.closeToExpirySystemTriggerIntervals
+            case .inApp:
+                NotificationConfiguration.closeToExpiryInAppTriggerIntervals
+            }
+        }
     }
 
-    var formattedDuration: String? {
-        let now = Date()
+    private let calendar = Calendar.current
 
+    var expiryDate: Date?
+
+    func nextTriggerDate(for trigger: Trigger) -> Date? {
+        let now = Date().secondsPrecision
+        let triggerDates = triggerDates(for: trigger)
+
+        // Get earliest trigger date and remove one day. Since we want to count whole days, If first
+        // notification should trigger 3 days before account expiry, we need to start checking when
+        // there's (less than) 4 days left.
         guard
             let expiryDate,
-            let triggerDate,
-            let duration = CustomDateComponentsFormatting.localizedString(
-                from: now,
-                to: expiryDate,
-                unitsStyle: .full
-            ),
-            now >= triggerDate,
-            now < expiryDate
-        else {
-            return nil
+            let earliestDate = triggerDates.min(),
+            let earliestTriggerDate = calendar.date(byAdding: .day, value: -1, to: earliestDate),
+            now <= expiryDate.secondsPrecision,
+            now > earliestTriggerDate.secondsPrecision
+        else { return nil }
+
+        let datesByTimeToTrigger = triggerDates.filter { date in
+            now.secondsPrecision <= date.secondsPrecision // Ignore dates that have passed.
+        }.sorted { date1, date2 in
+            abs(date1.timeIntervalSince(now)) < abs(date2.timeIntervalSince(now))
         }
 
-        return duration
+        return datesByTimeToTrigger.first
+    }
+
+    func daysRemaining(for trigger: Trigger) -> DateComponents? {
+        let nextTriggerDate = nextTriggerDate(for: trigger)
+        guard let expiryDate, let nextTriggerDate else { return nil }
+
+        let dateComponents = calendar.dateComponents(
+            [.day],
+            from: Date().secondsPrecision,
+            to: max(nextTriggerDate, expiryDate).secondsPrecision
+        )
+
+        return dateComponents
+    }
+
+    func triggerDates(for trigger: Trigger) -> [Date] {
+        guard let expiryDate else { return [] }
+
+        let dates = trigger.dateIntervals.compactMap {
+            calendar.date(
+                byAdding: .day,
+                value: -$0,
+                to: expiryDate
+            )
+        }
+
+        return dates
+    }
+}
+
+private extension Date {
+    // Used to compare dates with a precision of a minimum of seconds.
+    var secondsPrecision: Date {
+        let dateComponents = Calendar.current.dateComponents(
+            [.second, .minute, .hour, .day, .month, .year, .calendar],
+            from: self
+        )
+
+        return dateComponents.date ?? self
     }
 }

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpirySystemNotificationProvider.swift
@@ -11,8 +11,9 @@ import MullvadSettings
 import UserNotifications
 
 final class AccountExpirySystemNotificationProvider: NotificationProvider, SystemNotificationProvider {
-    private var accountExpiry: Date?
+    private var accountExpiry = AccountExpiry()
     private var tunnelObserver: TunnelBlockObserver?
+    private var accountHasExpired = false
 
     init(tunnelManager: TunnelManager) {
         super.init()
@@ -21,8 +22,16 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
             didLoadConfiguration: { [weak self] tunnelManager in
                 self?.invalidate(deviceState: tunnelManager.deviceState)
             },
+            didUpdateTunnelStatus: { [weak self] tunnelManager, _ in
+                self?.checkAccountExpiry(
+                    tunnelStatus: tunnelManager.tunnelStatus,
+                    deviceState: tunnelManager.deviceState
+                )
+            },
             didUpdateDeviceState: { [weak self] _, deviceState, _ in
-                self?.invalidate(deviceState: deviceState)
+                if self?.accountHasExpired == false {
+                    self?.invalidate(deviceState: deviceState)
+                }
             }
         )
 
@@ -38,22 +47,16 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
     // MARK: - SystemNotificationProvider
 
     var notificationRequest: UNNotificationRequest? {
-        guard let trigger else { return nil }
+        let trigger = accountHasExpired ? triggerExpiry : triggerCloseToExpiry
+
+        guard let trigger, let formattedRemainingDurationBody else {
+            return nil
+        }
 
         let content = UNMutableNotificationContent()
-        content.title = NSLocalizedString(
-            "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE",
-            tableName: "AccountExpiry",
-            value: "Account credit expires soon",
-            comment: "Title for system account expiry notification, fired 3 days prior to account expiry."
-        )
-        content.body = NSLocalizedString(
-            "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY",
-            tableName: "AccountExpiry",
-            value: "Account credit expires in 3 days. Buy more credit.",
-            comment: "Message for system account expiry notification, fired 3 days prior to account expiry."
-        )
-        content.sound = UNNotificationSound.default
+        content.title = formattedRemainingDurationTitle
+        content.body = formattedRemainingDurationBody
+        content.sound = .default
 
         return UNNotificationRequest(
             identifier: identifier.domainIdentifier,
@@ -74,19 +77,9 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
 
     // MARK: - Private
 
-    private var trigger: UNNotificationTrigger? {
-        guard let accountExpiry else { return nil }
+    private var triggerCloseToExpiry: UNNotificationTrigger? {
+        guard let triggerDate = accountExpiry.nextTriggerDate(for: .system) else { return nil }
 
-        guard let triggerDate = Calendar.current.date(
-            byAdding: .day,
-            value: -NotificationConfiguration.closeToExpiryTriggerInterval,
-            to: accountExpiry
-        ) else { return nil }
-
-        // Do not produce notification if less than 3 days left till expiry
-        guard triggerDate > Date() else { return nil }
-
-        // Create date components for calendar trigger
         let dateComponents = Calendar.current.dateComponents(
             [.second, .minute, .hour, .day, .month, .year],
             from: triggerDate
@@ -95,12 +88,107 @@ final class AccountExpirySystemNotificationProvider: NotificationProvider, Syste
         return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
     }
 
+    private var triggerExpiry: UNNotificationTrigger {
+        // When scheduling a user notification we need to make sure that the date has not passed
+        // when it's actually added to the system. Giving it a one second leeway lets us be sure
+        // that this is the case.
+        let dateComponents = Calendar.current.dateComponents(
+            [.second, .minute, .hour, .day, .month, .year],
+            from: Date().addingTimeInterval(1)
+        )
+
+        return UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+    }
+
     private var shouldRemovePendingOrDeliveredRequests: Bool {
-        accountExpiry == nil
+        return accountExpiry.expiryDate == nil
+    }
+
+    private func checkAccountExpiry(tunnelStatus: TunnelStatus, deviceState: DeviceState) {
+        if !accountHasExpired {
+            if case .accountExpired = tunnelStatus.observedState.blockedState?.reason {
+                accountHasExpired = true
+            }
+
+            if accountHasExpired {
+                invalidate(deviceState: deviceState)
+            }
+        }
     }
 
     private func invalidate(deviceState: DeviceState) {
-        accountExpiry = deviceState.accountData?.expiry
+        accountExpiry.expiryDate = deviceState.accountData?.expiry
         invalidate()
+    }
+}
+
+extension AccountExpirySystemNotificationProvider {
+    private var formattedRemainingDurationTitle: String {
+        accountHasExpired
+            ? NSLocalizedString(
+                "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE",
+                tableName: "AccountExpiry",
+                value: "Account credit has expired",
+                comment: "Title for system account expiry notification, fired on account expiry."
+            )
+            : NSLocalizedString(
+                "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_TITLE",
+                tableName: "AccountExpiry",
+                value: "Account credit expires soon",
+                comment: "Title for system account expiry notification, fired X days prior to account expiry."
+            )
+    }
+
+    private var formattedRemainingDurationBody: String? {
+        guard !accountHasExpired else { return expiredText }
+
+        switch accountExpiry.daysRemaining(for: .system)?.day {
+        case .none:
+            return nil
+        case 1:
+            return singleDayText
+        default:
+            return multipleDaysText
+        }
+    }
+
+    private var expiredText: String {
+        NSLocalizedString(
+            "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY",
+            tableName: "AccountExpiry",
+            value: """
+            Blocking internet: Your time on this account has expired. To continue using the internet, \
+            please add more time or disconnect the VPN.
+            """,
+            comment: "Message for in-app notification, displayed on account expiry while connected to VPN."
+        )
+    }
+
+    private var singleDayText: String {
+        NSLocalizedString(
+            "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY",
+            tableName: "AccountExpiry",
+            value: "You have one day left on this account. Please add more time to continue using the VPN.",
+            comment: "Message for in-app notification, displayed within the last 1 day until account expiry."
+        )
+    }
+
+    private var multipleDaysText: String? {
+        guard
+            let expiryDate = accountExpiry.expiryDate,
+            let nextTriggerDate = accountExpiry.nextTriggerDate(for: .system),
+            let duration = CustomDateComponentsFormatting.localizedString(
+                from: nextTriggerDate,
+                to: expiryDate,
+                unitsStyle: .full
+            )
+        else { return nil }
+
+        return String(format: NSLocalizedString(
+            "ACCOUNT_EXPIRY_SYSTEM_NOTIFICATION_BODY",
+            tableName: "AccountExpiry",
+            value: "You have %@ left on this account.",
+            comment: "Message for in-app notification, displayed within the last X days until account expiry."
+        ), duration.lowercased())
     }
 }

--- a/ios/MullvadVPN/Notifications/Notification Providers/NotificationConfiguration.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/NotificationConfiguration.swift
@@ -10,10 +10,16 @@ import Foundation
 
 enum NotificationConfiguration {
     /**
-     Duration measured in days, before the account expiry, when notification is scheduled to remind user to add more
-     time on account.
+     Duration measured in days, before the account expiry, when a system notification is scheduled to remind user
+     to add more time on account.
      */
-    static let closeToExpiryTriggerInterval = 3
+    static let closeToExpirySystemTriggerIntervals = [3, 1]
+
+    /**
+     Duration measured in days, before the account expiry, when an in-app notification is scheduled to remind user
+     to add more time on account.
+     */
+    static let closeToExpiryInAppTriggerIntervals: [Int] = [3, 2, 1, 0]
 
     /**
      Time interval measured in seconds at which to refresh account expiry in-app notification, which reformats

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -1112,7 +1112,7 @@ final class TunnelManager: StorePaymentObserver {
 
 extension TunnelManager {
     enum AccountExpirySimulationOption {
-        case closeToExpiry
+        case closeToExpiry(days: Int)
         case expired
         case active
 
@@ -1124,9 +1124,9 @@ extension TunnelManager {
             case .active:
                 return calendar.date(byAdding: .year, value: 1, to: now)
 
-            case .closeToExpiry:
+            case let .closeToExpiry(days):
                 return calendar.date(
-                    byAdding: DateComponents(day: NotificationConfiguration.closeToExpiryTriggerInterval, second: 5),
+                    byAdding: DateComponents(day: days, second: 5),
                     to: now
                 )
 

--- a/ios/MullvadVPNTests/MullvadVPN/Notifications/NotificationProviders/AccountExpiryTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Notifications/NotificationProviders/AccountExpiryTests.swift
@@ -9,40 +9,62 @@
 import XCTest
 
 class AccountExpiryTests: XCTestCase {
-    func testNoDateReturnsNoDuration() {
+    private let calendar = Calendar.current
+
+    func testNoDateDuration() {
         let accountExpiry = AccountExpiry()
-        XCTAssertNil(accountExpiry.formattedDuration)
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .system))
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .inApp))
     }
 
-    func testDateNowReturnsNoDuration() {
+    func testDateNowDuration() {
         let accountExpiry = AccountExpiry(expiryDate: Date())
-        XCTAssertNil(accountExpiry.formattedDuration)
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .system))
+        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .inApp)) // In-app expiry triggers on same date as well.
     }
 
-    func testDateInPastReturnsNoDuration() {
+    func testDateInPastDuration() {
         let accountExpiry = AccountExpiry(expiryDate: Date().addingTimeInterval(-10))
-        XCTAssertNil(accountExpiry.formattedDuration)
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .system))
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .inApp))
     }
 
-    func testDateWithinTriggerIntervalReturnsDuration() {
-        let date = Calendar.current.date(
-            byAdding: .day,
-            value: NotificationConfiguration.closeToExpiryTriggerInterval - 1,
-            to: Date()
-        )
+    func testDateInFutureDuration() {
+        let accountExpiry = AccountExpiry(expiryDate: calendar.date(byAdding: .day, value: 1, to: Date()))
 
-        let accountExpiry = AccountExpiry(expiryDate: date)
-        XCTAssertNotNil(accountExpiry.formattedDuration)
+        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .system))
+        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .inApp))
     }
 
-    func testDateNotWithinTriggerIntervalReturnsNoDuration() {
-        let date = Calendar.current.date(
-            byAdding: .day,
-            value: NotificationConfiguration.closeToExpiryTriggerInterval + 1,
-            to: Date()
+    func testNumberOfTriggerDates() {
+        var accountExpiry = AccountExpiry(
+            expiryDate: calendar.date(
+                byAdding: .day,
+                value: AccountExpiry.Trigger.system.dateIntervals.max()!,
+                to: Date()
+            )
         )
+        XCTAssertEqual(accountExpiry.triggerDates(for: .system).count, AccountExpiry.Trigger.system.dateIntervals.count)
 
-        let accountExpiry = AccountExpiry(expiryDate: date)
-        XCTAssertNil(accountExpiry.formattedDuration)
+        accountExpiry = AccountExpiry(
+            expiryDate: calendar.date(
+                byAdding: .day,
+                value: AccountExpiry.Trigger.inApp.dateIntervals.max()!,
+                to: Date()
+            )
+        )
+        XCTAssertEqual(accountExpiry.triggerDates(for: .inApp).count, AccountExpiry.Trigger.inApp.dateIntervals.count)
+    }
+
+    func testDaysRemaining() {
+        AccountExpiry.Trigger.system.dateIntervals.forEach { interval in
+            let accountExpiry = AccountExpiry(expiryDate: calendar.date(byAdding: .day, value: interval, to: Date()))
+            XCTAssertEqual(accountExpiry.daysRemaining(for: .system)?.day, interval)
+        }
+
+        AccountExpiry.Trigger.inApp.dateIntervals.forEach { interval in
+            let accountExpiry = AccountExpiry(expiryDate: calendar.date(byAdding: .day, value: interval, to: Date()))
+            XCTAssertEqual(accountExpiry.daysRemaining(for: .inApp)?.day, interval)
+        }
     }
 }


### PR DESCRIPTION
Currently the iOS app sends but a single notification about running out of time. 

We should schedule 4 in-app notifications, with improved copy:

- "You have 3 days left on this account."
- “You have 2 days left on this account.”
- “You have 1 day left on this account.”
- "You have less than a day left on this account. Please add more time to continue using the VPN.”

We should also schedule 3 system notifications, with improved copy:

- "You have 3 days left on this account. Please add more time to continue using the VPN.."
- “You have one day left on this account. Please add more time to continue using the VPN.”
- "Blocking internet: Your time on this account has expired. To continue using the internet, please add more time or disconnect the VPN.”

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6679)
<!-- Reviewable:end -->
