### PR TITLE
Add Encrypted DNS proxy as an access method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ dependencies = [
  "log",
  "log-panics",
  "mullvad-api",
+ "mullvad-encrypted-dns-proxy",
  "mullvad-fs",
  "mullvad-management-interface",
  "mullvad-paths",
@@ -2491,6 +2492,7 @@ dependencies = [
  "hickory-resolver",
  "log",
  "rustls 0.21.11",
+ "serde",
  "tokio",
  "webpki-roots",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,6 +2399,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "log",
+ "mullvad-encrypted-dns-proxy",
  "mullvad-fs",
  "mullvad-types",
  "rustls-pemfile 2.1.3",

--- a/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/mapper/FromDomain.kt
+++ b/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/mapper/FromDomain.kt
@@ -188,7 +188,11 @@ internal fun ApiAccessMethod.fromDomain(): ManagementInterface.AccessMethod =
                     it.setDirect(ManagementInterface.AccessMethod.Direct.getDefaultInstance())
                 ApiAccessMethod.Bridges ->
                     it.setBridges(ManagementInterface.AccessMethod.Bridges.getDefaultInstance())
-                is ApiAccessMethod.CustomProxy -> it.setCustom(this.fromDomain())
+                is ApiAccessMethod.CustomProxy -> it.setCustom(fromDomain())
+                is ApiAccessMethod.EncryptedDns ->
+                    it.setEncryptedDnsProxy(
+                        ManagementInterface.AccessMethod.EncryptedDnsProxy.getDefaultInstance()
+                    )
             }
         }
         .build()
@@ -197,8 +201,8 @@ internal fun ApiAccessMethod.CustomProxy.fromDomain(): ManagementInterface.Custo
     ManagementInterface.CustomProxy.newBuilder()
         .let {
             when (this) {
-                is ApiAccessMethod.CustomProxy.Shadowsocks -> it.setShadowsocks(this.fromDomain())
-                is ApiAccessMethod.CustomProxy.Socks5Remote -> it.setSocks5Remote(this.fromDomain())
+                is ApiAccessMethod.CustomProxy.Shadowsocks -> it.setShadowsocks(fromDomain())
+                is ApiAccessMethod.CustomProxy.Socks5Remote -> it.setSocks5Remote(fromDomain())
             }
         }
         .build()

--- a/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/mapper/ToDomain.kt
+++ b/android/lib/daemon-grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/daemon/grpc/mapper/ToDomain.kt
@@ -557,7 +557,12 @@ internal fun ManagementInterface.PlayPurchasePaymentToken.toDomain(): PlayPurcha
     PlayPurchasePaymentToken(value = token)
 
 internal fun ManagementInterface.ApiAccessMethodSettings.toDomain(): List<ApiAccessMethodSetting> =
