### PR TITLE
When phone loses connectivity it fails to reconnect ios 889

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9259,8 +9259,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
-				branch = "icmp-socket-always-on";
-				kind = branch;
+				kind = revision;
+				revision = cc6d3e918691c82d13389ad0fdbe8f35b683a6fc;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9259,8 +9259,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
-				kind = revision;
-				revision = afb345188c187dddafae0f9e27c5466be11451c2;
+				branch = "icmp-socket-always-on";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "afb345188c187dddafae0f9e27c5466be11451c2"
+        "branch" : "icmp-socket-always-on",
+        "revision" : "5e051810193e089230529691ea7b8d2244f3a05b"
       }
     }
   ],

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "branch" : "icmp-socket-always-on",
-        "revision" : "b7d280b42bd5899acaa3f2a5c569c50dda2c608f"
+        "revision" : "cc6d3e918691c82d13389ad0fdbe8f35b683a6fc"
       }
     }
   ],

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
         "branch" : "icmp-socket-always-on",
-        "revision" : "5e051810193e089230529691ea7b8d2244f3a05b"
+        "revision" : "b7d280b42bd5899acaa3f2a5c569c50dda2c608f"
       }
     }
   ],

--- a/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
+++ b/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
@@ -163,7 +163,8 @@ private extension TunnelAdapterConfiguration {
         return TunnelConfiguration(
             name: nil,
             interface: interfaceConfig,
-            peers: peers
+            peers: peers,
+            pingableGateway: pingableGateway
         )
     }
 }

