### PR TITLE
Install `cbindgen` in `rust-unused-dependencies` workflow

### DIFF
--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -81,6 +81,12 @@ jobs:
           git config --global --add safe.directory '*'
           git submodule update --init --recursive --depth=1 wireguard-go-rs
 
+      - name: Install cbindgen
+        run: |
+          # Temporary fix to address maybenot.h build issues.
+          # Remove this step when cbindgen has been added to the build container.
+          cargo install --force cbindgen --version "0.26.0"
+
       - name: Install nightly Rust toolchain
         run: |
           rustup default $RUST_NIGHTLY_TOOLCHAIN


### PR DESCRIPTION
Install `cbindgen` in `rust-unused-dependencies` workflow, which is missing since https://github.com/mullvad/mullvadvpn-app/pull/6684

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6757)
<!-- Reviewable:end -->
