### PR TITLE
Disable DNS redirect rule when custom DNS is set to localhost

### DIFF
--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -133,6 +133,19 @@ impl ResolvedDnsConfig {
     pub fn addresses(self) -> impl Iterator<Item = IpAddr> {
         self.non_tunnel_config.into_iter().chain(self.tunnel_config)
     }
+
+    /// Return whether the config contains only (and at least one) loopback addresses, and zero
+    /// non-loopback addresses
+    pub fn is_loopback(&self) -> bool {
+        let (loopback_addrs, non_loopback_addrs) = self
+            .tunnel_config
+            .iter()
+            .chain(self.non_tunnel_config.iter())
+            .copied()
+            .partition::<Vec<_>, _>(|ip| ip.is_loopback());
+
+        !loopback_addrs.is_empty() && non_loopback_addrs.is_empty()
+    }
 }
 
 /// Sets and monitors system DNS settings. Makes sure the desired DNS servers are being used.

--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -207,6 +207,7 @@ impl Firewall {
         policy: &FirewallPolicy,
     ) -> Result<Vec<pfctl::RedirectRule>> {
         let redirect_rules = match policy {
+            FirewallPolicy::Connected { dns_config, .. } if dns_config.is_loopback() => vec![],
             FirewallPolicy::Blocked {
                 dns_redirect_port, ..
             }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -165,11 +165,15 @@ impl ConnectedState {
 
         // On macOS, configure only the local DNS resolver
         #[cfg(target_os = "macos")]
-        shared_values.runtime.block_on(
-            shared_values
-                .filtering_resolver
-                .enable_forward(dns_config.addresses().collect()),
-        );
+        if !dns_config.is_loopback() {
+            shared_values.runtime.block_on(
+                shared_values
+                    .filtering_resolver
+                    .enable_forward(dns_config.addresses().collect()),
+            );
+        } else {
+            log::debug!("Not enabling DNS forwarding since loopback is used");
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This allows custom DNS to point to localhost without our resolver hijacking all of the things.

Fix DES-1309.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7001)
<!-- Reviewable:end -->
