### PR TITLE
Address TODO comment in `before-install.sh`

### DIFF
--- a/dist-assets/linux/before-install.sh
+++ b/dist-assets/linux/before-install.sh
@@ -12,9 +12,5 @@ if which systemctl &> /dev/null && systemctl is-system-running | grep -vq offlin
     fi
 fi
 
-# This can be removed when 2022.4 is unsupported. That version is the last version where
-# before-remove.sh doesn't kill the GUI on upgrade.
-pkill -x "mullvad-gui" || true
-
 rm -f /var/cache/mullvad-vpn/relays.json
 rm -f /var/cache/mullvad-vpn/api-ip-address.txt


### PR DESCRIPTION
This PR removes an old workaround in the `before-install.sh` script which is supposedly not required any longer :broom:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6878)
<!-- Reviewable:end -->
