### PR TITLE
Ignore GO-2024-3105, GO-2024-3107 and GO-2024-3106

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -1,0 +1,18 @@
+
+# Stack exhaustion in Decoder.Decode in encoding/gob
+[[IgnoredVulns]]
+id = "CVE-2024-34156" # GO-2024-3106
+ignoreUntil = 2024-12-18
+reason = "wireguard-go does not use the affected code"
+
+# Stack exhaustion in Parse in go/build/constraint
+[[IgnoredVulns]]
+id = "CVE-2024-34158" # GO-2024-3107
+ignoreUntil = 2024-12-18
+reason = "wireguard-go does not use the affected code"
+
+# Stack exhaustion in all Parse functions in go/parser
+[[IgnoredVulns]]
+id = "CVE-2024-34155" # GO-2024-3105
+ignoreUntil = 2024-12-18
+reason = "wireguard-go does not use the affected code"


### PR DESCRIPTION
As far as I can tell, wireguard-go does not use any of affected code. The affected code is mostly just parsing of golang code anyway, which it makes no sense that wiregurad-go would use internally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6809)
<!-- Reviewable:end -->
