### PR TITLE
Silence GO-2024-{3105,3106,3107} in osv-scanner

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -2,17 +2,17 @@
 # Stack exhaustion in Decoder.Decode in encoding/gob
 [[IgnoredVulns]]
 id = "CVE-2024-34156" # GO-2024-3106
-ignoreUntil = 2024-12-18
+ignoreUntil = 2025-03-18
 reason = "wireguard-go does not use the affected code"
 
 # Stack exhaustion in Parse in go/build/constraint
 [[IgnoredVulns]]
 id = "CVE-2024-34158" # GO-2024-3107
-ignoreUntil = 2024-12-18
+ignoreUntil = 2025-03-18
 reason = "wireguard-go does not use the affected code"
 
 # Stack exhaustion in all Parse functions in go/parser
 [[IgnoredVulns]]
 id = "CVE-2024-34155" # GO-2024-3105
-ignoreUntil = 2024-12-18
+ignoreUntil = 2025-03-18
 reason = "wireguard-go does not use the affected code"


### PR DESCRIPTION
This PR updates the osv-scanner config for `libwg` to silence [GO-2024-3105](https://osv.dev/vulnerability/GO-2024-3105), [GO-2024-3106](https://osv.dev/vulnerability/GO-2024-3106) and [GO-2024-3107](https://osv.dev/vulnerability/GO-2024-3107) for 3 more months. All of these have been fixed in go 1.23.1, so we should consider bumping our go version and unsilence these advisories.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7361)
<!-- Reviewable:end -->
