### PR TITLE
Replace misspelling of WireGuardObfuscationShadowsocksPort type name

### DIFF
--- a/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
+++ b/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
@@ -59,7 +59,7 @@ struct ObfuscatorPortSelector {
 
     private func filterShadowsocksRelays(
         from relays: REST.ServerRelaysResponse,
-        for port: WireGuardObfuscationShadowsockPort
+        for port: WireGuardObfuscationShadowsocksPort
     ) -> REST.ServerRelaysResponse {
         let portRanges = RelaySelector.parseRawPortRanges(relays.wireguard.shadowsocksPortRanges)
 

--- a/ios/MullvadSettings/WireGuardObfuscationSettings.swift
+++ b/ios/MullvadSettings/WireGuardObfuscationSettings.swift
@@ -81,7 +81,7 @@ public enum WireGuardObfuscationUdpOverTcpPort: Codable, Equatable, CustomString
     }
 }
 
-public enum WireGuardObfuscationShadowsockPort: Codable, Equatable, CustomStringConvertible {
+public enum WireGuardObfuscationShadowsocksPort: Codable, Equatable, CustomStringConvertible {
     case automatic
     case custom(UInt16)
 
@@ -126,12 +126,12 @@ public struct WireGuardObfuscationSettings: Codable, Equatable {
 
     public var state: WireGuardObfuscationState
     public var udpOverTcpPort: WireGuardObfuscationUdpOverTcpPort
-    public var shadowsocksPort: WireGuardObfuscationShadowsockPort
+    public var shadowsocksPort: WireGuardObfuscationShadowsocksPort
 
     public init(
         state: WireGuardObfuscationState = .automatic,
         udpOverTcpPort: WireGuardObfuscationUdpOverTcpPort = .automatic,
-        shadowsocksPort: WireGuardObfuscationShadowsockPort = .automatic
+        shadowsocksPort: WireGuardObfuscationShadowsocksPort = .automatic
     ) {
         self.state = state
         self.udpOverTcpPort = udpOverTcpPort
@@ -143,7 +143,7 @@ public struct WireGuardObfuscationSettings: Codable, Equatable {
 
         state = try container.decode(WireGuardObfuscationState.self, forKey: .state)
         shadowsocksPort = try container.decodeIfPresent(
-            WireGuardObfuscationShadowsockPort.self,
+            WireGuardObfuscationShadowsocksPort.self,
             forKey: .shadowsocksPort
         ) ?? .automatic
 

--- a/ios/MullvadVPN/View controllers/Settings/Obfuscation/ShadowsocksObfuscationSettingsView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/Obfuscation/ShadowsocksObfuscationSettingsView.swift
@@ -22,7 +22,7 @@ struct ShadowsocksObfuscationSettingsView<VM>: View where VM: ShadowsocksObfusca
 
         SingleChoiceList(
             title: portString,
-            options: [WireGuardObfuscationShadowsockPort.automatic],
+            options: [WireGuardObfuscationShadowsocksPort.automatic],
             value: $viewModel.value,
             itemDescription: { item in NSLocalizedString(
                 "SHADOWSOCKS_PORT_VALUE_\(item)",
@@ -30,7 +30,7 @@ struct ShadowsocksObfuscationSettingsView<VM>: View where VM: ShadowsocksObfusca
                 value: "\(item)",
                 comment: ""
             ) },
-            parseCustomValue: { UInt16($0).flatMap { $0 > 0 ? WireGuardObfuscationShadowsockPort.custom($0) : nil }
+            parseCustomValue: { UInt16($0).flatMap { $0 > 0 ? WireGuardObfuscationShadowsocksPort.custom($0) : nil }
             },
             formatCustomValue: {
                 if case let .custom(port) = $0 {

--- a/ios/MullvadVPN/View controllers/Settings/Obfuscation/ShadowsocksObfuscationSettingsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Settings/Obfuscation/ShadowsocksObfuscationSettingsViewModel.swift
@@ -10,16 +10,16 @@ import Foundation
 import MullvadSettings
 
 protocol ShadowsocksObfuscationSettingsViewModel: ObservableObject {
-    var value: WireGuardObfuscationShadowsockPort { get set }
+    var value: WireGuardObfuscationShadowsocksPort { get set }
 
     func commit()
 }
 
 /** A simple mock view model for use in Previews and similar */
 class MockShadowsocksObfuscationSettingsViewModel: ShadowsocksObfuscationSettingsViewModel {
-    @Published var value: WireGuardObfuscationShadowsockPort
+    @Published var value: WireGuardObfuscationShadowsocksPort
 
-    init(shadowsocksPort: WireGuardObfuscationShadowsockPort = .automatic) {
+    init(shadowsocksPort: WireGuardObfuscationShadowsocksPort = .automatic) {
         self.value = shadowsocksPort
     }
 
@@ -28,7 +28,7 @@ class MockShadowsocksObfuscationSettingsViewModel: ShadowsocksObfuscationSetting
 
 /// ** The live view model which interfaces with the TunnelManager  */
 class TunnelShadowsocksObfuscationSettingsViewModel: TunnelObfuscationSettingsWatchingObservableObject<
-    WireGuardObfuscationShadowsockPort
+    WireGuardObfuscationShadowsocksPort
 >,
     ShadowsocksObfuscationSettingsViewModel {
     init(tunnelManager: TunnelManager) {

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewModel.swift
@@ -98,7 +98,7 @@ struct VPNSettingsViewModel: Equatable {
 
     private(set) var obfuscationState: WireGuardObfuscationState
     private(set) var obfuscationUpdOverTcpPort: WireGuardObfuscationUdpOverTcpPort
-    private(set) var obfuscationShadowsocksPort: WireGuardObfuscationShadowsockPort
+    private(set) var obfuscationShadowsocksPort: WireGuardObfuscationShadowsocksPort
 
     private(set) var quantumResistance: TunnelQuantumResistance
     private(set) var multihopState: MultihopState
@@ -179,7 +179,7 @@ struct VPNSettingsViewModel: Equatable {
         obfuscationState = newState
     }
 
-    mutating func setWireGuardObfuscationShadowsockPort(_ newPort: WireGuardObfuscationShadowsockPort) {
+    mutating func setWireGuardObfuscationShadowsockPort(_ newPort: WireGuardObfuscationShadowsocksPort) {
         obfuscationShadowsocksPort = newPort
     }
 


### PR DESCRIPTION
The type name `WireGuardObfuscationShadowsocksPort` was misspelled as `WireGuardObfuscationShadowsockPort`. A minor annoyance, but this PR fixes it. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7260)
<!-- Reviewable:end -->
