### PR TITLE
Bump `tokio` to version 1.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4652,9 +4652,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ unused_async = "deny"
 hickory-proto = "0.24.2"
 hickory-resolver = "0.24.2"
 hickory-server = { version = "0.24.2", features = ["resolver"] }
-tokio = { version = "1.8" }
+tokio = { version = "1.42" }
 parity-tokio-ipc = "0.9"
 futures = "0.3.15"
 # Tonic and related crates

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -3790,9 +3790,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -37,7 +37,7 @@ unused_async = "deny"
 
 [workspace.dependencies]
 futures = "0.3"
-tokio = { version = "1.8", features = [
+tokio = { version = "1.42", features = [
   "macros",
   "rt",
   "process",


### PR DESCRIPTION
This version bumps `tokio` to version 1.42. We were already on a fairly recent version (1.39), but to implement https://github.com/mullvad/mullvadvpn-app/pull/7338 in a simple way it would be nice to have access to [SimplexStream](https://docs.rs/tokio/latest/tokio/io/struct.SimplexStream.html) which was introduced after version 1.39.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7339)
<!-- Reviewable:end -->
