### PR TITLE
Add the openPortSelectorMenuButton accessibility identifier to ... buttons

### DIFF
--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -59,6 +59,7 @@ public enum AccessibilityIdentifier: String {
     case listCustomListDoneButton
     case selectLocationFilterButton
     case relayFilterChipCloseButton
+    case openPortSelectorMenuButton
 
     // Cells
     case deviceCell

--- a/ios/MullvadVPN/View controllers/Settings/SelectableSettingsDetailsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SelectableSettingsDetailsCell.swift
@@ -22,6 +22,7 @@ class SelectableSettingsDetailsCell: SelectableSettingsCell {
             .withRenderingMode(.alwaysOriginal)
             .withTintColor(.white)
         actionButton.configuration = actionButtonConfiguration
+        actionButton.accessibilityIdentifier = .openPortSelectorMenuButton
 
         actionButton.addTarget(
             self,

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -14,13 +14,24 @@ class VPNSettingsPage: Page {
         super.init(app)
     }
 
-    private func cellExpandButton(_ cellAccessiblityIdentifier: AccessibilityIdentifier) -> XCUIElement {
+    private func cellSubButton(
+        _ cellAccessiblityIdentifier: AccessibilityIdentifier,
+        _ subButtonAccessibilityIdentifier: AccessibilityIdentifier
+    ) -> XCUIElement {
         let tableView = app.tables[AccessibilityIdentifier.vpnSettingsTableView]
         let matchingCells = tableView.otherElements[cellAccessiblityIdentifier.rawValue]
-        let expandButton = matchingCells.buttons[AccessibilityIdentifier.expandButton]
+        let expandButton = matchingCells.buttons[subButtonAccessibilityIdentifier]
         let lastCell = tableView.cells.allElementsBoundByIndex.last!
         tableView.scrollDownToElement(element: lastCell)
         return expandButton
+    }
+
+    private func cellExpandButton(_ cellAccessiblityIdentifier: AccessibilityIdentifier) -> XCUIElement {
+        return cellSubButton(cellAccessiblityIdentifier, .expandButton)
+    }
+
+    private func cellPortSelectorButton(_ cellAccessiblityIdentifier: AccessibilityIdentifier) -> XCUIElement {
+        return cellSubButton(cellAccessiblityIdentifier, .openPortSelectorMenuButton)
     }
 
     @discardableResult func tapBackButton() -> Self {
@@ -48,24 +59,40 @@ class VPNSettingsPage: Page {
         return self
     }
 
+    @discardableResult func tapUDPOverTCPPortSelectorButton() -> Self {
+        cellPortSelectorButton(AccessibilityIdentifier.wireGuardObfuscationUdpOverTcp).tap()
+
+        return self
+    }
+
+    @discardableResult func tapShadowsocksPortSelectorButton() -> Self {
+        cellPortSelectorButton(AccessibilityIdentifier.wireGuardObfuscationShadowsocks).tap()
+
+        return self
+    }
+
+    // this button no longer exists
     @discardableResult func tapUDPOverTCPPortExpandButton() -> Self {
         cellExpandButton(AccessibilityIdentifier.udpOverTCPPortCell).tap()
 
         return self
     }
 
+    // this button no longer exists
     @discardableResult func tapUDPOverTCPPortAutomaticCell() -> Self {
         app.cells["\(AccessibilityIdentifier.wireGuardObfuscationPort)Automatic"]
             .tap()
         return self
     }
 
+    // this button no longer exists
     @discardableResult func tapUDPOverTCPPort80Cell() -> Self {
         app.cells["\(AccessibilityIdentifier.wireGuardObfuscationPort)80"]
             .tap()
         return self
     }
 
+    // this button no longer exists
     @discardableResult func tapUDPOverTCPPort5001Cell() -> Self {
         app.cells["\(AccessibilityIdentifier.wireGuardObfuscationPort)5001"]
             .tap()


### PR DESCRIPTION
... in VPN Settings

This creates a new `AccessibilityIdentifier` named `.openPortSelectorMenuButton` and sets the "..." button, for calling up the port selector menu in obfuscation method cells, to have it. It also refactors `VPNSettingsPage`, combining the logic for tapping disclosure cells with that for tapping this button.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7282)
<!-- Reviewable:end -->
