### PR TITLE
Reduce flakiness of `test_ui_tunnel_settings`

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -35,7 +35,9 @@ test('App should connect', async () => {
 
   const relay = page.getByTestId('hostname-line');
   const inIp = page.locator(':text("In") + span');
-  const outIp = page.locator(':text("Out") + div > span');
+  // If IPv6 is enabled, there will be two "Out" IPs, one for IPv4 and one for IPv6
+  // Selecting the first resolves to the IPv4 address regardless of the IP setting
+  const outIp = page.locator(':text("Out") + div > span').first();
 
   await expect(relay).toHaveText(process.env.HOSTNAME!);
   await expect(inIp).not.toBeVisible();

--- a/mullvad-daemon/src/custom_list.rs
+++ b/mullvad-daemon/src/custom_list.rs
@@ -1,4 +1,5 @@
-use crate::{new_selector_config, Daemon, Error};
+use crate::{Daemon, Error};
+use mullvad_relay_selector::SelectorConfig;
 use mullvad_types::{
     constraints::Constraint,
     custom_list::{CustomList, Id},
@@ -38,7 +39,7 @@ impl Daemon {
 
         if let Ok(true) = settings_changed {
             self.relay_selector
-                .set_config(new_selector_config(&self.settings));
+                .set_config(SelectorConfig::from_settings(&self.settings));
 
             if self.change_should_cause_reconnect(Some(id)) {
                 log::info!("Initiating tunnel restart because a selected custom list was deleted");
@@ -65,7 +66,7 @@ impl Daemon {
 
         if let Ok(true) = settings_changed {
             self.relay_selector
-                .set_config(new_selector_config(&self.settings));
+                .set_config(SelectorConfig::from_settings(&self.settings));
 
             if self.change_should_cause_reconnect(Some(list_id)) {
                 log::info!("Initiating tunnel restart because a selected custom list changed");
@@ -89,7 +90,7 @@ impl Daemon {
 
         if let Ok(true) = settings_changed {
             self.relay_selector
-                .set_config(new_selector_config(&self.settings));
+                .set_config(SelectorConfig::from_settings(&self.settings));
 
             if self.change_should_cause_reconnect(None) {
                 log::info!("Initiating tunnel restart because a selected custom list was deleted");

--- a/mullvad-relay-selector/src/relay_selector/matcher.rs
+++ b/mullvad-relay-selector/src/relay_selector/matcher.rs
@@ -246,7 +246,7 @@ impl<'a> ResolvedLocationConstraint<'a> {
                         ResolvedLocationConstraint(custom_list.locations.iter().collect())
                     })
                     .unwrap_or_else(|| {
-                        log::warn!("Resolved non-existent custom list");
+                        log::warn!("Resolved non-existent custom list with id {list_id:?}");
                         ResolvedLocationConstraint(vec![])
                     }),
             }),

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -118,6 +118,40 @@ pub struct SelectorConfig {
     pub bridge_settings: BridgeSettings,
 }
 
+impl SelectorConfig {
+    pub fn from_settings(settings: &Settings) -> Self {
+        let additional_constraints = AdditionalRelayConstraints {
+            wireguard: AdditionalWireguardConstraints {
+                #[cfg(daita)]
+                daita: settings.tunnel_options.wireguard.daita.enabled,
+                #[cfg(daita)]
+                daita_use_multihop_if_necessary: settings
+                    .tunnel_options
+                    .wireguard
+                    .daita
+                    .use_multihop_if_necessary,
+
+                #[cfg(not(daita))]
+                daita: false,
+                #[cfg(not(daita))]
+                daita_use_multihop_if_necessary: false,
+
+                quantum_resistant: settings.tunnel_options.wireguard.quantum_resistant,
+            },
+        };
+
+        Self {
+            relay_settings: settings.relay_settings.clone(),
+            additional_constraints,
+            bridge_state: settings.bridge_state,
+            bridge_settings: settings.bridge_settings.clone(),
+            obfuscation_settings: settings.obfuscation_settings.clone(),
+            custom_lists: settings.custom_lists.clone(),
+            relay_overrides: settings.relay_overrides.clone(),
+        }
+    }
+}
+
 /// Extra relay constraints not specified in `relay_settings`.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct AdditionalRelayConstraints {

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -91,11 +91,19 @@ pub async fn test_ui_tunnel_settings(
     rpc: ServiceClient,
     mut mullvad_client: MullvadProxyClient,
 ) -> anyhow::Result<()> {
+    // NOTE: This test connects multiple times using various settings, some of which may cauase a
+    // significant increase in connection time, e.g. multihop and OpenVPN. For this reason, it is
+    // preferable to only target low latency servers.
+    use helpers::custom_lists::LowLatency;
+
     // tunnel-state.spec precondition: a single WireGuard relay should be selected
     log::info!("Select WireGuard relay");
     let entry = helpers::constrain_to_relay(
         &mut mullvad_client,
-        RelayQueryBuilder::new().wireguard().build(),
+        RelayQueryBuilder::new()
+            .wireguard()
+            .location(LowLatency)
+            .build(),
     )
     .await?;
 


### PR DESCRIPTION
Fixes a bug where `test_ui_tunnel_settings` failed on macOS since it has IPv6 enabled by default, which caused the parsing of the outbound IP to fail. 

The PR also sets the "LowLatency" custom list for the test, since it connects multiple times with different settings, including multihop and OpenVPN, and thus is highly dependent on connection stability.

CI job which ran the test 10 times in a row: https://github.com/mullvad/mullvadvpn-app/actions/runs/11838399382.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7166)
<!-- Reviewable:end -->
