### PR TITLE
Disable e2e tests for PR updates

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -488,7 +488,9 @@ jobs:
     name: Run instrumented e2e tests
     # Temporary workaround for targeting the runner android-runner-v1
     runs-on: [self-hosted, android-device, android-emulator]
-    if: github.event_name == 'schedule' || ${{ github.event.inputs.e2e_test_repeat }} != '0'
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event.inputs.e2e_test_repeat != '0' && github.event_name != 'pull_request')
     needs: [build-app, build-instrumented-tests]
     strategy:
       matrix:


### PR DESCRIPTION
Don't trigger instrumented e2e tests by PR updates.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7018)
<!-- Reviewable:end -->
