### PR TITLE
Fix test_split_tunnel

### DIFF
--- a/test/connection-checker/src/cli.rs
+++ b/test/connection-checker/src/cli.rs
@@ -10,8 +10,8 @@ pub struct Opt {
     #[clap(short, long)]
     pub interactive: bool,
 
-    /// Timeout for network connection to am.i.mullvad (in millis).
-    #[clap(short, long, default_value = "3000")]
+    /// Timeout for network connection to am.i.mullvad (in seconds).
+    #[clap(short, long, default_value = "3")]
     pub timeout: u64,
 
     /// Try to send some junk data over TCP to <leak>.
@@ -30,8 +30,8 @@ pub struct Opt {
     #[clap(long)]
     pub leak: Option<SocketAddr>,
 
-    /// Timeout for leak check network connections (in millis).
-    #[clap(long, default_value = "1000")]
+    /// Timeout for leak check network connections (in seconds).
+    #[clap(long, default_value = "1")]
     pub leak_timeout: u64,
 
     /// Junk data for each UDP and TCP packet

--- a/test/connection-checker/src/main.rs
+++ b/test/connection-checker/src/main.rs
@@ -54,7 +54,7 @@ fn am_i_mullvad(opt: &Opt) -> eyre::Result<bool> {
     let client = Client::new();
     let response: Response = client
         .get(url)
-        .timeout(Duration::from_millis(opt.timeout))
+        .timeout(Duration::from_secs(opt.timeout))
         .send()
         .and_then(|r| r.json())
         .wrap_err_with(|| eyre!("Failed to GET {url}"))?;

--- a/test/scripts/ssh-setup.sh
+++ b/test/scripts/ssh-setup.sh
@@ -128,6 +128,9 @@ function install_packages_apt {
     echo "Installing required apt packages"
     apt update
     apt install -yf xvfb wireguard-tools curl
+    if ! which ping &>/dev/null; then
+        apt install -yf iputils-ping
+    fi
     curl -fsSL https://get.docker.com | sh
 }
 

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -44,15 +44,15 @@ pub const THROTTLE_RETRY_DELAY: Duration = Duration::from_secs(120);
 const CHECKER_FILENAME_WINDOWS: &str = "connection-checker.exe";
 const CHECKER_FILENAME_UNIX: &str = "connection-checker";
 
-const AM_I_MULLVAD_TIMEOUT_MS: u64 = 10000;
-const LEAK_TIMEOUT_MS: u64 = 500;
+const AM_I_MULLVAD_TIMEOUT_S: u64 = 10;
+const LEAK_TIMEOUT_S: u64 = 1;
 
 /// Timeout of [ConnCheckerHandle::check_connection].
-const CONN_CHECKER_TIMEOUT: Duration = Duration::from_millis(
-    AM_I_MULLVAD_TIMEOUT_MS // https://am.i.mullvad.net timeout
-    + LEAK_TIMEOUT_MS // leak-tcp timeout
-    + LEAK_TIMEOUT_MS // leak-icmp timeout
-    + 1000, // plus some extra grace time
+const CONN_CHECKER_TIMEOUT: Duration = Duration::from_secs(
+    AM_I_MULLVAD_TIMEOUT_S // https://am.i.mullvad.net timeout
+    + LEAK_TIMEOUT_S // leak-tcp timeout
+    + LEAK_TIMEOUT_S // leak-icmp timeout
+    + 1, // plus some extra grace time
 );
 
 #[macro_export]
@@ -957,12 +957,12 @@ impl ConnChecker {
             let mut args = [
                 "--interactive",
                 "--timeout",
-                &AM_I_MULLVAD_TIMEOUT_MS.to_string(),
+                &AM_I_MULLVAD_TIMEOUT_S.to_string(),
                 // try to leak traffic to LEAK_DESTINATION
                 "--leak",
                 &self.leak_destination.to_string(),
                 "--leak-timeout",
-                &LEAK_TIMEOUT_MS.to_string(),
+                &LEAK_TIMEOUT_S.to_string(),
                 "--leak-tcp",
                 "--leak-udp",
                 "--leak-icmp",


### PR DESCRIPTION
`ping` uses raw sockets rather than `SOCK_DGRAM` by default. This only works as root.

Related test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/10593508501

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6682)
<!-- Reviewable:end -->
