### PR TITLE
Fix ANR due to the tokio runtime being blocked by `getaddrinfo` when dropped.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,6 +2371,7 @@ dependencies = [
  "either",
  "fern",
  "futures",
+ "hickory-resolver",
  "libc",
  "log",
  "log-panics",

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix a bug where the Android account expiry notifications would not be updated if the app was
   running in the background for a long time.
+- Fix ANR due to the tokio runtime being blocked by `getaddrinfo` when dropped.
 
 
 ## [android/2024.8] - 2024-11-01

--- a/android/lib/talpid/build.gradle.kts
+++ b/android/lib/talpid/build.gradle.kts
@@ -31,6 +31,7 @@ android {
 dependencies {
     implementation(projects.lib.model)
 
+    implementation(libs.androidx.ktx)
     implementation(libs.androidx.lifecycle.service)
     implementation(libs.kermit)
     implementation(libs.kotlin.stdlib)

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -75,15 +75,12 @@ class ConnectivityListener {
     fun unregister() {
         connectivityManager.unregisterNetworkCallback(callback)
         connectivityManager.unregisterNetworkCallback(defaultNetworkCallback)
-    }
 
-    // DROID-1401
-    // This function has never been used and should most likely be merged into unregister(),
-    // along with ensuring that the lifecycle of it is correct.
-    @Suppress("UnusedPrivateMember")
-    private fun finalize() {
-        destroySender(senderAddress)
-        senderAddress = 0L
+        if (senderAddress != 0L) {
+            var oldSender = senderAddress
+            senderAddress = 0L
+            destroySender(oldSender)
+        }
     }
 
     private external fun notifyConnectivityChange(isConnected: Boolean, senderAddress: Long)

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -161,7 +161,7 @@ open class TalpidVpnService : LifecycleVpnService() {
     private external fun waitForTunnelUp(tunFd: Int, isIpv6Enabled: Boolean)
 
     companion object {
-        private const val FALLBACK_DUMMY_DNS_SERVER = "192.0.2.1"
+        const val FALLBACK_DUMMY_DNS_SERVER = "192.0.2.1"
 
         private const val IPV4_PREFIX_LENGTH = 32
         private const val IPV6_PREFIX_LENGTH = 128

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -1,7 +1,10 @@
 package net.mullvad.talpid
 
+import android.net.ConnectivityManager
 import android.os.ParcelFileDescriptor
 import androidx.annotation.CallSuper
+import androidx.core.content.getSystemService
+import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
 import java.net.Inet4Address
 import java.net.Inet6Address
@@ -29,12 +32,13 @@ open class TalpidVpnService : LifecycleVpnService() {
     private var currentTunConfig: TunConfig? = null
 
     // Used by JNI
-    val connectivityListener = ConnectivityListener()
+    lateinit var connectivityListener: ConnectivityListener
 
     @CallSuper
     override fun onCreate() {
         super.onCreate()
-        connectivityListener.register(this)
+        connectivityListener = ConnectivityListener(getSystemService<ConnectivityManager>()!!)
+        connectivityListener.register(lifecycleScope)
     }
 
     @CallSuper

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/ConnectivityManagerUtil.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/ConnectivityManagerUtil.kt
@@ -1,0 +1,132 @@
+package net.mullvad.talpid.util
+
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+sealed interface NetworkEvent {
+    data class Available(val network: Network) : NetworkEvent
+
+    data object Unavailable : NetworkEvent
+
+    data class LinkPropertiesChanged(val network: Network, val linkProperties: LinkProperties) :
+        NetworkEvent
+
+    data class CapabilitiesChanged(
+        val network: Network,
+        val networkCapabilities: NetworkCapabilities,
+    ) : NetworkEvent
+
+    data class BlockedStatusChanged(val network: Network, val blocked: Boolean) : NetworkEvent
+
+    data class Losing(val network: Network, val maxMsToLive: Int) : NetworkEvent
+
+    data class Lost(val network: Network) : NetworkEvent
+}
+
+fun ConnectivityManager.defaultNetworkFlow(): Flow<NetworkEvent> =
+    callbackFlow<NetworkEvent> {
+        val callback =
+            object : NetworkCallback() {
+                override fun onLinkPropertiesChanged(
+                    network: Network,
+                    linkProperties: LinkProperties,
+                ) {
+                    super.onLinkPropertiesChanged(network, linkProperties)
+                    trySendBlocking(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
+                }
+
+                override fun onAvailable(network: Network) {
+                    super.onAvailable(network)
+                    trySendBlocking(NetworkEvent.Available(network))
+                }
+
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    networkCapabilities: NetworkCapabilities,
+                ) {
+                    super.onCapabilitiesChanged(network, networkCapabilities)
+                    trySendBlocking(NetworkEvent.CapabilitiesChanged(network, networkCapabilities))
+                }
+
+                override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
+                    super.onBlockedStatusChanged(network, blocked)
+                    trySendBlocking(NetworkEvent.BlockedStatusChanged(network, blocked))
+                }
+
+                override fun onLosing(network: Network, maxMsToLive: Int) {
+                    super.onLosing(network, maxMsToLive)
+                    trySendBlocking(NetworkEvent.Losing(network, maxMsToLive))
+                }
+
+                override fun onLost(network: Network) {
+                    super.onLost(network)
+                    trySendBlocking(NetworkEvent.Lost(network))
+                }
+
+                override fun onUnavailable() {
+                    super.onUnavailable()
+                    trySendBlocking(NetworkEvent.Unavailable)
+                }
+            }
+        registerDefaultNetworkCallback(callback)
+
+        awaitClose { unregisterNetworkCallback(callback) }
+    }
+
+fun ConnectivityManager.networkFlow(networkRequest: NetworkRequest): Flow<NetworkEvent> =
+    callbackFlow<NetworkEvent> {
+        val callback =
+            object : NetworkCallback() {
+                override fun onLinkPropertiesChanged(
+                    network: Network,
+                    linkProperties: LinkProperties,
+                ) {
+                    super.onLinkPropertiesChanged(network, linkProperties)
+                    trySendBlocking(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
+                }
+
+                override fun onAvailable(network: Network) {
+                    super.onAvailable(network)
+                    trySendBlocking(NetworkEvent.Available(network))
+                }
+
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    networkCapabilities: NetworkCapabilities,
+                ) {
+                    super.onCapabilitiesChanged(network, networkCapabilities)
+                    trySendBlocking(NetworkEvent.CapabilitiesChanged(network, networkCapabilities))
+                }
+
+                override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
+                    super.onBlockedStatusChanged(network, blocked)
+                    trySendBlocking(NetworkEvent.BlockedStatusChanged(network, blocked))
+                }
+
+                override fun onLosing(network: Network, maxMsToLive: Int) {
+                    super.onLosing(network, maxMsToLive)
+                    trySendBlocking(NetworkEvent.Losing(network, maxMsToLive))
+                }
+
+                override fun onLost(network: Network) {
+                    super.onLost(network)
+                    trySendBlocking(NetworkEvent.Lost(network))
+                }
+
+                override fun onUnavailable() {
+                    super.onUnavailable()
+                    trySendBlocking(NetworkEvent.Unavailable)
+                }
+            }
+        registerNetworkCallback(networkRequest, callback)
+
+        awaitClose { unregisterNetworkCallback(callback) }
+    }

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -203,6 +203,7 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     override fun onDestroy() {
+        super.onDestroy()
         Logger.i("MullvadVpnService: onDestroy")
         // Shutting down the daemon gracefully
         managementService.stop()
@@ -214,7 +215,6 @@ class MullvadVpnService : TalpidVpnService() {
         managementService.enterIdle()
 
         Logger.i("Shutdown complete")
-        super.onDestroy()
     }
 
     // If an intent is from the system it is because of the OS starting/stopping the VPN.

--- a/mullvad-api/src/bin/relay_list.rs
+++ b/mullvad-api/src/bin/relay_list.rs
@@ -2,13 +2,15 @@
 //! Used by the installer artifact packer to bundle the latest available
 //! relay list at the time of creating the installer.
 
-use mullvad_api::{proxy::ApiConnectionMode, rest::Error as RestError, RelayListProxy};
+use mullvad_api::{
+    proxy::ApiConnectionMode, rest::Error as RestError, DefaultDnsResolver, RelayListProxy,
+};
 use std::process;
 use talpid_types::ErrorExt;
 
 #[tokio::main]
 async fn main() {
-    let runtime = mullvad_api::Runtime::new(tokio::runtime::Handle::current())
+    let runtime = mullvad_api::Runtime::new(tokio::runtime::Handle::current(), DefaultDnsResolver)
         .expect("Failed to load runtime");
 
     let relay_list_request =

--- a/mullvad-api/src/https_client_with_sni.rs
+++ b/mullvad-api/src/https_client_with_sni.rs
@@ -2,17 +2,14 @@ use crate::{
     abortable_stream::{AbortableStream, AbortableStreamHandle},
     proxy::{ApiConnection, ApiConnectionMode, ProxyConfig},
     tls_stream::TlsStream,
-    AddressCache,
+    AddressCache, DnsResolver,
 };
 use futures::{channel::mpsc, future, pin_mut, StreamExt};
 #[cfg(target_os = "android")]
 use futures::{channel::oneshot, sink::SinkExt};
 use http::uri::Scheme;
 use hyper::Uri;
-use hyper_util::{
-    client::legacy::connect::dns::{GaiResolver, Name},
-    rt::TokioIo,
-};
+use hyper_util::rt::TokioIo;
 use mullvad_encrypted_dns_proxy::{
     config::ProxyConfig as EncryptedDNSConfig, Forwarder as EncryptedDNSForwarder,
 };
@@ -291,6 +288,7 @@ pub struct HttpsConnectorWithSni {
     sni_hostname: Option<String>,
     address_cache: AddressCache,
     abort_notify: Arc<tokio::sync::Notify>,
+    dns_resolver: Arc<dyn DnsResolver>,
     #[cfg(target_os = "android")]
     socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
 }
@@ -307,6 +305,7 @@ impl HttpsConnectorWithSni {
     pub fn new(
         sni_hostname: Option<String>,
         address_cache: AddressCache,
+        dns_resolver: Arc<dyn DnsResolver>,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> (Self, HttpsConnectorWithSniHandle) {
         let (tx, mut rx) = mpsc::unbounded();
@@ -355,6 +354,7 @@ impl HttpsConnectorWithSni {
                 sni_hostname,
                 address_cache,
                 abort_notify,
+                dns_resolver,
                 #[cfg(target_os = "android")]
                 socket_bypass_tx,
             },
@@ -388,7 +388,11 @@ impl HttpsConnectorWithSni {
             .map_err(|err| io::Error::new(io::ErrorKind::TimedOut, err))?
     }
 
-    async fn resolve_address(address_cache: AddressCache, uri: Uri) -> io::Result<SocketAddr> {
+    async fn resolve_address(
+        address_cache: AddressCache,
+        dns_resolver: &dyn DnsResolver,
+        uri: Uri,
+    ) -> io::Result<SocketAddr> {
         const DEFAULT_PORT: u16 = 443;
 
         let hostname = uri.host().ok_or_else(|| {
@@ -408,19 +412,13 @@ impl HttpsConnectorWithSni {
             ));
         }
 
-        // Use getaddrinfo as a fallback
+        // Use DNS resolution as fallback
         //
-        let mut addrs = GaiResolver::new()
-            .call(
-                Name::from_str(hostname)
-                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?,
-            )
-            .await
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        let addrs = dns_resolver.resolve(hostname.to_owned()).await?;
         let addr = addrs
-            .next()
+            .get(0)
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Empty DNS response"))?;
-        Ok(SocketAddr::new(addr.ip(), port.unwrap_or(DEFAULT_PORT)))
+        Ok(SocketAddr::new(*addr, port.unwrap_or(DEFAULT_PORT)))
     }
 }
 
@@ -455,6 +453,7 @@ impl Service<Uri> for HttpsConnectorWithSni {
         #[cfg(target_os = "android")]
         let socket_bypass_tx = self.socket_bypass_tx.clone();
         let address_cache = self.address_cache.clone();
+        let dns_resolver = self.dns_resolver.clone();
 
         let fut = async move {
             if uri.scheme() != Some(&Scheme::HTTPS) {
@@ -465,7 +464,7 @@ impl Service<Uri> for HttpsConnectorWithSni {
             }
 
             let hostname = sni_hostname?;
-            let addr = Self::resolve_address(address_cache, uri).await?;
+            let addr = Self::resolve_address(address_cache, &*dns_resolver, uri).await?;
 
             // Loop until we have established a connection. This starts over if a new endpoint
             // is selected while connecting.

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -6,6 +6,7 @@ use crate::{
     availability::ApiAvailability,
     https_client_with_sni::{HttpsConnectorWithSni, HttpsConnectorWithSniHandle},
     proxy::ConnectionModeProvider,
+    DnsResolver,
 };
 use futures::{
     channel::{mpsc, oneshot},
@@ -154,11 +155,13 @@ impl<T: ConnectionModeProvider + 'static> RequestService<T> {
         api_availability: ApiAvailability,
         address_cache: AddressCache,
         connection_mode_provider: T,
+        dns_resolver: Arc<dyn DnsResolver>,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> RequestServiceHandle {
         let (connector, connector_handle) = HttpsConnectorWithSni::new(
             sni_hostname,
             address_cache.clone(),
+            dns_resolver,
             #[cfg(target_os = "android")]
             socket_bypass_tx.clone(),
         );

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { workspace = true, features =  ["test-util"] }
 
 [target.'cfg(target_os="android")'.dependencies]
 android_logger = "0.8"
+hickory-resolver = { version = "0.24.1" }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"

--- a/mullvad-daemon/src/android_dns.rs
+++ b/mullvad-daemon/src/android_dns.rs
@@ -1,0 +1,53 @@
+#![cfg(target_os = "android")]
+//! A non-blocking DNS resolver. `getaddrinfo` tends to prevent the tokio runtime from being
+//! dropped, since it waits indefinitely on blocking threads. This is particularly bad on Android,
+//! so we use a non-blocking resolver instead.
+
+use hickory_resolver::{
+    config::{NameServerConfigGroup, ResolverConfig, ResolverOpts},
+    TokioAsyncResolver,
+};
+use mullvad_api::DnsResolver;
+use std::{future::Future, io, net::IpAddr, pin::Pin};
+
+pub struct AndroidDnsResolver {
+    connectivity_listener: talpid_core::connectivity_listener::ConnectivityListener,
+}
+
+impl AndroidDnsResolver {
+    pub fn new(
+        connectivity_listener: talpid_core::connectivity_listener::ConnectivityListener,
+    ) -> Self {
+        Self {
+            connectivity_listener,
+        }
+    }
+}
+
+impl DnsResolver for AndroidDnsResolver {
+    fn resolve(
+        &self,
+        host: String,
+    ) -> Pin<Box<dyn Future<Output = io::Result<Vec<IpAddr>>> + Send>> {
+        let ips = self.connectivity_listener.current_dns_servers();
+
+        Box::pin(async move {
+            let ips = ips.map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to retrieve current servers: {err}"),
+                )
+            })?;
+            let group = NameServerConfigGroup::from_ips_clear(&ips, 53, false);
+
+            let config = ResolverConfig::from_parts(None, vec![], group);
+            let resolver = TokioAsyncResolver::tokio(config, ResolverOpts::default());
+
+            let lookup = resolver.lookup_ip(host).await.map_err(|err| {
+                io::Error::new(io::ErrorKind::Other, format!("lookup_ip failed: {err}"))
+            })?;
+
+            Ok(lookup.into_iter().collect())
+        })
+    }
+}

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -624,7 +624,6 @@ impl Daemon {
 
         mullvad_api::proxy::ApiConnectionMode::try_delete_cache(&cache_dir).await;
         let api_runtime = mullvad_api::Runtime::with_cache(
-            // FIXME: clone is bad (single sender)
             #[cfg(target_os = "android")]
             android_dns::AndroidDnsResolver::new(connectivity_listener.clone()),
             #[cfg(not(target_os = "android"))]

--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -122,6 +122,8 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_shutdow
     if let Some(context) = DAEMON_CONTEXT.lock().unwrap().take() {
         _ = context.daemon_command_tx.shutdown();
         _ = context.runtime.block_on(context.running_daemon);
+
+        // Dropping the tokio runtime will block if there are any tasks in flight.
     }
 }
 

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -1,4 +1,4 @@
-use mullvad_api::proxy::ApiConnectionMode;
+use mullvad_api::{proxy::ApiConnectionMode, DefaultDnsResolver};
 use regex::Regex;
 use std::{
     borrow::Cow,
@@ -292,6 +292,8 @@ async fn send_problem_report_inner(
 ) -> Result<(), Error> {
     let metadata = ProblemReport::parse_metadata(report_content).unwrap_or_else(metadata::collect);
     let api_runtime = mullvad_api::Runtime::with_cache(
+        // This is irrelevant since no DNS lookups will be made
+        DefaultDnsResolver,
         cache_dir,
         false,
         #[cfg(target_os = "android")]

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::{path::PathBuf, process, str::FromStr, sync::LazyLock, time::Duration};
 
-use mullvad_api::{proxy::ApiConnectionMode, DEVICE_NOT_FOUND};
+use mullvad_api::{proxy::ApiConnectionMode, DefaultDnsResolver, DEVICE_NOT_FOUND};
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::version::ParsedAppVersion;
 use talpid_core::firewall::{self, Firewall};
@@ -152,7 +152,7 @@ async fn remove_device() -> Result<(), Error> {
         .await
         .map_err(Error::ReadDeviceCacheError)?;
     if let Some(device) = state.into_device() {
-        let api_runtime = mullvad_api::Runtime::with_cache(&cache_path, false)
+        let api_runtime = mullvad_api::Runtime::with_cache(DefaultDnsResolver, &cache_path, false)
             .await
             .map_err(Error::RpcInitializationError)?;
 

--- a/talpid-core/src/connectivity_listener.rs
+++ b/talpid-core/src/connectivity_listener.rs
@@ -1,0 +1,249 @@
+//! Rust wrapper around Android connectivity listener
+
+use futures::channel::mpsc::UnboundedSender;
+use jnix::{
+    jni::{
+        self,
+        objects::{GlobalRef, JObject, JValue},
+        signature::{JavaType, Primitive},
+        sys::{jboolean, jlong, JNI_TRUE},
+        JNIEnv, JavaVM,
+    },
+    JnixEnv,
+    FromJava,
+};
+use std::{net::IpAddr, sync::{Arc, Weak}};
+use talpid_types::{android::AndroidContext, net::Connectivity, ErrorExt};
+
+/// Error related to Android connectivity monitor
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Failed to attach Java VM to tunnel thread
+    #[error("Failed to attach Java VM to tunnel thread")]
+    AttachJvmToThread(#[source] jni::errors::Error),
+
+    /// Failed to call Java method
+    #[error("Failed to call Java method {0}.{1}")]
+    CallMethod(&'static str, &'static str, #[source] jni::errors::Error),
+
+    /// Failed to create global reference to Java object
+    #[error("Failed to create global reference to Java object")]
+    CreateGlobalRef(#[source] jni::errors::Error),
+
+    /// Failed to find method
+    #[error("Failed to find {0}.{1} method")]
+    FindMethod(&'static str, &'static str, #[source] jni::errors::Error),
+
+    /// Method returned invalid result
+    #[error("Received an invalid result from {0}.{1}: {2}")]
+    InvalidMethodResult(&'static str, &'static str, String),
+}
+
+/// Android connectivity listener
+#[derive(Clone)]
+pub struct ConnectivityListener {
+    jvm: Arc<JavaVM>,
+    class: GlobalRef,
+    object: GlobalRef,
+    _sender: Option<Arc<UnboundedSender<Connectivity>>>,
+}
+
+impl ConnectivityListener {
+    /// Create a new connectivity listener
+    pub fn new(android_context: AndroidContext) -> Result<Self, Error> {
+        let env = JnixEnv::from(
+            android_context
+                .jvm
+                .attach_current_thread_as_daemon()
+                .map_err(Error::AttachJvmToThread)?,
+        );
+
+        let get_connectivity_listener_method = env
+            .get_method_id(
+                &env.get_class("net/mullvad/talpid/TalpidVpnService"),
+                "getConnectivityListener",
+                "()Lnet/mullvad/talpid/ConnectivityListener;",
+            )
+            .map_err(|cause| {
+                Error::FindMethod("MullvadVpnService", "getConnectivityListener", cause)
+            })?;
+
+        let result = env
+            .call_method_unchecked(
+                android_context.vpn_service.as_obj(),
+                get_connectivity_listener_method,
+                JavaType::Object("Lnet/mullvad/talpid/ConnectivityListener;".to_owned()),
+                &[],
+            )
+            .map_err(|cause| {
+                Error::CallMethod("MullvadVpnService", "getConnectivityListener", cause)
+            })?;
+
+        let object = match result {
+            JValue::Object(object) => env.new_global_ref(object).map_err(Error::CreateGlobalRef)?,
+            value => {
+                return Err(Error::InvalidMethodResult(
+                    "MullvadVpnService",
+                    "getConnectivityListener",
+                    format!("{:?}", value),
+                ))
+            }
+        };
+
+        let class = env.get_class("net/mullvad/talpid/ConnectivityListener");
+
+        Ok(ConnectivityListener {
+            jvm: android_context.jvm,
+            class,
+            object,
+            _sender: None,
+        })
+    }
+
+    /// Register a channel that receives changes about the offline state
+    pub fn set_connectivity_listener(
+        &mut self,
+        sender: UnboundedSender<Connectivity>,
+    ) -> Result<(), Error> {
+        let sender = Arc::new(sender);
+
+        let weak_sender = Arc::downgrade(&sender);
+
+        let weak_sender_ptr = Box::new(weak_sender);
+        let weak_sender_address = Box::into_raw(weak_sender_ptr) as jlong;
+
+        let result = self.call_method(
+            "setSenderAddress",
+            "(J)V",
+            &[JValue::Long(weak_sender_address)],
+            JavaType::Primitive(Primitive::Void),
+        )?;
+
+        match result {
+            JValue::Void => Ok(()),
+            value => Err(Error::InvalidMethodResult(
+                "ConnectivityListener",
+                "setSenderAddress",
+                format!("{:?}", value),
+            )),
+        }?;
+
+        self._sender = Some(sender);
+
+        Ok(())
+    }
+
+    /// Return the current offline/connectivity state
+    pub fn connectivity(&self) -> Connectivity {
+        self.get_is_connected()
+            .map(|connected| Connectivity::Status { connected })
+            .unwrap_or_else(|error| {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Failed to check connectivity status")
+                );
+                Connectivity::PresumeOnline
+            })
+    }
+
+    fn get_is_connected(&self) -> Result<bool, Error> {
+        let is_connected = self.call_method(
+            "isConnected",
+            "()Z",
+            &[],
+            JavaType::Primitive(Primitive::Boolean),
+        )?;
+
+        match is_connected {
+            JValue::Bool(JNI_TRUE) => Ok(true),
+            JValue::Bool(_) => Ok(false),
+            value => Err(Error::InvalidMethodResult(
+                "ConnectivityListener",
+                "isConnected",
+                format!("{:?}", value),
+            )),
+        }
+    }
+
+    /// Return the current DNS servers according to Android
+    pub fn current_dns_servers(&self) -> Result<Vec<IpAddr>, Error> {
+        let env = JnixEnv::from(
+            self.jvm
+                .attach_current_thread_as_daemon()
+                .map_err(Error::AttachJvmToThread)?,
+        );
+
+        let current_dns_servers = self.call_method(
+            "getCurrentDnsServers",
+            "()Ljava/util/ArrayList;",
+            &[],
+            JavaType::Object("java/util/ArrayList".to_owned()),
+        )?;
+
+        match current_dns_servers {
+            JValue::Object(jaddrs) => Ok(Vec::from_java(&env, jaddrs)),
+            value => Err(Error::InvalidMethodResult(
+                "ConnectivityListener",
+                "currentDnsServers",
+                format!("{:?}", value),
+            )),
+        }
+    }
+
+    fn call_method(
+        &self,
+        method: &'static str,
+        signature: &str,
+        parameters: &[JValue<'_>],
+        return_type: JavaType,
+    ) -> Result<JValue<'_>, Error> {
+        let env = JnixEnv::from(
+            self.jvm
+                .attach_current_thread_as_daemon()
+                .map_err(Error::AttachJvmToThread)?,
+        );
+
+        let method_id = env
+            .get_method_id(&self.class, method, signature)
+            .map_err(|cause| Error::FindMethod("ConnectivityListener", method, cause))?;
+
+        env.call_method_unchecked(self.object.as_obj(), method_id, return_type, parameters)
+            .map_err(|cause| Error::CallMethod("ConnectivityListener", method, cause))
+    }
+}
+
+/// Entry point for Android Java code to notify the connectivity status.
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_talpid_ConnectivityListener_notifyConnectivityChange(
+    _: JNIEnv<'_>,
+    _: JObject<'_>,
+    connected: jboolean,
+    sender_address: jlong,
+) {
+    let connected = JNI_TRUE == connected;
+    let sender_ref = Box::leak(unsafe { get_sender_from_address(sender_address) });
+    if let Some(sender) = sender_ref.upgrade() {
+        if sender
+            .unbounded_send(Connectivity::Status { connected })
+            .is_err()
+        {
+            log::warn!("Failed to send offline change event");
+        }
+    }
+}
+
+/// Entry point for Android Java code to return ownership of the sender reference.
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_mullvad_talpid_ConnectivityListener_destroySender(
+    _: JNIEnv<'_>,
+    _: JObject<'_>,
+    sender_address: jlong,
+) {
+    let _ = unsafe { get_sender_from_address(sender_address) };
+}
+
+unsafe fn get_sender_from_address(address: jlong) -> Box<Weak<UnboundedSender<Connectivity>>> {
+    Box::from_raw(address as *mut Weak<UnboundedSender<Connectivity>>)
+}

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -42,3 +42,7 @@ mod linux;
 /// A resolver that's controlled by the tunnel state machine
 #[cfg(target_os = "macos")]
 pub(crate) mod resolver;
+
+/// Connectivity monitor for Android
+#[cfg(target_os = "android")]
+pub mod connectivity_listener;

--- a/talpid-core/src/offline/android.rs
+++ b/talpid-core/src/offline/android.rs
@@ -1,217 +1,32 @@
+use crate::connectivity_listener::{ConnectivityListener, Error};
 use futures::channel::mpsc::UnboundedSender;
-use jnix::{
-    jni::{
-        self,
-        objects::{GlobalRef, JObject, JValue},
-        signature::{JavaType, Primitive},
-        sys::{jboolean, jlong, JNI_TRUE},
-        JNIEnv, JavaVM,
-    },
-    JnixEnv,
-};
-use std::sync::{Arc, Weak};
-use talpid_types::{android::AndroidContext, net::Connectivity, ErrorExt};
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("Failed to attach Java VM to tunnel thread")]
-    AttachJvmToThread(#[source] jni::errors::Error),
-
-    #[error("Failed to call Java method {0}.{1}")]
-    CallMethod(&'static str, &'static str, #[source] jni::errors::Error),
-
-    #[error("Failed to create global reference to Java object")]
-    CreateGlobalRef(#[source] jni::errors::Error),
-
-    #[error("Failed to find {0}.{1} method")]
-    FindMethod(&'static str, &'static str, #[source] jni::errors::Error),
-
-    #[error("Received an invalid result from {0}.{1}: {2}")]
-    InvalidMethodResult(&'static str, &'static str, String),
-}
+use talpid_types::net::Connectivity;
 
 pub struct MonitorHandle {
-    jvm: Arc<JavaVM>,
-    class: GlobalRef,
-    object: GlobalRef,
-    _sender: Arc<UnboundedSender<Connectivity>>,
+    connectivity_listener: ConnectivityListener,
 }
 
 impl MonitorHandle {
-    pub fn new(
-        android_context: AndroidContext,
-        sender: Arc<UnboundedSender<Connectivity>>,
-    ) -> Result<Self, Error> {
-        let env = JnixEnv::from(
-            android_context
-                .jvm
-                .attach_current_thread_as_daemon()
-                .map_err(Error::AttachJvmToThread)?,
-        );
-
-        let get_connectivity_listener_method = env
-            .get_method_id(
-                &env.get_class("net/mullvad/talpid/TalpidVpnService"),
-                "getConnectivityListener",
-                "()Lnet/mullvad/talpid/ConnectivityListener;",
-            )
-            .map_err(|cause| {
-                Error::FindMethod("MullvadVpnService", "getConnectivityListener", cause)
-            })?;
-
-        let result = env
-            .call_method_unchecked(
-                android_context.vpn_service.as_obj(),
-                get_connectivity_listener_method,
-                JavaType::Object("Lnet/mullvad/talpid/ConnectivityListener;".to_owned()),
-                &[],
-            )
-            .map_err(|cause| {
-                Error::CallMethod("MullvadVpnService", "getConnectivityListener", cause)
-            })?;
-
-        let object = match result {
-            JValue::Object(object) => env.new_global_ref(object).map_err(Error::CreateGlobalRef)?,
-            value => {
-                return Err(Error::InvalidMethodResult(
-                    "MullvadVpnService",
-                    "getConnectivityListener",
-                    format!("{:?}", value),
-                ))
-            }
-        };
-
-        let class = env.get_class("net/mullvad/talpid/ConnectivityListener");
-
-        Ok(MonitorHandle {
-            jvm: android_context.jvm,
-            class,
-            object,
-            _sender: sender,
-        })
+    fn new(connectivity_listener: ConnectivityListener) -> Self {
+        MonitorHandle {
+            connectivity_listener,
+        }
     }
 
     #[allow(clippy::unused_async)]
     pub async fn connectivity(&self) -> Connectivity {
-        self.get_is_connected()
-            .map(|connected| Connectivity::Status { connected })
-            .unwrap_or_else(|error| {
-                log::error!(
-                    "{}",
-                    error.display_chain_with_msg("Failed to check connectivity status")
-                );
-                Connectivity::PresumeOnline
-            })
+        self.connectivity_listener.connectivity()
     }
-
-    fn get_is_connected(&self) -> Result<bool, Error> {
-        let is_connected = self.call_method(
-            "isConnected",
-            "()Z",
-            &[],
-            JavaType::Primitive(Primitive::Boolean),
-        )?;
-
-        match is_connected {
-            JValue::Bool(JNI_TRUE) => Ok(true),
-            JValue::Bool(_) => Ok(false),
-            value => Err(Error::InvalidMethodResult(
-                "ConnectivityListener",
-                "isConnected",
-                format!("{:?}", value),
-            )),
-        }
-    }
-
-    fn set_sender(&self, sender: Weak<UnboundedSender<Connectivity>>) -> Result<(), Error> {
-        let sender_ptr = Box::new(sender);
-        let sender_address = Box::into_raw(sender_ptr) as jlong;
-
-        let result = self.call_method(
-            "setSenderAddress",
-            "(J)V",
-            &[JValue::Long(sender_address)],
-            JavaType::Primitive(Primitive::Void),
-        )?;
-
-        match result {
-            JValue::Void => Ok(()),
-            value => Err(Error::InvalidMethodResult(
-                "ConnectivityListener",
-                "setSenderAddress",
-                format!("{:?}", value),
-            )),
-        }
-    }
-
-    fn call_method(
-        &self,
-        method: &'static str,
-        signature: &str,
-        parameters: &[JValue<'_>],
-        return_type: JavaType,
-    ) -> Result<JValue<'_>, Error> {
-        let env = JnixEnv::from(
-            self.jvm
-                .attach_current_thread_as_daemon()
-                .map_err(Error::AttachJvmToThread)?,
-        );
-
-        let method_id = env
-            .get_method_id(&self.class, method, signature)
-            .map_err(|cause| Error::FindMethod("ConnectivityListener", method, cause))?;
-
-        env.call_method_unchecked(self.object.as_obj(), method_id, return_type, parameters)
-            .map_err(|cause| Error::CallMethod("ConnectivityListener", method, cause))
-    }
-}
-
-/// Entry point for Android Java code to notify the connectivity status.
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "system" fn Java_net_mullvad_talpid_ConnectivityListener_notifyConnectivityChange(
-    _: JNIEnv<'_>,
-    _: JObject<'_>,
-    connected: jboolean,
-    sender_address: jlong,
-) {
-    let connected = JNI_TRUE == connected;
-    let sender_ref = Box::leak(unsafe { get_sender_from_address(sender_address) });
-    if let Some(sender) = sender_ref.upgrade() {
-        if sender
-            .unbounded_send(Connectivity::Status { connected })
-            .is_err()
-        {
-            log::warn!("Failed to send offline change event");
-        }
-    }
-}
-
-/// Entry point for Android Java code to return ownership of the sender reference.
-#[no_mangle]
-#[allow(non_snake_case)]
-pub extern "system" fn Java_net_mullvad_talpid_ConnectivityListener_destroySender(
-    _: JNIEnv<'_>,
-    _: JObject<'_>,
-    sender_address: jlong,
-) {
-    let _ = unsafe { get_sender_from_address(sender_address) };
-}
-
-unsafe fn get_sender_from_address(address: jlong) -> Box<Weak<UnboundedSender<Connectivity>>> {
-    Box::from_raw(address as *mut Weak<UnboundedSender<Connectivity>>)
 }
 
 #[allow(clippy::unused_async)]
 pub async fn spawn_monitor(
     sender: UnboundedSender<Connectivity>,
-    android_context: AndroidContext,
+    connectivity_listener: ConnectivityListener,
 ) -> Result<MonitorHandle, Error> {
-    let sender = Arc::new(sender);
-    let weak_sender = Arc::downgrade(&sender);
-    let monitor_handle = MonitorHandle::new(android_context, sender)?;
-
-    monitor_handle.set_sender(weak_sender)?;
-
+    let mut monitor_handle = MonitorHandle::new(connectivity_listener);
+    monitor_handle
+        .connectivity_listener
+        .set_connectivity_listener(sender)?;
     Ok(monitor_handle)
 }

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -1,9 +1,9 @@
+#[cfg(target_os = "android")]
+use crate::connectivity_listener::ConnectivityListener;
 use futures::channel::mpsc::UnboundedSender;
 use std::sync::LazyLock;
 #[cfg(not(target_os = "android"))]
 use talpid_routing::RouteManagerHandle;
-#[cfg(target_os = "android")]
-use talpid_types::android::AndroidContext;
 use talpid_types::{net::Connectivity, ErrorExt};
 
 #[cfg(target_os = "macos")]
@@ -44,7 +44,7 @@ pub async fn spawn_monitor(
     sender: UnboundedSender<Connectivity>,
     #[cfg(not(target_os = "android"))] route_manager: RouteManagerHandle,
     #[cfg(target_os = "linux")] fwmark: Option<u32>,
-    #[cfg(target_os = "android")] android_context: AndroidContext,
+    #[cfg(target_os = "android")] connectivity_listener: ConnectivityListener,
 ) -> MonitorHandle {
     let monitor = if *FORCE_DISABLE_OFFLINE_MONITOR {
         None
@@ -56,7 +56,7 @@ pub async fn spawn_monitor(
             #[cfg(target_os = "linux")]
             fwmark,
             #[cfg(target_os = "android")]
-            android_context,
+            connectivity_listener,
         )
         .await
         .inspect_err(|error| {

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -300,9 +300,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blake3"
@@ -1324,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -1702,7 +1702,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -1867,13 +1867,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "mio-serial"
 version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a4c60ca5c9c0e114b3bd66ff4aa5f9b2b175442be51ca6c4365d687a97a2ac"
 dependencies = [
  "log",
- "mio",
+ "mio 0.8.11",
  "nix 0.26.4",
  "serialport",
  "winapi",
@@ -2042,7 +2054,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2061,7 +2073,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2069,7 +2081,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -2107,16 +2119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2883,7 +2885,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno 0.3.8",
  "libc",
  "linux-raw-sys",
@@ -3079,7 +3081,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5a15d0be940df84846264b09b51b10b931fb2f275becb80934e3568a016828"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "core-foundation-sys",
  "io-kit-sys",
@@ -3624,28 +3626,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.2",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.6",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4525,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]


### PR DESCRIPTION
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
