### PR TITLE
Update rexml for vulnerability issues

### DIFF
--- a/ci/ios/upload-vm/Gemfile.lock
+++ b/ci/ios/upload-vm/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.5)
+    rexml (3.3.6)
       strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)

--- a/ci/ios/upload-vm/osv-scanner.toml
+++ b/ci/ios/upload-vm/osv-scanner.toml
@@ -1,8 +1,0 @@
-# See repository root `osv-scanner.toml` for instructions and rules for this file.
-
-# rexml: The REXML gem before 3.3.6 has a DoS vulnerability when it parses an XML
-# that has many deep elements that have same local name attributes.
-[[IgnoredVulns]]
-id = "CVE-2024-43398" # GHSA-952p-6rrq-rcjv
-ignoreUntil = 2024-11-23
-reason = "rexml only parses trusted input (responses from Apple's APIs) in this code"

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.5)
+    rexml (3.3.6)
       strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)

--- a/ios/osv-scanner.toml
+++ b/ios/osv-scanner.toml
@@ -1,8 +1,0 @@
-# See repository root `osv-scanner.toml` for instructions and rules for this file.
-
-# rexml: The REXML gem before 3.3.6 has a DoS vulnerability when it parses an XML
-# that has many deep elements that have same local name attributes.
-[[IgnoredVulns]]
-id = "CVE-2024-43398" # GHSA-952p-6rrq-rcjv
-ignoreUntil = 2024-11-23
-reason = "rexml only parses trusted input (responses from Apple's APIs) in this code"


### PR DESCRIPTION
This PR updates the `rexml` dependency we use for running screenshots to a version not known to be vulnerable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6695)
<!-- Reviewable:end -->
