### PR TITLE
Minor cleanup in tunnel config client

### DIFF
--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -89,20 +89,24 @@ pub async fn request_ephemeral_peer_with(
     mut client: RelayConfigService,
     parent_pubkey: PublicKey,
     ephemeral_pubkey: PublicKey,
-    enable_post_quantum: bool,
+    enable_quantum_resistant: bool,
     enable_daita: bool,
 ) -> Result<EphemeralPeer, Error> {
-    let (pq_request, kem_secrets) = post_quantum_secrets(enable_post_quantum).await;
-    let daita = Some(proto::DaitaRequestV1 {
-        activate_daita: enable_daita,
-    });
+    let (pq_request, kem_secrets) = if enable_quantum_resistant {
+        let (pq_request, kem_secrets) = post_quantum_secrets().await;
+        (Some(pq_request), Some(kem_secrets))
+    } else {
+        (None, None)
+    };
 
     let response = client
         .register_peer_v1(proto::EphemeralPeerRequestV1 {
             wg_parent_pubkey: parent_pubkey.as_bytes().to_vec(),
             wg_ephemeral_peer_pubkey: ephemeral_pubkey.as_bytes().to_vec(),
             post_quantum: pq_request,
-            daita,
+            daita: Some(proto::DaitaRequestV1 {
+                activate_daita: enable_daita,
+            }),
         })
         .await
         .map_err(Error::GrpcError)?;
@@ -175,34 +179,28 @@ pub async fn request_ephemeral_peer(
     .await
 }
 
-async fn post_quantum_secrets(
-    enable_post_quantum: bool,
-) -> (
-    Option<PostQuantumRequestV1>,
-    Option<(classic_mceliece_rust::SecretKey<'static>, ml_kem::Keypair)>,
+async fn post_quantum_secrets() -> (
+    PostQuantumRequestV1,
+    (classic_mceliece_rust::SecretKey<'static>, ml_kem::Keypair),
 ) {
-    if enable_post_quantum {
-        let (cme_kem_pubkey, cme_kem_secret) = classic_mceliece::generate_keys().await;
-        let ml_kem_keypair = ml_kem::keypair();
+    let (cme_kem_pubkey, cme_kem_secret) = classic_mceliece::generate_keys().await;
+    let ml_kem_keypair = ml_kem::keypair();
 
-        (
-            Some(proto::PostQuantumRequestV1 {
-                kem_pubkeys: vec![
-                    proto::KemPubkeyV1 {
-                        algorithm_name: classic_mceliece::ALGORITHM_NAME.to_owned(),
-                        key_data: cme_kem_pubkey.as_array().to_vec(),
-                    },
-                    proto::KemPubkeyV1 {
-                        algorithm_name: ml_kem::ALGORITHM_NAME.to_owned(),
-                        key_data: ml_kem_keypair.encapsulation_key(),
-                    },
-                ],
-            }),
-            Some((cme_kem_secret, ml_kem_keypair)),
-        )
-    } else {
-        (None, None)
-    }
+    (
+        proto::PostQuantumRequestV1 {
+            kem_pubkeys: vec![
+                proto::KemPubkeyV1 {
+                    algorithm_name: classic_mceliece::ALGORITHM_NAME.to_owned(),
+                    key_data: cme_kem_pubkey.as_array().to_vec(),
+                },
+                proto::KemPubkeyV1 {
+                    algorithm_name: ml_kem::ALGORITHM_NAME.to_owned(),
+                    key_data: ml_kem_keypair.encapsulation_key(),
+                },
+            ],
+        },
+        (cme_kem_secret, ml_kem_keypair),
+    )
 }
 
 /// Performs `dst = dst ^ src`.

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -85,6 +85,27 @@ pub struct EphemeralPeer {
     pub psk: Option<PresharedKey>,
 }
 
+/// Negotiate a short-lived peer with a PQ-safe PSK or with DAITA enabled.
+#[cfg(not(target_os = "ios"))]
+pub async fn request_ephemeral_peer(
+    service_address: Ipv4Addr,
+    parent_pubkey: PublicKey,
+    ephemeral_pubkey: PublicKey,
+    enable_post_quantum: bool,
+    enable_daita: bool,
+) -> Result<EphemeralPeer, Error> {
+    let client = new_client(service_address).await?;
+
+    request_ephemeral_peer_with(
+        client,
+        parent_pubkey,
+        ephemeral_pubkey,
+        enable_post_quantum,
+        enable_daita,
+    )
+    .await
+}
+
 pub async fn request_ephemeral_peer_with(
     mut client: RelayConfigService,
     parent_pubkey: PublicKey,
@@ -156,27 +177,6 @@ pub async fn request_ephemeral_peer_with(
     };
 
     Ok(EphemeralPeer { psk })
-}
-
-/// Negotiate a short-lived peer with a PQ-safe PSK or with DAITA enabled.
-#[cfg(not(target_os = "ios"))]
-pub async fn request_ephemeral_peer(
-    service_address: Ipv4Addr,
-    parent_pubkey: PublicKey,
-    ephemeral_pubkey: PublicKey,
-    enable_post_quantum: bool,
-    enable_daita: bool,
-) -> Result<EphemeralPeer, Error> {
-    let client = new_client(service_address).await?;
-
-    request_ephemeral_peer_with(
-        client,
-        parent_pubkey,
-        ephemeral_pubkey,
-        enable_post_quantum,
-        enable_daita,
-    )
-    .await
 }
 
 async fn post_quantum_secrets() -> (

--- a/talpid-tunnel-config-client/src/socket.rs
+++ b/talpid-tunnel-config-client/src/socket.rs
@@ -1,5 +1,10 @@
 //! A TCP stream with a low MSS set. This prevents incorrectly configured MTU from causing
 //! fragmentation/packet loss. This is only supported on non-Windows targets.
+//!
+//! On windows this solution does not work. So on Windows we instead temporarily lower the MTU
+//! while negotiating the ephemeral peer. This code lives in `talpid-wireguard/src/ephemeral.rs`
+//! These two solutions to the same problem should probably be refactored to end up closer
+//! to each other.
 
 use std::io;
 use std::net::SocketAddr;

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -34,6 +34,9 @@ pub async fn config_ephemeral_peers(
         tunnel.get_interface_name()
     };
 
+    // Lower the MTU in order to make the ephemeral peer handshake work more reliably.
+    // On unix based operating systems this is done by setting the MSS directly on the
+    // TCP socket. But that solution does not work on Windows, so we do this MTU hack instead.
     log::trace!("Temporarily lowering tunnel MTU before ephemeral peer config");
     try_set_ipv4_mtu(&iface_name, talpid_tunnel::MIN_IPV4_MTU);
 


### PR DESCRIPTION
As part of my cleanup week I decided to make some small improvements to the ephemeral peer negotiation code.

My main pet peeve that led me to this was:
```rust
fn post_quantum_secrets(enable: bool) {
    if enable {
        ...; Some(...)
    } else {
        None
    }
}
```
This is a code smell. So I moved the conditional logic out. It creates a few more lines of code, but makes the lower level function cleaner and focused on what its supposed to do.

I also made a few minor tweaks to improve documentation in the crate:
* Document why we run Classic McEliece in a separate thread
* Put higher level function over lower level function
* rename one instance of "post quantum" to "quantum resistant". We are not going to get away from the discrepancy that the field in the gRPC endpoint is called `post_quantum` and that the user facing feature is called `quantum-resistant tunnel`. But out of the two I think "quantum resistant" makes more sense most of the time. "Post quantum" in itself means nothing. At most it refers to the time after when quantum computers have been invented. It talks about nothing else. "Post quantum cryptography" is a term, but you need the word "cryptography" for it to have any meaning. And even then, it does not say much in our context. We want to express whether or not the ephemeral peer should be safe against quantum computers. So using "quantum resistant" is the proper term here.
* Added docs to link the two ephemeral peer MTU fix codes together. Ideally they would be refactored, but I won't do that in this PR.