### PR TITLE
Upgrade `tonic` and `prost`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,18 +225,17 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "itoa",
  "matchit",
  "memchr",
@@ -253,17 +252,20 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "5e6b8ba012a258d63c9adfa28b9ddcf66149da6f986c5b5452e629d5ee64bf00"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -1544,7 +1546,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1581,14 +1582,35 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 1.4.1",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2422,6 +2444,7 @@ name = "mullvad-ios"
 version = "0.0.0"
 dependencies = [
  "cbindgen",
+ "hyper-util",
  "libc",
  "log",
  "mullvad-encrypted-dns-proxy",
@@ -2462,13 +2485,14 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "futures",
+ "hyper-util",
  "log",
  "mullvad-paths",
  "mullvad-types",
  "nix 0.23.2",
  "parity-tokio-ipc",
- "prost",
- "prost-types",
+ "prost 0.13.3",
+ "prost-types 0.13.3",
  "talpid-types",
  "thiserror",
  "tokio",
@@ -3229,7 +3253,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.4",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -3246,8 +3280,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
  "regex",
  "syn 2.0.60",
  "tempfile",
@@ -3267,12 +3301,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
- "prost",
+ "prost 0.12.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -3982,9 +4038,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -4112,7 +4168,7 @@ dependencies = [
  "log",
  "once_cell",
  "parity-tokio-ipc",
- "prost",
+ "prost 0.13.3",
  "shadowsocks-service",
  "shell-escape",
  "talpid-routing",
@@ -4135,11 +4191,13 @@ name = "talpid-openvpn-plugin"
 version = "0.0.0"
 dependencies = [
  "env_logger 0.10.2",
+ "futures",
+ "hyper-util",
  "log",
  "mullvad-version",
  "openvpn-plugin",
  "parity-tokio-ipc",
- "prost",
+ "prost 0.13.3",
  "talpid-types",
  "thiserror",
  "tokio",
@@ -4215,11 +4273,13 @@ name = "talpid-tunnel-config-client"
 version = "0.0.0"
 dependencies = [
  "classic-mceliece-rust",
+ "futures",
+ "hyper-util",
  "libc",
  "log",
  "oslog",
  "pqc_kyber",
- "prost",
+ "prost 0.13.3",
  "rand 0.8.5",
  "talpid-types",
  "tokio",
@@ -4403,16 +4463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4512,23 +4562,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.3",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,12 @@ tokio = { version = "1.8" }
 parity-tokio-ipc = "0.9"
 futures = "0.3.15"
 # Tonic and related crates
-tonic = "0.10.0"
+tonic = "0.12.2"
 tonic-build = { version = "0.10.0", default-features = false }
 tower = "0.4"
-prost = "0.12.0"
-prost-types = "0.12.0"
+prost = "0.13.3"
+prost-types = "0.13.3"
+hyper-util = "0.1.8"
 
 env_logger = "0.10.0"
 thiserror = "1.0.57"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ unused_async = "deny"
 [workspace.dependencies]
 tokio = { version = "1.8" }
 parity-tokio-ipc = "0.9"
+futures = "0.3.15"
 # Tonic and related crates
 tonic = "0.10.0"
 tonic-build = { version = "0.10.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ unused_async = "deny"
 
 [workspace.dependencies]
 tokio = { version = "1.8" }
+parity-tokio-ipc = "0.9"
 # Tonic and related crates
 tonic = "0.10.0"
 tonic-build = { version = "0.10.0", default-features = false }

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -18,7 +18,7 @@ api-override = []
 libc = "0.2"
 chrono = { workspace = true }
 thiserror = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "stream", "http1", "tcp" ] }
 ipnetwork = { workspace = true }

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0"
 chrono = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 itertools = "0.10"
 natord = "1.0.9"
 

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 either = "1.11"
 fern = { version = "0.6", features = ["colored"] }
-futures = "0.3"
+futures = { workspace = true }
 libc = "0.2"
 log = { workspace = true }
 regex = "1.0"

--- a/mullvad-ios/Cargo.toml
+++ b/mullvad-ios/Cargo.toml
@@ -15,6 +15,7 @@ libc = "0.2"
 log = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }
+hyper-util = { workspace = true }
 tower = { workspace = true }
 tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 oslog = "0.2"

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib"]
 tokio = { workspace = true, features = ["rt"] }
 
 thiserror = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 ipnetwork = { workspace = true }
 jnix = { version = "0.5.1", features = ["derive"] }
 log = { workspace = true }

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -11,19 +11,20 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+log = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 mullvad-types = { path = "../mullvad-types" }
 mullvad-paths = { path = "../mullvad-paths" }
 talpid-types = { path = "../talpid-types" }
+
 tonic = { workspace = true }
 tower = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
-parity-tokio-ipc = "0.9"
 futures = "0.3"
 tokio = { workspace = true, features =  ["rt"] }
-log = { workspace = true }
+parity-tokio-ipc = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -20,6 +20,7 @@ talpid-types = { path = "../talpid-types" }
 
 tonic = { workspace = true }
 tower = { workspace = true }
+hyper-util = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 futures = { workspace = true }

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -22,7 +22,7 @@ tonic = { workspace = true }
 tower = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 tokio = { workspace = true, features =  ["rt"] }
 parity-tokio-ipc = { workspace = true }
 

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 chrono = { workspace = true, features = ["clock"] }
 thiserror = { workspace = true }
-futures = "0.3.15"
+futures = { workspace = true }
 ipnetwork = { workspace = true }
 libc = "0.2"
 log = { workspace = true }

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -17,12 +17,12 @@ crate-type = ["cdylib"]
 thiserror = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-parity-tokio-ipc = "0.9"
-tokio = { workspace = true, features =  ["rt"] }
 
 openvpn-plugin = { version = "0.4.2", features = ["serde", "log", "auth-failed-event"] }
 talpid-types = { path = "../talpid-types" }
 
+tokio = { workspace = true, features =  ["rt"] }
+parity-tokio-ipc = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 prost = { workspace = true }

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -26,6 +26,8 @@ parity-tokio-ipc = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 prost = { workspace = true }
+hyper-util = { workspace = true }
+futures = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true, default-features = false, features = ["transport", "prost"] }

