### PR TITLE
Hide Daita section in settings when logged out

### DIFF
--- a/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
@@ -155,7 +155,7 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
 
         return switch sectionIdentifier {
         case .main:
-            0
+            interactor.deviceState.isLoggedIn ? 0 : UITableView.automaticDimension
         case .daita, .version, .problemReport:
             UITableView.automaticDimension
         }
@@ -173,7 +173,6 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
         contentConfiguration.text = sectionFooterText
 
         headerView.contentConfiguration = contentConfiguration
-//        headerView.directionalLayoutMargins = UIMetrics.SettingsCell.apiAccessInsetLayoutMargins
 
         return headerView
     }
@@ -210,7 +209,11 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
     private func updateDataSnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
 
-        snapshot.appendSections([.daita, .main])
+        if interactor.deviceState.isLoggedIn {
+            snapshot.appendSections([.daita])
+        }
+
+        snapshot.appendSections([.main])
 
         if interactor.deviceState.isLoggedIn {
             snapshot.appendItems([.daita], toSection: .daita)

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -374,7 +374,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         return switch sectionIdentifier {
         // 0 due to there already being a separator between .dnsSettings and .ipOverrides.
         case .dnsSettings: 0
-        case .ipOverrides, .quantumResistance: UIMetrics.TableView.sectionSpacing
+        case .ipOverrides, .quantumResistance: UITableView.automaticDimension
         default: 0.5
         }
     }


### PR DESCRIPTION
The whole Daita section should be hidden when the user is logged out.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7027)
<!-- Reviewable:end -->
