### PR TITLE
Make `EncryptedDNSForwarder::from_stream` infallibe

### DIFF
--- a/mullvad-api/src/https_client_with_sni.rs
+++ b/mullvad-api/src/https_client_with_sni.rs
@@ -159,7 +159,8 @@ impl InnerConnectionMode {
             InnerConnectionMode::EncryptedDnsProxy(proxy_config) => {
                 let first_hop = SocketAddr::V4(proxy_config.addr);
                 let make_proxy_stream = |tcp_stream| async {
-                    EncryptedDNSForwarder::from_stream(&proxy_config, tcp_stream)
+                    let forwarder = EncryptedDNSForwarder::from_stream(&proxy_config, tcp_stream);
+                    Ok(forwarder)
                 };
                 Self::connect_proxied(
                     first_hop,

--- a/mullvad-encrypted-dns-proxy/src/forwarder.rs
+++ b/mullvad-encrypted-dns-proxy/src/forwarder.rs
@@ -7,12 +7,11 @@ use tokio::{
     net::TcpStream,
 };
 
-use crate::config::Obfuscator;
+use crate::config::{Obfuscator, ProxyConfig};
 
 /// Forwards local traffic to a proxy endpoint, obfuscating it if the proxy config says so.
 ///
-/// Obtain [`ProxyConfig`](crate::config::ProxyConfig)s with
-/// [resolve_configs](crate::config_resolver::resolve_configs).
+/// Obtain [`ProxyConfig`](ProxyConfig)s with [resolve_configs](crate::config_resolver::resolve_configs).
 pub struct Forwarder<S> {
     read_obfuscator: Option<Box<dyn Obfuscator>>,
     write_obfuscator: Option<Box<dyn Obfuscator>>,
@@ -24,7 +23,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     /// Create a [`Forwarder`] with a connected `stream` to an encrypted DNS proxy server
-    pub fn from_stream(proxy_config: &crate::config::ProxyConfig, stream: S) -> Self {
+    pub fn from_stream(proxy_config: &ProxyConfig, stream: S) -> Self {
         let (read_obfuscator, write_obfuscator) =
             if let Some(obfuscation_config) = &proxy_config.obfuscation {
                 (
@@ -46,7 +45,7 @@ where
 /// Forward TCP traffic over various proxy configurations.
 impl Forwarder<TcpStream> {
     /// Create a forwarder that will connect to a given proxy endpoint.
-    pub async fn connect(proxy_config: &crate::config::ProxyConfig) -> io::Result<Self> {
+    pub async fn connect(proxy_config: &ProxyConfig) -> io::Result<Self> {
         let server_connection = TcpStream::connect(proxy_config.addr).await?;
         Ok(Self::from_stream(proxy_config, server_connection))
     }

--- a/mullvad-encrypted-dns-proxy/src/forwarder.rs
+++ b/mullvad-encrypted-dns-proxy/src/forwarder.rs
@@ -24,7 +24,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     /// Create a [`Forwarder`] with a connected `stream` to an encrypted DNS proxy server
-    pub fn from_stream(proxy_config: &crate::config::ProxyConfig, stream: S) -> io::Result<Self> {
+    pub fn from_stream(proxy_config: &crate::config::ProxyConfig, stream: S) -> Self {
         let (read_obfuscator, write_obfuscator) =
             if let Some(obfuscation_config) = &proxy_config.obfuscation {
                 (
@@ -35,11 +35,11 @@ where
                 (None, None)
             };
 
-        Ok(Self {
+        Self {
             read_obfuscator,
             write_obfuscator,
             stream,
-        })
+        }
     }
 }
 
@@ -48,7 +48,7 @@ impl Forwarder<TcpStream> {
     /// Create a forwarder that will connect to a given proxy endpoint.
     pub async fn connect(proxy_config: &crate::config::ProxyConfig) -> io::Result<Self> {
         let server_connection = TcpStream::connect(proxy_config.addr).await?;
-        Self::from_stream(proxy_config, server_connection)
+        Ok(Self::from_stream(proxy_config, server_connection))
     }
 
     /// Forwards traffic from the client stream to the remote proxy, obfuscating and deobfuscating


### PR DESCRIPTION
This PR cleans up `mullvad_encrypted_dns_proxy::forwarder` a bit by correcting the `Forwarder::from_stream` type signature and importing `ProxyConfig`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7267)
<!-- Reviewable:end -->
