### PR TITLE
Fix yaml typo in settings migration test

### DIFF
--- a/.github/workflows/ios-end-to-end-tests-settings-migration.yml
+++ b/.github/workflows/ios-end-to-end-tests-settings-migration.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Uninstall app
         timeout-minutes: 5
-        run: ios-deploy --id $${{ env.TEST_DEVICE_UDID }} --uninstall_only --bundle_id net.mullvad.MullvadVPN
+        run: ios-deploy --id ${{ env.TEST_DEVICE_UDID }} --uninstall_only --bundle_id net.mullvad.MullvadVPN
 
       - name: Checkout old repository version
         uses: actions/checkout@v4


### PR DESCRIPTION
One `$` too many breaks the settings migration test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6937)
<!-- Reviewable:end -->
