### PR TITLE
Do not always rebuild `talpid-wireguard` on Android

### DIFF
--- a/talpid-wireguard/build.rs
+++ b/talpid-wireguard/build.rs
@@ -2,21 +2,18 @@ use std::{env, path::PathBuf};
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
-
-    declare_libs_dir("../dist-assets/binaries");
-
-    add_wireguard_go_cfg(&target_os);
-}
-
-fn add_wireguard_go_cfg(target_os: &str) {
+    // Keep track if `binaries/wireguard-nt` changes
+    if target_os == "windows" {
+        declare_libs_dir("../dist-assets/binaries");
+    }
+    // Wireguard-Go can be used on all platforms except Windows
     println!("cargo::rustc-check-cfg=cfg(wireguard_go)");
-    if matches!(target_os, "linux" | "macos" | "android") {
+    if matches!(target_os.as_str(), "linux" | "macos" | "android") {
         println!("cargo::rustc-cfg=wireguard_go");
     }
-
     // Enable DAITA by default on desktop and android
     println!("cargo::rustc-check-cfg=cfg(daita)");
-    println!(r#"cargo::rustc-cfg=daita"#);
+    println!("cargo::rustc-cfg=daita");
 }
 
 fn declare_libs_dir(base: &str) {


### PR DESCRIPTION
This PR removes `declare_libs_dir("../dist-assets/binaries");` for Android builds, which would add an unnecessary `rerun-if-changed` directive to `cargo`. This would cause `talpid-wireguard` to always rebuild on Android, since there are no android specific binaries which we should watch for changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6711)
<!-- Reviewable:end -->
