### PR TITLE
Add `libarchive-tools` to container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 **/*
-!gui/package.json
+!desktop/package.json

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update -y && \
 ENV PATH=/root/.volta/bin:$PATH
 # volta seemingly does not have a way to explicitly install the toolchain
 # versions from package.json, but `node --version` triggers an install
-COPY desktop/packages/mullvad-vpn/package.json .
+COPY desktop/package.json .
 RUN curl https://get.volta.sh | bash && node --version && rm package.json
 
 # === Golang ===

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -48,6 +48,8 @@ RUN dpkg --add-architecture arm64 && apt-get update -y && apt-get install -y \
     rpm \
     # For cross-compiling/linting towards Windows
     gcc-mingw-w64-x86-64 \
+    # For building Arch Linux packages
+    libarchive-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # === Rust ===


### PR DESCRIPTION
Adding `libarchive-tools` package to base Linux container. Needed to experiment with Arch Linux package building.

Also fixes an issue in the container building since `package.json` has moved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7364)
<!-- Reviewable:end -->
