### PR TITLE
Disable fund and audit output for npm install in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -365,7 +365,7 @@ cargo run --bin relay_list "${CARGO_ARGS[@]}" > build/relays.json
 log_header "Installing JavaScript dependencies"
 
 pushd desktop/packages/mullvad-vpn
-npm ci
+npm ci --no-audit --no-fund
 
 log_header "Packing Mullvad VPN $PRODUCT_VERSION artifact(s)"
 


### PR DESCRIPTION
This PR updates `build.sh` to not output audit and fund info when running `npm ci`. We rely on osv-scanner for dependency vulnerability auditing.

This only applies to the build-script. To disable the audit and fund output when running `npm install` manually, run the following:
```
npm config set audit false
npm config set fund false
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7190)
<!-- Reviewable:end -->
