### PR TITLE
Update node-gettext osv-scanner suppression

### DIFF
--- a/gui/osv-scanner.toml
+++ b/gui/osv-scanner.toml
@@ -27,5 +27,5 @@ reason = "This is just a dev dependency, and we don't have untrusted input to mi
 # node-gettext: Prototype Pullution via the addTranslations function
 [[IgnoredVulns]]
 id = "CVE-2024-21528" # GHSA-g974-hxvm-x689
-ignoreUntil = 2024-10-17
-reason = "There is no fix yet, in the meantime we'll have to verify translations thoroughly"
+ignoreUntil = 2025-01-17
+reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"


### PR DESCRIPTION
This PR extends the OSV scanner suppression for `node-gettext` by three months and updates the reason to include that we are not affected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7002)
<!-- Reviewable:end -->
