### PR TITLE
Add link to X41's announcement about the audit

### DIFF
--- a/audits/2024-12-10-X41-D-Sec.md
+++ b/audits/2024-12-10-X41-D-Sec.md
@@ -44,14 +44,18 @@ The main focus areas where we asked X41 to spend most of their time included:
 
 The audit report was first delivered to Mullvad on 2024-11-30. It was a really good report
 as is, but together with X41 we identified some sentences which were slightly unclear.
-X41 then handed us a revised final report on 2024-12-10. Both versions are hosted on X41's
-website:
+X41 then handed us a revised final report on 2024-12-10.
+
+X41 has [posted an announcement] about the audit
+on their website. Here are the direct links to both versions of the report:
 * [2024-11-30 first version](https://www.x41-dsec.de/static/reports/X41-Mullvad-Audit-Final-Report-2024-11-18.pdf)
 * [2024-12-10 final version](https://www.x41-dsec.de/static/reports/X41-Mullvad-Audit-Public-Report-2024-12-10.pdf)
 
 We host both versions of the report in this repository:
 * [2024-11-30-X41-D-Sec-Audit-Report-v1.pdf](./2024-11-30-X41-D-Sec-Audit-Report-v1.pdf)
 * [2024-12-10-X41-D-Sec-Audit-Report-v2.pdf](./2024-12-10-X41-D-Sec-Audit-Report-v2.pdf)
+
+[posted an announcement]: https://x41-dsec.de/news/2024/12/11/mullvad/
 
 ## Overview of findings
 


### PR DESCRIPTION
Small addition to the text about the audit added yesterday (#7323). Since then, X41 D-Sec has posted a public announcement about the audit. I felt it was relevant to link directly to that as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7331)
<!-- Reviewable:end -->
