### PR TITLE
Pin packages in RPM repo (using `includepkgs`)

### DIFF
--- a/ci/linux-repository-builder/prepare-rpm-repository.sh
+++ b/ci/linux-repository-builder/prepare-rpm-repository.sh
@@ -66,7 +66,8 @@ baseurl=$repository_server_url/$remote_repo_dir/\$basearch
 type=rpm
 enabled=1
 gpgcheck=1
-gpgkey=$repository_server_url/rpm/mullvad-keyring.asc" > "$repository_dir/mullvad.repo"
+gpgkey=$repository_server_url/rpm/mullvad-keyring.asc
+includepkgs=mullvad-vpn,mullvad-browser" > "$repository_dir/mullvad.repo"
 }
 
 for artifact_dir in "${artifact_dirs[@]}"; do


### PR DESCRIPTION
Restrict the packages that our RPM repo may install/update.

Close DES-1553.
Close #6270.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7342)
<!-- Reviewable:end -->
