### PR TITLE
Install `cbindgen` in `clippy` Android GHA

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -99,6 +99,10 @@ jobs:
           git config --global --add safe.directory '*'
           git submodule update --init --recursive --depth=1 wireguard-go-rs
 
+      # Temporary fix to address maybenot.h build issues.
+      - name: Install cbindgen
+        run: cargo install --force cbindgen --version "0.26.0"
+
       - name: Clippy check
         env:
           RUSTFLAGS: --deny warnings


### PR DESCRIPTION
Another GHA where `cbindgen` was missing :sweat_smile: 

Notcied due to this run failing: https://github.com/mullvad/mullvadvpn-app/actions/runs/10916749645/job/30298762844?pr=6806

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6808)
<!-- Reviewable:end -->
