### PR TITLE
Handle path-to-regexp and node-gettext-vulnerabilities

### DIFF
--- a/gui/osv-scanner.toml
+++ b/gui/osv-scanner.toml
@@ -23,3 +23,9 @@ reason = "This package is only used to match paths from either us or trusted lib
 id = "CVE-2024-4067" # GHSA-952p-6rrq-rcjv
 ignoreUntil = 2024-11-23
 reason = "This is just a dev dependency, and we don't have untrusted input to micromatch there"
+
+# node-gettext: Prototype Pullution via the addTranslations function
+[[IgnoredVulns]]
+id = "CVE-2024-4067" # GHSA-g974-hxvm-x689
+ignoreUntil = 2024-10-17
+reason = "There is no fix yet, in the meantime we'll have to verify translations thoroughly"

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -10031,9 +10031,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -21639,9 +21639,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "requires": {
         "isarray": "0.0.1"
       }


### PR DESCRIPTION
This PR updates `path-to-regexp` to `1.9.0` due to [GHSA-9wv6-86v2-598j](https://osv.dev/vulnerability/GHSA-9wv6-86v2-598j). We're not affected by this since we control the input.

I've also suppressed [GHSA-g974-hxvm-x689](https://osv.dev/vulnerability/GHSA-g974-hxvm-x689) due to there being no fix available. We're vulnerable to this since we have external translators that produce the input to `addTranslations()`. We will inspect translations thoroughly until this is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6797)
<!-- Reviewable:end -->
