### PR TITLE
Add trixie to list of debian versions to generate deb repositories for

### DIFF
--- a/ci/linux-repository-builder/build-linux-repositories-config.sh
+++ b/ci/linux-repository-builder/build-linux-repositories-config.sh
@@ -7,7 +7,7 @@
 export CODE_SIGNING_KEY_FINGERPRINT="A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF"
 
 # Debian codenames we support.
-SUPPORTED_DEB_CODENAMES=("sid" "testing" "bookworm" "bullseye")
+SUPPORTED_DEB_CODENAMES=("sid" "testing" "trixie" "bookworm" "bullseye")
 # Ubuntu codenames we support. Latest two LTS. But when adding a new
 # don't immediately remove the oldest one. Allow for some transition period
 # with the last three.


### PR DESCRIPTION
We already support `testing`. So this is not a big deal. Just that when you install/upgrade to trixie then `lsb_release -cs` will return `trixie` and not `testing`. So if we intend to support Debian versions in testing, we should probably add the names of the distros as soon as they are decided/used by the OS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6683)
<!-- Reviewable:end -->
