### PR TITLE
Create accounts using partner API when available

### DIFF
--- a/ios/MullvadVPNUITests/AccountTests.swift
+++ b/ios/MullvadVPNUITests/AccountTests.swift
@@ -9,13 +9,6 @@
 import XCTest
 
 class AccountTests: LoggedOutUITestCase {
-    lazy var mullvadAPIWrapper: MullvadAPIWrapper = {
-        do {
-            // swiftlint:disable:next force_try
-            return try! MullvadAPIWrapper()
-        }
-    }()
-
     override func setUpWithError() throws {
         continueAfterFailure = false
 
@@ -33,7 +26,7 @@ class AccountTests: LoggedOutUITestCase {
     }
 
     func testDeleteAccount() throws {
-        let accountNumber = mullvadAPIWrapper.createAccount()
+        let accountNumber = createTemporaryAccountWithoutTime()
 
         LoginPage(app)
             .tapAccountNumberTextField()
@@ -99,7 +92,7 @@ class AccountTests: LoggedOutUITestCase {
 
     func testLoginToAccountWithTooManyDevices() throws {
         // Setup
-        let temporaryAccountNumber = mullvadAPIWrapper.createAccount()
+        let temporaryAccountNumber = createTemporaryAccountWithoutTime()
         mullvadAPIWrapper.addDevices(5, account: temporaryAccountNumber)
 
         // Teardown
@@ -133,7 +126,7 @@ class AccountTests: LoggedOutUITestCase {
     }
 
     func testLogOut() throws {
-        let newAccountNumber = mullvadAPIWrapper.createAccount()
+        let newAccountNumber = createTemporaryAccountWithoutTime()
         login(accountNumber: newAccountNumber)
         XCTAssertEqual(try mullvadAPIWrapper.getDevices(newAccountNumber).count, 1, "Account has one device")
 

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -42,7 +42,15 @@ class BaseUITestCase: XCTestCase {
         .infoDictionary?["IOSDevicePinCode"] as! String
     let attachAppLogsOnFailure = Bundle(for: BaseUITestCase.self)
         .infoDictionary?["AttachAppLogsOnFailure"] as! String == "1"
+    let partnerApiToken = Bundle(for: BaseUITestCase.self).infoDictionary?["PartnerApiToken"] as? String
     // swiftlint:enable force_cast
+
+    lazy var mullvadAPIWrapper: MullvadAPIWrapper = {
+        do {
+            // swiftlint:disable:next force_try
+            return try! MullvadAPIWrapper()
+        }
+    }()
 
     static func testDeviceIsIPad() -> Bool {
         if let testDeviceIsIPad = Bundle(for: BaseUITestCase.self).infoDictionary?["TestDeviceIsIPad"] as? String {
@@ -77,6 +85,16 @@ class BaseUITestCase: XCTestCase {
     func deleteTemporaryAccountWithTime(accountNumber: String) {
         if bundleHasTimeAccountNumber?.isEmpty == true {
             PartnerAPIClient().deleteAccount(accountNumber: accountNumber)
+        }
+    }
+
+    /// Create temporary account without time. Will be created using partner API if token is configured, else falling back to app API
+    func createTemporaryAccountWithoutTime() -> String {
+        if let partnerApiToken {
+            let partnerAPIClient = PartnerAPIClient()
+            return partnerAPIClient.createAccount()
+        } else {
+            return mullvadAPIWrapper.createAccount()
         }
     }
 

--- a/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
+++ b/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
@@ -86,14 +86,13 @@ class MullvadAPIWrapper {
 
     func createAccount() -> String {
         var accountNumber = String()
-        var requestError: Error?
         let requestCompletedExpectation = XCTestExpectation(description: "Create account request completed")
 
         throttle {
             do {
                 accountNumber = try self.mullvadAPI.createAccount()
             } catch {
-                requestError = MullvadAPIError.requestError
+                XCTFail("Failed to create account with error: \(error.localizedDescription)")
             }
 
             requestCompletedExpectation.fulfill()
@@ -101,20 +100,18 @@ class MullvadAPIWrapper {
 
         let waitResult = XCTWaiter().wait(for: [requestCompletedExpectation], timeout: throttleWaitTimeout)
         XCTAssertEqual(waitResult, .completed, "Create account request completed")
-        XCTAssertNil(requestError, "Create account error is nil")
 
         return accountNumber
     }
 
     func deleteAccount(_ accountNumber: String) {
-        var requestError: Error?
         let requestCompletedExpectation = XCTestExpectation(description: "Delete account request completed")
 
         throttle {
             do {
                 try self.mullvadAPI.delete(account: accountNumber)
             } catch {
-                requestError = MullvadAPIError.requestError
+                XCTFail("Failed to delete account with error: \(error.localizedDescription)")
             }
 
             requestCompletedExpectation.fulfill()
@@ -122,12 +119,10 @@ class MullvadAPIWrapper {
 
         let waitResult = XCTWaiter().wait(for: [requestCompletedExpectation], timeout: throttleWaitTimeout)
         XCTAssertEqual(waitResult, .completed, "Delete account request completed")
-        XCTAssertNil(requestError, "Delete account error is nil")
     }
 
     /// Add another device to specified account. A dummy WireGuard key will be generated.
     func addDevice(_ account: String) {
-        var addDeviceError: Error?
         let requestCompletedExpectation = XCTestExpectation(description: "Add device request completed")
 
         throttle {
@@ -136,7 +131,7 @@ class MullvadAPIWrapper {
             do {
                 try self.mullvadAPI.addDevice(forAccount: account, publicKey: devicePublicKey)
             } catch {
-                addDeviceError = MullvadAPIError.requestError
+                XCTFail("Failed to add device with error: \(error.localizedDescription)")
             }
 
             requestCompletedExpectation.fulfill()
@@ -144,7 +139,6 @@ class MullvadAPIWrapper {
 
         let waitResult = XCTWaiter().wait(for: [requestCompletedExpectation], timeout: throttleWaitTimeout)
         XCTAssertEqual(waitResult, .completed, "Add device request completed")
-        XCTAssertNil(addDeviceError, "Add device error is nil")
     }
 
     /// Add multiple devices to specified account. Dummy WireGuard keys will be generated.
@@ -157,7 +151,6 @@ class MullvadAPIWrapper {
 
     func getAccountExpiry(_ account: String) throws -> Date {
         var accountExpiryDate: Date = .distantPast
-        var requestError: Error?
         let requestCompletedExpectation = XCTestExpectation(description: "Get account expiry request completed")
 
         throttle {
@@ -165,7 +158,7 @@ class MullvadAPIWrapper {
                 let accountExpiryTimestamp = Double(try self.mullvadAPI.getExpiry(forAccount: account))
                 accountExpiryDate = Date(timeIntervalSince1970: accountExpiryTimestamp)
             } catch {
-                requestError = MullvadAPIError.requestError
+                XCTFail("Failed to get account expiry with error: \(error.localizedDescription)")
             }
 
             requestCompletedExpectation.fulfill()
@@ -173,21 +166,19 @@ class MullvadAPIWrapper {
 
         let waitResult = XCTWaiter().wait(for: [requestCompletedExpectation], timeout: throttleWaitTimeout)
         XCTAssertEqual(waitResult, .completed, "Get account expiry request completed")
-        XCTAssertNil(requestError, "Get account expiry error is nil")
 
         return accountExpiryDate
     }
 
     func getDevices(_ account: String) throws -> [Device] {
         var devices: [Device] = []
-        var requestError: Error?
         let requestCompletedExpectation = XCTestExpectation(description: "Get devices request completed")
 
         throttle {
             do {
                 devices = try self.mullvadAPI.listDevices(forAccount: account)
             } catch {
-                requestError = MullvadAPIError.requestError
+                XCTFail("Failed to get devices with error: \(error.localizedDescription)")
             }
 
             requestCompletedExpectation.fulfill()
@@ -195,7 +186,6 @@ class MullvadAPIWrapper {
 
         let waitResult = XCTWaiter.wait(for: [requestCompletedExpectation], timeout: throttleWaitTimeout)
         XCTAssertEqual(waitResult, .completed, "Get devices request completed")
-        XCTAssertNil(requestError, "Get devices error is nil")
 
         return devices
     }


### PR DESCRIPTION
End to end test runs on PR updates were hitting the app API rate limit because accounts were created too often from the office IP address. With the changes in this PR accounts will be created using partner API if a partner API token is available, else fall back to app API. Also fail messages have been improved.

The changes in this PR can be tested by running end to end tests, especially the tests under `AccountTests`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6788)
<!-- Reviewable:end -->
