### PR TITLE
Remove some deprecated ref patterns

### DIFF
--- a/mullvad-encrypted-dns-proxy/src/config_resolver.rs
+++ b/mullvad-encrypted-dns-proxy/src/config_resolver.rs
@@ -34,8 +34,8 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::ResolutionError(ref err) => err.source(),
-            Self::Timeout(ref err) => err.source(),
+            Self::ResolutionError(err) => err.source(),
+            Self::Timeout(err) => err.source(),
         }
     }
 }

--- a/mullvad-types/src/constraints/constraint.rs
+++ b/mullvad-types/src/constraints/constraint.rs
@@ -107,7 +107,7 @@ impl<T> Constraint<T> {
     pub const fn as_ref(&self) -> Constraint<&T> {
         match self {
             Constraint::Any => Constraint::Any,
-            Constraint::Only(ref value) => Constraint::Only(value),
+            Constraint::Only(value) => Constraint::Only(value),
         }
     }
 
@@ -128,7 +128,7 @@ impl<T: PartialEq> Constraint<T> {
     pub fn matches_eq(&self, other: &T) -> bool {
         match self {
             Constraint::Any => true,
-            Constraint::Only(ref value) => value == other,
+            Constraint::Only(value) => value == other,
         }
     }
 }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -210,14 +210,14 @@ impl GeographicLocationConstraint {
 impl Match<Relay> for GeographicLocationConstraint {
     fn matches(&self, relay: &Relay) -> bool {
         match self {
-            GeographicLocationConstraint::Country(ref country) => {
+            GeographicLocationConstraint::Country(country) => {
                 relay.location.country_code == *country
             }
-            GeographicLocationConstraint::City(ref country, ref city) => {
+            GeographicLocationConstraint::City(country, city) => {
                 let loc = &relay.location;
                 loc.country_code == *country && loc.city_code == *city
             }
-            GeographicLocationConstraint::Hostname(ref country, ref city, ref hostname) => {
+            GeographicLocationConstraint::Hostname(country, city, hostname) => {
                 let loc = &relay.location;
                 loc.country_code == *country
                     && loc.city_code == *city

--- a/talpid-core/src/dns/linux/mod.rs
+++ b/talpid-core/src/dns/linux/mod.rs
@@ -151,15 +151,14 @@ impl DnsMonitorHolder {
     ) -> Result<()> {
         use self::DnsMonitorHolder::*;
         match self {
-            Resolvconf(ref mut resolvconf) => resolvconf.set_dns(interface, servers)?,
-            StaticResolvConf(ref mut static_resolv_conf) => {
-                static_resolv_conf.set_dns(servers.to_vec())?
-            }
-            SystemdResolved(ref mut systemd_resolved) => handle
-                .block_on(systemd_resolved.set_dns(route_manager.clone(), interface, servers))?,
-            NetworkManager(ref mut network_manager) => {
-                network_manager.set_dns(interface, servers)?
-            }
+            Resolvconf(resolvconf) => resolvconf.set_dns(interface, servers)?,
+            StaticResolvConf(static_resolv_conf) => static_resolv_conf.set_dns(servers.to_vec())?,
+            SystemdResolved(systemd_resolved) => handle.block_on(systemd_resolved.set_dns(
+                route_manager.clone(),
+                interface,
+                servers,
+            ))?,
+            NetworkManager(network_manager) => network_manager.set_dns(interface, servers)?,
         }
         Ok(())
     }
@@ -167,12 +166,10 @@ impl DnsMonitorHolder {
     fn reset(&mut self, handle: &tokio::runtime::Handle) -> Result<()> {
         use self::DnsMonitorHolder::*;
         match self {
-            Resolvconf(ref mut resolvconf) => resolvconf.reset()?,
-            StaticResolvConf(ref mut static_resolv_conf) => static_resolv_conf.reset()?,
-            SystemdResolved(ref mut systemd_resolved) => {
-                handle.block_on(systemd_resolved.reset())?
-            }
-            NetworkManager(ref mut network_manager) => network_manager.reset()?,
+            Resolvconf(resolvconf) => resolvconf.reset()?,
+            StaticResolvConf(static_resolv_conf) => static_resolv_conf.reset()?,
+            SystemdResolved(systemd_resolved) => handle.block_on(systemd_resolved.reset())?,
+            NetworkManager(network_manager) => network_manager.reset()?,
         }
         Ok(())
     }

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -236,7 +236,7 @@ impl TunnelMonitor {
         parameters: &TunnelParameters,
         log_dir: &Option<path::PathBuf>,
     ) -> Result<Option<path::PathBuf>> {
-        if let Some(ref log_dir) = log_dir {
+        if let Some(log_dir) = log_dir {
             match parameters {
                 TunnelParameters::OpenVpn(_) => {
                     let tunnel_log = log_dir.join(OPENVPN_LOG_FILENAME);
@@ -255,7 +255,7 @@ impl TunnelMonitor {
         parameters: &TunnelParameters,
         log_dir: &Option<path::PathBuf>,
     ) -> Result<Option<path::PathBuf>> {
-        if let Some(ref log_dir) = log_dir {
+        if let Some(log_dir) = log_dir {
             let filename = match parameters {
                 TunnelParameters::OpenVpn(_) => OPENVPN_LOG_FILENAME,
                 TunnelParameters::Wireguard(_) => WIREGUARD_LOG_FILENAME,

--- a/talpid-openvpn/src/lib.rs
+++ b/talpid-openvpn/src/lib.rs
@@ -141,7 +141,7 @@ impl Error {
     #[cfg(target_os = "windows")]
     pub fn get_tunnel_device_error(&self) -> Option<&io::Error> {
         match self {
-            Error::WintunCreateAdapterError(ref error) => Some(error),
+            Error::WintunCreateAdapterError(error) => Some(error),
             _ => None,
         }
     }
@@ -542,7 +542,7 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
     fn create_proxy_auth_file(
         proxy_settings: &Option<CustomProxy>,
     ) -> std::result::Result<Option<mktemp::TempFile>, io::Error> {
-        if let Some(CustomProxy::Socks5Remote(ref remote_proxy)) = proxy_settings {
+        if let Some(CustomProxy::Socks5Remote(remote_proxy)) = proxy_settings {
             if let Some(ref proxy_auth) = remote_proxy.auth {
                 return Ok(Some(Self::create_credentials_file(
                     proxy_auth.username(),
@@ -558,7 +558,7 @@ impl<C: OpenVpnBuilder + Send + 'static> OpenVpnMonitor<C> {
         proxy_settings: &Option<CustomProxy>,
         #[cfg(target_os = "linux")] fwmark: u32,
     ) -> Result<Option<Box<dyn ProxyMonitor>>> {
-        if let Some(ref settings) = proxy_settings {
+        if let Some(settings) = proxy_settings {
             let proxy_monitor = proxy::start_proxy(
                 settings,
                 #[cfg(target_os = "linux")]
@@ -837,7 +837,7 @@ mod event_server {
             let env = request.into_inner().env;
 
             let _ = tokio::fs::remove_file(&self.user_pass_file_path).await;
-            if let Some(ref file_path) = &self.proxy_auth_file_path {
+            if let Some(file_path) = &self.proxy_auth_file_path {
                 let _ = tokio::fs::remove_file(file_path).await;
             }
 

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -160,19 +160,19 @@ pub enum FirewallPolicyError {
 impl fmt::Display for ErrorStateCause {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::ErrorStateCause::*;
-        let description = match *self {
-            AuthFailed(ref reason) => {
+        let description = match self {
+            AuthFailed(reason) => {
                 return write!(
                     f,
                     "Authentication with remote server failed: {}",
                     match reason {
-                        Some(ref reason) => reason.as_str(),
+                        Some(reason) => reason.as_str(),
                         None => "No reason provided",
                     }
                 );
             }
             Ipv6Unavailable => "Failed to configure IPv6 because it's disabled in the platform",
-            SetFirewallPolicyError(ref err) => {
+            SetFirewallPolicyError(err) => {
                 return match err {
                     #[cfg(windows)]
                     FirewallPolicyError::Locked(Some(value)) => {
@@ -183,7 +183,7 @@ impl fmt::Display for ErrorStateCause {
             }
             SetDnsError => "Failed to set system DNS server",
             #[cfg(target_os = "android")]
-            InvalidDnsServers(ref addresses) => {
+            InvalidDnsServers(addresses) => {
                 return write!(
                     f,
                     "Invalid DNS server addresses used in tunnel configuration: {}",
@@ -201,9 +201,9 @@ impl fmt::Display for ErrorStateCause {
             } => return write!(f, "Failed to create tunnel device: {error}"),
             #[cfg(target_os = "windows")]
             CreateTunnelDevice { os_error: None } => {
-                return write!(f, "Failed to create tunnel device")
+                return write!(f, "Failed to create tunnel device");
             }
-            TunnelParameterError(ref err) => {
+            TunnelParameterError(err) => {
                 return write!(f, "Failure to generate tunnel parameters: {err}");
             }
             IsOffline => "This device is offline, no tunnels can be established",

--- a/talpid-wireguard/src/connectivity/check.rs
+++ b/talpid-wireguard/src/connectivity/check.rs
@@ -376,11 +376,7 @@ impl ConnState {
     }
 
     pub fn reset_after_suspension(&mut self, now: Instant) {
-        if let ConnState::Connected {
-            ref mut rx_timestamp,
-            ..
-        } = self
-        {
+        if let ConnState::Connected { rx_timestamp, .. } = self {
             *rx_timestamp = now;
         }
     }


### PR DESCRIPTION
These redundant refs have become a hard error in rust 2024.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7336)
<!-- Reviewable:end -->
