### PR TITLE
Fix unlabeled buttons in Android app

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -37,6 +37,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix VPN service being recreated multiple times when toggling certain options.
+- Fix unlabeled icon buttons for basic accessibility with screen readers.
 
 
 ## [android/2024.4] - 2024-09-03

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/button/SwitchLocationButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/button/SwitchLocationButton.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -157,7 +158,7 @@ fun SwitchLocationButton(
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.icon_reconnect),
-                        contentDescription = null,
+                        contentDescription = stringResource(id = R.string.reconnect),
                     )
                 }
             }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/DropdownMenuCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/DropdownMenuCell.kt
@@ -8,8 +8,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 
@@ -43,7 +45,7 @@ fun ThreeDotCell(
             IconButton(onClick = onClickDots) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.custom_lists),
                     tint = textColor,
                 )
             }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/ExpandableComposeCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/ExpandableComposeCell.kt
@@ -102,7 +102,7 @@ private fun ExpandableComposeCellBody(
             ) {
                 Icon(
                     imageVector = Icons.Default.Info,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.more_information),
                     tint = MaterialTheme.colorScheme.onPrimary,
                 )
             }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/InformationComposeCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/InformationComposeCell.kt
@@ -15,7 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import net.mullvad.mullvadvpn.R
 import net.mullvad.mullvadvpn.lib.theme.AppTheme
 import net.mullvad.mullvadvpn.lib.theme.Dimens
 import net.mullvad.mullvadvpn.lib.theme.color.AlphaInactive
@@ -80,7 +82,7 @@ private fun InformationComposeCellBody(modifier: Modifier, onInfoClicked: (() ->
             ) {
                 Icon(
                     imageVector = Icons.Default.Info,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.more_information),
                     tint = MaterialTheme.colorScheme.onPrimary,
                 )
             }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SwitchComposeCell.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/cell/SwitchComposeCell.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -168,7 +169,11 @@ fun SwitchCellView(
                         .padding(horizontal = Dimens.miniPadding),
                 onClick = onInfoClicked,
             ) {
-                Icon(imageVector = Icons.Default.Info, contentDescription = null, tint = iconColor)
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = stringResource(id = R.string.more_information),
+                    tint = iconColor,
+                )
             }
         }
 

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/ExpandChevron.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/ExpandChevron.kt
@@ -14,7 +14,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import net.mullvad.mullvadvpn.R
 
 @Composable
 @Preview
