### PR TITLE
Stop duplication in error source chain

### DIFF
--- a/mullvad-encrypted-dns-proxy/src/config_resolver.rs
+++ b/mullvad-encrypted-dns-proxy/src/config_resolver.rs
@@ -34,8 +34,8 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::ResolutionError(ref err) => Some(err),
-            Self::Timeout(ref err) => Some(err),
+            Self::ResolutionError(ref err) => err.source(),
+            Self::Timeout(ref err) => err.source(),
         }
     }
 }


### PR DESCRIPTION
Don't both print the contained error in the Display impl and also return it in source.

The error, as it was before, would print an error chain like this:
```
Error: Resolution error something something
Caused by: Resolution error something something
```

An error should avoid including its source error in its own `Display` impl. Or, if it is included, it should not return that from the `source` method.

If you want to dive more into how long I have cared about this, you can follow this URL :D https://github.com/rust-lang/api-guidelines/pull/210

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7105)
<!-- Reviewable:end -->
