### PR TITLE
Fix smart routing algorithm to select closest relay

### DIFF
--- a/ios/MullvadREST/Relay/RelaySelector+Wireguard.swift
+++ b/ios/MullvadREST/Relay/RelaySelector+Wireguard.swift
@@ -33,38 +33,106 @@ extension RelaySelector {
             from relayWithLocations: [RelayWithLocation<REST.ServerRelay>],
             relays: REST.ServerRelaysResponse,
             portConstraint: RelayConstraint<UInt16>,
-            numberOfFailedAttempts: UInt
+            numberOfFailedAttempts: UInt,
+            closeTo referenceLocation: Location? = nil
         ) throws -> RelaySelectorMatch {
-            let port = applyPortConstraint(
-                portConstraint,
-                rawPortRanges: relays.wireguard.portRanges,
+            let port = try evaluatePort(
+                relays: relays,
+                portConstraint: portConstraint,
                 numberOfFailedAttempts: numberOfFailedAttempts
             )
 
-            guard let port else {
-                throw NoRelaysSatisfyingConstraintsError(.invalidPort)
+            var relayWithLocation: RelayWithLocation<REST.ServerRelay>?
+            if let referenceLocation {
+                let relay = closestRelay(to: referenceLocation, using: relayWithLocations)
+                relayWithLocation = relayWithLocations.first(where: { $0.relay == relay })
             }
 
-            guard let relayWithLocation = pickRandomRelayByWeight(relays: relayWithLocations) else {
+            guard
+                let relayWithLocation = relayWithLocation ?? pickRandomRelayByWeight(relays: relayWithLocations)
+            else {
                 throw NoRelaysSatisfyingConstraintsError(.relayConstraintNotMatching)
             }
 
-            let endpoint = MullvadEndpoint(
-                ipv4Relay: IPv4Endpoint(
-                    ip: relayWithLocation.relay.ipv4AddrIn,
-                    port: port
-                ),
-                ipv6Relay: nil,
-                ipv4Gateway: relays.wireguard.ipv4Gateway,
-                ipv6Gateway: relays.wireguard.ipv6Gateway,
-                publicKey: relayWithLocation.relay.publicKey
-            )
-
-            return RelaySelectorMatch(
-                endpoint: endpoint,
-                relay: relayWithLocation.relay,
-                location: relayWithLocation.serverLocation
-            )
+            return createMatch(for: relayWithLocation, port: port, relays: relays)
         }
+
+        public static func closestRelay(
+            to location: Location,
+            using relayWithLocations: [RelayWithLocation<REST.ServerRelay>]
+        ) -> REST.ServerRelay? {
+            let relaysWithDistance = relayWithLocations.map {
+                RelayWithDistance(
+                    relay: $0.relay,
+                    distance: Haversine.distance(
+                        location.latitude,
+                        location.longitude,
+                        $0.serverLocation.latitude,
+                        $0.serverLocation.longitude
+                    )
+                )
+            }.sorted {
+                $0.distance < $1.distance
+            }.prefix(5)
+
+            let relaysGroupedByDistance = Dictionary(grouping: relaysWithDistance, by: { $0.distance })
+            guard let closetsRelayGroup = relaysGroupedByDistance.min(by: { $0.key < $1.key })?.value else {
+                return nil
+            }
+
+            var greatestDistance = 0.0
+            closetsRelayGroup.forEach {
+                if $0.distance > greatestDistance {
+                    greatestDistance = $0.distance
+                }
+            }
+
+            let closestRelay = rouletteSelection(relays: closetsRelayGroup, weightFunction: { relay in
+                UInt64(1 + greatestDistance - relay.distance)
+            })
+
+            return closestRelay?.relay
+        }
+    }
+
+    private static func evaluatePort(
+        relays: REST.ServerRelaysResponse,
+        portConstraint: RelayConstraint<UInt16>,
+        numberOfFailedAttempts: UInt
+    ) throws -> UInt16 {
+        let port = applyPortConstraint(
+            portConstraint,
+            rawPortRanges: relays.wireguard.portRanges,
+            numberOfFailedAttempts: numberOfFailedAttempts
+        )
+
+        guard let port else {
+            throw NoRelaysSatisfyingConstraintsError(.invalidPort)
+        }
+
+        return port
+    }
+
+    private static func createMatch(
+        for relayWithLocation: RelayWithLocation<REST.ServerRelay>,
+        port: UInt16,
+        relays: REST.ServerRelaysResponse
+    ) -> RelaySelectorMatch {
+        let endpoint = MullvadEndpoint(
+            ipv4Relay: IPv4Endpoint(
+                ip: relayWithLocation.relay.ipv4AddrIn,
+                port: port
+            ),
+            ipv6Relay: nil,
+            ipv4Gateway: relays.wireguard.ipv4Gateway,
+            ipv6Gateway: relays.wireguard.ipv6Gateway,
+            publicKey: relayWithLocation.relay.publicKey
+        )
+
+        return RelaySelectorMatch(
+            endpoint: endpoint,
+            relay: relayWithLocation.relay,
+            location: relayWithLocation.serverLocation
+        )
     }
 }

--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -22,20 +22,21 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol {
     ) throws -> SelectedRelays {
         let relays = try relayCache.read().relays
 
-        switch tunnelSettings.tunnelMultihopState {
+        return switch tunnelSettings.tunnelMultihopState {
         case .off:
-            return try SinglehopPicker(
-                constraints: tunnelSettings.relayConstraints,
-                daitaSettings: tunnelSettings.daita,
+            try SinglehopPicker(
                 relays: relays,
-                connectionAttemptCount: connectionAttemptCount
+                constraints: tunnelSettings.relayConstraints,
+                connectionAttemptCount: connectionAttemptCount,
+                daitaSettings: tunnelSettings.daita
             ).pick()
         case .on:
-            return try MultihopPicker(
-                constraints: tunnelSettings.relayConstraints,
-                daitaSettings: tunnelSettings.daita,
+            try MultihopPicker(
                 relays: relays,
-                connectionAttemptCount: connectionAttemptCount
+                constraints: tunnelSettings.relayConstraints,
+                connectionAttemptCount: connectionAttemptCount,
+                daitaSettings: tunnelSettings.daita,
+                automaticDaitaRouting: false
             ).pick()
         }
     }

--- a/ios/MullvadSettings/DAITASettings.swift
+++ b/ios/MullvadSettings/DAITASettings.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// Whether DAITA is enabled
+/// Whether DAITA is enabled.
 public enum DAITAState: Codable {
     case on
     case off
@@ -18,8 +18,8 @@ public enum DAITAState: Codable {
     }
 }
 
-/// Whether smart routing is enabled
-public enum SmartRoutingState: Codable {
+/// Whether "direct only" is enabled, meaning no automatic routing to DAITA relays.
+public enum DirectOnlyState: Codable {
     case on
     case off
 
@@ -38,11 +38,15 @@ public struct DAITASettings: Codable, Equatable {
     public let state: DAITAState = .off
 
     public let daitaState: DAITAState
-    public let smartRoutingState: SmartRoutingState
+    public let directOnlyState: DirectOnlyState
 
-    public init(daitaState: DAITAState = .off, smartRoutingState: SmartRoutingState = .off) {
+    public var shouldDoAutomaticRouting: Bool {
+        daitaState.isEnabled && !directOnlyState.isEnabled
+    }
+
+    public init(daitaState: DAITAState = .off, directOnlyState: DirectOnlyState = .off) {
         self.daitaState = daitaState
-        self.smartRoutingState = smartRoutingState
+        self.directOnlyState = directOnlyState
     }
 
     public init(from decoder: any Decoder) throws {
@@ -52,7 +56,7 @@ public struct DAITASettings: Codable, Equatable {
             ?? container.decodeIfPresent(DAITAState.self, forKey: .state)
             ?? .off
 
-        smartRoutingState = try container.decodeIfPresent(SmartRoutingState.self, forKey: .smartRoutingState)
+        directOnlyState = try container.decodeIfPresent(DirectOnlyState.self, forKey: .directOnlyState)
             ?? .off
     }
 }

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 		7A9F29392CABFAFC005F2089 /* InfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9F29382CABFAEC005F2089 /* InfoHeaderView.swift */; };
 		7A9F293B2CAC4443005F2089 /* InfoHeaderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9F293A2CAC4420005F2089 /* InfoHeaderConfig.swift */; };
 		7A9F293D2CAD2FD5005F2089 /* InfoModalConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9F293C2CAD2FCF005F2089 /* InfoModalConfig.swift */; };
+		7A9F28FC2CA69D0C005F2089 /* DAITASettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9F28FB2CA69D04005F2089 /* DAITASettingsTests.swift */; };
 		7A9FA1422A2E3306000B728D /* CheckboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9FA1412A2E3306000B728D /* CheckboxView.swift */; };
 		7A9FA1442A2E3FE5000B728D /* CheckableSettingsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9FA1432A2E3FE5000B728D /* CheckableSettingsCell.swift */; };
 		7AA513862BC91C6B00D081A4 /* LogRotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */; };
@@ -1891,6 +1892,7 @@
 		7A9F29382CABFAEC005F2089 /* InfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoHeaderView.swift; sourceTree = "<group>"; };
 		7A9F293A2CAC4420005F2089 /* InfoHeaderConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoHeaderConfig.swift; sourceTree = "<group>"; };
 		7A9F293C2CAD2FCF005F2089 /* InfoModalConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoModalConfig.swift; sourceTree = "<group>"; };
+		7A9F28FB2CA69D04005F2089 /* DAITASettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAITASettingsTests.swift; sourceTree = "<group>"; };
 		7A9FA1412A2E3306000B728D /* CheckboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxView.swift; sourceTree = "<group>"; };
 		7A9FA1432A2E3FE5000B728D /* CheckableSettingsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckableSettingsCell.swift; sourceTree = "<group>"; };
 		7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRotationTests.swift; sourceTree = "<group>"; };
@@ -2573,6 +2575,7 @@
 			children = (
 				7A83A0C52B29A750008B5CE7 /* APIAccessMethodsTests.swift */,
 				7A9BE5A82B90806800E2A7D0 /* CustomListsRepositoryStub.swift */,
+				7A9F28FB2CA69D04005F2089 /* DAITASettingsTests.swift */,
 				A9B6AC192ADE8FBB00F7802A /* InMemorySettingsStore.swift */,
 				7ADCB2D92B6A730400C88F89 /* IPOverrideRepositoryStub.swift */,
 				7A5869C22B5820CE00640D27 /* IPOverrideRepositoryTests.swift */,
@@ -5413,6 +5416,7 @@
 				A9A5FA2C2ACB05160083449F /* DeviceCheckOperationTests.swift in Sources */,
 				A9A5FA2D2ACB05160083449F /* DurationTests.swift in Sources */,
 				A9A5FA2E2ACB05160083449F /* FileCacheTests.swift in Sources */,
+				7A9F28FC2CA69D0C005F2089 /* DAITASettingsTests.swift in Sources */,
 				A9A5FA2F2ACB05160083449F /* FixedWidthIntegerArithmeticsTests.swift in Sources */,
 				7AA513862BC91C6B00D081A4 /* LogRotationTests.swift in Sources */,
 				F04413622BA45CE30018A6EE /* CustomListLocationNodeBuilder.swift in Sources */,

--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -118,7 +118,7 @@ enum TunnelState: Equatable, CustomStringConvertible {
             """
             negotiating key with exit relay: \(tunnelRelays.exit.hostname)\
             \(tunnelRelays.entry.flatMap { " via \($0.hostname)" } ?? "")\
-            "isPostQuantum: \(isPostQuantum), isDaita: \(isDaita)
+            , isPostQuantum: \(isPostQuantum), isDaita: \(isDaita)
             """
         }
     }

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
@@ -37,8 +37,8 @@ class MultihopDecisionFlowTests: XCTestCase {
         let oneToMany = OneToMany(next: nil, relayPicker: picker)
 
         XCTAssertTrue(oneToMany.canHandle(
-            entryCandidates: [seSto2, seSto6],
-            exitCandidates: [seSto2]
+            entryCandidates: [seSto2],
+            exitCandidates: [seSto2, seSto6]
         ))
 
         XCTAssertFalse(oneToMany.canHandle(
@@ -47,6 +47,25 @@ class MultihopDecisionFlowTests: XCTestCase {
         ))
 
         XCTAssertFalse(oneToMany.canHandle(
+            entryCandidates: [seSto2, seSto6],
+            exitCandidates: [seSto2, seSto6]
+        ))
+    }
+
+    func testManyToOneCanHandle() throws {
+        let manyToOne = ManyToOne(next: nil, relayPicker: picker)
+
+        XCTAssertTrue(manyToOne.canHandle(
+            entryCandidates: [seSto2, seSto6],
+            exitCandidates: [seSto2]
+        ))
+
+        XCTAssertFalse(manyToOne.canHandle(
+            entryCandidates: [seSto6],
+            exitCandidates: [seSto2]
+        ))
+
+        XCTAssertFalse(manyToOne.canHandle(
             entryCandidates: [seSto2, seSto6],
             exitCandidates: [seSto2, seSto6]
         ))
@@ -77,7 +96,11 @@ class MultihopDecisionFlowTests: XCTestCase {
         let entryCandidates = [seSto2]
         let exitCandidates = [seSto6]
 
-        let selectedRelays = try oneToOne.pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates)
+        let selectedRelays = try oneToOne.pick(
+            entryCandidates: entryCandidates,
+            exitCandidates: exitCandidates,
+            automaticDaitaRouting: false
+        )
 
         XCTAssertEqual(selectedRelays.entry?.hostname, "se2-wireguard")
         XCTAssertEqual(selectedRelays.exit.hostname, "se6-wireguard")
@@ -86,10 +109,30 @@ class MultihopDecisionFlowTests: XCTestCase {
     func testOneToManyPick() throws {
         let oneToMany = OneToMany(next: nil, relayPicker: picker)
 
+        let entryCandidates = [seSto2]
+        let exitCandidates = [seSto2, seSto6]
+
+        let selectedRelays = try oneToMany.pick(
+            entryCandidates: entryCandidates,
+            exitCandidates: exitCandidates,
+            automaticDaitaRouting: false
+        )
+
+        XCTAssertEqual(selectedRelays.entry?.hostname, "se2-wireguard")
+        XCTAssertEqual(selectedRelays.exit.hostname, "se6-wireguard")
+    }
+
+    func testManyToOnePick() throws {
+        let manyToOne = ManyToOne(next: nil, relayPicker: picker)
+
         let entryCandidates = [seSto2, seSto6]
         let exitCandidates = [seSto2]
 
-        let selectedRelays = try oneToMany.pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates)
+        let selectedRelays = try manyToOne.pick(
+            entryCandidates: entryCandidates,
+            exitCandidates: exitCandidates,
+            automaticDaitaRouting: false
+        )
 
         XCTAssertEqual(selectedRelays.entry?.hostname, "se6-wireguard")
         XCTAssertEqual(selectedRelays.exit.hostname, "se2-wireguard")
@@ -101,7 +144,11 @@ class MultihopDecisionFlowTests: XCTestCase {
         let entryCandidates = [seSto2, seSto6]
         let exitCandidates = [seSto2, seSto6]
 
-        let selectedRelays = try manyToMany.pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates)
+        let selectedRelays = try manyToMany.pick(
+            entryCandidates: entryCandidates,
+            exitCandidates: exitCandidates,
+            automaticDaitaRouting: false
+        )
 
         if selectedRelays.exit.hostname == "se2-wireguard" {
             XCTAssertEqual(selectedRelays.entry?.hostname, "se6-wireguard")
@@ -119,10 +166,11 @@ extension MultihopDecisionFlowTests {
         )
 
         return MultihopPicker(
-            constraints: constraints,
-            daitaSettings: DAITASettings(daitaState: .off),
             relays: sampleRelays,
-            connectionAttemptCount: 0
+            constraints: constraints,
+            connectionAttemptCount: 0,
+            daitaSettings: DAITASettings(daitaState: .off),
+            automaticDaitaRouting: false
         )
     }
 

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
@@ -136,6 +136,39 @@ class RelaySelectorTests: XCTestCase {
         XCTAssertTrue(allPorts.contains(result.endpoint.ipv4Relay.port))
     }
 
+    func testClosestRelay() throws {
+        let relayWithLocations = try sampleRelays.wireguard.relays.map {
+            let serverLocation = try XCTUnwrap(sampleRelays.locations[$0.location])
+            let location = Location(
+                country: serverLocation.country,
+                countryCode: serverLocation.country,
+                city: serverLocation.city,
+                cityCode: serverLocation.city,
+                latitude: serverLocation.latitude,
+                longitude: serverLocation.longitude
+            )
+
+            return RelayWithLocation(relay: $0, serverLocation: location)
+        }
+
+        let sampleLocation = try XCTUnwrap(sampleRelays.locations["se-got"])
+        let location = Location(
+            country: "Sweden",
+            countryCode: sampleLocation.country,
+            city: "Gothenburg",
+            cityCode: sampleLocation.city,
+            latitude: sampleLocation.latitude,
+            longitude: sampleLocation.longitude
+        )
+
+        let selectedRelay = RelaySelector.WireGuard.closestRelay(
+            to: location,
+            using: relayWithLocations
+        )
+
+        XCTAssertEqual(selectedRelay?.hostname, "se10-wireguard")
+    }
+
     func testClosestShadowsocksRelay() throws {
         let constraints = RelayConstraints(
             exitLocations: .only(UserSelectedRelays(locations: [.city("se", "sto")]))

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorWrapperTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorWrapperTests.swift
@@ -80,13 +80,13 @@ class RelaySelectorWrapperTests: XCTestCase {
         XCTAssertNoThrow(try wrapper.selectRelays(tunnelSettings: settings, connectionAttemptCount: 0))
     }
 
-    func testCannotSelectRelayWithMultihopOnAndDaitaOn() throws {
+    func testCannotSelectRelayWithMultihopOnDaitaOnDirectOnlyOn() throws {
         let wrapper = RelaySelectorWrapper(relayCache: relayCache)
 
         let settings = LatestTunnelSettings(
             relayConstraints: multihopWithoutDaitaConstraints,
             tunnelMultihopState: .on,
-            daita: DAITASettings(daitaState: .on)
+            daita: DAITASettings(daitaState: .on, directOnlyState: .on)
         )
 
         XCTAssertThrowsError(try wrapper.selectRelays(tunnelSettings: settings, connectionAttemptCount: 0))
@@ -107,7 +107,7 @@ class RelaySelectorWrapperTests: XCTestCase {
 
     // If DAITA is enabled and no supported relays are found, we should try to find the nearest
     // available relay that supports DAITA and use it as entry in a multihop selection.
-    func testCanSelectRelayWithMultihopOffAndDaitaOnThroughMultihop() throws {
+    func testCanSelectRelayWithMultihopOffDaitaOnThroughMultihop() throws {
         let wrapper = RelaySelectorWrapper(relayCache: relayCache)
 
         let settings = LatestTunnelSettings(

--- a/ios/MullvadVPNTests/MullvadSettings/DAITASettingsTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/DAITASettingsTests.swift
@@ -1,0 +1,21 @@
+//
+//  DAITASettingsTests.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2024-09-27.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+@testable import MullvadSettings
+import XCTest
+
+final class DAITASettingsTests: XCTestCase {
+    func testShouldDoDirectOnly() throws {
+        let settings = DAITASettings()
+
+        XCTAssertEqual(
+            settings.shouldDoAutomaticRouting,
+            settings.daitaState == .on && settings.directOnlyState == .off
+        )
+    }
+}


### PR DESCRIPTION
Currently, smart routing picks a random DAITA relay. It should pick the closest relay using the haversine distance. It should group relays that are the same distance away and use the roulette wheel selection algorithm to pick one between the group of closest relays.

Also includes: [update-the-relay-selector-wrapper-to-enable-smart-routing-ios-832](https://linear.app/mullvad/issue/IOS-832/update-the-relay-selector-wrapper-to-enable-smart-routing-for-multihop)

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6871)
<!-- Reviewable:end -->
