### PR TITLE
Upgrade `nftnl` to fix `cargo deny` error

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -29,9 +29,7 @@ jobs:
           # Ignored audit issues. This list should be kept short, and effort should be
           # put into removing items from the list.
           # RUSTSEC-2023-0079 - KyberSlash in `pqc_kyber`.
-          # RUSTSEC-2024-0370 - `proc-macro-error` is unmaintained.
-          # `nftnl 0.6.2` uses `proc-macro-error`.
-          ignore: RUSTSEC-2023-0079,RUSTSEC-2024-0370
+          ignore: RUSTSEC-2023-0079
 
       - uses: actions-rust-lang/audit@v1.1.11
         name: Audit testrunner Rust Dependencies
@@ -41,6 +39,4 @@ jobs:
           # Ignored audit issues. This list should be kept short, and effort should be
           # put into removing items from the list.
           # RUSTSEC-2023-0079 - KyberSlash in `pqc_kyber`.
-          # RUSTSEC-2024-0370 - `proc-macro-error` is unmaintained.
-          # `nftnl 0.6.2` uses `proc-macro-error`.
-          ignore: RUSTSEC-2023-0079,RUSTSEC-2024-0370
+          ignore: RUSTSEC-2023-0079

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,9 +330,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blake3"
@@ -989,20 +989,6 @@ name = "err-context"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449aad22b1364e927ff3bf50f55404efd705c40065fb47f73f28704de707c89e"
-
-[[package]]
-name = "err-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34a887c8df3ed90498c1c437ce21f211c8e27672921a8ffa293cb8d6d4caa9e"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
- "synstructure 0.12.6",
-]
 
 [[package]]
 name = "errno"
@@ -2096,7 +2082,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -2652,21 +2638,20 @@ dependencies = [
 
 [[package]]
 name = "nftnl"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9201688bd0bc571dfa4c21ce0a525480c8b782776cf88e12571fa89108dd920"
+checksum = "06a7491dd91b71643f65546389f25506da70723d1f1ec8c8d6d20444d1c23f27"
 dependencies = [
- "bitflags 1.3.2",
- "err-derive",
+ "bitflags 2.6.0",
  "log",
  "nftnl-sys",
 ]
 
 [[package]]
 name = "nftnl-sys"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b5c587b6a5e76a3a5d51e0a757ae66dbff38c277563485807ae979ce361b56"
+checksum = "b193f2c2a70e6421534c3f3b75eaaed4e4b9df45281b3d94f5bc8c32fb346cbb"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2703,7 +2688,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -2716,7 +2701,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -2734,7 +2719,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -3188,30 +3173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,7 +3189,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -3549,7 +3510,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno 0.3.8",
  "libc",
  "linux-raw-sys",
@@ -4006,18 +3967,6 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
@@ -4053,7 +4002,7 @@ name = "talpid-core"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "chrono",
  "duct",
  "futures",
@@ -4194,7 +4143,7 @@ dependencies = [
 name = "talpid-routing"
 version = "0.0.0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "futures",
  "ipnetwork",
  "libc",
@@ -4747,12 +4696,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -5321,7 +5264,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]
@@ -5362,7 +5305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -28,9 +28,6 @@ ignore = [
     # put into removing items from the list.
     # RUSTSEC-2023-0079 - KyberSlash in `pqc_kyber`.
     "RUSTSEC-2023-0079",
-    # RUSTSEC-2024-0370 - `proc-macro-error` is unmaintained.
-    # `nftnl 0.6.2` uses `proc-macro-error`.
-    "RUSTSEC-2024-0370",
 ]
 
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -50,11 +50,3 @@ KyberSlash is not exploitable in our usage of it:
 https://mullvad.net/en/blog/mullvads-usage-of-kyber-is-not-affected-by-kyberslash
 And no patched version is available.
 """
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2024-0370"
-ignoreUntil = 2024-12-06
-reason = """
-proc-macro-error is unmaintained, but it does not necessarily contain any vulns.
-Will be fixed by bumping `nftnl`.
-"""

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -37,7 +37,7 @@ jnix = { version = "0.5.1", features = ["derive"] }
 nix = "0.23"
 inotify = "0.10"
 resolv-conf = "0.7"
-nftnl = { version = "0.6.2", features = ["nftnl-1-1-0"] }
+nftnl = { version = "0.7.0", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2.2", features = ["mnl-1-0-4"] }
 which = { version = "4.0", default-features = false }
 talpid-dbus = { path = "../talpid-dbus" }
@@ -62,7 +62,7 @@ serde_json = { workspace = true }
 talpid-net = { path = "../talpid-net" }
 
 [target.'cfg(windows)'.dependencies]
-bitflags = "1.2"
+bitflags = "2.6"
 widestring = "1.0"
 winreg = { version = "0.51", features = ["transactions"] }
 memoffset = "0.6"

--- a/talpid-core/src/split_tunnel/windows/driver.rs
+++ b/talpid-core/src/split_tunnel/windows/driver.rs
@@ -155,6 +155,7 @@ pub enum EventBody {
 }
 
 bitflags! {
+    #[derive(Debug)]
     pub struct SplittingChangeReason: u32 {
         const BY_INHERITANCE = 1;
         const BY_CONFIG = 2;


### PR DESCRIPTION
This PR resolves #6747.

Fix `cargo deny` complaining about `proc-macro-error` being unmaintained by upgrading `nftnl` to a version which no longer depends on `err-derive`, which in turn depended on `proc-macro-error`.

This PR also upgrades `bitflags` to `2.6.0` from `2.5.0` in `talpid-core`. Version `2.6.0` is pinned by `nftnl` for some reason, and `cargo` was unhappy with having both `2.5.0` and `2.6.0` in the same crate.

With this change we also drop 5 direct dependencies, and even more indirect dependencies! :tada:

Fixes DES-1228

# TODO
* [x] Blocked on new release of [nftnl](https://github.com/mullvad/nftnl-rs).
* [x] Un-silence `RUSTSEC-2024-0370` in `cargo deny`
* [x] Un-silence `RUSTSEC-2024-0370` in `osv-scanner`
* [x] Un-silence `RUSTSEC-2024-0370` in `cargo audit`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6748)
<!-- Reviewable:end -->
