### PR TITLE
Refactor address cache in mullvad-api

### DIFF
--- a/mullvad-api/src/address_cache.rs
+++ b/mullvad-api/src/address_cache.rs
@@ -31,30 +31,28 @@ pub struct AddressCache {
 
 impl AddressCache {
     /// Initialize cache using the hardcoded address, and write changes to `write_path`.
-    pub fn new(write_path: Option<Box<Path>>) -> Result<Self, Error> {
+    pub fn new(write_path: Option<Box<Path>>) -> Self {
         Self::new_inner(API.address(), write_path)
     }
 
     pub fn with_static_addr(address: SocketAddr) -> Self {
         Self::new_inner(address, None)
-            .expect("Failed to construct an address cache from a static address")
     }
 
     /// Initialize cache using `read_path`, and write changes to `write_path`.
     pub async fn from_file(read_path: &Path, write_path: Option<Box<Path>>) -> Result<Self, Error> {
         log::debug!("Loading API addresses from {}", read_path.display());
-        Self::new_inner(read_address_file(read_path).await?, write_path)
+        Ok(Self::new_inner(read_address_file(read_path).await?, write_path))
     }
 
-    fn new_inner(address: SocketAddr, write_path: Option<Box<Path>>) -> Result<Self, Error> {
+    fn new_inner(address: SocketAddr, write_path: Option<Box<Path>>) -> Self {
         let cache = AddressCacheInner::from_address(address);
         log::debug!("Using API address: {}", cache.address);
 
-        let address_cache = Self {
+        Self {
             inner: Arc::new(Mutex::new(cache)),
             write_path: write_path.map(Arc::from),
-        };
-        Ok(address_cache)
+        }
     }
 
     /// Returns the address if the hostname equals `API.host`. Otherwise, returns `None`.

--- a/mullvad-api/src/address_cache.rs
+++ b/mullvad-api/src/address_cache.rs
@@ -1,6 +1,8 @@
 //! This module keeps track of the last known good API IP address and reads and stores it on disk.
 
 use super::API;
+use crate::DnsResolver;
+use async_trait::async_trait;
 use std::{io, net::SocketAddr, path::Path, sync::Arc};
 use tokio::{
     fs,
@@ -23,6 +25,17 @@ pub enum Error {
     Write(#[source] io::Error),
 }
 
+/// A DNS resolver which resolves using `AddressCache`.
+#[async_trait]
+impl DnsResolver for AddressCache {
+    async fn resolve(&self, host: String) -> Result<Vec<SocketAddr>, io::Error> {
+        self.resolve_hostname(&host)
+            .await
+            .map(|addr| vec![addr])
+            .ok_or(io::Error::other("host does not match API host"))
+    }
+}
+
 #[derive(Clone)]
 pub struct AddressCache {
     inner: Arc<Mutex<AddressCacheInner>>,
@@ -42,7 +55,10 @@ impl AddressCache {
     /// Initialize cache using `read_path`, and write changes to `write_path`.
     pub async fn from_file(read_path: &Path, write_path: Option<Box<Path>>) -> Result<Self, Error> {
         log::debug!("Loading API addresses from {}", read_path.display());
-        Ok(Self::new_inner(read_address_file(read_path).await?, write_path))
+        Ok(Self::new_inner(
+            read_address_file(read_path).await?,
+            write_path,
+        ))
     }
 
     fn new_inner(address: SocketAddr, write_path: Option<Box<Path>>) -> Self {
@@ -56,7 +72,7 @@ impl AddressCache {
     }
 
     /// Returns the address if the hostname equals `API.host`. Otherwise, returns `None`.
-    pub async fn resolve_hostname(&self, hostname: &str) -> Option<SocketAddr> {
+    async fn resolve_hostname(&self, hostname: &str) -> Option<SocketAddr> {
         if hostname.eq_ignore_ascii_case(API.host()) {
             Some(self.get_address().await)
         } else {

--- a/mullvad-api/src/bin/relay_list.rs
+++ b/mullvad-api/src/bin/relay_list.rs
@@ -2,15 +2,13 @@
 //! Used by the installer artifact packer to bundle the latest available
 //! relay list at the time of creating the installer.
 
-use mullvad_api::{
-    proxy::ApiConnectionMode, rest::Error as RestError, DefaultDnsResolver, RelayListProxy,
-};
+use mullvad_api::{proxy::ApiConnectionMode, rest::Error as RestError, RelayListProxy};
 use std::process;
 use talpid_types::ErrorExt;
 
 #[tokio::main]
 async fn main() {
-    let runtime = mullvad_api::Runtime::new(tokio::runtime::Handle::current(), DefaultDnsResolver)
+    let runtime = mullvad_api::Runtime::new(tokio::runtime::Handle::current())
         .expect("Failed to load runtime");
 
     let relay_list_request =

--- a/mullvad-api/src/https_client_with_sni.rs
+++ b/mullvad-api/src/https_client_with_sni.rs
@@ -286,7 +286,6 @@ impl TryFrom<ApiConnectionMode> for InnerConnectionMode {
 #[derive(Clone)]
 pub struct HttpsConnectorWithSni {
     inner: Arc<Mutex<HttpsConnectorWithSniInner>>,
-    sni_hostname: Option<String>,
     abort_notify: Arc<tokio::sync::Notify>,
     dns_resolver: Arc<dyn DnsResolver>,
     #[cfg(target_os = "android")]
@@ -303,7 +302,6 @@ pub type SocketBypassRequest = (RawFd, oneshot::Sender<()>);
 
 impl HttpsConnectorWithSni {
     pub fn new(
-        sni_hostname: Option<String>,
         dns_resolver: Arc<dyn DnsResolver>,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> (Self, HttpsConnectorWithSniHandle) {
@@ -350,7 +348,6 @@ impl HttpsConnectorWithSni {
         (
             HttpsConnectorWithSni {
                 inner,
-                sni_hostname,
                 abort_notify,
                 dns_resolver,
                 #[cfg(target_os = "android")]
@@ -432,13 +429,6 @@ impl Service<Uri> for HttpsConnectorWithSni {
     }
 
     fn call(&mut self, uri: Uri) -> Self::Future {
-        let sni_hostname = self
-            .sni_hostname
-            .clone()
-            .or_else(|| uri.host().map(str::to_owned))
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "invalid url, missing host")
-            });
         let inner = self.inner.clone();
         let abort_notify = self.abort_notify.clone();
         #[cfg(target_os = "android")]
@@ -452,8 +442,12 @@ impl Service<Uri> for HttpsConnectorWithSni {
                     "invalid url, not https",
                 ));
             }
-
-            let hostname = sni_hostname?;
+            let Some(hostname) = uri.host().map(str::to_owned) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "invalid url, missing host",
+                ));
+            };
             let addr = Self::resolve_address(&*dns_resolver, uri).await?;
 
             // Loop until we have established a connection. This starts over if a new endpoint

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -450,7 +450,6 @@ impl Runtime {
         connection_mode_provider: T,
     ) -> rest::MullvadRestHandle {
         let service = self.new_request_service(
-            Some(API.host().to_string()),
             connection_mode_provider,
             Arc::new(self.address_cache.clone()),
             #[cfg(target_os = "android")]
@@ -465,7 +464,6 @@ impl Runtime {
     /// This is only to be used in test code
     pub fn static_mullvad_rest_handle(&self, hostname: String) -> rest::MullvadRestHandle {
         let service = self.new_request_service(
-            Some(hostname.clone()),
             ApiConnectionMode::Direct.into_provider(),
             Arc::new(self.address_cache.clone()),
             #[cfg(target_os = "android")]
@@ -480,7 +478,6 @@ impl Runtime {
     /// Returns a new request service handle
     pub fn rest_handle(&self, dns_resolver: impl DnsResolver) -> rest::RequestServiceHandle {
         self.new_request_service(
-            None,
             ApiConnectionMode::Direct.into_provider(),
             Arc::new(dns_resolver),
             #[cfg(target_os = "android")]
@@ -491,13 +488,11 @@ impl Runtime {
     /// Creates a new request service and returns a handle to it.
     fn new_request_service<T: ConnectionModeProvider + 'static>(
         &self,
-        sni_hostname: Option<String>,
         connection_mode_provider: T,
         dns_resolver: Arc<dyn DnsResolver>,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> rest::RequestServiceHandle {
         rest::RequestService::spawn(
-            sni_hostname,
             self.api_availability.clone(),
             connection_mode_provider,
             dns_resolver,

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -308,7 +308,7 @@ impl ApiEndpoint {
 
 #[async_trait]
 pub trait DnsResolver: 'static + Send + Sync {
-    async fn resolve(&self, host: String) -> io::Result<Vec<IpAddr>>;
+    async fn resolve(&self, host: String) -> io::Result<Vec<SocketAddr>>;
 }
 
 /// DNS resolver that relies on `ToSocketAddrs` (`getaddrinfo`).
@@ -316,14 +316,14 @@ pub struct DefaultDnsResolver;
 
 #[async_trait]
 impl DnsResolver for DefaultDnsResolver {
-    async fn resolve(&self, host: String) -> io::Result<Vec<IpAddr>> {
+    async fn resolve(&self, host: String) -> io::Result<Vec<SocketAddr>> {
         use std::net::ToSocketAddrs;
         // Spawn a blocking thread, since `to_socket_addrs` relies on `libc::getaddrinfo`, which
         // blocks and either has no timeout or a very long one.
         let addrs = tokio::task::spawn_blocking(move || (host, 0).to_socket_addrs())
             .await
             .expect("DNS task panicked")?;
-        Ok(addrs.map(|addr| addr.ip()).collect())
+        Ok(addrs.collect())
     }
 }
 
@@ -332,7 +332,7 @@ pub struct NullDnsResolver;
 
 #[async_trait]
 impl DnsResolver for NullDnsResolver {
-    async fn resolve(&self, _host: String) -> io::Result<Vec<IpAddr>> {
+    async fn resolve(&self, _host: String) -> io::Result<Vec<SocketAddr>> {
         Ok(vec![])
     }
 }
@@ -342,7 +342,6 @@ pub struct Runtime {
     handle: tokio::runtime::Handle,
     address_cache: AddressCache,
     api_availability: availability::ApiAvailability,
-    dns_resolver: Arc<dyn DnsResolver>,
     #[cfg(target_os = "android")]
     socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
 }
@@ -364,13 +363,9 @@ pub enum Error {
 
 impl Runtime {
     /// Create a new `Runtime`.
-    pub fn new(
-        handle: tokio::runtime::Handle,
-        dns_resolver: impl DnsResolver,
-    ) -> Result<Self, Error> {
+    pub fn new(handle: tokio::runtime::Handle) -> Result<Self, Error> {
         Self::new_inner(
             handle,
-            dns_resolver,
             #[cfg(target_os = "android")]
             None,
         )
@@ -381,21 +376,18 @@ impl Runtime {
         Runtime {
             handle,
             address_cache: AddressCache::with_static_addr(address),
-            dns_resolver: Arc::new(NullDnsResolver),
             api_availability: ApiAvailability::default(),
         }
     }
 
     fn new_inner(
         handle: tokio::runtime::Handle,
-        dns_resolver: impl DnsResolver,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> Result<Self, Error> {
         Ok(Runtime {
             handle,
-            address_cache: AddressCache::new(None)?,
+            address_cache: AddressCache::new(None),
             api_availability: ApiAvailability::default(),
-            dns_resolver: Arc::new(dns_resolver),
             #[cfg(target_os = "android")]
             socket_bypass_tx,
         })
@@ -404,7 +396,6 @@ impl Runtime {
     /// Create a new `Runtime` using the specified directories.
     /// Try to use the cache directory first, and fall back on the bundled address otherwise.
     pub async fn with_cache(
-        dns_resolver: impl DnsResolver,
         cache_dir: &Path,
         write_changes: bool,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
@@ -415,7 +406,6 @@ impl Runtime {
         if API.disable_address_cache {
             return Self::new_inner(
                 handle,
-                dns_resolver,
                 #[cfg(target_os = "android")]
                 socket_bypass_tx,
             );
@@ -439,7 +429,7 @@ impl Runtime {
                         )
                     );
                 }
-                AddressCache::new(write_file)?
+                AddressCache::new(write_file)
             }
         };
 
@@ -449,28 +439,9 @@ impl Runtime {
             handle,
             address_cache,
             api_availability,
-            dns_resolver: Arc::new(dns_resolver),
             #[cfg(target_os = "android")]
             socket_bypass_tx,
         })
-    }
-
-    /// Creates a new request service and returns a handle to it.
-    fn new_request_service<T: ConnectionModeProvider + 'static>(
-        &self,
-        sni_hostname: Option<String>,
-        connection_mode_provider: T,
-        #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
-    ) -> rest::RequestServiceHandle {
-        rest::RequestService::spawn(
-            sni_hostname,
-            self.api_availability.clone(),
-            self.address_cache.clone(),
-            connection_mode_provider,
-            self.dns_resolver.clone(),
-            #[cfg(target_os = "android")]
-            socket_bypass_tx,
-        )
     }
 
     /// Returns a request factory initialized to create requests for the master API
@@ -481,6 +452,7 @@ impl Runtime {
         let service = self.new_request_service(
             Some(API.host().to_string()),
             connection_mode_provider,
+            Arc::new(self.address_cache.clone()),
             #[cfg(target_os = "android")]
             self.socket_bypass_tx.clone(),
         );
@@ -495,6 +467,7 @@ impl Runtime {
         let service = self.new_request_service(
             Some(hostname.clone()),
             ApiConnectionMode::Direct.into_provider(),
+            Arc::new(self.address_cache.clone()),
             #[cfg(target_os = "android")]
             self.socket_bypass_tx.clone(),
         );
@@ -505,12 +478,31 @@ impl Runtime {
     }
 
     /// Returns a new request service handle
-    pub fn rest_handle(&self) -> rest::RequestServiceHandle {
+    pub fn rest_handle(&self, dns_resolver: impl DnsResolver) -> rest::RequestServiceHandle {
         self.new_request_service(
             None,
             ApiConnectionMode::Direct.into_provider(),
+            Arc::new(dns_resolver),
             #[cfg(target_os = "android")]
             None,
+        )
+    }
+
+    /// Creates a new request service and returns a handle to it.
+    fn new_request_service<T: ConnectionModeProvider + 'static>(
+        &self,
+        sni_hostname: Option<String>,
+        connection_mode_provider: T,
+        dns_resolver: Arc<dyn DnsResolver>,
+        #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
+    ) -> rest::RequestServiceHandle {
+        rest::RequestService::spawn(
+            sni_hostname,
+            self.api_availability.clone(),
+            connection_mode_provider,
+            dns_resolver,
+            #[cfg(target_os = "android")]
+            socket_bypass_tx,
         )
     }
 

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -150,14 +150,12 @@ pub(crate) struct RequestService<T: ConnectionModeProvider> {
 impl<T: ConnectionModeProvider + 'static> RequestService<T> {
     /// Constructs a new request service.
     pub fn spawn(
-        sni_hostname: Option<String>,
         api_availability: ApiAvailability,
         connection_mode_provider: T,
         dns_resolver: Arc<dyn DnsResolver>,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> RequestServiceHandle {
         let (connector, connector_handle) = HttpsConnectorWithSni::new(
-            sni_hostname,
             dns_resolver,
             #[cfg(target_os = "android")]
             socket_bypass_tx.clone(),

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -2,7 +2,6 @@
 pub use crate::https_client_with_sni::SocketBypassRequest;
 use crate::{
     access::AccessTokenStore,
-    address_cache::AddressCache,
     availability::ApiAvailability,
     https_client_with_sni::{HttpsConnectorWithSni, HttpsConnectorWithSniHandle},
     proxy::ConnectionModeProvider,
@@ -153,14 +152,12 @@ impl<T: ConnectionModeProvider + 'static> RequestService<T> {
     pub fn spawn(
         sni_hostname: Option<String>,
         api_availability: ApiAvailability,
-        address_cache: AddressCache,
         connection_mode_provider: T,
         dns_resolver: Arc<dyn DnsResolver>,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
     ) -> RequestServiceHandle {
         let (connector, connector_handle) = HttpsConnectorWithSni::new(
             sni_hostname,
-            address_cache.clone(),
             dns_resolver,
             #[cfg(target_os = "android")]
             socket_bypass_tx.clone(),

--- a/mullvad-daemon/src/android_dns.rs
+++ b/mullvad-daemon/src/android_dns.rs
@@ -7,7 +7,7 @@ use hickory_resolver::{
     TokioAsyncResolver,
 };
 use mullvad_api::DnsResolver;
-use std::{io, net::IpAddr};
+use std::{io, net::SocketAddr};
 use talpid_core::connectivity_listener::ConnectivityListener;
 
 /// A non-blocking DNS resolver. The default resolver uses `getaddrinfo`, which often prevents the
@@ -27,7 +27,7 @@ impl AndroidDnsResolver {
 
 #[async_trait]
 impl DnsResolver for AndroidDnsResolver {
-    async fn resolve(&self, host: String) -> io::Result<Vec<IpAddr>> {
+    async fn resolve(&self, host: String) -> io::Result<Vec<SocketAddr>> {
         let ips = self
             .connectivity_listener
             .current_dns_servers()
@@ -44,6 +44,6 @@ impl DnsResolver for AndroidDnsResolver {
             .await
             .map_err(|err| io::Error::other(format!("lookup_ip failed: {err}")))?;
 
-        Ok(lookup.into_iter().collect())
+        Ok(lookup.into_iter().map(|ip| (ip, 0).into()).collect())
     }
 }

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -1,4 +1,4 @@
-use mullvad_api::{proxy::ApiConnectionMode, NullDnsResolver};
+use mullvad_api::proxy::ApiConnectionMode;
 use regex::Regex;
 use std::{
     borrow::Cow,
@@ -292,7 +292,6 @@ async fn send_problem_report_inner(
 ) -> Result<(), Error> {
     let metadata = ProblemReport::parse_metadata(report_content).unwrap_or_else(metadata::collect);
     let api_runtime = mullvad_api::Runtime::with_cache(
-        NullDnsResolver,
         cache_dir,
         false,
         #[cfg(target_os = "android")]

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::{path::PathBuf, process, str::FromStr, sync::LazyLock, time::Duration};
 
-use mullvad_api::{proxy::ApiConnectionMode, NullDnsResolver, DEVICE_NOT_FOUND};
+use mullvad_api::{proxy::ApiConnectionMode, DEVICE_NOT_FOUND};
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::version::ParsedAppVersion;
 use talpid_core::firewall::{self, Firewall};
@@ -152,7 +152,7 @@ async fn remove_device() -> Result<(), Error> {
         .await
         .map_err(Error::ReadDeviceCacheError)?;
     if let Some(device) = state.into_device() {
-        let api_runtime = mullvad_api::Runtime::with_cache(NullDnsResolver, &cache_path, false)
+        let api_runtime = mullvad_api::Runtime::with_cache(&cache_path, false)
             .await
             .map_err(Error::RpcInitializationError)?;
 

--- a/test/test-manager/src/tests/account.rs
+++ b/test/test-manager/src/tests/account.rs
@@ -295,11 +295,8 @@ pub async fn new_device_client() -> anyhow::Result<DevicesProxy> {
         ..api_endpoint
     });
 
-    let api = mullvad_api::Runtime::new(
-        tokio::runtime::Handle::current(),
-        mullvad_api::DefaultDnsResolver,
-    )
-    .expect("failed to create api runtime");
+    let api = mullvad_api::Runtime::new(tokio::runtime::Handle::current())
+        .expect("failed to create api runtime");
     let rest_handle = api.mullvad_rest_handle(ApiConnectionMode::Direct.into_provider());
     Ok(DevicesProxy::new(rest_handle))
 }


### PR DESCRIPTION
* Implement `DnsResolver` for the `AddressCache`. This decouples it from the REST client.
* Remove "fallback on DNS resolution" logic. Only give the geoip client an actual DNS resolver. Let the main client fail if it tries to resolve anything that isn't `api.mullvad.net`.
* Use URI host for SNI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7248)
<!-- Reviewable:end -->
