### PR TITLE
Rename test timeout constants

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/constant/TimeoutConstants.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/constant/TimeoutConstants.kt
@@ -1,9 +1,6 @@
 package net.mullvad.mullvadvpn.test.common.constant
 
-const val APP_LAUNCH_TIMEOUT = 5000L
-const val CONNECTION_TIMEOUT = 30000L
-const val DEFAULT_INTERACTION_TIMEOUT = 3000L
-const val LOGIN_TIMEOUT = 30000L
-const val LOGIN_FAILURE_TIMEOUT = 60000L
-const val LOGIN_PROMPT_TIMEOUT = 30000L
-const val WEB_TIMEOUT = 30000L
+const val DEFAULT_TIMEOUT = 3000L
+const val LONG_TIMEOUT = 10000L
+const val VERY_LONG_TIMEOUT = 30000L
+const val EXTREMELY_LONG_TIMEOUT = 60000L

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/extension/UiAutomatorExtensions.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/extension/UiAutomatorExtensions.kt
@@ -7,7 +7,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
 import java.util.regex.Pattern
-import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_INTERACTION_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
 
 fun UiDevice.findObjectByCaseInsensitiveText(text: String): UiObject2 {
     return findObjectWithTimeout(By.text(Pattern.compile(text, Pattern.CASE_INSENSITIVE)))
@@ -19,7 +19,7 @@ fun UiObject2.findObjectByCaseInsensitiveText(text: String): UiObject2 {
 
 fun UiDevice.findObjectWithTimeout(
     selector: BySelector,
-    timeout: Long = DEFAULT_INTERACTION_TIMEOUT,
+    timeout: Long = DEFAULT_TIMEOUT,
 ): UiObject2 {
 
     wait(Until.hasObject(selector), timeout)
@@ -45,7 +45,7 @@ fun UiDevice.dismissChangelogDialogIfShown() {
 }
 
 fun UiDevice.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove(
-    timeout: Long = DEFAULT_INTERACTION_TIMEOUT
+    timeout: Long = DEFAULT_TIMEOUT
 ) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
         // Skipping as notification permissions are not shown.
@@ -67,7 +67,7 @@ fun UiDevice.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove(
 
 fun UiObject2.findObjectWithTimeout(
     selector: BySelector,
-    timeout: Long = DEFAULT_INTERACTION_TIMEOUT,
+    timeout: Long = DEFAULT_TIMEOUT,
 ): UiObject2 {
 
     wait(Until.hasObject(selector), timeout)

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -8,12 +8,10 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import net.mullvad.mullvadvpn.lib.endpoint.ApiEndpointOverride
 import net.mullvad.mullvadvpn.lib.endpoint.putApiEndpointConfigurationExtra
-import net.mullvad.mullvadvpn.test.common.constant.APP_LAUNCH_TIMEOUT
-import net.mullvad.mullvadvpn.test.common.constant.CONNECTION_TIMEOUT
-import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_INTERACTION_TIMEOUT
-import net.mullvad.mullvadvpn.test.common.constant.LOGIN_FAILURE_TIMEOUT
-import net.mullvad.mullvadvpn.test.common.constant.LOGIN_PROMPT_TIMEOUT
-import net.mullvad.mullvadvpn.test.common.constant.LOGIN_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.EXTREMELY_LONG_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.LONG_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.VERY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
@@ -26,10 +24,7 @@ class AppInteractor(
     fun launch(customApiEndpointConfiguration: ApiEndpointOverride? = null) {
         device.pressHome()
         // Wait for launcher
-        device.wait(
-            Until.hasObject(By.pkg(device.launcherPackageName).depth(0)),
-            APP_LAUNCH_TIMEOUT,
-        )
+        device.wait(Until.hasObject(By.pkg(device.launcherPackageName).depth(0)), LONG_TIMEOUT)
 
         val intent =
             targetContext.packageManager.getLaunchIntentForPackage(targetPackageName)?.apply {
@@ -40,7 +35,7 @@ class AppInteractor(
                 }
             }
         targetContext.startActivity(intent)
-        device.wait(Until.hasObject(By.pkg(targetPackageName).depth(0)), APP_LAUNCH_TIMEOUT)
+        device.wait(Until.hasObject(By.pkg(targetPackageName).depth(0)), LONG_TIMEOUT)
     }
 
     fun launchAndEnsureLoggedIn(accountNumber: String) {
@@ -58,7 +53,7 @@ class AppInteractor(
                 text = accountNumber
             }
         val loginButton = loginObject.parent.findObject(By.clazz(Button::class.java))
-        loginButton.wait(Until.enabled(true), DEFAULT_INTERACTION_TIMEOUT)
+        loginButton.wait(Until.enabled(true), DEFAULT_TIMEOUT)
         loginButton.click()
     }
 
@@ -67,18 +62,16 @@ class AppInteractor(
     }
 
     fun ensureAccountCreated(accountNumber: String? = null) {
-        device.findObjectWithTimeout(By.text("Congrats!"), LOGIN_TIMEOUT)
-        accountNumber?.let {
-            device.findObjectWithTimeout(By.text(accountNumber), DEFAULT_INTERACTION_TIMEOUT)
-        }
+        device.findObjectWithTimeout(By.text("Congrats!"), VERY_LONG_TIMEOUT)
+        accountNumber?.let { device.findObjectWithTimeout(By.text(accountNumber), DEFAULT_TIMEOUT) }
     }
 
     fun ensureAccountCreationFailed() {
-        device.findObjectWithTimeout(By.text("Failed to create account"), LOGIN_FAILURE_TIMEOUT)
+        device.findObjectWithTimeout(By.text("Failed to create account"), EXTREMELY_LONG_TIMEOUT)
     }
 
     fun ensureLoggedIn() {
-        device.findObjectWithTimeout(By.text("UNSECURED CONNECTION"), LOGIN_TIMEOUT)
+        device.findObjectWithTimeout(By.text("UNSECURED CONNECTION"), VERY_LONG_TIMEOUT)
     }
 
     fun ensureOutOfTime() {
@@ -95,7 +88,7 @@ class AppInteractor(
             .findObjectWithTimeout(
                 // Text exist and contains IP address
                 By.res("location_info_connection_out_test_tag").textContains("."),
-                CONNECTION_TIMEOUT,
+                VERY_LONG_TIMEOUT,
             )
             .text
             .extractIpAddress()
@@ -117,7 +110,7 @@ class AppInteractor(
         device.findObjectWithTimeout(By.text(text)).click()
     }
 
-    fun waitForLoginPrompt(timeout: Long = LOGIN_PROMPT_TIMEOUT) {
+    fun waitForLoginPrompt(timeout: Long = VERY_LONG_TIMEOUT) {
         device.findObjectWithTimeout(By.text("Login"), timeout)
     }
 

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
@@ -2,7 +2,7 @@ package net.mullvad.mullvadvpn.test.e2e
 
 import androidx.test.uiautomator.By
 import net.mullvad.mullvadvpn.BuildConfig
-import net.mullvad.mullvadvpn.test.common.constant.CONNECTION_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.VERY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 import net.mullvad.mullvadvpn.test.common.rule.ForgetAllVpnAppsInSettingsTestRule
 import net.mullvad.mullvadvpn.test.e2e.misc.AccountTestRule
@@ -30,7 +30,7 @@ class ConnectionTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
         device.findObjectWithTimeout(By.text("OK")).click()
 
         // Then
-        device.findObjectWithTimeout(By.text("SECURE CONNECTION"), CONNECTION_TIMEOUT)
+        device.findObjectWithTimeout(By.text("SECURE CONNECTION"), VERY_LONG_TIMEOUT)
     }
 
     @Test
@@ -41,7 +41,7 @@ class ConnectionTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
         // When
         device.findObjectWithTimeout(By.text("Secure my connection")).click()
         device.findObjectWithTimeout(By.text("OK")).click()
-        device.findObjectWithTimeout(By.text("SECURE CONNECTION"), CONNECTION_TIMEOUT)
+        device.findObjectWithTimeout(By.text("SECURE CONNECTION"), VERY_LONG_TIMEOUT)
         val expected = ConnCheckState(true, app.extractIpAddress())
 
         // Then

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -1,7 +1,7 @@
 package net.mullvad.mullvadvpn.test.e2e
 
 import androidx.test.uiautomator.By
-import net.mullvad.mullvadvpn.test.common.constant.LOGIN_FAILURE_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.EXTREMELY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
@@ -40,6 +40,6 @@ class LoginTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
         app.attemptLogin(invalidDummyAccountNumber)
 
         // Then
-        device.findObjectWithTimeout(By.text("Invalid account number"), LOGIN_FAILURE_TIMEOUT)
+        device.findObjectWithTimeout(By.text("Invalid account number"), EXTREMELY_LONG_TIMEOUT)
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/WebLinkTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/WebLinkTest.kt
@@ -2,7 +2,7 @@ package net.mullvad.mullvadvpn.test.e2e
 
 import androidx.test.uiautomator.By
 import net.mullvad.mullvadvpn.test.common.annotation.SkipForFlavors
-import net.mullvad.mullvadvpn.test.common.constant.WEB_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.VERY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
@@ -25,7 +25,7 @@ class WebLinkTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
         // Then
         device.findObjectWithTimeout(
             selector = By.text("Mullvad help center"),
-            timeout = WEB_TIMEOUT,
+            timeout = VERY_LONG_TIMEOUT,
         )
     }
 }

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
@@ -3,7 +3,7 @@ package net.mullvad.mullvadvpn.test.mockapi
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import net.mullvad.mullvadvpn.compose.test.LOGIN_TITLE_TEST_TAG
-import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_INTERACTION_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
 import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
 import net.mullvad.mullvadvpn.test.common.extension.dismissChangelogDialogIfShown
@@ -36,7 +36,7 @@ class LoginMockApiTest : MockApiTest() {
         val result =
             device
                 .findObject(By.res(LOGIN_TITLE_TEST_TAG))
-                .wait(Until.textEquals("Login failed"), DEFAULT_INTERACTION_TIMEOUT)
+                .wait(Until.textEquals("Login failed"), DEFAULT_TIMEOUT)
 
         assertTrue(result)
     }


### PR DESCRIPTION
Renamed test timeout constants to have more generic names.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6764)
<!-- Reviewable:end -->
