### PR TITLE
Make shadowsocks obfuscation ready for production ios 879

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -22,6 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## Unreleased
+### Added
+- Add WireGuard over Shadowsocks obfuscation. It can be enabled in "VPN settings". This will
+  also be used automatically when connecting fails with other methods.
 
 ## [2024.10 - 2024-11-20]
 ### Fixed

--- a/ios/MullvadVPN/View controllers/Settings/SelectableSettingsDetailsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SelectableSettingsDetailsCell.swift
@@ -56,13 +56,11 @@ class SelectableSettingsDetailsCell: SelectableSettingsCell {
     }
 
     private func setViewContainer() {
-        #if DEBUG
         setTrailingView { superview in
             superview.addConstrainedSubviews([viewContainer]) {
                 viewContainer.pinEdgesToSuperview()
             }
         }
-        #endif
     }
 
     // MARK: - Actions

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -146,14 +146,12 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
 
-            #if DEBUG
             cell.detailTitleLabel.text = String(format: NSLocalizedString(
                 "WIREGUARD_OBFUSCATION_UDP_TCP_PORT",
                 tableName: "VPNSettings",
                 value: "Port: %@",
                 comment: ""
             ), viewModel.obfuscationUpdOverTcpPort.description)
-            #endif
 
             cell.accessibilityIdentifier = item.accessibilityIdentifier
             cell.applySubCellStyling()
@@ -172,14 +170,12 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
 
-            #if DEBUG
             cell.detailTitleLabel.text = String(format: NSLocalizedString(
                 "WIREGUARD_OBFUSCATION_SHADOWSOCKS_PORT",
                 tableName: "VPNSettings",
                 value: "Port: %@",
                 comment: ""
             ), viewModel.obfuscationShadowsocksPort.description)
-            #endif
 
             cell.accessibilityIdentifier = item.accessibilityIdentifier
             cell.applySubCellStyling()

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -94,13 +94,10 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         static var wireGuardObfuscation: [Item] {
             var items: [Item] = [
                 .wireGuardObfuscationAutomatic,
+                .wireGuardObfuscationShadowsocks,
                 .wireGuardObfuscationUdpOverTcp,
                 .wireGuardObfuscationOff,
             ]
-
-            #if DEBUG
-            items.insert(.wireGuardObfuscationShadowsocks, at: 1)
-            #endif
 
             return items
         }


### PR DESCRIPTION
This PR adds WireGuard over Shadowsocks obfuscation in `Release` and `MockRelease` builds.
It also amends the Changelog to mention said change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7257)
<!-- Reviewable:end -->
