### PR TITLE
Add end to end connection tests for multihop ios 778

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -2361,13 +2361,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		014449932CA1B55200C0C2F2 /* EncryptedDnsProxy */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = EncryptedDnsProxy;
-			sourceTree = "<group>";
-		};
 		062B45A228FD4C0F00746E77 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
@@ -4191,7 +4184,6 @@
 		F0DC77A02B2223290087F09D /* Transport */ = {
 			isa = PBXGroup;
 			children = (
-				014449932CA1B55200C0C2F2 /* EncryptedDnsProxy */,
 				F0164ED02B4F2DCB0020268D /* AccessMethodIterator.swift */,
 				F0DC77A32B2315800087F09D /* Direct */,
 				F0E5B2F62C9C689C0007F78C /* EncryptedDNS */,

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -21,7 +21,6 @@ public enum AccessibilityIdentifier: String {
     case appLogsShareButton
     case applyButton
     case cancelButton
-    case connectionPanelButton
     case continueWithLoginButton
     case collapseButton
     case expandButton

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionPanelView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionPanelView.swift
@@ -48,13 +48,14 @@ class ConnectionPanelView: UIView {
     }
 
     private let collapseView: ConnectionPanelCollapseView = {
-        let button = ConnectionPanelCollapseView()
-        button.axis = .horizontal
-        button.alignment = .top
-        button.distribution = .fill
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.tintColor = .white
-        return button
+        let collapseView = ConnectionPanelCollapseView()
+        collapseView.axis = .horizontal
+        collapseView.alignment = .top
+        collapseView.distribution = .fill
+        collapseView.translatesAutoresizingMaskIntoConstraints = false
+        collapseView.tintColor = .white
+        collapseView.isAccessibilityElement = false
+        return collapseView
     }()
 
     private let inAddressRow = ConnectionPanelAddressRow()
@@ -316,8 +317,6 @@ class ConnectionPanelCollapseView: UIStackView {
         addArrangedSubview(UIView()) // Pushes content left.
 
         updateImage()
-
-        accessibilityIdentifier = .connectionPanelButton
     }
 
     required init(coder: NSCoder) {

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionPanelView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionPanelView.swift
@@ -49,6 +49,9 @@ class ConnectionPanelView: UIView {
 
     private let collapseView: ConnectionPanelCollapseView = {
         let button = ConnectionPanelCollapseView()
+        button.axis = .horizontal
+        button.alignment = .top
+        button.distribution = .fill
         button.translatesAutoresizingMaskIntoConstraints = false
         button.tintColor = .white
         return button
@@ -294,19 +297,22 @@ class ConnectionPanelCollapseView: UIStackView {
     }()
 
     private(set) var imageView: UIImageView = {
-        return UIImageView()
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
     }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        let imageContainer = UIStackView()
-        imageContainer.axis = .vertical
-        imageContainer.addArrangedSubview(imageView)
-        imageContainer.addArrangedSubview(UIView()) // Pushes content up.
-
         addArrangedSubview(title)
-        addArrangedSubview(imageContainer)
+        addArrangedSubview(imageView)
+
+        title.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        imageView.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         addArrangedSubview(UIView()) // Pushes content left.
 
         updateImage()

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
@@ -44,7 +44,7 @@ final class TunnelControlView: UIView {
     private let locationContainerView: UIStackView = {
         let view = UIStackView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.isAccessibilityElement = true
+        view.isAccessibilityElement = false
         view.accessibilityTraits = .summaryElement
         view.axis = .vertical
         view.spacing = 8

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -121,7 +121,7 @@ class TunnelControlPage: Page {
     }
 
     @discardableResult func tapRelayStatusExpandCollapseButton() -> Self {
-        app.buttons[AccessibilityIdentifier.relayStatusCollapseButton].tap()
+        app.otherElements[AccessibilityIdentifier.relayStatusCollapseButton].press(forDuration: .leastNonzeroMagnitude)
         return self
     }
 
@@ -202,6 +202,13 @@ class TunnelControlPage: Page {
         return self
     }
 
+    /// Verify that the app attempts to connect over Multihop.
+    @discardableResult func verifyConnectingOverMultihop() -> Self {
+        let relayName = getCurrentRelayName().lowercased()
+        XCTAssertTrue(relayName.contains("via"))
+        return self
+    }
+
     func getInIPAddressFromConnectionStatus() -> String {
         let inAddressRow = app.otherElements[AccessibilityIdentifier.connectionPanelInAddressRow]
 
@@ -215,7 +222,7 @@ class TunnelControlPage: Page {
     }
 
     func getCurrentRelayName() -> String {
-        let relayExpandButton = app.buttons[.relayStatusCollapseButton]
+        let relayExpandButton = app.otherElements[.relayStatusCollapseButton]
 
         guard let relayName = relayExpandButton.value as? String else {
             XCTFail("Failed to read relay name from tunnel control page")

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -205,4 +205,22 @@ class VPNSettingsPage: Page {
         XCTAssertEqual(switchValue, "1")
         return self
     }
+
+    @discardableResult func tapDaitaSwitchIfOn() -> Self {
+        let switchElement = app.cells[.daitaSwitch].switches[AccessibilityIdentifier.customSwitch]
+
+        if switchElement.value as? String == "1" {
+            tapDaitaSwitch()
+        }
+        return self
+    }
+
+    @discardableResult func tapMultihopSwitchIfOn() -> Self {
+        let switchElement = app.cells[.multihopSwitch].switches[AccessibilityIdentifier.customSwitch]
+
+        if switchElement.value as? String == "1" {
+            tapMultihopSwitch()
+        }
+        return self
+    }
 }

--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -245,6 +245,43 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapDisconnectButton()
     }
 
+    func testMultihopSettings() throws {
+        // Undo enabling Multihop in teardown
+        addTeardownBlock {
+            HeaderBar(self.app)
+                .tapSettingsButton()
+
+            SettingsPage(self.app)
+                .tapVPNSettingsCell()
+
+            VPNSettingsPage(self.app)
+                .tapMultihopSwitchIfOn()
+        }
+
+        HeaderBar(app)
+            .tapSettingsButton()
+
+        SettingsPage(app)
+            .tapVPNSettingsCell()
+
+        VPNSettingsPage(app)
+            .tapMultihopSwitch()
+            .tapBackButton()
+
+        SettingsPage(app)
+            .tapDoneButton()
+
+        TunnelControlPage(app)
+            .tapSecureConnectionButton()
+
+        allowAddVPNConfigurationsIfAsked()
+
+        TunnelControlPage(app)
+            .waitForSecureConnectionLabel()
+            .verifyConnectingOverMultihop()
+            .tapDisconnectButton()
+    }
+
     /// Connect to a relay in the default country and city, get name and IP address of the relay the app successfully connects to. Assumes user is logged on and at tunnel control page.
     private func getDefaultRelayInfo() -> RelayInfo {
         TunnelControlPage(app)


### PR DESCRIPTION
This PR adds an end-to-end test for Multihop and fixes minor issues, such as the shrinking of the collapse button in the connection view. Additionally, after changing the data type for the collapse view, we forgot to update the UI tests to ensure compatibility in finding elements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6914)
<!-- Reviewable:end -->
