### PR TITLE
Reduce the maximum log file size to 2MB

### DIFF
--- a/ios/MullvadLogging/Logging.swift
+++ b/ios/MullvadLogging/Logging.swift
@@ -38,7 +38,7 @@ public struct LoggerBuilder {
 
         do {
             try LogRotation.rotateLogs(logDirectory: logsDirectoryURL, options: LogRotation.Options(
-                storageSizeLimit: 5_242_880, // 5 MB
+                storageSizeLimit: 2_000_000, // 2 MB
                 oldestAllowedDate: Date(timeIntervalSinceNow: -Duration.days(7).timeInterval)
             ))
         } catch {


### PR DESCRIPTION
This PR reduces the maximum log file size from 5MB to 2MB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7254)
<!-- Reviewable:end -->
