### PR TITLE
Do not enter blocked state if device check has network errors

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -305,9 +305,8 @@ extension PacketTunnelProvider {
             default:
                 providerLogger
                     .error(
-                        "Entering blocked state because device check encountered a generic error: \(error.localizedDescription)"
+                        "Device check encountered a network error: \(error.localizedDescription)"
                     )
-                actor.setErrorState(reason: .unknown)
             }
 
         case let .success(keyRotationResult):


### PR DESCRIPTION
As discussed, we should not force the Packet Tunnel Actor to enter the blocked state if the device checker
encounters a generic network error, because this request already went through the tunnel.
Unreliable networks should not make the app enter the blocked state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6856)
<!-- Reviewable:end -->