@@ -29,6 +31,12 @@ private fun PreviewChevron() {
 fun ExpandChevron(modifier: Modifier = Modifier, color: Color, isExpanded: Boolean) {
 
     val degree = remember(isExpanded) { if (isExpanded) UP_ROTATION else DOWN_ROTATION }
+    val stateLabel =
+        if (isExpanded) {
+            stringResource(id = R.string.collapse)
+        } else {
+            stringResource(id = R.string.expand)
+        }
     val animatedRotation =
         animateFloatAsState(
             targetValue = degree,
@@ -38,7 +46,7 @@ fun ExpandChevron(modifier: Modifier = Modifier, color: Color, isExpanded: Boole
 
     Icon(
         imageVector = Icons.Default.KeyboardArrowDown,
-        contentDescription = null,
+        contentDescription = stateLabel,
         tint = color,
         modifier = modifier.rotate(animatedRotation.value),
     )

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/NavigateButton.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/NavigateButton.kt
@@ -9,24 +9,35 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import net.mullvad.mullvadvpn.R
 
 @Composable
 fun NavigateBackIconButton(modifier: Modifier = Modifier, onNavigateBack: () -> Unit) {
     IconButton(onClick = onNavigateBack, modifier = modifier) {
-        Icon(imageVector = Icons.AutoMirrored.Default.ArrowBack, contentDescription = null)
+        Icon(
+            imageVector = Icons.AutoMirrored.Default.ArrowBack,
+            contentDescription = stringResource(id = R.string.back),
+        )
     }
 }
 
 @Composable
 fun NavigateBackDownIconButton(onNavigateBack: () -> Unit) {
     IconButton(onClick = onNavigateBack) {
-        Icon(imageVector = Icons.Default.ArrowDownward, contentDescription = null)
+        Icon(
+            imageVector = Icons.Default.ArrowDownward,
+            contentDescription = stringResource(id = R.string.back),
+        )
     }
 }
 
 @Composable
 fun NavigateCloseIconButton(onNavigateClose: () -> Unit) {
     IconButton(onClick = onNavigateClose) {
-        Icon(imageVector = Icons.Default.Close, contentDescription = null)
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = stringResource(id = R.string.close),
+        )
     }
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationBanner.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationBanner.kt
@@ -187,7 +187,7 @@ private fun Notification(notificationBannerData: NotificationData) {
                 Icon(
                     modifier = Modifier.padding(Dimens.notificationIconPadding),
                     imageVector = it.icon,
-                    contentDescription = null,
+                    contentDescription = it.contentDescription,
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationData.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/component/notificationbanner/NotificationData.kt
@@ -35,7 +35,11 @@ data class NotificationData(
     ) : this(title, message?.let { AnnotatedString(it) }, statusLevel, action)
 }
 
-data class NotificationAction(val icon: ImageVector, val onClick: (() -> Unit))
+data class NotificationAction(
+    val icon: ImageVector,
+    val onClick: (() -> Unit),
+    val contentDescription: String,
+)
 
 @Composable
 fun InAppNotification.toNotificationData(
@@ -64,7 +68,12 @@ fun InAppNotification.toNotificationData(
                                 )
                         ),
                 statusLevel = StatusLevel.Info,
-                action = NotificationAction(Icons.Default.Clear, onDismissNewDevice),
+                action =
+                    NotificationAction(
+                        Icons.Default.Clear,
+                        onDismissNewDevice,
+                        stringResource(id = R.string.dismiss),
+                    ),
             )
         is InAppNotification.AccountExpiry ->
             NotificationData(
@@ -74,7 +83,11 @@ fun InAppNotification.toNotificationData(
                 action =
                     if (isPlayBuild) null
                     else
-                        NotificationAction(Icons.AutoMirrored.Default.OpenInNew, onClickShowAccount),
+                        NotificationAction(
+                            Icons.AutoMirrored.Default.OpenInNew,
+                            onClickShowAccount,
+                            stringResource(id = R.string.open_url),
+                        ),
             )
         InAppNotification.TunnelStateBlocked ->
             NotificationData(
@@ -93,6 +106,7 @@ fun InAppNotification.toNotificationData(
                         NotificationAction(
                             Icons.AutoMirrored.Default.OpenInNew,
                             onClickUpdateVersion,
+                            stringResource(id = R.string.open_url),
                         ),
             )
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AccountScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/AccountScreen.kt
@@ -226,7 +226,7 @@ private fun DeviceNameRow(deviceName: String, onInfoClick: () -> Unit) {
             IconButton(onClick = onInfoClick) {
                 Icon(
                     imageVector = Icons.Default.Info,
-                    contentDescription = null,
+                    contentDescription = stringResource(id = R.string.more_information),
                     tint = MaterialTheme.colorScheme.onSurface,
                 )
             }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/FilterScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/FilterScreen.kt
@@ -232,7 +232,7 @@ private fun TopBar(onBackClick: () -> Unit) {
         IconButton(onClick = onBackClick) {
             Icon(
                 imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                contentDescription = null,
+                contentDescription = stringResource(id = R.string.back),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ImportOverridesByTextScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ImportOverridesByTextScreen.kt
@@ -55,7 +55,10 @@ fun ImportOverridesByTextScreen(onNavigateBack: () -> Unit, onImportClicked: (St
                 title = stringResource(R.string.import_overrides_text_title),
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(imageVector = Icons.Default.Close, contentDescription = null)
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(id = R.string.close),
+                        )
                     }
                 },
                 actions = {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/SelectLocationScreen.kt
@@ -491,7 +491,7 @@ private fun SelectLocationTopBar(onBackClick: () -> Unit, onFilterClick: () -> U
             Icon(
                 imageVector = Icons.Default.Close,
                 tint = MaterialTheme.colorScheme.onSurface,
-                contentDescription = null,
+                contentDescription = stringResource(id = R.string.back),
             )
         }
         Text(
@@ -504,7 +504,7 @@ private fun SelectLocationTopBar(onBackClick: () -> Unit, onFilterClick: () -> U
         IconButton(onClick = onFilterClick) {
             Icon(
                 imageVector = Icons.Default.FilterList,
-                contentDescription = null,
+                contentDescription = stringResource(id = R.string.filter),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ViewLogsScreen.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/screen/ViewLogsScreen.kt
@@ -114,13 +114,19 @@ private fun TopBar(
                 onClick = { clipboardHandle(state.text(), clipboardToastMessage) },
                 modifier = Modifier.focusProperties { down = FocusRequester.Cancel },
             ) {
-                Icon(imageVector = Icons.Default.ContentCopy, contentDescription = null)
+                Icon(
+                    imageVector = Icons.Default.ContentCopy,
+                    contentDescription = stringResource(id = R.string.copy),
+                )
             }
             IconButton(
                 onClick = { scope.launch { shareText(context, state.text()) } },
                 modifier = Modifier.focusProperties { down = FocusRequester.Cancel },
             ) {
-                Icon(imageVector = Icons.Default.Share, contentDescription = null)
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = stringResource(id = R.string.share),
+                )
             }
         },
     )

--- a/android/lib/resource/src/main/res/values-da/strings.xml
+++ b/android/lib/resource/src/main/res/values-da/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Annuller</string>
     <string name="changes_dialog_subtitle">Ændringer i denne version:</string>
     <string name="cipher">Chiffer</string>
+    <string name="close">Luk</string>
     <string name="confirm_local_dns">Den lokale DNS-server fungerer ikke, medmindre du aktiverer \"Lokal netværksdeling\" under Indstillinger.</string>
     <string name="confirm_no_email">Du er ved at sende rapporten om problemet, men har ikke angivet hvordan vi kan kontakte dig. Hvis du ønsker et svar på din rapport, skal du indtaste en e-mail-adresse.</string>
     <string name="confirm_removal">Ja, log enhed af</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Log ud af mindst én ved at fjerne den fra listen nedenfor. Du kan finde det tilsvarende enhedsnavn under enhedens kontoindstillinger.</string>
     <string name="max_devices_warning_title">For mange enheder</string>
+    <string name="more_information">Mere information</string>
     <string name="mullvad_account_number">Mullvad-kontonummer</string>
     <string name="mullvad_owned_only">Kun ejet af Mullvad</string>
     <string name="name">Navn</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard-tilsløring</string>
     <string name="off">Fra</string>
     <string name="on">Til</string>
+    <string name="open_url">Åbn URL</string>
     <string name="out_address">Ud</string>
     <string name="out_of_time">Tid udløbet</string>
     <string name="overrides_cleared">Tilsidesættelser ryddet</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Denne funktion gør WireGuard-tunnelen modstandsdygtig over for potentielle angreb fra kvantecomputere.</string>
     <string name="quantum_resistant_info_second_paragaph">Det gør den ved at udføre en ekstra nøgleudveksling ved hjælp af en kvantesikker algoritme og blande resultatet med WireGuards almindelige kryptering. Dette ekstra trin bruger cirka 500 kB trafik, hver gang en ny tunnel etableres.</string>
     <string name="quantum_resistant_title">Kvante-modstandsdygtig tunnel</string>
+    <string name="reconnect">Genopret forbindelse</string>
     <string name="redeem">Indløs</string>
     <string name="redeem_voucher">Indløs kupon</string>
     <string name="remove_button">Fjern</string>

--- a/android/lib/resource/src/main/res/values-de/strings.xml
+++ b/android/lib/resource/src/main/res/values-de/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Abbrechen</string>
     <string name="changes_dialog_subtitle">Änderungen in dieser Version:</string>
     <string name="cipher">Chiffre</string>
+    <string name="close">Schließen</string>
     <string name="confirm_local_dns">Der lokale DNS-Server wird nicht funktionieren, solange „Teilen im lokalen Netzwerk“ nicht in den Einstellungen aktiviert ist.</string>
     <string name="confirm_no_email">Sie wollen einen Problembericht senden, ohne uns die Möglichkeit zu geben, Sie zu erreichen. Wenn Sie sich eine Antwort zu Ihrem Problem wünschen, müssen Sie eine E-Mail-Adresse eingeben.</string>
     <string name="confirm_removal">Ja, von Gerät abmelden</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Bitte melden Sie sich von mindestens einem Gerät ab, indem Sie es aus der Liste unten entfernen. Sie finden den entsprechenden Gerätenamen unter den Kontoeinstellungen des Geräts.</string>
     <string name="max_devices_warning_title">Zu viele Geräte</string>
+    <string name="more_information">Weitere Informationen</string>
     <string name="mullvad_account_number">Mullvad-Kontonummer</string>
     <string name="mullvad_owned_only">Nur im Besitz von Mullvad</string>
     <string name="name">Name</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard-Verschleierung</string>
     <string name="off">Aus</string>
     <string name="on">Ein</string>
+    <string name="open_url">URL öffnen</string>
     <string name="out_address">Ausgehend</string>
     <string name="out_of_time">Zeit abgelaufen</string>
     <string name="overrides_cleared">Überschreibungen entfernt</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Diese Funktion macht den WireGuard-Tunnel resistent gegen mögliche Angriffe von Quantencomputern.</string>
     <string name="quantum_resistant_info_second_paragaph">Dazu wird ein zusätzlicher Schlüsselaustausch mit einem quantensicheren Algorithmus durchgeführt und das Ergebnis mit der regulären Verschlüsselung von WireGuard vermischt. Dieser zusätzliche Schritt verbraucht jedes Mal, wenn ein neuer Tunnel aufgebaut wird, etwa 500 KiB an Datenverkehr.</string>
     <string name="quantum_resistant_title">Quantenresistenter Tunnel</string>
+    <string name="reconnect">Erneut verbinden</string>
     <string name="redeem">Einlösen</string>
     <string name="redeem_voucher">Gutschein einlösen</string>
     <string name="remove_button">Entfernen</string>

--- a/android/lib/resource/src/main/res/values-es/strings.xml
+++ b/android/lib/resource/src/main/res/values-es/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Cancelar</string>
     <string name="changes_dialog_subtitle">Cambios en esta versión:</string>
     <string name="cipher">Cifrado</string>
+    <string name="close">Cerrar</string>
     <string name="confirm_local_dns">El servidor DNS local no funcionará a no ser que habilite la opción «Uso compartido de red local» en Preferencias.</string>
     <string name="confirm_no_email">Va a enviar el informe de problemas sin indicar una forma de contacto. Para obtener una respuesta sobre el informe, necesita especificar su dirección de correo electrónico.</string>
     <string name="confirm_removal">Sí, cerrar sesión</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">¡Genial!</string>
     <string name="max_devices_warning_description">Cierre la sesión como mínimo en un dispositivo (para hacerlo, quítelo de la lista siguiente). Consulte el nombre del dispositivo en la configuración de la cuenta del dispositivo.</string>
     <string name="max_devices_warning_title">Demasiados dispositivos</string>
+    <string name="more_information">Más información</string>
     <string name="mullvad_account_number">Número de cuenta de Mullvad</string>
     <string name="mullvad_owned_only">Solo propiedad de Mullvad</string>
     <string name="name">Nombre</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">Ofuscación de WireGuard</string>
     <string name="off">Desactivado</string>
     <string name="on">Activado</string>
+    <string name="open_url">Abrir URL</string>
     <string name="out_address">Salida</string>
     <string name="out_of_time">Tiempo agotado</string>
     <string name="overrides_cleared">Anulaciones borradas</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Esta característica permite que el túnel de WireGuard resista posibles ataques de ordenadores cuánticos.</string>
     <string name="quantum_resistant_info_second_paragaph">Lo hace al realizar un intercambio de claves adicional usando un algoritmo cuántico seguro y combinando el resultado en el cifrado normal de WireGuard. Este paso extra utiliza aproximadamente 500 kiB de tráfico cada vez que se establece un nuevo túnel.</string>
     <string name="quantum_resistant_title">Túnel con resistencia cuántica</string>
+    <string name="reconnect">Reconectar</string>
     <string name="redeem">Canjear</string>
     <string name="redeem_voucher">Canjear cupón</string>
     <string name="remove_button">Quitar</string>

--- a/android/lib/resource/src/main/res/values-fi/strings.xml
+++ b/android/lib/resource/src/main/res/values-fi/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Peruuta</string>
     <string name="changes_dialog_subtitle">Muutokset tässä versiossa:</string>
     <string name="cipher">Salaus</string>
+    <string name="close">Sulje</string>
     <string name="confirm_local_dns">Paikallinen DNS-palvelin ei toimi, ellet ota paikallisen verkon jakamisasetusta käyttöön asetuksissa.</string>
     <string name="confirm_no_email">Olet aikeissa lähettää ongelmaraportin ilman yhteystietojasi. Mikäli haluat vastauksen raporttiisi, anna sähköpostosoite.</string>
     <string name="confirm_removal">Kyllä, kirjaa laite ulos</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Mahtavaa!</string>
     <string name="max_devices_warning_description">Kirjaudu ulos vähintään yhdestä luettelon laitteesta poistamalla se. Löydät vastaavan laitteen nimen laitteen tiliasetuksista.</string>
     <string name="max_devices_warning_title">Liikaa laitteita</string>
+    <string name="more_information">Lisätietoja</string>
     <string name="mullvad_account_number">Mullvad-tilin numero</string>
     <string name="mullvad_owned_only">Vain Mullvadin omistamat</string>
     <string name="name">Nimi</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard-obfuskointi</string>
     <string name="off">Pois</string>
     <string name="on">Päällä</string>
+    <string name="open_url">Avaa URL</string>
     <string name="out_address">Lähtevä</string>
     <string name="out_of_time">Ei käyttöaikaa</string>
     <string name="overrides_cleared">Ohitukset on poistettu</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Tämä ominaisuus tekee WireGuard-tunnelista kestävän kvanttitietokoneiden mahdollisia hyökkäyksiä vastaan.</string>
     <string name="quantum_resistant_info_second_paragaph">Tunneli torjuu hyökkäykset suorittamalla ylimääräisen avaimenvaihdon käyttämällä ensin kvanttiturvallista algoritmia, jonka tuloksen se sekoittaa WireGuardin tavalliseen salaukseen. Tämä ylimääräinen vaihe käyttää noin 500 kiB liikennettä joka kerta, kun uusi tunneli luodaan.</string>
     <string name="quantum_resistant_title">Kvanttihyökkäyksiä kestävä tunneli</string>
+    <string name="reconnect">Yhdistä uudelleen</string>
     <string name="redeem">Lunasta</string>
     <string name="redeem_voucher">Lunasta kuponki</string>
     <string name="remove_button">Poista</string>

--- a/android/lib/resource/src/main/res/values-fr/strings.xml
+++ b/android/lib/resource/src/main/res/values-fr/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Annuler</string>
     <string name="changes_dialog_subtitle">Modifications dans cette version :</string>
     <string name="cipher">Chiffre</string>
+    <string name="close">Fermer</string>
     <string name="confirm_local_dns">Le serveur DNS local ne fonctionnera pas si vous n\'activez pas le « Partage du réseau local » dans les préférences.</string>
     <string name="confirm_no_email">Vous êtes sur le point d\'envoyer un signalement de problème sans nous fournir un moyen de vous contacter. Si vous désirez une réponse à votre signalement, vous devez saisir une adresse e-mail.</string>
     <string name="confirm_removal">Oui, déconnecter l\'appareil</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Super !</string>
     <string name="max_devices_warning_description">Merci de vous déconnecter d\'au moins un appareil en le supprimant de la liste ci-dessous. Vous trouverez le nom de l\'appareil correspondant dans les paramètres du compte de l\'appareil.</string>
     <string name="max_devices_warning_title">Trop d\'appareils</string>
+    <string name="more_information">Plus d\'informations</string>
     <string name="mullvad_account_number">Numéro de compte Mullvad</string>
     <string name="mullvad_owned_only">Propriété de Mullvad uniquement</string>
     <string name="name">Nom</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">Obfuscation WireGuard</string>
     <string name="off">Désactivé</string>
     <string name="on">Activé</string>
+    <string name="open_url">Ouvrir l\'URL</string>
     <string name="out_address">Sortante</string>
     <string name="out_of_time">Plus de temps</string>
     <string name="overrides_cleared">Substitutions supprimées</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Cette fonctionnalité rend le tunnel WireGuard résistant aux attaques potentielles des ordinateurs quantiques.</string>
     <string name="quantum_resistant_info_second_paragaph">Pour ce faire, il effectue un échange de clés supplémentaire à l\'aide d\'un algorithme à sécurité quantique et mélange le résultat au chiffrement habituel de WireGuard. Cette étape supplémentaire utilise environ 500 kiB de trafic chaque fois qu\'un nouveau tunnel est établi.</string>
     <string name="quantum_resistant_title">Tunnel résistant aux attaques quantiques</string>
+    <string name="reconnect">Reconnexion</string>
     <string name="redeem">Échanger</string>
     <string name="redeem_voucher">Échanger un bon</string>
     <string name="remove_button">Supprimer</string>

--- a/android/lib/resource/src/main/res/values-it/strings.xml
+++ b/android/lib/resource/src/main/res/values-it/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Annulla</string>
     <string name="changes_dialog_subtitle">Modifiche in questa versione:</string>
     <string name="cipher">Codice</string>
+    <string name="close">Chiudi</string>
     <string name="confirm_local_dns">Il server DNS locale non funzionerà a meno che non si abiliti \"Condivisione rete locale\" in Preferenze.</string>
     <string name="confirm_no_email">Stai inviando la segnalazione di un problema senza averci indicato un modo per ricontattarti. Se desideri ricevere risposta, inserisci un indirizzo e-mail.</string>
     <string name="confirm_removal">Sì, disconnetti dal dispositivo</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Fantastico!</string>
     <string name="max_devices_warning_description">Disconnettiti da almeno un dispositivo rimuovendolo dall\'elenco seguente. Puoi trovare il nome del dispositivo corrispondente nelle impostazioni dell\'account del dispositivo.</string>
     <string name="max_devices_warning_title">Troppi dispositivi</string>
+    <string name="more_information">Maggiori informazioni</string>
     <string name="mullvad_account_number">Numero di account Mullvad</string>
     <string name="mullvad_owned_only">Solo di proprietà di Mullvad</string>
     <string name="name">Nome</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">Offuscamento WireGuard</string>
     <string name="off">Off</string>
     <string name="on">On</string>
+    <string name="open_url">Apri URL</string>
     <string name="out_address">Invio</string>
     <string name="out_of_time">Scaduto</string>
     <string name="overrides_cleared">Sovrascritture cancellate</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Questa funzionalità rende il tunnel WireGuard resistente ai potenziali attacchi dei computer quantistici.</string>
     <string name="quantum_resistant_info_second_paragaph">L\'operazione viene effettuata eseguendo uno scambio di chiavi aggiuntivo con un algoritmo di sicurezza quantistica e mescolando il risultato nella normale crittografia di WireGuard. Questo passaggio aggiuntivo utilizza circa 500 kiB di traffico ogni volta che viene stabilito un nuovo tunnel.</string>
     <string name="quantum_resistant_title">Tunnel resistente agli attacchi quantistici</string>
+    <string name="reconnect">Riconnetti</string>
     <string name="redeem">Riscatta</string>
     <string name="redeem_voucher">Riscatta voucher</string>
     <string name="remove_button">Rimuovi</string>

--- a/android/lib/resource/src/main/res/values-ja/strings.xml
+++ b/android/lib/resource/src/main/res/values-ja/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">キャンセル</string>
     <string name="changes_dialog_subtitle">このバージョンでの変更内容:</string>
     <string name="cipher">暗号化</string>
+    <string name="close">閉じる</string>
     <string name="confirm_local_dns">環境設定で \"ローカルネットワーク共有\" を有効にしない限り、ローカルDNSサーバーは機能しません。</string>
     <string name="confirm_no_email">お客様への返信先を入力せずに問題の報告を送信しようとしています。ご報告に対する返信が必要な場合は、返信先のメールアドレスを入力する必要があります。</string>
     <string name="confirm_removal">はい。デバイスをログアウトさせます</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">素晴らしい！</string>
     <string name="max_devices_warning_description">以下のリストから少なくとも1つを削除してログアウトしてください。対応するデバイス名はデバイスのアカウント設定で確認できます。</string>
     <string name="max_devices_warning_title">デバイスが多すぎます</string>
+    <string name="more_information">詳細情報</string>
     <string name="mullvad_account_number">Mullvadアカウント番号</string>
     <string name="mullvad_owned_only">Mullvad 所有サーバーのみ</string>
     <string name="name">名前</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuardの難読化</string>
     <string name="off">オフ</string>
     <string name="on">オン</string>
+    <string name="open_url">URLを開く</string>
     <string name="out_address">外側</string>
     <string name="out_of_time">時間切れ</string>
     <string name="overrides_cleared">オーバーライドがクリアされました</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">この機能は、WireGuardトンネルに量子コンピューターからの潜在的な攻撃に対する耐性を与えます。</string>
     <string name="quantum_resistant_info_second_paragaph">耐量子アルゴリズムで追加の鍵の交換を実行し、結果をWireGuardの通常の暗号化に混合させることで行われます。この追加ステップでは、新しいトンネルが確立されるたびに約500kiBのトラフィックが使用されます。</string>
     <string name="quantum_resistant_title">耐量子トンネル</string>
+    <string name="reconnect">再接続</string>
     <string name="redeem">使用する</string>
     <string name="redeem_voucher">バウチャーを使用する</string>
     <string name="remove_button">削除</string>

--- a/android/lib/resource/src/main/res/values-ko/strings.xml
+++ b/android/lib/resource/src/main/res/values-ko/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">취소</string>
     <string name="changes_dialog_subtitle">이 버전의 변경 사항:</string>
     <string name="cipher">암호</string>
+    <string name="close">닫기</string>
     <string name="confirm_local_dns">환경 설정에서 ”로컬 네트워크 공유”를 활성화하지 않으면 로컬 DNS 서버가 작동하지 않습니다.</string>
     <string name="confirm_no_email">연락처 없이 문제 보고서를 보내려고 합니다. 보고서에 대한 답변을 원하면 이메일 주소를 입력해야 합니다.</string>
     <string name="confirm_removal">예, 장치에서 로그아웃</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">좋습니다!</string>
     <string name="max_devices_warning_description">하나 이상의 항목을 아래 목록에서 제거하여 로그아웃하세요. 장치의 계정 설정에서 해당 장치 이름을 찾을 수 있습니다.</string>
     <string name="max_devices_warning_title">장치가 너무 많음</string>
+    <string name="more_information">추가 정보</string>
     <string name="mullvad_account_number">Mullvad 계정 번호</string>
     <string name="mullvad_owned_only">Mullvad 소유만</string>
     <string name="name">이름</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard 난독화</string>
     <string name="off">끄기</string>
     <string name="on">켜기</string>
+    <string name="open_url">URL 열기</string>
     <string name="out_address">아웃</string>
     <string name="out_of_time">시간 초과</string>
     <string name="overrides_cleared">재정의 지워짐</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">이 기능은 WireGuard 터널이 양자 컴퓨터의 잠재적인 공격에 맞서도록 합니다.</string>
     <string name="quantum_resistant_info_second_paragaph">이를 위해 양자 안전 알고리즘을 사용하여 추가 키 교환을 수행하고 결과를 WireGuard의 일반 암호화에 혼합하는 방법이 이용됩니다. 이 추가 단계는 새 터널이 설정될 때마다 약 500kiB의 트래픽을 사용합니다.</string>
     <string name="quantum_resistant_title">양자 저항 터널</string>
+    <string name="reconnect">다시 연결</string>
     <string name="redeem">사용</string>
     <string name="redeem_voucher">바우처 사용</string>
     <string name="remove_button">제거</string>

--- a/android/lib/resource/src/main/res/values-my/strings.xml
+++ b/android/lib/resource/src/main/res/values-my/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">မလုပ်တော့ပါ</string>
     <string name="changes_dialog_subtitle">ဤဗားရှင်းတွင် ပြောင်းလဲမှုများ-</string>
     <string name="cipher">ဝှက်စာ</string>
+    <string name="close">ပိတ်ရန်</string>
     <string name="confirm_local_dns">လိုကယ် DNS ဆာဗာသည် လိုလားမှုများအောက်ရှိ \"လိုကယ် ကွန်ရက် ဝေမျှမှု\"ကို မဖွင့်မချင်း အလုပ်လုပ်မည် မဟုတ်ပါ။</string>
     <string name="confirm_no_email">သင်သည် သင့်ထံ ကျွန်ုပ်တို့ ပြန်ဆက်သွယ်နိုင်မည့် နည်းလမ်း မပါဘဲ ပြဿနာ ရီပို့တ်ကို ပေးပို့တော့မည် ဖြစ်ပါသည်။ သင့်ရီပို့တ်အတွက် အဖြေ ရရှိလိုပါက အီမေးလိပ်စာ ဖြည့်သွင်းပေးရပါမည်။</string>
     <string name="confirm_removal">စက်မှ ထွက်မည်</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">အလွန်ကောင်း။</string>
     <string name="max_devices_warning_description">အောက်ပါစာရင်းမှ အနည်းဆုံး တစ်ခုကို ဖယ်ရှားခြင်းဖြင့် ၎င်းမှ ထွက်ပါ။ စက်၏ အကောင့်ဆက်တင်အောက်တွင် သက်ဆိုင်သော စက်အမည်ကို သင် ရှာနိုင်သည်။</string>
     <string name="max_devices_warning_title">စက်များလွန်းနေသည်</string>
+    <string name="more_information">နောက်ထပ်အချက်အလက်</string>
     <string name="mullvad_account_number">Mullvad အကောင့်နံပါတ်</string>
     <string name="mullvad_owned_only">Mullvad ပိုင်ဆိုင်သည်များသာ</string>
     <string name="name">အမည်</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard Obfuscation\\n</string>
     <string name="off">ပိတ်</string>
     <string name="on">ဖွင့်</string>
+    <string name="open_url">URL ဖွင့်ရန်</string>
     <string name="out_address">အထွက်</string>
     <string name="out_of_time">အချိန်စေ့သွားပါပြီ</string>
     <string name="overrides_cleared">ကျော်လွန် ပယ်ဖျက်မှုများ ရှင်းပြီးပါပြီ</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">ဤလုပ်ဆောင်ချက်သည် Quantum ကွန်ပျူတာများမှ ဖြစ်လာနိုင်ခြေရှိသော တိုက်ခိုက်မှုများကို ခုခံနိုင်သည့် WireGuard Tunnel ကို ပြုလုပ်သည်။</string>
     <string name="quantum_resistant_info_second_paragaph">Quantum Safe အယ်လဂိုရီသမ်တစ်ခုကို သုံး၍ ထပ်ဆောင်း ကီးဖလှယ်မှုတစ်ခုကို ဆောင်ရွက်ပြီး WireGuard ၏ ပုံမှန် ကုဒ်ပြောင်းဝှက်မှုအတွင်း ရလဒ်ကို ရောနှောခြင်းအားဖြင့် ဤသည်ကို လုပ်ဆောင်ပါသည်။ ဤထပ်ဆောင်းအဆင့်သည် Tunnel အသစ်တစ်ခု တည်ဆောက်တိုင်း ဒေတာ 500 kiB ခန့်ကို သုံးပါသည်။</string>
     <string name="quantum_resistant_title">Quantum-resistant Tunnel</string>
+    <string name="reconnect">ပြန်ချိတ်ဆက်ရန်</string>
     <string name="redeem">လဲယူရန်</string>
     <string name="redeem_voucher">ဘောက်ချာဖြင့် လဲယူရန်</string>
     <string name="remove_button">ဖယ်ရှားရန်</string>

--- a/android/lib/resource/src/main/res/values-nb/strings.xml
+++ b/android/lib/resource/src/main/res/values-nb/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Avbryt</string>
     <string name="changes_dialog_subtitle">Endringer i denne versjonen:</string>
     <string name="cipher">Chiffer</string>
+    <string name="close">Lukk</string>
     <string name="confirm_local_dns">Den lokale DNS-serveren fungerer ikke med mindre du aktiverer «Deling av lokalt nettverk» under Innstillinger.</string>
     <string name="confirm_no_email">Problemrapporten blir nå sendt uten en måte for oss å kontakte deg på. Hvis du ønsker svar på rapporten, må du oppgi en e-postadresse.</string>
     <string name="confirm_removal">Ja, logg av enhet</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Supert!</string>
     <string name="max_devices_warning_description">Logg ut av minst én ved å fjerne den fra listen nedenfor. Du finner det tilsvarende enhetsnavnet under enhetens kontoinnstillinger.</string>
     <string name="max_devices_warning_title">For mange enheter</string>
+    <string name="more_information">Mer informasjon</string>
     <string name="mullvad_account_number">Mullvad-kontonummer</string>
     <string name="mullvad_owned_only">Kun eid av Mullvad</string>
     <string name="name">Navn</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">Tilsløring av WireGuard</string>
     <string name="off">Av</string>
     <string name="on">På</string>
+    <string name="open_url">Åpne URL</string>
     <string name="out_address">Utgående</string>
     <string name="out_of_time">Tiden har utløpt</string>
     <string name="overrides_cleared">Overstyringer fjernet</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Denne funksjonen gjør WireGuard-tunnelen motstandsdyktig mot potensielle angrep fra kvantemaskiner.</string>
     <string name="quantum_resistant_info_second_paragaph">Det gjøres ved at å utføre en ekstra nøkkelutveksling med en kvantesikker algoritme og kombinere resultatet med WireGuard sin vanlige kryptering. Dette ekstratrinnet bruker omtrent 500 kiB trafikk hver gang det opprettes en ny tunnel.</string>
     <string name="quantum_resistant_title">Kvantebestandig tunnel</string>
+    <string name="reconnect">Koble til på nytt</string>
     <string name="redeem">Løs inn</string>
     <string name="redeem_voucher">Løs inn kupong</string>
     <string name="remove_button">Fjern</string>

--- a/android/lib/resource/src/main/res/values-nl/strings.xml
+++ b/android/lib/resource/src/main/res/values-nl/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Annuleren</string>
     <string name="changes_dialog_subtitle">Wijzigingen in deze versie:</string>
     <string name="cipher">Versleuteling</string>
+    <string name="close">Sluiten</string>
     <string name="confirm_local_dns">De lokale DNS-server werkt niet tenzij u \"Lokale netwerken delen\" inschakelt onder Voorkeuren.</string>
     <string name="confirm_no_email">U staat op het punt om het probleemrapport te verzenden zonder een contactmethode op te geven. Voer een e-mailadres in als u een antwoord wenst op het rapport.</string>
     <string name="confirm_removal">Ja, apparaat afmelden</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Meld u bij minstens één apparaat af door het te verwijderen uit de onderstaande lijst. U kunt de bijbehorende apparaatnaam vinden in de accountinstellingen van het apparaat.</string>
     <string name="max_devices_warning_title">Te veel apparaten</string>
+    <string name="more_information">Meer informatie</string>
     <string name="mullvad_account_number">Mullvad-accountnummer</string>
     <string name="mullvad_owned_only">Alleen in eigendom van Multivad</string>
     <string name="name">Naam</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard-obfuscatie</string>
     <string name="off">Uit</string>
     <string name="on">Aan</string>
+    <string name="open_url">URL openen</string>
     <string name="out_address">Uit</string>
     <string name="out_of_time">Geen tijd meer</string>
     <string name="overrides_cleared">Overschrijvingen gewist</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Deze eigenschap maakt de WireGuard-tunnel bestand tegen mogelijke aanvallen met kwantumcomputers.</string>
     <string name="quantum_resistant_info_second_paragaph">Het doet dit door een extra sleuteluitwisseling uit te voeren met een kwantumveilig algoritme en het resultaat te mengen met de reguliere versleuteling van WireGuard. Deze extra stap gebruikt ongeveer 500 kiB aan verkeer elke keer dat een nieuwe tunnel wordt opgezet.</string>
     <string name="quantum_resistant_title">Kwantumbestendige tunnel</string>
+    <string name="reconnect">Opnieuw verbinden</string>
     <string name="redeem">Inwisselen</string>
     <string name="redeem_voucher">Voucher inwisselen</string>
     <string name="remove_button">Verwijderen</string>

--- a/android/lib/resource/src/main/res/values-pl/strings.xml
+++ b/android/lib/resource/src/main/res/values-pl/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Anuluj</string>
     <string name="changes_dialog_subtitle">Zmiany w tej wersji:</string>
     <string name="cipher">Szyfrowanie</string>
+    <string name="close">Zamknij</string>
     <string name="confirm_local_dns">Lokalny serwer DNS nie będzie działał, dopóki nie włączysz opcji „Udostępnianie sieci lokalnej” w Preferencjach.</string>
     <string name="confirm_no_email">Za chwilę wyślesz zgłoszenie problemu, nie umożliwiając nam skontaktowania się z Tobą. Aby uzyskać odpowiedź na zgłoszenie, musisz podać adres e-mail.</string>
     <string name="confirm_removal">Tak, wyloguj urządzenie</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Wyloguj się z co najmniej jednego urządzenia, usuwając je z poniższej listy. Odpowiednią nazwę urządzenia można znaleźć w ustawieniach konta urządzenia.</string>
     <string name="max_devices_warning_title">Zbyt wiele urządzeń</string>
+    <string name="more_information">Więcej informacji</string>
     <string name="mullvad_account_number">Numer konta Mullvad</string>
     <string name="mullvad_owned_only">Wyłącznie firmy Mullvad</string>
     <string name="name">Nazwa</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">Zaciemnianie WireGuard</string>
     <string name="off">Wył.</string>
     <string name="on">Wł.</string>
+    <string name="open_url">Otwórz adres URL</string>
     <string name="out_address">Wyjście</string>
     <string name="out_of_time">Koniec czasu</string>
     <string name="overrides_cleared">Usunięto zastąpienia</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Ta funkcja sprawia, że tunel WireGuard jest odporny na potencjalne ataki ze strony komputerów kwantowych.</string>
     <string name="quantum_resistant_info_second_paragaph">Jest to wykonywane poprzez dodatkową wymianę kluczy przy użyciu algorytmu odpornego na ataki z użyciem komputerów kwantowych i zmieszanie wyniku ze zwykłym szyfrowaniem WireGuard. Ten dodatkowy krok zużywa około 500 kB ruchu za każdym razem, gdy ustanawiany jest nowy tunel.</string>
     <string name="quantum_resistant_title">Tunel odporny na ataki z użyciem komputerów kwantowych</string>
+    <string name="reconnect">Połącz ponownie</string>
     <string name="redeem">Zrealizuj</string>
     <string name="redeem_voucher">Zrealizuj kupon</string>
     <string name="remove_button">Usuń</string>

--- a/android/lib/resource/src/main/res/values-pt/strings.xml
+++ b/android/lib/resource/src/main/res/values-pt/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Cancelar</string>
     <string name="changes_dialog_subtitle">Alterações nesta versão:</string>
     <string name="cipher">Cifra</string>
+    <string name="close">Fechar</string>
     <string name="confirm_local_dns">O servidor DNS local não funcionará exceto se ativar \"Partilha de rede local\" em Preferências.</string>
     <string name="confirm_no_email">Está prestes a enviar o relatório de problema sem que tenhamos uma forma de lhe responder. Se pretender uma resposta ao seu relatório, tem de introduzir um endereço de email.</string>
     <string name="confirm_removal">Sim, desligar o dispositivo</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Excelente!</string>
     <string name="max_devices_warning_description">Desligue-se de pelo menos um dos dispositivos removendo-o da lista abaixo. Pode encontrar o nome do dispositivo correspondente nas definições de Conta do dispositivo.</string>
     <string name="max_devices_warning_title">Demasiados dispositivos</string>
+    <string name="more_information">Mais informações</string>
     <string name="mullvad_account_number">Número de conta Mullvad</string>
     <string name="mullvad_owned_only">Apenas propriedade de Mullvad</string>
     <string name="name">Nome</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">Ofuscação WireGuard</string>
     <string name="off">Desligado</string>
     <string name="on">Ligado</string>
+    <string name="open_url">Abrir URL</string>
     <string name="out_address">Saída</string>
     <string name="out_of_time">Sem tempo</string>
     <string name="overrides_cleared">Substituições eliminadas</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Esta funcionalidade torna o túnel do WireGuard resistente a potenciais ataques de computadores quânticos.</string>
     <string name="quantum_resistant_info_second_paragaph">Fá-lo ao realizar uma troca de chaves adicional utilizando um algoritmo de segurança quântica e misturando o resultado na encriptação regular do WireGuard. Este passo adicional utiliza aproximadamente 500 kiB de tráfego sempre que um novo túnel é estabelecido.</string>
     <string name="quantum_resistant_title">Túnel com resistência quântica</string>
+    <string name="reconnect">Religar</string>
     <string name="redeem">Reclamar</string>
     <string name="redeem_voucher">Reclamar voucher</string>
     <string name="remove_button">Remover</string>

--- a/android/lib/resource/src/main/res/values-ru/strings.xml
+++ b/android/lib/resource/src/main/res/values-ru/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Отмена</string>
     <string name="changes_dialog_subtitle">Изменения в этой версии:</string>
     <string name="cipher">Шифр</string>
+    <string name="close">Закрыть</string>
     <string name="confirm_local_dns">Локальный DNS-сервер не будет работать, пока вы не включите «Обмен данными в локальной сети» в разделе «Параметры».</string>
     <string name="confirm_no_email">Вы собираетесь отправить отчет о проблеме, не оставив контакты. Если вы хотите получить ответ, введите свой адрес электронной почты.</string>
     <string name="confirm_removal">Выйти из профиля на устройстве</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Отлично!</string>
     <string name="max_devices_warning_description">Выйдите из учетной записи хотя бы на одном из устройств, удалив его из списка ниже. Имя устройства указано в настройках учетной записи.</string>
     <string name="max_devices_warning_title">Слишком много устройств</string>
+    <string name="more_information">Подробнее</string>
     <string name="mullvad_account_number">Номер учетной записи Mullvad</string>
     <string name="mullvad_owned_only">Только принадлежащие Mullvad</string>
     <string name="name">Имя</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">Обфускация WireGuard</string>
     <string name="off">Выключен</string>
     <string name="on">Включен</string>
+    <string name="open_url">Открыть URL</string>
     <string name="out_address">Выход</string>
     <string name="out_of_time">Закончилось время</string>
     <string name="overrides_cleared">Переопределения удалены</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Эта функция делает туннель WireGuard устойчивым к потенциальным атакам с использованием квантовых компьютеров.</string>
     <string name="quantum_resistant_info_second_paragaph">Для этого функция выполняет дополнительный обмен ключами с использованием квантово-устойчивого алгоритма и добавляет результат к обычному шифрованию WireGuard. Эта дополнительная мера использует примерно 500 КиБ трафика при каждом создании нового туннеля.</string>
     <string name="quantum_resistant_title">Квантово-устойчивый туннель</string>
+    <string name="reconnect">Переподключить</string>
     <string name="redeem">Погасить</string>
     <string name="redeem_voucher">Погасить ваучер</string>
     <string name="remove_button">Удалить</string>

--- a/android/lib/resource/src/main/res/values-sv/strings.xml
+++ b/android/lib/resource/src/main/res/values-sv/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">Avbryt</string>
     <string name="changes_dialog_subtitle">Ändringar i den här versionen:</string>
     <string name="cipher">Chiffrering</string>
+    <string name="close">Stäng</string>
     <string name="confirm_local_dns">Den lokala DNS-servern fungerar inte om du inte aktiverar \"Lokal nätverksdelning\" under Inställningar.</string>
     <string name="confirm_no_email">Du är på väg att skicka problemrapporten utan att vi har möjlighet att besvara dig. Om du vill ha svar på din rapport måste du ange en e-postadress.</string>
     <string name="confirm_removal">Ja, logga ut enheten</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Logga ut på minst en enhet genom att ta bort den från listan nedan. Du hittar motsvarande enhetsnamn i enhetens kontoinställningar.</string>
     <string name="max_devices_warning_title">För många enheter</string>
+    <string name="more_information">Mer information</string>
     <string name="mullvad_account_number">Mullvad-kontonummer</string>
     <string name="mullvad_owned_only">Endast Mullvad-ägd</string>
     <string name="name">Namn</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard-obfuskering</string>
     <string name="off">Av</string>
     <string name="on">På</string>
+    <string name="open_url">Öppna URL</string>
     <string name="out_address">Ut</string>
     <string name="out_of_time">Ingen tid kvar</string>
     <string name="overrides_cleared">Åsidosättningar rensade</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Den här funktionen gör WireGuard-tunneln resistent mot potentiella attacker från kvantdatorer.</string>
     <string name="quantum_resistant_info_second_paragaph">Den gör det genom att göra ett extra nyckelutbyte med en kvantsäker algoritm och kombinera resultatet med WireGuards vanliga kryptering. Det här extra steget använder ungefär 500 KiB i trafik varje gång en ny tunnel upprättas.</string>
     <string name="quantum_resistant_title">Kvantresistent tunnel</string>
+    <string name="reconnect">Återanslut</string>
     <string name="redeem">Lös in</string>
     <string name="redeem_voucher">Lös in kupong</string>
     <string name="remove_button">Ta bort</string>

--- a/android/lib/resource/src/main/res/values-th/strings.xml
+++ b/android/lib/resource/src/main/res/values-th/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">ยกเลิก</string>
     <string name="changes_dialog_subtitle">การเปลี่ยนแปลงในเวอร์ชันนี้:</string>
     <string name="cipher">เข้ารหัส</string>
+    <string name="close">ปิด</string>
     <string name="confirm_local_dns">เซิร์ฟเวอร์ DNS ท้องถิ่นจะไม่ทำงาน เว้นแต่คุณจะเปิดใช้ \"การแชร์ในเครือข่ายท้องถิ่น\" ซึ่งอยู่ในส่วนการกำหนดค่า</string>
     <string name="confirm_no_email">คุณกำลังจะส่งรายงานปัญหา โดยไม่มีการระบุวิธีการติดต่อกลับให้กับเรา และคุณจำเป็นต้องป้อนที่อยู่อีเมลของคุณ หากคุณอยากให้เราตอบกลับการรายงานของคุณ</string>
     <string name="confirm_removal">ใช่ นำอุปกรณ์ออกจากระบบ</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">เยี่ยมยอด!</string>
     <string name="max_devices_warning_description">โปรดลงชื่อออกจากระบบบนอุปกรณ์อย่างน้อยหนึ่งเครื่อง เพื่อนำอุปกรณ์ออกจากรายการด้านล่าง คุณสามารถดูชื่ออุปกรณ์ที่เกี่ยวข้องได้ ภายใต้การตั้งค่าบัญชีของอุปกรณ์</string>
     <string name="max_devices_warning_title">มีอุปกรณ์มากเกินไป</string>
+    <string name="more_information">ข้อมูลเพิ่มเติม</string>
     <string name="mullvad_account_number">หมายเลขบัญชี Mullvad</string>
     <string name="mullvad_owned_only">ของ Mullvad เท่านั้น</string>
     <string name="name">ชื่อ</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">การทำให้ข้อมูลยุ่งเหยิงของ WireGuard</string>
     <string name="off">ปิด</string>
     <string name="on">เปิด</string>
+    <string name="open_url">Open URL</string>
     <string name="out_address">ออก</string>
     <string name="out_of_time">หมดเวลา</string>
     <string name="overrides_cleared">ล้างโอเวอร์ไรด์แล้ว</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">คุณลักษณะนี้จะช่วยให้ช่องทาง WireGuard สามารถสกัดกั้นการโจมตีที่อาจมาจากคอมพิวเตอร์ควอนตัมได้</string>
     <string name="quantum_resistant_info_second_paragaph">ระบบจะดำเนินการสิ่งนี้ผ่านการแลกเปลี่ยนคีย์เพิ่มเติม โดยการใช้อัลกอริทึมแบบควอนตัมที่ปลอดภัย และผสมผลลัพธ์เข้ากับการเข้ารหัสตามปกติของ WireGuard และขั้นตอนพิเศษนี้ใช้การรับส่งข้อมูลประมาณ 500 kiB ในทุกครั้งที่สร้างช่องทางใหม่</string>
     <string name="quantum_resistant_title">ช่องทางการสกัดกั้นควอนตัม</string>
+    <string name="reconnect">เชื่อมต่อใหม่</string>
     <string name="redeem">แลกรับ</string>
     <string name="redeem_voucher">แลกบัตรกำนัล</string>
     <string name="remove_button">ลบ</string>

--- a/android/lib/resource/src/main/res/values-tr/strings.xml
+++ b/android/lib/resource/src/main/res/values-tr/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">İptal et</string>
     <string name="changes_dialog_subtitle">Bu sürümdeki değişiklikler:</string>
     <string name="cipher">Şifre</string>
+    <string name="close">Kapat</string>
     <string name="confirm_local_dns">Tercihler sekmesinin altındaki \"Yerel Ağ Paylaşımı\" seçeneğini etkinleştirmediğiniz sürece yerel DNS sunucusu çalışmaz.</string>
     <string name="confirm_no_email">Sorun raporunu, size geri dönüş yapmamıza imkan vermeyen bir şekilde göndermek üzeresiniz. Sorununuz için yanıt almak istiyorsanız bir e-posta adresi girmelisiniz.</string>
     <string name="confirm_removal">Evet, cihazdan çıkış yap</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">Süper!</string>
     <string name="max_devices_warning_description">Lütfen aşağıdaki listeden en az bir cihazı kaldırarak çıkış yapın. İlgili cihaz adını cihazın Hesap ayarları altında bulabilirsiniz.</string>
     <string name="max_devices_warning_title">Cihaz sayısı çok fazla</string>
+    <string name="more_information">Daha fazla bilgi</string>
     <string name="mullvad_account_number">Mullvad hesap numarası</string>
     <string name="mullvad_owned_only">Sadece Mullvad\'a ait olanlar</string>
     <string name="name">Ad</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard gizlemesi</string>
     <string name="off">Kapalı</string>
     <string name="on">Açık</string>
+    <string name="open_url">URL\'yi aç</string>
     <string name="out_address">Çıkış</string>
     <string name="out_of_time">Süre doldu</string>
     <string name="overrides_cleared">Geçersiz kılmalar temizlendi</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">Bu özellik, WireGuard tünelini kuantum bilgisayarlardan gelebilecek potansiyel saldırılara karşı dayanıklı hale getirir.</string>
     <string name="quantum_resistant_info_second_paragaph">Bu işlemi, bir kuantum güvenlik algoritmasıyla ekstra bir anahtar değişimi gerçekleştirdikten sonra sonucu WireGuard\'ın normal şifrelemesiyle karıştırarak yapar. Bu ekstra adım, her yeni tünel kurulduğunda yaklaşık 500 kiB trafik kullanır.</string>
     <string name="quantum_resistant_title">Kuantuma dayanıklı tünel</string>
+    <string name="reconnect">Yeniden Bağlan</string>
     <string name="redeem">Kullan</string>
     <string name="redeem_voucher">Kuponu kullan</string>
     <string name="remove_button">Kaldır</string>

--- a/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">取消</string>
     <string name="changes_dialog_subtitle">此版本中的变更：</string>
     <string name="cipher">加密方式</string>
+    <string name="close">关闭</string>
     <string name="confirm_local_dns">除非您在“偏好设置”下启用“本地网络共享”，否则本地 DNS 服务器将不会运行。</string>
     <string name="confirm_no_email">您即将发送问题报告，但没有提供让我们可以联系到您的方式。如果您希望获得回复，必须输入您的电子邮件地址。</string>
     <string name="confirm_removal">是，退出设备</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">太棒了！</string>
     <string name="max_devices_warning_description">请通过从以下列表中移除的方式退出至少一个帐户。您可以在设备的帐户设置下找到相应设备名称。</string>
     <string name="max_devices_warning_title">设备过多</string>
+    <string name="more_information">更多信息</string>
     <string name="mullvad_account_number">Mullvad 帐号</string>
     <string name="mullvad_owned_only">仅 Mullvad 自有</string>
     <string name="name">名称</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard 混淆</string>
     <string name="off">关</string>
     <string name="on">开</string>
+    <string name="open_url">打开网址</string>
     <string name="out_address">外部</string>
     <string name="out_of_time">已没有时间</string>
     <string name="overrides_cleared">覆盖设置已清除</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">借助此功能，WireGuard 隧道能够抵抗可能通过量子计算机发起的攻击。</string>
     <string name="quantum_resistant_info_second_paragaph">实现方法是使用量子安全算法执行额外的密钥交换，并将结果混合到 WireGuard 的常规加密中。每次建立新隧道时，这一额外步骤都会使用约 500 kiB 的流量。</string>
     <string name="quantum_resistant_title">抗量子隧道</string>
+    <string name="reconnect">重新连接</string>
     <string name="redeem">兑换</string>
     <string name="redeem_voucher">兑换优惠券</string>
     <string name="remove_button">移除</string>

--- a/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
@@ -64,6 +64,7 @@
     <string name="cancel">取消</string>
     <string name="changes_dialog_subtitle">此版本中的變更：</string>
     <string name="cipher">加密方式</string>
+    <string name="close">關閉</string>
     <string name="confirm_local_dns">若要使本機 DNS 伺服器運作，需先在「偏好設定」下啟用「本機網路共用」。</string>
     <string name="confirm_no_email">您即將傳送的問題報告未包含回覆方式資訊。如果想收到您這份報告的回覆，請輸入您的電子郵件位址。</string>
     <string name="confirm_removal">是，將裝置登出</string>
@@ -193,6 +194,7 @@
     <string name="max_devices_resolved_title">太好了！</string>
     <string name="max_devices_warning_description">請從底下清單至少移除一個裝置來將其登出。您可以在裝置的「帳戶」設定下找到相應裝置名稱。</string>
     <string name="max_devices_warning_title">裝置過多</string>
+    <string name="more_information">更多資訊</string>
     <string name="mullvad_account_number">Mullvad 帳號</string>
     <string name="mullvad_owned_only">僅 Mullvad 自有</string>
     <string name="name">名稱</string>
@@ -213,6 +215,7 @@
     <string name="obfuscation_title">WireGuard 混淆</string>
     <string name="off">關閉</string>
     <string name="on">開啟</string>
+    <string name="open_url">開啟 URL</string>
     <string name="out_address">出境</string>
     <string name="out_of_time">逾時</string>
     <string name="overrides_cleared">覆寫設定已清除</string>
@@ -244,6 +247,7 @@
     <string name="quantum_resistant_info_first_paragaph">借助此功能，WireGuard 通道便能夠抵抗可能從量子電腦發起的攻擊。</string>
     <string name="quantum_resistant_info_second_paragaph">實現方法是使用量子安全演算法執行額外的金鑰交換，並將結果混合至 WireGuard 的常規加密。每次建立新通道時，這一額外步驟都會使用約 500 kiB 流量。</string>
     <string name="quantum_resistant_title">抗量子通道</string>
+    <string name="reconnect">重新連線</string>
     <string name="redeem">兌換</string>
     <string name="redeem_voucher">兌換憑證</string>
     <string name="remove_button">移除</string>

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="cancel">Cancel</string>
     <string name="disconnect">Disconnect</string>
     <string name="disconnected">Disconnected</string>
+    <string name="reconnect">Reconnect</string>
     <string name="dismiss">Dismiss</string>
     <string name="switch_location">Switch location</string>
     <string name="tcp">TCP</string>
@@ -405,4 +406,11 @@
     <string name="connect">Connect</string>
     <string name="connect_on_start">Connect on device start-up</string>
     <string name="connect_on_start_footer">Automatically connect on device start-up. Only works if the app has been granted the VPN permission.</string>
+    <string name="close">Close</string>
+    <string name="more_information">More information</string>
+    <string name="open_url">Open URL</string>
+    <string name="expand">Expand</string>
+    <string name="collapse">Collapse</string>
+    <string name="copy">Copy</string>
+    <string name="share">Share…</string>
 </resources>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2334,6 +2334,9 @@ msgstr ""
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr ""
 
+msgid "Collapse"
+msgstr ""
+
 msgid "Connect on device start-up"
 msgstr ""
 
@@ -2347,6 +2350,9 @@ msgid "Copied logs to clipboard"
 msgstr ""
 
 msgid "Copied to clipboard"
+msgstr ""
+
+msgid "Copy"
 msgstr ""
 
 msgid "Create"
@@ -2422,6 +2428,9 @@ msgid "Enter MTU"
 msgstr ""
 
 msgid "Excluded applications"
+msgstr ""
+
+msgid "Expand"
 msgstr ""
 
 msgid "Failed to apply patch"
@@ -2584,6 +2593,9 @@ msgid "Set WireGuard MTU value. Valid range: %d - %d."
 msgstr ""
 
 msgid "Set port"
+msgstr ""
+
+msgid "Share…"
 msgstr ""
 
 msgid "Show system apps"


### PR DESCRIPTION
As a long-time blind user of this app on both Android and Windows, I've encountered significant accessibility challenges that I believe need to be addressed. On Android, many buttons are simply read as "button," without conveying any meaningful information. This forces screen reader users like myself to rely on intuition, memory, and sometimes luck, particularly when attempting tasks beyond basic actions like connecting to the VPN.

While there are still many accessibility improvements needed, such as adding proper semantics, roles, and ensuring states are announced correctly, labeling the buttons is a crucial first step. This change will greatly enhance the usability of the app for screen reader users.

If this pull request is merged, I plan to continue working on improving the accessibility of the app, addressing the other aspects mentioned. I'm also open to any suggestions, improvements, reviews, or comments from the community as I work through these changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6897)
<!-- Reviewable:end -->
