### PR TITLE
Fix failing log rotation test

### DIFF
--- a/ios/MullvadLogging/LogFileOutputStream.swift
+++ b/ios/MullvadLogging/LogFileOutputStream.swift
@@ -75,6 +75,13 @@ class LogFileOutputStream: TextOutputStream {
         }
     }
 
+    /// Waits for write operations to finish by issuing a synchronous closure.
+    /// - Note: This function is mainly used in unit tests to facilitate acting
+    /// on disk writes. It should typically not be used in production code.
+    func synchronize() {
+        queue.sync {}
+    }
+
     private func writeOnQueue(_ string: String) {
         guard let data = string.data(using: encoding) else { return }
 

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -2498,8 +2498,8 @@
 		440E9EFA2BDA976800B1FD11 /* MullvadLogging */ = {
 			isa = PBXGroup;
 			children = (
-				7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */,
 				44B02E3A2BC5732D008EDF34 /* LoggingTests.swift */,
+				7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */,
 			);
 			path = MullvadLogging;
 			sourceTree = "<group>";

--- a/ios/MullvadVPNTests/MullvadLogging/LogRotationTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LogRotationTests.swift
@@ -41,10 +41,8 @@ final class LogRotationTests: XCTestCase {
         let stream = LogFileOutputStream(fileURL: logPath, header: "", fileSizeLimit: UInt64(totalLogSizeLimit))
         for _ in 0 ..< writeOperationCount {
             stream.write(stringOfSize(logChunkSize))
-
-            // Without sync between every write the test fails on Github.
-            sync()
         }
+        stream.synchronize()
 
         let actualLogCount = try fileManager.contentsOfDirectory(atPath: directoryPath.relativePath).count
         XCTAssertEqual(expectedLogCount, actualLogCount)

--- a/ios/MullvadVPNTests/MullvadLogging/LoggingTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LoggingTests.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import MullvadLogging
 import XCTest
 
-class MullvadLoggingTests: XCTestCase {
+class LoggingTests: XCTestCase {
     let fileManager = FileManager.default
     var directoryPath: URL!
 
@@ -33,7 +33,7 @@ class MullvadLoggingTests: XCTestCase {
         let fileURL = directoryPath.appendingPathComponent(UUID().uuidString)
         let stream = LogFileOutputStream(fileURL: fileURL, header: headerText)
         stream.write(logMessage)
-        sync()
+        stream.synchronize()
 
         let contents = try XCTUnwrap(String(contentsOf: fileURL))
         XCTAssertEqual(contents, "\(headerText)\n\(logMessage)")
@@ -71,7 +71,7 @@ class MullvadLoggingTests: XCTestCase {
         logPaths.forEach { url in
             let stream = LogFileOutputStream(fileURL: url, header: "")
             stream.write("test")
-            sync()
+            stream.synchronize()
         }
 
         var urls = ApplicationConfiguration.logFileURLs(for: .mainApp, in: directoryPath)


### PR DESCRIPTION
The test `testRotatingActiveLogWhenSizeLimitIsExceeded` has been failing on the CI for a while. This PR enables forced synchronization of the asynchronous writes in that tests and similar to it.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6936)
<!-- Reviewable:end -->
