### PR TITLE
Fix `mullvad status -v` not printing udp2tcp port and transport protocol

### DIFF
--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -229,16 +229,14 @@ fn format_relay_connection(
     location: Option<&GeoIpLocation>,
     verbose: bool,
 ) -> String {
-    let exit_endpoint = format_endpoint(
-        location.and_then(|l| l.hostname.as_deref()),
-        &endpoint.endpoint,
-        verbose,
-    );
-
     let first_hop = endpoint.entry_endpoint.as_ref().map(|entry| {
         let endpoint = format_endpoint(
             location.and_then(|l| l.entry_hostname.as_deref()),
-            entry,
+            // Check if we *actually* want to print an obfuscator endpoint ..
+            match endpoint.obfuscation {
+                Some(ref obfuscation) => &obfuscation.endpoint,
+                _ => entry,
+            },
             verbose,
         );
         format!(" via {endpoint}")
@@ -253,6 +251,17 @@ fn format_relay_connection(
 
         format!(" via {proxy_endpoint}")
     });
+
+    let exit_endpoint = format_endpoint(
+        location.and_then(|l| l.hostname.as_deref()),
+        // Check if we *actually* want to print an obfuscator endpoint ..
+        // The obfuscator information should be printed for the exit relay if multihop is disabled
+        match (endpoint.obfuscation, &first_hop) {
+            (Some(ref obfuscation), None) => &obfuscation.endpoint,
+            _ => &endpoint.endpoint,
+        },
+        verbose,
+    );
 
     format!(
         "{exit_endpoint}{first_hop}{bridge}",


### PR DESCRIPTION
Fixes a regression in the CLI since last stable release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6815)
<!-- Reviewable:end -->
