### PR TITLE
Add counter and 'all' switch to DNS content blockers

### DIFF
--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -179,6 +179,7 @@ public enum AccessibilityIdentifier: String {
     case wireGuardPort
 
     // Custom DNS
+    case blockAll
     case blockAdvertising
     case blockTracking
     case blockMalware

--- a/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
@@ -59,6 +59,7 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
         }
     }
 
+    private var subCellLeadingIndentation: CGFloat = 0
     private let buttonWidth: CGFloat = 24
     private let infoButton: UIButton = {
         let button = UIButton(type: .custom)
@@ -84,6 +85,8 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
 
         infoButton.isHidden = true
         infoButton.addTarget(self, action: #selector(handleInfoButton(_:)), for: .touchUpInside)
+
+        subCellLeadingIndentation = contentView.layoutMargins.left + UIMetrics.TableView.cellIndentationWidth
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = UIFont.systemFont(ofSize: 17)
@@ -149,7 +152,7 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
     }
 
     func applySubCellStyling() {
-        contentView.layoutMargins.left += UIMetrics.TableView.cellIndentationWidth
+        contentView.layoutMargins.left = subCellLeadingIndentation
         backgroundView?.backgroundColor = UIColor.Cell.Background.indentationLevelOne
     }
 

--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
@@ -46,7 +46,7 @@ final class CustomDNSCellFactory: CellFactoryProtocol {
         cell.titleLabel.text = title
         cell.accessibilityIdentifier = preference.accessibilityIdentifier
         cell.applySubCellStyling()
-        cell.setOn(toggleSetting, animated: false)
+        cell.setOn(toggleSetting, animated: true)
         cell.action = { [weak self] isOn in
             self?.delegate?.didChangeState(
                 for: preference,
@@ -58,6 +58,21 @@ final class CustomDNSCellFactory: CellFactoryProtocol {
     // swiftlint:disable:next function_body_length
     func configureCell(_ cell: UITableViewCell, item: CustomDNSDataSource.Item, indexPath: IndexPath) {
         switch item {
+        case .blockAll:
+            let localizedString = NSLocalizedString(
+                "BLOCK_ALL_CELL_LABEL",
+                tableName: "VPNSettings",
+                value: "All",
+                comment: ""
+            )
+
+            configure(
+                cell,
+                toggleSetting: viewModel.blockAll,
+                title: localizedString,
+                for: .blockAll
+            )
+
         case .blockAdvertising:
             let localizedString = NSLocalizedString(
                 "BLOCK_ADS_CELL_LABEL",

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
@@ -128,6 +128,7 @@ extension VPNSettingsViewController: VPNSettingsDataSourceDelegate {
         interactor.evaluateDaitaSettingsCompatibility(settings)
     }
 
+    // swiftlint:disable:next function_body_length
     func showPrompt(
         for item: VPNSettingsPromptAlertItem,
         onSave: @escaping () -> Void,


### PR DESCRIPTION
Currently there is no way to know that you have content blockers enabled unless you expand the tree.

This first iteration would have an "All" switch that activates all toggles - and the number of activated toggles would be shown at the top level. 

Toggling "All" would activate all the other toggles. But if the user then deactivates a toggle, "All" would have to be deactivated as well since all of them are not activated. Only by actively deactivating "All" does the user deactivate all the other toggles.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6800)
<!-- Reviewable:end -->
