### PR TITLE
Run `obfuscation.spec.ts` in e2e tests

### DIFF
--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -276,3 +276,11 @@ pub async fn test_import_settings_ui(_: TestContext, rpc: ServiceClient) -> Resu
     assert!(ui_result.success());
     Ok(())
 }
+
+/// Test obufscation settings in the GUI
+#[test_function]
+pub async fn test_obfuscation_settings_ui(_: TestContext, rpc: ServiceClient) -> Result<(), Error> {
+    let ui_result = run_test(&rpc, &["obfuscation.spec"]).await?;
+    assert!(ui_result.success());
+    Ok(())
+}


### PR DESCRIPTION
This PR simply adds `obfuscation.spec` to the arsenal of GUI e2e tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6756)
<!-- Reviewable:end -->
