### PR TITLE
Update node-gettext CVE id in gui/osv-scanner.toml

### DIFF
--- a/gui/osv-scanner.toml
+++ b/gui/osv-scanner.toml
@@ -26,6 +26,6 @@ reason = "This is just a dev dependency, and we don't have untrusted input to mi
 
 # node-gettext: Prototype Pullution via the addTranslations function
 [[IgnoredVulns]]
-id = "CVE-2024-4067" # GHSA-g974-hxvm-x689
+id = "CVE-2024-21528" # GHSA-g974-hxvm-x689
 ignoreUntil = 2024-10-17
 reason = "There is no fix yet, in the meantime we'll have to verify translations thoroughly"


### PR DESCRIPTION
In https://github.com/mullvad/mullvadvpn-app/pull/6797 I forgot to set the correct CVE id, this PR fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6798)
<!-- Reviewable:end -->
