### PR TITLE
Check AddressCache as well when overriding hostname for SSL validation

### DIFF
--- a/ios/MullvadREST/ApiHandlers/RESTURLSession.swift
+++ b/ios/MullvadREST/ApiHandlers/RESTURLSession.swift
@@ -7,9 +7,10 @@
 //
 
 import Foundation
+import Network
 
 extension REST {
-    public static func makeURLSession() -> URLSession {
+    public static func makeURLSession(addressCache: AddressCache) -> URLSession {
         let certificatePath = Bundle(for: SSLPinningURLSessionDelegate.self)
             .path(forResource: "le_root_cert", ofType: "cer")!
         let data = FileManager.default.contents(atPath: certificatePath)!
@@ -17,7 +18,8 @@ extension REST {
 
         let sessionDelegate = SSLPinningURLSessionDelegate(
             sslHostname: defaultAPIHostname,
-            trustedRootCertificates: [secCertificate]
+            trustedRootCertificates: [secCertificate],
+            addressCache: addressCache
         )
 
         let sessionConfiguration = URLSessionConfiguration.ephemeral

--- a/ios/MullvadREST/ApiHandlers/SSLPinningURLSessionDelegate.swift
+++ b/ios/MullvadREST/ApiHandlers/SSLPinningURLSessionDelegate.swift
@@ -14,12 +14,14 @@ import Security
 final class SSLPinningURLSessionDelegate: NSObject, URLSessionDelegate {
     private let sslHostname: String
     private let trustedRootCertificates: [SecCertificate]
+    private let addressCache: REST.AddressCache
 
     private let logger = Logger(label: "SSLPinningURLSessionDelegate")
 
-    init(sslHostname: String, trustedRootCertificates: [SecCertificate]) {
+    init(sslHostname: String, trustedRootCertificates: [SecCertificate], addressCache: REST.AddressCache) {
         self.sslHostname = sslHostname
         self.trustedRootCertificates = trustedRootCertificates
+        self.addressCache = addressCache
     }
 
     // MARK: - URLSessionDelegate
@@ -40,6 +42,7 @@ final class SSLPinningURLSessionDelegate: NSObject, URLSessionDelegate {
                 "\(IPv4Address.loopback)",
                 "\(IPv6Address.loopback)",
                 "\(REST.defaultAPIEndpoint.ip)",
+                "\(addressCache.getCurrentEndpoint().ip)",
             ]
             if overridenHostnames.contains(hostName) {
                 hostName = sslHostname

--- a/ios/MullvadREST/Transport/ProxyConfigurationTransportProvider.swift
+++ b/ios/MullvadREST/Transport/ProxyConfigurationTransportProvider.swift
@@ -27,7 +27,7 @@ public class ProxyConfigurationTransportProvider {
     }
 
     public func makeTransport(with configuration: PersistentProxyConfiguration) throws -> RESTTransport {
-        let urlSession = REST.makeURLSession()
+        let urlSession = REST.makeURLSession(addressCache: addressCache)
         switch configuration {
         case .direct:
             return URLSessionTransport(urlSession: urlSession)

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -110,7 +110,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             accountsProxy: accountsProxy,
             transactionLog: .default
         )
-        let urlSessionTransport = URLSessionTransport(urlSession: REST.makeURLSession())
+        let urlSessionTransport = URLSessionTransport(urlSession: REST.makeURLSession(addressCache: addressCache))
         let shadowsocksCache = ShadowsocksConfigurationCache(cacheDirectory: containerURL)
         let shadowsocksRelaySelector = ShadowsocksRelaySelector(
             relayCache: ipOverrideWrapper

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -74,7 +74,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, SettingsMigrationUIHand
             accountsProxy: appDelegate.accountsProxy,
             outgoingConnectionService: OutgoingConnectionService(
                 outgoingConnectionProxy: OutgoingConnectionProxy(
-                    urlSession: REST.makeURLSession(),
+                    urlSession: REST.makeURLSession(addressCache: appDelegate.addressCache),
                     hostname: ApplicationConfiguration.hostName
                 )
             ),

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
@@ -5,7 +5,7 @@
 //  Created by Marco Nikic on 2023-10-02.
 //  Copyright © 2023 Mullvad VPN AB. All rights reserved.
 //
-import MullvadREST
+@testable import MullvadREST
 
 @testable import MullvadMockData
 @testable import MullvadSettings
@@ -24,6 +24,7 @@ class TunnelManagerTests: XCTestCase {
     var accessTokenManager: AccessTokenManagerStub!
     var devicesProxy: DevicesProxyStub!
     var apiProxy: APIProxyStub!
+    var addressCache: REST.AddressCache!
 
     var transportProvider: TransportProvider!
 
@@ -42,9 +43,13 @@ class TunnelManagerTests: XCTestCase {
         accessTokenManager = AccessTokenManagerStub()
         devicesProxy = DevicesProxyStub(deviceResult: .success(Device.mock(publicKey: PrivateKey().publicKey)))
         apiProxy = APIProxyStub()
+        addressCache = REST.AddressCache(
+            canWriteToCache: false,
+            fileCache: MockFileCache(initialState: .fileNotFound)
+        )
 
         transportProvider = TransportProvider(
-            urlSessionTransport: URLSessionTransport(urlSession: REST.makeURLSession()),
+            urlSessionTransport: URLSessionTransport(urlSession: REST.makeURLSession(addressCache: addressCache)),
             addressCache: REST.AddressCache(
                 canWriteToCache: true,
                 cacheDirectory: FileManager.default.temporaryDirectory

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -203,7 +203,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         ipOverrideWrapper: IPOverrideWrapper,
         addressCache: REST.AddressCache
     ) -> TransportProvider {
-        let urlSession = REST.makeURLSession()
+        let urlSession = REST.makeURLSession(addressCache: addressCache)
         let urlSessionTransport = URLSessionTransport(urlSession: urlSession)
         let shadowsocksCache = ShadowsocksConfigurationCache(cacheDirectory: appContainerURL)
 


### PR DESCRIPTION
This PR adds the ability for `SSLPinningURLSessionDelegate` to also check for addresses in the `AddressCache` 
which means that rotating the IP address of the API endpoint shouldn't result in invalid SSL errors anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6978)
<!-- Reviewable:end -->
