### PR TITLE
Lock `hickory-resolver` to version 0.24.2 in `test` workspace

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -1238,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
 dependencies = [
  "cfg-if",
  "futures-util",


### PR DESCRIPTION
This PR is a follow up to https://github.com/mullvad/mullvadvpn-app/pull/7318 which just updates the lock file slightly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7325)
<!-- Reviewable:end -->
