### PR TITLE
Run android-validate-gradle-wrapper on every matching push

### DIFF
--- a/.github/workflows/android-validate-gradle-wrapper.yml
+++ b/.github/workflows/android-validate-gradle-wrapper.yml
@@ -2,10 +2,10 @@ name: "Android - Validate gradle wrapper"
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     paths:
       - .github/workflows/android-validate-gradle-wrapper.yml
-      - android/gradle/wrapper/gradle-wrapper.jar
+      - '**/gradle-wrapper.jar'
 
 permissions: {}
 


### PR DESCRIPTION
This prevents the following possible ways of commiting a malicious gradle-wrapper.jar to the repository:
* Commiting to another path than the one previously specified
* Pushing to `main` without going through a PR

Please see these three comments for context: https://github.com/ossf/scorecard/pull/4097#issuecomment-2371193844

I have not yet verified if scorecard will treat this new setup as a warning or not. But my impression was that the `scorecard` contributor in the comments sort of agreed that their verifier should be updated anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6863)
<!-- Reviewable:end -->
