### PR TITLE
Add Encrypted DNS Proxy access method to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Add a new access method: Encrypted DNS Proxy. Encrypted DNS proxy is a way to reach the API via
+  proxies. The access method is enabled by default.
+
 #### Windows
 - Add experimental support for Windows ARM64.
 


### PR DESCRIPTION
This PR adds "Encrypted DNS Proxy" access method to the changelog. It was implemented for Desktop and Android in this PR: https://github.com/mullvad/mullvadvpn-app/pull/7010

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7067)
<!-- Reviewable:end -->
