### PR TITLE
Fix daita and multihop warning being shown when multihop is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Handle network switching better when using WG over Shadowsocks.
+- Fix multihop entry location list sometimes being shown when multihop is disabled.
 
 #### macOS
 - Fix packets being duplicated on LAN when split tunneling is enabled.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/select-location/SelectLocation.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/select-location/SelectLocation.tsx
@@ -302,7 +302,7 @@ function SelectLocationContent() {
       </>
     );
   } else if (relaySettings?.tunnelProtocol !== 'openvpn') {
-    if (daita && !directOnly) {
+    if (daita && !directOnly && relaySettings?.wireguard.useMultihop) {
       return <DisabledEntrySelection />;
     }
 

--- a/desktop/packages/mullvad-vpn/src/renderer/components/select-location/SelectLocationContainer.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/select-location/SelectLocationContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useMemo, useState } from 'react';
 
 import useActions from '../../lib/actionsHook';
+import { useNormalRelaySettings } from '../../lib/relay-settings-hooks';
 import { useSelector } from '../../redux/store';
 import userInterface from '../../redux/userinterface/actions';
 import { RelayListContextProvider } from './RelayListContext';
@@ -23,12 +24,25 @@ export function useSelectLocationContext() {
 }
 
 export default function SelectLocationContainer() {
-  const locationType = useSelector((state) => state.userInterface.selectLocationView);
+  const locationTypeSelector = useSelector((state) => state.userInterface.selectLocationView);
   const { setSelectLocationView } = useActions(userInterface);
   const [searchTerm, setSearchTerm] = useState('');
+  const relaySettings = useNormalRelaySettings();
+
+  const locationType = useMemo(() => {
+    if (relaySettings?.wireguard.useMultihop) {
+      return locationTypeSelector;
+    }
+    return LocationType.exit;
+  }, [locationTypeSelector, relaySettings]);
 
   const value = useMemo(
-    () => ({ locationType, setLocationType: setSelectLocationView, searchTerm, setSearchTerm }),
+    () => ({
+      locationType,
+      setLocationType: setSelectLocationView,
+      searchTerm,
+      setSearchTerm,
+    }),
     [locationType, searchTerm, setSelectLocationView],
   );
 


### PR DESCRIPTION
Since the `directOnly` boolean is separate from the multihop setting we need to check the multihop setting as well before disabling the entry selection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7242)
<!-- Reviewable:end -->
