### PR TITLE
Extend ignoreUntil for CVEs that still don't affect us

### DIFF
--- a/gui/osv-scanner.toml
+++ b/gui/osv-scanner.toml
@@ -4,25 +4,25 @@
 # excess of the grpc.max_receive_message_length channel option
 [[IgnoredVulns]]
 id = "CVE-2024-37168" # GHSA-7v5v-9h63-cj86
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "This component only receives gRPC messages from the trusted mullvad-daemon"
 
 # yargs-parser Vulnerable to Prototype Pollution
 [[IgnoredVulns]]
 id = "CVE-2020-7608" # GHSA-p9pc-299p-vxgp
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "This package is only used to parse commands run by either us or trusted libraries"
 
 # PostCSS line return parsing error
 [[IgnoredVulns]]
 id = "CVE-2023-44270" # GHSA-7fh5-64p2-3v2j
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "This project does not use PostCSS to parse untrusted CSS"
 
 # braces: Uncontrolled resource consumption
 [[IgnoredVulns]]
 id = "CVE-2024-4068" # GHSA-grv7-fg5c-xmjg
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "This package is only used to match paths from either us or trusted libraries"
 
 # elliptic: Elliptic allows BER-encoded signatures

--- a/gui/scripts/osv-scanner.toml
+++ b/gui/scripts/osv-scanner.toml
@@ -3,41 +3,41 @@
 # Pillow arbitrary code execution
 [[IgnoredVulns]]
 id = "CVE-2023-50447" # GHSA-3f63-hfp8-52jq
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
 
 # Pillow buffer overflow
 [[IgnoredVulns]]
 id = "CVE-2024-28219" # GHSA-44wm-f244-xhp3
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
 
 # Pillow DoS
 [[IgnoredVulns]]
 id = "CVE-2023-44271" # GHSA-8ghj-p4vj-mr35
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
 
 # libwebp: OOB write in BuildHuffmanTable
 [[IgnoredVulns]]
 id = "CVE-2023-5129" # GHSA-j7hp-h8jx-5ppr
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
 
 # Pillow versions before v10.0.1 bundled libwebp binaries in wheels that are vulnerable to CVE-2023-5129 (previously CVE-2023-4863)
 [[IgnoredVulns]]
 id = "PYSEC-2023-175"
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
 
 # Pillow versions before v10.0.1 bundled libwebp binaries in wheels that are vulnerable to CVE-2023-5129 (previously CVE-2023-4863)
 [[IgnoredVulns]]
 id = "GHSA-56pw-mpj4-fxww"
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"
 
 # Pillow vulnerable to Data Amplification attack.
 [[IgnoredVulns]]
 id = "CVE-2022-45198" # GHSA-m2vv-5vj5-2hm7
-ignoreUntil = 2024-09-05
+ignoreUntil = 2024-12-05
 reason = "Only used internally, on trusted input. This tool is also scheduled for removal completely, so not worth trying to upgrade"


### PR DESCRIPTION
This is only for desktop frontend and python helper scripts.

These should be safe to ignore still. I don't think anything changed that would make them dangerous to us now. The ideal would of course to get rid of the python scripts and eventually upgrade the npm dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6743)
<!-- Reviewable:end -->
