### PR TITLE
Use iPhone 16 as a build destination

### DIFF
--- a/.github/workflows/ios-build-xcode-16.yml
+++ b/.github/workflows/ios-build-xcode-16.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   test:
     if: github.event.pull_request.merged == true
-    name: Validate build schemas
+    name: Build with Xcode 16
     runs-on: macos-15-xlarge
     env:
       SOURCE_PACKAGES_PATH: .spm
@@ -82,7 +82,7 @@ jobs:
             -project MullvadVPN.xcodeproj \
             -scheme MullvadVPN \
             -configuration MockRelease \
-            -destination "platform=iOS Simulator,name=iPhone 15" \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
             -disableAutomaticPackageResolution \
             build
@@ -90,7 +90,7 @@ jobs:
             -project MullvadVPN.xcodeproj \
             -scheme MullvadVPN \
             -configuration Staging \
-            -destination "platform=iOS Simulator,name=iPhone 15" \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
             -disableAutomaticPackageResolution \
             build
@@ -98,7 +98,7 @@ jobs:
             -project MullvadVPN.xcodeproj \
             -scheme MullvadVPNUITests \
             -configuration Debug \
-            -destination "platform=iOS Simulator,name=iPhone 15" \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
             -disableAutomaticPackageResolution \
             build


### PR DESCRIPTION
The last part needed to have builds on Xcode 16, build on a device that is supported in iOS 16.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7218)
<!-- Reviewable:end -->
