### PR TITLE
Bump wireguard-apple to include multihop fix

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9226,7 +9226,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = 82ae19d03fcaa83b9636e560ce9bea8fec9dc96f;
+				revision = 5d5fbf1af490c2ec893cae908f5a204ac6f0da46;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "82ae19d03fcaa83b9636e560ce9bea8fec9dc96f"
+        "revision" : "5d5fbf1af490c2ec893cae908f5a204ac6f0da46"
       }
     }
   ],


### PR DESCRIPTION
We've made some small changes to fix DAITA and the makefile. Let's use them in `main`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6867)
<!-- Reviewable:end -->
