### PR TITLE
Bump iOS changelog and version

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -21,11 +21,14 @@ Line wrap the file at 100 chars.                                              Th
 * **Fixed**: for any bug fixes.
 * **Security**: in case of vulnerabilities.
 
-## Unreleased
+## [2024.11 - 2024-12-12]
 ### Added
 - Add WireGuard over Shadowsocks obfuscation. It can be enabled in "VPN settings". This will
   also be used automatically when connecting fails with other methods.
 - Add new settings views for DAITA and multihop.
+
+### Fixed
+- When loading logs, a spinner will be shown to indicate the app is busy.
 
 ## [2024.10 - 2024-11-20]
 ### Fixed

--- a/ios/Configurations/Version.xcconfig
+++ b/ios/Configurations/Version.xcconfig
@@ -2,7 +2,7 @@
 VERSIONING_SYSTEM = apple-generic
 
 // Marketing version, aka major.minor
-MARKETING_VERSION = 2024.11
+MARKETING_VERSION = 2024.12
 
 // Build number
 // Normally we reset the build number to 1 after bumping MARKETING_VERSION.


### PR DESCRIPTION
Since we've released 2024.11, I'm updating the changelog and, very optimistically, the build version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7356)
<!-- Reviewable:end -->
