### PR TITLE
Add oracular to list of ubuntu versions to generate deb repositories for

### DIFF
--- a/ci/linux-repository-builder/build-linux-repositories-config.sh
+++ b/ci/linux-repository-builder/build-linux-repositories-config.sh
@@ -15,7 +15,7 @@ SUPPORTED_DEB_CODENAMES+=("noble" "jammy" "focal")
 # ... + latest non-LTS Ubuntu. We officially only support the latest non-LTS.
 # But to not cause too much disturbance just when Ubuntu is released, we keep
 # the last two codenames working in the repository.
-SUPPORTED_DEB_CODENAMES+=("mantic")
+SUPPORTED_DEB_CODENAMES+=("oracular" "mantic")
 export SUPPORTED_DEB_CODENAMES
 
 export SUPPORTED_RPM_ARCHITECTURES=("x86_64" "aarch64")


### PR DESCRIPTION
This PR prepares the repository generation for the upcoming Ubuntu release "Oracular Oriole" with code name `oracular` which is due to be released in the coming weeks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6883)
<!-- Reviewable:end -->
