### PR TITLE
Disable OpenVPN option when a core privacy feature is enabled

### DIFF
--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -2004,6 +2004,10 @@ msgctxt "vpn-settings-view"
 msgid "This might cause issues on certain websites, services, and apps."
 msgstr ""
 
+msgctxt "vpn-settings-view"
+msgid "To select %(openvpn)s, please disable these settings: %(featureList)s."
+msgstr ""
+
 #. Label for settings that enables tracker blocking.
 msgctxt "vpn-settings-view"
 msgid "Trackers"

--- a/gui/src/renderer/components/VpnSettings.tsx
+++ b/gui/src/renderer/components/VpnSettings.tsx
@@ -11,7 +11,7 @@ import { useRelaySettingsUpdater } from '../lib/constraint-updater';
 import { useHistory } from '../lib/history';
 import { formatHtml } from '../lib/html-formatter';
 import { RoutePath } from '../lib/routes';
-import { useBoolean } from '../lib/utilityHooks';
+import { useBoolean, useTunnelProtocol } from '../lib/utilityHooks';
 import { RelaySettingsRedux } from '../redux/settings/reducers';
 import { useSelector } from '../redux/store';
 import * as AppButton from './AppButton';
@@ -799,21 +799,12 @@ function WireguardSettingsButton() {
 
 function OpenVpnSettingsButton() {
   const history = useHistory();
-  const tunnelProtocol = useSelector((state) =>
-    mapRelaySettingsToProtocol(state.settings.relaySettings),
-  );
-  const relaySettings = useSelector((state) => state.settings.relaySettings);
-  const multihop = 'normal' in relaySettings ? relaySettings.normal.wireguard.useMultihop : false;
-  const daita = useSelector((state) => state.settings.wireguard.daita?.enabled ?? false);
-  const quantumResistant = useSelector((state) => state.settings.wireguard.quantumResistant);
-  const openVpnDisabled = daita || multihop || quantumResistant;
+  const tunnelProtocol = useTunnelProtocol();
 
   const navigate = useCallback(() => history.push(RoutePath.openVpnSettings), [history]);
 
   return (
-    <Cell.CellNavigationButton
-      onClick={navigate}
-      disabled={tunnelProtocol === 'wireguard' || openVpnDisabled}>
+    <Cell.CellNavigationButton onClick={navigate} disabled={tunnelProtocol === 'wireguard'}>
       <Cell.Label>
         {sprintf(
           // TRANSLATORS: %(openvpn)s will be replaced with the string "OpenVPN"

--- a/gui/src/renderer/components/select-location/RelayListContext.tsx
+++ b/gui/src/renderer/components/select-location/RelayListContext.tsx
@@ -9,7 +9,11 @@ import {
   getLocationsExpandedBySearch,
   searchForLocations,
 } from '../../lib/filter-locations';
-import { useNormalBridgeSettings, useNormalRelaySettings } from '../../lib/utilityHooks';
+import {
+  useNormalBridgeSettings,
+  useNormalRelaySettings,
+  useTunnelProtocol,
+} from '../../lib/utilityHooks';
 import { IRelayLocationCountryRedux } from '../../redux/settings/reducers';
 import { useSelector } from '../../redux/store';
 import { useCustomListsRelayList } from './custom-list-helpers';
@@ -66,13 +70,19 @@ export function RelayListContextProvider(props: RelayListContextProviderProps) {
 
   const fullRelayList = useSelector((state) => state.settings.relayLocations);
   const relaySettings = useNormalRelaySettings();
+  const tunnelProtocol = useTunnelProtocol();
 
   // Filters the relays to only keep the ones of the desired endpoint type, e.g. "wireguard",
   // "openvpn" or "bridge"
   const relayListForEndpointType = useMemo(() => {
     const endpointType =
       locationType === LocationType.entry ? EndpointType.entry : EndpointType.exit;
-    return filterLocationsByEndPointType(fullRelayList, endpointType, relaySettings);
+    return filterLocationsByEndPointType(
+      fullRelayList,
+      endpointType,
+      tunnelProtocol,
+      relaySettings,
+    );
   }, [fullRelayList, locationType, relaySettings?.tunnelProtocol]);
 
   const relayListForDaita = useMemo(() => {

--- a/gui/src/renderer/lib/filter-locations.ts
+++ b/gui/src/renderer/lib/filter-locations.ts
@@ -29,9 +29,13 @@ export enum EndpointType {
 export function filterLocationsByEndPointType(
   locations: IRelayLocationCountryRedux[],
   endpointType: EndpointType,
+  tunnelProtocol: LiftedConstraint<TunnelProtocol>,
   relaySettings?: NormalRelaySettingsRedux,
 ): IRelayLocationCountryRedux[] {
-  return filterLocationsImpl(locations, getTunnelProtocolFilter(endpointType, relaySettings));
+  return filterLocationsImpl(
+    locations,
+    getTunnelProtocolFilter(endpointType, tunnelProtocol, relaySettings),
+  );
 }
 
 export function filterLocationsByDaita(
@@ -74,9 +78,9 @@ export function filterLocations(
 
 function getTunnelProtocolFilter(
   endpointType: EndpointType,
+  tunnelProtocol: LiftedConstraint<TunnelProtocol>,
   relaySettings?: NormalRelaySettingsRedux,
 ): (relay: IRelayLocationRelayRedux) => boolean {
-  const tunnelProtocol = relaySettings?.tunnelProtocol ?? 'any';
   const endpointTypes: Array<RelayEndpointType> = [];
   if (endpointType !== EndpointType.exit && tunnelProtocol === 'openvpn') {
     endpointTypes.push('bridge');

--- a/gui/src/renderer/lib/utilityHooks.ts
+++ b/gui/src/renderer/lib/utilityHooks.ts
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import { LiftedConstraint, TunnelProtocol } from '../../shared/daemon-rpc-types';
 import { useSelector } from '../redux/store';
 
 export function useMounted() {
@@ -63,6 +64,19 @@ export function useBoolean(initialValue = false) {
 export function useNormalRelaySettings() {
   const relaySettings = useSelector((state) => state.settings.relaySettings);
   return 'normal' in relaySettings ? relaySettings.normal : undefined;
+}
+
+// Some features are considered core privacy features and when enabled prevent OpenVPN from being
+// used. This hook returns the tunnelprotocol with the exception that it always returns WireGuard
+// when any of those features are enabled.
+export function useTunnelProtocol(): LiftedConstraint<TunnelProtocol> {
+  const relaySettings = useNormalRelaySettings();
+  const multihop = relaySettings?.wireguard.useMultihop ?? false;
+  const daita = useSelector((state) => state.settings.wireguard.daita?.enabled ?? false);
+  const quantumResistant = useSelector((state) => state.settings.wireguard.quantumResistant);
+  const openVpnDisabled = daita || multihop || quantumResistant;
+
+  return openVpnDisabled ? 'wireguard' : (relaySettings?.tunnelProtocol ?? 'any');
 }
 
 export function useNormalBridgeSettings() {


### PR DESCRIPTION
This PR makes the OpenVPN alternative in VPN settings unavailable when a core privacy feature is enabled (DAITA, Multihop, Quantum-resistant tunnel). Texts aren't finished yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6959)
<!-- Reviewable:end -->
