### PR TITLE
Make the packet tunnel enter error state when failing device check

### DIFF
--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
@@ -241,7 +241,7 @@ class DeviceCheckOperationTests: XCTestCase {
         waitForExpectations(timeout: .UnitTest.timeout)
     }
 
-    func testShouldReportFailedKeyRotataionAttempt() {
+    func testShouldReportFailedKeyRotationAttempt() {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()

--- a/ios/PacketTunnel/DeviceCheck/DeviceCheckOperation.swift
+++ b/ios/PacketTunnel/DeviceCheck/DeviceCheckOperation.swift
@@ -278,14 +278,14 @@ final class DeviceCheckOperation: ResultOperation<DeviceCheck> {
 }
 
 /// An error used internally by `DeviceCheckOperation`.
-private enum DeviceCheckError: LocalizedError, Equatable {
+public enum DeviceCheckError: LocalizedError, Equatable {
     /// Device is no longer logged in.
     case invalidDeviceState
 
     /// Main process has likely performed key rotation at the same time when packet tunnel was doing so.
     case keyRotationRace
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .invalidDeviceState:
             return "Cannot complete device check because device is no longer logged in."

--- a/ios/PacketTunnel/PacketTunnelProvider/DeviceChecker.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/DeviceChecker.swift
@@ -35,7 +35,7 @@ final class DeviceChecker {
         key.
      4. Rotate WireGuard key on key mismatch.
      */
-    func start(rotateKeyOnMismatch: Bool) async throws -> DeviceCheck {
+    func start(rotateKeyOnMismatch: Bool) async -> Result<DeviceCheck, Error> {
         let checkOperation = DeviceCheckOperation(
             dispatchQueue: dispatchQueue,
             remoteSevice: DeviceCheckRemoteService(accountsProxy: accountsProxy, devicesProxy: devicesProxy),
@@ -43,10 +43,10 @@ final class DeviceChecker {
             rotateImmediatelyOnKeyMismatch: rotateKeyOnMismatch
         )
 
-        return try await withTaskCancellationHandler {
-            return try await withCheckedThrowingContinuation { continuation in
+        return await withTaskCancellationHandler {
+            return await withCheckedContinuation { continuation in
                 checkOperation.completionHandler = { result in
-                    continuation.resume(with: result)
+                    continuation.resume(with: .success(result))
                 }
                 operationQueue.addOperation(checkOperation)
             }

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -289,26 +289,40 @@ extension PacketTunnelProvider {
 extension PacketTunnelProvider {
     private func startDeviceCheck(rotateKeyOnMismatch: Bool = false) {
         Task {
-            do {
-                try await startDeviceCheckInner(rotateKeyOnMismatch: rotateKeyOnMismatch)
-            } catch {
-                providerLogger.error(error: error, message: "Failed to perform device check.")
-            }
+            await startDeviceCheckInner(rotateKeyOnMismatch: rotateKeyOnMismatch)
         }
     }
 
-    private func startDeviceCheckInner(rotateKeyOnMismatch: Bool) async throws {
-        let result = try await deviceChecker.start(rotateKeyOnMismatch: rotateKeyOnMismatch)
+    private func startDeviceCheckInner(rotateKeyOnMismatch: Bool) async {
+        let result = await deviceChecker.start(rotateKeyOnMismatch: rotateKeyOnMismatch)
 
-        if let blockedStateReason = result.blockedStateReason {
-            actor.setErrorState(reason: blockedStateReason)
-        }
+        switch result {
+        case let .failure(error):
+            switch error {
+            case is DeviceCheckError:
+                providerLogger.error("\(error.localizedDescription) Forcing a log out")
+                actor.setErrorState(reason: .deviceLoggedOut)
+            default:
+                providerLogger
+                    .error(
+                        "Entering blocked state because device check encountered a generic error: \(error.localizedDescription)"
+                    )
+                actor.setErrorState(reason: .unknown)
+            }
 
-        switch result.keyRotationStatus {
-        case let .attempted(date), let .succeeded(date):
-            actor.notifyKeyRotation(date: date)
-        case .noAction:
-            break
+        case let .success(keyRotationResult):
+            if let blockedStateReason = keyRotationResult.blockedStateReason {
+                providerLogger.error("Entering blocked state after unsuccessful device check: \(blockedStateReason)")
+                actor.setErrorState(reason: blockedStateReason)
+                return
+            }
+
+            switch keyRotationResult.keyRotationStatus {
+            case let .attempted(date), let .succeeded(date):
+                actor.notifyKeyRotation(date: date)
+            case .noAction:
+                break
+            }
         }
     }
 }


### PR DESCRIPTION
This PR makes sure that when a device check error happens on each connection of the Packet Tunnel,  we do enter the error state instead of silently logging the issue and doing nothing.

When this happens, the users will be told via the in app banner that they will have to log out and log in again because their device's integrity couldn't be checked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6813)
<!-- Reviewable:end -->
