### PR TITLE
Extend ignore for CVE-2024-4067

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -21,7 +21,7 @@ reason = "This package is only used to match paths from either us or trusted lib
 # micromatch (dev): Regular Expression Denial of Service (ReDoS) in micromatch
 [[IgnoredVulns]]
 id = "CVE-2024-4067" # GHSA-952p-6rrq-rcjv
-ignoreUntil = 2024-11-23
+ignoreUntil = 2025-02-23
 reason = "This is just a dev dependency, and we don't have untrusted input to micromatch there"
 
 # node-gettext: Prototype Pullution via the addTranslations function


### PR DESCRIPTION
Extend ignore for CVE-2024-4067 since it has expired.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7241)
<!-- Reviewable:end -->
