### PR TITLE
Add settings e2e test

### DIFF
--- a/gui/test/e2e/installed/state-dependent/settings.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/settings.spec.ts
@@ -45,7 +45,7 @@ test.describe('VPN Settings', () => {
   });
 
   test('Launch on startup setting', async () => {
-    // Find the auto-connect toggle
+    // Find the launch on start-up toggle
     const launchOnStartupToggle =
       page.getByText('Launch app on start-up').locator('..').getByRole('checkbox');
 
@@ -55,7 +55,7 @@ test.describe('VPN Settings', () => {
     await expect(launchOnStartupToggle).toHaveAttribute('aria-checked', 'false')
     expect(fileExists(AUTOSTART_PATH)).toBeFalsy();
 
-    // Toggle auto-connect
+    // Toggle launch on start-up
     await launchOnStartupToggle.click();
 
     // Verify the setting was applied correctly
@@ -63,6 +63,14 @@ test.describe('VPN Settings', () => {
     expect(fileExists(AUTOSTART_PATH)).toBeTruthy();
     const newCliState = execSync('mullvad auto-connect get').toString().trim();
     expect(newCliState).toMatch(/on$/);
+
+    await launchOnStartupToggle.click();
+
+    // Toggle auto-connect back off
+    // NOTE: This must be done to clean up the auto-start file
+    // TODO: Reset GUI settings between all tests
+    const autoConnectToggle = page.getByText('Auto-connect').locator('..').getByRole('checkbox');
+    await autoConnectToggle.click();
   });
 
   test('LAN settings', async () => {

--- a/gui/test/e2e/installed/state-dependent/settings.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/settings.spec.ts
@@ -1,0 +1,85 @@
+import path from 'path';
+import { execSync } from 'child_process';
+import { expect, Page, test } from '@playwright/test';
+import { startInstalledApp } from '../installed-utils';
+import { fileExists, TestUtils } from '../../utils';
+
+if (process.env.HOME === undefined) {
+  throw new Error('$HOME not set');
+}
+
+const AUTOSTART_PATH = path.join(process.env.HOME, '.config', 'autostart', 'mullvad-vpn.desktop');
+
+let page: Page;
+let util: TestUtils;
+
+test.beforeAll(async () => {
+  ({ page, util } = await startInstalledApp());
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test.describe('VPN Settings', () => {
+  test('Auto-connect setting', async () => {
+    // Navigate to the VPN settings view
+    await util.waitForNavigation(async () => await page.click('button[aria-label="Settings"]'));
+    await util.waitForNavigation(async () => await page.click('text=VPN settings'));
+
+    // Find the auto-connect toggle
+    const autoConnectToggle = page.getByText('Auto-connect').locator('..').getByRole('checkbox');
+
+    // Check initial state
+    const initialCliState = execSync('mullvad auto-connect get').toString().trim();
+    expect(initialCliState).toMatch(/off$/);
+    await expect(autoConnectToggle).toHaveAttribute('aria-checked', 'false')
+
+    // Toggle auto-connect
+    await autoConnectToggle.click();
+
+    // Verify the setting was applied correctly
+    await expect(autoConnectToggle).toHaveAttribute('aria-checked', 'true')
+    const newCliState = execSync('mullvad auto-connect get').toString().trim();
+    expect(newCliState).toMatch(/off$/);
+  });
+
+  test('Launch on startup setting', async () => {
+    // Find the auto-connect toggle
+    const launchOnStartupToggle =
+      page.getByText('Launch app on start-up').locator('..').getByRole('checkbox');
+
+    // Check initial state
+    const initialCliState = execSync('mullvad auto-connect get').toString().trim();
+    expect(initialCliState).toMatch(/off$/);
+    await expect(launchOnStartupToggle).toHaveAttribute('aria-checked', 'false')
+    expect(fileExists(AUTOSTART_PATH)).toBeFalsy();
+
+    // Toggle auto-connect
+    await launchOnStartupToggle.click();
+
+    // Verify the setting was applied correctly
+    await expect(launchOnStartupToggle).toHaveAttribute('aria-checked', 'true')
+    expect(fileExists(AUTOSTART_PATH)).toBeTruthy();
+    const newCliState = execSync('mullvad auto-connect get').toString().trim();
+    expect(newCliState).toMatch(/on$/);
+  });
+
+  test('LAN settings', async () => {
+    // Find the LAN toggle
+    const lanToggle = page.getByText('Local network sharing').locator('..').getByRole('checkbox');
+
+    // Check initial state
+    const initialCliState = execSync('mullvad lan get').toString().trim();
+    expect(initialCliState).toMatch(/block$/);
+    await expect(lanToggle).toHaveAttribute('aria-checked', 'false')
+
+    // Toggle LAN setting
+    await lanToggle.click();
+
+    // Verify the setting was applied correctly
+    await expect(lanToggle).toHaveAttribute('aria-checked', 'true')
+    const newState = execSync('mullvad lan get').toString().trim();
+    expect(newState).toMatch(/allow$/);
+  });
+});

--- a/gui/test/e2e/installed/state-dependent/settings.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/settings.spec.ts
@@ -1,9 +1,10 @@
-import path from 'path';
-import os from 'os';
-import { execSync } from 'child_process';
 import { expect, Page, test } from '@playwright/test';
-import { startInstalledApp } from '../installed-utils';
+import { execSync } from 'child_process';
+import os from 'os';
+import path from 'path';
+
 import { fileExists, TestUtils } from '../../utils';
+import { startInstalledApp } from '../installed-utils';
 
 function getAutoStartPath() {
   return path.join(os.homedir(), '.config', 'autostart', 'mullvad-vpn.desktop');
@@ -27,8 +28,8 @@ test.afterAll(async () => {
 test.describe('VPN Settings', () => {
   test('Auto-connect setting', async () => {
     // Navigate to the VPN settings view
-    await util.waitForNavigation(async () => await page.click('button[aria-label="Settings"]'));
-    await util.waitForNavigation(async () => await page.click('text=VPN settings'));
+    await util.waitForNavigation(() => page.click('button[aria-label="Settings"]'));
+    await util.waitForNavigation(() => page.click('text=VPN settings'));
 
     // Find the auto-connect toggle
     const autoConnectToggle = page.getByText('Auto-connect').locator('..').getByRole('checkbox');
@@ -36,26 +37,28 @@ test.describe('VPN Settings', () => {
     // Check initial state
     const initialCliState = execSync('mullvad auto-connect get').toString().trim();
     expect(initialCliState).toMatch(/off$/);
-    await expect(autoConnectToggle).toHaveAttribute('aria-checked', 'false')
+    await expect(autoConnectToggle).toHaveAttribute('aria-checked', 'false');
 
     // Toggle auto-connect
     await autoConnectToggle.click();
 
     // Verify the setting was applied correctly
-    await expect(autoConnectToggle).toHaveAttribute('aria-checked', 'true')
+    await expect(autoConnectToggle).toHaveAttribute('aria-checked', 'true');
     const newCliState = execSync('mullvad auto-connect get').toString().trim();
     expect(newCliState).toMatch(/off$/);
   });
 
   test('Launch on startup setting', async () => {
     // Find the launch on start-up toggle
-    const launchOnStartupToggle =
-      page.getByText('Launch app on start-up').locator('..').getByRole('checkbox');
+    const launchOnStartupToggle = page
+      .getByText('Launch app on start-up')
+      .locator('..')
+      .getByRole('checkbox');
 
     // Check initial state
     const initialCliState = execSync('mullvad auto-connect get').toString().trim();
     expect(initialCliState).toMatch(/off$/);
-    await expect(launchOnStartupToggle).toHaveAttribute('aria-checked', 'false')
+    await expect(launchOnStartupToggle).toHaveAttribute('aria-checked', 'false');
     if (process.platform === 'linux') {
       expect(autoStartPathExists()).toBeFalsy();
     }
@@ -64,7 +67,7 @@ test.describe('VPN Settings', () => {
     await launchOnStartupToggle.click();
 
     // Verify the setting was applied correctly
-    await expect(launchOnStartupToggle).toHaveAttribute('aria-checked', 'true')
+    await expect(launchOnStartupToggle).toHaveAttribute('aria-checked', 'true');
     if (process.platform === 'linux') {
       expect(autoStartPathExists()).toBeTruthy();
     }
@@ -87,13 +90,13 @@ test.describe('VPN Settings', () => {
     // Check initial state
     const initialCliState = execSync('mullvad lan get').toString().trim();
     expect(initialCliState).toMatch(/block$/);
-    await expect(lanToggle).toHaveAttribute('aria-checked', 'false')
+    await expect(lanToggle).toHaveAttribute('aria-checked', 'false');
 
     // Toggle LAN setting
     await lanToggle.click();
 
     // Verify the setting was applied correctly
-    await expect(lanToggle).toHaveAttribute('aria-checked', 'true')
+    await expect(lanToggle).toHaveAttribute('aria-checked', 'true');
     const newState = execSync('mullvad lan get').toString().trim();
     expect(newState).toMatch(/allow$/);
   });

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { Locator, Page, _electron as electron, ElectronApplication } from 'playwright';
+import { _electron as electron, ElectronApplication, Locator, Page } from 'playwright';
 
 export interface StartAppResponse {
   app: ElectronApplication;
@@ -124,12 +124,11 @@ export function escapeRegExp(regexp: string): string {
   return regexp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
-
 export function fileExists(filePath: string): boolean {
   try {
     fs.accessSync(filePath);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/gui/test/e2e/utils.ts
+++ b/gui/test/e2e/utils.ts
@@ -1,4 +1,5 @@
-import { _electron as electron, ElectronApplication, Locator, Page } from 'playwright';
+import fs from 'fs';
+import { Locator, Page, _electron as electron, ElectronApplication } from 'playwright';
 
 export interface StartAppResponse {
   app: ElectronApplication;
@@ -121,4 +122,14 @@ export function anyOf(...values: string[]): RegExp {
 
 export function escapeRegExp(regexp: string): string {
   return regexp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+
+export function fileExists(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -3409,6 +3409,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "chrono",
+ "dirs",
  "futures",
  "libc",
  "log",

--- a/test/scripts/ssh-setup.sh
+++ b/test/scripts/ssh-setup.sh
@@ -22,8 +22,9 @@ for file in test-runner connection-checker $APP_PACKAGE $PREVIOUS_APP $UI_RUNNER
     cp -f "$SCRIPT_DIR/$file" "$RUNNER_DIR"
 done
 
-# Unprivileged users need execute rights for connection checker
-chmod 551 "${RUNNER_DIR}/connection-checker"
+# Unprivileged users need execute rights for some executables
+chmod 775 "${RUNNER_DIR}/connection-checker"
+chmod 775 "${RUNNER_DIR}/$UI_RUNNER"
 
 chown -R root "$RUNNER_DIR/"
 

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -284,3 +284,11 @@ pub async fn test_obfuscation_settings_ui(_: TestContext, rpc: ServiceClient) ->
     assert!(ui_result.success());
     Ok(())
 }
+
+/// Test settings in the GUI
+#[test_function]
+pub async fn test_settings_ui(_: TestContext, rpc: ServiceClient) -> Result<(), Error> {
+    let ui_result = run_test(&rpc, &["settings.spec"]).await?;
+    assert!(ui_result.success());
+    Ok(())
+}

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+dirs = "5.0.1"
 futures = { workspace = true }
 tarpc = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Add settings e2e test that tests:
 - That the auto-connect and launch on start-up settings work as expected and together toggles the daemon auto-connect
 - That the Local network sharing toggle toggles the daemon setting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6776)
<!-- Reviewable:end -->
