### PR TITLE
Configure DNS resolver port in SCDynamicStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 #### macOS
 - Fix packets being duplicated on LAN when split tunneling is enabled.
+- Fix DNS not working due to broken PF redirect.
 
 
 ## [2024.6] - 2024-10-23

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -67,11 +67,17 @@ enum InnerDnsConfig {
 }
 
 impl DnsConfig {
-    pub(crate) fn resolve(&self, default_tun_config: &[IpAddr]) -> ResolvedDnsConfig {
+    pub(crate) fn resolve(
+        &self,
+        default_tun_config: &[IpAddr],
+        #[cfg(target_os = "macos")] port: u16,
+    ) -> ResolvedDnsConfig {
         match &self.config {
             InnerDnsConfig::Default => ResolvedDnsConfig {
                 tunnel_config: default_tun_config.to_owned(),
                 non_tunnel_config: vec![],
+                #[cfg(target_os = "macos")]
+                port,
             },
             InnerDnsConfig::Override {
                 tunnel_config,
@@ -79,6 +85,8 @@ impl DnsConfig {
             } => ResolvedDnsConfig {
                 tunnel_config: tunnel_config.to_owned(),
                 non_tunnel_config: non_tunnel_config.to_owned(),
+                #[cfg(target_os = "macos")]
+                port,
             },
         }
     }
@@ -93,6 +101,9 @@ pub struct ResolvedDnsConfig {
     /// For the most part, the tunnel state machine will not handle any of this configuration
     /// on non-tunnel interface, only allow them in the firewall.
     non_tunnel_config: Vec<IpAddr>,
+    /// Port to use
+    #[cfg(target_os = "macos")]
+    port: u16,
 }
 
 impl fmt::Display for ResolvedDnsConfig {

--- a/talpid-core/src/dns/mod.rs
+++ b/talpid-core/src/dns/mod.rs
@@ -112,7 +112,12 @@ impl fmt::Display for ResolvedDnsConfig {
         Self::fmt_addr_set(f, &self.tunnel_config)?;
 
         f.write_str(" Non-tunnel DNS: ")?;
-        Self::fmt_addr_set(f, &self.non_tunnel_config)
+        Self::fmt_addr_set(f, &self.non_tunnel_config)?;
+
+        #[cfg(target_os = "macos")]
+        write!(f, " Port: {}", self.port)?;
+
+        Ok(())
     }
 }
 

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -175,8 +175,22 @@ impl ConnectedState {
                     .filtering_resolver
                     .enable_forward(dns_config.addresses().collect()),
             );
+            shared_values
+                .dns_monitor
+                .set(
+                    "lo",
+                    crate::dns::DnsConfig::default().resolve(
+                        &[std::net::Ipv4Addr::LOCALHOST.into()],
+                        shared_values.filtering_resolver.listening_port(),
+                    ),
+                )
+                .map_err(BoxedError::new)?;
         } else {
             log::debug!("Not enabling DNS forwarding since loopback is used");
+            shared_values
+                .dns_monitor
+                .set(&self.metadata.interface, dns_config)
+                .map_err(BoxedError::new)?;
         }
 
         Ok(())

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -151,11 +151,15 @@ impl ConnectedState {
         metadata: &TunnelMetadata,
         shared_values: &SharedTunnelStateValues,
     ) -> ResolvedDnsConfig {
-        shared_values.dns_config.resolve(&metadata.gateways())
+        shared_values.dns_config.resolve(
+            &metadata.gateways(),
+            #[cfg(target_os = "macos")]
+            53,
+        )
     }
 
     fn set_dns(&self, shared_values: &mut SharedTunnelStateValues) -> Result<(), BoxedError> {
-        let dns_config = Self::resolve_dns(&self.metadata, shared_values);
+        let dns_config: ResolvedDnsConfig = Self::resolve_dns(&self.metadata, shared_values);
 
         #[cfg(not(target_os = "macos"))]
         shared_values

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -60,7 +60,10 @@ impl ConnectingState {
         #[cfg(target_os = "macos")]
         if let Err(err) = shared_values.dns_monitor.set(
             "lo",
-            crate::dns::DnsConfig::default().resolve(&[std::net::Ipv4Addr::LOCALHOST.into()]),
+            crate::dns::DnsConfig::default().resolve(
+                &[std::net::Ipv4Addr::LOCALHOST.into()],
+                shared_values.filtering_resolver.listening_port(),
+            ),
         ) {
             log::error!(
                 "{}",

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -137,7 +137,10 @@ impl DisconnectedState {
 
         shared_values.dns_monitor.set(
             "lo",
-            dns::DnsConfig::default().resolve(&[Ipv4Addr::LOCALHOST.into()]),
+            dns::DnsConfig::default().resolve(
+                &[Ipv4Addr::LOCALHOST.into()],
+                shared_values.filtering_resolver.listening_port(),
+            ),
         )
     }
 }

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -37,7 +37,10 @@ impl ErrorState {
         if !block_reason.prevents_filtering_resolver() {
             if let Err(err) = shared_values.dns_monitor.set(
                 "lo",
-                DnsConfig::default().resolve(&[Ipv4Addr::LOCALHOST.into()]),
+                DnsConfig::default().resolve(
+                    &[Ipv4Addr::LOCALHOST.into()],
+                    shared_values.filtering_resolver.listening_port(),
+                ),
             ) {
                 log::error!(
                     "{}",


### PR DESCRIPTION
Works around an issue where the PF redirect rule is ignored.

This PR only makes the minimal changes required. The redirect rule is still kept, though we may wish to remove it later.

Fix DES-1372.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7070)
<!-- Reviewable:end -->
