### PR TITLE
Clean up workarounds in macOS preinstall script

### DIFF
--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -44,10 +44,4 @@ rm "$NEW_CACHE_DIR/api-ip-address.txt" || true
 dscl . -delete /groups/mullvad-exclusion &>/dev/null || true
 
 # Kill the GUI before proceeding with the upgrade.
-#
-# When we drop support for all app versions older than 2022.5, we can skip this
-# check and always try to kill the GUI.
-if "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad-setup" is-older-version 2022.5; then
-    pkill -x "Mullvad VPN" || echo "Unable to kill GUI, not running?"
-    sleep 1
-fi
+pkill -x "Mullvad VPN" && sleep 1 || echo "Unable to kill GUI, not running?"

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -40,8 +40,5 @@ fi
 rm "$NEW_CACHE_DIR/relays.json" || true
 rm "$NEW_CACHE_DIR/api-ip-address.txt" || true
 
-# Remove deprecated exclusion group. This line can be removed when 2023.4 is no longer supported
-dscl . -delete /groups/mullvad-exclusion &>/dev/null || true
-
 # Kill the GUI before proceeding with the upgrade.
 pkill -x "Mullvad VPN" && sleep 1 || echo "Unable to kill GUI, not running?"

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -6,7 +6,9 @@ INSTALL_DIR=$2
 
 # Workaround for issue in electron-builder where the pkg-scripts are run twice, once with the
 # correct install dir and once with an incorrect one. This guard prevents running the script when
-# called the second time. This can be reverted when the following issue has been fixed:
+# called the second time.
+#
+# TODO: This can be reverted when the following issue has been fixed:
 # https://github.com/electron-userland/electron-builder/issues/8166
 if [[ $INSTALL_DIR == *"Mullvad VPN.app" ]]; then
     exit 0


### PR DESCRIPTION
This PR cleans up some workarounds present in the preinstall script for macOS which supposedly can be removed because we no longer support the app versions that these workarounds target. I only noticed this because of log output when running the end-to-end tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7162)
<!-- Reviewable:end -->
