### PR TITLE
Make AccessibilityIdentifier no longer a String enum

### DIFF
--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public enum AccessibilityIdentifier: String {
+public enum AccessibilityIdentifier: Equatable {
     // Buttons
     case addAccessMethodButton
     case accessMethodAddButton
@@ -214,8 +214,14 @@ public enum AccessibilityIdentifier: String {
     case unknown
 }
 
+extension AccessibilityIdentifier: CustomStringConvertible {
+    public var description: String {
+        "\(self)"
+    }
+}
+
 extension UIAccessibilityIdentification {
     func setAccessibilityIdentifier(_ value: AccessibilityIdentifier?) {
-        accessibilityIdentifier = value.map { "\($0)" }
+        accessibilityIdentifier = value.map(\.description)
     }
 }

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -215,13 +215,7 @@ public enum AccessibilityIdentifier: String {
 }
 
 extension UIAccessibilityIdentification {
-    var accessibilityIdentifier: AccessibilityIdentifier? {
-        get {
-            guard let accessibilityIdentifier else { return nil }
-            return AccessibilityIdentifier(rawValue: accessibilityIdentifier)
-        }
-        set {
-            accessibilityIdentifier = newValue?.rawValue
-        }
+    func setAccessibilityIdentifier(_ value: AccessibilityIdentifier?) {
+        accessibilityIdentifier = value.map { "\($0)" }
     }
 }

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -214,14 +214,14 @@ public enum AccessibilityIdentifier: Equatable {
     case unknown
 }
 
-extension AccessibilityIdentifier: CustomStringConvertible {
-    public var description: String {
+extension AccessibilityIdentifier {
+    public var asString: String {
         "\(self)"
     }
 }
 
 extension UIAccessibilityIdentification {
     func setAccessibilityIdentifier(_ value: AccessibilityIdentifier?) {
-        accessibilityIdentifier = value.map(\.description)
+        accessibilityIdentifier = value.map(\.asString)
     }
 }

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -181,7 +181,7 @@ public enum AccessibilityIdentifier: Equatable {
     case wireGuardObfuscationOff
     case wireGuardObfuscationUdpOverTcp
     case wireGuardObfuscationShadowsocks
-    case wireGuardPort
+    case wireGuardPort(UInt16?)
     case udpOverTcpObfuscationSettings
 
     // Custom DNS

--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -33,7 +33,7 @@ class HeaderBarView: UIView {
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = UIColor(white: 1.0, alpha: 0.8)
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        label.accessibilityIdentifier = .headerDeviceNameLabel
+        label.setAccessibilityIdentifier(.headerDeviceNameLabel)
         return label
     }()
 
@@ -58,7 +58,7 @@ class HeaderBarView: UIView {
 
     let accountButton: UIButton = {
         let button = makeHeaderBarButton(with: UIImage(named: "IconAccount"))
-        button.accessibilityIdentifier = .accountButton
+        button.setAccessibilityIdentifier(.accountButton)
         button.accessibilityLabel = NSLocalizedString(
             "HEADER_BAR_ACCOUNT_BUTTON_ACCESSIBILITY_LABEL",
             tableName: "HeaderBar",
@@ -72,7 +72,7 @@ class HeaderBarView: UIView {
 
     let settingsButton: UIButton = {
         let button = makeHeaderBarButton(with: UIImage(named: "IconSettings"))
-        button.accessibilityIdentifier = .settingsButton
+        button.setAccessibilityIdentifier(.settingsButton)
         button.accessibilityLabel = NSLocalizedString(
             "HEADER_BAR_SETTINGS_BUTTON_ACCESSIBILITY_LABEL",
             tableName: "HeaderBar",
@@ -170,7 +170,7 @@ class HeaderBarView: UIView {
         )
 
         accessibilityContainerType = .semanticGroup
-        accessibilityIdentifier = .headerBarView
+        setAccessibilityIdentifier(.headerBarView)
 
         let brandImageSize = brandNameImage?.size ?? .zero
         let brandNameAspectRatio = brandImageSize.width / max(brandImageSize.height, 1)

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -559,7 +559,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         )
 
         let navigationController = CustomNavigationController()
-        navigationController.view.accessibilityIdentifier = .settingsContainerView
+        navigationController.view.setAccessibilityIdentifier(.settingsContainerView)
 
         let configurationTester = ProxyConfigurationTester(transportProvider: configuredTransportProvider)
 

--- a/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/AddLocationsViewController.swift
@@ -27,7 +27,7 @@ class AddLocationsViewController: UIViewController {
         tableView.separatorInset = .zero
         tableView.rowHeight = 56
         tableView.indicatorStyle = .white
-        tableView.accessibilityIdentifier = .editCustomListEditLocationsTableView
+        tableView.setAccessibilityIdentifier(.editCustomListEditLocationsTableView)
         return tableView
     }()
 
@@ -46,7 +46,7 @@ class AddLocationsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.accessibilityIdentifier = .editCustomListEditLocationsView
+        view.setAccessibilityIdentifier(.editCustomListEditLocationsView)
         tableView.backgroundColor = view.backgroundColor
         view.backgroundColor = .secondaryColor
         addConstraints()

--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListCellConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListCellConfiguration.swift
@@ -79,7 +79,7 @@ struct CustomListCellConfiguration {
         contentConfiguration.maxLength = NameInputFormatter.maxLength
         contentConfiguration.editingEvents.onChange = subject.bindTextAction(to: \.name)
 
-        cell.accessibilityIdentifier = AccessibilityIdentifier.customListEditNameFieldCell
+        cell.setAccessibilityIdentifier(.customListEditNameFieldCell)
         cell.contentConfiguration = contentConfiguration
     }
 
@@ -88,7 +88,7 @@ struct CustomListCellConfiguration {
 
         contentConfiguration.text = itemIdentifier.text
         cell.contentConfiguration = contentConfiguration
-        cell.accessibilityIdentifier = AccessibilityIdentifier.customListEditAddOrEditLocationCell
+        cell.setAccessibilityIdentifier(.customListEditAddOrEditLocationCell)
 
         if let cell = cell as? CustomCellDisclosureHandling {
             cell.disclosureType = .chevron
@@ -104,7 +104,7 @@ struct CustomListCellConfiguration {
             onDelete?()
         }
 
-        cell.accessibilityIdentifier = AccessibilityIdentifier.customListEditDeleteListCell
+        cell.setAccessibilityIdentifier(.customListEditDeleteListCell)
         cell.contentConfiguration = contentConfiguration
     }
 }

--- a/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/CustomListViewController.swift
@@ -58,7 +58,7 @@ class CustomListViewController: UIViewController {
             }
         )
         barButtonItem.style = .done
-        barButtonItem.accessibilityIdentifier = AccessibilityIdentifier.saveCreateCustomListButton
+        barButtonItem.setAccessibilityIdentifier(.saveCreateCustomListButton)
 
         return barButtonItem
     }()
@@ -87,7 +87,7 @@ class CustomListViewController: UIViewController {
         navigationItem.rightBarButtonItem = saveBarButton
         view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         view.backgroundColor = .secondaryColor
-        view.accessibilityIdentifier = .newCustomListView
+        view.setAccessibilityIdentifier(.newCustomListView)
         isModalInPresentation = true
 
         addSubviews()
@@ -104,7 +104,7 @@ class CustomListViewController: UIViewController {
         tableView.delegate = dataSourceConfiguration
         tableView.backgroundColor = .secondaryColor
         tableView.registerReusableViews(from: CustomListItemIdentifier.CellIdentifier.self)
-        tableView.accessibilityIdentifier = AccessibilityIdentifier.customListEditTableView
+        tableView.setAccessibilityIdentifier(.customListEditTableView)
     }
 
     private func configureDataSource() {

--- a/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListViewController.swift
+++ b/ios/MullvadVPN/Coordinators/CustomLists/ListCustomListViewController.swift
@@ -50,7 +50,7 @@ class ListCustomListViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .secondaryColor
-        view.accessibilityIdentifier = .listCustomListsView
+        view.setAccessibilityIdentifier(.listCustomListsView)
 
         addSubviews()
         configureNavigationItem()
@@ -89,7 +89,7 @@ class ListCustomListViewController: UIViewController {
         tableView.separatorStyle = .singleLine
         tableView.rowHeight = UIMetrics.SettingsCell.customListsCellHeight
         tableView.registerReusableViews(from: CellReuseIdentifier.self)
-        tableView.accessibilityIdentifier = .listCustomListsTableView
+        tableView.setAccessibilityIdentifier(.listCustomListsTableView)
     }
 
     private func configureNavigationItem() {
@@ -107,7 +107,7 @@ class ListCustomListViewController: UIViewController {
             })
         )
 
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = .listCustomListDoneButton
+        navigationItem.rightBarButtonItem?.setAccessibilityIdentifier(.listCustomListDoneButton)
     }
 
     private func configureDataSource() {

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -284,7 +284,7 @@ extension LocationCoordinator: LocationViewControllerWrapperDelegate {
                 self?.showAddCustomList(nodes: nodes)
             }
         )
-        addCustomListAction.accessibilityIdentifier = AccessibilityIdentifier.addNewCustomListButton
+        addCustomListAction.setAccessibilityIdentifier(.addNewCustomListButton)
         actionSheet.addAction(addCustomListAction)
 
         let editAction = UIAlertAction(
@@ -297,7 +297,7 @@ extension LocationCoordinator: LocationViewControllerWrapperDelegate {
             }
         )
         editAction.isEnabled = !customListRepository.fetchAll().isEmpty
-        editAction.accessibilityIdentifier = AccessibilityIdentifier.editCustomListButton
+        editAction.setAccessibilityIdentifier(.editCustomListButton)
         actionSheet.addAction(editAction)
 
         actionSheet.addAction(UIAlertAction(

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
@@ -76,7 +76,7 @@ class SwitchCellContentView: UIView, UIContentView, UITextFieldDelegate {
     private func configureSwitch() {
         switchContainer.control.isOn = actualConfiguration.isOn
         switchContainer.transform = CGAffineTransform(scaleX: 0.85, y: 0.85)
-        switchContainer.accessibilityIdentifier = actualConfiguration.accessibilityIdentifier
+        switchContainer.setAccessibilityIdentifier(actualConfiguration.accessibilityIdentifier)
     }
 
     private func addSubviews() {

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Common/SocksSectionHandler.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Common/SocksSectionHandler.swift
@@ -38,7 +38,7 @@ struct SocksSectionHandler {
         contentConfiguration.inputText = subject.value.socks.server
         contentConfiguration.textFieldProperties = .withSmartFeaturesDisabled()
         contentConfiguration.editingEvents.onChange = subject.bindTextAction(to: \.socks.server)
-        cell.accessibilityIdentifier = .socks5ServerCell
+        cell.setAccessibilityIdentifier(.socks5ServerCell)
         cell.contentConfiguration = contentConfiguration
     }
 
@@ -51,7 +51,7 @@ struct SocksSectionHandler {
         contentConfiguration.editingEvents.onChange = subject.bindTextAction(to: \.socks.port)
         contentConfiguration.textFieldProperties = .withSmartFeaturesDisabled()
         contentConfiguration.textFieldProperties.keyboardType = .numberPad
-        cell.accessibilityIdentifier = .socks5PortCell
+        cell.setAccessibilityIdentifier(.socks5PortCell)
         cell.contentConfiguration = contentConfiguration
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
@@ -47,7 +47,7 @@ class EditAccessMethodViewController: UIViewController {
 
         view.backgroundColor = .secondaryColor
 
-        tableView.accessibilityIdentifier = .editAccessMethodView
+        tableView.setAccessibilityIdentifier(.editAccessMethodView)
         tableView.backgroundColor = .secondaryColor
         tableView.delegate = self
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsCellConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsCellConfiguration.swift
@@ -113,7 +113,7 @@ class MethodSettingsCellConfiguration {
         contentConfiguration.maxLength = NameInputFormatter.maxLength
         contentConfiguration.editingEvents.onChange = subject.bindTextAction(to: \.name)
 
-        cell.accessibilityIdentifier = .accessMethodNameTextField
+        cell.setAccessibilityIdentifier(.accessMethodNameTextField)
         cell.setDisabled(isTesting)
         cell.contentConfiguration = contentConfiguration
     }
@@ -156,7 +156,7 @@ class MethodSettingsCellConfiguration {
             cell.disclosureType = .chevron
         }
 
-        cell.accessibilityIdentifier = .accessMethodProtocolSelectionCell
+        cell.setAccessibilityIdentifier(.accessMethodProtocolSelectionCell)
         cell.setDisabled(isTesting)
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsViewController.swift
@@ -76,12 +76,12 @@ class MethodSettingsViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.accessibilityIdentifier = .addAccessMethodTableView
+        view.setAccessibilityIdentifier(.addAccessMethodTableView)
         view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
         view.backgroundColor = .secondaryColor
 
         navigationItem.rightBarButtonItem = saveBarButton
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = .accessMethodAddButton
+        navigationItem.rightBarButtonItem?.setAccessibilityIdentifier(.accessMethodAddButton)
         navigationItem.rightBarButtonItem?.isAccessibilityElement = true
         isModalInPresentation = true
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodTestingStatusCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodTestingStatusCellContentView.swift
@@ -139,11 +139,11 @@ class MethodTestingStatusCellContentView: UIView, UIContentView {
         // Set accessibility identifier for the text label based on the status it is indicating
         switch actualConfiguration.status {
         case .reachable:
-            textLabel.accessibilityIdentifier = .addAccessMethodTestStatusReachableLabel
+            textLabel.setAccessibilityIdentifier(.addAccessMethodTestStatusReachableLabel)
         case .unreachable:
-            textLabel.accessibilityIdentifier = .addAccessMethodTestStatusUnreachableLabel
+            textLabel.setAccessibilityIdentifier(.addAccessMethodTestStatusUnreachableLabel)
         case .testing:
-            textLabel.accessibilityIdentifier = .addAccessMethodTestStatusTestingLabel
+            textLabel.setAccessibilityIdentifier(.addAccessMethodTestStatusTestingLabel)
         }
 
         // Text label is always the last one, so only add it into the stack if it's not there yet.

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodViewController.swift
@@ -62,7 +62,7 @@ class ListAccessMethodViewController: UIViewController, UITableViewDelegate {
 
         tableView.registerReusableViews(from: CellReuseIdentifier.self)
 
-        view.accessibilityIdentifier = .apiAccessView
+        view.setAccessibilityIdentifier(.apiAccessView)
 
         let headerView = createHeaderView()
         view.addConstrainedSubviews([headerView, tableView]) {
@@ -115,7 +115,7 @@ class ListAccessMethodViewController: UIViewController, UITableViewDelegate {
         button.addAction(UIAction { [weak self] _ in
             self?.sendAddNew()
         }, for: .touchUpInside)
-        button.accessibilityIdentifier = .addAccessMethodButton
+        button.setAccessibilityIdentifier(.addAccessMethodButton)
 
         let fontSize = button.titleLabel?.font.pointSize ?? 0
         button.titleLabel?.font = UIFont.systemFont(ofSize: fontSize, weight: .regular)

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Pickers/AccessMethodProtocolPicker.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Pickers/AccessMethodProtocolPicker.swift
@@ -23,7 +23,7 @@ struct AccessMethodProtocolPicker {
 
         let dataSource = AccessMethodProtocolPickerDataSource()
         let controller = ListItemPickerViewController(dataSource: dataSource, selectedItemID: currentValue)
-        controller.view.accessibilityIdentifier = .accessMethodProtocolPickerView
+        controller.view.setAccessibilityIdentifier(.accessMethodProtocolPickerView)
 
         controller.navigationItem.title = NSLocalizedString(
             "SELECT_PROTOCOL_NAV_TITLE",

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsViewControllerFactory.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsViewControllerFactory.swift
@@ -103,7 +103,7 @@ struct SettingsViewControllerFactory {
             value: "Multihop",
             comment: ""
         )
-        host.view.accessibilityIdentifier = AccessibilityIdentifier.multihopView.rawValue
+        host.view.setAccessibilityIdentifier(.multihopView)
 
         return .viewController(host)
     }
@@ -129,7 +129,7 @@ struct SettingsViewControllerFactory {
             value: "DAITA",
             comment: ""
         )
-        host.view.accessibilityIdentifier = AccessibilityIdentifier.daitaView.rawValue
+        host.view.setAccessibilityIdentifier(.daitaView)
 
         return .viewController(host)
     }

--- a/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
@@ -11,13 +11,13 @@ import UIKit
 class AccountContentView: UIView {
     let purchaseButton: InAppPurchaseButton = {
         let button = InAppPurchaseButton()
-        button.accessibilityIdentifier = .purchaseButton
+        button.setAccessibilityIdentifier(.purchaseButton)
         return button
     }()
 
     let redeemVoucherButton: AppButton = {
         let button = AppButton(style: .success)
-        button.accessibilityIdentifier = .redeemVoucherButton
+        button.setAccessibilityIdentifier(.redeemVoucherButton)
         button.setTitle(NSLocalizedString(
             "REDEEM_VOUCHER_BUTTON_TITLE",
             tableName: "Account",
@@ -29,7 +29,7 @@ class AccountContentView: UIView {
 
     let logoutButton: AppButton = {
         let button = AppButton(style: .danger)
-        button.accessibilityIdentifier = .logoutButton
+        button.setAccessibilityIdentifier(.logoutButton)
         button.setTitle(NSLocalizedString(
             "LOGOUT_BUTTON_TITLE",
             tableName: "Account",
@@ -41,7 +41,7 @@ class AccountContentView: UIView {
 
     let deleteButton: AppButton = {
         let button = AppButton(style: .danger)
-        button.accessibilityIdentifier = .deleteButton
+        button.setAccessibilityIdentifier(.deleteButton)
         button.setTitle(NSLocalizedString(
             "DELETE_BUTTON_TITLE",
             tableName: "Account",
@@ -101,7 +101,7 @@ class AccountContentView: UIView {
         super.init(frame: frame)
 
         directionalLayoutMargins = UIMetrics.contentLayoutMargins
-        accessibilityIdentifier = .accountView
+        setAccessibilityIdentifier(.accountView)
 
         addConstrainedSubviews([contentStackView, buttonStackView]) {
             contentStackView.pinEdgesToSuperviewMargins(.all().excluding(.bottom))

--- a/ios/MullvadVPN/View controllers/Account/AccountDeviceRow.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountDeviceRow.swift
@@ -13,7 +13,7 @@ class AccountDeviceRow: UIView {
         didSet {
             deviceLabel.text = deviceName?.capitalized ?? ""
             accessibilityValue = deviceName
-            accessibilityIdentifier = .accountPageDeviceNameLabel
+            setAccessibilityIdentifier(.accountPageDeviceNameLabel)
         }
     }
 
@@ -41,7 +41,7 @@ class AccountDeviceRow: UIView {
 
     private let infoButton: UIButton = {
         let button = IncreasedHitButton(type: .system)
-        button.accessibilityIdentifier = .infoButton
+        button.setAccessibilityIdentifier(.infoButton)
         button.tintColor = .white
         button.setImage(UIImage(named: "IconInfo"), for: .normal)
         return button

--- a/ios/MullvadVPN/View controllers/Account/AccountExpiryRow.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountExpiryRow.swift
@@ -62,7 +62,7 @@ class AccountExpiryRow: UIView {
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
         valueLabel.font = UIFont.systemFont(ofSize: 17)
         valueLabel.textColor = .white
-        valueLabel.accessibilityIdentifier = .accountPagePaidUntilLabel
+        valueLabel.setAccessibilityIdentifier(.accountPagePaidUntilLabel)
         return valueLabel
     }()
 

--- a/ios/MullvadVPN/View controllers/Account/RestorePurchasesView.swift
+++ b/ios/MullvadVPN/View controllers/Account/RestorePurchasesView.swift
@@ -24,7 +24,7 @@ class RestorePurchasesView: UIView {
 
     private lazy var restoreButton: UILabel = {
         let label = UILabel()
-        label.accessibilityIdentifier = .restorePurchasesButton
+        label.setAccessibilityIdentifier(.restorePurchasesButton)
         label.attributedText = makeAttributedString()
         label.isUserInteractionEnabled = true
         label.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapRestoreButton)))

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
@@ -376,9 +376,9 @@ class AccountDeletionContentView: UIView {
 
     @objc private func didPress(button: AppButton) {
         switch button.accessibilityIdentifier {
-        case AccessibilityIdentifier.deleteButton.description:
+        case AccessibilityIdentifier.deleteButton.asString:
             delegate?.didTapDeleteButton(contentView: self, button: button)
-        case AccessibilityIdentifier.cancelButton.description:
+        case AccessibilityIdentifier.cancelButton.asString:
             delegate?.didTapCancelButton(contentView: self, button: button)
         default: return
         }

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
@@ -375,10 +375,10 @@ class AccountDeletionContentView: UIView {
     }
 
     @objc private func didPress(button: AppButton) {
-        switch AccessibilityIdentifier(rawValue: button.accessibilityIdentifier ?? "") {
-        case .deleteButton:
+        switch button.accessibilityIdentifier {
+        case AccessibilityIdentifier.deleteButton.description:
             delegate?.didTapDeleteButton(contentView: self, button: button)
-        case .cancelButton:
+        case AccessibilityIdentifier.cancelButton.description:
             delegate?.didTapCancelButton(contentView: self, button: button)
         default: return
         }

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionContentView.swift
@@ -81,7 +81,7 @@ class AccountDeletionContentView: UIView {
     private lazy var accountTextField: AccountTextField = {
         let groupingStyle = AccountTextField.GroupingStyle.lastPart
         let textField = AccountTextField(groupingStyle: groupingStyle)
-        textField.accessibilityIdentifier = .deleteAccountTextField
+        textField.setAccessibilityIdentifier(.deleteAccountTextField)
         textField.font = .preferredFont(forTextStyle: .body, weight: .bold)
         textField.placeholder = Array(repeating: "X", count: 4).joined()
         textField.placeholderTextColor = .lightGray
@@ -101,7 +101,7 @@ class AccountDeletionContentView: UIView {
 
     private let deleteButton: AppButton = {
         let button = AppButton(style: .danger)
-        button.accessibilityIdentifier = .deleteButton
+        button.setAccessibilityIdentifier(.deleteButton)
         button.setTitle(NSLocalizedString(
             "DELETE_ACCOUNT_BUTTON_TITLE",
             tableName: "Account",
@@ -113,7 +113,7 @@ class AccountDeletionContentView: UIView {
 
     private let cancelButton: AppButton = {
         let button = AppButton(style: .default)
-        button.accessibilityIdentifier = .cancelButton
+        button.setAccessibilityIdentifier(.cancelButton)
         button.setTitle(NSLocalizedString(
             "CANCEL_BUTTON_TITLE",
             tableName: "Account",
@@ -347,7 +347,7 @@ class AccountDeletionContentView: UIView {
     }
 
     private func setupAppearance() {
-        accessibilityIdentifier = .deleteAccountView
+        setAccessibilityIdentifier(.deleteAccountView)
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .secondaryColor
         directionalLayoutMargins = UIMetrics.contentLayoutMargins

--- a/ios/MullvadVPN/View controllers/Alert/AlertViewController.swift
+++ b/ios/MullvadVPN/View controllers/Alert/AlertViewController.swift
@@ -108,7 +108,7 @@ class AlertViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.accessibilityIdentifier = presentation.accessibilityIdentifier ?? .alertContainerView
+        view.setAccessibilityIdentifier(presentation.accessibilityIdentifier ?? .alertContainerView)
         view.backgroundColor = .black.withAlphaComponent(0.5)
 
         setContent()
@@ -207,7 +207,7 @@ class AlertViewController: UIViewController {
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         label.numberOfLines = 0
-        label.accessibilityIdentifier = .alertTitle
+        label.setAccessibilityIdentifier(.alertTitle)
 
         contentView.addArrangedSubview(label)
         contentView.setCustomSpacing(16, after: label)
@@ -270,7 +270,7 @@ class AlertViewController: UIViewController {
         let button = AppButton(style: style.buttonStyle)
 
         button.setTitle(title, for: .normal)
-        button.accessibilityIdentifier = accessibilityId
+        button.setAccessibilityIdentifier(accessibilityId)
         button.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
 
         buttonView.addArrangedSubview(button)

--- a/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
@@ -142,9 +142,9 @@ class SetupAccountCompletedContentView: UIView {
 
     @objc private func tapped(button: AppButton) {
         switch button.accessibilityIdentifier {
-        case AccessibilityIdentifier.learnAboutPrivacyButton.description:
+        case AccessibilityIdentifier.learnAboutPrivacyButton.asString:
             delegate?.didTapPrivacyButton(view: self, button: button)
-        case AccessibilityIdentifier.startUsingTheAppButton.description:
+        case AccessibilityIdentifier.startUsingTheAppButton.asString:
             delegate?.didTapStartingAppButton(view: self, button: button)
         default: return
         }

--- a/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
@@ -141,10 +141,10 @@ class SetupAccountCompletedContentView: UIView {
     }
 
     @objc private func tapped(button: AppButton) {
-        switch AccessibilityIdentifier(rawValue: button.accessibilityIdentifier ?? "") {
-        case .learnAboutPrivacyButton:
+        switch button.accessibilityIdentifier {
+        case AccessibilityIdentifier.learnAboutPrivacyButton.description:
             delegate?.didTapPrivacyButton(view: self, button: button)
-        case .startUsingTheAppButton:
+        case AccessibilityIdentifier.startUsingTheAppButton.description:
             delegate?.didTapStartingAppButton(view: self, button: button)
         default: return
         }

--- a/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedContentView.swift
@@ -56,7 +56,7 @@ class SetupAccountCompletedContentView: UIView {
 
     private let privacyButton: AppButton = {
         let button = AppButton(style: .success)
-        button.accessibilityIdentifier = .learnAboutPrivacyButton
+        button.setAccessibilityIdentifier(.learnAboutPrivacyButton)
         let localizedString = NSLocalizedString(
             "LEARN_ABOUT_PRIVACY_BUTTON",
             tableName: "CreatedAccountConfirmation",
@@ -70,7 +70,7 @@ class SetupAccountCompletedContentView: UIView {
 
     private let startButton: AppButton = {
         let button = AppButton(style: .success)
-        button.accessibilityIdentifier = .startUsingTheAppButton
+        button.setAccessibilityIdentifier(.startUsingTheAppButton)
         button.setTitle(NSLocalizedString(
             "START_USING_THE_APP_BUTTON",
             tableName: "CreatedAccountConfirmation",

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
@@ -250,12 +250,12 @@ final class WelcomeContentView: UIView {
     }
 
     @objc private func tapped(button: AppButton) {
-        switch AccessibilityIdentifier(rawValue: button.accessibilityIdentifier ?? "") {
-        case .purchaseButton:
+        switch button.accessibilityIdentifier {
+        case AccessibilityIdentifier.purchaseButton.description:
             delegate?.didTapPurchaseButton(welcomeContentView: self, button: button)
-        case .redeemVoucherButton:
+        case AccessibilityIdentifier.redeemVoucherButton.description:
             delegate?.didTapRedeemVoucherButton(welcomeContentView: self, button: button)
-        case .infoButton:
+        case AccessibilityIdentifier.infoButton.description:
             delegate?.didTapInfoButton(welcomeContentView: self, button: button)
         default: return
         }

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
@@ -54,7 +54,7 @@ final class WelcomeContentView: UIView {
 
     private let accountNumberLabel: UILabel = {
         let label = UILabel()
-        label.accessibilityIdentifier = .welcomeAccountNumberLabel
+        label.setAccessibilityIdentifier(.welcomeAccountNumberLabel)
         label.adjustsFontForContentSizeCategory = true
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = .zero
@@ -76,7 +76,7 @@ final class WelcomeContentView: UIView {
 
     private let infoButton: UIButton = {
         let button = IncreasedHitButton(type: .system)
-        button.accessibilityIdentifier = .infoButton
+        button.setAccessibilityIdentifier(.infoButton)
         button.tintColor = .white
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setImage(UIImage(named: "IconInfo"), for: .normal)
@@ -108,7 +108,7 @@ final class WelcomeContentView: UIView {
 
     private let purchaseButton: InAppPurchaseButton = {
         let button = InAppPurchaseButton()
-        button.accessibilityIdentifier = .purchaseButton
+        button.setAccessibilityIdentifier(.purchaseButton)
         let localizedString = NSLocalizedString(
             "BUY_CREDIT_BUTTON",
             tableName: "Welcome",
@@ -121,7 +121,7 @@ final class WelcomeContentView: UIView {
 
     private let redeemVoucherButton: AppButton = {
         let button = AppButton(style: .success)
-        button.accessibilityIdentifier = .redeemVoucherButton
+        button.setAccessibilityIdentifier(.redeemVoucherButton)
         button.setTitle(NSLocalizedString(
             "REDEEM_VOUCHER_BUTTON_TITLE",
             tableName: "Account",
@@ -193,7 +193,7 @@ final class WelcomeContentView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        accessibilityIdentifier = .welcomeView
+        setAccessibilityIdentifier(.welcomeView)
         backgroundColor = .primaryColor
         directionalLayoutMargins = UIMetrics.contentLayoutMargins
         backgroundColor = .secondaryColor

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
@@ -251,11 +251,11 @@ final class WelcomeContentView: UIView {
 
     @objc private func tapped(button: AppButton) {
         switch button.accessibilityIdentifier {
-        case AccessibilityIdentifier.purchaseButton.description:
+        case AccessibilityIdentifier.purchaseButton.asString:
             delegate?.didTapPurchaseButton(welcomeContentView: self, button: button)
-        case AccessibilityIdentifier.redeemVoucherButton.description:
+        case AccessibilityIdentifier.redeemVoucherButton.asString:
             delegate?.didTapRedeemVoucherButton(welcomeContentView: self, button: button)
-        case AccessibilityIdentifier.infoButton.description:
+        case AccessibilityIdentifier.infoButton.asString:
             delegate?.didTapInfoButton(welcomeContentView: self, button: button)
         default: return
         }

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
@@ -69,7 +69,7 @@ class DeviceManagementContentView: UIView {
             for: .normal
         )
         button.isEnabled = false
-        button.accessibilityIdentifier = .continueWithLoginButton
+        button.setAccessibilityIdentifier(.continueWithLoginButton)
         return button
     }()
 
@@ -114,7 +114,7 @@ class DeviceManagementContentView: UIView {
         constraintViews()
         updateView()
 
-        accessibilityIdentifier = .deviceManagementView
+        setAccessibilityIdentifier(.deviceManagementView)
     }
 
     private func addViews() {

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
@@ -70,7 +70,7 @@ class DeviceRowView: UIView {
 
         super.init(frame: .zero)
 
-        accessibilityIdentifier = .deviceCell
+        setAccessibilityIdentifier(.deviceCell)
         backgroundColor = .primaryColor
         directionalLayoutMargins = UIMetrics.TableView.rowViewLayoutMargins
 
@@ -91,7 +91,7 @@ class DeviceRowView: UIView {
         )
 
         removeButton.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
-        removeButton.accessibilityIdentifier = .deviceCellRemoveButton
+        removeButton.setAccessibilityIdentifier(.deviceCellRemoveButton)
 
         NSLayoutConstraint.activate([
             textLabel.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),

--- a/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
@@ -24,7 +24,7 @@ final class AccountInputGroupView: UIView {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setImage(UIImage(named: "IconArrow"), for: .normal)
         button.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        button.accessibilityIdentifier = .loginTextFieldButton
+        button.setAccessibilityIdentifier(.loginTextFieldButton)
         button.accessibilityLabel = NSLocalizedString(
             "ACCOUNT_INPUT_LOGIN_BUTTON_ACCESSIBILITY_LABEL",
             tableName: "AccountInput",

--- a/ios/MullvadVPN/View controllers/Login/LoginContentView.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginContentView.swift
@@ -85,7 +85,7 @@ class LoginContentView: UIView {
 
     let createAccountButton: AppButton = {
         let button = AppButton(style: .default)
-        button.accessibilityIdentifier = .createAccountButton
+        button.setAccessibilityIdentifier(.createAccountButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(NSLocalizedString(
             "CREATE_ACCOUNT_BUTTON_LABEL",
@@ -104,9 +104,9 @@ class LoginContentView: UIView {
 
         backgroundColor = .primaryColor
         directionalLayoutMargins = UIMetrics.contentLayoutMargins
-        accessibilityIdentifier = .loginView
+        setAccessibilityIdentifier(.loginView)
 
-        accountInputGroup.textField.accessibilityIdentifier = .loginTextField
+        accountInputGroup.textField.setAccessibilityIdentifier(.loginTextField)
 
         keyboardResponder = AutomaticKeyboardResponder(
             targetView: self,

--- a/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
@@ -59,7 +59,7 @@ class LoginViewController: UIViewController, RootContainment {
             target: self,
             action: #selector(doLogin)
         )
-        barButtonItem.accessibilityIdentifier = .loginBarButton
+        barButtonItem.setAccessibilityIdentifier(.loginBarButton)
 
         return barButtonItem
     }()

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
@@ -95,7 +95,7 @@ class OutOfTimeContentView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        accessibilityIdentifier = .outOfTimeView
+        setAccessibilityIdentifier(.outOfTimeView)
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .secondaryColor
         directionalLayoutMargins = UIMetrics.contentLayoutMargins

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
@@ -30,7 +30,7 @@ class ProblemReportReviewViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .secondaryColor
-        view.accessibilityIdentifier = .appLogsView
+        view.setAccessibilityIdentifier(.appLogsView)
 
         navigationItem.title = NSLocalizedString(
             "NAVIGATION_TITLE",
@@ -45,7 +45,7 @@ class ProblemReportReviewViewController: UIViewController {
                 self?.dismiss(animated: true)
             })
         )
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = .appLogsDoneButton
+        navigationItem.rightBarButtonItem?.setAccessibilityIdentifier(.appLogsDoneButton)
 
         #if DEBUG
         navigationItem.leftBarButtonItem = UIBarButtonItem(
@@ -54,10 +54,10 @@ class ProblemReportReviewViewController: UIViewController {
                 self?.share()
             })
         )
-        navigationItem.leftBarButtonItem?.accessibilityIdentifier = .appLogsShareButton
+        navigationItem.leftBarButtonItem?.setAccessibilityIdentifier(.appLogsShareButton)
         #endif
 
-        textView.accessibilityIdentifier = .problemReportAppLogsTextView
+        textView.setAccessibilityIdentifier(.problemReportAppLogsTextView)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.isEditable = false
         textView.font = UIFont.monospacedSystemFont(

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportSubmissionOverlayView.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportSubmissionOverlayView.swift
@@ -174,7 +174,7 @@ class ProblemReportSubmissionOverlayView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        accessibilityIdentifier = AccessibilityIdentifier.problemReportSubmittedView
+        setAccessibilityIdentifier(.problemReportSubmittedView)
 
         addSubviews()
         transitionToState(state)

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController+ViewManagement.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController+ViewManagement.swift
@@ -88,7 +88,7 @@ extension ProblemReportViewController {
 
     func makeViewLogsButton() -> AppButton {
         let button = AppButton(style: .default)
-        button.accessibilityIdentifier = .problemReportAppLogsButton
+        button.setAccessibilityIdentifier(.problemReportAppLogsButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(Self.persistentViewModel.viewLogsButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(handleViewLogsButtonTap), for: .touchUpInside)
@@ -97,7 +97,7 @@ extension ProblemReportViewController {
 
     func makeSendButton() -> AppButton {
         let button = AppButton(style: .success)
-        button.accessibilityIdentifier = .problemReportSendButton
+        button.setAccessibilityIdentifier(.problemReportSendButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(Self.persistentViewModel.sendLogsButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(handleSendButtonTap), for: .touchUpInside)

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController.swift
@@ -75,7 +75,7 @@ final class ProblemReportViewController: UIViewController, UITextFieldDelegate {
         super.viewDidLoad()
 
         view.backgroundColor = .secondaryColor
-        view.accessibilityIdentifier = .problemReportView
+        view.setAccessibilityIdentifier(.problemReportView)
 
         navigationItem.title = Self.persistentViewModel.navigationTitle
 
@@ -91,8 +91,8 @@ final class ProblemReportViewController: UIViewController, UITextFieldDelegate {
         messageTextView.setContentHuggingPriority(.defaultLow, for: .vertical)
         messageTextView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
-        emailTextField.accessibilityIdentifier = .problemReportEmailTextField
-        messageTextView.accessibilityIdentifier = .problemReportMessageTextView
+        emailTextField.setAccessibilityIdentifier(.problemReportEmailTextField)
+        messageTextView.setAccessibilityIdentifier(.problemReportMessageTextView)
 
         addConstraints()
         registerForNotifications()

--- a/ios/MullvadVPN/View controllers/RelayFilter/ChipViewCell.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/ChipViewCell.swift
@@ -25,7 +25,7 @@ class ChipViewCell: UIView, UIContentView {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.accessibilityIdentifier = .relayFilterChipLabel
+        label.setAccessibilityIdentifier(.relayFilterChipLabel)
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 1
@@ -39,7 +39,7 @@ class ChipViewCell: UIView, UIContentView {
         var buttonConfiguration = UIButton.Configuration.plain()
         buttonConfiguration.image = UIImage(resource: .iconCloseSml).withTintColor(.white.withAlphaComponent(0.6))
         buttonConfiguration.contentInsets = .zero
-        button.accessibilityIdentifier = .relayFilterChipCloseButton
+        button.setAccessibilityIdentifier(.relayFilterChipCloseButton)
         button.configuration = buttonConfiguration
         return button
     }()
@@ -73,7 +73,7 @@ class ChipViewCell: UIView, UIContentView {
     }
 
     func addSubviews() {
-        self.accessibilityIdentifier = .relayFilterChipView
+        self.setAccessibilityIdentifier(.relayFilterChipView)
 
         let stackView = UIStackView(arrangedSubviews: [titleLabel, closeButton])
         stackView.spacing = UIMetrics.FilterView.chipViewLabelSpacing

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterCellFactory.swift
@@ -34,13 +34,13 @@ struct RelayFilterCellFactory: CellFactoryProtocol {
         switch item {
         case .ownershipAny:
             title = "Any"
-            cell.accessibilityIdentifier = .ownershipAnyCell
+            cell.setAccessibilityIdentifier(.ownershipAnyCell)
         case .ownershipOwned:
             title = "Mullvad owned only"
-            cell.accessibilityIdentifier = .ownershipMullvadOwnedCell
+            cell.setAccessibilityIdentifier(.ownershipMullvadOwnedCell)
         case .ownershipRented:
             title = "Rented only"
-            cell.accessibilityIdentifier = .ownershipRentedCell
+            cell.setAccessibilityIdentifier(.ownershipRentedCell)
         default:
             assertionFailure("Item mismatch. Got: \(item)")
         }
@@ -80,7 +80,7 @@ struct RelayFilterCellFactory: CellFactoryProtocol {
         )
 
         cell.applySubCellStyling()
-        cell.accessibilityIdentifier = .relayFilterProviderCell
+        cell.setAccessibilityIdentifier(.relayFilterProviderCell)
     }
 
     private func setFontWeight(_ weight: UIFont.Weight, to label: UILabel) {

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterDataSource.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterDataSource.swift
@@ -254,7 +254,7 @@ extension RelayFilterDataSource: UITableViewDelegate {
             title = "Providers"
         }
 
-        view.accessibilityIdentifier = accessibilityIdentifier
+        view.setAccessibilityIdentifier(accessibilityIdentifier)
         view.titleLabel.text = NSLocalizedString(
             "RELAY_FILTER_HEADER_LABEL",
             tableName: "Relay filter header",

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterViewController.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterViewController.swift
@@ -21,7 +21,7 @@ class RelayFilterViewController: UIViewController {
 
     private let applyButton: AppButton = {
         let button = AppButton(style: .success)
-        button.accessibilityIdentifier = .applyButton
+        button.setAccessibilityIdentifier(.applyButton)
         button.setTitle(NSLocalizedString(
             "RELAY_FILTER_BUTTON_TITLE",
             tableName: "RelayFilter",

--- a/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
+++ b/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
@@ -62,7 +62,7 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
 
     private lazy var logoutButton: AppButton = {
         let button = AppButton(style: .default)
-        button.accessibilityIdentifier = .revokedDeviceLoginButton
+        button.setAccessibilityIdentifier(.revokedDeviceLoginButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(
             NSLocalizedString(
@@ -109,7 +109,7 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.accessibilityIdentifier = .revokedDeviceView
+        view.setAccessibilityIdentifier(.revokedDeviceView)
         view.backgroundColor = .secondaryColor
         view.directionalLayoutMargins = UIMetrics.contentLayoutMargins
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -265,7 +265,7 @@ class LocationCell: UITableViewCell {
     private func updateCollapseImage() {
         let image = isExpanded ? chevronUp : chevronDown
 
-        collapseButton.accessibilityIdentifier = isExpanded ? .collapseButton : .expandButton
+        collapseButton.setAccessibilityIdentifier(isExpanded ? .collapseButton : .expandButton)
         collapseButton.setImage(image, for: .normal)
     }
 
@@ -314,7 +314,7 @@ extension LocationCell {
         showsCollapseControl = !item.node.children.isEmpty
         isExpanded = item.node.showsChildren
         accessibilityValue = item.node.code
-        checkboxButton.accessibilityIdentifier = .customListLocationCheckmarkButton
+        checkboxButton.setAccessibilityIdentifier(.customListLocationCheckmarkButton)
 
         for view in checkboxButton.subviews where view is CheckboxView {
             let checkboxView = view as? CheckboxView
@@ -322,19 +322,18 @@ extension LocationCell {
         }
 
         if item.node is CustomListLocationNode {
-            accessibilityIdentifier = .customListLocationCell
+            setAccessibilityIdentifier(.customListLocationCell)
         } else {
             // Only custom list nodes have more than one location. Therefore checking first
             // location here is fine.
-            switch item.node.locations.first {
-            case .country:
-                accessibilityIdentifier = .countryLocationCell
-            case .city:
-                accessibilityIdentifier = .cityLocationCell
-            case .hostname:
-                accessibilityIdentifier = .relayLocationCell
-            case nil:
-                break
+            if let location = item.node.locations.first {
+                // we can probably replace this with a tagged AccessibilityIdentifier and cut this case statement
+                let accessibilityId: AccessibilityIdentifier = switch location {
+                case .country: .countryLocationCell
+                case .city: .cityLocationCell
+                case .hostname: .relayLocationCell
+                }
+                setAccessibilityIdentifier(accessibilityId)
             }
         }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -327,7 +327,6 @@ extension LocationCell {
             // Only custom list nodes have more than one location. Therefore checking first
             // location here is fine.
             if let location = item.node.locations.first {
-                // we can probably replace this with a tagged AccessibilityIdentifier and cut this case statement
                 let accessibilityId: AccessibilityIdentifier = switch location {
                 case .country: .countryLocationCell
                 case .city: .cityLocationCell

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderView.swift
@@ -67,7 +67,7 @@ class LocationSectionHeaderView: UIView, UIContentView {
         actionButton.isHidden = isActionHidden
         actionButton.accessibilityIdentifier = nil
         actualConfiguration.primaryAction.flatMap { action in
-            actionButton.accessibilityIdentifier = .openCustomListsMenuButton
+            actionButton.setAccessibilityIdentifier(.openCustomListsMenuButton)
             actionButton.addAction(action, for: .touchUpInside)
         }
     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -57,7 +57,7 @@ final class LocationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.accessibilityIdentifier = .selectLocationView
+        view.setAccessibilityIdentifier(.selectLocationView)
         view.backgroundColor = .secondaryColor
 
         setUpDataSource()
@@ -162,7 +162,7 @@ final class LocationViewController: UIViewController {
         tableView.sectionHeaderHeight = 56
         tableView.indicatorStyle = .white
         tableView.keyboardDismissMode = .onDrag
-        tableView.accessibilityIdentifier = .selectLocationTableView
+        tableView.setAccessibilityIdentifier(.selectLocationTableView)
     }
 
     private func setUpTopContent() {
@@ -189,7 +189,7 @@ final class LocationViewController: UIViewController {
             value: "Search for...",
             comment: ""
         )
-        searchBar.searchTextField.accessibilityIdentifier = .selectLocationSearchTextField
+        searchBar.searchTextField.setAccessibilityIdentifier(.selectLocationSearchTextField)
 
         UITextField.SearchTextFieldAppearance.inactive.apply(to: searchBar)
     }

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
@@ -105,7 +105,7 @@ final class LocationViewControllerWrapper: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.accessibilityIdentifier = .selectLocationViewWrapper
+        view.setAccessibilityIdentifier(.selectLocationViewWrapper)
         view.backgroundColor = .secondaryColor
 
         setUpNavigation()
@@ -179,7 +179,7 @@ final class LocationViewControllerWrapper: UIViewController {
                 self?.delegate?.navigateToFilter()
             })
         )
-        navigationItem.leftBarButtonItem?.accessibilityIdentifier = .selectLocationFilterButton
+        navigationItem.leftBarButtonItem?.setAccessibilityIdentifier(.selectLocationFilterButton)
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             systemItem: .done,
@@ -187,7 +187,7 @@ final class LocationViewControllerWrapper: UIViewController {
                 self?.didFinish?()
             })
         )
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = .closeSelectLocationButton
+        navigationItem.rightBarButtonItem?.setAccessibilityIdentifier(.closeSelectLocationButton)
     }
 
     private func setUpSegmentedControl() {

--- a/ios/MullvadVPN/View controllers/Settings/SelectableSettingsDetailsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SelectableSettingsDetailsCell.swift
@@ -22,7 +22,7 @@ class SelectableSettingsDetailsCell: SelectableSettingsCell {
             .withRenderingMode(.alwaysOriginal)
             .withTintColor(.white)
         actionButton.configuration = actionButtonConfiguration
-        actionButton.accessibilityIdentifier = .openPortSelectorMenuButton
+        actionButton.setAccessibilityIdentifier(.openPortSelectorMenuButton)
 
         actionButton.addTarget(
             self,

--- a/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
@@ -81,7 +81,7 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
 
     private let infoButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.accessibilityIdentifier = .infoButton
+        button.setAccessibilityIdentifier(.infoButton)
         button.tintColor = .white
         button.setImage(UIImage(named: "IconInfo"), for: .normal)
         button.isHidden = true

--- a/ios/MullvadVPN/View controllers/Settings/SettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCellFactory.swift
@@ -47,7 +47,7 @@ final class SettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
             cell.detailTitleLabel.text = nil
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.disclosureType = .chevron
 
         case .version:
@@ -60,7 +60,7 @@ final class SettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
             cell.detailTitleLabel.text = Bundle.main.productVersion
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.disclosureType = .none
 
         case .problemReport:
@@ -73,7 +73,7 @@ final class SettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
             cell.detailTitleLabel.text = nil
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.disclosureType = .chevron
 
         case .faq:
@@ -86,7 +86,7 @@ final class SettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
             cell.detailTitleLabel.text = nil
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.disclosureType = .externalLink
 
         case .apiAccess:
@@ -99,7 +99,7 @@ final class SettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
             cell.detailTitleLabel.text = nil
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.disclosureType = .chevron
 
         case .daita:
@@ -119,7 +119,7 @@ final class SettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
 
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.disclosureType = .chevron
 
         case .multihop:
@@ -139,7 +139,7 @@ final class SettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
 
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.disclosureType = .chevron
         }
     }

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDNSTextCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDNSTextCell.swift
@@ -34,7 +34,7 @@ class SettingsDNSTextCell: SettingsCell, UITextFieldDelegate {
             value: "Enter IP",
             comment: ""
         )
-        textField.accessibilityIdentifier = .dnsSettingsEnterIPAddressTextField
+        textField.setAccessibilityIdentifier(.dnsSettingsEnterIPAddressTextField)
         textField.cornerRadius = 0
         textField.keyboardType = .numbersAndPunctuation
         textField.returnKeyType = .done

--- a/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
@@ -23,7 +23,7 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
 
     let infoButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.accessibilityIdentifier = .infoButton
+        button.setAccessibilityIdentifier(.infoButton)
         button.tintColor = .white
         button.setImage(UIImage(named: "IconInfo"), for: .normal)
         return button
@@ -31,7 +31,7 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
 
     let collapseButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.accessibilityIdentifier = .expandButton
+        button.setAccessibilityIdentifier(.expandButton)
         button.tintColor = .white
         return button
     }()
@@ -123,7 +123,7 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
         let image = isExpanded ? chevronUp : chevronDown
 
         collapseButton.setImage(image, for: .normal)
-        collapseButton.accessibilityIdentifier = isExpanded ? .collapseButton : .expandButton
+        collapseButton.setAccessibilityIdentifier(isExpanded ? .collapseButton : .expandButton)
     }
 
     private func updateAccessibilityCustomActions() {

--- a/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsViewController.swift
@@ -58,10 +58,10 @@ class SettingsViewController: UITableViewController {
                 delegate?.settingsViewControllerDidFinish(self)
             })
         )
-        doneButton.accessibilityIdentifier = .settingsDoneButton
+        doneButton.setAccessibilityIdentifier(.settingsDoneButton)
         navigationItem.rightBarButtonItem = doneButton
 
-        tableView.accessibilityIdentifier = .settingsTableView
+        tableView.setAccessibilityIdentifier(.settingsTableView)
         tableView.backgroundColor = .secondaryColor
         tableView.separatorColor = .secondaryColor
         tableView.rowHeight = UITableView.automaticDimension

--- a/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceContentView.swift
+++ b/ios/MullvadVPN/View controllers/TermsOfService/TermsOfServiceContentView.swift
@@ -69,7 +69,7 @@ class TermsOfServiceContentView: UIView {
     let agreeButton: AppButton = {
         let button = AppButton(style: .default)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.accessibilityIdentifier = .agreeButton
+        button.setAccessibilityIdentifier(.agreeButton)
         button.setTitle(NSLocalizedString(
             "CONTINUE_BUTTON_TITLE",
             tableName: "TermsOfService",
@@ -103,7 +103,7 @@ class TermsOfServiceContentView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        self.accessibilityIdentifier = .termsOfServiceView
+        self.setAccessibilityIdentifier(.termsOfServiceView)
 
         addSubviews()
     }

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionPanelView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionPanelView.swift
@@ -29,7 +29,7 @@ class ConnectionPanelView: UIView {
 
     var connectedRelayName = "" {
         didSet {
-            collapseView.accessibilityIdentifier = .relayStatusCollapseButton
+            collapseView.setAccessibilityIdentifier(.relayStatusCollapseButton)
             collapseView.title.text = connectedRelayName
             collapseView.accessibilityLabel = NSLocalizedString(
                 "RELAY_ACCESSIBILITY_LABEL",
@@ -80,8 +80,8 @@ class ConnectionPanelView: UIView {
         inAddressRow.translatesAutoresizingMaskIntoConstraints = false
         outAddressRow.translatesAutoresizingMaskIntoConstraints = false
 
-        inAddressRow.accessibilityIdentifier = .connectionPanelInAddressRow
-        outAddressRow.accessibilityIdentifier = .connectionPanelOutAddressRow
+        inAddressRow.setAccessibilityIdentifier(.connectionPanelInAddressRow)
+        outAddressRow.setAccessibilityIdentifier(.connectionPanelOutAddressRow)
 
         inAddressRow.title = NSLocalizedString(
             "IN_ADDRESS_LABEL",
@@ -205,7 +205,7 @@ class ConnectionPanelAddressRow: UIView {
 
     private let detailTextLabel: UILabel = {
         let detailTextLabel = UILabel()
-        detailTextLabel.accessibilityIdentifier = .connectionPanelDetailLabel
+        detailTextLabel.setAccessibilityIdentifier(.connectionPanelDetailLabel)
         detailTextLabel.font = .systemFont(ofSize: 17)
         detailTextLabel.textColor = .white
         detailTextLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelControlView.swift
@@ -67,21 +67,21 @@ final class TunnelControlView: UIView {
 
     private let connectButton: AppButton = {
         let button = AppButton(style: .success)
-        button.accessibilityIdentifier = .secureConnectionButton
+        button.setAccessibilityIdentifier(.secureConnectionButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
 
     private let cancelButton: AppButton = {
         let button = AppButton(style: .translucentDanger)
-        button.accessibilityIdentifier = .cancelButton
+        button.setAccessibilityIdentifier(.cancelButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
 
     private let selectLocationButton: AppButton = {
         let button = AppButton(style: .translucentNeutral)
-        button.accessibilityIdentifier = .selectLocationButton
+        button.setAccessibilityIdentifier(.selectLocationButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
@@ -92,7 +92,7 @@ final class TunnelControlView: UIView {
 
     private let splitDisconnectButton: DisconnectSplitButton = {
         let button = DisconnectSplitButton()
-        button.primaryButton.accessibilityIdentifier = .disconnectButton
+        button.primaryButton.setAccessibilityIdentifier(.disconnectButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
@@ -122,7 +122,7 @@ final class TunnelControlView: UIView {
         backgroundColor = .clear
         directionalLayoutMargins = UIMetrics.contentLayoutMargins
         accessibilityContainerType = .semanticGroup
-        accessibilityIdentifier = .tunnelControlView
+        setAccessibilityIdentifier(.tunnelControlView)
 
         addSubviews()
         addButtonHandlers()
@@ -172,11 +172,11 @@ final class TunnelControlView: UIView {
 
         switch tunnelState {
         case .connected:
-            secureLabel.accessibilityIdentifier = .connectionStatusConnectedLabel
+            secureLabel.setAccessibilityIdentifier(.connectionStatusConnectedLabel)
         case .connecting:
-            secureLabel.accessibilityIdentifier = .connectionStatusConnectingLabel
+            secureLabel.setAccessibilityIdentifier(.connectionStatusConnectingLabel)
         default:
-            secureLabel.accessibilityIdentifier = .connectionStatusNotConnectedLabel
+            secureLabel.setAccessibilityIdentifier(.connectionStatusNotConnectedLabel)
         }
     }
 

--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
@@ -44,7 +44,7 @@ final class CustomDNSCellFactory: CellFactoryProtocol {
         guard let cell = cell as? SettingsSwitchCell else { return }
 
         cell.titleLabel.text = title
-        cell.accessibilityIdentifier = preference.accessibilityIdentifier
+        cell.setAccessibilityIdentifier(preference.accessibilityIdentifier)
         cell.applySubCellStyling()
         cell.setOn(toggleSetting, animated: true)
         cell.action = { [weak self] isOn in
@@ -176,7 +176,7 @@ final class CustomDNSCellFactory: CellFactoryProtocol {
             cell.setOn(viewModel.effectiveEnableCustomDNS, animated: false)
             cell.accessibilityHint = viewModel.customDNSPrecondition
                 .localizedDescription(isEditing: isEditing)
-            cell.accessibilityIdentifier = .dnsSettingsUseCustomDNSCell
+            cell.setAccessibilityIdentifier(.dnsSettingsUseCustomDNSCell)
             cell.action = { [weak self] isOn in
                 self?.delegate?.didChangeState(for: .useCustomDNS, isOn: isOn)
             }
@@ -190,7 +190,7 @@ final class CustomDNSCellFactory: CellFactoryProtocol {
                 value: "Add a server",
                 comment: ""
             )
-            cell.accessibilityIdentifier = .dnsSettingsAddServerCell
+            cell.setAccessibilityIdentifier(.dnsSettingsAddServerCell)
             cell.tapAction = { [weak self] in
                 self?.delegate?.addDNSEntry()
             }

--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSDataSource.swift
@@ -605,7 +605,7 @@ final class CustomDNSDataSource: UITableViewDiffableDataSource<
 
         header.accessibilityCustomActionName = title
         header.accessibilityValue = "\(enabledBlockersCount)"
-        header.accessibilityIdentifier = .dnsContentBlockersHeaderView
+        header.setAccessibilityIdentifier(.dnsContentBlockersHeaderView)
 
         header.infoButtonHandler = { [weak self] in
             self?.delegate?.showInfo(for: .contentBlockers)

--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSViewController.swift
@@ -32,7 +32,7 @@ class CustomDNSViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.accessibilityIdentifier = .dnsSettingsTableView
+        tableView.setAccessibilityIdentifier(.dnsSettingsTableView)
         tableView.backgroundColor = .secondaryColor
         tableView.separatorColor = .secondaryColor
         tableView.rowHeight = UITableView.automaticDimension
@@ -50,7 +50,7 @@ class CustomDNSViewController: UITableViewController {
         )
 
         navigationItem.rightBarButtonItem = editButtonItem
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = .dnsSettingsEditButton
+        navigationItem.rightBarButtonItem?.setAccessibilityIdentifier(.dnsSettingsEditButton)
 
         interactor.tunnelSettingsDidChange = { [weak self] newSettings in
             self?.dataSource?.update(from: newSettings)

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -80,8 +80,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
             }
 
             cell.titleLabel.text = portString
-            // TODO: replace this with a tagged AccessibilityIdentifier
-            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.asString) (\(portString))"
+            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.asString)"
             cell.applySubCellStyling()
 
         case .wireGuardCustomPort:

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -51,7 +51,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
             )
 
             cell.disclosureType = .chevron
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
 
         case .ipOverrides:
             guard let cell = cell as? SettingsCell else { return }
@@ -64,7 +64,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
             )
 
             cell.disclosureType = .chevron
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
 
         case let .wireGuardPort(port):
             guard let cell = cell as? SelectableSettingsCell else { return }
@@ -99,8 +99,8 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             )
 
-            cell.textField.accessibilityIdentifier = .customWireGuardPortTextField
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.textField.setAccessibilityIdentifier(.customWireGuardPortTextField)
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
 
             cell.inputDidChange = { [weak self] text in
@@ -133,7 +133,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 value: "Automatic",
                 comment: ""
             )
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
 
         case .wireGuardObfuscationUdpOverTcp:
@@ -153,7 +153,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             ), viewModel.obfuscationUpdOverTcpPort.description)
 
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
 
             cell.buttonAction = { [weak self] in
@@ -177,7 +177,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 comment: ""
             ), viewModel.obfuscationShadowsocksPort.description)
 
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
 
             cell.buttonAction = { [weak self] in
@@ -193,7 +193,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 value: "Off",
                 comment: ""
             )
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
 
         case let .wireGuardObfuscationPort(port):
@@ -206,7 +206,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 value: portString,
                 comment: ""
             )
-            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.rawValue)\(portString)"
+            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier)\(portString)"
             cell.applySubCellStyling()
 
         case .quantumResistanceAutomatic:
@@ -218,7 +218,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 value: "Automatic",
                 comment: ""
             )
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
 
         case .quantumResistanceOn:
@@ -230,7 +230,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 value: "On",
                 comment: ""
             )
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
 
         case .quantumResistanceOff:
@@ -242,7 +242,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
                 value: "Off",
                 comment: ""
             )
-            cell.accessibilityIdentifier = item.accessibilityIdentifier
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.applySubCellStyling()
         }
     }

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -80,7 +80,8 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
             }
 
             cell.titleLabel.text = portString
-            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.rawValue) (\(portString))"
+            // TODO: replace this with a tagged AccessibilityIdentifier
+            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.description) (\(portString))"
             cell.applySubCellStyling()
 
         case .wireGuardCustomPort:

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -81,7 +81,7 @@ final class VPNSettingsCellFactory: CellFactoryProtocol {
 
             cell.titleLabel.text = portString
             // TODO: replace this with a tagged AccessibilityIdentifier
-            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.description) (\(portString))"
+            cell.accessibilityIdentifier = "\(item.accessibilityIdentifier.asString) (\(portString))"
             cell.applySubCellStyling()
 
         case .wireGuardCustomPort:

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -112,8 +112,8 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
                 return .dnsSettings
             case .ipOverrides:
                 return .ipOverrides
-            case .wireGuardPort:
-                return .wireGuardPort
+            case let .wireGuardPort(port):
+                return .wireGuardPort(port)
             case .wireGuardCustomPort:
                 return .wireGuardCustomPort
             case .wireGuardObfuscationAutomatic:

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -475,7 +475,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
             comment: ""
         )
 
-        header.accessibilityIdentifier = .wireGuardPortsCell
+        header.setAccessibilityIdentifier(.wireGuardPortsCell)
         header.titleLabel.text = title
         header.accessibilityCustomActionName = title
         header.isExpanded = isExpanded(.wireGuardPorts)
@@ -519,7 +519,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
             comment: ""
         )
 
-        header.accessibilityIdentifier = .wireGuardObfuscationCell
+        header.setAccessibilityIdentifier(.wireGuardObfuscationCell)
         header.titleLabel.text = title
         header.accessibilityCustomActionName = title
         header.isExpanded = isExpanded(.wireGuardObfuscation)
@@ -549,7 +549,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
             comment: ""
         )
 
-        header.accessibilityIdentifier = .quantumResistantTunnelCell
+        header.setAccessibilityIdentifier(.quantumResistantTunnelCell)
         header.titleLabel.text = title
         header.accessibilityCustomActionName = title
         header.isExpanded = isExpanded(.quantumResistance)

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
@@ -39,7 +39,7 @@ class VPNSettingsViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.accessibilityIdentifier = .vpnSettingsTableView
+        tableView.setAccessibilityIdentifier(.vpnSettingsTableView)
         tableView.backgroundColor = .secondaryColor
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 60

--- a/ios/MullvadVPN/Views/CustomSwitch.swift
+++ b/ios/MullvadVPN/Views/CustomSwitch.swift
@@ -31,7 +31,7 @@ class CustomSwitch: UISwitch {
         onTintColor = .clear
         overrideUserInterfaceStyle = .light
 
-        accessibilityIdentifier = .customSwitch
+        setAccessibilityIdentifier(.customSwitch)
 
         updateThumbColor(isOn: isOn, animated: false)
 

--- a/ios/MullvadVPN/Views/CustomToggleStyle.swift
+++ b/ios/MullvadVPN/Views/CustomToggleStyle.swift
@@ -56,7 +56,7 @@ struct CustomToggleStyle: ToggleStyle {
                     )
                     .opacity(disabled ? 0.4 : 1)
             }
-            .accessibilityIdentifier(accessibilityId?.description ?? "")
+            .accessibilityIdentifier(accessibilityId?.asString ?? "")
             .onTapGesture {
                 toggle(configuration)
             }

--- a/ios/MullvadVPN/Views/CustomToggleStyle.swift
+++ b/ios/MullvadVPN/Views/CustomToggleStyle.swift
@@ -56,7 +56,7 @@ struct CustomToggleStyle: ToggleStyle {
                     )
                     .opacity(disabled ? 0.4 : 1)
             }
-            .accessibilityIdentifier(accessibilityId?.rawValue ?? "")
+            .accessibilityIdentifier(accessibilityId?.description ?? "")
             .onTapGesture {
                 toggle(configuration)
             }

--- a/ios/MullvadVPN/Views/StatusImageView.swift
+++ b/ios/MullvadVPN/Views/StatusImageView.swift
@@ -58,7 +58,7 @@ class StatusImageView: UIImageView {
         self.style = style
         super.init(image: style.image)
         image = style.image
-        accessibilityIdentifier = .statusImageView
+        setAccessibilityIdentifier(.statusImageView)
     }
 
     required init?(coder: NSCoder) {

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -214,13 +214,13 @@ class BaseUITestCase: XCTestCase {
     /// Check if currently logged on to an account. Note that it is assumed that we are logged in if login view isn't currently shown.
     func isLoggedIn() -> Bool {
         return !app
-            .otherElements[AccessibilityIdentifier.loginView]
+            .otherElements[.loginView]
             .waitForExistence(timeout: 1.0)
     }
 
     func isPresentingSettings() -> Bool {
         return app
-            .otherElements[AccessibilityIdentifier.settingsContainerView]
+            .otherElements[.settingsContainerView]
             .exists
     }
 
@@ -248,7 +248,7 @@ class BaseUITestCase: XCTestCase {
 
         // Ensure changelog is no longer shown
         _ = app
-            .otherElements[AccessibilityIdentifier.changeLogAlert.asString]
+            .otherElements[.changeLogAlert]
             .waitForNonExistence(timeout: Self.shortTimeout)
     }
 

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -248,7 +248,7 @@ class BaseUITestCase: XCTestCase {
 
         // Ensure changelog is no longer shown
         _ = app
-            .otherElements[AccessibilityIdentifier.changeLogAlert.description]
+            .otherElements[AccessibilityIdentifier.changeLogAlert.asString]
             .waitForNonExistence(timeout: Self.shortTimeout)
     }
 

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -248,7 +248,7 @@ class BaseUITestCase: XCTestCase {
 
         // Ensure changelog is no longer shown
         _ = app
-            .otherElements[AccessibilityIdentifier.changeLogAlert.rawValue]
+            .otherElements[AccessibilityIdentifier.changeLogAlert.description]
             .waitForNonExistence(timeout: Self.shortTimeout)
     }
 

--- a/ios/MullvadVPNUITests/ConnectivityTests.swift
+++ b/ios/MullvadVPNUITests/ConnectivityTests.swift
@@ -67,7 +67,7 @@ class ConnectivityTests: LoggedOutUITestCase {
                 .tapSelectLocationButton()
 
             let filterCloseButtons = self.app.buttons
-                .matching(identifier: AccessibilityIdentifier.relayFilterChipCloseButton.description)
+                .matching(identifier: AccessibilityIdentifier.relayFilterChipCloseButton.asString)
                 .allElementsBoundByIndex
 
             for filterCloseButton in filterCloseButtons where filterCloseButton.isHittable {

--- a/ios/MullvadVPNUITests/ConnectivityTests.swift
+++ b/ios/MullvadVPNUITests/ConnectivityTests.swift
@@ -67,7 +67,7 @@ class ConnectivityTests: LoggedOutUITestCase {
                 .tapSelectLocationButton()
 
             let filterCloseButtons = self.app.buttons
-                .matching(identifier: AccessibilityIdentifier.relayFilterChipCloseButton.rawValue)
+                .matching(identifier: AccessibilityIdentifier.relayFilterChipCloseButton.description)
                 .allElementsBoundByIndex
 
             for filterCloseButton in filterCloseButtons where filterCloseButton.isHittable {

--- a/ios/MullvadVPNUITests/Pages/AccountPage.swift
+++ b/ios/MullvadVPNUITests/Pages/AccountPage.swift
@@ -18,27 +18,27 @@ class AccountPage: Page {
     }
 
     @discardableResult func tapRedeemVoucherButton() -> Self {
-        app.buttons[AccessibilityIdentifier.redeemVoucherButton.description].tap()
+        app.buttons[AccessibilityIdentifier.redeemVoucherButton.asString].tap()
         return self
     }
 
     @discardableResult func tapAdd30DaysTimeButton() -> Self {
-        app.buttons[AccessibilityIdentifier.purchaseButton.description].tap()
+        app.buttons[AccessibilityIdentifier.purchaseButton.asString].tap()
         return self
     }
 
     @discardableResult func tapRestorePurchasesButton() -> Self {
-        app.buttons[AccessibilityIdentifier.restorePurchasesButton.description].tap()
+        app.buttons[AccessibilityIdentifier.restorePurchasesButton.asString].tap()
         return self
     }
 
     @discardableResult func tapLogOutButton() -> Self {
-        app.buttons[AccessibilityIdentifier.logoutButton.description].tap()
+        app.buttons[AccessibilityIdentifier.logoutButton.asString].tap()
         return self
     }
 
     @discardableResult func tapDeleteAccountButton() -> Self {
-        app.buttons[AccessibilityIdentifier.deleteButton.description].tap()
+        app.buttons[AccessibilityIdentifier.deleteButton.asString].tap()
         return self
     }
 

--- a/ios/MullvadVPNUITests/Pages/AccountPage.swift
+++ b/ios/MullvadVPNUITests/Pages/AccountPage.swift
@@ -18,27 +18,27 @@ class AccountPage: Page {
     }
 
     @discardableResult func tapRedeemVoucherButton() -> Self {
-        app.buttons[AccessibilityIdentifier.redeemVoucherButton.rawValue].tap()
+        app.buttons[AccessibilityIdentifier.redeemVoucherButton.description].tap()
         return self
     }
 
     @discardableResult func tapAdd30DaysTimeButton() -> Self {
-        app.buttons[AccessibilityIdentifier.purchaseButton.rawValue].tap()
+        app.buttons[AccessibilityIdentifier.purchaseButton.description].tap()
         return self
     }
 
     @discardableResult func tapRestorePurchasesButton() -> Self {
-        app.buttons[AccessibilityIdentifier.restorePurchasesButton.rawValue].tap()
+        app.buttons[AccessibilityIdentifier.restorePurchasesButton.description].tap()
         return self
     }
 
     @discardableResult func tapLogOutButton() -> Self {
-        app.buttons[AccessibilityIdentifier.logoutButton.rawValue].tap()
+        app.buttons[AccessibilityIdentifier.logoutButton.description].tap()
         return self
     }
 
     @discardableResult func tapDeleteAccountButton() -> Self {
-        app.buttons[AccessibilityIdentifier.deleteButton.rawValue].tap()
+        app.buttons[AccessibilityIdentifier.deleteButton.description].tap()
         return self
     }
 

--- a/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
+++ b/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
@@ -19,7 +19,7 @@ class DeviceManagementPage: Page {
 
     @discardableResult func tapRemoveDeviceButton(cellIndex: Int) -> Self {
         app
-            .otherElements.matching(identifier: AccessibilityIdentifier.deviceCell.description).element(boundBy: cellIndex)
+            .otherElements.matching(identifier: AccessibilityIdentifier.deviceCell.asString).element(boundBy: cellIndex)
             .buttons[AccessibilityIdentifier.deviceCellRemoveButton]
             .tap()
 

--- a/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
+++ b/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
@@ -19,7 +19,7 @@ class DeviceManagementPage: Page {
 
     @discardableResult func tapRemoveDeviceButton(cellIndex: Int) -> Self {
         app
-            .otherElements.matching(identifier: AccessibilityIdentifier.deviceCell.rawValue).element(boundBy: cellIndex)
+            .otherElements.matching(identifier: AccessibilityIdentifier.deviceCell.description).element(boundBy: cellIndex)
             .buttons[AccessibilityIdentifier.deviceCellRemoveButton]
             .tap()
 

--- a/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
+++ b/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
@@ -30,7 +30,7 @@ class SelectLocationPage: Page {
     }
 
     @discardableResult func tapCountryLocationCellExpandButton(withIndex: Int) -> Self {
-        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.countryLocationCell.description)
+        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.countryLocationCell.asString)
             .element(boundBy: withIndex)
         let expandButton = cell.buttons[AccessibilityIdentifier.expandButton]
         expandButton.tap()
@@ -38,7 +38,7 @@ class SelectLocationPage: Page {
     }
 
     @discardableResult func tapCityLocationCellExpandButton(withIndex: Int) -> Self {
-        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.cityLocationCell.description)
+        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.cityLocationCell.asString)
             .element(boundBy: withIndex)
         let expandButton = cell.buttons[AccessibilityIdentifier.expandButton]
         expandButton.tap()
@@ -46,7 +46,7 @@ class SelectLocationPage: Page {
     }
 
     @discardableResult func tapRelayLocationCell(withIndex: Int) -> Self {
-        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.relayLocationCell.description)
+        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.relayLocationCell.asString)
             .element(boundBy: withIndex)
         cell.tap()
         return self
@@ -79,7 +79,7 @@ class SelectLocationPage: Page {
         _ = app.buttons[.openCustomListsMenuButton].waitForExistence(timeout: BaseUITestCase.shortTimeout)
 
         let customListEllipsisButtons = app.buttons
-            .matching(identifier: AccessibilityIdentifier.openCustomListsMenuButton.description).allElementsBoundByIndex
+            .matching(identifier: AccessibilityIdentifier.openCustomListsMenuButton.asString).allElementsBoundByIndex
 
         // This is a workaround for an issue we have with the ellipsis showing up multiple times in the accessibility hieararchy even though in the view hierarchy there is only one
         // Only the actually visual one is hittable, so only the visible button will be tapped

--- a/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
+++ b/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
@@ -30,7 +30,7 @@ class SelectLocationPage: Page {
     }
 
     @discardableResult func tapCountryLocationCellExpandButton(withIndex: Int) -> Self {
-        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.countryLocationCell.rawValue)
+        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.countryLocationCell.description)
             .element(boundBy: withIndex)
         let expandButton = cell.buttons[AccessibilityIdentifier.expandButton]
         expandButton.tap()
@@ -38,7 +38,7 @@ class SelectLocationPage: Page {
     }
 
     @discardableResult func tapCityLocationCellExpandButton(withIndex: Int) -> Self {
-        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.cityLocationCell.rawValue)
+        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.cityLocationCell.description)
             .element(boundBy: withIndex)
         let expandButton = cell.buttons[AccessibilityIdentifier.expandButton]
         expandButton.tap()
@@ -46,7 +46,7 @@ class SelectLocationPage: Page {
     }
 
     @discardableResult func tapRelayLocationCell(withIndex: Int) -> Self {
-        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.relayLocationCell.rawValue)
+        let cell = app.cells.containing(.any, identifier: AccessibilityIdentifier.relayLocationCell.description)
             .element(boundBy: withIndex)
         cell.tap()
         return self
@@ -79,7 +79,7 @@ class SelectLocationPage: Page {
         _ = app.buttons[.openCustomListsMenuButton].waitForExistence(timeout: BaseUITestCase.shortTimeout)
 
         let customListEllipsisButtons = app.buttons
-            .matching(identifier: AccessibilityIdentifier.openCustomListsMenuButton.rawValue).allElementsBoundByIndex
+            .matching(identifier: AccessibilityIdentifier.openCustomListsMenuButton.description).allElementsBoundByIndex
 
         // This is a workaround for an issue we have with the ellipsis showing up multiple times in the accessibility hieararchy even though in the view hierarchy there is only one
         // Only the actually visual one is hittable, so only the visible button will be tapped

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -19,7 +19,7 @@ class VPNSettingsPage: Page {
         _ subButtonAccessibilityIdentifier: AccessibilityIdentifier
     ) -> XCUIElement {
         let tableView = app.tables[AccessibilityIdentifier.vpnSettingsTableView]
-        let matchingCells = tableView.otherElements[cellAccessiblityIdentifier.description]
+        let matchingCells = tableView.otherElements[cellAccessiblityIdentifier.asString]
         let expandButton = matchingCells.buttons[AccessibilityIdentifier.expandButton]
         let lastCell = tableView.cells.allElementsBoundByIndex.last!
         tableView.scrollDownToElement(element: lastCell)

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -19,8 +19,8 @@ class VPNSettingsPage: Page {
         _ subButtonAccessibilityIdentifier: AccessibilityIdentifier
     ) -> XCUIElement {
         let tableView = app.tables[AccessibilityIdentifier.vpnSettingsTableView]
-        let matchingCells = tableView.otherElements[cellAccessiblityIdentifier.rawValue]
-        let expandButton = matchingCells.buttons[subButtonAccessibilityIdentifier]
+        let matchingCells = tableView.otherElements[cellAccessiblityIdentifier.description]
+        let expandButton = matchingCells.buttons[AccessibilityIdentifier.expandButton]
         let lastCell = tableView.cells.allElementsBoundByIndex.last!
         tableView.scrollDownToElement(element: lastCell)
         return expandButton

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -20,7 +20,7 @@ class VPNSettingsPage: Page {
     ) -> XCUIElement {
         let tableView = app.tables[AccessibilityIdentifier.vpnSettingsTableView]
         let matchingCells = tableView.otherElements[cellAccessiblityIdentifier.asString]
-        let expandButton = matchingCells.buttons[AccessibilityIdentifier.expandButton]
+        let expandButton = matchingCells.buttons[subButtonAccessibilityIdentifier]
         let lastCell = tableView.cells.allElementsBoundByIndex.last!
         tableView.scrollDownToElement(element: lastCell)
         return expandButton

--- a/ios/MullvadVPNUITests/XCUIElementQuery+Extensions.swift
+++ b/ios/MullvadVPNUITests/XCUIElementQuery+Extensions.swift
@@ -15,6 +15,6 @@ extension XCUIElementQuery {
     }
 
     subscript(key: AccessibilityIdentifier) -> XCUIElement {
-        self[key.description]
+        self[key.asString]
     }
 }

--- a/ios/MullvadVPNUITests/XCUIElementQuery+Extensions.swift
+++ b/ios/MullvadVPNUITests/XCUIElementQuery+Extensions.swift
@@ -15,6 +15,6 @@ extension XCUIElementQuery {
     }
 
     subscript(key: AccessibilityIdentifier) -> XCUIElement {
-        self[key.rawValue]
+        self[key.description]
     }
 }


### PR DESCRIPTION
This removes the backing String value type from `AccessibilityIdentifier`. As of this change,

- `AccessibilityIdentifier` no longer has a `.rawValue`. For producing the string-based identifier, there is a `.asString` value which does the same thing
- `UIAccessibilityIdentification` no longer has an `accessibilityIdentifier` variable typed to `AccessibilityIdentifier`, but in turn has a `setAccessibilityIdentifier` method. The handful of use cases that involved matching a string to an `AccessibilityIdentifier` value are done by comparing the resulting strings.

Why have we done this, you may be wondering? The main thing this unblocks is more sophisticated `AccessibilityIdentifier` types and less boilerplate.  Whereas until now, each value that had its own cell/button would have had its own `AccessibilityIdentifier` value, with a case statement to convert the underlying values to them, with this change it will be possible to have tagged values of `AccessibilityIdentifier`, with all options having the same underlying value and each differing only in the data value it encapsulates.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7293)
<!-- Reviewable:end -->
