### PR TITLE
Lower MTU during ephemeral peer negotiation

### DIFF
--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -24,6 +24,8 @@ classic-mceliece-rust = { version = "2.0.0", features = [
 ] }
 pqc_kyber = { version = "0.4.0", features = ["std", "kyber1024", "zeroize"] }
 zeroize = "1.5.7"
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -5,8 +5,6 @@ use std::net::SocketAddr;
 #[cfg(not(target_os = "ios"))]
 use std::net::{IpAddr, Ipv4Addr};
 use talpid_types::net::wireguard::{PresharedKey, PublicKey};
-#[cfg(not(target_os = "ios"))]
-use tokio::net::TcpSocket;
 use tonic::transport::Channel;
 #[cfg(not(target_os = "ios"))]
 use tonic::transport::Endpoint;
@@ -16,20 +14,13 @@ use zeroize::Zeroize;
 
 mod classic_mceliece;
 mod kyber;
+#[cfg(not(target_os = "ios"))]
+mod socket;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 mod proto {
     tonic::include_proto!("ephemeralpeer");
 }
-
-#[cfg(not(any(target_os = "windows", target_os = "ios")))]
-mod sys {
-    pub use libc::{setsockopt, socklen_t, IPPROTO_TCP, TCP_MAXSEG};
-    pub use std::os::fd::{AsRawFd, RawFd};
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "ios")))]
-use sys::*;
 
 #[derive(Debug)]
 pub enum Error {
@@ -92,14 +83,6 @@ pub type RelayConfigService = proto::ephemeral_peer_client::EphemeralPeerClient<
 
 /// Port used by the tunnel config service.
 pub const CONFIG_SERVICE_PORT: u16 = 1337;
-
-/// MTU to set on the tunnel config client socket. We want a low value to prevent fragmentation.
-/// Especially on Android, we've found that the real MTU is often lower than the default MTU, and
-/// we cannot lower it further. This causes the outer packets to be dropped. Also, MTU detection
-/// will likely occur after the PQ handshake, so we cannot assume that the MTU is already
-/// correctly configured.
-#[cfg(not(any(target_os = "windows", target_os = "ios")))]
-const CONFIG_CLIENT_MTU: u16 = 576;
 
 pub struct EphemeralPeer {
     pub psk: Option<PresharedKey>,
@@ -239,11 +222,7 @@ async fn new_client(addr: Ipv4Addr) -> Result<RelayConfigService, Error> {
 
     let conn = endpoint
         .connect_with_connector(service_fn(move |_| async move {
-            let sock = TcpSocket::new_v4()?;
-
-            #[cfg(not(target_os = "windows"))]
-            try_set_tcp_sock_mtu(&addr, sock.as_raw_fd(), CONFIG_CLIENT_MTU);
-
+            let sock = socket::TcpSocket::new()?;
             sock.connect(SocketAddr::new(addr, CONFIG_SERVICE_PORT))
                 .await
         }))
@@ -251,37 +230,4 @@ async fn new_client(addr: Ipv4Addr) -> Result<RelayConfigService, Error> {
         .map_err(Error::GrpcConnectError)?;
 
     Ok(RelayConfigService::new(conn))
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "ios")))]
-fn try_set_tcp_sock_mtu(dest: &IpAddr, sock: RawFd, mut mtu: u16) {
-    const IPV4_HEADER_SIZE: u16 = 20;
-    const IPV6_HEADER_SIZE: u16 = 40;
-    const MAX_TCP_HEADER_SIZE: u16 = 60;
-
-    if dest.is_ipv4() {
-        mtu = mtu.saturating_sub(IPV4_HEADER_SIZE);
-    } else {
-        mtu = mtu.saturating_sub(IPV6_HEADER_SIZE);
-    }
-
-    let mss = u32::from(mtu.saturating_sub(MAX_TCP_HEADER_SIZE));
-
-    log::debug!("Config client socket MSS: {mss}");
-
-    let result = unsafe {
-        setsockopt(
-            sock,
-            IPPROTO_TCP,
-            TCP_MAXSEG,
-            &mss as *const _ as _,
-            socklen_t::try_from(std::mem::size_of_val(&mss)).unwrap(),
-        )
-    };
-    if result != 0 {
-        log::error!(
-            "Failed to set MSS on config client socket: {}",
-            std::io::Error::last_os_error()
-        );
-    }
 }

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -12,15 +12,13 @@ mod sys {
 
     pub use libc::{setsockopt, socklen_t, IPPROTO_TCP, TCP_MAXSEG};
     pub use std::os::fd::{AsRawFd, RawFd};
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
     /// MTU to set on the tunnel config client socket. We want a low value to prevent fragmentation.
     /// Especially on Android, we've found that the real MTU is often lower than the default MTU, and
     /// we cannot lower it further. This causes the outer packets to be dropped. Also, MTU detection
     /// will likely occur after the PQ handshake, so we cannot assume that the MTU is already
     /// correctly configured.
+    /// This is set to the lowest possible IPv4 MTU.
     const CONFIG_CLIENT_MTU: u16 = 576;
 
     pub struct TcpSocket {

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -1,0 +1,92 @@
+//! A TCP stream with a low MSS set. This prevents incorrectly configured MTU from causing
+//! fragmentation/packet loss. This is only supported on non-Windows targets.
+
+use std::io;
+use std::net::SocketAddr;
+use tokio::net::TcpSocket as StdTcpSocket;
+use tokio::net::TcpStream;
+
+#[cfg(unix)]
+mod sys {
+    use super::*;
+
+    pub use libc::{setsockopt, socklen_t, IPPROTO_TCP, TCP_MAXSEG};
+    pub use std::os::fd::{AsRawFd, RawFd};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+    /// MTU to set on the tunnel config client socket. We want a low value to prevent fragmentation.
+    /// Especially on Android, we've found that the real MTU is often lower than the default MTU, and
+    /// we cannot lower it further. This causes the outer packets to be dropped. Also, MTU detection
+    /// will likely occur after the PQ handshake, so we cannot assume that the MTU is already
+    /// correctly configured.
+    const CONFIG_CLIENT_MTU: u16 = 576;
+
+    pub struct TcpSocket {
+        socket: StdTcpSocket,
+    }
+
+    impl TcpSocket {
+        pub fn new() -> io::Result<Self> {
+            let socket = StdTcpSocket::new_v4()?;
+            try_set_tcp_sock_mtu(socket.as_raw_fd());
+            Ok(Self { socket })
+        }
+
+        pub async fn connect(self, addr: SocketAddr) -> io::Result<TcpStream> {
+            self.socket.connect(addr).await
+        }
+    }
+
+    fn try_set_tcp_sock_mtu(sock: RawFd) {
+        let mss = desired_mss();
+        log::debug!("Tunnel config TCP socket MSS: {mss}");
+
+        let result = unsafe {
+            setsockopt(
+                sock,
+                IPPROTO_TCP,
+                TCP_MAXSEG,
+                &mss as *const _ as _,
+                socklen_t::try_from(std::mem::size_of_val(&mss)).unwrap(),
+            )
+        };
+        if result != 0 {
+            log::error!(
+                "Failed to set MSS on tunnel config TCP socket: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    const fn desired_mss() -> u32 {
+        const IPV4_HEADER_SIZE: u16 = 20;
+        const MAX_TCP_HEADER_SIZE: u16 = 60;
+        let mtu = CONFIG_CLIENT_MTU.saturating_sub(IPV4_HEADER_SIZE);
+        mtu.saturating_sub(MAX_TCP_HEADER_SIZE) as u32
+    }
+}
+
+#[cfg(windows)]
+mod sys {
+    use super::*;
+
+    pub struct TcpSocket {
+        socket: StdTcpSocket,
+    }
+
+    impl TcpSocket {
+        pub fn new() -> io::Result<Self> {
+            Ok(Self {
+                socket: StdTcpSocket::new_v4()?,
+            })
+        }
+
+        pub async fn connect(self, addr: SocketAddr) -> io::Result<TcpStream> {
+            self.socket.connect(addr).await
+        }
+    }
+}
+
+pub use sys::*;

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -16,7 +16,6 @@ futures = "0.3.15"
 hex = "0.4"
 ipnetwork = { workspace = true }
 once_cell = { workspace = true }
-libc = "0.2.150"
 log = { workspace = true }
 parking_lot = "0.12.0"
 talpid-routing = { path = "../talpid-routing" }
@@ -44,6 +43,7 @@ tokio-stream = { version = "0.1", features = ["io-util"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
+libc = "0.2.150"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 talpid-net = { path = "../talpid-net" }

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -1,0 +1,244 @@
+//! This module takes care of obtaining ephemeral peers, updating the WireGuard configuration and
+//! restarting obfuscation and WG tunnels when necessary.
+
+use super::{config::Config, obfuscation::ObfuscatorHandle, CloseMsg, Error, Tunnel};
+#[cfg(target_os = "android")]
+use std::sync::Mutex;
+use std::{
+    net::IpAddr,
+    sync::{mpsc as sync_mpsc, Arc},
+    time::Duration,
+};
+#[cfg(target_os = "android")]
+use talpid_tunnel::tun_provider::TunProvider;
+
+use ipnetwork::IpNetwork;
+use talpid_types::net::wireguard::{PresharedKey, PrivateKey, PublicKey};
+use tokio::sync::Mutex as AsyncMutex;
+
+const INITIAL_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(8);
+const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(48);
+const PSK_EXCHANGE_TIMEOUT_MULTIPLIER: u32 = 2;
+
+#[cfg(windows)]
+pub async fn config_ephemeral_peers(
+    tunnel: &Arc<AsyncMutex<Option<Box<dyn Tunnel>>>>,
+    config: &mut Config,
+    retry_attempt: u32,
+    obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
+    close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+) -> std::result::Result<(), CloseMsg> {
+    let iface_name = {
+        let tunnel = tunnel.lock().await;
+        let tunnel = tunnel.as_ref().unwrap();
+        tunnel.get_interface_name()
+    };
+
+    log::trace!("Temporarily lowering tunnel MTU before ephemeral peer config");
+    try_set_ipv4_mtu(&iface_name, talpid_tunnel::MIN_IPV4_MTU);
+
+    config_ephemeral_peers_inner(tunnel, config, retry_attempt, obfuscator, close_obfs_sender)
+        .await?;
+
+    log::trace!("Resetting tunnel MTU");
+    try_set_ipv4_mtu(&iface_name, config.mtu);
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn try_set_ipv4_mtu(alias: &str, mtu: u16) {
+    use talpid_windows::net::*;
+    match luid_from_alias(alias) {
+        Ok(luid) => {
+            if let Err(error) = set_mtu(u32::from(mtu), luid, AddressFamily::Ipv4) {
+                log::error!("Failed to set tunnel interface MTU: {error}");
+            }
+        }
+        Err(error) => {
+            log::error!("Failed to obtain tunnel interface LUID: {error}")
+        }
+    }
+}
+
+#[cfg(not(windows))]
+pub async fn config_ephemeral_peers(
+    tunnel: &Arc<AsyncMutex<Option<Box<dyn Tunnel>>>>,
+    config: &mut Config,
+    retry_attempt: u32,
+    obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
+    close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+    #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
+) -> std::result::Result<(), CloseMsg> {
+    config_ephemeral_peers_inner(
+        tunnel,
+        config,
+        retry_attempt,
+        obfuscator,
+        close_obfs_sender,
+        #[cfg(target_os = "android")]
+        tun_provider,
+    )
+    .await
+}
+
+async fn config_ephemeral_peers_inner(
+    tunnel: &Arc<AsyncMutex<Option<Box<dyn Tunnel>>>>,
+    config: &mut Config,
+    retry_attempt: u32,
+    obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
+    close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+    #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
+) -> std::result::Result<(), CloseMsg> {
+    let ephemeral_private_key = PrivateKey::new_from_random();
+    let close_obfs_sender = close_obfs_sender.clone();
+
+    let exit_should_have_daita = config.daita && !config.is_multihop();
+    let exit_psk = request_ephemeral_peer(
+        retry_attempt,
+        config,
+        ephemeral_private_key.public_key(),
+        config.quantum_resistant,
+        exit_should_have_daita,
+    )
+    .await?;
+
+    log::debug!("Retrieved ephemeral peer");
+
+    if config.is_multihop() {
+        // Set up tunnel to lead to entry
+        let mut entry_tun_config = config.clone();
+        entry_tun_config
+            .entry_peer
+            .allowed_ips
+            .push(IpNetwork::new(IpAddr::V4(config.ipv4_gateway), 32).unwrap());
+
+        let close_obfs_sender = close_obfs_sender.clone();
+        let entry_config = reconfigure_tunnel(
+            tunnel,
+            entry_tun_config,
+            obfuscator.clone(),
+            close_obfs_sender,
+            #[cfg(target_os = "android")]
+            &tun_provider,
+        )
+        .await?;
+        let entry_psk = request_ephemeral_peer(
+            retry_attempt,
+            &entry_config,
+            ephemeral_private_key.public_key(),
+            config.quantum_resistant,
+            config.daita,
+        )
+        .await?;
+        log::debug!("Successfully exchanged PSK with entry peer");
+
+        config.entry_peer.psk = entry_psk;
+    }
+
+    config.exit_peer_mut().psk = exit_psk;
+    #[cfg(daita)]
+    if config.daita {
+        log::trace!("Enabling constant packet size for entry peer");
+        config.entry_peer.constant_packet_size = true;
+    }
+
+    config.tunnel.private_key = ephemeral_private_key;
+
+    *config = reconfigure_tunnel(
+        tunnel,
+        config.clone(),
+        obfuscator,
+        close_obfs_sender,
+        #[cfg(target_os = "android")]
+        &tun_provider,
+    )
+    .await?;
+
+    #[cfg(daita)]
+    if config.daita {
+        // Start local DAITA machines
+        let mut tunnel = tunnel.lock().await;
+        if let Some(tunnel) = tunnel.as_mut() {
+            tunnel
+                .start_daita()
+                .map_err(Error::TunnelError)
+                .map_err(CloseMsg::SetupError)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Reconfigures the tunnel to use the provided config while potentially modifying the config
+/// and restarting the obfuscation provider. Returns the new config used by the new tunnel.
+async fn reconfigure_tunnel(
+    tunnel: &Arc<AsyncMutex<Option<Box<dyn Tunnel>>>>,
+    mut config: Config,
+    obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
+    close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+    #[cfg(target_os = "android")] tun_provider: &Arc<Mutex<TunProvider>>,
+) -> std::result::Result<Config, CloseMsg> {
+    let mut obfs_guard = obfuscator.lock().await;
+    if let Some(obfuscator_handle) = obfs_guard.take() {
+        obfuscator_handle.abort();
+        *obfs_guard = super::obfuscation::apply_obfuscation_config(
+            &mut config,
+            close_obfs_sender,
+            #[cfg(target_os = "android")]
+            tun_provider.clone(),
+        )
+        .await
+        .map_err(CloseMsg::ObfuscatorFailed)?;
+    }
+
+    let mut tunnel = tunnel.lock().await;
+
+    let set_config_future = tunnel
+        .as_mut()
+        .map(|tunnel| tunnel.set_config(config.clone()));
+
+    if let Some(f) = set_config_future {
+        f.await
+            .map_err(Error::TunnelError)
+            .map_err(CloseMsg::SetupError)?;
+    }
+
+    Ok(config)
+}
+
+async fn request_ephemeral_peer(
+    retry_attempt: u32,
+    config: &Config,
+    wg_psk_pubkey: PublicKey,
+    enable_pq: bool,
+    enable_daita: bool,
+) -> std::result::Result<Option<PresharedKey>, CloseMsg> {
+    log::debug!("Requesting ephemeral peer");
+
+    let timeout = std::cmp::min(
+        MAX_PSK_EXCHANGE_TIMEOUT,
+        INITIAL_PSK_EXCHANGE_TIMEOUT
+            .saturating_mul(PSK_EXCHANGE_TIMEOUT_MULTIPLIER.saturating_pow(retry_attempt)),
+    );
+
+    let ephemeral = tokio::time::timeout(
+        timeout,
+        talpid_tunnel_config_client::request_ephemeral_peer(
+            config.ipv4_gateway,
+            config.tunnel.private_key.public_key(),
+            wg_psk_pubkey,
+            enable_pq,
+            enable_daita,
+        ),
+    )
+    .await
+    .map_err(|_timeout_err| {
+        log::warn!("Timeout while negotiating ephemeral peer");
+        CloseMsg::EphemeralPeerNegotiationTimeout
+    })?
+    .map_err(Error::EphemeralPeerNegotiationError)
+    .map_err(CloseMsg::SetupError)?;
+
+    Ok(ephemeral.psk)
+}

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -17,7 +17,6 @@ use std::{
     path::Path,
     pin::Pin,
     sync::{mpsc as sync_mpsc, Arc, Mutex},
-    time::Duration,
 };
 #[cfg(target_os = "linux")]
 use std::{env, sync::LazyLock};
@@ -27,12 +26,8 @@ use talpid_routing::{self, RequiredRoute};
 use talpid_tunnel::tun_provider;
 use talpid_tunnel::{tun_provider::TunProvider, TunnelArgs, TunnelEvent, TunnelMetadata};
 
-use ipnetwork::IpNetwork;
 use talpid_types::{
-    net::{
-        wireguard::{PresharedKey, PrivateKey, PublicKey},
-        AllowedTunnelTraffic, Endpoint, TransportProtocol,
-    },
+    net::{AllowedTunnelTraffic, Endpoint, TransportProtocol},
     BoxedError, ErrorExt,
 };
 use tokio::sync::Mutex as AsyncMutex;
@@ -40,6 +35,7 @@ use tokio::sync::Mutex as AsyncMutex;
 /// WireGuard config data-types
 pub mod config;
 mod connectivity_check;
+mod ephemeral;
 mod logging;
 mod obfuscation;
 mod ping_monitor;
@@ -140,10 +136,6 @@ pub struct WireguardMonitor {
     pinger_stop_sender: sync_mpsc::Sender<()>,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
 }
-
-const INITIAL_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(8);
-const MAX_PSK_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(48);
-const PSK_EXCHANGE_TIMEOUT_MULTIPLIER: u32 = 2;
 
 #[cfg(target_os = "linux")]
 /// Overrides the preference for the kernel module for WireGuard.
@@ -253,13 +245,7 @@ impl WireguardMonitor {
 
             let ephemeral_obfs_sender = close_obfs_sender.clone();
             if config.quantum_resistant || config.daita {
-                #[cfg(windows)]
-                {
-                    log::trace!("Temporarily lowering tunnel MTU before ephemeral peer config");
-                    try_set_ipv4_mtu(&iface_name, talpid_tunnel::MIN_IPV4_MTU);
-                }
-
-                Self::config_ephemeral_peers(
+                ephemeral::config_ephemeral_peers(
                     &tunnel,
                     &mut config,
                     args.retry_attempt,
@@ -267,12 +253,6 @@ impl WireguardMonitor {
                     ephemeral_obfs_sender,
                 )
                 .await?;
-
-                #[cfg(windows)]
-                {
-                    log::trace!("Resetting tunnel MTU");
-                    try_set_ipv4_mtu(&iface_name, config.mtu);
-                }
 
                 let metadata = Self::tunnel_metadata(&iface_name, &config);
                 (on_event)(TunnelEvent::InterfaceUp(
@@ -484,7 +464,7 @@ impl WireguardMonitor {
                 // Ping before negotiating the ephemeral peer to make sure that the tunnel works.
                 tokio::task::spawn_blocking(ping()).await.unwrap()?;
                 let ephemeral_obfs_sender = close_obfs_sender.clone();
-                Self::config_ephemeral_peers(
+                ephemeral::config_ephemeral_peers(
                     &tunnel,
                     &mut config,
                     args.retry_attempt,
@@ -569,131 +549,6 @@ impl WireguardMonitor {
         AllowedTunnelTraffic::All
     }
 
-    async fn config_ephemeral_peers(
-        tunnel: &Arc<AsyncMutex<Option<Box<dyn Tunnel>>>>,
-        config: &mut Config,
-        retry_attempt: u32,
-        obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
-        close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
-        #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
-    ) -> std::result::Result<(), CloseMsg> {
-        let ephemeral_private_key = PrivateKey::new_from_random();
-        let close_obfs_sender = close_obfs_sender.clone();
-
-        let exit_should_have_daita = config.daita && !config.is_multihop();
-        let exit_psk = Self::request_ephemeral_peer(
-            retry_attempt,
-            config,
-            ephemeral_private_key.public_key(),
-            config.quantum_resistant,
-            exit_should_have_daita,
-        )
-        .await?;
-
-        log::debug!("Retrieved ephemeral peer");
-
-        if config.is_multihop() {
-            // Set up tunnel to lead to entry
-            let mut entry_tun_config = config.clone();
-            entry_tun_config
-                .entry_peer
-                .allowed_ips
-                .push(IpNetwork::new(IpAddr::V4(config.ipv4_gateway), 32).unwrap());
-
-            let close_obfs_sender = close_obfs_sender.clone();
-            let entry_config = Self::reconfigure_tunnel(
-                tunnel,
-                entry_tun_config,
-                obfuscator.clone(),
-                close_obfs_sender,
-                #[cfg(target_os = "android")]
-                &tun_provider,
-            )
-            .await?;
-            let entry_psk = Self::request_ephemeral_peer(
-                retry_attempt,
-                &entry_config,
-                ephemeral_private_key.public_key(),
-                config.quantum_resistant,
-                config.daita,
-            )
-            .await?;
-            log::debug!("Successfully exchanged PSK with entry peer");
-
-            config.entry_peer.psk = entry_psk;
-        }
-
-        config.exit_peer_mut().psk = exit_psk;
-        #[cfg(daita)]
-        if config.daita {
-            log::trace!("Enabling constant packet size for entry peer");
-            config.entry_peer.constant_packet_size = true;
-        }
-
-        config.tunnel.private_key = ephemeral_private_key;
-
-        *config = Self::reconfigure_tunnel(
-            tunnel,
-            config.clone(),
-            obfuscator,
-            close_obfs_sender,
-            #[cfg(target_os = "android")]
-            &tun_provider,
-        )
-        .await?;
-
-        #[cfg(daita)]
-        if config.daita {
-            // Start local DAITA machines
-            let mut tunnel = tunnel.lock().await;
-            if let Some(tunnel) = tunnel.as_mut() {
-                tunnel
-                    .start_daita()
-                    .map_err(Error::TunnelError)
-                    .map_err(CloseMsg::SetupError)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Reconfigures the tunnel to use the provided config while potentially modifying the config
-    /// and restarting the obfuscation provider. Returns the new config used by the new tunnel.
-    async fn reconfigure_tunnel(
-        tunnel: &Arc<AsyncMutex<Option<Box<dyn Tunnel>>>>,
-        mut config: Config,
-        obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
-        close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
-        #[cfg(target_os = "android")] tun_provider: &Arc<Mutex<TunProvider>>,
-    ) -> std::result::Result<Config, CloseMsg> {
-        let mut obfs_guard = obfuscator.lock().await;
-        if let Some(obfuscator_handle) = obfs_guard.take() {
-            obfuscator_handle.abort();
-            *obfs_guard = obfuscation::apply_obfuscation_config(
-                &mut config,
-                close_obfs_sender,
-                #[cfg(target_os = "android")]
-                tun_provider.clone(),
-            )
-            .await
-            .map_err(CloseMsg::ObfuscatorFailed)?;
-        }
-
-        let mut tunnel = tunnel.lock().await;
-
-        let set_config_future = tunnel
-            .as_mut()
-            .map(|tunnel| tunnel.set_config(config.clone()));
-
-        if let Some(f) = set_config_future {
-            f.await
-                .map_err(Error::TunnelError)
-                .map_err(CloseMsg::SetupError)?;
-        }
-
-        Ok(config)
-    }
-
     /// Replace `0.0.0.0/0`/`::/0` with the gateway IPs when `gateway_only` is true.
     /// Used to block traffic to other destinations while connecting on Android.
     #[cfg(target_os = "android")]
@@ -762,42 +617,6 @@ impl WireguardMonitor {
                 .map_err(|error| CloseMsg::SetupError(Error::SetIpAddressesError(error)))?;
         }
         Ok(())
-    }
-
-    async fn request_ephemeral_peer(
-        retry_attempt: u32,
-        config: &Config,
-        wg_psk_pubkey: PublicKey,
-        enable_pq: bool,
-        enable_daita: bool,
-    ) -> std::result::Result<Option<PresharedKey>, CloseMsg> {
-        log::debug!("Requesting ephemeral peer");
-
-        let timeout = std::cmp::min(
-            MAX_PSK_EXCHANGE_TIMEOUT,
-            INITIAL_PSK_EXCHANGE_TIMEOUT
-                .saturating_mul(PSK_EXCHANGE_TIMEOUT_MULTIPLIER.saturating_pow(retry_attempt)),
-        );
-
-        let ephemeral = tokio::time::timeout(
-            timeout,
-            talpid_tunnel_config_client::request_ephemeral_peer(
-                config.ipv4_gateway,
-                config.tunnel.private_key.public_key(),
-                wg_psk_pubkey,
-                enable_pq,
-                enable_daita,
-            ),
-        )
-        .await
-        .map_err(|_timeout_err| {
-            log::warn!("Timeout while negotiating ephemeral peer");
-            CloseMsg::EphemeralPeerNegotiationTimeout
-        })?
-        .map_err(Error::EphemeralPeerNegotiationError)
-        .map_err(CloseMsg::SetupError)?;
-
-        Ok(ephemeral.psk)
     }
 
     #[allow(unused_variables)]
@@ -1231,19 +1050,4 @@ fn will_nm_manage_dns() -> bool {
             Ok(true)
         })
         .unwrap_or(false)
-}
-
-#[cfg(windows)]
-fn try_set_ipv4_mtu(alias: &str, mtu: u16) {
-    use talpid_windows::net::*;
-    match luid_from_alias(alias) {
-        Ok(luid) => {
-            if let Err(error) = set_mtu(u32::from(mtu), luid, AddressFamily::Ipv4) {
-                log::error!("Failed to set tunnel interface MTU: {error}");
-            }
-        }
-        Err(error) => {
-            log::error!("Failed to obtain tunnel interface LUID: {error}")
-        }
-    }
 }


### PR DESCRIPTION
`IP_USER_MTU` doesn't work like MSS, which can cause PQ negotiation to fail on Windows when the MTU is incorrectly configured (see https://github.com/mullvad/mullvadvpn-app/actions/runs/10975572685/job/30475498014).

This PR fixes this by lowering the tunnel interface MTU during ephemeral peer negotiation.

Fix DES-1257.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6836)
<!-- Reviewable:end -->
