### PR TITLE
Fix parsing of build tags

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
-          git fetch --tags --force
+          git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
@@ -234,7 +234,7 @@ jobs:
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
-          git fetch --tags --force
+          git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3
@@ -311,7 +311,7 @@ jobs:
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
-          git fetch --tags --force
+          git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
       - uses: actions/upload-artifact@v3

--- a/test/scripts/test-utils.sh
+++ b/test/scripts/test-utils.sh
@@ -91,12 +91,23 @@ function nice_time {
     echo "\"$*\" completed in $((s/60))m:$((s%60))s"
     return $result
 }
+# Matches $1 with a build version string and sets the following exported variables:
+# - BUILD_VERSION: The version part of the build string (e.g., "2024.3-beta1-dev-").
+# - COMMIT_HASH: The commit hash part of the build string (e.g., "abcdef").
+# - TAG: The tag part of the build string (e.g., "+tag").
+function parse_build_version {
+    if [[ "$1" =~ (^[0-9.]+(-beta[0-9]+)?-dev-)([0-9a-z]+)(\+[0-9a-z|-]+)?$ ]]; then
+        BUILD_VERSION="${BASH_REMATCH[1]}"
+        COMMIT_HASH="${BASH_REMATCH[3]}"
+        TAG="${BASH_REMATCH[4]}"
+        return 0
+    fi
+    return 1
+}
 
-# Returns 0 if $1 is a development build. `BASH_REMATCH` contains match groups
-# if that is the case.
+# Returns 0 if $1 is a development build.
 function is_dev_version {
-    local pattern="(^[0-9.]+(-beta[0-9]+)?-dev-)([0-9a-z]+)(\+[0-9a-z|-]+)?$"
-    if [[ "$1" =~ $pattern ]]; then
+    if [[ "$1" == *"-dev-"* ]]; then
         return 0
     fi
     return 1
@@ -106,13 +117,8 @@ function get_app_filename {
     local version=$1
     local os=$2
     if is_dev_version "$version"; then
-        # only save 6 chars of the hash
-        local commit="${BASH_REMATCH[3]}"
-        version="${BASH_REMATCH[1]}${commit}"
-        # If the dev-version includes a tag, we need to append it to the app filename
-        if [[ -n ${BASH_REMATCH[4]} ]]; then
-            version="${version}${BASH_REMATCH[4]}"
-        fi
+        parse_build_version "$version"
+        version="${BUILD_VERSION}${COMMIT_HASH}${TAG:-}"
     fi
     case $os in
         debian*|ubuntu*)
@@ -166,9 +172,8 @@ function get_e2e_filename {
     local version=$1
     local os=$2
     if is_dev_version "$version"; then
-        # only save 6 chars of the hash
-        local commit="${BASH_REMATCH[3]}"
-        version="${BASH_REMATCH[1]}${commit}"
+        parse_build_version "$version"
+        version="${BUILD_VERSION}${COMMIT_HASH}"
     fi
     case $os in
         debian*|ubuntu*|fedora*)

--- a/test/scripts/test-utils.sh
+++ b/test/scripts/test-utils.sh
@@ -46,7 +46,8 @@ commit=${commit:0:6}
 TAG=$(git describe --exact-match HEAD 2>/dev/null || echo "")
 
 if [[ -n "$TAG" && ${CURRENT_VERSION} =~ -dev- ]]; then
-    CURRENT_VERSION+="+${TAG}"
+    # Remove disallowed version characters from the tag
+    CURRENT_VERSION+="+${TAG//[^0-9a-z_-]/}"
 fi
 
 export CURRENT_VERSION


### PR DESCRIPTION
This PR fixes a few issue regarding how the test framework used tags when constructing the path to the build artifact.

* The regex which parsed the build version was broken because it included quotation marks. 
* The test framework never pruned tags, which made it use local tags even when they were outdated.
* The buildserver scripts remove forbidden characters from the "+$tag" suffix , which is now mirrored by the test framework.

I also split the parsing of build version regex from the function that decides if a build is a dev version.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6993)
<!-- Reviewable:end -->
