### PR TITLE
Add commit_hash to end to end test

### DIFF
--- a/.github/workflows/ios-end-to-end-tests.yml
+++ b/.github/workflows/ios-end-to-end-tests.yml
@@ -12,6 +12,9 @@ on:
       arg_tests_json_key:
         type: string
         required: false
+      commit_hash:
+        type: string
+        required: false
   workflow_dispatch:
     inputs:
       # Optionally specify a test case or suite to run.
@@ -75,10 +78,21 @@ jobs:
     needs: set-up-outputs-directory
     timeout-minutes: 20
     steps:
+      - name: Set commit hash or default to github.sha
+        id: set-commit-hash
+        run: |
+          # If the input has a value, it is filled by that value; otherwise, use github.sha
+          if [ -n "${{ inputs.commit_hash }}" ]; then
+            echo "COMMIT_HASH=${{ inputs.commit_hash }}" >> $GITHUB_ENV
+          else
+            echo "COMMIT_HASH=${{ github.sha }}" >> $GITHUB_ENV
+          fi
+        shell: bash
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           clean: true
+          ref: ${{ env.COMMIT_HASH }}
 
       - name: Configure Rust
         uses: actions-rs/toolchain@v1.0.6


### PR DESCRIPTION
This PR enables iOS end-to-end tests to receive a commit_hash as an input, allowing the workflow to check out that specific commit. This input is optional, and if no value is provided, the workflow will use the latest commit from the branch that triggered it. The primary reason for this change is that iOS settings migration tests require an older commit version. By reusing iOS end-to-end tests for these cases and consolidating workflows and jobs in one place, it becomes necessary to fetch the repository at a specific reference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7093)
<!-- Reviewable:end -->
