### PR TITLE
Pass secrets to reused workflow

### DIFF
--- a/.github/workflows/ios-end-to-end-tests-api.yml
+++ b/.github/workflows/ios-end-to-end-tests-api.yml
@@ -13,3 +13,4 @@ jobs:
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "api-tests"
+    secrets: inherit

--- a/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
+++ b/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
@@ -21,3 +21,4 @@ jobs:
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "pr-merge-to-main"
+    secrets: inherit

--- a/.github/workflows/ios-end-to-end-tests-nightly.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly.yml
@@ -21,3 +21,4 @@ jobs:
     uses: ./.github/workflows/ios-end-to-end-tests.yml
     with:
       arg_tests_json_key: "nightly"
+    secrets: inherit


### PR DESCRIPTION
If secrets are not passed explicitly to the called reused action, the called action will not have access to them. Since the secrets contain the device UUID and the partner API token, the tests which invoke the end-to-end action should allow it access to the secrets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6984)
<!-- Reviewable:end -->
