### PR TITLE
Fix feature indicator sorting

### DIFF
--- a/gui/src/renderer/components/main-view/FeatureIndicators.tsx
+++ b/gui/src/renderer/components/main-view/FeatureIndicators.tsx
@@ -160,6 +160,8 @@ export default function FeatureIndicators(props: FeatureIndicatorsProps) {
     }, 0);
   });
 
+  const sortedIndicators = [...featureIndicators.current].sort((a, b) => a - b);
+
   return (
     <StyledAccordion expanded={featureIndicatorsVisible && featureIndicators.current.length > 0}>
       <StyledFeatureIndicatorsContainer onClick={props.expandIsland} $expanded={props.expanded}>
@@ -170,7 +172,7 @@ export default function FeatureIndicators(props: FeatureIndicatorsProps) {
           <StyledFeatureIndicatorsWrapper
             ref={featureIndicatorsContainerRef}
             $expanded={props.expanded}>
-            {featureIndicators.current.sort().map((indicator) => (
+            {sortedIndicators.map((indicator) => (
               <StyledFeatureIndicatorLabel
                 key={indicator.toString()}
                 data-testid="feature-indicator"


### PR DESCRIPTION
Currently feature indicators are presented sorted alphabetically (1, 11, 2 etc.). This PR changes the sorting to be numerically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6790)
<!-- Reviewable:end -->
