### PR TITLE
Add shadowsocks fields to relay list response from the API

### DIFF
--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -62,6 +62,7 @@ extension REST {
         public let publicKey: Data
         public let includeInCountry: Bool
         public let daita: Bool?
+        public let shadowsocksExtraAddrIn: [String]?
 
         public func override(ipv4AddrIn: IPv4Address?, ipv6AddrIn: IPv6Address?) -> Self {
             return ServerRelay(
@@ -75,7 +76,8 @@ extension REST {
                 ipv6AddrIn: ipv6AddrIn ?? self.ipv6AddrIn,
                 publicKey: publicKey,
                 includeInCountry: includeInCountry,
-                daita: daita
+                daita: daita,
+                shadowsocksExtraAddrIn: shadowsocksExtraAddrIn
             )
         }
 
@@ -91,7 +93,8 @@ extension REST {
                 ipv6AddrIn: ipv6AddrIn,
                 publicKey: publicKey,
                 includeInCountry: includeInCountry,
-                daita: daita
+                daita: daita,
+                shadowsocksExtraAddrIn: shadowsocksExtraAddrIn
             )
         }
     }
@@ -101,12 +104,20 @@ extension REST {
         public let ipv6Gateway: IPv6Address
         public let portRanges: [[UInt16]]
         public let relays: [ServerRelay]
+        public let shadowsocksPortRanges: [[UInt16]]
 
-        public init(ipv4Gateway: IPv4Address, ipv6Gateway: IPv6Address, portRanges: [[UInt16]], relays: [ServerRelay]) {
+        public init(
+            ipv4Gateway: IPv4Address,
+            ipv6Gateway: IPv6Address,
+            portRanges: [[UInt16]],
+            relays: [ServerRelay],
+            shadowsocksPortRanges: [[UInt16]]
+        ) {
             self.ipv4Gateway = ipv4Gateway
             self.ipv6Gateway = ipv6Gateway
             self.portRanges = portRanges
             self.relays = relays
+            self.shadowsocksPortRanges = shadowsocksPortRanges
         }
     }
 

--- a/ios/MullvadREST/Relay/IPOverrideWrapper.swift
+++ b/ios/MullvadREST/Relay/IPOverrideWrapper.swift
@@ -58,7 +58,8 @@ public class IPOverrideWrapper: RelayCacheProtocol {
                 ipv4Gateway: wireguard.ipv4Gateway,
                 ipv6Gateway: wireguard.ipv6Gateway,
                 portRanges: wireguard.portRanges,
-                relays: overridenWireguardRelays
+                relays: overridenWireguardRelays,
+                shadowsocksPortRanges: wireguard.shadowsocksPortRanges
             ),
             bridge: REST.ServerBridges(
                 shadowsocks: bridge.shadowsocks,

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -110,7 +110,8 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol {
             cachedRelays.relays.wireguard.ipv4Gateway,
             ipv6Gateway: cachedRelays.relays.wireguard.ipv6Gateway,
             portRanges: cachedRelays.relays.wireguard.portRanges,
-            relays: cachedRelaysWithFixedDaita
+            relays: cachedRelaysWithFixedDaita,
+            shadowsocksPortRanges: cachedRelays.relays.wireguard.shadowsocksPortRanges
         )
 
         let updatedRelays = REST.ServerRelaysResponse(

--- a/ios/MullvadVPN/View controllers/Settings/SettingsInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsInteractor.swift
@@ -54,7 +54,7 @@ final class SettingsInteractor {
         } catch let error as NoRelaysSatisfyingConstraintsError where error.reason == .noDaitaRelaysFound {
             // Return error if no relays could be selected due to DAITA constraints.
             compatibilityError = tunnelSettings.tunnelMultihopState.isEnabled ? .multihop : .singlehop
-        } catch let error as NoRelaysSatisfyingConstraintsError {
+        } catch _ as NoRelaysSatisfyingConstraintsError {
             // Even if the constraints error is not DAITA specific, if both DAITA and Direct only are enabled,
             // we should return a DAITA related error since the current settings would have resulted in the
             // relay selector not being able to select a DAITA relay anyway.

--- a/ios/MullvadVPNTests/MullvadREST/ApiHandlers/ServerRelaysResponse+Stubs.swift
+++ b/ios/MullvadVPNTests/MullvadREST/ApiHandlers/ServerRelaysResponse+Stubs.swift
@@ -86,7 +86,8 @@ enum ServerRelaysResponseStubs {
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
                     includeInCountry: true,
-                    daita: true
+                    daita: true,
+                    shadowsocksExtraAddrIn: nil
                 ),
                 REST.ServerRelay(
                     hostname: "se10-wireguard",
@@ -99,7 +100,8 @@ enum ServerRelaysResponseStubs {
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
                     includeInCountry: true,
-                    daita: false
+                    daita: false,
+                    shadowsocksExtraAddrIn: nil
                 ),
                 REST.ServerRelay(
                     hostname: "se2-wireguard",
@@ -112,7 +114,8 @@ enum ServerRelaysResponseStubs {
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
                     includeInCountry: true,
-                    daita: false
+                    daita: false,
+                    shadowsocksExtraAddrIn: nil
                 ),
                 REST.ServerRelay(
                     hostname: "se6-wireguard",
@@ -125,7 +128,8 @@ enum ServerRelaysResponseStubs {
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
                     includeInCountry: true,
-                    daita: false
+                    daita: false,
+                    shadowsocksExtraAddrIn: nil
                 ),
                 REST.ServerRelay(
                     hostname: "us-dal-wg-001",
@@ -138,7 +142,8 @@ enum ServerRelaysResponseStubs {
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
                     includeInCountry: true,
-                    daita: true
+                    daita: true,
+                    shadowsocksExtraAddrIn: nil
                 ),
                 REST.ServerRelay(
                     hostname: "us-nyc-wg-301",
@@ -151,7 +156,8 @@ enum ServerRelaysResponseStubs {
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
                     includeInCountry: true,
-                    daita: true
+                    daita: true,
+                    shadowsocksExtraAddrIn: nil
                 ),
                 REST.ServerRelay(
                     hostname: "us-nyc-wg-302",
@@ -164,9 +170,11 @@ enum ServerRelaysResponseStubs {
                     ipv6AddrIn: .loopback,
                     publicKey: PrivateKey().publicKey.rawValue,
                     includeInCountry: true,
-                    daita: true
+                    daita: true,
+                    shadowsocksExtraAddrIn: nil
                 ),
-            ]
+            ],
+            shadowsocksPortRanges: []
         ),
         bridge: REST.ServerBridges(shadowsocks: [
             REST.ServerShadowsocks(protocol: "tcp", port: 443, cipher: "aes-256-gcm", password: "mullvad"),

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayCacheTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayCacheTests.swift
@@ -50,7 +50,8 @@ extension REST.ServerRelaysResponse {
                 ipv4Gateway: .loopback,
                 ipv6Gateway: .loopback,
                 portRanges: [],
-                relays: serverRelays
+                relays: serverRelays,
+                shadowsocksPortRanges: []
             ),
             bridge: REST.ServerBridges(shadowsocks: [], relays: bridgeRelays)
         )

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
@@ -338,9 +338,11 @@ extension RelaySelectorTests {
                         ipv6AddrIn: .loopback,
                         publicKey: PrivateKey().publicKey.rawValue,
                         includeInCountry: true,
-                        daita: true
+                        daita: true,
+                        shadowsocksExtraAddrIn: nil
                     ),
-                ]
+                ],
+                shadowsocksPortRanges: []
             ),
             bridge: REST.ServerBridges(shadowsocks: [], relays: [])
         )

--- a/ios/MullvadVPNTests/MullvadSettings/IPOverrideWrapperTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/IPOverrideWrapperTests.swift
@@ -84,7 +84,8 @@ extension IPOverrideWrapperTests {
             ipv6AddrIn: .any,
             publicKey: Data(),
             includeInCountry: true,
-            daita: false
+            daita: false,
+            shadowsocksExtraAddrIn: nil
         )
     }
 


### PR DESCRIPTION
The relay list should contain a couple of new fields for shadowsocks proxying:

- `shadowsocks_extra_addr_in` - a list of additional IP addresses that can be used to reach a specific relay over shadowsocks.  This field will be added to a relay struct (`wireguard.relays.[*].shadowsocks_extra_addr_in`). These IP addresess will have shadowsocks listening on literally every port. These addresses will all be backed by the same relay. 

- `shadowsocks_port_ranges` - a field in the toplevel wireguard object that represents all the port ranges that shadowsocks will be listening on the default entry IPs for relays. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7096)
<!-- Reviewable:end -->
