### PR TITLE
Improve strings in the DAITA view

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -152,7 +152,7 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-msgid "Enable \"Direct only\""
+msgid "Enable \"%(directOnly)s\""
 msgstr ""
 
 msgid "Enable anyway"
@@ -2066,11 +2066,11 @@ msgid "%(wireguard)s settings"
 msgstr ""
 
 msgctxt "wireguard-settings-view"
-msgid "Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with WireGuard."
+msgid "Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with %(wireguard)s."
 msgstr ""
 
 msgctxt "wireguard-settings-view"
-msgid "By enabling “Direct only” you will have to manually select a server that is %(daita)s-enabled. This can cause you to end up in a blocked state until you have selected a compatible server in the “Select location” view."
+msgid "By enabling “%(directOnly)s” you will have to manually select a server that is %(daita)s-enabled. This can cause you to end up in a blocked state until you have selected a compatible server in the “Select location” view."
 msgstr ""
 
 msgctxt "wireguard-settings-view"

--- a/gui/src/renderer/components/DaitaSettings.tsx
+++ b/gui/src/renderer/components/DaitaSettings.tsx
@@ -104,9 +104,12 @@ export default function DaitaSettings() {
                         )}
                       </StyledHeaderSubTitle>
                       <StyledHeaderSubTitle>
-                        {messages.pgettext(
-                          'wireguard-settings-view',
-                          'Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with WireGuard.',
+                        {sprintf(
+                          messages.pgettext(
+                            'wireguard-settings-view',
+                            'Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with %(wireguard)s.',
+                          ),
+                          { wireguard: strings.wireguard },
                         )}
                       </StyledHeaderSubTitle>
                     </React.Fragment>,
@@ -155,6 +158,8 @@ function DaitaToggle() {
     hideConfirmationDialog();
   }, []);
 
+  const directOnlyString = messages.gettext('Direct only');
+
   return (
     <>
       <AriaInputGroup>
@@ -177,7 +182,7 @@ function DaitaToggle() {
       <AriaInputGroup>
         <Cell.Container disabled={!daita || unavailable}>
           <AriaLabel>
-            <Cell.InputLabel>{messages.gettext('Direct only')}</Cell.InputLabel>
+            <Cell.InputLabel>{directOnlyString}</Cell.InputLabel>
           </AriaLabel>
           <InfoButton>
             <DirectOnlyModalMessage />
@@ -208,7 +213,7 @@ function DaitaToggle() {
             key="confirm"
             onClick={confirmEnableDirectOnly}
             color={SmallButtonColor.blue}>
-            {messages.gettext('Enable "Direct only"')}
+            {sprintf(messages.gettext('Enable "%(directOnly)s"'), { directOnly: directOnlyString })}
           </SmallButton>,
           <SmallButton key="cancel" onClick={hideConfirmationDialog} color={SmallButtonColor.blue}>
             {messages.pgettext('wireguard-settings-view', 'Cancel')}
@@ -231,15 +236,18 @@ function DaitaToggle() {
 }
 
 function DirectOnlyModalMessage() {
+  const directOnlyString = messages.gettext('Direct only');
+
   return (
     <ModalMessage>
       {sprintf(
         messages.pgettext(
           'wireguard-settings-view',
-          'By enabling “Direct only” you will have to manually select a server that is %(daita)s-enabled. This can cause you to end up in a blocked state until you have selected a compatible server in the “Select location” view.',
+          'By enabling “%(directOnly)s” you will have to manually select a server that is %(daita)s-enabled. This can cause you to end up in a blocked state until you have selected a compatible server in the “Select location” view.',
         ),
         {
           daita: strings.daita,
+          directOnly: directOnlyString,
         },
       )}
     </ModalMessage>


### PR DESCRIPTION
This PR improves the strings in the DAITA view by referencing the translation for "Direct only" where it is reused in help-texts, and references the non-translatable string "WireGuard" correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6940)
<!-- Reviewable:end -->
