### PR TITLE
Make Smart routing override Multihop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Replace the draft key encapsulation mechanism Kyber (round 3) with the standardized
   ML-KEM (FIPS 203) dito in the handshake for Quantum-resistant tunnels.
+- Make Smart Routing override multihop if both are enabled. To manually set the entry relay,
+  explicitly enable the "Direct only" option in the DAITA settings.
 
 #### Windows
 - Enable quantum-resistant tunnels by default (when set to `auto`).

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2403,10 +2403,9 @@ impl Daemon {
                     .intersection(Constraint::Only(TunnelType::Wireguard))
                     .is_some();
 
-                let multihop_enabled = constraints.wireguard_constraints.use_multihop;
                 let daita_enabled = self.settings.tunnel_options.wireguard.daita.enabled;
 
-                if settings_changed && wireguard_enabled && daita_enabled && !multihop_enabled {
+                if settings_changed && wireguard_enabled && daita_enabled {
                     log::info!("Reconnecting because DAITA settings changed");
                     self.reconnect_tunnel();
                 }

--- a/mullvad-relay-selector/src/error.rs
+++ b/mullvad-relay-selector/src/error.rs
@@ -3,7 +3,8 @@
 
 use mullvad_types::{relay_constraints::MissingCustomBridgeSettings, relay_list::Relay};
 
-use crate::{detailer, WireguardConfig};
+use crate::detailer;
+use crate::relay_selector::relays::WireguardConfig;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/mullvad-relay-selector/src/error.rs
+++ b/mullvad-relay-selector/src/error.rs
@@ -3,8 +3,7 @@
 
 use mullvad_types::{relay_constraints::MissingCustomBridgeSettings, relay_list::Relay};
 
-use crate::detailer;
-use crate::relay_selector::relays::WireguardConfig;
+use crate::{detailer, relay_selector::relays::WireguardConfig};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -8,8 +8,10 @@ mod relay_selector;
 
 // Re-exports
 pub use error::Error;
+pub use relay_selector::detailer;
+pub use relay_selector::query;
+pub use relay_selector::relays::WireguardConfig;
 pub use relay_selector::{
-    detailer, query, AdditionalRelayConstraints, AdditionalWireguardConstraints, GetRelay,
-    RelaySelector, RuntimeParameters, SelectedBridge, SelectedObfuscator, SelectorConfig,
-    WireguardConfig, RETRY_ORDER,
+    AdditionalRelayConstraints, AdditionalWireguardConstraints, GetRelay, RelaySelector,
+    RuntimeParameters, SelectedBridge, SelectedObfuscator, SelectorConfig, RETRY_ORDER,
 };

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -8,10 +8,8 @@ mod relay_selector;
 
 // Re-exports
 pub use error::Error;
-pub use relay_selector::detailer;
-pub use relay_selector::query;
-pub use relay_selector::relays::WireguardConfig;
 pub use relay_selector::{
-    AdditionalRelayConstraints, AdditionalWireguardConstraints, GetRelay, RelaySelector,
-    RuntimeParameters, SelectedBridge, SelectedObfuscator, SelectorConfig, RETRY_ORDER,
+    detailer, query, relays::WireguardConfig, AdditionalRelayConstraints,
+    AdditionalWireguardConstraints, GetRelay, RelaySelector, RuntimeParameters, SelectedBridge,
+    SelectedObfuscator, SelectorConfig, RETRY_ORDER,
 };

--- a/mullvad-relay-selector/src/relay_selector/helpers.rs
+++ b/mullvad-relay-selector/src/relay_selector/helpers.rs
@@ -207,8 +207,8 @@ fn port_if_in_range<R: RangeBounds<u16>>(port_ranges: &[R], port: u16) -> Result
 /// - `port_ranges`: A slice of port numbers.
 ///
 /// # Returns
-/// - On success, a randomly selected port number within the given ranges. Otherwise,
-///   an error is returned.
+/// - On success, a randomly selected port number within the given ranges. Otherwise, an error is
+///   returned.
 pub fn select_random_port<R: RangeBounds<u16> + Iterator<Item = u16> + Clone>(
     port_ranges: &[R],
 ) -> Result<u16, Error> {

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -14,7 +14,8 @@ use relays::{Multihop, Singlehop, WireguardConfig};
 use crate::detailer::{openvpn_endpoint, wireguard_endpoint};
 use crate::error::{EndpointErrorDetails, Error};
 use crate::query::{
-    BridgeQuery, ObfuscationQuery, OpenVpnRelayQuery, RelayQuery, WireguardRelayQuery,
+    BridgeQuery, ObfuscationQuery, OpenVpnRelayQuery, RelayQuery, RelayQueryExt,
+    WireguardRelayQuery,
 };
 
 use std::path::Path;
@@ -668,8 +669,7 @@ impl RelaySelector {
         custom_lists: &CustomListsSettings,
         parsed_relays: &ParsedRelays,
     ) -> Result<WireguardConfig, Error> {
-        let singlehop = !query.wireguard_constraints().multihop();
-        let inner = if singlehop {
+        let inner = if query.singlehop() {
             match Self::get_wireguard_singlehop_config(query, custom_lists, parsed_relays) {
                 Some(exit) => WireguardConfig::from(exit),
                 None => {
@@ -686,17 +686,8 @@ impl RelaySelector {
             // A DAITA compatible entry should be used even when the exit is DAITA compatible.
             // This only makes sense in context: The user is no longer able to explicitly choose an
             // entry relay with smarting routing enabled, even if multihop is turned on
-            // TODO: Move this somewhere common?
-            let using_daita = || query.wireguard_constraints().daita == Constraint::Only(true);
-            // TODO: Move this somewhere common?
-            let smart_routing_enabled = || {
-                query
-                    .wireguard_constraints()
-                    .daita_use_multihop_if_necessary
-                    .is_only_and(|on| on)
-            };
             // Also implied: Multihop is enabled.
-            let multihop = if using_daita() && smart_routing_enabled() {
+            let multihop = if query.using_daita() && query.use_multihop_if_necessary() {
                 Self::get_wireguard_auto_multihop_config(query, custom_lists, parsed_relays)?
             } else {
                 Self::get_wireguard_multihop_config(query, custom_lists, parsed_relays)?
@@ -730,9 +721,6 @@ impl RelaySelector {
         custom_lists: &CustomListsSettings,
         parsed_relays: &ParsedRelays,
     ) -> Result<Multihop, Error> {
-        // are we using daita?
-        let using_daita = || query.wireguard_constraints().daita == Constraint::Only(true);
-
         // is the `candidates` list empty because DAITA is enabled?
         let no_relay_because_daita = || {
             let mut query = query.clone();
@@ -743,19 +731,10 @@ impl RelaySelector {
             Result::<_, Error>::Ok(!candidates.is_empty())
         };
 
-        // is `use_multihop_if_necessary` enabled?
-        let use_multihop_if_necessary = || {
-            query
-                .wireguard_constraints()
-                .daita_use_multihop_if_necessary
-                .intersection(Constraint::Only(true))
-                .is_some()
-        };
-
         // if we found no matching relays because DAITA was enabled, and `use_multihop_if_necessary`
         // is enabled, try enabling multihop and connecting using an automatically selected
         // entry relay.
-        if using_daita() && no_relay_because_daita()? && use_multihop_if_necessary() {
+        if query.using_daita() && query.use_multihop_if_necessary() && no_relay_because_daita()? {
             Self::get_wireguard_auto_multihop_config(query, custom_lists, parsed_relays)
         } else {
             Err(Error::NoRelay)

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -674,7 +674,12 @@ impl RelaySelector {
         custom_lists: &CustomListsSettings,
         parsed_relays: &ParsedRelays,
     ) -> Result<WireguardConfig, Error> {
-        // TODO: Make sure that this works differently on Android.
+        // TODO: Remove when Android gets support for multihop.
+        if cfg!(target_os = "android") {
+            let relay = Self::get_wireguard_singlehop_config(query, custom_lists, parsed_relays)
+                .ok_or(Error::NoRelay)?;
+            return Ok(WireguardConfig::from(relay));
+        }
         let inner = if query.singlehop() {
             match Self::get_wireguard_singlehop_config(query, custom_lists, parsed_relays) {
                 Some(exit) => WireguardConfig::from(exit),

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -629,7 +629,7 @@ impl RelaySelector {
         Self::get_wireguard_relay(&query, custom_lists, parsed_relays)
     }
 
-    /// Derive a valid Wireguard relay configuration from `query`.
+    /// Derive a valid relay configuration from `query`.
     ///
     /// # Note
     /// This function should *only* be called with a Wireguard query.
@@ -663,23 +663,35 @@ impl RelaySelector {
         })
     }
 
-    /// TODO: Document
+    /// Derive a valid Wireguard relay configuration from `query`.
+    ///
+    /// # Returns
+    /// * An `Err` if no exit relay can be chosen
+    /// * An `Err` if no entry relay can be chosen (if multihop is enabled on `query`)
+    /// * `Ok(WireguardConfig)` otherwise
     fn get_wireguard_relay_config(
         query: &RelayQuery,
         custom_lists: &CustomListsSettings,
         parsed_relays: &ParsedRelays,
     ) -> Result<WireguardConfig, Error> {
+        // TODO: Make sure that this works differently on Android.
         let inner = if query.singlehop() {
             match Self::get_wireguard_singlehop_config(query, custom_lists, parsed_relays) {
                 Some(exit) => WireguardConfig::from(exit),
                 None => {
-                    // No exit candidate was found.. Time to try smart routing!
-                    let multihop = Self::select_daita_multihop_through_smart_routing(
-                        query,
-                        custom_lists,
-                        parsed_relays,
-                    )?;
-                    WireguardConfig::from(multihop)
+                    // If we found no matching relays because DAITA was enabled, and `use_multihop_if_necessary`
+                    // is enabled, try enabling multihop and connecting using an automatically selected
+                    // entry relay.
+                    if query.using_daita() && query.use_multihop_if_necessary() {
+                        let multihop = Self::get_wireguard_auto_multihop_config(
+                            query,
+                            custom_lists,
+                            parsed_relays,
+                        )?;
+                        WireguardConfig::from(multihop)
+                    } else {
+                        return Err(Error::NoRelay);
+                    }
                 }
             }
         } else {
@@ -701,7 +713,7 @@ impl RelaySelector {
     /// Select a valid Wireguard exit relay.
     ///
     /// # Returns
-    /// * `Ok(WireguardConfig)` if an exit relay was selected
+    /// * `Ok(Singlehop)` if an exit relay was selected
     /// * `None` otherwise
     fn get_wireguard_singlehop_config(
         query: &RelayQuery,
@@ -712,33 +724,6 @@ impl RelaySelector {
         helpers::pick_random_relay(&candidates)
             .cloned()
             .map(Singlehop::new)
-    }
-
-    /// TODO: Make sure to make a comment regarding the fact that we no longer check for 'empty'
-    /// candidates.
-    fn select_daita_multihop_through_smart_routing(
-        query: &RelayQuery,
-        custom_lists: &CustomListsSettings,
-        parsed_relays: &ParsedRelays,
-    ) -> Result<Multihop, Error> {
-        // is the `candidates` list empty because DAITA is enabled?
-        let no_relay_because_daita = || {
-            let mut query = query.clone();
-            let mut wireguard_constraints = query.wireguard_constraints().clone();
-            wireguard_constraints.daita = Constraint::Any;
-            query.set_wireguard_constraints(wireguard_constraints)?;
-            let candidates = filter_matching_relay_list(&query, parsed_relays, custom_lists);
-            Result::<_, Error>::Ok(!candidates.is_empty())
-        };
-
-        // if we found no matching relays because DAITA was enabled, and `use_multihop_if_necessary`
-        // is enabled, try enabling multihop and connecting using an automatically selected
-        // entry relay.
-        if query.using_daita() && query.use_multihop_if_necessary() && no_relay_because_daita()? {
-            Self::get_wireguard_auto_multihop_config(query, custom_lists, parsed_relays)
-        } else {
-            Err(Error::NoRelay)
-        }
     }
 
     /// Select a valid Wireguard exit relay, together with with an automatically chosen entry relay.

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -717,7 +717,7 @@ impl RelaySelector {
     ///
     /// # Returns
     /// * An `Err` if no exit relay can be chosen
-    /// * `Ok(WireguardInner::Singlehop)` otherwise
+    /// * `Ok(WireguardConfig)` otherwise
     fn get_wireguard_singlehop_config(
         query: &RelayQuery,
         custom_lists: &CustomListsSettings,
@@ -768,7 +768,7 @@ impl RelaySelector {
     ///
     /// # Returns
     /// * An `Err` if no entry/exit relay can be chosen
-    /// * `Ok(WireguardInner::Multihop)` otherwise
+    /// * `Ok(WireguardConfig::Multihop)` otherwise
     fn get_wireguard_auto_multihop_config(
         query: &RelayQuery,
         custom_lists: &CustomListsSettings,
@@ -819,7 +819,7 @@ impl RelaySelector {
     /// * An `Err` if no exit relay can be chosen
     /// * An `Err` if no entry relay can be chosen
     /// * An `Err` if the chosen entry and exit relays are the same
-    /// * `Ok(WireguardInner::Multihop)` otherwise
+    /// * `Ok(WireguardConfig::Multihop)` otherwise
     fn get_wireguard_multihop_config(
         query: &RelayQuery,
         custom_lists: &CustomListsSettings,

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -913,6 +913,32 @@ pub mod builder {
     }
 }
 
+/// This trait defines a bunch of helper methods on [`RelayQuery`].
+pub trait RelayQueryExt {
+    /// Are we using daita?
+    fn using_daita(&self) -> bool;
+    /// is `use_multihop_if_necessary` enabled? In other words, is `Direct only` disabled?
+    fn use_multihop_if_necessary(&self) -> bool;
+    /// Are we using singlehop? I.e. is multihop *not* explicitly enabled?
+    fn singlehop(&self) -> bool;
+}
+
+impl RelayQueryExt for RelayQuery {
+    fn using_daita(&self) -> bool {
+        self.wireguard_constraints()
+            .daita
+            .is_only_and(|enabled| enabled)
+    }
+    fn use_multihop_if_necessary(&self) -> bool {
+        self.wireguard_constraints()
+            .daita_use_multihop_if_necessary
+            .is_only_and(|enabled| enabled)
+    }
+    fn singlehop(&self) -> bool {
+        !self.wireguard_constraints().multihop()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use mullvad_types::{

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -932,7 +932,9 @@ impl RelayQueryExt for RelayQuery {
     fn use_multihop_if_necessary(&self) -> bool {
         self.wireguard_constraints()
             .daita_use_multihop_if_necessary
-            .is_only_and(|enabled| enabled)
+            // The default value is `Any`, which means that we need to check the intersection.
+            .intersection(Constraint::Only(true))
+            .is_some()
     }
     fn singlehop(&self) -> bool {
         !self.wireguard_constraints().multihop()

--- a/mullvad-relay-selector/src/relay_selector/relays.rs
+++ b/mullvad-relay-selector/src/relay_selector/relays.rs
@@ -1,0 +1,72 @@
+//! TODO: Document this module
+
+use mullvad_types::relay_list::{Relay, RelayEndpointData};
+
+// TODO: Import `Either` and convert `Multihop` and `Singlehop` into concrete types.
+/// This struct defines the different Wireguard relays the the relay selector can end up selecting
+/// for an arbitrary Wireguard [`query`].
+///
+/// - [`WireguardConfig::Singlehop`]; A normal wireguard relay where VPN traffic enters and exits
+///   through this sole relay.
+/// - [`WireguardConfig::Multihop`]; Two wireguard relays to be used in a multihop circuit. VPN
+///   traffic will enter through `entry` and eventually come out from `exit` before the traffic will
+///   actually be routed to the broader internet.
+#[derive(Clone, Debug)]
+pub enum WireguardConfig {
+    /// Strongly prefer to instantiate this variant using [`WireguardConfig::singlehop`] as that
+    /// will assert that the relay is of the expected type.
+    Singlehop { exit: Relay },
+    /// Strongly prefer to instantiate this variant using [`WireguardConfig::multihop`] as that
+    /// will assert that the entry & exit relays are of the expected type.
+    Multihop { exit: Relay, entry: Relay },
+}
+
+/// TODO: Document
+pub struct Singlehop(Relay);
+/// TODO: Document
+pub struct Multihop {
+    entry: Relay,
+    exit: Relay,
+}
+
+impl From<Singlehop> for WireguardConfig {
+    fn from(relay: Singlehop) -> Self {
+        Self::Singlehop { exit: relay.0 }
+    }
+}
+
+impl From<Multihop> for WireguardConfig {
+    fn from(relay: Multihop) -> Self {
+        WireguardConfig::Multihop {
+            exit: relay.exit,
+            entry: relay.entry,
+        }
+    }
+}
+
+impl Singlehop {
+    pub const fn new(exit: Relay) -> Self {
+        // FIXME: This assert would be better to encode at the type level.
+        assert!(matches!(
+            exit.endpoint_data,
+            RelayEndpointData::Wireguard(_)
+        ));
+        Self(exit)
+    }
+}
+
+impl Multihop {
+    pub const fn new(entry: Relay, exit: Relay) -> Self {
+        // FIXME: This assert would be better to encode at the type level.
+        assert!(matches!(
+            exit.endpoint_data,
+            RelayEndpointData::Wireguard(_)
+        ));
+        // FIXME: This assert would be better to encode at the type level.
+        assert!(matches!(
+            entry.endpoint_data,
+            RelayEndpointData::Wireguard(_)
+        ));
+        Multihop { exit, entry }
+    }
+}

--- a/mullvad-relay-selector/src/relay_selector/relays.rs
+++ b/mullvad-relay-selector/src/relay_selector/relays.rs
@@ -17,8 +17,8 @@ pub enum WireguardConfig {
 
 /// A type representing single Wireguard relay.
 ///
-/// Before you can read any data out of a [`Singlehop`] value uou need to convert it to [`WireguardConfig`].
-/// This is easy since [`Singlehop`] implements [`Into<WireguardConfig>`].
+/// Before you can read any data out of a [`Singlehop`] value uou need to convert it to
+/// [`WireguardConfig`]. This is easy since [`Singlehop`] implements [`Into<WireguardConfig>`].
 ///
 /// # Why not simply use [`Relay`]?
 /// The only way to construct a [`Singlehop`] value is with [`Singlehop::new`] which performs
@@ -27,8 +27,8 @@ pub enum WireguardConfig {
 pub struct Singlehop(Relay);
 /// A type representing two Wireguard relay - an entry and an exit.
 ///
-/// Before you can read any data out of a [`Multihop`] value uou need to convert it to [`WireguardConfig`].
-/// This is easy since [`Multihop`] implements [`Into<WireguardConfig>`].
+/// Before you can read any data out of a [`Multihop`] value uou need to convert it to
+/// [`WireguardConfig`]. This is easy since [`Multihop`] implements [`Into<WireguardConfig>`].
 ///
 /// # Why not simply use [`Relay`]?
 /// The same rationale as for [`Singlehop`] applies - [`Multihop::new`] performs additional

--- a/mullvad-relay-selector/src/relay_selector/relays.rs
+++ b/mullvad-relay-selector/src/relay_selector/relays.rs
@@ -1,29 +1,38 @@
-//! TODO: Document this module
+//! This module defines wrapper types around [`Relay`], often to provide certain runtime guarantees
+//! or disambiguate the type of relay which is used in the relay selector's internal APIs.
 
 use mullvad_types::relay_list::{Relay, RelayEndpointData};
 
-// TODO: Import `Either` and convert `Multihop` and `Singlehop` into concrete types.
-/// This struct defines the different Wireguard relays the the relay selector can end up selecting
-/// for an arbitrary Wireguard [`query`].
-///
-/// - [`WireguardConfig::Singlehop`]; A normal wireguard relay where VPN traffic enters and exits
-///   through this sole relay.
-/// - [`WireguardConfig::Multihop`]; Two wireguard relays to be used in a multihop circuit. VPN
-///   traffic will enter through `entry` and eventually come out from `exit` before the traffic will
-///   actually be routed to the broader internet.
+/// - [`WireguardConfig::Singlehop`]: A wireguard relay where VPN traffic enters and exits.
+/// - [`WireguardConfig::Multihop`]: Two wireguard relays to be used in a multihop circuit. VPN
+///   traffic will enter through `entry` and eventually exit through `exit` before the traffic will
+///   actually be routed to the internet.
 #[derive(Clone, Debug)]
 pub enum WireguardConfig {
-    /// Strongly prefer to instantiate this variant using [`WireguardConfig::singlehop`] as that
-    /// will assert that the relay is of the expected type.
+    /// An exit relay.
     Singlehop { exit: Relay },
-    /// Strongly prefer to instantiate this variant using [`WireguardConfig::multihop`] as that
-    /// will assert that the entry & exit relays are of the expected type.
+    /// An entry and an exit relay.
     Multihop { exit: Relay, entry: Relay },
 }
 
-/// TODO: Document
+/// A type representing single Wireguard relay.
+///
+/// Before you can read any data out of a [`Singlehop`] value uou need to convert it to [`WireguardConfig`].
+/// This is easy since [`Singlehop`] implements [`Into<WireguardConfig>`].
+///
+/// # Why not simply use [`Relay`]?
+/// The only way to construct a [`Singlehop`] value is with [`Singlehop::new`] which performs
+/// additional validation which guarantees that the relay actually is a Wireguard relay, while
+/// [`Relay`] is not guaranteed to be a Wireguard relay.
 pub struct Singlehop(Relay);
-/// TODO: Document
+/// A type representing two Wireguard relay - an entry and an exit.
+///
+/// Before you can read any data out of a [`Multihop`] value uou need to convert it to [`WireguardConfig`].
+/// This is easy since [`Multihop`] implements [`Into<WireguardConfig>`].
+///
+/// # Why not simply use [`Relay`]?
+/// The same rationale as for [`Singlehop`] applies - [`Multihop::new`] performs additional
+/// validation on the entry and exit relays.
 pub struct Multihop {
     entry: Relay,
     exit: Relay,

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -1422,8 +1422,8 @@ fn test_daita_any_tunnel_protocol() {
     );
 }
 
-/// Always use smart routing to select a DAITA-enabled entry relay if both smart routing and multihop is enabled.
-/// This applies even if the entry is set explicitly.
+/// Always use smart routing to select a DAITA-enabled entry relay if both smart routing and
+/// multihop is enabled. This applies even if the entry is set explicitly.
 /// DAITA is a core privacy feature
 #[test]
 fn test_daita_smart_routing_overrides_multihop() {

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -96,6 +96,27 @@ static RELAYS: LazyLock<RelayList> = LazyLock::new(|| RelayList {
                     location: DUMMY_LOCATION.clone(),
                 },
                 Relay {
+                    hostname: "se11-wireguard".to_string(),
+                    ipv4_addr_in: "185.213.154.69".parse().unwrap(),
+                    ipv6_addr_in: Some("2a03:1b20:5:f011::a11f".parse().unwrap()),
+                    overridden_ipv4: false,
+                    overridden_ipv6: false,
+                    include_in_country: true,
+                    active: true,
+                    owned: false,
+                    provider: "provider2".to_string(),
+                    weight: 1,
+                    endpoint_data: RelayEndpointData::Wireguard(WireguardRelayEndpointData {
+                        public_key: PublicKey::from_base64(
+                            "BLNHNoGO88LjV/wDBa7CUUwUzPq/fO2UwcGLy56hKy4=",
+                        )
+                        .unwrap(),
+                        daita: true,
+                        shadowsocks_extra_addr_in: vec![],
+                    }),
+                    location: DUMMY_LOCATION.clone(),
+                },
+                Relay {
                     hostname: "se-got-001".to_string(),
                     ipv4_addr_in: "185.213.154.131".parse().unwrap(),
                     ipv6_addr_in: None,
@@ -1398,6 +1419,59 @@ fn test_daita_any_tunnel_protocol() {
     assert!(
         matches!(relay, Ok(GetRelay::Wireguard { .. })),
         "expected wg relay, got {relay:?}"
+    );
+}
+
+/// Always use smart routing to select a DAITA-enabled entry relay if both smart routing and multihop is enabled.
+/// This applies even if the entry is set explicitly.
+/// DAITA is a core privacy feature
+#[test]
+fn test_daita_smart_routing_overrides_multihop() {
+    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
+    let query = RelayQueryBuilder::new()
+        .wireguard()
+        .daita()
+        .daita_use_multihop_if_necessary(true)
+        .multihop()
+        // Set the entry to a relay that explicitly does *not* support DAITA.
+        // Later, we check that the smart routing disregards this choice and selects a DAITA-enabled
+        // relay instead.
+        .entry(NON_DAITA_RELAY_LOCATION.clone())
+        .build();
+
+    for _ in 0..100 {
+        // Make sure a DAITA-enabled relay is always selected due to smart routing.
+        let relay = relay_selector
+            .get_relay_by_query(query.clone())
+            .expect("Expected to find a relay with daita_use_multihop_if_necessary");
+        match relay {
+                GetRelay::Wireguard {
+                    inner: WireguardConfig::Multihop { entry, exit: _ },
+                    ..
+                } => {
+                    assert!(supports_daita(&entry), "entry relay must support DAITA");
+                }
+                wrong_relay => panic!(
+                "Relay selector should have picked two Wireguard relays, instead chose {wrong_relay:?}"
+            ),
+            }
+    }
+
+    // Assert that disabling smart routing for this query will fail to generate a valid multihop
+    // config, thus blocking the user.
+    let query = RelayQueryBuilder::new()
+        .wireguard()
+        .daita()
+        .daita_use_multihop_if_necessary(false)
+        .multihop()
+        .entry(NON_DAITA_RELAY_LOCATION.clone())
+        .build();
+
+    let relay = relay_selector.get_relay_by_query(query);
+
+    assert!(
+        relay.is_err(),
+        "expected there to be no valid multihop configuration! Instead got {relay:#?}"
     );
 }
 


### PR DESCRIPTION
This PR includes changes to `mullvad-relay-selector` for making Smart routing override Multihop. It also includes some drive-by changes intended to make it easier to follow what's happening in the relay selector.

### How it works
If both multihop and DAITA (with smart routing) is enabled, a DAITA-enabled entry relay will be selected. If the user has selected an entry relay which is not DAITA-enabled, the relay selector will override the user's choice and force a DAITA-enabled relay as entry. If smart routing is subsequently disabled, the user's selected entry will always be selected even if this means that the user will end up in a blocked state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6996)
<!-- Reviewable:end -->
