### PR TITLE
Fix bug when overriding API with only MULLVAD_API_HOST

### DIFF
--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -199,6 +199,7 @@ impl ApiEndpoint {
                         )
                     })
                     .next();
+                api.host = Some(host);
             }
             (host, Some(address)) => {
                 let addr = address.parse().unwrap_or_else(|_| {


### PR DESCRIPTION
I'm trying to run the daemon against stagemole. I found a bug! :partying_face: 

When the override is done with only `MULLVAD_API_HOST` it should look up the IP via DNS. This part works but, it uses the wrong hostname. In this code path we never update `api.host`, resulting it in falling back to the default (`api.mullvad.net`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6893)
<!-- Reviewable:end -->