--- a/talpid-openvpn-plugin/src/processing.rs
+++ b/talpid-openvpn-plugin/src/processing.rs
@@ -1,11 +1,11 @@
 use super::{Arguments, Error};
-use parity_tokio_ipc::Endpoint as IpcEndpoint;
 use std::collections::HashMap;
-use tower::service_fn;
 
-use tonic::transport::{Endpoint, Uri};
-
+use futures::TryFutureExt;
+use parity_tokio_ipc::Endpoint as IpcEndpoint;
 use tokio::runtime::{self, Runtime};
+use tonic::transport::{Endpoint, Uri};
+use tower::service_fn;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 mod proto {
@@ -42,7 +42,7 @@ impl EventProcessor {
         // The URI will be ignored
         let channel = Endpoint::from_static("lttp://[::]:50051")
             .connect_with_connector(service_fn(move |_: Uri| {
-                IpcEndpoint::connect(ipc_path.clone())
+                IpcEndpoint::connect(ipc_path.clone()).map_ok(hyper_util::rt::tokio::TokioIo::new)
             }))
             .await?;
 

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 shadowsocks-service = { workspace = true,  features = [ "local", "stream-cipher" ] }
 
 [target.'cfg(not(target_os="android"))'.dependencies]
-parity-tokio-ipc = "0.9"
+parity-tokio-ipc = { workspace = true }
 triggered = "0.1.1"
 tonic = { workspace = true }
 prost = { workspace = true }

--- a/talpid-openvpn/Cargo.toml
+++ b/talpid-openvpn/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1"
 thiserror = { workspace = true }
-futures = "0.3.15"
+futures = { workspace = true }
 log = { workspace = true }
 shell-escape = "0.1"
 talpid-routing = { path = "../talpid-routing" }

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
-futures = "0.3.15"
+futures = { workspace = true }
 ipnetwork = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "net", "io-util", "time"] }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -14,9 +14,11 @@ workspace = true
 log = { workspace = true }
 rand = "0.8"
 talpid-types = { path = "../talpid-types" }
