### PR TITLE
Fix `npm run build-x86` command in `nsventforwarder`

### DIFF
--- a/desktop/packages/nseventforwarder/package.json
+++ b/desktop/packages/nseventforwarder/package.json
@@ -9,7 +9,7 @@
     "cargo-build": "tsc && cargo build",
     "build-debug": "npm run cargo-build && mkdir -p debug && cp ${CARGO_TARGET_DIR:-../../../target}/debug/libnseventforwarder.dylib debug/index.node",
     "build-arm": "npm run cargo-build -- --release --target aarch64-apple-darwin && mkdir -p dist/darwin-arm64 && cp ${CARGO_TARGET_DIR:-../../../target}/aarch64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-arm64/index.node",
-    "build-x86": "npm run cargo-build -- --release --target x86_64-apple-darwin && mkdir -p dist/darwin-x64 && cp ${CARGO_TARGET_DIR:--../../../target}/x86_64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-x64/index.node",
+    "build-x86": "npm run cargo-build -- --release --target x86_64-apple-darwin && mkdir -p dist/darwin-x64 && cp ${CARGO_TARGET_DIR:-../../../target}/x86_64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-x64/index.node",
     "clean": "rm -rf debug; rm -rf dist",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/mullvad/mullvadvpn-app/pull/7211 where a an extra dash (`-`) snuck into the `build-x86` npm command in the `nsventforwarder` workspace. This messed up the variable substitution, which tripped up `cp` because we provided it with a nonsensical path.

* Bad `build-x86`:  `cp ${CARGO_TARGET_DIR:--../../../target}`
* Good `build-x86`: `cp ${CARGO_TARGET_DIR:-../../../target}`

The consequence of this is that we can not package the `x86`-version of the macOS app, which subsequently disallows us from producing universal installers.

I've double-checked that this PR actually fixes the problem, and here is the proof:
```bash
$ ./build.sh --optimize --universal
..
  • building        target=pkg arch=universal file=/Users/markus/projects/mullvadvpn-app/dist/MullvadVPN-2024.7-dev-f01e57.pkg
[14:29:20] Finished 'builder-mac' after 33 s
[14:29:20] Finished 'pack-mac' after 41 s
~/projects/mullvadvpn-app
**********************************

 The build finished successfully!
 You have built:

 2024.7-dev-1f330c

**********************************
```

Sorry for the inconvenience 👉 👈 🥺

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7220)
<!-- Reviewable:end -->
