### PR TITLE
Fix `api-access-methods.spec` - counting of access methods was off

### DIFF
--- a/gui/test/e2e/installed/state-dependent/api-access-methods.spec.ts
+++ b/gui/test/e2e/installed/state-dependent/api-access-methods.spec.ts
@@ -84,7 +84,8 @@ test('App should add invalid access method', async () => {
   ).toEqual(RoutePath.apiAccessMethods);
 
   const accessMethods = page.getByTestId('access-method');
-  await expect(accessMethods).toHaveCount(3);
+  // Direct, Bridges, Encrypted DNS Proxy & the non-functioning access method.
+  await expect(accessMethods).toHaveCount(4);
 
   await expect(accessMethods.last()).toHaveText(NON_FUNCTIONING_METHOD_NAME);
 });
@@ -137,7 +138,8 @@ test('App should edit access method', async () => {
   );
 
   const accessMethods = page.getByTestId('access-method');
-  await expect(accessMethods).toHaveCount(3);
+  // Direct, Bridges, Encrypted DNS Proxy & the custom access method.
+  await expect(accessMethods).toHaveCount(4);
 
   await expect(accessMethods.last()).toHaveText(FUNCTIONING_METHOD_NAME);
 });
@@ -172,5 +174,6 @@ test('App should delete method', async () => {
 
   await expect(page.getByText(`Delete ${FUNCTIONING_METHOD_NAME}?`)).toBeVisible();
   await page.locator('button:has-text("Delete")').click();
-  await expect(accessMethods).toHaveCount(2);
+  // Direct, Bridges, Encrypted DNS Proxy.
+  await expect(accessMethods).toHaveCount(3);
 });


### PR DESCRIPTION
Did an oopsie and forgot to update some values in the `api-access-methods` end-to-end GUI test. I could have sworn that I ran these tests before merging, but supposedly I didn't.. :thinking:

Here is a test run to prove that it works as intended: https://github.com/mullvad/mullvadvpn-app/actions/runs/11559889398

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7090)
<!-- Reviewable:end -->
