### PR TITLE
Fix non-English IME input in custom list input

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CreateCustomListDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CreateCustomListDialog.kt
@@ -2,10 +2,9 @@ package net.mullvad.mullvadvpn.compose.dialog
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -97,8 +96,8 @@ fun CreateCustomListDialog(
     onInputChanged: () -> Unit = {},
     onDismiss: () -> Unit = {},
 ) {
-    val name = remember { mutableStateOf("") }
-    val isValidName by remember { derivedStateOf { name.value.isNotBlank() } }
+    val name = rememberSaveable { mutableStateOf("") }
+    val isValidName = name.value.isNotBlank()
 
     InputDialog(
         title = stringResource(id = R.string.create_new_list),

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomListNameTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomListNameTextField.kt
@@ -33,9 +33,7 @@ fun CustomListNameTextField(
                 onSubmit(it)
             }
         },
-        // This can not be set to KeyboardType.Text because it will show the
-        // suggestions, this will cause an infinite loop on Android TV with Gboard
-        keyboardType = KeyboardType.Password,
+        keyboardType = KeyboardType.Text,
         placeholderText = null,
         isValidValue = error == null,
         isDigitsOnlyAllowed = false,


### PR DESCRIPTION
I could not reproduce the bug with using KeyboardType.Text on Android TV with gboard so this change should be safe. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6925)
<!-- Reviewable:end -->
