### PR TITLE
Bump Linux build container to mullvadvpn-app-build:124ce3fef

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -19,7 +19,7 @@
 # patch for a given go version can be identified by checking the wireguard-android
 # repo: https://git.zx2c4.com/wireguard-android/tree/tunnel/tools/libwg-go.
 # It's also important to keep the go path in sync.
-FROM ghcr.io/mullvad/mullvadvpn-app-build:2301dbd5b
+FROM ghcr.io/mullvad/mullvadvpn-app-build:124ce3fef
 
 # === Metadata ===
 LABEL org.opencontainers.image.source=https://github.com/mullvad/mullvadvpn-app

--- a/building/linux-container-image.txt
+++ b/building/linux-container-image.txt
@@ -1,1 +1,1 @@
-ghcr.io/mullvad/mullvadvpn-app-build:2301dbd5b
+ghcr.io/mullvad/mullvadvpn-app-build:124ce3fef


### PR DESCRIPTION
The new version of the Linux build container contains:
* Rust upgraded to 1.83
* Added package `libarchive-tools` (needed for experimenting with Arch Linux packaging

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7367)
<!-- Reviewable:end -->
