### PR TITLE
Bump Linux container to 2301dbd5b with Rust 1.81

### DIFF
--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:0186b645c
+ghcr.io/mullvad/mullvadvpn-app-build:2301dbd5b


### PR DESCRIPTION
We usually don't bump to the latest Rust version this fast. But Rust 1.81 will be needed for the dependency we want to use for ML-KEM (#6915).

We also need to build and bump the Android container. But desktop comes first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6917)
<!-- Reviewable:end -->
