### PR TITLE
Use low latency servers for all tests

### DIFF
--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -154,6 +154,10 @@ impl RelayQuery {
         &self.openvpn_constraints
     }
 
+    pub fn into_openvpn_constraints(self) -> OpenVpnRelayQuery {
+        self.openvpn_constraints
+    }
+
     pub fn set_openvpn_constraints(
         &mut self,
         openvpn_constraints: OpenVpnRelayQuery,
@@ -163,6 +167,10 @@ impl RelayQuery {
 
     pub fn wireguard_constraints(&self) -> &WireguardRelayQuery {
         &self.wireguard_constraints
+    }
+
+    pub fn into_wireguard_constraints(self) -> WireguardRelayQuery {
+        self.wireguard_constraints
     }
 
     pub fn set_wireguard_constraints(
@@ -890,9 +898,8 @@ pub mod builder {
 
     impl<Transport> RelayQueryBuilder<OpenVPN<Transport, BridgeConstraints>> {
         /// Constraint the geographical location of the selected bridge.
-        pub fn bridge_location(mut self, location: GeographicLocationConstraint) -> Self {
-            self.protocol.bridge_settings.location =
-                Constraint::Only(LocationConstraint::from(location));
+        pub fn bridge_location(mut self, location: impl Into<LocationConstraint>) -> Self {
+            self.protocol.bridge_settings.location = Constraint::Only(location.into());
             self.query.openvpn_constraints.bridge_settings =
                 BridgeQuery::Normal(self.protocol.bridge_settings.clone());
             self

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -743,7 +743,7 @@ pub async fn constrain_to_relay(
 ///
 /// This can be used to query the relay selector without triggering a tunnel state change in the
 /// daemon.
-fn get_daemon_relay_selector(
+pub fn get_daemon_relay_selector(
     settings: &mullvad_types::settings::Settings,
     relay_list: mullvad_types::relay_list::RelayList,
 ) -> RelaySelector {

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -767,7 +767,7 @@ pub fn into_constraint(relay: &Relay) -> Constraint<LocationConstraint> {
 
 /// Ping monitoring made easy!
 ///
-/// Continously ping some destination while monitoring to detect diverging
+/// Continuously ping some destination while monitoring to detect diverging
 /// packets.
 ///
 /// To customize [`Pinger`] before the pinging and network monitoring starts,
@@ -897,7 +897,7 @@ impl PingerBuilder {
     }
 }
 
-/// This helper spawns a seperate process which checks if we are connected to Mullvad, and tries to
+/// This helper spawns a separate process which checks if we are connected to Mullvad, and tries to
 /// leak traffic outside the tunnel by sending TCP, UDP, and ICMP packets to [LEAK_DESTINATION].
 pub struct ConnChecker {
     rpc: ServiceClient,
@@ -962,7 +962,7 @@ impl ConnChecker {
         self.payload = Some(payload.into())
     }
 
-    /// Spawn the connecton checker process and return a handle to it.
+    /// Spawn the connection checker process and return a handle to it.
     ///
     /// Dropping the handle will stop the process.
     /// **NOTE**: The handle must be dropped from a tokio runtime context.
@@ -1101,7 +1101,7 @@ impl ConnCheckerHandle<'_> {
     }
 
     pub async fn check_connection(&mut self) -> anyhow::Result<ConnectionStatus> {
-        // Monitor all pakets going to LEAK_DESTINATION during the check.
+        // Monitor all packets going to LEAK_DESTINATION during the check.
         let leak_destination = self.checker.leak_destination;
         let monitor = start_packet_monitor(
             move |packet| packet.destination.ip() == leak_destination.ip(),
@@ -1216,7 +1216,7 @@ pub mod custom_lists {
     /// name to a specific list before runtime.
     static IDS: LazyLock<Mutex<HashMap<List, Id>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
-    /// Pre-defined (well-typed) custom lists which may be useuful in different test scenarios.
+    /// Pre-defined (well-typed) custom lists which may be useful in different test scenarios.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub enum List {
         /// A selection of Nordic servers

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -124,6 +124,7 @@ pub async fn prepare_daemon(
         .context("Failed to disconnect daemon after test")?;
     helpers::ensure_logged_in(&mut mullvad_client).await?;
     helpers::custom_lists::add_default_lists(&mut mullvad_client).await?;
+    helpers::custom_lists::set_default_location(&mut mullvad_client).await?;
 
     Ok(())
 }

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -83,9 +83,12 @@ pub fn get_tests() -> Vec<&'static TestMetadata> {
 }
 
 pub fn get_filtered_tests(specified_tests: &[String]) -> Result<Vec<&TestMetadata>, anyhow::Error> {
-    let mut tests = get_tests();
-    tests.retain(|test| test.should_run_on_os(TEST_CONFIG.os));
-    if !specified_tests.is_empty() {
+    let tests = get_tests();
+
+    let mut tests = if specified_tests.is_empty() {
+        // Keep all tests
+        tests
+    } else {
         specified_tests
             .iter()
             .map(|f| {
@@ -95,11 +98,10 @@ pub fn get_filtered_tests(specified_tests: &[String]) -> Result<Vec<&TestMetadat
                     .cloned()
                     .ok_or(anyhow::anyhow!("Test '{f}' not found"))
             })
-            .collect()
-    } else {
-        // Keep all tests
-        Ok(tests)
-    }
+            .collect::<Result<_, anyhow::Error>>()?
+    };
+    tests.retain(|test| test.should_run_on_os(TEST_CONFIG.os));
+    Ok(tests)
 }
 
 /// Make sure the daemon is installed and logged in and restore settings to the defaults.

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -223,8 +223,6 @@ async fn test_custom_bridge_gui(
     rpc: ServiceClient,
     mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
-    use mullvad_relay_selector::{RelaySelector, SelectorConfig};
-
     // For this test to work, we need to supply the following env-variables:
     //
     // * SHADOWSOCKS_SERVER_IP
@@ -238,8 +236,9 @@ async fn test_custom_bridge_gui(
     // `test_manager::tests::access_methods::test_shadowsocks`.
 
     let gui_test = "custom-bridge.spec";
+    let settings = mullvad_client.get_settings().await.unwrap();
     let relay_list = mullvad_client.get_relay_locations().await.unwrap();
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relay_list);
+    let relay_selector = helpers::get_daemon_relay_selector(&settings, relay_list);
     let custom_proxy = relay_selector
         .get_bridge_forced()
         .expect("`test_shadowsocks` needs at least one shadowsocks relay to execute. Found none in relay list.");

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -91,7 +91,7 @@ pub async fn test_ui_tunnel_settings(
     rpc: ServiceClient,
     mut mullvad_client: MullvadProxyClient,
 ) -> anyhow::Result<()> {
-    // NOTE: This test connects multiple times using various settings, some of which may cauase a
+    // NOTE: This test connects multiple times using various settings, some of which may cause a
     // significant increase in connection time, e.g. multihop and OpenVPN. For this reason, it is
     // preferable to only target low latency servers.
     use helpers::custom_lists::LowLatency;
@@ -236,6 +236,7 @@ async fn test_custom_bridge_gui(
     // `test_manager::tests::access_methods::test_shadowsocks`.
 
     let gui_test = "custom-bridge.spec";
+
     let settings = mullvad_client.get_settings().await.unwrap();
     let relay_list = mullvad_client.get_relay_locations().await.unwrap();
     let relay_selector = helpers::get_daemon_relay_selector(&settings, relay_list);
@@ -278,7 +279,7 @@ pub async fn test_import_settings_ui(_: TestContext, rpc: ServiceClient) -> Resu
     Ok(())
 }
 
-/// Test obufscation settings in the GUI
+/// Test obfuscation settings in the GUI
 #[test_function]
 pub async fn test_obfuscation_settings_ui(_: TestContext, rpc: ServiceClient) -> Result<(), Error> {
     let ui_result = run_test(&rpc, &["obfuscation.spec"]).await?;


### PR DESCRIPTION
Add to `prepare_daemon` a step where the default location, including entry for multihop (but not bridges as it turned out to be problematic), is set to the `Nordic` custom list.

Link to full test run https://github.com/mullvad/mullvadvpn-app/actions/runs/11892409373/job/33137399707. I left in a `dbg!()` statement by accident, so the logs are a little cluttered.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7184)
<!-- Reviewable:end -->
