### PR TITLE
Remove old E2E test VMs, and bump minimum supported Debian version

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -13,10 +13,13 @@ on:
   workflow_dispatch:
     inputs:
       oses:
-        description: "Space-delimited list of targets to run tests on, e.g. `debian11 debian12`. \
-          Available images are:\n
+        description: "Space-delimited list of targets to run tests on, e.g. `debian12 ubuntu2004`. \
+          Available images:\n
           `debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2404 ubuntu2410 fedora39 \
-          fedora40 fedora41 windows10 windows11 macos12 macos13 macos14 macos15`."
+          fedora40 fedora41 windows10 windows11 macos12 macos13 macos14 macos15`.\n
+          Default images:\n
+          `debian12 ubuntu2004 ubuntu2204 ubuntu2404 ubuntu2410 fedora39 \
+          fedora40 fedora41 windows10 windows11 macos13 macos14 macos15`."
         default: ''
         required: false
         type: string
@@ -39,10 +42,11 @@ jobs:
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
           all='["debian11","debian12","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","fedora39","fedora40","fedora41"]'
+          default='["debian12","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","fedora39","fedora40","fedora41"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then
-            selected="$all"
+            selected="$default"
           else
             oses=$(printf '%s\n' $oses | jq . -R | jq . -s)
             selected=$(jq -cn --argjson oses "$oses" --argjson all "$all" '$all - ($all - $oses)')
@@ -53,9 +57,10 @@ jobs:
         shell: bash
         run: |
           all='["windows10","windows11"]'
+          default='["windows10","windows11"]'
           oses="${{ github.event.inputs.oses }}"
           if [[ -z "$oses" || "$oses" == "null" ]]; then
-            selected="$all"
+            selected="$default"
           else
             oses=$(printf '%s\n' $oses | jq . -R | jq . -s)
             selected=$(jq -cn --argjson oses "$oses" --argjson all "$all" '$all - ($all - $oses)')
@@ -66,9 +71,10 @@ jobs:
         shell: bash
         run: |
           all='["macos12","macos13","macos14","macos15"]'
+          default='["macos13","macos14","macos15"]'
           oses="${{ github.event.inputs.oses }}"
           if [[ -z "$oses" || "$oses" == "null" ]]; then
-            selected="$all"
+            selected="$default"
           else
             oses=$(printf '%s\n' $oses | jq . -R | jq . -s)
             selected=$(jq -cn --argjson oses "$oses" --argjson all "$all" '$all - ($all - $oses)')

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ security.
 | macOS       | The three latest major releases |
 | Linux (Ubuntu)| The two latest LTS releases and the latest non-LTS releases |
 | Linux (Fedora) | The versions that are not yet [EOL](https://fedoraproject.org/wiki/End_of_life) |
-| Linux (Debian) | 11 and newer    |
+| Linux (Debian) | 12 and newer    |
 | Android     | 8 and newer        |
 | iOS         | 15.0 and newer     |
 


### PR DESCRIPTION
This PR removes Debian 11 and macOS 12 from the test runs (unless explicitly requested).

Fix DES-1410.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7123)
<!-- Reviewable:end -->
