### PR TITLE
Make `test_wireguard_tunnel` use `location: Any`

### DIFF
--- a/test/test-manager/src/tests/tunnel.rs
+++ b/test/test-manager/src/tests/tunnel.rs
@@ -18,7 +18,7 @@ use mullvad_types::{
     constraints::Constraint,
     relay_constraints::{
         self, BridgeConstraints, BridgeSettings, BridgeType, OpenVpnConstraints, RelayConstraints,
-        RelaySettings, TransportPort, WireguardConstraints,
+        RelaySettings, TransportPort,
     },
     wireguard,
 };
@@ -103,18 +103,11 @@ pub async fn test_wireguard_tunnel(
     for (port, should_succeed) in PORTS {
         log::info!("Connect to WireGuard endpoint on port {port}");
 
-        let relay_settings = RelaySettings::Normal(RelayConstraints {
-            tunnel_protocol: Constraint::Only(TunnelType::Wireguard),
-            wireguard_constraints: WireguardConstraints {
-                port: Constraint::Only(port),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
+        let query = RelayQueryBuilder::new().wireguard().port(port).build();
 
-        set_relay_settings(&mut mullvad_client, relay_settings)
+        apply_settings_from_relay_query(&mut mullvad_client, query)
             .await
-            .expect("failed to update relay settings");
+            .unwrap();
 
         let connection_result = connect_and_wait(&mut mullvad_client).await;
         assert_eq!(


### PR DESCRIPTION
`test_daita` sets each relay manually, so we skip setting the `Any` location constraint for it.

Test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/11934895345

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7209)
<!-- Reviewable:end -->
