### PR TITLE
Add `http1` feature to `hyper-util`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ tonic-build = { version = "0.10.0", default-features = false }
 tower = { version = "0.5.1", features = ["util"] }
 prost = "0.13.3"
 prost-types = "0.13.3"
-hyper-util = {version = "0.1.8", features = ["client", "client-legacy", "http2"]}
+hyper-util = {version = "0.1.8", features = ["client", "client-legacy", "http2", "http1"]}
 
 env_logger = "0.10.0"
 thiserror = "1.0.57"


### PR DESCRIPTION
Fixes crash when legacy hyper client tries to use `http1`, by enabling the feature in `hyper-util`.

Normally. we promote `http1.1` connections to `http2` using Application-Layer Protocol Negotiation (ALPN). This behavior seems to not be reliable as seen in this test run
https://github.com/mullvad/mullvadvpn-app/actions/runs/11438592659/job/31820684203

This is the correponding error message:
```
thread 'tokio-runtime-worker' panicked at /Users/mullemullvad/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-util-0.1.9/src/client/legacy/client.rs:607:37:
http1 feature is not enabled
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
/Users/mullemullvad/actions-runner/_work/mullvadvpn-app/mullvadvpn-app/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift:114: error: -[MullvadVPNUITests.AccountTests testCreateAccount] : failed - Failed to delete account with error: The operation couldn’t be completed. (MullvadVPNUITests.ApiError error 1.)
```` 


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
