### PR TITLE
Add video recording of e2e tests

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/misc/CaptureScreenRecordingsExtension.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/misc/CaptureScreenRecordingsExtension.kt
@@ -1,0 +1,60 @@
+package net.mullvad.mullvadvpn.test.common.misc
+
+import android.os.Environment
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import co.touchlab.kermit.Logger
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class CaptureScreenRecordingsExtension : BeforeEachCallback, AfterEachCallback {
+    private lateinit var job: Job
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+    private lateinit var device: UiDevice
+
+    override fun beforeEach(context: ExtensionContext?) {
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        val testMethodName = context?.testMethod!!.get().name
+        val fileName = "${testMethodName}.mp4"
+        Logger.v("Starting screen recording. Saving to $testMethodName")
+        startScreenRecord(fileName)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        Logger.v("Stopping screen recording")
+        stopScreenRecord()
+    }
+
+    private fun startScreenRecord(fileName: String) {
+        if (File(OUTPUT_DIRECTORY).exists().not()) {
+            File(OUTPUT_DIRECTORY).mkdirs()
+        }
+
+        job =
+            coroutineScope.launch {
+                device.executeShellCommand("screenrecord $OUTPUT_DIRECTORY/$fileName")
+            }
+    }
+
+    private fun stopScreenRecord() {
+        try {
+            device.executeShellCommand("pkill -2 screenrecord")
+            runBlocking { job.join() }
+        } catch (e: Exception) {
+            fail("Failed to stop screen recording")
+        }
+    }
+
+    companion object {
+        val OUTPUT_DIRECTORY =
+            "${Environment.getExternalStorageDirectory().path}/Download/test-attachments/video"
+    }
+}

--- a/android/test/e2e/README.md
+++ b/android/test/e2e/README.md
@@ -54,3 +54,6 @@ docker run --rm --volumes-from gcloud-config -v ${PWD}:/android gcr.io/google.co
     --use-orchestrator \
     --environment-variables clearPackageData=true,valid_test_account_number=XXXX,invalid_test_account_number=XXXX
 ```
+
+## Test artefacts
+Test artefacts are stored on the test device in `/sdcard/Download/test-attachments`. In CI this directory is cleared in between each test run, but note that when running tests locally the directory isn't cleared but already existing files are overwritten.

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/EndToEndTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/EndToEndTest.kt
@@ -8,11 +8,14 @@ import androidx.test.uiautomator.UiDevice
 import co.touchlab.kermit.Logger
 import de.mannodermaus.junit5.extensions.GrantPermissionExtension
 import net.mullvad.mullvadvpn.test.common.interactor.AppInteractor
+import net.mullvad.mullvadvpn.test.common.misc.CaptureScreenRecordingsExtension
 import net.mullvad.mullvadvpn.test.common.rule.CaptureScreenshotOnFailedTestRule
 import net.mullvad.mullvadvpn.test.e2e.constant.LOG_TAG
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 
+@ExtendWith(CaptureScreenRecordingsExtension::class)
 abstract class EndToEndTest(private val infra: String) {
 
     @RegisterExtension @JvmField val rule = CaptureScreenshotOnFailedTestRule(LOG_TAG)


### PR DESCRIPTION
Added video recording for all end to end tests. The videos are stored in `/sdcard/Download/test-attachments/video` on the test device. To try out the changes run any test(s) and see produced videos in this directory.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6912)
<!-- Reviewable:end -->
