### PR TITLE
Prevent install of x86 app on arm64 Windows, and vice versa

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -690,6 +690,22 @@
 		Abort
 	${EndIf}
 
+	Var /GLOBAL NativeTarget
+	${If} ${IsNativeAMD64}
+		StrCpy $NativeTarget "x64"
+	${ElseIf} ${IsNativeARM64}
+		StrCpy $NativeTarget "arm64"
+	${Else}
+		StrCpy $NativeTarget "unsupported arch"
+	${EndIf}
+
+	# $%TARGET_ARCHITECTURE% is set by distribution.js to the corresponding architecture
+	# in https://www.electron.build/builder-util.typealias.archtype
+	${If} $%TARGET_ARCHITECTURE% != $NativeTarget
+		MessageBox MB_ICONSTOP|MB_TOPMOST|MB_OK "This build of the app does not run on $NativeTarget Windows. Please find the appropriate installer on the website."
+		Abort
+	${EndIf}
+
 	# Application settings key
 	# Migrate 2018.(x<6) to current
 	registry::MoveKey "HKLM\SOFTWARE\8fa2c331-e09e-5709-bc74-c59df61f0c7e" "HKLM\SOFTWARE\${PRODUCT_NAME}"

--- a/gui/tasks/distribution.js
+++ b/gui/tasks/distribution.js
@@ -283,6 +283,7 @@ function packWin() {
       beforeBuild: (options) => {
         process.env.CPP_BUILD_MODE = release ? 'Release' : 'Debug';
         process.env.CPP_BUILD_TARGET = options.arch;
+        process.env.TARGET_ARCHITECTURE = options.arch;
         switch (options.arch) {
           case 'x64':
             process.env.TARGET_TRIPLE = 'x86_64-pc-windows-msvc';


### PR DESCRIPTION
Since there is currently a separate build for ARM Windows.

Close DES-187.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7149)
<!-- Reviewable:end -->
