### PR TITLE
Disable chromium sandbox when running e2e tests on Linux in GitHub actions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -65,7 +65,15 @@ jobs:
         shell: bash
         run: npm test
 
-      - name: Run Playwright tests
+      - name: Run Playwright tests on Linux
+        if: runner.os == 'Linux'
+        working-directory: gui
+        # The sandbox is disabled as a workaround for lacking userns permisisons which is required
+        # since Ubuntu 24.04.
+        run: NO_SANDBOX=1 npm run e2e:no-build
+
+      - name: Run Playwright tests on Windows
+        if: runner.os != 'Linux'
         working-directory: gui
         shell: bash
         run: npm run e2e:no-build

--- a/gui/test/e2e/mocked/mocked-utils.ts
+++ b/gui/test/e2e/mocked/mocked-utils.ts
@@ -2,6 +2,10 @@ import { ElectronApplication } from 'playwright';
 
 import { startApp, TestUtils } from '../utils';
 
+// This option can be removed in the future when/if we're able to tun the tests with the sandbox
+// enabled in GitHub actions (frontend.yml).
+const noSandbox = process.env.NO_SANDBOX === '1';
+
 interface StartMockedAppResponse extends Awaited<ReturnType<typeof startApp>> {
   util: MockedTestUtils;
 }
@@ -12,7 +16,13 @@ export interface MockedTestUtils extends TestUtils {
 }
 
 export const startMockedApp = async (): Promise<StartMockedAppResponse> => {
-  const startAppResult = await startApp({ args: ['build/test/e2e/setup/main.js'] });
+  const args = ['build/test/e2e/setup/main.js'];
+  if (noSandbox) {
+    console.log('Running tests without chromium sandbox');
+    args.unshift('--no-sandbox');
+  }
+
+  const startAppResult = await startApp({ args });
   const mockIpcHandle = generateMockIpcHandle(startAppResult.app);
   const sendMockIpcResponse = generateSendMockIpcResponse(startAppResult.app);
 


### PR DESCRIPTION
This PR disables the chromium sandbox when running the e2e tests in GitHub actions on Linux runners. This is due to AppArmor restrictions.

Fixes DES-1161.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6970)
<!-- Reviewable:end -->
