### PR TITLE
Revert reset of pinger establish timeout

### DIFF
--- a/talpid-wireguard/src/connectivity/check.rs
+++ b/talpid-wireguard/src/connectivity/check.rs
@@ -125,8 +125,6 @@ impl<S: Strategy> Check<S> {
     // checks if the tunnel has ever worked. Intended to check if a connection to a tunnel is
     // successful at the start of a connection.
     pub fn establish_connectivity(&mut self, tunnel_handle: &TunnelType) -> Result<bool, Error> {
-        self.conn_state = ConnState::new(Instant::now(), Default::default());
-
         // Send initial ping to prod WireGuard into connecting.
         self.ping_state
             .pinger


### PR DESCRIPTION
Partially revert #7348. `establish_connectivity` only works on the first attempt when enabling PQ, multihop, and udp2tcp.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7368)
<!-- Reviewable:end -->
