### PR TITLE
Correctly set insets for primary button

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/DisconnectSplitButton.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/DisconnectSplitButton.swift
@@ -42,6 +42,8 @@ class DisconnectSplitButton: UIView {
             secondaryButton.heightAnchor.constraint(equalToConstant: secondaryButtonSize.height)
         }
 
+        primaryButton.configuration?.contentInsets.leading += secondaryButtonSize
+
         // Ideally, we shouldn't need to manually resize the image ourselves.
         // However, since UIButton.Configuration doesn't provide a direct property
         // for controlling image scaling (like imageScaling or contentMode in other contexts),


### PR DESCRIPTION
The size of the secondary button wasn't being used to adjust the insets of the disconnect button. I've gone and done did make it do it now. Feel free to reject or suggest a better solution.

Since the inset rectangle is RTL aware, I presume this change would work there too? Or do we not display the reconnect button on the left in RTL locales?

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7061)
<!-- Reviewable:end -->
