### PR TITLE
Move pick_random_relay_excluding to helpers module for consistency

### DIFF
--- a/mullvad-relay-selector/src/relay_selector/helpers.rs
+++ b/mullvad-relay-selector/src/relay_selector/helpers.rs
@@ -29,6 +29,17 @@ pub enum Error {
     NoMatchingPort,
 }
 
+/// Picks a relay at random from `relays`, but don't pick `exclude`.
+pub fn pick_random_relay_excluding<'a>(
+    relays: &'a [Relay],
+    exclude: &'_ Relay,
+) -> Option<&'a Relay> {
+    relays
+        .iter()
+        .filter(|&a| a != exclude)
+        .choose(&mut thread_rng())
+}
+
 /// Picks a relay using [pick_random_relay_weighted], using the `weight` member of each relay
 /// as the weight function.
 pub fn pick_random_relay(relays: &[Relay]) -> Option<&Relay> {


### PR DESCRIPTION
All other helper methods for selecting random relays are there. So I thought it would be easier to read if we have them all in one place. Renaming the function to align more consistently with the others at the same time.

I also added tiny amount of docs. And "fixed" a lifetime nitpick.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6873)
<!-- Reviewable:end -->
