### PR TITLE
Don't run the *scheduled* OSV scanner on pushes

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -4,8 +4,6 @@ name: OSV-Scanner Scheduled Scan
 on:
   schedule:
     - cron: "30 7 * * MON-FRI"
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
This job should only run on a daily schedule. There is a separate workflow for running on PRs.

The reason for disabling it is that it currently runs on every merge, but even if it fails, the PR owner is not notified anyway. And even if it does, it might not be related to their PR. The separate PR workflow should catch newly introduced CVE issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6799)
<!-- Reviewable:end -->
