### PR TITLE
Stop waiting for transition if failed

### DIFF
--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -83,7 +83,12 @@ const waitForNoTransition = async (page: Page) => {
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
 
-    transitionContentsCount = await page.getByTestId('transition-content').count();
+    try {
+      transitionContentsCount = await page.getByTestId('transition-content').count();
+    } catch {
+      console.log('Transition content count failed');
+      break;
+    }
   } while (transitionContentsCount !== 1);
 };
 


### PR DESCRIPTION
This PR stops waiting for transitions to end if the page closes. This could potentially fix flakiness in the tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6723)
<!-- Reviewable:end -->
