### PR TITLE
Fix signing of `talpid_openvpn_plugin.dll` for arm64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -287,13 +287,16 @@ function build {
     done
 
     if [[ "$current_target" == "aarch64-pc-windows-msvc" ]]; then
-        # TODO: We still ship x64 OpenVPN with ARM64, so we need an x64 talpid-openvpn-plugin
+        # We ship x64 OpenVPN with ARM64, so we need an x64 talpid-openvpn-plugin
         # to include in the package.
+        local source="$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/$RUST_BUILD_MODE/talpid_openvpn_plugin.dll"
+        local destination="dist-assets/aarch64-pc-windows-msvc/talpid_openvpn_plugin.dll"
+
         log_info "Workaround: building x64 talpid-openvpn-plugin"
         cargo build --target x86_64-pc-windows-msvc "${CARGO_ARGS[@]}" -p talpid-openvpn-plugin --lib
-        cp "$CARGO_TARGET_DIR/x86_64-pc-windows-msvc/$RUST_BUILD_MODE/talpid_openvpn_plugin.dll" "dist-assets/aarch64-pc-windows-msvc/talpid_openvpn_plugin.dll"
+        cp "$source" "$destination"
         if [[ "$SIGN" == "true" ]]; then
-            sign_win "dist-assets/talpid_openvpn_plugin.dll"
+            sign_win "$destination"
         fi
     fi
 }


### PR DESCRIPTION
Pretty self-explanatory. The incorrect wrong path was signed here.

Fix DES-1215.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6733)
<!-- Reviewable:end -->
