### PR TITLE
Add WireGuard over Shadowsocks to feature table

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ the current state of the latest code in git, not necessarily any existing releas
 | [DAITA]                       |    ✓    |   ✓   |   ✓   |         |  ✓  |
 | WireGuard multihop            |    ✓    |   ✓   |   ✓   |         |  ✓  |
 | WireGuard over TCP            |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| WireGuard over Shadowsocks    |    ✓    |   ✓   |   ✓   |    ✓    |     |
 | OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |
 | Split tunneling               |    ✓    |   ✓   |   ✓   |    ✓    |     |
 | Custom DNS server             |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |


### PR DESCRIPTION
Reflect platforms that support WireGuard over Shadowsocks in the feature table presented in the README.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7085)
<!-- Reviewable:end -->
