### PR TITLE
Make height prop in Spacing transient

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/Layout.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/Layout.tsx
@@ -56,8 +56,8 @@ export const Footer = styled.div({
   },
 });
 
-export const Spacing = styled.div<{ height: string }>((props) => ({
-  height: props.height,
+export const Spacing = styled.div<{ $height: string }>((props) => ({
+  height: props.$height,
 }));
 
 export const ButtonStack = styled.div({

--- a/desktop/packages/mullvad-vpn/src/renderer/components/SplitTunnelingSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/SplitTunnelingSettings.tsx
@@ -548,18 +548,18 @@ function MacOsSplitTunnelingAvailability({
               'To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings.',
             )}
           </HeaderSubTitle>
-          <Spacing height="24px" />
+          <Spacing $height="24px" />
           <WideSmallButton onClick={showFullDiskAccessSettings}>
             {messages.pgettext('split-tunneling-view', 'Open System Settings')}
           </WideSmallButton>
-          <Spacing height="32px" />
+          <Spacing $height="32px" />
           <StyledMiniTitle>
             {messages.pgettext(
               'split-tunneling-view',
               'Enabled "Full disk access" and still having issues?',
             )}
           </StyledMiniTitle>
-          <Spacing height="8px" />
+          <Spacing $height="8px" />
           <WideSmallButton onClick={restartDaemon}>
             {messages.pgettext('split-tunneling-view', 'Restart Mullvad Service')}
           </WideSmallButton>


### PR DESCRIPTION
I noticed that the `height` property on `Spacing` was missing a `$`. Transient props in styled components are marked with `$` and won't be passed onto the html tag.

https://styled-components.com/docs/api#transient-props

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7255)
<!-- Reviewable:end -->
