### PR TITLE
Fix relay selector for smart routing

### DIFF
--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayPickingTests.swift
@@ -16,6 +16,8 @@ import XCTest
 class RelayPickingTests: XCTestCase {
     let sampleRelays = ServerRelaysResponseStubs.sampleRelays
 
+    // MARK: Single-/multihop
+
     func testSinglehopPicker() throws {
         let constraints = RelayConstraints(
             entryLocations: .only(UserSelectedRelays(locations: [.hostname("se", "sto", "se2-wireguard")])),
@@ -75,6 +77,10 @@ class RelayPickingTests: XCTestCase {
         }
     }
 
+    // MARK: DAITA/Direct only
+
+    // DAITA - ON, Direct only - OFF, Multihop - OFF, Exit supports DAITA - FALSE
+    // Direct only is off, so we should automatically pick the entry that is closest to exit.
     func testDirectOnlyOffDaitaOnForSinglehopWithoutDaitaRelay() throws {
         let constraints = RelayConstraints(
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
@@ -93,6 +99,8 @@ class RelayPickingTests: XCTestCase {
         XCTAssertEqual(selectedRelays.exit.hostname, "se10-wireguard")
     }
 
+    // DAITA - ON, Direct only - ON, Multihop - OFF, Exit supports DAITA - FALSE
+    // Go into blocked state since Direct only requires a DAITA entry.
     func testDirectOnlyOnDaitaOnForSinglehopWithoutDaitaRelay() throws {
         let constraints = RelayConstraints(
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")]))
@@ -108,6 +116,8 @@ class RelayPickingTests: XCTestCase {
         XCTAssertThrowsError(try picker.pick())
     }
 
+    // DAITA - ON, Direct only - OFF, Multihop - OFF, Exit supports DAITA - TRUE
+    // Select the DAITA entry, no automatic routing needed.
     func testDirectOnlyOffDaitaOnForSinglehopWithDaitaRelay() throws {
         let constraints = RelayConstraints(
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("es", "mad", "es1-wireguard")]))
@@ -122,10 +132,12 @@ class RelayPickingTests: XCTestCase {
 
         let selectedRelays = try picker.pick()
 
-        XCTAssertEqual(selectedRelays.entry?.hostname, "us-nyc-wg-301") // New York relay is closest to exit relay.
+        XCTAssertNil(selectedRelays.entry)
         XCTAssertEqual(selectedRelays.exit.hostname, "es1-wireguard")
     }
 
+    // DAITA - ON, Direct only - ON, Multihop - OFF, Exit supports DAITA - TRUE
+    // Select the DAITA entry.
     func testDirectOnlyOnDaitaOnForSinglehopWithDaitaRelay() throws {
         let constraints = RelayConstraints(
             exitLocations: .only(UserSelectedRelays(locations: [.hostname("es", "mad", "es1-wireguard")]))
@@ -144,6 +156,9 @@ class RelayPickingTests: XCTestCase {
         XCTAssertEqual(selectedRelays.exit.hostname, "es1-wireguard")
     }
 
+    // DAITA - ON, Direct only - OFF, Multihop - ON, Entry supports DAITA - TRUE
+    // Direct only is off, so we should automatically pick the entry that is closest to exit, ignoring
+    // selected multihop entry.
     func testDirectOnlyOffDaitaOnForMultihopWithDaitaRelay() throws {
         let constraints = RelayConstraints(
             entryLocations: .only(UserSelectedRelays(locations: [.hostname("us", "nyc", "us-nyc-wg-301")])),
@@ -163,6 +178,9 @@ class RelayPickingTests: XCTestCase {
         XCTAssertEqual(selectedRelays.exit.hostname, "se10-wireguard")
     }
 
+    // DAITA - ON, Direct only - OFF, Multihop - ON, Entry supports DAITA - FALSE
+    // Direct only is off, so we should automatically pick the entry that is closest to exit, ignoring
+    // selected multihop entry.
     func testDirectOnlyOffDaitaOnForMultihopWithoutDaitaRelay() throws {
         let constraints = RelayConstraints(
             entryLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")])),
@@ -182,6 +200,8 @@ class RelayPickingTests: XCTestCase {
         XCTAssertEqual(selectedRelays.exit.hostname, "se10-wireguard")
     }
 
+    // DAITA - ON, Direct only - ON, Multihop - ON, Entry supports DAITA - FALSE
+    // Go into blocked state since Direct only requires a DAITA entry.
     func testDirectOnlyOnDaitaOnForMultihopWithoutDaitaRelay() throws {
         let constraints = RelayConstraints(
             entryLocations: .only(UserSelectedRelays(locations: [.hostname("se", "got", "se10-wireguard")])),


### PR DESCRIPTION
When exit constraints match a DAITA relay, multihop is off, direct only is off and DAITA is turned on, the app should connect via singlehop to the eligible DAITA relays.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7050)
<!-- Reviewable:end -->
