### PR TITLE
Enable IPv6 by default on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Line wrap the file at 100 chars.                                              Th
   the daemon when the VPN is disconnected.
 - Don't hijack DNS when localhost is configured. This is more in line with other platforms.
   Unexpected DNS traffic is still blocked when leaving the host.
+- Enable IPv6 by default. This fixes DNS and routing being broken on some platforms.
 
 ### Fixed
 #### Linux

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -285,8 +285,8 @@ impl Default for TunnelOptions {
             openvpn: openvpn::TunnelOptions::default(),
             wireguard: wireguard::TunnelOptions::default(),
             generic: GenericTunnelOptions {
-                // Enable IPv6 be default on Android
-                enable_ipv6: cfg!(target_os = "android"),
+                // Enable IPv6 by default on Android and macOS
+                enable_ipv6: cfg!(target_os = "android") || cfg!(target_os = "macos"),
             },
             dns_options: DnsOptions::default(),
         }


### PR DESCRIPTION
Fix DES-449.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6853)
<!-- Reviewable:end -->
