### PR TITLE
Fix text color for disabled state

### DIFF
--- a/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
+++ b/ios/MullvadVPN/UI appearance/UIColor+Palette.swift
@@ -50,7 +50,7 @@ extension UIColor {
     enum AppButton {
         static let normalTitleColor = UIColor.white
         static let highlightedTitleColor = UIColor.lightGray
-        static let disabledTitleColor = UIColor.lightGray
+        static let disabledTitleColor = UIColor.white.withAlphaComponent(0.2)
     }
 
     enum Switch {

--- a/ios/MullvadVPN/Views/AppButton.swift
+++ b/ios/MullvadVPN/Views/AppButton.swift
@@ -113,15 +113,15 @@ class AppButton: CustomButton {
         config.background.image = style.backgroundImage
         config.background.imageContentMode = .scaleAspectFill
         config.titleTextAttributesTransformer =
-            UIConfigurationTextAttributesTransformer { attributeContainer in
+            UIConfigurationTextAttributesTransformer { [weak self] attributeContainer in
                 var updatedAttributeContainer = attributeContainer
                 updatedAttributeContainer.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+                updatedAttributeContainer.foregroundColor = self?.state.customButtonTitleColor
                 return updatedAttributeContainer
             }
 
-        let configurationHandler: UIButton.ConfigurationUpdateHandler = { [weak self] button in
+        let configurationHandler: UIButton.ConfigurationUpdateHandler = { [weak self] _ in
             guard let self else { return }
-            button.configuration?.baseForegroundColor = button.state.customButtonTitleColor
             updateButtonBackground()
         }
         configuration = config

--- a/ios/MullvadVPN/Views/CustomButton.swift
+++ b/ios/MullvadVPN/Views/CustomButton.swift
@@ -14,7 +14,7 @@ extension UIControl.State {
         case .normal:
             return UIColor.AppButton.normalTitleColor
         case .disabled:
-            return UIColor.AppButton.disabledTitleColor.withAlphaComponent(0.5)
+            return UIColor.AppButton.disabledTitleColor
         case .highlighted:
             return UIColor.AppButton.highlightedTitleColor
         default:


### PR DESCRIPTION
This PR sets the color to white with 0.2 opacity for the disabled state of the AppButton.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7040)
<!-- Reviewable:end -->
