### PR TITLE
Disable split tunneling when disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Line wrap the file at 100 chars.                                              Th
 - Never use OpenVPN as a fallback protocol when any of the following features is enabled:
   multihop, quantum-resistant tunnels, or DAITA.
 
+#### macOS
+- Disable split tunnel interface when disconnected. This prevents traffic from being sent through
+  the daemon when the VPN is disconnected.
+
 ### Fixed
 - macOS and Linux: Fix potential crash when disconnecting with DAITA enabled.
 

--- a/talpid-core/src/split_tunnel/macos/mod.rs
+++ b/talpid-core/src/split_tunnel/macos/mod.rs
@@ -113,6 +113,11 @@ enum Message {
         result_tx: oneshot::Sender<Result<(), Error>>,
         vpn_interface: VpnInterface,
     },
+    /// Remove VPN tunnel interface. It is sufficient to call this when entering the disconnected
+    /// state, to avoid pointless cleanup during reconnects.
+    ResetTunnel {
+        result_tx: oneshot::Sender<Result<(), Error>>,
+    },
 }
 
 /// Handle for interacting with the split tunnel module
@@ -155,6 +160,14 @@ impl Handle {
             result_tx,
             vpn_interface,
         });
+        result_rx.await.map_err(|_| Error::unavailable())?
+    }
+
+    /// Forget the VPN tunnel interface. This destroys the split tunneling interface when it is
+    /// active.
+    pub async fn reset_tunnel(&self) -> Result<(), Error> {
+        let (result_tx, result_rx) = oneshot::channel();
+        let _ = self.tx.send(Message::ResetTunnel { result_tx });
         result_rx.await.map_err(|_| Error::unavailable())?
     }
 }
@@ -258,6 +271,9 @@ impl SplitTunnel {
                 vpn_interface,
             } => {
                 let _ = result_tx.send(self.state.set_tunnel(vpn_interface).await);
+            }
+            Message::ResetTunnel { result_tx } => {
+                let _ = result_tx.send(self.state.reset_tunnel().await);
             }
         }
         true
@@ -470,6 +486,50 @@ impl State {
             }
             // Otherwise, remain in the failed state
             State::Failed { cause, .. } => Err(cause.unwrap_or(Error::unavailable()).into()),
+        }
+    }
+
+    /// Forget the VPN tunnel interface. This destroys the split tunneling interface when it is
+    /// active.
+    pub async fn reset_tunnel(&mut self) -> Result<(), Error> {
+        self.transition(|state| state.reset_tunnel_inner()).await
+    }
+
+    async fn reset_tunnel_inner(self) -> Result<Self, ErrorWithTransition> {
+        match self {
+            // If split tunneling is currently active, that means that there are paths to exclude,
+            // so shut down the ST utun but keep the process monitor.
+            State::Active {
+                route_manager,
+                process,
+                tun_handle,
+                vpn_interface: _,
+            } => {
+                if let Err(error) = tun_handle.shutdown().await {
+                    log::error!("Failed to stop split tunnel: {error}");
+                }
+                Ok(State::ProcessMonitorOnly {
+                    route_manager,
+                    process,
+                })
+            }
+            // If we're in standby mode, simply forget the VPN interface.
+            State::StandBy {
+                route_manager,
+                vpn_interface: _,
+            } => Ok(State::NoExclusions { route_manager }),
+            // If we're in `Failed`, just forget the VPN interface.
+            State::Failed {
+                route_manager,
+                vpn_interface: _,
+                cause,
+            } => Ok(State::Failed {
+                route_manager,
+                vpn_interface: None,
+                cause,
+            }),
+            // For any other state, do nothing.
+            _ => Ok(self),
         }
     }
 

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -21,6 +21,16 @@ impl DisconnectedState {
         should_reset_firewall: bool,
     ) -> (Box<dyn TunnelState>, TunnelStateTransition) {
         #[cfg(target_os = "macos")]
+        if let Err(err) = shared_values
+            .runtime
+            .block_on(shared_values.split_tunnel.reset_tunnel())
+        {
+            log::error!(
+                "{}",
+                err.display_chain_with_msg("Failed to disable split tunneling")
+            );
+        }
+        #[cfg(target_os = "macos")]
         if shared_values.block_when_disconnected {
             if let Err(err) = Self::setup_local_dns_config(shared_values) {
                 log::error!(


### PR DESCRIPTION
This breaks existing connections in the disconnected state, but hopefully it should be more stable, since split tunneling will be completely disabled.

Fix DES-1206.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6700)
<!-- Reviewable:end -->
