### PR TITLE
Fix connection method test ios 843

### DIFF
--- a/ios/MullvadREST/Transport/ProxyConfigurationTransportProvider.swift
+++ b/ios/MullvadREST/Transport/ProxyConfigurationTransportProvider.swift
@@ -14,10 +14,16 @@ import MullvadTypes
 public class ProxyConfigurationTransportProvider {
     private let shadowsocksLoader: ShadowsocksLoaderProtocol
     private let addressCache: REST.AddressCache
+    private let encryptedDNSTransport: RESTTransport
 
-    public init(shadowsocksLoader: ShadowsocksLoaderProtocol, addressCache: REST.AddressCache) {
+    public init(
+        shadowsocksLoader: ShadowsocksLoaderProtocol,
+        addressCache: REST.AddressCache,
+        encryptedDNSTransport: RESTTransport
+    ) {
         self.shadowsocksLoader = shadowsocksLoader
         self.addressCache = addressCache
+        self.encryptedDNSTransport = encryptedDNSTransport
     }
 
     public func makeTransport(with configuration: PersistentProxyConfiguration) throws -> RESTTransport {
@@ -33,7 +39,7 @@ public class ProxyConfigurationTransportProvider {
                 addressCache: addressCache
             )
         case .encryptedDNS:
-            return EncryptedDNSTransport(urlSession: urlSession)
+            return encryptedDNSTransport
         case let .shadowsocks(shadowSocksConfiguration):
             return ShadowsocksTransport(
                 urlSession: urlSession,

--- a/ios/MullvadREST/Transport/TransportProvider.swift
+++ b/ios/MullvadREST/Transport/TransportProvider.swift
@@ -17,18 +17,19 @@ public final class TransportProvider: RESTTransportProvider {
     private var currentTransport: RESTTransport?
     private var currentTransportType: TransportStrategy.Transport
     private let parallelRequestsMutex = NSLock()
-    private let encryptedDNSTransport: EncryptedDNSTransport
+    private let encryptedDNSTransport: RESTTransport
 
     public init(
         urlSessionTransport: URLSessionTransport,
         addressCache: REST.AddressCache,
-        transportStrategy: TransportStrategy
+        transportStrategy: TransportStrategy,
+        encryptedDNSTransport: RESTTransport
     ) {
         self.urlSessionTransport = urlSessionTransport
         self.addressCache = addressCache
         self.transportStrategy = transportStrategy
         self.currentTransportType = transportStrategy.connectionTransport()
-        self.encryptedDNSTransport = EncryptedDNSTransport(urlSession: urlSessionTransport.urlSession)
+        self.encryptedDNSTransport = encryptedDNSTransport
     }
 
     public func makeTransport() -> RESTTransport? {
@@ -56,7 +57,7 @@ public final class TransportProvider: RESTTransportProvider {
 
         if strategy == transportStrategy {
             if strategy.connectionTransport() == .encryptedDNS {
-                encryptedDNSTransport.stop()
+                (encryptedDNSTransport as? EncryptedDNSTransport)?.stop()
             }
             transportStrategy.didFail()
             currentTransport = nil

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -821,6 +821,7 @@
 		A9B6AC1B2ADEA3AD00F7802A /* MemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDEB9C2A98F69E00F578F2 /* MemoryCache.swift */; };
 		A9BA08312BA32FA9005A7A2D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A92962582B1F4FDB00DFB93B /* PrivacyInfo.xcprivacy */; };
 		A9BA08322BA32FB6005A7A2D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A92962582B1F4FDB00DFB93B /* PrivacyInfo.xcprivacy */; };
+		A9BD4D552CA58C3700C8A0E6 /* RESTTransportStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A932D9F42B5EBB9D00999395 /* RESTTransportStub.swift */; };
 		A9BFAFFF2BD004ED00F2BCA1 /* CustomListsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BFAFFE2BD004ED00F2BCA1 /* CustomListsTests.swift */; };
 		A9BFB0012BD00B7F00F2BCA1 /* CustomListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BFB0002BD00B7F00F2BCA1 /* CustomListPage.swift */; };
 		A9C342C12ACC37E30045F00E /* TunnelStatusBlockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E0317D2ACC32920095D843 /* TunnelStatusBlockObserver.swift */; };
@@ -5426,6 +5427,7 @@
 				A9A5FA312ACB05160083449F /* MockFileCache.swift in Sources */,
 				A9A5FA322ACB05160083449F /* RelayCacheTests.swift in Sources */,
 				A9A5FA332ACB05160083449F /* RelaySelectorTests.swift in Sources */,
+				A9BD4D552CA58C3700C8A0E6 /* RESTTransportStub.swift in Sources */,
 				F073FCB32C6617D70062EA1D /* TunnelStore+Stubs.swift in Sources */,
 				58DFF7D32B02570000F864E0 /* MarkdownStylingOptions.swift in Sources */,
 				A9A5FA342ACB05160083449F /* StringTests.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -49,6 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private(set) var configuredTransportProvider: ProxyConfigurationTransportProvider!
     private(set) var ipOverrideRepository = IPOverrideRepository()
     private var launchArguments = LaunchArguments()
+    private var encryptedDNSTransport: EncryptedDNSTransport!
 
     // MARK: - Application lifecycle
 
@@ -121,9 +122,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             settingsUpdater: tunnelSettingsUpdater
         )
 
+        encryptedDNSTransport = EncryptedDNSTransport(urlSession: urlSessionTransport.urlSession)
+
         configuredTransportProvider = ProxyConfigurationTransportProvider(
             shadowsocksLoader: shadowsocksLoader,
-            addressCache: addressCache
+            addressCache: addressCache,
+            encryptedDNSTransport: encryptedDNSTransport
         )
 
         let transportStrategy = TransportStrategy(
@@ -134,7 +138,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let transportProvider = TransportProvider(
             urlSessionTransport: urlSessionTransport,
             addressCache: addressCache,
-            transportStrategy: transportStrategy
+            transportStrategy: transportStrategy,
+            encryptedDNSTransport: encryptedDNSTransport
         )
         setUpTransportMonitor(transportProvider: transportProvider)
         setUpSimulatorHost(transportProvider: transportProvider, relaySelector: relaySelector)

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
@@ -61,7 +61,7 @@ class TunnelManagerTests: XCTestCase {
                     relaySelector: ShadowsocksRelaySelectorStub(relays: .mock()),
                     settingsUpdater: SettingsUpdater(listener: TunnelSettingsListener())
                 )
-            )
+            ), encryptedDNSTransport: RESTTransportStub()
         )
 
         try SettingsManager.writeSettings(LatestTunnelSettings())

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -28,6 +28,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var relaySelector: RelaySelectorWrapper!
     private var ephemeralPeerExchangingPipeline: EphemeralPeerExchangingPipeline!
     private let tunnelSettingsUpdater: SettingsUpdater!
+    private var encryptedDNSTransport: EncryptedDNSTransport!
 
     private let tunnelSettingsListener = TunnelSettingsListener()
     private lazy var ephemeralPeerReceiver = {
@@ -189,10 +190,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             )
         )
 
+        encryptedDNSTransport = EncryptedDNSTransport(urlSession: urlSession)
         return TransportProvider(
             urlSessionTransport: urlSessionTransport,
             addressCache: addressCache,
-            transportStrategy: transportStrategy
+            transportStrategy: transportStrategy,
+            encryptedDNSTransport: encryptedDNSTransport
         )
     }
 }


### PR DESCRIPTION
This PR makes it so that only a single instance of `EncryptedDNSTransport` is ever used in either process.

# Important

This should only be merged after https://github.com/mullvad/mullvadvpn-app/pull/6874

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6875)
<!-- Reviewable:end -->
