### PR TITLE
Upgrade the UX in Daita scenarios

### DIFF
--- a/ios/MullvadSettings/DAITASettings.swift
+++ b/ios/MullvadSettings/DAITASettings.swift
@@ -18,6 +18,11 @@ public enum DAITAState: Codable {
     }
 }
 
+/// Selected relay is incompatible with Daita, either through singlehop or multihop.
+public enum DAITASettingsCompatibilityError {
+    case singlehop, multihop
+}
+
 public struct DAITASettings: Codable, Equatable {
     public let state: DAITAState
 

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -535,6 +535,15 @@ final class TunnelManager: StorePaymentObserver {
         try relayCacheTracker.refreshCachedRelays()
     }
 
+    func selectRelays(tunnelSettings: LatestTunnelSettings) throws -> SelectedRelays {
+        let retryAttempts = tunnelStatus.observedState.connectionState?.connectionAttemptCount ?? 0
+
+        return try relaySelector.selectRelays(
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: retryAttempts
+        )
+    }
+
     // MARK: - Tunnel observeration
 
     /// Add tunnel observer.
@@ -780,15 +789,6 @@ final class TunnelManager: StorePaymentObserver {
 
     private func didUpdateNetworkPath(_ path: Network.NWPath) {
         updateTunnelStatus(tunnel?.status ?? .disconnected)
-    }
-
-    fileprivate func selectRelays() throws -> SelectedRelays {
-        let retryAttempts = tunnelStatus.observedState.connectionState?.connectionAttemptCount ?? 0
-
-        return try relaySelector.selectRelays(
-            tunnelSettings: settings,
-            connectionAttemptCount: retryAttempts
-        )
     }
 
     fileprivate func prepareForVPNConfigurationDeletion() {
@@ -1265,7 +1265,7 @@ private struct TunnelInteractorProxy: TunnelInteractor {
     }
 
     func selectRelays() throws -> SelectedRelays {
-        try tunnelManager.selectRelays()
+        try tunnelManager.selectRelays(tunnelSettings: tunnelManager.settings)
     }
 
     func handleRestError(_ error: Error) {

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSourceDelegate.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSourceDelegate.swift
@@ -15,7 +15,8 @@ protocol DNSSettingsDataSourceDelegate: AnyObject {
 }
 
 protocol VPNSettingsDataSourceDelegate: AnyObject {
-    func didChangeViewModel(_ viewModel: VPNSettingsViewModel)
+    func didUpdateTunnelSettings(_ update: TunnelSettingsUpdate)
+    func didAttemptToChangeDaitaSettings(_ settings: DAITASettings) -> DAITASettingsCompatibilityError?
     func showInfo(for: VPNSettingsInfoButtonItem)
     func showDNSSettings()
     func showIPOverrides()

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
@@ -18,5 +18,6 @@ enum VPNSettingsInfoButtonItem {
 }
 
 enum VPNSettingsPromptAlertItem {
-    case daita
+    case daitaSettingIncompatibleWithSinglehop
+    case daitaSettingIncompatibleWithMultihop
 }

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInteractor.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInteractor.swift
@@ -51,6 +51,22 @@ final class VPNSettingsInteractor {
 
         tunnelManager.updateSettings([.relayConstraints(relayConstraints)], completionHandler: completion)
     }
+
+    func evaluateDaitaSettingsCompatibility(_ settings: DAITASettings) -> DAITASettingsCompatibilityError? {
+        guard settings.state.isEnabled else { return nil }
+
+        var tunnelSettings = tunnelSettings
+        tunnelSettings.daita = settings
+
+        let selectedRelays = try? tunnelManager.selectRelays(tunnelSettings: tunnelSettings)
+        let multihopEnabled = tunnelSettings.tunnelMultihopState.isEnabled
+
+        return if multihopEnabled {
+            selectedRelays?.entry == nil ? .multihop : nil
+        } else {
+            selectedRelays?.exit == nil ? .singlehop : nil
+        }
+    }
 }
 
 extension VPNSettingsInteractor: RelayCacheTrackerObserver {


### PR DESCRIPTION
After discussing with the stakeholders, and the design team, we want to ship Daita with an improved UX, which will behave as following:

- If the single hop selected location already supports Daita, there is no warning shown when Daita is enabled, it just works
- If the single hop selected location does not support Daita, the "Enable anyway" warning is shown, and if the user accepts, they enter the blocked state.
- If the multihop entry selected location already supports Daita, there is no warning, it just works
- If the multihop entry selected location does not support Daita, the "Enable anyway" warning is shown

The copy that is shown for the warning text is aware of multihop, and will have a different text accordingly.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6745)
<!-- Reviewable:end -->
