### PR TITLE
Bump iOS version to 2023.5

### DIFF
--- a/ios/Configurations/Version.xcconfig
+++ b/ios/Configurations/Version.xcconfig
@@ -2,7 +2,7 @@
 VERSIONING_SYSTEM = apple-generic
 
 // Marketing version, aka major.minor
-MARKETING_VERSION = 2024.5
+MARKETING_VERSION = 2024.6
 
 // Build number
 // Normally we reset the build number to 1 after bumping MARKETING_VERSION.


### PR DESCRIPTION
We released 2024.5, now we must bump the version in `main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6722)
<!-- Reviewable:end -->
