### PR TITLE
Fix multiple Wireguard port selection in settings view

### DIFF
--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -186,9 +186,12 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
     weak var delegate: VPNSettingsDataSourceDelegate?
 
     var selectedIndexPaths: [IndexPath] {
-        let wireGuardPortItem: Item = viewModel.customWireGuardPort == nil
-            ? .wireGuardPort(viewModel.wireGuardPort)
-            : .wireGuardCustomPort
+        var wireGuardPortItem: Item = .wireGuardPort(viewModel.wireGuardPort)
+        if let customPort = indexPath(for: .wireGuardCustomPort) {
+            if tableView?.indexPathsForSelectedRows?.contains(customPort) ?? false {
+                wireGuardPortItem = .wireGuardCustomPort
+            }
+        }
 
         let obfuscationStateItem: Item = switch viewModel.obfuscationState {
         case .automatic: .wireGuardObfuscationAutomatic
@@ -253,6 +256,9 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
 
             Item.wireGuardPorts.forEach { item in
                 if case let .wireGuardPort(port) = item, port == viewModel.wireGuardPort {
+                    if let indexPath = indexPath(for: item) {
+                        deselectAllRowsInSectionExceptRowAt(indexPath)
+                    }
                     selectRow(at: item)
                     return
                 }


### PR DESCRIPTION
If you select any Wireguard port except custom port, then select custom port, then toggle any of the other sections, you will have multiple selections in the Wireguard section.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7264)
<!-- Reviewable:end -->
