### PR TITLE
Bumping wireguard-apple

### DIFF
--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.14
+          go-version: 1.21.13
 
       - name: Set up yeetd to workaround XCode being slow in CI
         run: |

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.14
+          go-version: 1.21.13
 
       - name: Set up yeetd to workaround XCode being slow in CI
         run: |

--- a/.github/workflows/ios-validate-build-schemas.yml
+++ b/.github/workflows/ios-validate-build-schemas.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.14
+          go-version: 1.21.13
 
       - name: Set up yeetd to workaround XCode being slow in CI
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup go-lang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.14
+          go-version: 1.21.13
 
       - name: Install xcbeautify
         run: |

--- a/ios/BuildInstructions.md
+++ b/ios/BuildInstructions.md
@@ -1,9 +1,9 @@
 ## Dependencies
 
-One needs Go v1.20 and the latest stable rust to build the app.
+One needs Go v1.21 and the latest stable rust to build the app.
 Go can be installed via
 ```bash
-brew install go@1.20
+brew install go@1.21
 ```
 
 Rust should be installed via [rustup](https://rustup.rs). Once rust is

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9244,7 +9244,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = f1401d43f9d03438a81ca806b9f0c20269b116cb;
+				revision = afb345188c187dddafae0f9e27c5466be11451c2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "f1401d43f9d03438a81ca806b9f0c20269b116cb"
+        "revision" : "afb345188c187dddafae0f9e27c5466be11451c2"
       }
     }
   ],

--- a/ios/MullvadVPNUITests/README.md
+++ b/ios/MullvadVPNUITests/README.md
@@ -18,15 +18,15 @@ When adding more files with test suites they must be added to the `MullvadVPNUIT
 To run tests locally you need to make sure you have copied the configuration template `UITests.xcconfig.template` to `UITests.xcconfig` and set up the configuration attributes. The configuration attributes you're mostly likely to want to set custom values for are at the top:
 ```
 // Pin code of the iOS device under test.
-IOS_DEVICE_PIN_CODE = 
+IOS_DEVICE_PIN_CODE =
 
 // UUID to identify test runs. Should be unique per test device. Generate with for example uuidgen on macOS.
-TEST_DEVICE_IDENTIFIER_UUID = 
+TEST_DEVICE_IDENTIFIER_UUID =
 ```
 
 Look through other configuration attributes as well, but it is likely that their default value should be kept. Default values are set with local test execution in mind. They are changed in CI.
 
-The test device must be on the office WiFi `app-team-ios-tests` in order to be able to run tests making use of the firewall and packet capture APIs. 
+The test device must be on the office WiFi `app-team-ios-tests` in order to be able to run tests making use of the firewall and packet capture APIs.
 
 ## CI setup
 ### iOS device setup
@@ -56,8 +56,8 @@ The test device must be on the office WiFi `app-team-ios-tests` in order to be a
 9. Install Rust and add iOS targets
   - `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
   - `rustup target install aarch64-apple-ios aarch64-apple-ios-sim`
-10. Install Go 1.20
-  - `brew install go@1.20`
+10. Install Go 1.21
+  - `brew install go@1.21`
 
 ### GitHub runner setup
 1. Ask GitHub admin for new runner token and setup steps from GitHub. Set it up according to the steps, pass `--labels ios-test` to `config.sh` when running it. By default it will also have the labels `self-hosted` and `macOS` which are required as well.

--- a/ios/build-wireguard-go.sh
+++ b/ios/build-wireguard-go.sh
@@ -37,7 +37,7 @@ fi
 WIREGUARD_KIT_GO_PATH="$RESOLVED_SOURCE_PACKAGES_PATH/checkouts/wireguard-apple/Sources/WireGuardKitGo"
 echo "WireGuardKitGo path resolved to $WIREGUARD_KIT_GO_PATH"
 
-export PATH=/opt/homebrew/opt/go@1.20/bin:$PATH
+export PATH=/opt/homebrew/opt/go@1.21/bin:$PATH
 
 # Run make
 # shellcheck disable=SC2086


### PR DESCRIPTION
I've recently added changes to `wireguard-apple` to use the multihop tunnel implementation from our fork of `wireguard-go`. Incidentally, our fork of `wireguard-go` has bumped their dependency of go to `1.21`. So, along with the commit bump, come changes to the build scripts, CI scripts and READMEs.

When building this locally, remember to clear your build folder, otherwise the build will fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/6999)
<!-- Reviewable:end -->
