### PR TITLE
Set net.ipv4.conf.all.arp_ignore=2 when bringing up tunnels on Linux (MLLVD-CR-24-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ Line wrap the file at 100 chars.                                              Th
   leak (as easily) when the VPN tunnel is up. Previously, WSL would leak while in the blocked or
   connecting state, or while lockdown mode was active.
 
+#### Linux
+- Prevent attackers able to send ARP requests to the device running Mullvad from figuring out
+  the in-tunnel IP. Fixes 2024 audit issue `MLLVD-CR-24-03`.
+
 
 ## [2024.7] - 2024-10-30
 This release is identical to 2024.7-beta1.

--- a/README.md
+++ b/README.md
@@ -136,11 +136,19 @@ See [this](Release.md) for instructions on how to make a new release.
     * Set to `"pass"` to add logging to rules allowing packets.
     * Set to `"drop"` to add logging to rules blocking packets.
 
-* `TALPID_FIREWALL_DONT_SET_SRC_VALID_MARK` - Forces the daemon to not set `src_valid_mark` config
-    on Linux. The kernel config option is set because otherwise strict reverse path filtering may
-    prevent relay traffic from reaching the daemon. If `rp_filter` is set to `1` on the interface
+* `TALPID_FIREWALL_DONT_SET_SRC_VALID_MARK` - Set this variable to `1` to stop the daemon from
+    setting the `net.ipv4.conf.all.src_valid_mark` kernel parameter to `1` on Linux when a tunnel
+    is established.
+    The kernel config parameter is set by default, because otherwise strict reverse path filtering
+    may prevent relay traffic from reaching the daemon. If `rp_filter` is set to `1` on the interface
     that will be receiving relay traffic, and `src_valid_mark` is not set to `1`, the daemon will
     not be able to receive relay traffic.
+
+* `TALPID_FIREWALL_DONT_SET_ARP_IGNORE` - Set this variable to `1` to stop the daemon from
+    setting the `net.ipv4.conf.all.arp_ignore` kernel parameter to `2` on Linux when a tunnel
+    is established.
+    The kernel config parameter is set by default, because otherwise an attacker who can send ARP
+    requests to the device running Mullvad can figure out the in-tunnel IP.
 
 * `TALPID_DNS_MODULE` - Allows changing the method that will be used for DNS configuration.
   By default this is automatically detected, but you can set it to one of the options below to


### PR DESCRIPTION
Prevent attackers able to send ARP requests to the device running Mullvad from figuring out the in-tunnel IP.

Fixes 2024 audit issue `MLLVD-CR-24-03`.

Please note that this only fixes the issue on Linux. The issue also exists on Android, but this PR does not touch that.

Documentation about `arp_ignore` and what the different config values mean can be found here: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
A 2019 report about something very related, that brings up the `arp_ignore=2` solution can be found here: https://seclists.org/oss-sec/2019/q4/123

It should be noted that `arp_ignore=1` seems to be enough to solve the immediate issue. But I don't see any downside in being slightly stricter than that. And the blog post linked above used `2` also.

TODO: Add an end-to-end-test? I'll do that in a separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7141)
<!-- Reviewable:end -->
