### PR TITLE
Do not fallback to making direct API connections when testing access methods

### DIFF
--- a/mullvad-api/src/proxy.rs
+++ b/mullvad-api/src/proxy.rs
@@ -98,6 +98,12 @@ impl From<proxy::CustomProxy> for ProxyConfig {
     }
 }
 
+impl From<mullvad_encrypted_dns_proxy::config::ProxyConfig> for ProxyConfig {
+    fn from(value: mullvad_encrypted_dns_proxy::config::ProxyConfig) -> Self {
+        ProxyConfig::EncryptedDnsProxy(value)
+    }
+}
+
 impl ApiConnectionMode {
     /// Reads the proxy config from `CURRENT_CONFIG_FILENAME`.
     /// This returns `ApiConnectionMode::Direct` if reading from disk fails for any reason.

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -2752,8 +2752,19 @@ impl Daemon {
             }
         };
 
-        let test_subject = match self.access_mode_handler.resolve(access_method).await {
-            Ok(test_subject) => test_subject,
+        let test_subject = match self
+            .access_mode_handler
+            .resolve(access_method.clone())
+            .await
+        {
+            Ok(Some(test_subject)) => test_subject,
+            Ok(None) => {
+                let error = Error::ApiConnectionModeError(self::api::Error::Resolve {
+                    access_method: access_method.access_method,
+                });
+                reply(Err(error));
+                return;
+            }
             Err(err) => {
                 reply(Err(Error::ApiConnectionModeError(err)));
                 return;

--- a/mullvad-daemon/src/tunnel.rs
+++ b/mullvad-daemon/src/tunnel.rs
@@ -185,8 +185,8 @@ impl InnerParametersGenerator {
                     bridge: bridge_relay.cloned(),
                     server_override,
                 });
-                let bridge_settings = bridge.as_ref().map(|bridge| bridge.settings());
-                Ok(self.create_openvpn_tunnel_parameters(endpoint, data, bridge_settings.cloned()))
+                let bridge_settings = bridge.map(|bridge| bridge.to_proxy());
+                Ok(self.create_openvpn_tunnel_parameters(endpoint, data, bridge_settings))
             }
             GetRelay::Wireguard {
                 endpoint,

--- a/mullvad-relay-selector/src/relay_selector/detailer.rs
+++ b/mullvad-relay-selector/src/relay_selector/detailer.rs
@@ -21,7 +21,7 @@ use mullvad_types::{
 };
 use talpid_types::net::{
     all_of_the_internet,
-    proxy::CustomProxy,
+    proxy::Shadowsocks,
     wireguard::{PeerConfig, PublicKey},
     Endpoint, IpVersion, TransportProtocol,
 };
@@ -266,7 +266,7 @@ fn compatible_openvpn_port_combo(
 }
 
 /// Picks a random bridge from a relay.
-pub fn bridge_endpoint(data: &BridgeEndpointData, relay: &Relay) -> Option<CustomProxy> {
+pub fn bridge_endpoint(data: &BridgeEndpointData, relay: &Relay) -> Option<Shadowsocks> {
     use rand::seq::SliceRandom;
     if relay.endpoint_data != RelayEndpointData::Bridge {
         return None;

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -46,7 +46,9 @@ use mullvad_types::{
 };
 use talpid_types::{
     net::{
-        obfuscation::ObfuscatorConfig, proxy::CustomProxy, Endpoint, TransportProtocol, TunnelType,
+        obfuscation::ObfuscatorConfig,
+        proxy::{CustomProxy, Shadowsocks},
+        Endpoint, TransportProtocol, TunnelType,
     },
     ErrorExt,
 };
@@ -228,15 +230,19 @@ pub enum GetRelay {
 
 #[derive(Clone, Debug)]
 pub enum SelectedBridge {
-    Normal { settings: CustomProxy, relay: Relay },
+    Normal {
+        // Mullvad operated bridges will always be Shadowsocks proxies.
+        settings: Shadowsocks,
+        relay: Relay,
+    },
     Custom(CustomProxy),
 }
 
 impl SelectedBridge {
     /// Get the bridge settings.
-    pub fn settings(&self) -> &CustomProxy {
+    pub fn to_proxy(self) -> CustomProxy {
         match self {
-            SelectedBridge::Normal { settings, .. } => settings,
+            SelectedBridge::Normal { settings, .. } => CustomProxy::Shadowsocks(settings),
             SelectedBridge::Custom(settings) => settings,
         }
     }
@@ -444,7 +450,7 @@ impl RelaySelector {
 
     /// Returns a non-custom bridge based on the relay and bridge constraints, ignoring the bridge
     /// state.
-    pub fn get_bridge_forced(&self) -> Option<CustomProxy> {
+    pub fn get_bridge_forced(&self) -> Option<Shadowsocks> {
         let parsed_relays = &self.parsed_relays.lock().unwrap();
         let config = self.config.lock().unwrap();
         let specialized_config = SpecializedSelectorConfig::from(&*config);
@@ -1049,7 +1055,7 @@ impl RelaySelector {
         constraints: &InternalBridgeConstraints,
         location: Option<T>,
         custom_lists: &CustomListsSettings,
-    ) -> Result<(CustomProxy, Relay), Error> {
+    ) -> Result<(Shadowsocks, Relay), Error> {
         let bridges = filter_matching_bridges(constraints, parsed_relays.relays(), custom_lists);
         let bridge_data = &parsed_relays.parsed_list().bridge;
         let bridge = match location {

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -4,10 +4,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::RangeInclusive,
 };
-use talpid_types::net::{
-    proxy::{CustomProxy, Shadowsocks},
-    wireguard, TransportProtocol,
-};
+use talpid_types::net::{proxy::Shadowsocks, wireguard, TransportProtocol};
 
 /// Stores a list of relays for each country obtained from the API using
 /// `mullvad_api::RelayListProxy`. This can also be passed to frontends.
@@ -246,11 +243,11 @@ pub struct ShadowsocksEndpointData {
 }
 
 impl ShadowsocksEndpointData {
-    pub fn to_proxy_settings(&self, addr: IpAddr) -> CustomProxy {
-        CustomProxy::Shadowsocks(Shadowsocks {
+    pub fn to_proxy_settings(&self, addr: IpAddr) -> Shadowsocks {
+        Shadowsocks {
             endpoint: SocketAddr::new(addr, self.port),
             password: self.password.clone(),
             cipher: self.cipher.clone(),
-        })
+        }
     }
 }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
  "http-body-util",
  "itoa",
@@ -242,7 +242,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -1123,6 +1123,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -1132,7 +1151,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1183,19 +1202,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
 dependencies = [
  "async-trait",
+ "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
  "idna 0.4.0",
  "ipnet",
  "once_cell",
  "rand 0.8.5",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "thiserror",
  "tinyvec",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
 ]
@@ -1215,9 +1240,11 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "resolv-conf",
+ "rustls 0.21.12",
  "smallvec",
  "thiserror",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tracing",
 ]
 
@@ -1252,6 +1279,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1268,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1279,7 +1317,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -1311,8 +1349,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
+ "h2 0.4.6",
+ "http 1.1.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -1330,16 +1368,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http",
+ "http 1.1.0",
  "hyper",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -1364,7 +1402,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -1848,16 +1886,17 @@ dependencies = [
  "cbindgen",
  "chrono",
  "futures",
- "http",
+ "http 1.1.0",
  "http-body-util",
  "hyper",
  "hyper-util",
  "ipnetwork",
  "libc",
  "log",
+ "mullvad-encrypted-dns-proxy",
  "mullvad-fs",
  "mullvad-types",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
  "shadowsocks",
@@ -1865,10 +1904,22 @@ dependencies = [
  "talpid-types",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tokio-socks",
  "tower 0.5.1",
  "uuid",
+]
+
+[[package]]
+name = "mullvad-encrypted-dns-proxy"
+version = "0.0.0"
+dependencies = [
+ "hickory-resolver",
+ "log",
+ "rustls 0.21.12",
+ "serde",
+ "tokio",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -2530,7 +2581,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.13",
  "socket2 0.5.6",
  "thiserror",
  "tokio",
@@ -2547,7 +2598,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.13",
  "slab",
  "thiserror",
  "tinyvec",
@@ -2716,7 +2767,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2730,21 +2781,21 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.23.13",
+ "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.6",
  "windows-registry",
 ]
 
@@ -2834,6 +2885,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
@@ -2842,9 +2905,18 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2862,6 +2934,16 @@ name = "rustls-pki-types"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2900,6 +2982,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -3392,13 +3484,13 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "log",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
  "tarpc",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tokio-serde",
  "tokio-util",
 ]
@@ -3556,11 +3648,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3668,8 +3770,8 @@ dependencies = [
  "axum",
  "base64 0.22.0",
  "bytes",
- "h2",
- "http",
+ "h2 0.4.6",
+ "http 1.1.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4033,6 +4135,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -146,7 +146,7 @@ async fn test_custom_access_methods_gui(
 ) -> anyhow::Result<()> {
     use mullvad_api::env;
     use mullvad_relay_selector::{RelaySelector, SelectorConfig};
-    use talpid_types::net::proxy::CustomProxy;
+
     // For this test to work, we need to supply the following env-variables:
     //
     // * SHADOWSOCKS_SERVER_IP
@@ -179,10 +179,6 @@ async fn test_custom_access_methods_gui(
     let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relay_list);
     let access_method = relay_selector
         .get_bridge_forced()
-        .and_then(|proxy| match proxy {
-            CustomProxy::Shadowsocks(s) => Some(s),
-            _ => None
-        })
         .expect("`test_shadowsocks` needs at least one shadowsocks relay to execute. Found none in relay list.");
 
     let ui_result = run_test_env(
@@ -219,7 +215,7 @@ async fn test_custom_bridge_gui(
     mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     use mullvad_relay_selector::{RelaySelector, SelectorConfig};
-    use talpid_types::net::proxy::CustomProxy;
+
     // For this test to work, we need to supply the following env-variables:
     //
     // * SHADOWSOCKS_SERVER_IP
@@ -236,10 +232,6 @@ async fn test_custom_bridge_gui(
     let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relay_list);
     let custom_proxy = relay_selector
         .get_bridge_forced()
-        .and_then(|proxy| match proxy {
-            CustomProxy::Shadowsocks(s) => Some(s),
-            _ => None
-        })
         .expect("`test_shadowsocks` needs at least one shadowsocks relay to execute. Found none in relay list.");
 
     let ui_result = run_test_env(


### PR DESCRIPTION
This PR addresses an issue in the logic for testing access methods whre if an access methods fails to resolve to a set of connection details (e.g. if the relay selector / mullvad encrypted dns cache is empty) the daemon would fall back to making a direct API connection. The current behaviour is straight up misleading.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7091)
<!-- Reviewable:end -->
