### PR TITLE
Upgrade cargo audit CI action ta latest version

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: actions-rust-lang/audit@v1.1.11
+      - uses: actions-rust-lang/audit@531fba54daed81c23724925a1892a60c74969c38 # v1.2.1
         name: Audit Rust Dependencies
         with:
           file: Cargo.lock
@@ -29,7 +29,7 @@ jobs:
           # Ignored audit issues. This list should be kept short, and effort should be
           # put into removing items from the list.
 
-      - uses: actions-rust-lang/audit@v1.1.11
+      - uses: actions-rust-lang/audit@531fba54daed81c23724925a1892a60c74969c38 # v1.2.1
         name: Audit testrunner Rust Dependencies
         with:
           file: test/Cargo.lock


### PR DESCRIPTION
Our cargo audit CI job breaks for some reason: https://github.com/mullvad/mullvadvpn-app/actions/runs/11398684502/job/31716118294. I saw we were not on the latest version. So I figured just upgrading the action could help

Pin to commit since that's best practice. We might eventually start doing that for all third party actions, but that's a separate discussion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7009)
<!-- Reviewable:end -->
