### PR TITLE
Change Rust opt-level from 3 to "s" to optimize for binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,11 +93,12 @@ ipnetwork = "0.20"
 proptest = "1.4"
 
 [profile.release]
-opt-level = 3
+opt-level = "s"
 lto = true
 strip = true
 
-# Key generation may take over one minute without optimizations
-# enabled.
+# Key generation may take over one minute without optimizations enabled.
 [profile.dev.package."classic-mceliece-rust"]
+opt-level = 3
+[profile.release.package."classic-mceliece-rust"]
 opt-level = 3


### PR DESCRIPTION
I took some measurements with this change. Here are the results:

## Linux
**Build time (`cargo build --release`):** 624s -> 488s = 22% drop in compile time
**Binary size (`mullvad-daemon`):** 22.9 MiB -> 15.9 MiB = 31% drop in binary size
**Binary size (`mullvad` (cli)):** 7.5 MiB -> 5.7 MiB = 24% drop in binary size

## macOS

**Build time (`./build.sh --optimize --universal`)**: 3970s -> 3142s = 21% drop in compile time
**Binary size (`mullvad-daemon`):** 19.5 MiB -> 13.9 MiB = 29% drop in binary size

## Windows

**Build time (`./build.sh --optimize`):** 17m33s -> 11m19s = 35% drop in compile time
**Binary size (`mullvad-daemon`):** 22.3 MiB -> 14.5 MiB = 35% drop in binary size

As you can see, both the compile times and produced binary size goes down significantly on all desktop platforms. This change will also affect Android and iOS. I have not measured the mobile platforms, but have no reason to believe it would have any negative impact.

I selectively still keep `opt-level = 3` for `classic-mceliece-rust`. This is because generating a keypair is approximately ~x7 slower if compiled with `opt-level = "s"`. I don't have any strong reason to believe many other crates we use will be noticeably negatively impacted by this change. And just blindly enabling optimization for more crates would be premature optimization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6703)
<!-- Reviewable:end -->
