### PR TITLE
Add cbindgen to the android build container

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -111,4 +111,11 @@ RUN patch -p1 -f -N -r- -d /usr/local/go < /tmp/goruntime-boottime-over-monotoni
 # Add rust targets
 RUN rustup target add x86_64-linux-android i686-linux-android aarch64-linux-android armv7-linux-androideabi
 
+# Install cbindgen to address maybenot.h (checked in) sometimes needing to be
+# re-generated due to how `make` looks at last-modifications while git neither
+# stores nor consistently sets modification metadata on file checkout.
+# This is an intermediate solution that will be further improved as part of
+# issue: DROID-1328.
+RUN cargo install --force cbindgen --version "0.26.0" && rm -rf ~/.cargo/registry
+
 WORKDIR /build


### PR DESCRIPTION
This PR aims to add `cbindgen` as part of the Android build container. This is an improvement to how it was added in multiple build scripts and workflows in #6684 as well as #6808 and #6757 (which will be partially reverted after the new container image has been published). We also aim to improve this further as part of our internal issue: DROID-1328.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6811)
<!-- Reviewable:end -->
