### PR TITLE
Silence `RUSTSEC-2024-0370` in `osv-scanner`

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -50,3 +50,11 @@ KyberSlash is not exploitable in our usage of it:
 https://mullvad.net/en/blog/mullvads-usage-of-kyber-is-not-affected-by-kyberslash
 And no patched version is available.
 """
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0370"
+ignoreUntil = 2024-12-06
+reason = """
+proc-macro-error is unmaintained, but it does not necessarily contain any vulns.
+Will be fixed by bumping `nftnl`.
+"""


### PR DESCRIPTION
Temporary fix until https://github.com/mullvad/mullvadvpn-app/pull/6748 is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6755)
<!-- Reviewable:end -->
