### PR TITLE
Expose option for changing OpenVPN CA certificate in `test-by-version` script

### DIFF
--- a/test/scripts/test-utils.sh
+++ b/test/scripts/test-utils.sh
@@ -294,6 +294,7 @@ function run_tests_for_os {
             "${test_report_arg[@]}" \
             --package-dir "${package_dir}" \
             --vm "$vm" \
+            --openvpn-certificate "${OPENVPN_CERTIFICATE:-"assets/openvpn.ca.crt"}" \
             "${test_filters_arg[@]}" \
             "${runner_dir_flag[@]}" \
             2>&1 | sed -r "s/${ACCOUNT_TOKEN}/\{ACCOUNT_TOKEN\}/g"; then

--- a/test/test-by-version.sh
+++ b/test/test-by-version.sh
@@ -11,6 +11,7 @@ usage() {
     echo "Optional environment variables:"
     echo "  - APP_VERSION: The version of the app to test (defaults to the latest stable release)"
     echo "  - APP_PACKAGE_TO_UPGRADE_FROM: The package version to upgrade from (defaults to none)"
+    echo "  - OPENVPN_CERTIFICATE: Path to an OpenVPN CA certificate the app should use during test (defaults to assets/openvpn.ca.crt)"
     echo "  - TEST_DIST_DIR: Relative path to a directory with prebuilt binaries as produced by scripts/build.sh."
     echo "  - TEST_FILTERS: specifies which tests to run (defaults to all)"
     echo "  - TEST_REPORT : path to save the test results in a structured format"


### PR DESCRIPTION
This PR adds the `OPENVPN_CERTIFICATE` argument to `test-by-version`, which really just exposes the `--openvpn-certificate` option of `test-manager`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6729)
<!-- Reviewable:end -->
