### PR TITLE
Add codeowners for the actions workflow that verifies commit signatures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,9 @@
 **/osv-scanner.toml @faern @raksooo @pinkisemils @albin-mullvad
 /.github/workflows/osv-scanner*.yml @faern @raksooo @pinkisemils @albin-mullvad
 
+# GitHub actions workflow that verifies that commits are signed if they are required to be
+/.github/workflows/verify-locked-down-signatures.yml @faern @raksooo @pinkisemils @albin-mullvad
+
 # The CODEOWNERS itself must be protected from unauthorized changes,
 # otherwise the protection becomes quite moot.
 # Keep this entry last, so it is sure to override any existing previous wildcard match


### PR DESCRIPTION
This PR adds code owners for `.github/workflows/verify-locked-down-signatures.yml`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7221)
<!-- Reviewable:end -->
