### PR TITLE
Fix unsupported `mullvad-version` gradle execution

### DIFF
--- a/android/buildSrc/src/main/kotlin/Utils.kt
+++ b/android/buildSrc/src/main/kotlin/Utils.kt
@@ -13,18 +13,11 @@ fun Project.generateVersionName(localProperties: Properties): String {
 }
 
 private fun Project.execVersionCodeCargoCommand() =
-    execWithOutput { commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode") }
-        .toInt()
+    providers.exec {
+        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode")
+    }.standardOutput.asText.get().trim().toInt()
 
-private fun Project.execVersionNameCargoCommand() = execWithOutput {
-    commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName")
-}
-
-private fun Project.execWithOutput(spec: ExecSpec.() -> Unit) =
-    ByteArrayOutputStream().use { outputStream ->
-        exec {
-            this.spec()
-            this.standardOutput = outputStream
-        }
-        outputStream.toString().trim()
-    }
+private fun Project.execVersionNameCargoCommand() =
+    providers.exec {
+        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName")
+    }.standardOutput.asText.get().trim()


### PR DESCRIPTION
This PR aims to fix the deprecated gradle `exec` calls previously used to execute `mullvad-version`. This fix is also needed to enable configuration cache.

Documentation: https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:external_processes

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7309)
<!-- Reviewable:end -->
