### PR TITLE
Update the select location view

### DIFF
--- a/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
+++ b/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
@@ -15,7 +15,7 @@ protocol MultihopDecisionFlow {
     func pick(
         entryCandidates: [RelayCandidate],
         exitCandidates: [RelayCandidate],
-        automaticDaitaRouting: Bool
+        daitaAutomaticRouting: Bool
     ) throws -> SelectedRelays
 }
 
@@ -30,7 +30,7 @@ struct OneToOne: MultihopDecisionFlow {
     func pick(
         entryCandidates: [RelayCandidate],
         exitCandidates: [RelayCandidate],
-        automaticDaitaRouting: Bool
+        daitaAutomaticRouting: Bool
     ) throws -> SelectedRelays {
         guard canHandle(entryCandidates: entryCandidates, exitCandidates: exitCandidates) else {
             guard let next else {
@@ -39,7 +39,7 @@ struct OneToOne: MultihopDecisionFlow {
             return try next.pick(
                 entryCandidates: entryCandidates,
                 exitCandidates: exitCandidates,
-                automaticDaitaRouting: automaticDaitaRouting
+                daitaAutomaticRouting: daitaAutomaticRouting
             )
         }
 
@@ -50,7 +50,7 @@ struct OneToOne: MultihopDecisionFlow {
         let exitMatch = try relayPicker.findBestMatch(from: exitCandidates)
         let entryMatch = try relayPicker.findBestMatch(
             from: entryCandidates,
-            closeTo: automaticDaitaRouting ? exitMatch.location : nil
+            closeTo: daitaAutomaticRouting ? exitMatch.location : nil
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
@@ -73,7 +73,7 @@ struct OneToMany: MultihopDecisionFlow {
     func pick(
         entryCandidates: [RelayCandidate],
         exitCandidates: [RelayCandidate],
-        automaticDaitaRouting: Bool
+        daitaAutomaticRouting: Bool
     ) throws -> SelectedRelays {
         guard let multihopPicker = relayPicker as? MultihopPicker else {
             fatalError("Could not cast picker to MultihopPicker")
@@ -86,13 +86,13 @@ struct OneToMany: MultihopDecisionFlow {
             return try next.pick(
                 entryCandidates: entryCandidates,
                 exitCandidates: exitCandidates,
-                automaticDaitaRouting: automaticDaitaRouting
+                daitaAutomaticRouting: daitaAutomaticRouting
             )
         }
 
-        guard !automaticDaitaRouting else {
+        guard !daitaAutomaticRouting else {
             return try ManyToOne(next: next, relayPicker: relayPicker)
-                .pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates, automaticDaitaRouting: true)
+                .pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates, daitaAutomaticRouting: true)
         }
 
         let entryMatch = try multihopPicker.findBestMatch(from: entryCandidates)
@@ -118,7 +118,7 @@ struct ManyToOne: MultihopDecisionFlow {
     func pick(
         entryCandidates: [RelayCandidate],
         exitCandidates: [RelayCandidate],
-        automaticDaitaRouting: Bool
+        daitaAutomaticRouting: Bool
     ) throws -> SelectedRelays {
         guard let multihopPicker = relayPicker as? MultihopPicker else {
             fatalError("Could not cast picker to MultihopPicker")
@@ -131,7 +131,7 @@ struct ManyToOne: MultihopDecisionFlow {
             return try next.pick(
                 entryCandidates: entryCandidates,
                 exitCandidates: exitCandidates,
-                automaticDaitaRouting: automaticDaitaRouting
+                daitaAutomaticRouting: daitaAutomaticRouting
             )
         }
 
@@ -139,7 +139,7 @@ struct ManyToOne: MultihopDecisionFlow {
         let entryMatch = try multihopPicker.exclude(
             relay: exitMatch,
             from: entryCandidates,
-            closeTo: automaticDaitaRouting ? exitMatch.location : nil
+            closeTo: daitaAutomaticRouting ? exitMatch.location : nil
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
@@ -162,7 +162,7 @@ struct ManyToMany: MultihopDecisionFlow {
     func pick(
         entryCandidates: [RelayCandidate],
         exitCandidates: [RelayCandidate],
-        automaticDaitaRouting: Bool
+        daitaAutomaticRouting: Bool
     ) throws -> SelectedRelays {
         guard let multihopPicker = relayPicker as? MultihopPicker else {
             fatalError("Could not cast picker to MultihopPicker")
@@ -175,7 +175,7 @@ struct ManyToMany: MultihopDecisionFlow {
             return try next.pick(
                 entryCandidates: entryCandidates,
                 exitCandidates: exitCandidates,
-                automaticDaitaRouting: automaticDaitaRouting
+                daitaAutomaticRouting: daitaAutomaticRouting
             )
         }
 
@@ -183,7 +183,7 @@ struct ManyToMany: MultihopDecisionFlow {
         let entryMatch = try multihopPicker.exclude(
             relay: exitMatch,
             from: entryCandidates,
-            closeTo: automaticDaitaRouting ? exitMatch.location : nil
+            closeTo: daitaAutomaticRouting ? exitMatch.location : nil
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)

--- a/ios/MullvadREST/Relay/RelayPicking.swift
+++ b/ios/MullvadREST/Relay/RelayPicking.swift
@@ -46,31 +46,23 @@ struct SinglehopPicker: RelayPicking {
 
     func pick() throws -> SelectedRelays {
         do {
-            let exitCandidates = try RelaySelector.WireGuard.findCandidates(
-                by: constraints.exitLocations,
-                in: relays,
-                filterConstraint: constraints.filter,
-                daitaEnabled: daitaSettings.daitaState.isEnabled
-            )
-
-            let match = try findBestMatch(from: exitCandidates)
-            return SelectedRelays(entry: nil, exit: match, retryAttempt: connectionAttemptCount)
-        } catch let error as NoRelaysSatisfyingConstraintsError where error.reason == .noDaitaRelaysFound {
-            // If DAITA is on and Direct only is off, and no supported relays are found, we should try to find the nearest
-            // available relay that supports DAITA and use it as entry in a multihop selection.
-            if daitaSettings.shouldDoAutomaticRouting {
-                var constraints = constraints
-                constraints.entryLocations = .any
-
+            if daitaSettings.isAutomaticRouting {
                 return try MultihopPicker(
                     relays: relays,
                     constraints: constraints,
                     connectionAttemptCount: connectionAttemptCount,
-                    daitaSettings: daitaSettings,
-                    automaticDaitaRouting: true
+                    daitaSettings: daitaSettings
                 ).pick()
             } else {
-                throw error
+                let exitCandidates = try RelaySelector.WireGuard.findCandidates(
+                    by: constraints.exitLocations,
+                    in: relays,
+                    filterConstraint: constraints.filter,
+                    daitaEnabled: daitaSettings.daitaState.isEnabled
+                )
+
+                let match = try findBestMatch(from: exitCandidates)
+                return SelectedRelays(entry: nil, exit: match, retryAttempt: connectionAttemptCount)
             }
         }
     }
@@ -81,7 +73,6 @@ struct MultihopPicker: RelayPicking {
     let constraints: RelayConstraints
     let connectionAttemptCount: UInt
     let daitaSettings: DAITASettings
-    let automaticDaitaRouting: Bool
 
     func pick() throws -> SelectedRelays {
         let exitCandidates = try RelaySelector.WireGuard.findCandidates(
@@ -117,7 +108,7 @@ struct MultihopPicker: RelayPicking {
 
         do {
             let entryCandidates = try RelaySelector.WireGuard.findCandidates(
-                by: constraints.entryLocations,
+                by: daitaSettings.isAutomaticRouting ? .any : constraints.entryLocations,
                 in: relays,
                 filterConstraint: constraints.filter,
                 daitaEnabled: daitaSettings.daitaState.isEnabled
@@ -126,27 +117,8 @@ struct MultihopPicker: RelayPicking {
             return try decisionFlow.pick(
                 entryCandidates: entryCandidates,
                 exitCandidates: exitCandidates,
-                automaticDaitaRouting: automaticDaitaRouting
+                daitaAutomaticRouting: daitaSettings.isAutomaticRouting
             )
-        } catch let error as NoRelaysSatisfyingConstraintsError where error.reason == .noDaitaRelaysFound {
-            // If DAITA is on and Direct only is off, and no supported relays are found, we should try to find the nearest
-            // available relay that supports DAITA and use it as entry in a multihop selection.
-            if daitaSettings.shouldDoAutomaticRouting {
-                let entryCandidates = try RelaySelector.WireGuard.findCandidates(
-                    by: .any,
-                    in: relays,
-                    filterConstraint: constraints.filter,
-                    daitaEnabled: true
-                )
-
-                return try decisionFlow.pick(
-                    entryCandidates: entryCandidates,
-                    exitCandidates: exitCandidates,
-                    automaticDaitaRouting: true
-                )
-            } else {
-                throw error
-            }
         }
     }
 

--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -35,8 +35,7 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol {
                 relays: relays,
                 constraints: tunnelSettings.relayConstraints,
                 connectionAttemptCount: connectionAttemptCount,
-                daitaSettings: tunnelSettings.daita,
-                automaticDaitaRouting: false
+                daitaSettings: tunnelSettings.daita
             ).pick()
         }
     }

--- a/ios/MullvadSettings/DAITASettings.swift
+++ b/ios/MullvadSettings/DAITASettings.swift
@@ -44,6 +44,10 @@ public struct DAITASettings: Codable, Equatable {
         daitaState.isEnabled && !directOnlyState.isEnabled
     }
 
+    public var shouldDoDirectOnly: Bool {
+        daitaState.isEnabled && directOnlyState.isEnabled
+    }
+
     public init(daitaState: DAITAState = .off, directOnlyState: DirectOnlyState = .off) {
         self.daitaState = daitaState
         self.directOnlyState = directOnlyState

--- a/ios/MullvadSettings/DAITASettings.swift
+++ b/ios/MullvadSettings/DAITASettings.swift
@@ -40,11 +40,11 @@ public struct DAITASettings: Codable, Equatable {
     public let daitaState: DAITAState
     public let directOnlyState: DirectOnlyState
 
-    public var shouldDoAutomaticRouting: Bool {
+    public var isAutomaticRouting: Bool {
         daitaState.isEnabled && !directOnlyState.isEnabled
     }
 
-    public var shouldDoDirectOnly: Bool {
+    public var isDirectOnly: Bool {
         daitaState.isEnabled && directOnlyState.isEnabled
     }
 

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -465,6 +465,7 @@
 		7A21DACF2A30AA3700A787A9 /* UITextField+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A21DACE2A30AA3700A787A9 /* UITextField+Appearance.swift */; };
 		7A27E3C92CAE85710088BCFF /* SettingsInfoButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A27E3C82CAE85660088BCFF /* SettingsInfoButtonItem.swift */; };
 		7A27E3CB2CAE861D0088BCFF /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A27E3CA2CAE86170088BCFF /* SettingsViewModel.swift */; };
+		7A27E3CD2CB814EF0088BCFF /* DAITAInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A27E3CC2CB814EA0088BCFF /* DAITAInfoView.swift */; };
 		7A28826A2BA8336600FD9F20 /* VPNSettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2882692BA8336600FD9F20 /* VPNSettingsCoordinator.swift */; };
 		7A2960F62A963F7500389B82 /* AlertCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2960F52A963F7500389B82 /* AlertCoordinator.swift */; };
 		7A2960FD2A964BB700389B82 /* AlertPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2960FC2A964BB700389B82 /* AlertPresentation.swift */; };
@@ -1801,6 +1802,7 @@
 		7A21DACE2A30AA3700A787A9 /* UITextField+Appearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+Appearance.swift"; sourceTree = "<group>"; };
 		7A27E3C82CAE85660088BCFF /* SettingsInfoButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsInfoButtonItem.swift; sourceTree = "<group>"; };
 		7A27E3CA2CAE86170088BCFF /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		7A27E3CC2CB814EA0088BCFF /* DAITAInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAITAInfoView.swift; sourceTree = "<group>"; };
 		7A2882692BA8336600FD9F20 /* VPNSettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNSettingsCoordinator.swift; sourceTree = "<group>"; };
 		7A2960F52A963F7500389B82 /* AlertCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertCoordinator.swift; sourceTree = "<group>"; };
 		7A2960FC2A964BB700389B82 /* AlertPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresentation.swift; sourceTree = "<group>"; };
@@ -2779,6 +2781,7 @@
 				F050AE5F2B73A41E003F4EDB /* AllLocationDataSource.swift */,
 				F04413602BA45CD70018A6EE /* CustomListLocationNodeBuilder.swift */,
 				F050AE612B74DBAC003F4EDB /* CustomListsDataSource.swift */,
+				7A27E3CC2CB814EA0088BCFF /* DAITAInfoView.swift */,
 				5888AD82227B11080051EB06 /* LocationCell.swift */,
 				F050AE4D2B70D7F8003F4EDB /* LocationCellViewModel.swift */,
 				583DA21325FA4B5C00318683 /* LocationDataSource.swift */,
@@ -2799,7 +2802,6 @@
 			isa = PBXGroup;
 			children = (
 				7A9FA1432A2E3FE5000B728D /* CheckableSettingsCell.swift */,
-				F041BE4E2C983C2B0083EC28 /* DAITASettingsPromptItem.swift */,
 				7A1A264A2A29D65E00B978AA /* SelectableSettingsCell.swift */,
 				5819C2162729595500D6EC38 /* SettingsAddDNSEntryCell.swift */,
 				582BB1AE229566420055B6EF /* SettingsCell.swift */,
@@ -2813,7 +2815,7 @@
 				7A42DEC82A05164100B209BE /* SettingsInputCell.swift */,
 				58677711290976FB006F721F /* SettingsInteractor.swift */,
 				5867770F290975E8006F721F /* SettingsInteractorFactory.swift */,
-				F041BE4E2C983C2B0083EC28 /* SettingsPromptAlertItem.swift */,
+				F041BE4E2C983C2B0083EC28 /* DAITASettingsPromptItem.swift */,
 				58ACF64A26553C3F00ACE4B7 /* SettingsSwitchCell.swift */,
 				58CCA01122424D11004F3011 /* SettingsViewController.swift */,
 				7A27E3CA2CAE86170088BCFF /* SettingsViewModel.swift */,
@@ -5811,6 +5813,7 @@
 				7AB4CCBB2B691BBB006037F5 /* IPOverrideInteractor.swift in Sources */,
 				7A3353912AAA014400F0A71C /* SimulatorVPNConnection.swift in Sources */,
 				F02F41A22B9723AF00625A4F /* AddLocationsCoordinator.swift in Sources */,
+				7A27E3CD2CB814EF0088BCFF /* DAITAInfoView.swift in Sources */,
 				F028A56A2A34D4E700C0CAA3 /* RedeemVoucherViewController.swift in Sources */,
 				7A5869C52B5A899C00640D27 /* MethodSettingsCellConfiguration.swift in Sources */,
 				58E11188292FA11F009FCA84 /* SettingsMigrationUIHandler.swift in Sources */,

--- a/ios/MullvadVPN/Classes/AppRoutes.swift
+++ b/ios/MullvadVPN/Classes/AppRoutes.swift
@@ -57,8 +57,10 @@ enum AppRouteGroup: AppRouteGroupProtocol {
         switch self {
         case .primary:
             return 0
-        case .settings, .account, .selectLocation, .changelog:
+        case .account, .selectLocation, .changelog:
             return 1
+        case .settings:
+            return 2
         case .alert:
             // Alerts should always be topmost.
             return .max
@@ -103,7 +105,7 @@ enum AppRoute: AppRouteProtocol {
 
     var isExclusive: Bool {
         switch self {
-        case .selectLocation, .account, .settings, .changelog, .alert:
+        case .account, .settings, .changelog, .alert:
             return true
         default:
             return false

--- a/ios/MullvadVPN/Coordinators/AccountCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/AccountCoordinator.swift
@@ -196,7 +196,7 @@ final class AccountCoordinator: Coordinator, Presentable, Presenting {
             "RESTORE_PURCHASES_DIALOG_MESSAGE",
             tableName: "Account",
             value: """
-            You can use the “restore purchases” function to check for any in-app payments \
+            You can use the "restore purchases" function to check for any in-app payments \
             made via Apple services. If there is a payment that has not been credited, it will \
             add the time to the currently logged in Mullvad account.
             """,

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -52,10 +52,6 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
         self.tunnelManager = tunnelManager
         self.relayCacheTracker = relayCacheTracker
         self.customListRepository = customListRepository
-
-        super.init()
-
-        addTunnelObserver()
     }
 
     func start() {
@@ -84,6 +80,8 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
             }
             didFinish?(self)
         }
+
+        addTunnelObserver()
         relayCacheTracker.addObserver(self)
 
         if let cachedRelays = try? relayCacheTracker.getCachedRelays() {

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodViewModel.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodViewModel.swift
@@ -147,7 +147,7 @@ extension AccessMethodViewModel {
                         "DIRECT_ACCESS_METHOD_MODAL_BODY_PART_1",
                         tableName: "APIAccess",
                         value: """
-                        With the “Direct” method, the app communicates with a Mullvad API server \
+                        With the "Direct" method, the app communicates with a Mullvad API server \
                         directly without any intermediate proxies.
                         """,
                         comment: ""
@@ -179,7 +179,7 @@ extension AccessMethodViewModel {
                         "BRIDGES_ACCESS_METHOD_MODAL_BODY_PART_1",
                         tableName: "APIAccess",
                         value: """
-                        With the “Mullvad bridges” method, the app communicates with a Mullvad API server via a \
+                        With the "Mullvad bridges" method, the app communicates with a Mullvad API server via a \
                         Mullvad bridge server. It does this by sending the traffic obfuscated by Shadowsocks.
                         """,
                         comment: ""
@@ -211,7 +211,7 @@ extension AccessMethodViewModel {
                         "ENCRYPTED_DNS_ACCESS_METHOD_MODAL_BODY_PART_1",
                         tableName: "APIAccess",
                         value: """
-                        With the “Encrypted DNS proxy” method, the app will communicate with our \
+                        With the "Encrypted DNS proxy" method, the app will communicate with our \
                         Mullvad API through a proxy address.
                         It does this by retrieving an address from a DNS over HTTPS (DoH) server and \
                         then using that to reach our API servers.

--- a/ios/MullvadVPN/View controllers/SelectLocation/DAITAInfoView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/DAITAInfoView.swift
@@ -1,0 +1,78 @@
+//
+//  DAITAInfoView.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2024-10-10.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+import UIKit
+
+class DAITAInfoView: UIView {
+    let infoLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+
+        let infoTextParagraphStyle = NSMutableParagraphStyle()
+        infoTextParagraphStyle.lineSpacing = 1.3
+        infoTextParagraphStyle.alignment = .center
+
+        label.attributedText = NSAttributedString(
+            string: NSLocalizedString(
+                "SELECT_LOCATION_DAITA_INFO",
+                tableName: "SelectLocation",
+                value: """
+                DAITA overrides Multihop. To use Multihop, please enable "Direct only" or \
+                disable "DAITA" in the settings.
+                """,
+                comment: ""
+            ),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 15),
+                .foregroundColor: UIColor.white,
+                .paragraphStyle: infoTextParagraphStyle,
+            ]
+        )
+
+        return label
+    }()
+
+    let settingsButton: UIButton = {
+        let settingsButton = AppButton(style: .default)
+        settingsButton.setTitle(NSLocalizedString(
+            "SELECT_LOCATION_DAITA_BUTTON",
+            tableName: "SelectLocation",
+            value: "Go to DAITA settings",
+            comment: ""
+        ), for: .normal)
+
+        return settingsButton
+    }()
+
+    var didPressDaitaSettingsButton: (() -> Void)?
+
+    init() {
+        super.init(frame: .zero)
+
+        backgroundColor = .secondaryColor
+        layoutMargins = UIMetrics.contentInsets
+
+        settingsButton.addTarget(self, action: #selector(didPressButton), for: .touchUpInside)
+
+        addConstrainedSubviews([infoLabel, settingsButton]) {
+            infoLabel.pinEdgesToSuperviewMargins(.init([.leading(24), .trailing(24)]))
+
+            settingsButton.pinEdgesToSuperviewMargins(.init([.leading(0), .trailing(0)]))
+            settingsButton.topAnchor.constraint(equalTo: infoLabel.bottomAnchor, constant: 32)
+            settingsButton.bottomAnchor.constraint(equalTo: centerYAnchor)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func didPressButton() {
+        didPressDaitaSettingsButton?()
+    }
+}

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -118,7 +118,7 @@ final class LocationViewController: UIViewController {
         dataSource?.setSelectedRelays(selectedRelays)
     }
 
-    func addDaitaInfoView() {
+    func enableDaitaAutomaticRouting() {
         guard daitaInfoView == nil else { return }
 
         let daitaInfoView = DAITAInfoView()
@@ -132,11 +132,16 @@ final class LocationViewController: UIViewController {
             daitaInfoView.pinEdgesToSuperview(.all().excluding(.top))
             daitaInfoView.topAnchor.constraint(equalTo: tableView.topAnchor)
         }
+
+        searchBar.searchTextField.isEnabled = false
     }
 
-    func removeDaitaInfoView() {
+    func disableDaitaAutomaticRouting() {
         daitaInfoView?.removeFromSuperview()
         daitaInfoView = nil
+
+        searchBar.searchTextField.isEnabled = true
+        UITextField.SearchTextFieldAppearance.inactive.apply(to: searchBar)
     }
 
     // MARK: - Private

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -92,11 +92,11 @@ final class LocationViewController: UIViewController {
         self.relaysWithLocation = relaysWithLocation
         self.filter = filter
 
+        filterView.setFilter(filter)
         if filterViewShouldBeHidden {
             filterView.isHidden = true
         } else {
             filterView.isHidden = false
-            filterView.setFilter(filter)
         }
 
         dataSource?.setRelays(relaysWithLocation, selectedRelays: selectedRelays)

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -13,6 +13,7 @@ import UIKit
 
 protocol LocationViewControllerDelegate: AnyObject {
     func navigateToCustomLists(nodes: [LocationNode])
+    func navigateToDaitaSettings()
     func didSelectRelays(relays: UserSelectedRelays)
     func didUpdateFilter(filter: RelayFilter)
 }
@@ -22,6 +23,7 @@ final class LocationViewController: UIViewController {
     private let tableView = UITableView(frame: .zero, style: .grouped)
     private let topContentView = UIStackView()
     private let filterView = RelayFilterView()
+    private var daitaInfoView: UIView?
     private var dataSource: LocationDataSource?
     private var relaysWithLocation: LocationRelays?
     private var filter = RelayFilter()
@@ -100,6 +102,13 @@ final class LocationViewController: UIViewController {
         dataSource?.setRelays(relaysWithLocation, selectedRelays: selectedRelays)
     }
 
+    func setShouldFilterDaita(_ shouldFilterDaita: Bool) {
+        self.shouldFilterDaita = shouldFilterDaita
+
+        filterView.isHidden = filterViewShouldBeHidden
+        filterView.setDaita(shouldFilterDaita)
+    }
+
     func refreshCustomLists() {
         dataSource?.refreshCustomLists(selectedRelays: selectedRelays)
     }
@@ -107,6 +116,27 @@ final class LocationViewController: UIViewController {
     func setSelectedRelays(_ selectedRelays: RelaySelection) {
         self.selectedRelays = selectedRelays
         dataSource?.setSelectedRelays(selectedRelays)
+    }
+
+    func addDaitaInfoView() {
+        guard daitaInfoView == nil else { return }
+
+        let daitaInfoView = DAITAInfoView()
+        self.daitaInfoView = daitaInfoView
+
+        daitaInfoView.didPressDaitaSettingsButton = { [weak self] in
+            self?.delegate?.navigateToDaitaSettings()
+        }
+
+        view.addConstrainedSubviews([daitaInfoView]) {
+            daitaInfoView.pinEdgesToSuperview(.all().excluding(.top))
+            daitaInfoView.topAnchor.constraint(equalTo: tableView.topAnchor)
+        }
+    }
+
+    func removeDaitaInfoView() {
+        daitaInfoView?.removeFromSuperview()
+        daitaInfoView = nil
     }
 
     // MARK: - Private

--- a/ios/MullvadVPN/View controllers/Settings/SettingsInfoButtonItem.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsInfoButtonItem.swift
@@ -35,9 +35,9 @@ enum SettingsInfoButtonItem: CustomStringConvertible {
                 "DIRECT_ONLY_INFORMATION_TEXT",
                 tableName: "DAITA",
                 value: """
-                By enabling “Direct only” you will have to manually select a server that is DAITA-enabled. \
+                By enabling "Direct only" you will have to manually select a server that is DAITA-enabled. \
                 This can cause you to end up in a blocked state until you have selected a compatible server \
-                in the “Select location” view.
+                in the "Select location" view.
                 """,
                 comment: ""
             )

--- a/ios/MullvadVPN/View controllers/Settings/SettingsInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsInteractor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MullvadREST
 import MullvadSettings
 
 final class SettingsInteractor {
@@ -46,11 +47,22 @@ final class SettingsInteractor {
         var tunnelSettings = tunnelSettings
         tunnelSettings.daita = settings
 
-        // Return error if no relays could be selected.
-        guard (try? tunnelManager.selectRelays(tunnelSettings: tunnelSettings)) != nil else {
-            return tunnelSettings.tunnelMultihopState.isEnabled ? .multihop : .singlehop
-        }
+        var compatibilityError: DAITASettingsCompatibilityError?
 
-        return nil
+        do {
+            _ = try tunnelManager.selectRelays(tunnelSettings: tunnelSettings)
+        } catch let error as NoRelaysSatisfyingConstraintsError where error.reason == .noDaitaRelaysFound {
+            // Return error if no relays could be selected due to DAITA constraints.
+            compatibilityError = tunnelSettings.tunnelMultihopState.isEnabled ? .multihop : .singlehop
+        } catch let error as NoRelaysSatisfyingConstraintsError {
+            // Even if the constraints error is not DAITA specific, if both DAITA and Direct only are enabled,
+            // we should return a DAITA related error since the current settings would have resulted in the
+            // relay selector not being able to select a DAITA relay anyway.
+            if settings.isDirectOnly {
+                compatibilityError = tunnelSettings.tunnelMultihopState.isEnabled ? .multihop : .singlehop
+            }
+        } catch {}
+
+        return compatibilityError
     }
 }

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
@@ -169,8 +169,7 @@ extension MultihopDecisionFlowTests {
             relays: sampleRelays,
             constraints: constraints,
             connectionAttemptCount: 0,
-            daitaSettings: DAITASettings(daitaState: .off),
-            automaticDaitaRouting: false
+            daitaSettings: DAITASettings(daitaState: .off)
         )
     }
 

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
@@ -99,7 +99,7 @@ class MultihopDecisionFlowTests: XCTestCase {
         let selectedRelays = try oneToOne.pick(
             entryCandidates: entryCandidates,
             exitCandidates: exitCandidates,
-            automaticDaitaRouting: false
+            daitaAutomaticRouting: false
         )
 
         XCTAssertEqual(selectedRelays.entry?.hostname, "se2-wireguard")
@@ -115,7 +115,7 @@ class MultihopDecisionFlowTests: XCTestCase {
         let selectedRelays = try oneToMany.pick(
             entryCandidates: entryCandidates,
             exitCandidates: exitCandidates,
-            automaticDaitaRouting: false
+            daitaAutomaticRouting: false
         )
 
         XCTAssertEqual(selectedRelays.entry?.hostname, "se2-wireguard")
@@ -131,7 +131,7 @@ class MultihopDecisionFlowTests: XCTestCase {
         let selectedRelays = try manyToOne.pick(
             entryCandidates: entryCandidates,
             exitCandidates: exitCandidates,
-            automaticDaitaRouting: false
+            daitaAutomaticRouting: false
         )
 
         XCTAssertEqual(selectedRelays.entry?.hostname, "se6-wireguard")
@@ -147,7 +147,7 @@ class MultihopDecisionFlowTests: XCTestCase {
         let selectedRelays = try manyToMany.pick(
             entryCandidates: entryCandidates,
             exitCandidates: exitCandidates,
-            automaticDaitaRouting: false
+            daitaAutomaticRouting: false
         )
 
         if selectedRelays.exit.hostname == "se2-wireguard" {

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
@@ -122,7 +122,7 @@ class RelayPickingTests: XCTestCase {
 
         let selectedRelays = try picker.pick()
 
-        XCTAssertNil(selectedRelays.entry?.hostname)
+        XCTAssertEqual(selectedRelays.entry?.hostname, "us-nyc-wg-301") // New York relay is closest to exit relay.
         XCTAssertEqual(selectedRelays.exit.hostname, "es1-wireguard")
     }
 
@@ -150,7 +150,7 @@ class RelayPickingTests: XCTestCase {
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
         )
 
-        let picker = SinglehopPicker(
+        let picker = MultihopPicker(
             relays: sampleRelays,
             constraints: constraints,
             connectionAttemptCount: 0,
@@ -169,7 +169,7 @@ class RelayPickingTests: XCTestCase {
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
         )
 
-        let picker = SinglehopPicker(
+        let picker = MultihopPicker(
             relays: sampleRelays,
             constraints: constraints,
             connectionAttemptCount: 0,
@@ -188,7 +188,7 @@ class RelayPickingTests: XCTestCase {
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
         )
 
-        let picker = SinglehopPicker(
+        let picker = MultihopPicker(
             relays: sampleRelays,
             constraints: constraints,
             connectionAttemptCount: 0,

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
@@ -45,8 +45,7 @@ class RelayPickingTests: XCTestCase {
             relays: sampleRelays,
             constraints: constraints,
             connectionAttemptCount: 0,
-            daitaSettings: DAITASettings(),
-            automaticDaitaRouting: false
+            daitaSettings: DAITASettings()
         )
 
         let selectedRelays = try picker.pick()
@@ -65,8 +64,7 @@ class RelayPickingTests: XCTestCase {
             relays: sampleRelays,
             constraints: constraints,
             connectionAttemptCount: 0,
-            daitaSettings: DAITASettings(),
-            automaticDaitaRouting: false
+            daitaSettings: DAITASettings()
         )
 
         XCTAssertThrowsError(

--- a/ios/MullvadVPNTests/MullvadSettings/DAITASettingsTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/DAITASettingsTests.swift
@@ -10,12 +10,21 @@
 import XCTest
 
 final class DAITASettingsTests: XCTestCase {
-    func testShouldDoDirectOnly() throws {
+    func testIsAutomaticRouting() throws {
         let settings = DAITASettings()
 
         XCTAssertEqual(
-            settings.shouldDoAutomaticRouting,
+            settings.isAutomaticRouting,
             settings.daitaState == .on && settings.directOnlyState == .off
+        )
+    }
+
+    func testIsDirectOnly() throws {
+        let settings = DAITASettings()
+
+        XCTAssertEqual(
+            settings.isDirectOnly,
+            settings.daitaState == .on && settings.directOnlyState == .on
         )
     }
 }


### PR DESCRIPTION
When smart routing and multihop are enabled, the entry selection view should be updated to explain to the user that they cannot change an entry location when DAITA is on and Direct only is off.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6950)
<!-- Reviewable:end -->
