### PR TITLE
resolve alpha button override issues in configuration

### DIFF
--- a/ios/MullvadVPN/Extensions/UIImage+Helpers.swift
+++ b/ios/MullvadVPN/Extensions/UIImage+Helpers.swift
@@ -26,4 +26,10 @@ extension UIImage {
 
         return resizedImage.withRenderingMode(renderingMode)
     }
+
+    func withAlpha(_ alpha: CGFloat) -> UIImage? {
+        return UIGraphicsImageRenderer(size: size, format: imageRendererFormat).image { _ in
+            draw(in: CGRect(origin: .zero, size: size), blendMode: .normal, alpha: alpha)
+        }
+    }
 }

--- a/ios/MullvadVPN/Views/AppButton.swift
+++ b/ios/MullvadVPN/Views/AppButton.swift
@@ -119,9 +119,10 @@ class AppButton: CustomButton {
                 return updatedAttributeContainer
             }
 
-        let configurationHandler: UIButton.ConfigurationUpdateHandler = { button in
-            button.alpha = !button.isEnabled ? 0.5 : 1.0
+        let configurationHandler: UIButton.ConfigurationUpdateHandler = { [weak self] button in
+            guard let self else { return }
             button.configuration?.baseForegroundColor = button.state.customButtonTitleColor
+            updateButtonBackground()
         }
         configuration = config
         configurationUpdateHandler = configurationHandler
@@ -129,6 +130,12 @@ class AppButton: CustomButton {
 
     /// Set background image based on current style.
     private func updateButtonBackground() {
-        configuration?.background.image = style.backgroundImage
+        if isEnabled {
+            // Load the normal image and set it as the background
+            configuration?.background.image = style.backgroundImage
+        } else {
+            // Adjust the image for the disabled state
+            configuration?.background.image = style.backgroundImage.withAlpha(0.5)
+        }
     }
 }

--- a/ios/MullvadVPN/Views/CustomButton.swift
+++ b/ios/MullvadVPN/Views/CustomButton.swift
@@ -14,7 +14,7 @@ extension UIControl.State {
         case .normal:
             return UIColor.AppButton.normalTitleColor
         case .disabled:
-            return UIColor.AppButton.disabledTitleColor
+            return UIColor.AppButton.disabledTitleColor.withAlphaComponent(0.5)
         case .highlighted:
             return UIColor.AppButton.highlightedTitleColor
         default:


### PR DESCRIPTION
The issue was that the `AppButton` was messing with the button's alpha when switching between normal and disabled states to keep a nice look for the disabled mode. At the same time, the disconnectButton was getting shown and hidden using its alpha value. This conflicts in how we were handling alpha values caused the problem.

To fix it, I added a function that creates a new image with the opacity for the UIButton's background. Now, I apply the alpha to that image instead of changing the UIButton's alpha directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7035)
<!-- Reviewable:end -->
