### PR TITLE
Fix no relays when in blocked state triggered by Daita

### DIFF
--- a/ios/MullvadSettings/TunnelSettingsV6.swift
+++ b/ios/MullvadSettings/TunnelSettingsV6.swift
@@ -22,7 +22,7 @@ public struct TunnelSettingsV6: Codable, Equatable, TunnelSettings {
     /// Whether Post Quantum exchanges are enabled.
     public var tunnelQuantumResistance: TunnelQuantumResistance
 
-    /// Whether Multi-hop is enabled.
+    /// Whether Multihop is enabled.
     public var tunnelMultihopState: MultihopState
 
     /// DAITA settings.

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -54,9 +54,11 @@ class LocationCoordinator: Coordinator, Presentable, Presenting {
     }
 
     func start() {
-        let startContext: LocationViewControllerWrapper.MultihopContext =
-            if case .noRelaysSatisfyingDaitaConstraints = tunnelManager.tunnelStatus.observedState
+        var startContext: LocationViewControllerWrapper.MultihopContext = .exit
+        if tunnelManager.settings.tunnelMultihopState.isEnabled {
+            startContext = if case .noRelaysSatisfyingDaitaConstraints = tunnelManager.tunnelStatus.observedState
                 .blockedState?.reason { .entry } else { .exit }
+        }
 
         let locationViewControllerWrapper = LocationViewControllerWrapper(
             customListRepository: customListRepository,


### PR DESCRIPTION
Reproduction steps:

- Launch the app, make sure all options are off
- Select a Sweden relay and connect normally
- Disconnect
- Turn on both Daita and Direct connection
- Tap on Secure connection and enter blocked state
- Tap on Select location

What happens

- The location list is empy, and the user cannot select any relays to exit blocked state
- If the user disconnects, and tries to select a relay when the VPN is not running, the Daita + Direct mode filter works as intended

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6952)
<!-- Reviewable:end -->
