### PR TITLE
Proxy DNS lookups through a local resolver on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ Line wrap the file at 100 chars.                                              Th
 - Don't hijack DNS when localhost is configured. This is more in line with other platforms.
   Unexpected DNS traffic is still blocked when leaving the host.
 - Enable IPv6 by default. This fixes DNS and routing being broken on some platforms.
+- Proxy DNS queries through a local resolver.
+
+### Fixed
+#### macOS
+- Fix Apple leak toggle not working. The issue was that DNS queries to the tunnel resolver were
+  being sent on the physical interface.
+
 
 ## [2024.6-beta1] - 2024-09-26
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4107,6 +4107,7 @@ dependencies = [
  "subslice",
  "system-configuration",
  "talpid-dbus",
+ "talpid-macos",
  "talpid-net",
  "talpid-openvpn",
  "talpid-platform-metadata",
@@ -4147,6 +4148,14 @@ dependencies = [
  "rand 0.8.5",
  "talpid-time",
  "tokio",
+]
+
+[[package]]
+name = "talpid-macos"
+version = "0.0.0"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "talpid-core",
     "talpid-dbus",
     "talpid-future",
+    "talpid-macos",
     "talpid-net",
     "talpid-openvpn",
     "talpid-openvpn-plugin",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -56,9 +56,10 @@ talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 pcap = { version = "2.1", features = ["capture-stream"] }
 pnet_packet = "0.34"
 tun = { version = "0.5.5", features = ["async"] }
-nix = { version = "0.28", features = ["socket"] }
+nix = { version = "0.28", features = ["socket", "signal"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+talpid-macos = { path = "../talpid-macos" }
 talpid-net = { path = "../talpid-net" }
 
 [target.'cfg(windows)'.dependencies]

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -177,6 +177,12 @@ impl Firewall {
         let redirect_rules = match policy {
             FirewallPolicy::Blocked {
                 dns_redirect_port, ..
+            }
+            | FirewallPolicy::Connecting {
+                dns_redirect_port, ..
+            }
+            | FirewallPolicy::Connected {
+                dns_redirect_port, ..
             } => {
                 vec![pfctl::RedirectRuleBuilder::default()
                     .action(pfctl::RedirectRuleAction::Redirect)
@@ -186,7 +192,6 @@ impl Firewall {
                     .redirect_to(pfctl::Port::from(*dns_redirect_port))
                     .build()?]
             }
-            _ => vec![],
         };
         Ok(redirect_rules)
     }
@@ -204,6 +209,7 @@ impl Firewall {
                 allowed_tunnel_traffic,
                 redirect_interface,
                 apple_services_bypass,
+                dns_redirect_port: _,
             } => {
                 let mut rules = vec![self.get_allow_relay_rule(peer_endpoint)?];
                 rules.push(self.get_allowed_endpoint_rule(allowed_endpoint)?);
@@ -253,6 +259,7 @@ impl Firewall {
                 dns_config,
                 redirect_interface,
                 apple_services_bypass,
+                dns_redirect_port: _,
             } => {
                 let mut rules = vec![];
 

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -98,6 +98,10 @@ pub enum FirewallPolicy {
         /// Flag setting if we should leak traffic to apple services.
         #[cfg(target_os = "macos")]
         apple_services_bypass: bool,
+        /// Destination port for DNS traffic redirection. Traffic destined to `127.0.0.1:53` will
+        /// be redirected to `127.0.0.1:$dns_redirect_port`.
+        #[cfg(target_os = "macos")]
+        dns_redirect_port: u16,
     },
 
     /// Allow traffic only to server and over tunnel interface
@@ -118,6 +122,10 @@ pub enum FirewallPolicy {
         /// Flag setting if we should leak traffic to apple services.
         #[cfg(target_os = "macos")]
         apple_services_bypass: bool,
+        /// Destination port for DNS traffic redirection. Traffic destined to `127.0.0.1:53` will
+        /// be redirected to `127.0.0.1:$dns_redirect_port`.
+        #[cfg(target_os = "macos")]
+        dns_redirect_port: u16,
     },
 
     /// Block all network traffic in and out from the computer.

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -41,4 +41,4 @@ mod linux;
 
 /// A resolver that's controlled by the tunnel state machine
 #[cfg(target_os = "macos")]
-pub mod resolver;
+pub(crate) mod resolver;

--- a/talpid-core/src/resolver.rs
+++ b/talpid-core/src/resolver.rs
@@ -7,7 +7,6 @@
 use std::{
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::{Path, PathBuf},
     str::FromStr,
     sync::{Arc, Weak},
     time::{Duration, Instant},
@@ -40,7 +39,6 @@ use hickory_server::{
     server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
     ServerFuture,
 };
-use libc::{c_void, kill, pid_t, proc_listallpids, proc_pidpath, SIGHUP};
 use std::sync::LazyLock;
 
 const ALLOWED_RECORD_TYPES: &[RecordType] =
@@ -358,73 +356,13 @@ const MDNS_RESPONDER_PATH: &str = "/usr/sbin/mDNSResponder";
 
 /// Find and kill mDNSResponder. The OS will restart the service.
 fn kill_mdnsresponder() -> io::Result<()> {
-    if let Some(mdns_pid) = pid_of_path(MDNS_RESPONDER_PATH) {
-        if unsafe { kill(mdns_pid as i32, SIGHUP) } != 0 {
-            return Err(io::Error::last_os_error());
-        }
+    if let Some(mdns_pid) = talpid_macos::process::pid_of_path(MDNS_RESPONDER_PATH) {
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(mdns_pid),
+            nix::sys::signal::SIGHUP,
+        )?;
     }
     Ok(())
-}
-
-/// Return the first process identifier matching a specified path, if one exists.
-fn pid_of_path(find_path: impl AsRef<Path>) -> Option<pid_t> {
-    match list_pids() {
-        Ok(pids) => {
-            for pid in pids {
-                if let Ok(path) = process_path(pid) {
-                    if path == find_path.as_ref() {
-                        return Some(pid);
-                    }
-                }
-            }
-            None
-        }
-        Err(error) => {
-            log::error!("Failed to list processes: {error}");
-            None
-        }
-    }
-}
-
-/// Obtain a list of all pids
-fn list_pids() -> io::Result<Vec<pid_t>> {
-    // SAFETY: Passing in null and 0 returns the number of processes
-    let num_pids = unsafe { proc_listallpids(std::ptr::null_mut(), 0) };
-    if num_pids <= 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let num_pids = usize::try_from(num_pids).unwrap();
-    let mut pids = vec![0i32; num_pids];
-
-    let buf_sz = (num_pids * std::mem::size_of::<pid_t>()) as i32;
-    // SAFETY: 'pids' is large enough to contain 'num_pids' processes
-    let num_pids = unsafe { proc_listallpids(pids.as_mut_ptr() as *mut c_void, buf_sz) };
-    if num_pids == -1 {
-        return Err(io::Error::last_os_error());
-    }
-
-    pids.resize(usize::try_from(num_pids).unwrap(), 0);
-
-    Ok(pids)
-}
-
-fn process_path(pid: pid_t) -> io::Result<PathBuf> {
-    let mut buffer = [0u8; libc::MAXPATHLEN as usize];
-    // SAFETY: `proc_pidpath` returns at most `buffer.len()` bytes
-    let buf_len = unsafe {
-        proc_pidpath(
-            pid,
-            buffer.as_mut_ptr() as *mut c_void,
-            u32::try_from(buffer.len()).unwrap(),
-        )
-    };
-    if buf_len == -1 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(PathBuf::from(
-        std::str::from_utf8(&buffer[0..buf_len as usize])
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid process path"))?,
-    ))
 }
 
 type LookupResponse<'a> = MessageResponse<

--- a/talpid-core/src/resolver.rs
+++ b/talpid-core/src/resolver.rs
@@ -1,3 +1,9 @@
+//! This module implements a forwarding DNS resolver with two states:
+//! * In the `Blocked` state, most queries receive an empty response, but certain captive portal
+//!   domains receive a spoofed answer. This fools the OS into thinking that it has connectivity.
+//! * In the `Forwarding` state, queries are forwarded to a set of configured DNS servers. This
+//!   lets us use the routing table to determine where to send them, instead of them being forced
+//!   out on the primary interface (in some cases).
 use std::{
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},

--- a/talpid-core/src/split_tunnel/macos/mod.rs
+++ b/talpid-core/src/split_tunnel/macos/mod.rs
@@ -614,7 +614,7 @@ impl State {
                     Some(vpn_interface.clone()),
                     route_manager.clone(),
                     Box::new(move |packet| {
-                        match states.get_process_status(packet.header.pth_pid as u32) {
+                        match states.get_process_status(packet.header.pth_pid) {
                             ExclusionStatus::Excluded => tun::RoutingDecision::DefaultInterface,
                             ExclusionStatus::Included => tun::RoutingDecision::VpnTunnel,
                             ExclusionStatus::Unknown => {

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -133,6 +133,10 @@ impl DisconnectedState {
     fn setup_local_dns_config(
         shared_values: &mut SharedTunnelStateValues,
     ) -> Result<(), dns::Error> {
+        shared_values
+            .runtime
+            .block_on(shared_values.filtering_resolver.disable_forward());
+
         shared_values.dns_monitor.set(
             "lo",
             dns::DnsConfig::default().resolve(&[Ipv4Addr::LOCALHOST.into()]),

--- a/talpid-macos/Cargo.toml
+++ b/talpid-macos/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "talpid-macos"
+description = "Abstractions for macOS"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[target.'cfg(target_os="macos")'.dependencies]
+libc = "0.2"
+log = { workspace = true }

--- a/talpid-macos/src/lib.rs
+++ b/talpid-macos/src/lib.rs
@@ -1,0 +1,7 @@
+//! Interface with macOS-specific bits.
+
+#![deny(missing_docs)]
+#![cfg(target_os = "macos")]
+
+/// Processes
+pub mod process;

--- a/talpid-macos/src/process.rs
+++ b/talpid-macos/src/process.rs
@@ -1,0 +1,67 @@
+use libc::{c_void, pid_t, proc_listallpids, proc_pidpath};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+/// Return the first process identifier matching a specified path, if one exists.
+pub fn pid_of_path(find_path: impl AsRef<Path>) -> Option<pid_t> {
+    match list_pids() {
+        Ok(pids) => {
+            for pid in pids {
+                if let Ok(path) = process_path(pid) {
+                    if path == find_path.as_ref() {
+                        return Some(pid);
+                    }
+                }
+            }
+            None
+        }
+        Err(error) => {
+            log::error!("Failed to list processes: {error}");
+            None
+        }
+    }
+}
+
+/// Obtain a list of all process identifiers
+pub fn list_pids() -> io::Result<Vec<pid_t>> {
+    // SAFETY: Passing in null and 0 returns the number of processes
+    let num_pids = unsafe { proc_listallpids(std::ptr::null_mut(), 0) };
+    if num_pids <= 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let num_pids = usize::try_from(num_pids).unwrap();
+    let mut pids = vec![0i32; num_pids];
+
+    let buf_sz = (num_pids * std::mem::size_of::<pid_t>()) as i32;
+    // SAFETY: 'pids' is large enough to contain 'num_pids' processes
+    let num_pids = unsafe { proc_listallpids(pids.as_mut_ptr() as *mut c_void, buf_sz) };
+    if num_pids == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    pids.resize(usize::try_from(num_pids).unwrap(), 0);
+
+    Ok(pids)
+}
+
+/// Return the path of the process `pid`
+pub fn process_path(pid: pid_t) -> io::Result<PathBuf> {
+    let mut buffer = [0u8; libc::MAXPATHLEN as usize];
+    // SAFETY: `proc_pidpath` returns at most `buffer.len()` bytes
+    let buf_len = unsafe {
+        proc_pidpath(
+            pid,
+            buffer.as_mut_ptr() as *mut c_void,
+            u32::try_from(buffer.len()).unwrap(),
+        )
+    };
+    if buf_len == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(PathBuf::from(
+        std::str::from_utf8(&buffer[0..buf_len as usize])
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid process path"))?,
+    ))
+}


### PR DESCRIPTION
This allows us to force queries to be sent on the tunnel interface. It will also let us control whether to return IPv6 addresses regardless of whether the primary interface has enabled them.

Fix DES-1279.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6890)
<!-- Reviewable:end -->
