### PR TITLE
Remove config changes handling from manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,7 +37,6 @@
             since after that it has been patched on a OS level.
         -->
         <activity android:name="net.mullvad.mullvadvpn.ui.MainActivity"
-                  android:configChanges="orientation|screenSize|screenLayout"
                   android:exported="true"
                   android:launchMode="singleInstance"
                   android:screenOrientation="fullUser"


### PR DESCRIPTION
The AndroidManifest.xml file contains the line ```android:configChanges="orientation|screenSize|screenLayout``` which tells the system to not recreate the UI when for example rotating the screen. This should be removed as it causes issues where screens that have UI elements that do layout calculations based on the screen size are not re-run when the screen is rotated. The default Android behavior of recreating the Activity/UI on config changes should be used, so this line should be removed.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6794)
<!-- Reviewable:end -->
