### PR TITLE
Add a github workflow to build on Xcode 16

### DIFF
--- a/.github/workflows/ios-build-xcode-16.yml
+++ b/.github/workflows/ios-build-xcode-16.yml
@@ -1,0 +1,105 @@
+---
+name: iOS Build with Xcode 16
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - .github/workflows/ios.yml
+      - .github/workflows/ios-build-xcode-16.yml
+      - ios/.swiftformat
+      - ios/**/*.swift
+      - ios/**/*.xctestplan
+      - Cargo.toml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  test:
+    if: github.event.pull_request.merged == true
+    name: Validate build schemas
+    runs-on: macos-15-xlarge
+    env:
+      SOURCE_PACKAGES_PATH: .spm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure cache
+        uses: actions/cache@v3
+        with:
+          path: ios/${{ env.SOURCE_PACKAGES_PATH }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('ios/**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Setup go-lang
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21.13
+
+      - name: Set up yeetd to workaround XCode being slow in CI
+        run: |
+          wget https://github.com/biscuitehh/yeetd/releases/download/1.0/yeetd-normal.pkg
+          sudo installer -pkg yeetd-normal.pkg -target /
+          yeetd &
+      - name: Configure Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.1'
+      - name: Configure Rust
+        run: |
+          rustup default stable
+          rustup update stable
+          rustup target add aarch64-apple-ios-sim
+
+      - name: Configure Xcode project
+        run: |
+          cp Base.xcconfig.template Base.xcconfig
+          cp App.xcconfig.template App.xcconfig
+          cp PacketTunnel.xcconfig.template PacketTunnel.xcconfig
+          cp Screenshots.xcconfig.template Screenshots.xcconfig
+          cp Api.xcconfig.template Api.xcconfig
+          cp UITests.xcconfig.template UITests.xcconfig
+        working-directory: ios/Configurations
+
+      - name: Install xcbeautify
+        run: |
+          brew update
+          brew install xcbeautify
+
+      - name: Install protobuf
+        run: |
+          brew update
+          brew install protobuf
+
+      - name: Run build validation for Staging and MockRelease configurations as well as the MullvadVPNUITests target
+        run: |
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
+            -project MullvadVPN.xcodeproj \
+            -scheme MullvadVPN \
+            -configuration MockRelease \
+            -destination "platform=iOS Simulator,name=iPhone 15" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
+            build
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
+            -project MullvadVPN.xcodeproj \
+            -scheme MullvadVPN \
+            -configuration Staging \
+            -destination "platform=iOS Simulator,name=iPhone 15" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
+            build
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
+            -project MullvadVPN.xcodeproj \
+            -scheme MullvadVPNUITests \
+            -configuration Debug \
+            -destination "platform=iOS Simulator,name=iPhone 15" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            -disableAutomaticPackageResolution \
+            build
+        working-directory: ios/


### PR DESCRIPTION
This PR adds a new workflow that will run build validation schemas with Xcode 16 on macOS 15

It is mostly a copy of `ios-validate-build-schemas.yml`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7215)
<!-- Reviewable:end -->
