### PR TITLE
Force install of deb packages in tests

### DIFF
--- a/test/scripts/ssh-setup.sh
+++ b/test/scripts/ssh-setup.sh
@@ -129,15 +129,15 @@ robust_apt () {
     # We don't want to fail due to the global apt lock being
     # held, which happens sporadically. It is fine to wait for
     # some time if it means that the test run can continue.
-    apt -o DPkg::Lock::Timeout=60 "$@"
+    DEBIAN_FRONTEND=noninteractive apt-get -qy -o DPkg::Lock::Timeout=60 "$@"
 }
 
 function install_packages_apt {
     echo "Installing required apt packages"
     robust_apt update
-    robust_apt install -yf xvfb wireguard-tools curl
+    robust_apt install xvfb wireguard-tools curl
     if ! which ping &>/dev/null; then
-        robust_apt install -yf iputils-ping
+        robust_apt install iputils-ping
     fi
     curl -fsSL https://get.docker.com | sh
 }


### PR DESCRIPTION
`apt` seems to get stuck at times due interactive use (missing `-y`): https://github.com/mullvad/mullvadvpn-app/actions/runs/10692668900/job/29641524336

I also switched to `apt-get` to get rid of this warning: "WARNING: apt does not have a stable CLI interface. Use with caution in scripts."


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6741)
<!-- Reviewable:end -->
