### PR TITLE
Do not display post quantum label for daita non pq connections

### DIFF
--- a/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
@@ -35,6 +35,7 @@ class MapConnectionStatusOperation: AsyncOperation {
         super.init(dispatchQueue: queue)
     }
 
+    // swiftlint:disable:next function_body_length
     override func main() {
         guard let tunnel = interactor.tunnel else {
             setTunnelDisconnectedStatus()
@@ -51,19 +52,36 @@ class MapConnectionStatusOperation: AsyncOperation {
                 switch observedState {
                 case let .connected(connectionState):
                     return connectionState.isNetworkReachable
-                        ? .connected(connectionState.selectedRelays, isPostQuantum: connectionState.isPostQuantum)
+                        ? .connected(
+                            connectionState.selectedRelays,
+                            isPostQuantum: connectionState.isPostQuantum,
+                            isDaita: connectionState.isDaitaEnabled
+                        )
                         : .waitingForConnectivity(.noConnection)
                 case let .connecting(connectionState):
                     return connectionState.isNetworkReachable
-                        ? .connecting(connectionState.selectedRelays, isPostQuantum: connectionState.isPostQuantum)
+                        ? .connecting(
+                            connectionState.selectedRelays,
+                            isPostQuantum: connectionState.isPostQuantum,
+                            isDaita: connectionState.isDaitaEnabled
+                        )
                         : .waitingForConnectivity(.noConnection)
                 case let .negotiatingEphemeralPeer(connectionState, privateKey):
                     return connectionState.isNetworkReachable
-                        ? .negotiatingEphemeralPeer(connectionState.selectedRelays, privateKey)
+                        ? .negotiatingEphemeralPeer(
+                            connectionState.selectedRelays,
+                            privateKey,
+                            isPostQuantum: connectionState.isPostQuantum,
+                            isDaita: connectionState.isDaitaEnabled
+                        )
                         : .waitingForConnectivity(.noConnection)
                 case let .reconnecting(connectionState):
                     return connectionState.isNetworkReachable
-                        ? .reconnecting(connectionState.selectedRelays, isPostQuantum: connectionState.isPostQuantum)
+                        ? .reconnecting(
+                            connectionState.selectedRelays,
+                            isPostQuantum: connectionState.isPostQuantum,
+                            isDaita: connectionState.isDaitaEnabled
+                        )
                         : .waitingForConnectivity(.noConnection)
                 case let .error(blockedState):
                     return .error(blockedState.reason)

--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -92,7 +92,8 @@ class StartTunnelOperation: ResultOperation<Void> {
             tunnelStatus = TunnelStatus()
             tunnelStatus.state = .connecting(
                 selectedRelays,
-                isPostQuantum: interactor.settings.tunnelQuantumResistance.isEnabled
+                isPostQuantum: interactor.settings.tunnelQuantumResistance.isEnabled,
+                isDaita: interactor.settings.daita.state.isEnabled
             )
         }
 

--- a/ios/MullvadVPN/TunnelManager/TunnelState+UI.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState+UI.swift
@@ -32,7 +32,7 @@ extension TunnelState {
 
     var localizedTitleForSecureLabel: String {
         switch self {
-        case let .connecting(_, isPostQuantum), let .reconnecting(_, isPostQuantum):
+        case let .connecting(_, isPostQuantum, _), let .reconnecting(_, isPostQuantum, _):
             if isPostQuantum {
                 NSLocalizedString(
                     "TUNNEL_STATE_PQ_CONNECTING",
@@ -49,16 +49,23 @@ extension TunnelState {
                 )
             }
 
-        // TODO: Handle Daita here in an upcoming PR for the UI
-        case .negotiatingEphemeralPeer:
-            NSLocalizedString(
-                "TUNNEL_STATE_NEGOTIATING_KEY",
-                tableName: "Main",
-                value: "Creating quantum secure connection",
-                comment: ""
-            )
-
-        case let .connected(_, isPostQuantum):
+        case let .negotiatingEphemeralPeer(_, _, isPostQuantum, _):
+            if isPostQuantum {
+                NSLocalizedString(
+                    "TUNNEL_STATE_NEGOTIATING_KEY",
+                    tableName: "Main",
+                    value: "Creating quantum secure connection",
+                    comment: ""
+                )
+            } else {
+                NSLocalizedString(
+                    "TUNNEL_STATE_CONNECTING",
+                    tableName: "Main",
+                    value: "Creating secure connection",
+                    comment: ""
+                )
+            }
+        case let .connected(_, isPostQuantum, _):
             if isPostQuantum {
                 NSLocalizedString(
                     "TUNNEL_STATE_PQ_CONNECTED",
@@ -152,34 +159,33 @@ extension TunnelState {
         }
     }
 
-    var localizedAccessibilityLabel: String {
-        switch self {
-        case let .connecting(_, isPostQuantum):
-            if isPostQuantum {
-                NSLocalizedString(
-                    "TUNNEL_STATE_PQ_CONNECTING_ACCESSIBILITY_LABEL",
-                    tableName: "Main",
-                    value: "Creating quantum secure connection",
-                    comment: ""
-                )
-            } else {
-                NSLocalizedString(
-                    "TUNNEL_STATE_CONNECTING_ACCESSIBILITY_LABEL",
-                    tableName: "Main",
-                    value: "Creating secure connection",
-                    comment: ""
-                )
-            }
-
-        case .negotiatingEphemeralPeer:
+    func secureConnectionLabel(isPostQuantum: Bool) -> String {
+        if isPostQuantum {
             NSLocalizedString(
-                "TUNNEL_STATE_CONNECTING_ACCESSIBILITY_LABEL",
+                "TUNNEL_STATE_PQ_CONNECTING_ACCESSIBILITY_LABEL",
                 tableName: "Main",
                 value: "Creating quantum secure connection",
                 comment: ""
             )
+        } else {
+            NSLocalizedString(
+                "TUNNEL_STATE_CONNECTING_ACCESSIBILITY_LABEL",
+                tableName: "Main",
+                value: "Creating secure connection",
+                comment: ""
+            )
+        }
+    }
 
-        case let .connected(tunnelInfo, isPostQuantum):
+    var localizedAccessibilityLabel: String {
+        switch self {
+        case let .connecting(_, isPostQuantum, _):
+            secureConnectionLabel(isPostQuantum: isPostQuantum)
+
+        case let .negotiatingEphemeralPeer(_, _, isPostQuantum, _):
+            secureConnectionLabel(isPostQuantum: isPostQuantum)
+
+        case let .connected(tunnelInfo, isPostQuantum, _):
             if isPostQuantum {
                 String(
                     format: NSLocalizedString(
@@ -212,7 +218,7 @@ extension TunnelState {
                 comment: ""
             )
 
-        case let .reconnecting(tunnelInfo, _):
+        case let .reconnecting(tunnelInfo, _, _):
             String(
                 format: NSLocalizedString(
                     "TUNNEL_STATE_RECONNECTING_ACCESSIBILITY_LABEL",

--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -50,13 +50,13 @@ enum TunnelState: Equatable, CustomStringConvertible {
     case pendingReconnect
 
     /// Connecting the tunnel.
-    case connecting(SelectedRelays?, isPostQuantum: Bool)
+    case connecting(SelectedRelays?, isPostQuantum: Bool, isDaita: Bool)
 
     /// Negotiating an ephemeral peer either for post-quantum resistance or Daita
-    case negotiatingEphemeralPeer(SelectedRelays, PrivateKey)
+    case negotiatingEphemeralPeer(SelectedRelays, PrivateKey, isPostQuantum: Bool, isDaita: Bool)
 
     /// Connected the tunnel
-    case connected(SelectedRelays, isPostQuantum: Bool)
+    case connected(SelectedRelays, isPostQuantum: Bool, isDaita: Bool)
 
     /// Disconnecting the tunnel
     case disconnecting(ActionAfterDisconnect)
@@ -69,7 +69,7 @@ enum TunnelState: Equatable, CustomStringConvertible {
     /// 1. Asking the running tunnel to reconnect to new relays via IPC.
     /// 2. Tunnel attempts to reconnect to new relays as the current relays appear to be
     ///    dysfunctional.
-    case reconnecting(SelectedRelays, isPostQuantum: Bool)
+    case reconnecting(SelectedRelays, isPostQuantum: Bool, isDaita: Bool)
 
     /// Waiting for connectivity to come back up.
     case waitingForConnectivity(WaitingForConnectionReason)
@@ -81,19 +81,21 @@ enum TunnelState: Equatable, CustomStringConvertible {
         switch self {
         case .pendingReconnect:
             "pending reconnect after disconnect"
-        case let .connecting(tunnelRelays, isPostQuantum):
+        case let .connecting(tunnelRelays, isPostQuantum, isDaita):
             if let tunnelRelays {
                 """
                 connecting \(isPostQuantum ? "(PQ) " : "")\
+                daita: \(isDaita) \
                 to \(tunnelRelays.exit.hostname)\
                 \(tunnelRelays.entry.flatMap { " via \($0.hostname)" } ?? "")
                 """
             } else {
                 "connecting\(isPostQuantum ? " (PQ)" : ""), fetching relay"
             }
-        case let .connected(tunnelRelays, isPostQuantum):
+        case let .connected(tunnelRelays, isPostQuantum, isDaita):
             """
             connected \(isPostQuantum ? "(PQ) " : "")\
+            daita: \(isDaita) \
             to \(tunnelRelays.exit.hostname)\
             \(tunnelRelays.entry.flatMap { " via \($0.hostname)" } ?? "")
             """
@@ -101,9 +103,10 @@ enum TunnelState: Equatable, CustomStringConvertible {
             "disconnecting and then \(actionAfterDisconnect)"
         case .disconnected:
             "disconnected"
-        case let .reconnecting(tunnelRelays, isPostQuantum):
+        case let .reconnecting(tunnelRelays, isPostQuantum, isDaita):
             """
             reconnecting \(isPostQuantum ? "(PQ) " : "")\
+            daita: \(isDaita) \
             to \(tunnelRelays.exit.hostname)\
             \(tunnelRelays.entry.flatMap { " via \($0.hostname)" } ?? "")
             """
@@ -111,11 +114,11 @@ enum TunnelState: Equatable, CustomStringConvertible {
             "waiting for connectivity"
         case let .error(blockedStateReason):
             "error state: \(blockedStateReason)"
-        case let .negotiatingEphemeralPeer(tunnelRelays, _):
-            // TODO: Handle Daita and PQ here in an upcoming PR for the UI
+        case let .negotiatingEphemeralPeer(tunnelRelays, _, isPostQuantum, isDaita):
             """
             negotiating key with exit relay: \(tunnelRelays.exit.hostname)\
-            \(tunnelRelays.entry.flatMap { " via \($0.hostname)" } ?? "")
+            \(tunnelRelays.entry.flatMap { " via \($0.hostname)" } ?? "")\
+            "isPostQuantum: \(isPostQuantum), isDaita: \(isDaita)
             """
         }
     }
@@ -132,9 +135,11 @@ enum TunnelState: Equatable, CustomStringConvertible {
 
     var relays: SelectedRelays? {
         switch self {
-        case let .connected(relays, _), let .reconnecting(relays, _), let .negotiatingEphemeralPeer(relays, _):
+        case let .connected(relays, _, _),
+             let .reconnecting(relays, _, _),
+             let .negotiatingEphemeralPeer(relays, _, _, _):
             relays
-        case let .connecting(relays, _):
+        case let .connecting(relays, _, _):
             relays
         case .disconnecting, .disconnected, .waitingForConnectivity, .pendingReconnect, .error:
             nil

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -147,17 +147,17 @@ class TunnelViewController: UIViewController, RootContainment {
 
     private func updateMap(animated: Bool) {
         switch tunnelState {
-        case let .connecting(tunnelRelays, _):
+        case let .connecting(tunnelRelays, _, _):
             mapViewController.removeLocationMarker()
             contentView.setAnimatingActivity(true)
             mapViewController.setCenter(tunnelRelays?.exit.location.geoCoordinate, animated: animated)
 
-        case let .reconnecting(tunnelRelays, _), let .negotiatingEphemeralPeer(tunnelRelays, _):
+        case let .reconnecting(tunnelRelays, _, _), let .negotiatingEphemeralPeer(tunnelRelays, _, _, _):
             mapViewController.removeLocationMarker()
             contentView.setAnimatingActivity(true)
             mapViewController.setCenter(tunnelRelays.exit.location.geoCoordinate, animated: animated)
 
-        case let .connected(tunnelRelays, _):
+        case let .connected(tunnelRelays, _, _):
             let center = tunnelRelays.exit.location.geoCoordinate
             mapViewController.setCenter(center, animated: animated) {
                 self.contentView.setAnimatingActivity(false)


### PR DESCRIPTION
This PR changes the "creating secure connection" label to correctly reflect when a connection is PQ enabled or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6766)
<!-- Reviewable:end -->