-    listOf(direct.toDomain(), mullvadBridges.toDomain()).plus(customList.map { it.toDomain() })
+    buildList {
+        add(direct.toDomain())
+        add(mullvadBridges.toDomain())
+        add(encryptedDnsProxy.toDomain())
+        addAll(customList.map { it.toDomain() })
+    }
 
 internal fun ManagementInterface.AccessMethodSetting.toDomain(): ApiAccessMethodSetting =
     ApiAccessMethodSetting(
@@ -571,6 +576,7 @@ internal fun ManagementInterface.AccessMethod.toDomain(): ApiAccessMethod =
     when {
         hasDirect() -> ApiAccessMethod.Direct
         hasBridges() -> ApiAccessMethod.Bridges
+        hasEncryptedDnsProxy() -> ApiAccessMethod.EncryptedDns
         hasCustom() -> custom.toDomain()
         else -> error("Type not found")
     }

--- a/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/ApiAccessMethod.kt
+++ b/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/ApiAccessMethod.kt
@@ -8,6 +8,8 @@ sealed interface ApiAccessMethod : Parcelable {
 
     @Parcelize data object Bridges : ApiAccessMethod
 
+    @Parcelize data object EncryptedDns : ApiAccessMethod
+
     sealed interface CustomProxy : ApiAccessMethod {
         @Parcelize
         data class Socks5Remote(val ip: String, val port: Port, val auth: SocksAuth?) : CustomProxy

--- a/gui/locales/messages.pot
+++ b/gui/locales/messages.pot
@@ -467,6 +467,10 @@ msgid "Enter port"
 msgstr ""
 
 msgctxt "api-access-methods-view"
+msgid "If you are not connected to our VPN, then the Encrypted DNS proxy will use your own non-VPN IP when connecting. The DoH servers are hosted by one of the following providers: Quad 9, CloudFlare, or Google."
+msgstr ""
+
+msgctxt "api-access-methods-view"
 msgid "In use"
 msgstr ""
 
@@ -564,6 +568,10 @@ msgstr ""
 
 msgctxt "api-access-methods-view"
 msgid "With the “Direct” method, the app communicates with a Mullvad API server directly without any intermediate proxies."
+msgstr ""
+
+msgctxt "api-access-methods-view"
+msgid "With the “Encrypted DNS proxy” method, the app will communicate with our Mullvad API through a proxy address. It does this by retrieving an address from a DNS over HTTPS (DoH) server and then using that to reach our API servers."
 msgstr ""
 
 msgctxt "api-access-methods-view"

--- a/gui/src/main/default-settings.ts
+++ b/gui/src/main/default-settings.ts
@@ -104,6 +104,12 @@ export function getDefaultApiAccessMethods(): ApiAccessMethodSettings {
       enabled: false,
       type: 'bridges',
     },
+    encryptedDnsProxy: {
+      id: '',
+      name: 'Encrypted DNS Proxy',
+      enabled: false,
+      type: 'encrypted-dns-proxy',
+    },
     custom: [],
   };
 }

--- a/gui/src/renderer/components/ApiAccessMethods.tsx
+++ b/gui/src/renderer/components/ApiAccessMethods.tsx
@@ -133,6 +133,10 @@ export default function ApiAccessMethods() {
                       method={methods.mullvadBridges}
                       inUse={methods.mullvadBridges.id === currentMethod?.id}
                     />
+                    <ApiAccessMethod
+                      method={methods.encryptedDnsProxy}
+                      inUse={methods.encryptedDnsProxy.id === currentMethod?.id}
+                    />
                     {methods.custom.map((method) => (
                       <ApiAccessMethod
                         key={method.id}
@@ -211,7 +215,7 @@ function ApiAccessMethod(props: ApiAccessMethodProps) {
       },
     ];
 
-    // Edit and Delete shouldn't be available for direct and bridges.
+    // Edit and Delete shouldn't be available for direct, bridges or encrypted DNS proxy.
     if (props.custom) {
       items.push(
         { type: 'separator' as const },
@@ -286,6 +290,20 @@ function ApiAccessMethod(props: ApiAccessMethodProps) {
             messages.pgettext(
               'api-access-methods-view',
               'This can be useful if the API is censored but Mullvad’s bridge servers are not.',
+            ),
+          ]}
+        />
+      )}
+      {props.method.type === 'encrypted-dns-proxy' && (
+        <StyledMethodInfoButton
+          message={[
+            messages.pgettext(
+              'api-access-methods-view',
+              'With the “Encrypted DNS proxy” method, the app will communicate with our Mullvad API through a proxy address. It does this by retrieving an address from a DNS over HTTPS (DoH) server and then using that to reach our API servers.',
+            ),
+            messages.pgettext(
+              'api-access-methods-view',
+              'If you are not connected to our VPN, then the Encrypted DNS proxy will use your own non-VPN IP when connecting. The DoH servers are hosted by one of the following providers: Quad 9, CloudFlare, or Google.',
             ),
           ]}
         />

--- a/gui/src/renderer/components/ApiAccessMethods.tsx
+++ b/gui/src/renderer/components/ApiAccessMethods.tsx
@@ -52,6 +52,7 @@ const StyledSpinner = styled(ImageView)({
 });
 
 const StyledNameLabel = styled(Cell.Label)({
+  display: 'block',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',

--- a/gui/src/renderer/components/ApiAccessMethods.tsx
+++ b/gui/src/renderer/components/ApiAccessMethods.tsx
@@ -36,6 +36,8 @@ import { StyledContent, StyledNavigationScrollbars, StyledSettingsContent } from
 import { SmallButton, SmallButtonColor, SmallButtonGroup } from './SmallButton';
 
 const StyledContextMenuButton = styled(Cell.Icon)({
+  alignItems: 'center',
+  justifyContent: 'center',
   marginRight: '8px',
 });
 

--- a/gui/src/renderer/components/ContextMenu.tsx
+++ b/gui/src/renderer/components/ContextMenu.tsx
@@ -36,6 +36,8 @@ const menuContext = React.createContext<MenuContext>({
 const StyledMenuContainer = styled.div({
   position: 'relative',
   padding: '8px 4px',
+  display: 'flex',
+  justifyContent: 'center',
 });
 
 export function ContextMenuContainer(props: React.PropsWithChildren) {

--- a/gui/src/renderer/components/InfoButton.tsx
+++ b/gui/src/renderer/components/InfoButton.tsx
@@ -8,7 +8,7 @@ import ImageView from './ImageView';
 import { ModalAlert, ModalAlertType } from './Modal';
 
 const StyledInfoButton = styled.button({
-  margin: '0 16px 0 0',
+  margin: '0 16px 0 8px',
   borderWidth: 0,
   padding: 0,
   cursor: 'default',

--- a/gui/src/renderer/components/cell/Label.tsx
+++ b/gui/src/renderer/components/cell/Label.tsx
@@ -15,10 +15,14 @@ const StyledLabel = styled.div<{ disabled: boolean }>(buttonText, (props) => ({
   textAlign: 'left',
 
   [`${LabelContainer} &&`]: {
-    marginTop: '5px',
+    marginTop: '0px',
     marginBottom: 0,
     height: '20px',
     lineHeight: '20px',
+  },
+
+  [`${LabelContainer}:has(${StyledSubLabel}) &&`]: {
+    marginTop: '5px',
   },
 }));
 

--- a/gui/src/shared/daemon-rpc-types.ts
+++ b/gui/src/shared/daemon-rpc-types.ts
@@ -524,7 +524,8 @@ export type NamedCustomProxy = CustomProxy & { name: string };
 
 export type DirectMethod = { type: 'direct' };
 export type BridgesMethod = { type: 'bridges' };
-export type AccessMethod = DirectMethod | BridgesMethod | CustomProxy;
+export type EncryptedDnsProxy = { type: 'encrypted-dns-proxy' };
+export type AccessMethod = DirectMethod | BridgesMethod | EncryptedDnsProxy | CustomProxy;
 
 export type NamedAccessMethod<T extends AccessMethod> = T & { name: string };
 
@@ -540,6 +541,7 @@ export type AccessMethodSetting<T extends AccessMethod = AccessMethod> =
 export type ApiAccessMethodSettings = {
   direct: AccessMethodSetting<DirectMethod>;
   mullvadBridges: AccessMethodSetting<BridgesMethod>;
+  encryptedDnsProxy: AccessMethodSetting<EncryptedDnsProxy>;
   custom: Array<AccessMethodSetting<CustomProxy>>;
 };
 

--- a/gui/test/e2e/installed/state-dependent/api-access-methods.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/api-access-methods.spec.ts
@@ -15,6 +15,7 @@ import { startInstalledApp } from '../installed-utils';
 
 const DIRECT_NAME = 'Direct';
 const BRIDGES_NAME = 'Mullvad Bridges';
+const ENCRYPTED_DNS_PROXY_NAME = 'Encrypted DNS proxy';
 const IN_USE_LABEL = 'In use';
 const FUNCTIONING_METHOD_NAME = 'Test method';
 const NON_FUNCTIONING_METHOD_NAME = 'Non functioning test method';
@@ -42,12 +43,14 @@ test('App should display access methods', async () => {
   await navigateToAccessMethods();
 
   const accessMethods = page.getByTestId('access-method');
-  await expect(accessMethods).toHaveCount(2);
+  await expect(accessMethods).toHaveCount(3);
 
   const direct = accessMethods.first();
-  const bridges = accessMethods.last();
+  const bridges = accessMethods.nth(1);
+  const encryptedDnsProxy = accessMethods.nth(2);
   await expect(direct).toContainText(DIRECT_NAME);
   await expect(bridges).toContainText(BRIDGES_NAME);
+  await expect(encryptedDnsProxy).toContainText(ENCRYPTED_DNS_PROXY_NAME);
   await expect(page.getByText(IN_USE_LABEL)).toHaveCount(1);
 });
 
@@ -144,6 +147,7 @@ test('App should use valid method', async () => {
 
   const direct = accessMethods.first();
   const bridges = accessMethods.nth(1);
+  const encryptedDnsProxy = accessMethods.nth(2);
   const functioningTestMethod = accessMethods.last();
 
   await expect(page.getByText(IN_USE_LABEL)).toHaveCount(1);
@@ -154,6 +158,7 @@ test('App should use valid method', async () => {
   await functioningTestMethod.getByText('Use').click();
   await expect(direct).not.toContainText(IN_USE_LABEL);
   await expect(bridges).not.toContainText(IN_USE_LABEL);
+  await expect(encryptedDnsProxy).not.toContainText(IN_USE_LABEL);
   await expect(functioningTestMethod).toContainText('API reachable');
   await expect(functioningTestMethod).toContainText(IN_USE_LABEL);
 });

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -33,6 +33,7 @@ tokio-rustls = { version = "0.26.0", features = ["logging", "tls12", "ring"], de
 tokio-socks = "0.5.1"
 rustls-pemfile = "2.1.3"
 
+mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-fs = { path = "../mullvad-fs" }
 mullvad-types = { path = "../mullvad-types" }
 talpid-types = { path = "../talpid-types" }

--- a/mullvad-api/src/https_client_with_sni.rs
+++ b/mullvad-api/src/https_client_with_sni.rs
@@ -83,7 +83,6 @@ enum InnerConnectionMode {
     Socks5(SocksConfig),
     /// Connect to the destination via Mullvad Encrypted DNS proxy.
     /// See [`mullvad-encrypted-dns-proxy`] for how the proxy works.
-    #[allow(dead_code)] // TODO: Remove this allow
     EncryptedDnsProxy(EncryptedDNSConfig),
 }
 
@@ -277,6 +276,9 @@ impl TryFrom<ApiConnectionMode> for InnerConnectionMode {
                     peer: config.endpoint,
                     authentication: config.auth,
                 }),
+                ProxyConfig::EncryptedDnsProxy(config) => {
+                    InnerConnectionMode::EncryptedDnsProxy(config)
+                }
             },
         })
     }

--- a/mullvad-api/src/proxy.rs
+++ b/mullvad-api/src/proxy.rs
@@ -2,6 +2,7 @@ use hyper_util::client::legacy::connect::{Connected, Connection};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt, io,
+    net::SocketAddr,
     path::Path,
     pin::Pin,
     task::{self, Poll},
@@ -74,6 +75,7 @@ pub enum ProxyConfig {
     Shadowsocks(proxy::Shadowsocks),
     Socks5Local(proxy::Socks5Local),
     Socks5Remote(proxy::Socks5Remote),
+    EncryptedDnsProxy(mullvad_encrypted_dns_proxy::config::ProxyConfig),
 }
 
 impl ProxyConfig {
@@ -87,6 +89,10 @@ impl ProxyConfig {
             ProxyConfig::Socks5Remote(remote) => {
                 Endpoint::from_socket_address(remote.endpoint, TransportProtocol::Tcp)
             }
+            ProxyConfig::EncryptedDnsProxy(proxy) => {
+                let addr = SocketAddr::V4(proxy.addr);
+                Endpoint::from_socket_address(addr, TransportProtocol::Tcp)
+            }
         }
     }
 }
@@ -99,6 +105,9 @@ impl fmt::Display for ProxyConfig {
             ProxyConfig::Socks5Remote(_) => write!(f, "Socks5 {}", endpoint),
             ProxyConfig::Socks5Local(local) => {
                 write!(f, "Socks5 {} via localhost:{}", endpoint, local.local_port)
+            }
+            ProxyConfig::EncryptedDnsProxy(proxy) => {
+                write!(f, "ApiSusan {}", proxy.addr)
             }
         }
     }

--- a/mullvad-api/src/proxy.rs
+++ b/mullvad-api/src/proxy.rs
@@ -1,7 +1,7 @@
 use hyper_util::client::legacy::connect::{Connected, Connection};
 use serde::{Deserialize, Serialize};
 use std::{
-    fmt, io,
+    io,
     net::SocketAddr,
     path::Path,
     pin::Pin,
@@ -61,15 +61,6 @@ pub enum ApiConnectionMode {
     Proxied(ProxyConfig),
 }
 
-impl fmt::Display for ApiConnectionMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            ApiConnectionMode::Direct => write!(f, "unproxied"),
-            ApiConnectionMode::Proxied(settings) => settings.fmt(f),
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum ProxyConfig {
     Shadowsocks(proxy::Shadowsocks),
@@ -92,22 +83,6 @@ impl ProxyConfig {
             ProxyConfig::EncryptedDnsProxy(proxy) => {
                 let addr = SocketAddr::V4(proxy.addr);
                 Endpoint::from_socket_address(addr, TransportProtocol::Tcp)
-            }
-        }
-    }
-}
-
-impl fmt::Display for ProxyConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        let endpoint = self.get_endpoint();
-        match self {
-            ProxyConfig::Shadowsocks(_) => write!(f, "Shadowsocks {}", endpoint),
-            ProxyConfig::Socks5Remote(_) => write!(f, "Socks5 {}", endpoint),
-            ProxyConfig::Socks5Local(local) => {
-                write!(f, "Socks5 {} via localhost:{}", endpoint, local.local_port)
-            }
-            ProxyConfig::EncryptedDnsProxy(proxy) => {
-                write!(f, "ApiSusan {}", proxy.addr)
             }
         }
     }

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -31,6 +31,7 @@ tokio-stream = "0.1"
 mullvad-relay-selector = { path = "../mullvad-relay-selector" }
 mullvad-types = { path = "../mullvad-types" }
 mullvad-api = { path = "../mullvad-api" }
+mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-fs = { path = "../mullvad-fs" }
 mullvad-paths = { path = "../mullvad-paths" }
 mullvad-version = { path = "../mullvad-version" }

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -536,6 +536,9 @@ fn resolve_connection_mode(
                 );
                 ApiConnectionMode::Direct
             }),
+        AccessMethod::BuiltIn(BuiltInAccessMethod::EncryptedDnsProxy) => {
+            todo!("Implement me!")
+        }
         AccessMethod::Custom(config) => ApiConnectionMode::Proxied(ProxyConfig::from(config)),
     }
 }

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -425,13 +425,10 @@ impl AccessModeSelector {
 
         // Save the new connection mode to cache!
         let cache_dir = self.cache_dir.clone();
-        let new_connection_mode = resolved.connection_mode.clone();
+        let connection_mode = resolved.connection_mode.clone();
         tokio::spawn(async move {
-            if new_connection_mode.save(&cache_dir).await.is_err() {
-                log::warn!(
-                    "Failed to save {connection_mode} to cache",
-                    connection_mode = new_connection_mode
-                )
+            if connection_mode.save(&cache_dir).await.is_err() {
+                log::warn!("Failed to save {connection_mode:#?} to cache")
             }
         });
 

--- a/mullvad-encrypted-dns-proxy/Cargo.toml
+++ b/mullvad-encrypted-dns-proxy/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 tokio = { workspace = true, features = [ "macros" ] }
 log = { workspace = true }
 hickory-resolver = { version = "0.24.1", features = [ "dns-over-https-rustls" ]}
+serde = { workspace = true }
 webpki-roots = "0.25.0"
 rustls = "0.21"
 

--- a/mullvad-encrypted-dns-proxy/src/config/mod.rs
+++ b/mullvad-encrypted-dns-proxy/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::net::{Ipv6Addr, SocketAddrV4};
 mod plain;
 mod xor;
 
+use serde::{Deserialize, Serialize};
 pub use xor::XorKey;
 
 /// All the errors that can happen during deserialization of a [`ProxyConfig`].
@@ -67,7 +68,7 @@ pub trait Obfuscator: Send {
 
 /// Represents a Mullvad Encrypted DNS proxy configuration. Created by parsing
 /// the config out of an IPv6 address resolved over DoH.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ProxyConfig {
     /// The remote address to connect to the proxy over. This is the address
     /// on the internet where the proxy is listening.
@@ -77,7 +78,7 @@ pub struct ProxyConfig {
     pub obfuscation: Option<ObfuscationConfig>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ObfuscationConfig {
     XorV2(xor::XorKey),
 }

--- a/mullvad-encrypted-dns-proxy/src/config/xor.rs
+++ b/mullvad-encrypted-dns-proxy/src/config/xor.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
+use serde::{Deserialize, Serialize};
+
 /// Parse a proxy config that XORs all traffic with the given key.
 ///
 /// A Xor configuration is represented by the proxy type `ProxyType::XorV2`. There used to be a `XorV1`, but it
@@ -37,7 +39,7 @@ pub fn parse_xor(data: [u8; 12]) -> Result<super::ProxyConfig, super::Error> {
 
 /// A bunch of bytes, representing a "key" Simply meaning a slice of bytes that the data
 /// will be XORed with.
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct XorKey {
     data: [u8; 6],
     len: usize,

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -411,10 +411,12 @@ message CustomProxy {
 message AccessMethod {
   message Direct {}
   message Bridges {}
+  message EncryptedDnsProxy {}
   oneof access_method {
     Direct direct = 1;
     Bridges bridges = 2;
-    CustomProxy custom = 3;
+    EncryptedDnsProxy encrypted_dns_proxy = 3;
+    CustomProxy custom = 4;
   }
 }
 
@@ -434,7 +436,8 @@ message NewAccessMethodSetting {
 message ApiAccessMethodSettings {
   AccessMethodSetting direct = 1;
   AccessMethodSetting mullvad_bridges = 2;
-  repeated AccessMethodSetting custom = 3;
+  AccessMethodSetting encrypted_dns_proxy = 3;
+  repeated AccessMethodSetting custom = 4;
 }
 
 message Settings {

--- a/mullvad-management-interface/src/types/conversions/access_method.rs
+++ b/mullvad-management-interface/src/types/conversions/access_method.rs
@@ -10,6 +10,7 @@ mod settings {
             Self {
                 direct: Some(settings.direct().clone().into()),
                 mullvad_bridges: Some(settings.mullvad_bridges().clone().into()),
+                encrypted_dns_proxy: Some(settings.encrypted_dns_proxy().clone().into()),
                 custom: settings
                     .iter_custom()
                     .cloned()
@@ -37,6 +38,13 @@ mod settings {
                 ))
                 .and_then(access_method::AccessMethodSetting::try_from)?;
 
+            let encrypted_dns_proxy = settings
+                .encrypted_dns_proxy
+                .ok_or(FromProtobufTypeError::InvalidArgument(
+                    "Could not deserialize Encrypted DNS proxy Access Method from protobuf",
+                ))
+                .and_then(access_method::AccessMethodSetting::try_from)?;
+
             let custom = settings
                 .custom
                 .iter()
@@ -46,6 +54,7 @@ mod settings {
             Ok(access_method::Settings::new(
                 direct,
                 mullvad_bridges,
+                encrypted_dns_proxy,
                 custom,
             ))
         }
@@ -118,6 +127,9 @@ mod data {
             Ok(match access_method {
                 proto::access_method::AccessMethod::Direct(direct) => AccessMethod::from(direct),
                 proto::access_method::AccessMethod::Bridges(bridge) => AccessMethod::from(bridge),
+                proto::access_method::AccessMethod::EncryptedDnsProxy(proxy) => {
+                    AccessMethod::from(proxy)
+                }
                 proto::access_method::AccessMethod::Custom(custom) => {
                     CustomProxy::try_from(custom).map(AccessMethod::from)?
                 }
@@ -143,6 +155,12 @@ mod data {
     impl From<proto::access_method::Bridges> for AccessMethod {
         fn from(_value: proto::access_method::Bridges) -> Self {
             AccessMethod::from(BuiltInAccessMethod::Bridge)
+        }
+    }
+
+    impl From<proto::access_method::EncryptedDnsProxy> for AccessMethod {
+        fn from(_value: proto::access_method::EncryptedDnsProxy) -> Self {
+            AccessMethod::from(BuiltInAccessMethod::EncryptedDnsProxy)
         }
     }
 
@@ -186,6 +204,11 @@ mod data {
                 }
                 mullvad_types::access_method::BuiltInAccessMethod::Bridge => {
                     proto::access_method::AccessMethod::Bridges(proto::access_method::Bridges {})
+                }
+                mullvad_types::access_method::BuiltInAccessMethod::EncryptedDnsProxy => {
+                    proto::access_method::AccessMethod::EncryptedDnsProxy(
+                        proto::access_method::EncryptedDnsProxy {},
+                    )
                 }
             }
         }

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -4,8 +4,11 @@ use talpid_types::net::proxy::{CustomProxy, Shadowsocks, Socks5Local, Socks5Remo
 /// Settings for API access methods.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Settings {
+    #[serde(default = "Settings::create_direct")]
     direct: AccessMethodSetting,
+    #[serde(default = "Settings::create_mullvad_bridges")]
     mullvad_bridges: AccessMethodSetting,
+    #[serde(default = "Settings::create_encrypted_dns_proxy")]
     encrypted_dns_proxy: AccessMethodSetting,
     /// Custom API access methods.
     custom: Vec<AccessMethodSetting>,

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -6,6 +6,7 @@ use talpid_types::net::proxy::{CustomProxy, Shadowsocks, Socks5Local, Socks5Remo
 pub struct Settings {
     direct: AccessMethodSetting,
     mullvad_bridges: AccessMethodSetting,
+    encrypted_dns_proxy: AccessMethodSetting,
     /// Custom API access methods.
     custom: Vec<AccessMethodSetting>,
 }
@@ -14,11 +15,13 @@ impl Settings {
     pub fn new(
         direct: AccessMethodSetting,
         mullvad_bridges: AccessMethodSetting,
+        encrypted_dns_proxy: AccessMethodSetting,
         custom: Vec<AccessMethodSetting>,
     ) -> Settings {
         Settings {
             direct,
             mullvad_bridges,
+            encrypted_dns_proxy,
             custom,
         }
     }
@@ -93,6 +96,7 @@ impl Settings {
         use std::iter::once;
         once(&self.direct)
             .chain(once(&self.mullvad_bridges))
+            .chain(once(&self.encrypted_dns_proxy))
             .chain(&self.custom)
     }
 
@@ -112,9 +116,7 @@ impl Settings {
     /// Return the total number of access methods.
     /// This counts both enabled and disabled [`AccessMethodSetting`]s.
     pub fn cardinality(&self) -> usize {
-        1 + // 'Direct'
-        1 + // 'Mullvad bridges'
-        self.custom.len()
+        self.iter().count()
     }
 
     pub fn direct(&self) -> &AccessMethodSetting {
@@ -123,6 +125,10 @@ impl Settings {
 
     pub fn mullvad_bridges(&self) -> &AccessMethodSetting {
         &self.mullvad_bridges
+    }
+
+    pub fn encrypted_dns_proxy(&self) -> &AccessMethodSetting {
+        &self.encrypted_dns_proxy
     }
 
     fn create_direct() -> AccessMethodSetting {
@@ -134,6 +140,11 @@ impl Settings {
         let method = BuiltInAccessMethod::Bridge;
         AccessMethodSetting::new(method.canonical_name(), true, AccessMethod::from(method))
     }
+
+    fn create_encrypted_dns_proxy() -> AccessMethodSetting {
+        let method = BuiltInAccessMethod::EncryptedDnsProxy;
+        AccessMethodSetting::new(method.canonical_name(), true, AccessMethod::from(method))
+    }
 }
 
 impl Default for Settings {
@@ -141,6 +152,7 @@ impl Default for Settings {
         Self {
             direct: Settings::create_direct(),
             mullvad_bridges: Settings::create_mullvad_bridges(),
+            encrypted_dns_proxy: Settings::create_encrypted_dns_proxy(),
             custom: vec![],
         }
     }
@@ -271,6 +283,7 @@ impl AccessMethodSetting {
 pub enum BuiltInAccessMethod {
     Direct,
     Bridge,
+    EncryptedDnsProxy,
 }
 
 impl AccessMethod {
@@ -287,6 +300,7 @@ impl BuiltInAccessMethod {
         match self {
             BuiltInAccessMethod::Direct => "Direct".to_string(),
             BuiltInAccessMethod::Bridge => "Mullvad Bridges".to_string(),
+            BuiltInAccessMethod::EncryptedDnsProxy => "Encrypted DNS proxy".to_string(),
         }
     }
 }

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -105,6 +105,7 @@ impl Settings {
         use std::iter::once;
         once(&mut self.direct)
             .chain(once(&mut self.mullvad_bridges))
+            .chain(once(&mut self.encrypted_dns_proxy))
             .chain(&mut self.custom)
     }
 


### PR DESCRIPTION
This PR tracks the progress of adding Encrypted DNS as an access method in the daemon.

## TODO
- [x] Rebase on top of https://github.com/mullvad/mullvadvpn-app/pull/7008
- [x] Rebase on top of https://github.com/mullvad/mullvadvpn-app/pull/7025


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7010)
<!-- Reviewable:end -->