--- a/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
+++ b/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
@@ -28,6 +28,7 @@ public struct ConfigurationBuilder {
     var endpoint: MullvadEndpoint?
     var allowedIPs: [IPAddressRange]
     var preSharedKey: PreSharedKey?
+    var pingableGateway: IPv4Address
 
     public init(
         privateKey: PrivateKey,
@@ -35,7 +36,8 @@ public struct ConfigurationBuilder {
         dns: SelectedDNSServers? = nil,
         endpoint: MullvadEndpoint? = nil,
         allowedIPs: [IPAddressRange],
-        preSharedKey: PreSharedKey? = nil
+        preSharedKey: PreSharedKey? = nil,
+        pingableGateway: IPv4Address
     ) {
         self.privateKey = privateKey
         self.interfaceAddresses = interfaceAddresses
@@ -43,6 +45,7 @@ public struct ConfigurationBuilder {
         self.endpoint = endpoint
         self.allowedIPs = allowedIPs
         self.preSharedKey = preSharedKey
+        self.pingableGateway = pingableGateway
     }
 
     public func makeConfiguration() throws -> TunnelAdapterConfiguration {
@@ -51,7 +54,8 @@ public struct ConfigurationBuilder {
             interfaceAddresses: interfaceAddresses,
             dns: dnsServers,
             peer: try peer,
-            allowedIPs: allowedIPs
+            allowedIPs: allowedIPs,
+            pingableGateway: pingableGateway
         )
     }
 

--- a/ios/PacketTunnelCore/Actor/ConnectionConfigurationBuilder.swift
+++ b/ios/PacketTunnelCore/Actor/ConnectionConfigurationBuilder.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+import MullvadTypes
+import Network
 import WireGuardKitTypes
 
 protocol Configuration {
@@ -69,7 +71,8 @@ private struct NormalConnectionConfiguration: Configuration {
                 endpoint: connectionData.connectedEndpoint,
                 allowedIPs: [
                     IPAddressRange(from: "\(connectionData.selectedRelays.exit.endpoint.ipv4Relay.ip)/32")!,
-                ]
+                ],
+                pingableGateway: IPv4Address(LocalNetworkIPs.gatewayAddress.rawValue)!
             ).makeConfiguration()
         } else {
             nil
@@ -84,7 +87,8 @@ private struct NormalConnectionConfiguration: Configuration {
             allowedIPs: [
                 IPAddressRange(from: "0.0.0.0/0")!,
                 IPAddressRange(from: "::/0")!,
-            ]
+            ],
+            pingableGateway: IPv4Address(LocalNetworkIPs.gatewayAddress.rawValue)!
         ).makeConfiguration()
 
         return ConnectionConfiguration(
@@ -112,7 +116,8 @@ private struct EphemeralConnectionConfiguration: Configuration {
                 dns: settings.dnsServers,
                 endpoint: connectionData.connectedEndpoint,
                 allowedIPs: hop.configuration.allowedIPs,
-                preSharedKey: hop.configuration.preSharedKey
+                preSharedKey: hop.configuration.preSharedKey,
+                pingableGateway: IPv4Address(LocalNetworkIPs.gatewayAddress.rawValue)!
             ).makeConfiguration()
 
             return ConnectionConfiguration(entryConfiguration: nil, exitConfiguration: exitConfiguration)
@@ -124,7 +129,8 @@ private struct EphemeralConnectionConfiguration: Configuration {
                 dns: settings.dnsServers,
                 endpoint: connectionData.connectedEndpoint,
                 allowedIPs: firstHop.configuration.allowedIPs,
-                preSharedKey: firstHop.configuration.preSharedKey
+                preSharedKey: firstHop.configuration.preSharedKey,
+                pingableGateway: IPv4Address(LocalNetworkIPs.gatewayAddress.rawValue)!
             ).makeConfiguration()
 
             let exitConfiguration = try ConfigurationBuilder(
@@ -133,7 +139,8 @@ private struct EphemeralConnectionConfiguration: Configuration {
                 dns: settings.dnsServers,
                 endpoint: secondHop.relay.endpoint,
                 allowedIPs: secondHop.configuration.allowedIPs,
-                preSharedKey: secondHop.configuration.preSharedKey
+                preSharedKey: secondHop.configuration.preSharedKey,
+                pingableGateway: IPv4Address(LocalNetworkIPs.gatewayAddress.rawValue)!
             ).makeConfiguration()
 
             return ConnectionConfiguration(entryConfiguration: entryConfiguration, exitConfiguration: exitConfiguration)

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -117,7 +117,8 @@ extension PacketTunnelActor {
             let configurationBuilder = ConfigurationBuilder(
                 privateKey: PrivateKey(),
                 interfaceAddresses: [],
-                allowedIPs: []
+                allowedIPs: [],
+                pingableGateway: IPv4Address(LocalNetworkIPs.gatewayAddress.rawValue)!
             )
             var config = try configurationBuilder.makeConfiguration()
             config.dns = [IPv4Address.loopback]

--- a/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
@@ -35,6 +35,7 @@ public struct TunnelAdapterConfiguration {
     public var dns: [IPAddress]
     public var peer: TunnelPeer?
     public var allowedIPs: [IPAddressRange]
+    public var pingableGateway: IPv4Address
 }
 
 /// Struct describing a single peer.

--- a/ios/PacketTunnelCore/Pinger/PingerProtocol.swift
+++ b/ios/PacketTunnelCore/Pinger/PingerProtocol.swift
@@ -32,7 +32,7 @@ public struct PingerSendResult {
 public protocol PingerProtocol {
     var onReply: ((PingerReply) -> Void)? { get set }
 
-    func openSocket(bindTo interfaceName: String?, destAddress: IPv4Address) throws
-    func closeSocket()
+    func startPinging(destAddress: IPv4Address) throws
+    func stopPinging()
     func send() throws -> PingerSendResult
 }

--- a/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
+++ b/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
@@ -31,12 +31,7 @@ public final class TunnelPinger: PingerProtocol {
         self.logger = Logger(label: "TunnelPinger")
     }
 
-    deinit {
-        pingProvider.closeICMP()
-    }
-
-    public func openSocket(bindTo interfaceName: String?, destAddress: IPv4Address) throws {
-        try pingProvider.openICMP(address: destAddress)
+    public func startPinging(destAddress: IPv4Address) throws {
         stateLock.withLock {
             self.destAddress = destAddress
         }
@@ -64,10 +59,9 @@ public final class TunnelPinger: PingerProtocol {
         }
     }
 
-    public func closeSocket() {
+    public func stopPinging() {
         stateLock.withLock {
             self.destAddress = nil
-            pingProvider.closeICMP()
         }
     }
 

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
@@ -298,12 +298,12 @@ public final class TunnelMonitor: TunnelMonitorProtocol {
 
     private func startMonitoring() {
         do {
-            guard let interfaceName = tunnelDeviceInfo.interfaceName, let probeAddress else {
-                logger.debug("Failed to obtain utun interface name or probe address.")
+            guard let probeAddress else {
+                logger.debug("Failed to obtain probe address.")
                 return
             }
 
-            try pinger.openSocket(bindTo: interfaceName, destAddress: probeAddress)
+            try pinger.startPinging(destAddress: probeAddress)
 
             state.connectionState = .connecting
             startConnectivityCheckTimer()
@@ -314,7 +314,7 @@ public final class TunnelMonitor: TunnelMonitorProtocol {
 
     private func stopMonitoring(resetRetryAttempt: Bool) {
         stopConnectivityCheckTimer()
-        pinger.closeSocket()
+        pinger.stopPinging()
 
         state.netStats = WgStats()
         state.lastSeenRx = nil

--- a/ios/PacketTunnelCoreTests/Mocks/PingerMock.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/PingerMock.swift
@@ -34,14 +34,14 @@ class PingerMock: PingerProtocol {
         self.decideOutcome = decideOutcome
     }
 
-    func openSocket(bindTo interfaceName: String?, destAddress: IPv4Address) throws {
+    func startPinging(destAddress: IPv4Address) throws {
         stateLock.withLock {
             state.destAddress = destAddress
             state.isSocketOpen = true
         }
     }
 
-    func closeSocket() {
+    func stopPinging() {
         stateLock.withLock {
             state.isSocketOpen = false
         }


### PR DESCRIPTION
This PR removes the concept of opening and closing a socket for pinging the gateway address, that functionality has been moved into WireGuardKit.
Which address to ping is now passed via the `ConfigurationBuilder` 


⚠️ This PR requires https://github.com/mullvad/wireguard-apple/pull/31 to be merged first, the commit hash used for wireguard-go will need to be updated to point to the `mullvad-master` branch instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7113)
<!-- Reviewable:end -->
