### PR TITLE
Rename x86 windows installer to not include the architechture in the name

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -225,7 +225,7 @@ function build_ref {
         # Pipes all matching names and their new name to mv
         pushd "$artifact_dir"
         for original_file in MullvadVPN-*-dev-*{.deb,.rpm,.exe,.pkg}; do
-            new_file=$(echo "$original_file" | sed -nE "s/^(MullvadVPN-.*-dev-.*)(_amd64\.deb|_x86_64\.rpm|_arm64\.deb|_aarch64\.rpm|_x64\.exe|_arm64\.exe|\.pkg)$/\1$version_suffix\2/p")
+            new_file=$(echo "$original_file" | perl -pe "s/^(MullvadVPN-.*?)(_arm64|_aarch64|_amd64|_x86_64)?(\.deb|\.rpm|\.exe|\.pkg)$/\1$version_suffix\2\3/p")
             mv "$original_file" "$new_file"
         done
         popd

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -135,7 +135,7 @@ const config = {
         arch: getWindowsTargetArch(),
       },
     ],
-    artifactName: 'MullvadVPN-${version}_${arch}.${ext}',
+    artifactName: getWindowsArtifactName(),
     publisherName: 'Mullvad VPN AB',
     extraResources: [
       { from: distAssets(path.join(getWindowsDistSubdir(), 'mullvad.exe')), to: '.' },
@@ -462,6 +462,13 @@ function getWindowsTargetArch() {
   }
   // Use host architecture (we assume this is x64 since building on Arm64 isn't supported).
   return 'x64';
+}
+
+function getWindowsArtifactName() {
+  if (targets === 'aarch64-pc-windows-msvc') {
+    return 'MullvadVPN-${version}_${arch}.${ext}';
+  }
+  return 'MullvadVPN-${version}.${ext}';
 }
 
 function getWindowsTargetSubdir() {

--- a/test/scripts/test-utils.sh
+++ b/test/scripts/test-utils.sh
@@ -122,7 +122,7 @@ function get_app_filename {
             echo "MullvadVPN-${version}_x86_64.rpm"
             ;;
         windows*)
-            echo "MullvadVPN-${version}_x64.exe"
+            echo "MullvadVPN-${version}.exe"
             ;;
         macos*)
             echo "MullvadVPN-${version}.pkg"


### PR DESCRIPTION
Until we have the universal Windows installer we want to upload the x64 installer but without the architecture suffix. This is to avoid making changes to other parts of the release process in the meanwhile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6885)
<!-- Reviewable:end -->
