### PR TITLE
Add Unicode-3.0 to approved licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -51,7 +51,8 @@ allow = [
     # https://github.com/briansmith/ring/issues/902
     "LicenseRef-ring",
     "Unicode-DFS-2016",
-    "Zlib"
+    "Zlib",
+    "Unicode-3.0"
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
It appears to be GPL-3 compatible: https://spdx.org/licenses/Unicode-3.0.html

Needed due to dependency updates: https://github.com/mullvad/mullvadvpn-app/actions/runs/10559185495/job/29250107186

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6680)
<!-- Reviewable:end -->
