### PR TITLE
Add src and dst fields to request

### DIFF
--- a/ios/MullvadVPNUITests/Networking/FirewallAPIClient.swift
+++ b/ios/MullvadVPNUITests/Networking/FirewallAPIClient.swift
@@ -32,8 +32,10 @@ class FirewallAPIClient {
 
         let dataDictionary: [String: Any] = [
             "label": sessionIdentifier,
-            "from": firewallRule.fromIPAddress,
-            "to": firewallRule.toIPAddress,
+            "from": firewallRule.fromIPAddress, // Deprecated, replaced by "src"
+            "to": firewallRule.toIPAddress, // Deprectated, replaced by "dst"
+            "src": firewallRule.fromIPAddress,
+            "dst": firewallRule.toIPAddress,
             "protocols": firewallRule.protocolsAsStringArray(),
         ]
 


### PR DESCRIPTION
Adds fields to create firewall rule request. Adds the fields `src` and `dst` which for now are duplicates of `from` and `to` which are to be removed later on. To test these changes run any test that create a firewall rule:
 * `testAPIConnectionViaBridges`
 * `testConnectionRetryLogic`
 * `testWireGuardOverTCPAutomatically`

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