+futures = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 prost = { workspace = true }
+hyper-util = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 classic-mceliece-rust = { version = "2.0.0", features = [
     "mceliece460896f",

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -217,6 +217,8 @@ fn xor_assign(dst: &mut [u8; 32], src: &[u8; 32]) {
 
 #[cfg(not(target_os = "ios"))]
 async fn new_client(addr: Ipv4Addr) -> Result<RelayConfigService, Error> {
+    use futures::TryFutureExt;
+
     let endpoint = Endpoint::from_static("tcp://0.0.0.0:0");
     let addr = IpAddr::V4(addr);
 
@@ -224,6 +226,7 @@ async fn new_client(addr: Ipv4Addr) -> Result<RelayConfigService, Error> {
         .connect_with_connector(service_fn(move |_| async move {
             let sock = socket::TcpSocket::new()?;
             sock.connect(SocketAddr::new(addr, CONFIG_SERVICE_PORT))
+                .map_ok(hyper_util::rt::tokio::TokioIo::new)
                 .await
         }))
         .await

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = "1.0"
 ipnetwork = { workspace = true }
 talpid-routing = { path = "../talpid-routing" }
 talpid-types = { path = "../talpid-types" }
-futures = "0.3.15"
+futures = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 
 [target.'cfg(all(unix, not(target_os = "android")))'.dependencies]

--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [target.'cfg(windows)'.dependencies]
 thiserror = { workspace = true }
 socket2 = { version = "0.5.3" }
-futures = "0.3.15"
+futures = { workspace = true }
 
 talpid-types = { path = "../talpid-types" }
 

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
-futures = "0.3.15"
+futures = { workspace = true }
 hex = "0.4"
 ipnetwork = { workspace = true }
 once_cell = { workspace = true }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -195,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,18 +208,17 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "itoa",
  "matchit",
  "memchr",
@@ -222,7 +227,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -230,17 +235,20 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "5e6b8ba012a258d63c9adfa28b9ddcf66149da6f986c5b5452e629d5ee64bf00"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
 ]
@@ -1146,7 +1154,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1276,13 +1303,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1314,9 +1375,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1329,14 +1390,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "log",
  "rustls",
  "rustls-native-certs",
@@ -1347,14 +1429,35 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper",
+ "hyper 1.4.1",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2 0.5.6",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1831,8 +1934,8 @@ dependencies = [
  "cbindgen",
  "chrono",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "ipnetwork",
  "libc",
  "log",
@@ -1867,13 +1970,14 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "futures",
+ "hyper-util",
  "log",
  "mullvad-paths",
  "mullvad-types",
  "nix 0.23.2",
  "parity-tokio-ipc",
- "prost",
- "prost-types",
+ "prost 0.13.3",
+ "prost-types 0.13.3",
  "talpid-types",
  "thiserror",
  "tokio",
@@ -2411,7 +2515,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.4",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -2428,8 +2542,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
  "regex",
  "syn 2.0.60",
  "tempfile",
@@ -2449,12 +2563,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
- "prost",
+ "prost 0.12.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -2621,10 +2757,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -2638,7 +2774,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -3174,6 +3310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,6 +3439,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "futures",
+ "hyper-util",
  "inventory",
  "ipnetwork",
  "itertools 0.10.5",
@@ -3341,7 +3484,7 @@ dependencies = [
  "bytes",
  "colored",
  "futures",
- "hyper",
+ "hyper 0.14.28",
  "hyper-rustls",
  "log",
  "rustls-pemfile 0.2.1",
@@ -3495,16 +3638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,23 +3752,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.3",
+ "socket2 0.5.6",
  "tokio",
  "tokio-stream",
  "tower",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -54,11 +54,11 @@ serde_json = "1.0"
 tokio-serde = { version = "0.8.0", features = ["json"] }
 
 # Tonic and related crates
-tonic = "0.10.0"
+tonic = "0.12.2"
 tonic-build = { version = "0.10.0", default-features = false }
 tower = "0.4"
-prost = "0.12.0"
-prost-types = "0.12.0"
+prost = "0.13.3"
+prost-types = "0.13.3"
 tarpc = { version = "0.30", features = ["tokio1", "serde-transport", "serde1"] }
 
 # Logging

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -49,6 +49,7 @@ socks-server = { path = "../socks-server" }
 env_logger = { workspace = true }
 
 tonic = { workspace = true }
+hyper-util = "0.1.8"
 tower = { workspace = true }
 colored = { workspace = true }
 


### PR DESCRIPTION
Upgrade `tonic` to version 0.12, as a prerequisite to later on upgrading `hyper`.

As of version 1, `hyper` no longer uses tokios `AsyncWriter` and `AsyncReader` traits, instead defining its own versions, see <https://github.com/hyperium/hyper/issues/3110>. As tonic `0.12` is updated to use the `hyper 1.0` ecosystem, it changed some of its trait-bounds to the new `hyper` traits. The `hyper-utils` crate provides the wrapper `TokioIo`, which converts between the two.

`prost` had to be upgraded as well, for compatibility.

<!--
PR checklist (just intended as a reminder for the PR author. No need to fill it in):

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6847)
<!-- Reviewable:end -->
