### PR TITLE
Show create account confirm when user has account

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CreateAccountConfirmationDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/CreateAccountConfirmationDialog.kt
@@ -1,0 +1,54 @@
+package net.mullvad.mullvadvpn.compose.dialog
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.result.EmptyResultBackNavigator
+import com.ramcosta.composedestinations.result.ResultBackNavigator
+import com.ramcosta.composedestinations.spec.DestinationStyle
+import net.mullvad.mullvadvpn.R
+import net.mullvad.mullvadvpn.compose.dialog.info.InfoConfirmationDialog
+import net.mullvad.mullvadvpn.compose.dialog.info.InfoConfirmationDialogTitleType
+import net.mullvad.mullvadvpn.lib.theme.AppTheme
+import net.mullvad.mullvadvpn.lib.theme.Dimens
+
+@Preview
+@Composable
+private fun PreviewCreateAccountConfirmationDialog() {
+    AppTheme { CreateAccountConfirmation(EmptyResultBackNavigator()) }
+}
+
+@Composable
+@Destination<RootGraph>(style = DestinationStyle.Dialog::class)
+fun CreateAccountConfirmation(navigator: ResultBackNavigator<Boolean>) {
+    InfoConfirmationDialog(
+        navigator = navigator,
+        titleType = InfoConfirmationDialogTitleType.IconOnly,
+        confirmButtonTitle = stringResource(R.string.create_new_account),
+        cancelButtonTitle = stringResource(R.string.cancel),
+    ) {
+        Text(
+            text = stringResource(id = R.string.create_new_account_warning_paragraph1),
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(modifier = Modifier.height(Dimens.verticalSpace))
+
+        Text(
+            text = stringResource(id = R.string.create_new_account_warning_paragraph2),
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="login_fail_description">Invalid account number</string>
     <string name="dont_have_an_account">Don’t have an account number?</string>
     <string name="create_account">Create account</string>
+    <string name="create_new_account_warning_paragraph1">You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone.</string>
+    <string name="create_new_account_warning_paragraph2">Do you want to create a new account?</string>
     <string name="creating_new_account">Creating account...</string>
     <string name="failed_to_create_account">Failed to create account</string>
     <string name="account_created">Account created</string>
@@ -282,6 +284,7 @@
     <string name="all_locations">All locations</string>
     <string name="edit_lists">Edit lists</string>
     <string name="create_new_list">Create new list</string>
+    <string name="create_new_account">Create new account</string>
     <string name="create">Create</string>
     <string name="no_locations_found">No locations found</string>
     <string name="add_locations">Add locations</string>

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2341,6 +2341,9 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
+msgid "Create new account"
+msgstr ""
+
 msgid "Create new list"
 msgstr ""
 
@@ -2387,6 +2390,9 @@ msgid "Disconnecting..."
 msgstr ""
 
 msgid "Dismiss"
+msgstr ""
+
+msgid "Do you want to create a new account?"
 msgstr ""
 
 msgid "Edit custom lists"
@@ -2723,6 +2729,9 @@ msgid "WireGuard port"
 msgstr ""
 
 msgid "YOU MIGHT BE LEAKING NETWORK TRAFFIC"
+msgstr ""
+
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
 msgstr ""
 
 msgid "You are running an unsupported app version."


### PR DESCRIPTION
Now showing a confirmation dialog when creating an account when the user has already logged in on another account on the device. The text is a placeholder and needs to be decided on.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6951)
<!-- Reviewable:end -->
