### PR TITLE
Fix off-screen element detection issue

### DIFF
--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -457,6 +457,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         header.accessibilityIdentifier = .wireGuardPortsCell
         header.titleLabel.text = title
         header.accessibilityCustomActionName = title
+        header.isExpanded = isExpanded(.wireGuardPorts)
         header.infoButtonHandler = { [weak self] in
             if let self {
                 self.delegate?.showInfo(for: .wireGuardPorts)
@@ -500,6 +501,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         header.accessibilityIdentifier = .wireGuardObfuscationCell
         header.titleLabel.text = title
         header.accessibilityCustomActionName = title
+        header.isExpanded = isExpanded(.wireGuardObfuscation)
         header.didCollapseHandler = { [weak self] header in
             guard let self else { return }
 
@@ -529,6 +531,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         header.accessibilityIdentifier = .udpOverTCPPortCell
         header.titleLabel.text = title
         header.accessibilityCustomActionName = title
+        header.isExpanded = isExpanded(.wireGuardObfuscationPort)
         header.didCollapseHandler = { [weak self] header in
             guard let self else { return }
 
@@ -558,6 +561,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         header.accessibilityIdentifier = .quantumResistantTunnelCell
         header.titleLabel.text = title
         header.accessibilityCustomActionName = title
+        header.isExpanded = isExpanded(.quantumResistance)
         header.didCollapseHandler = { [weak self] header in
             guard let self else { return }
 
@@ -592,6 +596,15 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         }
 
         return nil
+    }
+
+    /*
+      Since we are dequeuing headers, it's crucial to maintain the state of expansion.
+      Using screenshots as a single source of truth to capture the state allows us to determine whether headers are expanded or not.
+     */
+    private func isExpanded(_ section: Section) -> Bool {
+        let snapshot = snapshot()
+        return snapshot.numberOfItems(inSection: section) != 0
     }
 }
 

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -15,10 +15,11 @@ class VPNSettingsPage: Page {
     }
 
     private func cellExpandButton(_ cellAccessiblityIdentifier: AccessibilityIdentifier) -> XCUIElement {
-        let table = app.tables[AccessibilityIdentifier.vpnSettingsTableView]
-        let matchingCells = table.otherElements.containing(.any, identifier: cellAccessiblityIdentifier.rawValue)
+        let tableView = app.tables[AccessibilityIdentifier.vpnSettingsTableView]
+        let matchingCells = tableView.otherElements[cellAccessiblityIdentifier.rawValue]
         let expandButton = matchingCells.buttons[AccessibilityIdentifier.expandButton]
-
+        let lastCell = tableView.cells.allElementsBoundByIndex.last!
+        tableView.scrollDownToElement(element: lastCell)
         return expandButton
     }
 

--- a/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
+++ b/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
@@ -16,4 +16,25 @@ extension XCUIElement {
         _ = XCTWaiter().wait(for: [expectation], timeout: timeout)
         return !exists
     }
+
+    func scrollDownToElement(element: XCUIElement, maxScrolls: UInt = 5) {
+        var count = 0
+        while !element.isVisible && count < maxScrolls {
+            swipeUp(velocity: .slow)
+            count += 1
+        }
+    }
+
+    func scrollUpToElement(element: XCUIElement, maxScrolls: UInt = 5) {
+        var count = 0
+        while !element.isVisible && count < maxScrolls {
+            swipeDown(velocity: .slow)
+            count += 1
+        }
+    }
+
+    var isVisible: Bool {
+        guard self.exists && !self.frame.isEmpty else { return false }
+        return XCUIApplication().windows.element(boundBy: 0).frame.contains(self.frame)
+    }
 }


### PR DESCRIPTION
Due to the increasing number of items in VPN settings, our current UI test struggles to locate elements that are off-screen. This update resolves the issue by implementing scrolling to find the targeted elements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6696)
<!-- Reviewable:end -->
