### PR TITLE
Add helper script for configuring VS/Windows build environment

### DIFF
--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -93,6 +93,9 @@ The host has to have the following installed:
 
 - Windows 10 (or Windows 11) SDK.
 
+- `bash` installed as well as a few base unix utilities, including `sed` and `tail`.
+  You are recommended to use [Git for Windows].
+
 - `msbuild.exe` available in `%PATH%`. If you installed Visual Studio Community edition, the
   binary can be found under:
 
@@ -102,8 +105,8 @@ The host has to have the following installed:
 
   Where `<arch>` refers to the host architecture, either `amd64` or `arm64`.
 
-- `bash` installed as well as a few base unix utilities, including `sed` and `tail`.
-  You are recommended to use [Git for Windows].
+  The environment can also be set up in bash by sourcing `vcvars.sh`: `. ./scripts/vcvars.sh`. Note
+  that that script assumes that you're running VS 2022 Community.
 
 - The `x86` target is required for building some NSIS plugins:
 
@@ -142,6 +145,9 @@ In addition to the above requirements:
 
   `INCLUDE` also needs to include the correct headers for clang. This can be found by running
   `vcvarsall.bat arm64` and typing `set INCLUDE`.
+
+  The environment can also be set up in bash by sourcing `vcvars.sh`: `. ./scripts/vcvars.sh`. Note
+  that that script assumes that you're running VS 2022 Community.
 
 - `grpc-tools` currently doesn't include ARM builds. The x64 binaries must be installed to build
   the Electron app:

--- a/scripts/vcvars.sh
+++ b/scripts/vcvars.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+#
+# Sourcing this file should set up the appropriate environment for Visual Studio using vcvarsall.bat
+#
+# Currently, this script runs vcvarsall.bat and exports the following (after appropriate
+# conversions):
+# * PATH
+# * INCLUDE
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/utils/host"
+
+case $HOST in
+    x86_64-pc-windows-msvc) HOST_TARGET=x64;;
+    aarch64-pc-windows-msvc) HOST_TARGET=arm64;;
+    *)
+        log_error "Unexpected architecture: $HOST"
+        exit 1
+        ;;
+esac
+
+# Target architecture. Use the host architecture if unspecified.
+TARGET=${TARGET:-"$HOST_TARGET"}
+
+# Path to vcvarsall. This assumes that VS 2022 Community is available
+VCVARSPATH="C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+
+if [[ ! -f "$VCVARSPATH" ]]; then
+    echo -e "vcvarsall.bat not found. Please update the path in the script (${BASH_SOURCE[0]})"
+    exit 1
+fi
+
+VCVARSENV=$(MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' cmd.exe /c "$VCVARSPATH" "$TARGET" \>nul \& set)
+
+declare -A vcenvmap
+
+function populate_vcenvmap {
+    while IFS='=' read -r key value; do
+        vcenvmap[$key]=$value
+    done <<< "$VCVARSENV"
+}
+
+function to_unix_path {
+    # Converts a Windows-style PATH to a UNIX-style PATH
+    # eg from "C:\1\2\3;C:\4\5\6" to "/c/1/2/3:/c/4/5/6"
+    echo "$1" | sed -e 's|\([a-zA-Z]\):|\/\1|g' -e 's|\\|/|g' -e 's|;|:|g'
+}
+
+populate_vcenvmap
+
+export INCLUDE="${vcenvmap["INCLUDE"]}"
+PATH="$(to_unix_path "${vcenvmap["PATH"]}")"
+export PATH
+
+echo "Initialized VS environment for $TARGET"


### PR DESCRIPTION
Add a convenience script that sets up `INCLUDE` and `PATH` for Git Bash correctly by running `vcvarsall.bat <arch>` and converting and exporting those variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7181)
<!-- Reviewable:end -->
