### PR TITLE
Only allow toggling connection island when connected/connecting

### DIFF
--- a/gui/src/renderer/components/main-view/ConnectionPanel.tsx
+++ b/gui/src/renderer/components/main-view/ConnectionPanel.tsx
@@ -68,7 +68,7 @@ const StyledConnectionStatusContainer = styled.div<{
 }));
 
 export default function ConnectionPanel() {
-  const [expanded, expandImpl, collapse, toggleExpanded] = useBoolean();
+  const [expanded, expandImpl, collapse, toggleExpandedImpl] = useBoolean();
   const tunnelState = useSelector((state) => state.connection.status);
 
   const allowExpand = tunnelState.state === 'connected' || tunnelState.state === 'connecting';
@@ -78,6 +78,12 @@ export default function ConnectionPanel() {
       expandImpl();
     }
   }, [allowExpand, expandImpl]);
+
+  const toggleExpanded = useCallback(() => {
+    if (allowExpand) {
+      toggleExpandedImpl();
+    }
+  }, [allowExpand, toggleExpandedImpl]);
 
   const hasFeatureIndicators =
     allowExpand &&


### PR DESCRIPTION
This fixes a bug where `toggleExpanded` doesn't check if the connection panel can be expanded. This was previously only done for `expand`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6803)
<!-- Reviewable:end -->
