### PR TITLE
Lower log level of shadowsocks write errors

### DIFF
--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -182,10 +182,11 @@ async fn handle_outgoing(
         };
 
         if let Err(error) = ss_write.send(&wg_addr, &rx_buffer[0..read_n]).await {
-            log::error!("Failed to write to Shadowsocks client: {error}");
             if is_fatal_socket_error(&error) {
+                log::error!("Failed to write to Shadowsocks client: {error}");
                 break;
             }
+            log::trace!("Failed to write to Shadowsocks client: {error}");
         }
     }
 }


### PR DESCRIPTION
If the wg device MTU is set too high, the log is filled with the following error:

```
[2024-08-29 10:00:41.937][tunnel_obfuscation::shadowsocks][ERROR] Failed to write to Shadowsocks client: Message too long (os error 90)
[2024-08-29 10:00:41.937][tunnel_obfuscation::shadowsocks][ERROR] Failed to write to Shadowsocks client: Message too long (os error 90)
[2024-08-29 10:00:42.068][tunnel_obfuscation::shadowsocks][ERROR] Failed to write to Shadowsocks client: Message too long (os error 90)
[2024-08-29 10:00:42.447][tunnel_obfuscation::shadowsocks][ERROR] Failed to write to Shadowsocks client: Message too long (os error 90)
[2024-08-29 10:00:42.447][tunnel_obfuscation::shadowsocks][ERROR] Failed to write to Shadowsocks client: Message too long (os error 90)
```

PR simply lowers the log level to trace to prevent this.

MTU detection should alleviate the underlying issue, but it's disabled when using DAITA, and MTU detection itself may trigger this spam.

Fix DES-1179.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6698)
<!-- Reviewable:end -->
