### PR TITLE
Fix selected relay label being too long when multihoping with Daita

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
@@ -41,11 +41,13 @@ final class TunnelControlView: UIView {
         return activityIndicator
     }()
 
-    private let locationContainerView: UIView = {
-        let view = UIView()
+    private let locationContainerView: UIStackView = {
+        let view = UIStackView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isAccessibilityElement = true
         view.accessibilityTraits = .summaryElement
+        view.axis = .vertical
+        view.spacing = 8
         return view
     }()
 
@@ -249,16 +251,11 @@ final class TunnelControlView: UIView {
     // MARK: - Private
 
     private func addSubviews() {
-        for subview in [secureLabel, countryLabel, cityLabel] {
-            locationContainerView.addSubview(subview)
+        for subview in [secureLabel, countryLabel, cityLabel, connectionPanel] {
+            locationContainerView.addArrangedSubview(subview)
         }
 
-        for subview in [
-            activityIndicator,
-            locationContainerView,
-            connectionPanel,
-            buttonsStackView,
-        ] {
+        for subview in [activityIndicator, buttonsStackView, locationContainerView] {
             containerView.addSubview(subview)
         }
 
@@ -268,6 +265,7 @@ final class TunnelControlView: UIView {
             containerView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
             containerView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
             containerView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+            containerView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
 
             locationContainerView.topAnchor.constraint(greaterThanOrEqualTo: containerView.topAnchor),
             locationContainerView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
@@ -279,36 +277,14 @@ final class TunnelControlView: UIView {
                 constant: 22
             ),
 
-            secureLabel.topAnchor.constraint(equalTo: locationContainerView.topAnchor),
-            secureLabel.leadingAnchor.constraint(equalTo: locationContainerView.leadingAnchor),
-            secureLabel.trailingAnchor.constraint(equalTo: locationContainerView.trailingAnchor),
-
-            countryLabel.topAnchor.constraint(equalTo: secureLabel.bottomAnchor, constant: 8),
-            countryLabel.leadingAnchor.constraint(equalTo: locationContainerView.leadingAnchor),
-            countryLabel.trailingAnchor.constraint(equalTo: locationContainerView.trailingAnchor),
-
-            cityLabel.topAnchor.constraint(equalTo: countryLabel.bottomAnchor, constant: 8),
-            cityLabel.leadingAnchor.constraint(equalTo: locationContainerView.leadingAnchor),
-            cityLabel.trailingAnchor.constraint(equalTo: locationContainerView.trailingAnchor),
-            cityLabel.bottomAnchor.constraint(equalTo: locationContainerView.bottomAnchor),
-
-            connectionPanel.topAnchor.constraint(
-                equalTo: locationContainerView.bottomAnchor,
-                constant: 8
-            ),
-            connectionPanel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            connectionPanel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-
             buttonsStackView.topAnchor.constraint(
-                equalTo: connectionPanel.bottomAnchor,
+                equalTo: locationContainerView.bottomAnchor,
                 constant: 24
             ),
             buttonsStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             buttonsStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             buttonsStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
         ])
-
-        updateTraitConstraints()
     }
 
     private func addButtonHandlers() {
@@ -337,18 +313,6 @@ final class TunnelControlView: UIView {
             action: #selector(handleSelectLocation),
             for: .touchUpInside
         )
-    }
-
-    private func updateTraitConstraints() {
-        var layoutConstraints = [NSLayoutConstraint]()
-
-        layoutConstraints.append(
-            containerView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
-        )
-
-        removeConstraints(traitConstraints)
-        traitConstraints = layoutConstraints
-        NSLayoutConstraint.activate(layoutConstraints)
     }
 
     private func setArrangedButtons(_ newButtons: [UIView]) {
@@ -380,7 +344,7 @@ final class TunnelControlView: UIView {
     private func attributedStringForLocation(string: String) -> NSAttributedString {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = 0
-        paragraphStyle.lineHeightMultiple = 0.80
+        paragraphStyle.lineHeightMultiple = 0.8
 
         return NSAttributedString(
             string: string,


### PR DESCRIPTION
Currently, when we turn on multihop and Daita on, the label "server abc using Daita via server xyz" is too long, and cut in the middle.

This fix may seem unintuitive in that it uses a stackview with label and image rather than the previous custom buttom. However, adding multiline support to button titles requires extra constraints to align text with button bounds, plus opens up a world of headache when trying to freely position the button image. With the stackviews we can move things around freely while still keeping the original look and feel by emulating button pressing behavior.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6739)
<!-- Reviewable:end -->
