### PR TITLE
Fix ci permissions

### DIFF
--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -7,6 +7,9 @@ on:
       - clippy.toml
       - '**/*.rs'
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   build-ios:
     runs-on: macos-latest

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -5,14 +5,16 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
-  # Only need to read contents
-  contents: read
-  actions: read
+permissions: {}
 
 jobs:
   scan-pr:
+    permissions:
+      # Require writing security events to upload SARIF file to security tab
+      security-events: write
+      # Only need to read contents
+      contents: read
+      actions: read
+
     # yamllint disable rule:line-length
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@dfa8609a7da62968d73f63f279418e504c1f523f"  # v1.8.1

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -8,14 +8,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
-  # Only need to read contents
-  contents: read
-  actions: read
+permissions: {}
 
 jobs:
   scan-scheduled:
+    permissions:
+      # Require writing security events to upload SARIF file to security tab
+      security-events: write
+      # Only need to read contents
+      contents: read
+      actions: read
+
     # yamllint disable rule:line-length
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@dfa8609a7da62968d73f63f279418e504c1f523f"  # v1.8.1


### PR DESCRIPTION
Commit 1: @dlon Add an empty `permissions: {}` to `ios-rust-ffi.yml`.

Commit 2: We still get warnings from OpenSSF. See under "Token permissions" here: https://securityscorecards.dev/viewer/?uri=github.com/mullvad/mullvadvpn-app. The warning is:

> Warn: topLevel 'security-events' permission set to 'write': .github/workflows/osv-scanner-pr.yml:10
> Warn: topLevel 'security-events' permission set to 'write': .github/workflows/osv-scanner-scheduled.yml:13

My understanding of their documentation is that they warn if `security-events` is allowed on the top level specifically. My guess is that it will be happy if we move it down to the job level.