### PR TITLE
Force a sync of the whole system before reading config

### DIFF
--- a/.github/actions/run-ios-e2e-tests/action.yml
+++ b/.github/actions/run-ios-e2e-tests/action.yml
@@ -19,6 +19,9 @@ runs:
     # Set up a unique output directory
     - name: Set up outputs directory
       run: |
+        # Forcing the filesystem buffers to be flushed to ensure the
+        # directory tree is updated
+        sync
         if [ -n "$TEST_NAME" ]; then
           # Strip slashes to avoid creating subdirectories
           test_name_sanitized=$(printf "$TEST_NAME" | sed 's/\//_/g')
@@ -45,6 +48,9 @@ runs:
 
     - name: Run end-to-end-tests
       run: |
+        # Forcing the filesystem buffers to be flushed to ensure the
+        # directory tree is updated
+        sync
         if [ -n "$TEST_NAME" ]; then
           TEST_NAME_ARGUMENT=" -only-testing $TEST_NAME"
         else

--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -47,6 +47,9 @@ jobs:
           if [ -n "${{ inputs.arg_tests_json_key }}" ]; then
           # JSON key supplied by another workflow calling this reusable workflow
           echo "Using calling workflow supplied test suites JSON key: ${{ inputs.arg_tests_json_key }}"
+            # Forcing the filesystem buffers to be flushed to ensure the
+            # directory tree is updated
+            sync
             test_suites_json=$(jq -r --compact-output '.tests."${{ inputs.arg_tests_json_key }}"' tests.json)
             echo "test_suites_json=$test_suites_json" >> $GITHUB_ENV
           elif [ -n "${{ inputs.user_supplied_test_name }}" ]; then


### PR DESCRIPTION
It seems that our tests sometimes fail to find json files that should be there. This might be due to checking out files via git in a previous execution context that isn't then passed over to the next GitHub actions step. So, I am throwing a `sync` at the wall and trying to see if it helps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7000)
<!-- Reviewable:end -->
