### PR TITLE
Fix duplicated incoming packets when split tunneling is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Fix Apple services not working by forcing stray connections out through the VPN tunnel. The
   "bypass" toggle has been removed.
+- Fix packets being duplicated on LAN when split tunneling is enabled.
 
 
 ## [2024.6-beta1] - 2024-09-26

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -119,6 +119,15 @@ impl Firewall {
             }
         }
 
+        if let Some(endpoint) = policy.allowed_endpoint() {
+            // Keep states to the allowed endpoint.
+            // Note that we're not taking into account allowed clients here, because it's highly
+            // impractical.
+            if endpoint.endpoint.address == remote_address {
+                return Ok(false);
+            }
+        }
+
         let Some(peer) = policy.peer_endpoint().map(|endpoint| endpoint.endpoint) else {
             // If there's no peer, there's also no tunnel. We have no states to preserve
             return Ok(true);

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -143,6 +143,20 @@ impl FirewallPolicy {
         }
     }
 
+    /// Return the allowed endpoint, if available
+    pub fn allowed_endpoint(&self) -> Option<&AllowedEndpoint> {
+        match self {
+            FirewallPolicy::Connecting {
+                allowed_endpoint, ..
+            }
+            | FirewallPolicy::Blocked {
+                allowed_endpoint: Some(allowed_endpoint),
+                ..
+            } => Some(allowed_endpoint),
+            _ => None,
+        }
+    }
+
     /// Return tunnel metadata, if available
     pub fn tunnel(&self) -> Option<&crate::tunnel::TunnelMetadata> {
         match self {

--- a/talpid-core/src/split_tunnel/macos/tun.rs
+++ b/talpid-core/src/split_tunnel/macos/tun.rs
@@ -19,10 +19,11 @@ use pnet_packet::{
     udp::MutableUdpPacket,
     MutablePacket, Packet,
 };
+use talpid_types::net::{ALLOWED_LAN_NETS, ALLOWED_LAN_MULTICAST_NETS};
 use std::{
     ffi::{c_uint, CStr},
     io::{self, IoSlice, Write},
-    net::{Ipv4Addr, Ipv6Addr},
+    net::{Ipv4Addr, Ipv6Addr, IpAddr},
 };
 use talpid_routing::RouteManagerHandle;
 use tokio::{
@@ -676,6 +677,9 @@ async fn handle_incoming_data_v4(
         log::trace!("Dropping packet to VPN IP on default interface");
         return;
     }
+    if is_non_vpn_destination(IpAddr::from(ip.get_destination())) {
+        return;
+    }
 
     fix_ipv4_checksums(&mut ip, None, Some(vpn_addr));
 
@@ -698,6 +702,9 @@ async fn handle_incoming_data_v6(
         log::trace!("Dropping packet to VPN IP on default interface");
         return;
     }
+    if is_non_vpn_destination(IpAddr::from(ip.get_destination())) {
+        return;
+    }
 
     fix_ipv6_checksums(&mut ip, None, Some(vpn_addr));
 
@@ -708,6 +715,15 @@ async fn handle_incoming_data_v6(
     {
         log::error!("Failed to redirect incoming IPv6 packet: {error}");
     }
+}
+
+/// Packets routed outside of the split tunneling interface should not be duplicated on the VPN
+/// utun. As a shortcut we do not duplicate any private IPs.
+fn is_non_vpn_destination(ip: IpAddr) -> bool {
+    ALLOWED_LAN_NETS
+        .iter()
+        .chain(ALLOWED_LAN_MULTICAST_NETS.iter())
+        .any(|net| net.contains(ip))
 }
 
 // Recalculate L3 and L4 checksums. Silently fail on error


### PR DESCRIPTION
This PR prevents incoming packets from private IPs from being forwarded to the VPN tun, which previously caused incoming packets on the LAN (notably/noticeably ICMP) to be duplicated.

The correct implementation would be to forward only packets that weren't originally sent via the VPN utun. For simplicity, the proposed implementation discards packets destined for private IP ranges. This is so we don't have to rely on the routing table.

Unrelatedly, don't kill states related to API traffic (`allowed_endpoint`) when flushing PF states.

Fix DES-1217.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6924)
<!-- Reviewable:end -->
