### PR TITLE
Upgrade osv-scanner to 1.9.0

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -17,4 +17,4 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@dfa8609a7da62968d73f63f279418e504c1f523f"  # v1.8.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@19ec1116569a47416e11a45848722b1af31a857b"  # v1.9.0

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@dfa8609a7da62968d73f63f279418e504c1f523f"  # v1.8.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@19ec1116569a47416e11a45848722b1af31a857b"  # v1.9.0


### PR DESCRIPTION
Contains, among other things, stricter validation of osv-scanner.toml config files. Ignores invalid config files, making their ignores not ignored. This solves our previous small issue where we invalidly used `ignoreUntil` in sections where the config were supposed to use `effectiveUntil`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7065)
<!-- Reviewable:end -->
