### PR TITLE
Replace hardcoded usage of "podman" with configurable version

### DIFF
--- a/test/scripts/container-run.sh
+++ b/test/scripts/container-run.sh
@@ -23,7 +23,7 @@ if [[ "$(uname -s)" != "Linux" ]]; then
 fi
 
 container_image=$(cat "$REPO_DIR/building/linux-container-image.txt")
-podman build -t mullvadvpn-app-tests --build-arg IMAGE="${container_image}" .
+"$CONTAINER_RUNNER" build -t mullvadvpn-app-tests --build-arg IMAGE="${container_image}" .
 
 exec "$CONTAINER_RUNNER" run --rm -it \
     -v "${CARGO_REGISTRY_VOLUME_NAME}":/root/.cargo/registry:Z \


### PR DESCRIPTION
Very minor fix. Just making the script consistent in whether or not it hardcodes the container runner. I opted for making it configurable even if no one has tried using it with docker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7144)
<!-- Reviewable:end -->
