### PR TITLE
Don't hijack DNS config when localhost is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Disable split tunnel interface when disconnected. This prevents traffic from being sent through
   the daemon when the VPN is disconnected.
+- Don't hijack DNS when localhost is configured. This is more in line with other platforms.
+  Unexpected DNS traffic is still blocked when leaving the host.
 
 ### Fixed
 #### Linux


### PR DESCRIPTION
If the resolver is set to (e.g.) `127.0.0.1`, don't replace it with `10.64.0.1`. Hopefully prevents some fighting with other software.

This does not change affect any of the firewall rules.

Close DES-1227.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6861)
<!-- Reviewable:end -->
