### PR TITLE
Add missing relay list useMemo dependencies

### DIFF
--- a/gui/src/renderer/components/select-location/RelayListContext.tsx
+++ b/gui/src/renderer/components/select-location/RelayListContext.tsx
@@ -84,7 +84,7 @@ export function RelayListContextProvider(props: RelayListContextProviderProps) {
       relaySettings?.tunnelProtocol ?? 'any',
       relaySettings?.wireguard.useMultihop ?? false,
     );
-  }, [daita, relayListForEndpointType]);
+  }, [daita, directOnly, locationType, relaySettings, relayListForEndpointType]);
 
   // Filters the relays to only keep the relays matching the currently selected filters, e.g.
   // ownership and providers


### PR DESCRIPTION
This PR adds a few missing dependencies to the `useMemo` hook for when calculating the relay list.
