### PR TITLE
POC of using page object pattern

### DIFF
--- a/android/scripts/run-instrumented-tests.sh
+++ b/android/scripts/run-instrumented-tests.sh
@@ -109,10 +109,6 @@ case "$TEST_TYPE" in
         echo ""
         echo "Error: The 'e2e' test type with billing flavor 'play' require infra flavor 'stagemole'."
         exit 1
-    elif [[ $BILLING_FLAVOR == "oss" && $INFRA_FLAVOR != "prod" ]]; then
-        echo ""
-        echo "Error: The 'e2e' test type with billing flavor 'oss' require infra flavor 'prod'."
-        exit 1
     fi
     OPTIONAL_TEST_ARGUMENTS=""
     if [[ -n ${INVALID_TEST_ACCOUNT_NUMBER-} ]]; then

--- a/android/test/common/build.gradle.kts
+++ b/android/test/common/build.gradle.kts
@@ -57,4 +57,5 @@ dependencies {
     implementation(libs.kotlin.stdlib)
 
     androidTestUtil(libs.androidx.test.orchestrator)
+    implementation(kotlin("reflect"))
 }

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/ConnectPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/ConnectPage.kt
@@ -1,0 +1,10 @@
+package net.mullvad.mullvadvpn.test.common.page
+
+import androidx.test.uiautomator.By
+import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+
+class ConnectPage internal constructor() : Page() {
+    override fun assertIsDisplayed() {
+        uiDevice.findObjectWithTimeout(By.res("connect_card_header_test_tag"))
+    }
+}

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
@@ -1,0 +1,29 @@
+package net.mullvad.mullvadvpn.test.common.page
+
+import android.widget.Button
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.EXTREMELY_LONG_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+
+class LoginPage internal constructor() : Page() {
+    fun enterAccountNumber(accountNumber: String)  {
+        uiDevice.findObjectWithTimeout(By.clazz("android.widget.EditText")).text = accountNumber
+    }
+
+    fun tapLoginButton() {
+        val accountTextField = uiDevice.findObjectWithTimeout(By.clazz("android.widget.EditText"))
+        val loginButton = accountTextField.parent.findObject(By.clazz(Button::class.java))
+        loginButton.wait(Until.enabled(true), DEFAULT_TIMEOUT)
+        loginButton.click()
+    }
+
+    fun verifyShowingInvalidAccount() {
+        uiDevice.findObjectWithTimeout(By.text("Invalid account number"), EXTREMELY_LONG_TIMEOUT)
+    }
+
+    override fun assertIsDisplayed() {
+        uiDevice.findObjectWithTimeout(By.text("Login"))
+    }
+}

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/Page.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/Page.kt
@@ -1,0 +1,16 @@
+package net.mullvad.mullvadvpn.test.common.page
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+
+sealed class Page {
+    protected val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    abstract fun assertIsDisplayed()
+}
+
+inline fun <reified T : Page> on(scope: T.() -> Unit = {}) {
+    val page = T::class.constructors.first().call()
+    page.assertIsDisplayed()
+    return page.scope()
+}

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/PrivacyPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/PrivacyPage.kt
@@ -1,0 +1,38 @@
+package net.mullvad.mullvadvpn.test.common.page
+
+import android.os.Build
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+
+class PrivacyPage internal constructor() : Page() {
+    override fun assertIsDisplayed() {
+       uiDevice.findObjectWithTimeout(By.text("Privacy"))
+    }
+
+    fun clickAgreeOnPrivacyDisclaimer() {
+        uiDevice.findObjectWithTimeout(By.text("Agree and continue")).click()
+    }
+
+    fun clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove(
+        timeout: Long = DEFAULT_TIMEOUT
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            // Skipping as notification permissions are not shown.
+            return
+        }
+
+        val selector = By.text("Allow")
+
+        uiDevice.wait(Until.hasObject(selector), timeout)
+
+        try {
+            uiDevice.findObjectWithTimeout(selector).click()
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException(
+                "Failed to allow notification permission within timeout ($timeout)"
+            )
+        }
+    }
+}

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -1,10 +1,9 @@
 package net.mullvad.mullvadvpn.test.e2e
 
-import androidx.test.uiautomator.By
-import net.mullvad.mullvadvpn.test.common.constant.EXTREMELY_LONG_TIMEOUT
-import net.mullvad.mullvadvpn.test.common.extension.clickAgreeOnPrivacyDisclaimer
-import net.mullvad.mullvadvpn.test.common.extension.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove
-import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
+import net.mullvad.mullvadvpn.test.common.page.ConnectPage
+import net.mullvad.mullvadvpn.test.common.page.LoginPage
+import net.mullvad.mullvadvpn.test.common.page.PrivacyPage
+import net.mullvad.mullvadvpn.test.common.page.on
 import net.mullvad.mullvadvpn.test.e2e.misc.AccountTestRule
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -16,30 +15,39 @@ class LoginTest : EndToEndTest(BuildConfig.FLAVOR_infrastructure) {
 
     @Test
     fun testLoginWithValidCredentials() {
-        // Given
         val validTestAccountNumber = accountTestRule.validAccountNumber
 
-        // When
-        app.launchAndEnsureLoggedIn(validTestAccountNumber)
+        app.launch()
 
-        // Then
-        app.ensureLoggedIn()
+        on<PrivacyPage> {
+            clickAgreeOnPrivacyDisclaimer()
+            clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
+        }
+
+        on<LoginPage> {
+            enterAccountNumber(validTestAccountNumber)
+            tapLoginButton()
+        }
+
+        on<ConnectPage>()
     }
 
     @Test
     @Disabled("Failed login attempts are highly rate limited and cause test flakiness")
     fun testLoginWithInvalidCredentials() {
-        // Given
         val invalidDummyAccountNumber = accountTestRule.invalidAccountNumber
 
-        // When
         app.launch()
-        device.clickAgreeOnPrivacyDisclaimer()
-        device.clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
-        app.waitForLoginPrompt()
-        app.attemptLogin(invalidDummyAccountNumber)
 
-        // Then
-        device.findObjectWithTimeout(By.text("Invalid account number"), EXTREMELY_LONG_TIMEOUT)
+        on<PrivacyPage> {
+            clickAgreeOnPrivacyDisclaimer()
+            clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
+        }
+
+        on<LoginPage> {
+            enterAccountNumber(invalidDummyAccountNumber)
+            tapLoginButton()
+            verifyShowingInvalidAccount()
+        }
     }
 }


### PR DESCRIPTION
POC of using page object pattern for the login tests. Basically moving UI automator interactions to page classes with abstract functions representing user actions in test cases. Automated tests read like manual test cases and code is reused more.

In this POC PR I have not updated the detekt config but if we go with something like this we probably would like to set up some rules for `Page` subclasses?

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7017)
<!-- Reviewable:end -->
