### PR TITLE
Add missing `serde` feature in `mullvad-encrypted-dns-proxy`

### DIFF
--- a/mullvad-encrypted-dns-proxy/Cargo.toml
+++ b/mullvad-encrypted-dns-proxy/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 tokio = { workspace = true, features = [ "macros" ] }
 log = { workspace = true }
 hickory-resolver = { version = "0.24.1", features = [ "dns-over-https-rustls" ]}
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 webpki-roots = "0.25.0"
 rustls = "0.21"
 


### PR DESCRIPTION
As the title suggests, this PR adds a missing `serde` feature to `mullvad-encrypted-dns-proxy`. Currently, the crate fails to build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7074)
<!-- Reviewable:end -->
