### PR TITLE
Silence `RUSTSEC-2024-0384` in `cargo-deny` / test framework

### DIFF
--- a/test/deny.toml
+++ b/test/deny.toml
@@ -18,6 +18,10 @@ yanked = "deny"
 ignore = [
     # Ignored audit issues. This list should be kept short, and effort should be
     # put into removing items from the list.
+
+    # RUSTSEC-2024-0384 - `instant` is unmaintained.
+    # `ssh2 0.9.4` uses `instant`.
+    "RUSTSEC-2024-0384",
 ]
 
 


### PR DESCRIPTION
This is a follow up to #7157 which only silenced `RUSTSEC-2024-0384` for the `osv-scanner` tool, but [I was made aware](https://github.com/mullvad/mullvadvpn-app/actions/runs/11792740683/job/32846900264?pr=7119) that we also need to silence the `cargo-deny` security advisory for our CI to be happy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7163)
<!-- Reviewable:end -->
