### PR TITLE
Avoid deadlocking the Packet Tunnel after a reboot

### DIFF
--- a/ios/MullvadSettings/MigrationManager.swift
+++ b/ios/MullvadSettings/MigrationManager.swift
@@ -68,6 +68,9 @@ public struct MigrationManager {
                 )
             } catch .itemNotFound as KeychainError {
                 migrationCompleted(.nothing)
+            } catch let couldNotReadKeychainError as KeychainError
+                where couldNotReadKeychainError == .interactionNotAllowed {
+                migrationCompleted(.failure(couldNotReadKeychainError))
             } catch {
                 resetStoreHandler(.failure(error))
             }


### PR DESCRIPTION
This PR fixes a deadlock that was triggered by rebooting the phone when the VPN was connected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7089)
<!-- Reviewable:end -->
