### PR TITLE
Apply the obfuscation port to the entry configuration only

### DIFF
--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -37,7 +37,7 @@ extension REST {
         public var daita: Bool?
 
         public func override(ipv4AddrIn: IPv4Address?) -> Self {
-            return BridgeRelay(
+            BridgeRelay(
                 hostname: hostname,
                 active: active,
                 owned: owned,
@@ -65,7 +65,7 @@ extension REST {
         public let shadowsocksExtraAddrIn: [String]?
 
         public func override(ipv4AddrIn: IPv4Address?, ipv6AddrIn: IPv6Address?) -> Self {
-            return ServerRelay(
+            ServerRelay(
                 hostname: hostname,
                 active: active,
                 owned: owned,
@@ -82,7 +82,7 @@ extension REST {
         }
 
         public func override(daita: Bool) -> Self {
-            return ServerRelay(
+            ServerRelay(
                 hostname: hostname,
                 active: active,
                 owned: owned,

--- a/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
+++ b/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
@@ -22,6 +22,7 @@ protocol MultihopDecisionFlow {
 struct OneToOne: MultihopDecisionFlow {
     let next: MultihopDecisionFlow?
     let relayPicker: RelayPicking
+
     init(next: (any MultihopDecisionFlow)?, relayPicker: RelayPicking) {
         self.next = next
         self.relayPicker = relayPicker
@@ -47,10 +48,11 @@ struct OneToOne: MultihopDecisionFlow {
             throw NoRelaysSatisfyingConstraintsError(.entryEqualsExit)
         }
 
-        let exitMatch = try relayPicker.findBestMatch(from: exitCandidates)
+        let exitMatch = try relayPicker.findBestMatch(from: exitCandidates, obfuscate: false)
         let entryMatch = try relayPicker.findBestMatch(
             from: entryCandidates,
-            closeTo: daitaAutomaticRouting ? exitMatch.location : nil
+            closeTo: daitaAutomaticRouting ? exitMatch.location : nil,
+            obfuscate: true
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
@@ -95,8 +97,8 @@ struct OneToMany: MultihopDecisionFlow {
                 .pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates, daitaAutomaticRouting: true)
         }
 
-        let entryMatch = try multihopPicker.findBestMatch(from: entryCandidates)
-        let exitMatch = try multihopPicker.exclude(relay: entryMatch, from: exitCandidates)
+        let entryMatch = try multihopPicker.findBestMatch(from: entryCandidates, obfuscate: true)
+        let exitMatch = try multihopPicker.exclude(relay: entryMatch, from: exitCandidates, obfuscate: false)
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
     }
@@ -135,11 +137,12 @@ struct ManyToOne: MultihopDecisionFlow {
             )
         }
 
-        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates)
+        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates, obfuscate: false)
         let entryMatch = try multihopPicker.exclude(
             relay: exitMatch,
             from: entryCandidates,
-            closeTo: daitaAutomaticRouting ? exitMatch.location : nil
+            closeTo: daitaAutomaticRouting ? exitMatch.location : nil,
+            obfuscate: true
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
@@ -179,11 +182,12 @@ struct ManyToMany: MultihopDecisionFlow {
             )
         }
 
-        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates)
+        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates, obfuscate: false)
         let entryMatch = try multihopPicker.exclude(
             relay: exitMatch,
             from: entryCandidates,
-            closeTo: daitaAutomaticRouting ? exitMatch.location : nil
+            closeTo: daitaAutomaticRouting ? exitMatch.location : nil,
+            obfuscate: true
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)

--- a/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
+++ b/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
@@ -48,11 +48,11 @@ struct OneToOne: MultihopDecisionFlow {
             throw NoRelaysSatisfyingConstraintsError(.entryEqualsExit)
         }
 
-        let exitMatch = try relayPicker.findBestMatch(from: exitCandidates, obfuscate: false)
+        let exitMatch = try relayPicker.findBestMatch(from: exitCandidates, useObfuscatedPortIfAvailable: false)
         let entryMatch = try relayPicker.findBestMatch(
             from: entryCandidates,
             closeTo: daitaAutomaticRouting ? exitMatch.location : nil,
-            obfuscate: true
+            useObfuscatedPortIfAvailable: true
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
@@ -97,8 +97,12 @@ struct OneToMany: MultihopDecisionFlow {
                 .pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates, daitaAutomaticRouting: true)
         }
 
-        let entryMatch = try multihopPicker.findBestMatch(from: entryCandidates, obfuscate: true)
-        let exitMatch = try multihopPicker.exclude(relay: entryMatch, from: exitCandidates, obfuscate: false)
+        let entryMatch = try multihopPicker.findBestMatch(from: entryCandidates, useObfuscatedPortIfAvailable: true)
+        let exitMatch = try multihopPicker.exclude(
+            relay: entryMatch,
+            from: exitCandidates,
+            useObfuscatedPortIfAvailable: false
+        )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
     }
@@ -137,12 +141,12 @@ struct ManyToOne: MultihopDecisionFlow {
             )
         }
 
-        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates, obfuscate: false)
+        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates, useObfuscatedPortIfAvailable: false)
         let entryMatch = try multihopPicker.exclude(
             relay: exitMatch,
             from: entryCandidates,
             closeTo: daitaAutomaticRouting ? exitMatch.location : nil,
-            obfuscate: true
+            useObfuscatedPortIfAvailable: true
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)
@@ -182,12 +186,12 @@ struct ManyToMany: MultihopDecisionFlow {
             )
         }
 
-        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates, obfuscate: false)
+        let exitMatch = try multihopPicker.findBestMatch(from: exitCandidates, useObfuscatedPortIfAvailable: false)
         let entryMatch = try multihopPicker.exclude(
             relay: exitMatch,
             from: entryCandidates,
             closeTo: daitaAutomaticRouting ? exitMatch.location : nil,
-            obfuscate: true
+            useObfuscatedPortIfAvailable: true
         )
 
         return SelectedRelays(entry: entryMatch, exit: exitMatch, retryAttempt: relayPicker.connectionAttemptCount)

--- a/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
+++ b/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
@@ -12,6 +12,7 @@ import MullvadTypes
 struct ObfuscatorPortSelection {
     let relays: REST.ServerRelaysResponse
     let port: RelayConstraint<UInt16>
+    let method: WireGuardObfuscationState
 }
 
 struct ObfuscatorPortSelector {
@@ -44,7 +45,7 @@ struct ObfuscatorPortSelector {
             break
         }
 
-        return ObfuscatorPortSelection(relays: relays, port: port)
+        return ObfuscatorPortSelection(relays: relays, port: port, method: obfuscationMethod)
     }
 
     private func obfuscateShadowsocksRelays(tunnelSettings: LatestTunnelSettings) -> REST.ServerRelaysResponse {

--- a/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
+++ b/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
@@ -9,7 +9,7 @@
 import MullvadSettings
 import MullvadTypes
 
-struct ObfuscatorPortSelectorResult {
+struct ObfuscatorPortSelection {
     let relays: REST.ServerRelaysResponse
     let port: RelayConstraint<UInt16>
 }
@@ -20,7 +20,7 @@ struct ObfuscatorPortSelector {
     func obfuscate(
         tunnelSettings: LatestTunnelSettings,
         connectionAttemptCount: UInt
-    ) throws -> ObfuscatorPortSelectorResult {
+    ) throws -> ObfuscatorPortSelection {
         var relays = relays
         var port = tunnelSettings.relayConstraints.port
         let obfuscationMethod = ObfuscationMethodSelector.obfuscationMethodBy(
@@ -44,7 +44,7 @@ struct ObfuscatorPortSelector {
             break
         }
 
-        return ObfuscatorPortSelectorResult(relays: relays, port: port)
+        return ObfuscatorPortSelection(relays: relays, port: port)
     }
 
     private func obfuscateShadowsocksRelays(tunnelSettings: LatestTunnelSettings) -> REST.ServerRelaysResponse {

--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -20,28 +20,25 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol {
         tunnelSettings: LatestTunnelSettings,
         connectionAttemptCount: UInt
     ) throws -> SelectedRelays {
-        let obfuscationResult = try ObfuscatorPortSelector(
+        let obfuscation = try ObfuscatorPortSelector(
             relays: try relayCache.read().relays
         ).obfuscate(
             tunnelSettings: tunnelSettings,
             connectionAttemptCount: connectionAttemptCount
         )
 
-        var constraints = tunnelSettings.relayConstraints
-        constraints.port = obfuscationResult.port
-
         return switch tunnelSettings.tunnelMultihopState {
         case .off:
             try SinglehopPicker(
-                relays: obfuscationResult.relays,
-                constraints: constraints,
+                obfuscation: obfuscation,
+                constraints: tunnelSettings.relayConstraints,
                 connectionAttemptCount: connectionAttemptCount,
                 daitaSettings: tunnelSettings.daita
             ).pick()
         case .on:
             try MultihopPicker(
-                relays: obfuscationResult.relays,
-                constraints: constraints,
+                obfuscation: obfuscation,
+                constraints: tunnelSettings.relayConstraints,
                 connectionAttemptCount: connectionAttemptCount,
                 daitaSettings: tunnelSettings.daita
             ).pick()

--- a/ios/MullvadSettings/TunnelSettingsStrategy.swift
+++ b/ios/MullvadSettings/TunnelSettingsStrategy.swift
@@ -18,9 +18,7 @@ public struct TunnelSettingsStrategy: TunnelSettingsStrategyProtocol {
         newSettings: LatestTunnelSettings
     ) -> Bool {
         switch (oldSettings, newSettings) {
-        case let (old, new) where old.relayConstraints != new.relayConstraints,
-             let (old, new) where old.tunnelMultihopState != new.tunnelMultihopState,
-             let (old, new) where old.daita != new.daita:
+        case let (old, new) where old != new:
             true
         default:
             false

--- a/ios/MullvadTypes/MullvadEndpoint.swift
+++ b/ios/MullvadTypes/MullvadEndpoint.swift
@@ -30,4 +30,14 @@ public struct MullvadEndpoint: Equatable, Codable {
         self.ipv6Gateway = ipv6Gateway
         self.publicKey = publicKey
     }
+
+    public func override(ipv4Relay: IPv4Endpoint) -> Self {
+        MullvadEndpoint(
+            ipv4Relay: ipv4Relay,
+            ipv6Relay: ipv6Relay,
+            ipv4Gateway: ipv4Gateway,
+            ipv6Gateway: ipv6Gateway,
+            publicKey: publicKey
+        )
+    }
 }

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
@@ -160,13 +160,16 @@ class MultihopDecisionFlowTests: XCTestCase {
 
 extension MultihopDecisionFlowTests {
     var picker: MultihopPicker {
+        let obfuscation = try? ObfuscatorPortSelector(relays: sampleRelays)
+            .obfuscate(tunnelSettings: LatestTunnelSettings(), connectionAttemptCount: 0)
+
         let constraints = RelayConstraints(
             entryLocations: .only(UserSelectedRelays(locations: [.city("se", "sto")])),
             exitLocations: .only(UserSelectedRelays(locations: [.city("se", "sto")]))
         )
 
         return MultihopPicker(
-            relays: sampleRelays,
+            obfuscation: obfuscation.unsafelyUnwrapped,
             constraints: constraints,
             connectionAttemptCount: 0,
             daitaSettings: DAITASettings(daitaState: .off)

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelSettingsStrategyTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelSettingsStrategyTests.swift
@@ -52,7 +52,7 @@ final class TunnelSettingsStrategyTests: XCTestCase {
         TunnelSettingsUpdate.dnsSettings(dnsSettings).apply(to: &updatedSettings)
 
         let tunnelSettingsStrategy = TunnelSettingsStrategy()
-        XCTAssertFalse(tunnelSettingsStrategy.shouldReconnectToNewRelay(
+        XCTAssertTrue(tunnelSettingsStrategy.shouldReconnectToNewRelay(
             oldSettings: currentSettings,
             newSettings: updatedSettings
         ))
@@ -66,7 +66,7 @@ final class TunnelSettingsStrategyTests: XCTestCase {
         TunnelSettingsUpdate.quantumResistance(.on).apply(to: &updatedSettings)
 
         let tunnelSettingsStrategy = TunnelSettingsStrategy()
-        XCTAssertFalse(tunnelSettingsStrategy.shouldReconnectToNewRelay(
+        XCTAssertTrue(tunnelSettingsStrategy.shouldReconnectToNewRelay(
             oldSettings: currentSettings,
             newSettings: updatedSettings
         ))
@@ -88,7 +88,7 @@ final class TunnelSettingsStrategyTests: XCTestCase {
         .apply(to: &updatedSettings)
 
         let tunnelSettingsStrategy = TunnelSettingsStrategy()
-        XCTAssertFalse(tunnelSettingsStrategy.shouldReconnectToNewRelay(
+        XCTAssertTrue(tunnelSettingsStrategy.shouldReconnectToNewRelay(
             oldSettings: currentSettings,
             newSettings: updatedSettings
         ))


### PR DESCRIPTION
Currently, the obfuscation port is applied to the exit configuration at all times. Instead, it should be applied to the entry configuration when using multihop.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7199)
<!-- Reviewable:end -->
