### PR TITLE
Remove global API endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +600,16 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1067,7 +1087,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
 dependencies = [
- "colored",
+ "colored 1.9.4",
  "log",
 ]
 
@@ -2322,6 +2342,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored 2.2.0",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "mullvad-api"
 version = "0.0.0"
 dependencies = [
@@ -2336,6 +2380,7 @@ dependencies = [
  "ipnetwork",
  "libc",
  "log",
+ "mockito",
  "mullvad-encrypted-dns-proxy",
  "mullvad-fs",
  "mullvad-types",
@@ -4113,6 +4158,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple-signal"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -33,6 +33,7 @@ import net.mullvad.mullvadvpn.repository.UserPreferencesMigration
 import net.mullvad.mullvadvpn.repository.UserPreferencesRepository
 import net.mullvad.mullvadvpn.repository.UserPreferencesSerializer
 import net.mullvad.mullvadvpn.repository.WireguardConstraintsRepository
+import net.mullvad.mullvadvpn.service.DaemonConfig
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
@@ -129,7 +130,7 @@ val uiModule = module {
     single { ChangelogRepository(get()) }
     single { UserPreferencesRepository(get()) }
     single { SettingsRepository(get()) }
-    single { MullvadProblemReport(get()) }
+    single { MullvadProblemReport(get(), get<DaemonConfig>().apiEndpointOverride, get()) }
     single { RelayOverridesRepository(get()) }
     single { CustomListsRepository(get()) }
     single { RelayListRepository(get(), get()) }

--- a/android/lib/endpoint/src/main/kotlin/net/mullvad/mullvadvpn/lib/endpoint/ApiEndpointOverride.kt
+++ b/android/lib/endpoint/src/main/kotlin/net/mullvad/mullvadvpn/lib/endpoint/ApiEndpointOverride.kt
@@ -7,7 +7,6 @@ import kotlinx.parcelize.Parcelize
 data class ApiEndpointOverride(
     val hostname: String,
     val port: Int = CUSTOM_ENDPOINT_HTTPS_PORT,
-    val disableAddressCache: Boolean = true,
     val disableTls: Boolean = false,
     val forceDirectConnection: Boolean = true,
 ) : Parcelable {

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiTest.kt
@@ -55,11 +55,6 @@ abstract class MockApiTest {
     }
 
     private fun createEndpoint(port: Int): ApiEndpointOverride {
-        return ApiEndpointOverride(
-            InetAddress.getLocalHost().hostName,
-            port,
-            disableAddressCache = true,
-            disableTls = true,
-        )
+        return ApiEndpointOverride(InetAddress.getLocalHost().hostName, port, disableTls = true)
     }
 }

--- a/ios/MullvadVPNUITests/MullvadApi.swift
+++ b/ios/MullvadVPNUITests/MullvadApi.swift
@@ -56,7 +56,8 @@ class MullvadApi {
         let result = mullvad_api_client_initialize(
             &clientContext,
             apiAddress,
-            hostname
+            hostname,
+            false
         )
         try ApiError(result).throwIfErr()
     }

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread", "ne
 tokio-rustls = { version = "0.26.0", features = ["logging", "tls12", "ring"], default-features = false}
 tokio-socks = "0.5.1"
 rustls-pemfile = "2.1.3"
+uuid = { version = "1.4.1", features = ["v4"] }
 
 mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-fs = { path = "../mullvad-fs" }
@@ -50,14 +51,6 @@ mockito = "1.6.1"
 [build-dependencies]
 cbindgen = { version = "0.24.3", default-features = false }
 
-[target.'cfg(target_os = "ios")'.dependencies]
-uuid = { version = "1.4.1", features = ["v4"] }
-
 [lib]
 crate-type = [ "rlib", "staticlib" ]
 bench = false
-
-[[test]]
-name = "ffi"
-# required-features = [ "api-override" ]
-features = [ "api-override" ]

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -45,6 +45,7 @@ shadowsocks = { workspace = true,  features = [ "stream-cipher" ] }
 [dev-dependencies]
 talpid-time = { path = "../talpid-time", features = ["test"] }
 tokio = { workspace = true, features = ["test-util", "time"] }
+mockito = "1.6.1"
 
 [build-dependencies]
 cbindgen = { version = "0.24.3", default-features = false }
@@ -55,3 +56,8 @@ uuid = { version = "1.4.1", features = ["v4"] }
 [lib]
 crate-type = [ "rlib", "staticlib" ]
 bench = false
+
+[[test]]
+name = "ffi"
+# required-features = [ "api-override" ]
+features = [ "api-override" ]

--- a/mullvad-api/include/mullvad-api.h
+++ b/mullvad-api/include/mullvad-api.h
@@ -49,15 +49,16 @@ typedef struct MullvadApiDevice {
  *   struct.
  *
  * * `api_address`: pointer to nul-terminated UTF-8 string containing a socket address
- *   representation
- *   ("143.32.4.32:9090"), the port is mandatory.
+ *   representation ("143.32.4.32:9090"), the port is mandatory.
  *
  * * `hostname`: pointer to a null-terminated UTF-8 string representing the hostname that will be
  *   used for TLS validation.
+ * * `disable_tls`: only valid when built for tests, can be ignored when consumed by Swift.
  */
 struct MullvadApiError mullvad_api_client_initialize(struct MullvadApiClient *client_ptr,
                                                      const char *api_address_ptr,
-                                                     const char *hostname);
+                                                     const char *hostname,
+                                                     bool disable_tls);
 
 /**
  * Removes all devices from a given account
@@ -98,8 +99,8 @@ struct MullvadApiError mullvad_api_get_expiry(struct MullvadApiClient client_ptr
  * * `account_str_ptr`: pointer to nul-terminated UTF-8 string containing the account number of the
  *   account that will have all of it's devices removed.
  *
- * * `device_iter_ptr`: a pointer to a `device::MullvadApiDeviceIterator`. If this function
- *   doesn't return an error, the pointer will be initialized with a valid instance of
+ * * `device_iter_ptr`: a pointer to a `device::MullvadApiDeviceIterator`. If this function doesn't
+ *   return an error, the pointer will be initialized with a valid instance of
  *   `device::MullvadApiDeviceIterator`, which can be used to iterate through the devices.
  */
 struct MullvadApiError mullvad_api_list_devices(struct MullvadApiClient client_ptr,

--- a/mullvad-api/src/bin/relay_list.rs
+++ b/mullvad-api/src/bin/relay_list.rs
@@ -2,14 +2,18 @@
 //! Used by the installer artifact packer to bundle the latest available
 //! relay list at the time of creating the installer.
 
-use mullvad_api::{proxy::ApiConnectionMode, rest::Error as RestError, RelayListProxy};
+use mullvad_api::{
+    proxy::ApiConnectionMode, rest::Error as RestError, ApiEndpoint, RelayListProxy,
+};
 use std::process;
 use talpid_types::ErrorExt;
 
 #[tokio::main]
 async fn main() {
-    let runtime = mullvad_api::Runtime::new(tokio::runtime::Handle::current())
-        .expect("Failed to load runtime");
+    let runtime = mullvad_api::Runtime::new(
+        tokio::runtime::Handle::current(),
+        &ApiEndpoint::from_env_vars(),
+    );
 
     let relay_list_request =
         RelayListProxy::new(runtime.mullvad_rest_handle(ApiConnectionMode::Direct.into_provider()))

--- a/mullvad-api/src/ffi/error.rs
+++ b/mullvad-api/src/ffi/error.rs
@@ -13,6 +13,7 @@ pub enum MullvadApiErrorKind {
 
 /// MullvadApiErrorKind contains a description and an error kind. If the error kind is
 /// `MullvadApiErrorKind` is NoError, the pointer will be nil.
+#[derive(Debug)]
 #[repr(C)]
 pub struct MullvadApiError {
     description: *mut libc::c_char,
@@ -44,6 +45,13 @@ impl MullvadApiError {
         Self {
             description: std::ptr::null_mut(),
             kind: MullvadApiErrorKind::NoError,
+        }
+    }
+
+    pub fn unwrap(&self) {
+        if !matches!(self.kind, MullvadApiErrorKind::NoError) {
+            let desc = unsafe { std::ffi::CStr::from_ptr(self.description) };
+            panic!("API ERROR - {:?} - {}", self.kind, desc.to_str().unwrap());
         }
     }
 

--- a/mullvad-api/src/ffi/mod.rs
+++ b/mullvad-api/src/ffi/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "android"))]
 use std::{
     ffi::{CStr, CString},
     net::SocketAddr,
@@ -6,8 +7,9 @@ use std::{
 };
 
 use crate::{
+    proxy::ApiConnectionMode,
     rest::{self, MullvadRestHandle},
-    AccountsProxy, DevicesProxy,
+    AccountsProxy, ApiEndpoint, DevicesProxy,
 };
 
 mod device;
@@ -48,13 +50,13 @@ impl MullvadApiClient {
 struct FfiClient {
     tokio_runtime: tokio::runtime::Runtime,
     api_runtime: crate::Runtime,
-    api_hostname: String,
 }
 
 impl FfiClient {
     unsafe fn new(
         api_address_ptr: *const libc::c_char,
         hostname: *const libc::c_char,
+        #[cfg(any(feature = "api-override", test))] disable_tls: bool,
     ) -> Result<Self, MullvadApiError> {
         // SAFETY: addr_str must be a valid pointer to a null-terminated string.
         let addr_str = unsafe { string_from_raw_ptr(api_address_ptr)? };
@@ -68,12 +70,15 @@ impl FfiClient {
             )
         })?;
 
-        // The call site guarantees that
-        // api_hostname and api_address will never change after the first call to new.
-        std::env::set_var(crate::env::API_HOST_VAR, &api_hostname);
-        std::env::set_var(crate::env::API_ADDR_VAR, &addr_str);
-        std::env::set_var(crate::env::API_FORCE_DIRECT_VAR, "0");
-        std::env::set_var(crate::env::DISABLE_TLS_VAR, "0");
+        let endpoint = ApiEndpoint {
+            host: Some(api_hostname.clone()),
+            address: Some(api_address),
+            #[cfg(feature = "api-override")]
+            force_direct: false,
+            #[cfg(any(feature = "api-override", test))]
+            disable_tls,
+        };
+
         let mut runtime_builder = tokio::runtime::Builder::new_multi_thread();
 
         runtime_builder.worker_threads(2).enable_all();
@@ -83,14 +88,12 @@ impl FfiClient {
 
         // It is imperative that the REST runtime is created within an async context, otherwise
         // ApiAvailability panics.
-        let api_runtime = tokio_runtime.block_on(async {
-            crate::Runtime::with_static_addr(tokio_runtime.handle().clone(), api_address)
-        });
+        let api_runtime = tokio_runtime
+            .block_on(async { crate::Runtime::new(tokio_runtime.handle().clone(), &endpoint) });
 
         let context = FfiClient {
             tokio_runtime,
             api_runtime,
-            api_hostname,
         };
 
         Ok(context)
@@ -204,7 +207,7 @@ impl FfiClient {
     fn rest_handle(&self) -> MullvadRestHandle {
         self.tokio_handle().block_on(async {
             self.api_runtime
-                .static_mullvad_rest_handle(self.api_hostname.clone())
+                .mullvad_rest_handle(ApiConnectionMode::Direct.into_provider())
         })
     }
 
@@ -229,18 +232,31 @@ impl FfiClient {
 ///   struct.
 ///
 /// * `api_address`: pointer to nul-terminated UTF-8 string containing a socket address
-///   representation
-///   ("143.32.4.32:9090"), the port is mandatory.
+///   representation ("143.32.4.32:9090"), the port is mandatory.
 ///
 /// * `hostname`: pointer to a null-terminated UTF-8 string representing the hostname that will be
 ///   used for TLS validation.
+/// * `disable_tls`: only valid when built for tests, can be ignored when consumed by Swift.
 #[no_mangle]
 pub unsafe extern "C" fn mullvad_api_client_initialize(
     client_ptr: *mut MullvadApiClient,
     api_address_ptr: *const libc::c_char,
     hostname: *const libc::c_char,
+    disable_tls: bool,
 ) -> MullvadApiError {
-    match unsafe { FfiClient::new(api_address_ptr, hostname) } {
+    #[cfg(not(any(feature = "api-override", test)))]
+    if disable_tls {
+        log::error!("disable_tls has no effect when mullvad-api is built without api-override");
+    }
+
+    match unsafe {
+        FfiClient::new(
+            api_address_ptr,
+            hostname,
+            #[cfg(any(feature = "api-override", test))]
+            disable_tls,
+        )
+    } {
         Ok(client) => {
             unsafe {
                 std::ptr::write(client_ptr, MullvadApiClient::new(client));
@@ -306,8 +322,8 @@ pub unsafe extern "C" fn mullvad_api_get_expiry(
 /// * `account_str_ptr`: pointer to nul-terminated UTF-8 string containing the account number of the
 ///   account that will have all of it's devices removed.
 ///
-/// * `device_iter_ptr`: a pointer to a `device::MullvadApiDeviceIterator`. If this function
-///   doesn't return an error, the pointer will be initialized with a valid instance of
+/// * `device_iter_ptr`: a pointer to a `device::MullvadApiDeviceIterator`. If this function doesn't
+///   return an error, the pointer will be initialized with a valid instance of
 ///   `device::MullvadApiDeviceIterator`, which can be used to iterate through the devices.
 #[no_mangle]
 pub unsafe extern "C" fn mullvad_api_list_devices(
@@ -442,4 +458,58 @@ unsafe fn string_from_raw_ptr(ptr: *const libc::c_char) -> Result<String, Mullva
             )
         })?
         .to_owned())
+}
+
+#[cfg(test)]
+mod test {
+    use mockito::{Server, ServerGuard};
+    use std::{mem::MaybeUninit, net::Ipv4Addr};
+
+    use super::*;
+    const STAGING_HOSTNAME: &[u8] = b"api-app.stagemole.eu\0";
+
+    #[test]
+    fn test_initialization() {
+        let _ = create_client(&SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1));
+    }
+
+    fn create_client(addr: &SocketAddr) -> MullvadApiClient {
+        let mut client = MaybeUninit::<MullvadApiClient>::uninit();
+        let cstr_address = CString::new(addr.to_string()).unwrap();
+        unsafe {
+            mullvad_api_client_initialize(
+                client.as_mut_ptr(),
+                cstr_address.as_ptr().cast(),
+                STAGING_HOSTNAME.as_ptr().cast(),
+                true,
+            )
+            .unwrap();
+        };
+        unsafe { client.assume_init() }
+    }
+
+    #[test]
+    fn test_create_delete_account() {
+        let server = test_server();
+        let client = create_client(&server.socket_address());
+
+        let mut account_buf = vec![0 as libc::c_char; 100];
+        unsafe { mullvad_api_create_account(client, account_buf.as_mut_ptr().cast()).unwrap() };
+    }
+
+    fn test_server() -> ServerGuard {
+        let mut server = Server::new();
+        let expected_create_account_response = br#"{"id":"085df870-0fc2-47cb-9e8c-cb43c1bdaac0","expiry":"2024-12-11T12:56:32+00:00","max_ports":0,"can_add_ports":false,"max_devices":5,"can_add_devices":true,"number":"6705749539195318"}"#;
+        server
+            .mock(
+                "POST",
+                &*("/".to_string() + crate::ACCOUNTS_URL_PREFIX + "/accounts"),
+            )
+            .with_header("content-type", "application/json")
+            .with_status(201)
+            .with_body(expected_create_account_response)
+            .create();
+
+        server
+    }
 }

--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -154,11 +154,14 @@ impl<T: ConnectionModeProvider + 'static> RequestService<T> {
         connection_mode_provider: T,
         dns_resolver: Arc<dyn DnsResolver>,
         #[cfg(target_os = "android")] socket_bypass_tx: Option<mpsc::Sender<SocketBypassRequest>>,
+        #[cfg(any(feature = "api-override", test))] disable_tls: bool,
     ) -> RequestServiceHandle {
         let (connector, connector_handle) = HttpsConnectorWithSni::new(
             dns_resolver,
             #[cfg(target_os = "android")]
             socket_bypass_tx.clone(),
+            #[cfg(any(feature = "api-override", test))]
+            disable_tls,
         );
 
         connector_handle.set_connection_mode(connection_mode_provider.initial());
@@ -461,7 +464,6 @@ where
         }
 
         // Parse unexpected responses and errors
-
         let response = response?;
 
         if !self.expected_status.contains(&response.status()) {

--- a/mullvad-daemon/src/api_address_updater.rs
+++ b/mullvad-daemon/src/api_address_updater.rs
@@ -1,5 +1,7 @@
 //! A small updater that keeps the API IP address cache up to date by fetching changes from the
 //! Mullvad API.
+#[cfg(feature = "api-override")]
+use mullvad_api::ApiEndpoint;
 use mullvad_api::{rest::MullvadRestHandle, AddressCache, ApiProxy};
 use std::time::Duration;
 
@@ -7,9 +9,13 @@ const API_IP_CHECK_INITIAL: Duration = Duration::from_secs(15 * 60);
 const API_IP_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const API_IP_CHECK_ERROR_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
-pub async fn run_api_address_fetcher(address_cache: AddressCache, handle: MullvadRestHandle) {
+pub async fn run_api_address_fetcher(
+    address_cache: AddressCache,
+    handle: MullvadRestHandle,
+    #[cfg(feature = "api-override")] endpoint: ApiEndpoint,
+) {
     #[cfg(feature = "api-override")]
-    if mullvad_api::API.disable_address_cache {
+    if endpoint.should_disable_address_cache() {
         return;
     }
 

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, thread, time::Duration};
 
+use mullvad_api::ApiEndpoint;
 #[cfg(not(windows))]
 use mullvad_daemon::cleanup_old_rpc_socket;
 use mullvad_daemon::{
@@ -221,6 +222,7 @@ async fn create_daemon(log_dir: Option<PathBuf>) -> Result<Daemon, String> {
         cache_dir,
         rpc_socket_path,
         daemon_command_channel,
+        ApiEndpoint::from_env_vars(),
     )
     .await
     .map_err(|e| e.display_chain_with_msg("Unable to initialize daemon"))

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -1,11 +1,10 @@
 use std::{path::PathBuf, thread, time::Duration};
 
-use mullvad_api::ApiEndpoint;
 #[cfg(not(windows))]
 use mullvad_daemon::cleanup_old_rpc_socket;
 use mullvad_daemon::{
     exception_logging, logging, rpc_uniqueness_check, runtime, version, Daemon,
-    DaemonCommandChannel,
+    DaemonCommandChannel, DaemonConfig,
 };
 use talpid_types::ErrorExt;
 
@@ -213,16 +212,16 @@ async fn create_daemon(log_dir: Option<PathBuf>) -> Result<Daemon, String> {
     let cache_dir = mullvad_paths::cache_dir()
         .map_err(|e| e.display_chain_with_msg("Unable to get cache dir"))?;
 
-    let daemon_command_channel = DaemonCommandChannel::new();
-
     Daemon::start(
-        log_dir,
-        resource_dir,
-        settings_dir,
-        cache_dir,
-        rpc_socket_path,
-        daemon_command_channel,
-        ApiEndpoint::from_env_vars(),
+        DaemonConfig {
+            log_dir,
+            resource_dir,
+            settings_dir,
+            cache_dir,
+            rpc_socket_path,
+            endpoint: mullvad_api::ApiEndpoint::from_env_vars(),
+        },
+        DaemonCommandChannel::new(),
     )
     .await
     .map_err(|e| e.display_chain_with_msg("Unable to initialize daemon"))

--- a/mullvad-jni/src/api.rs
+++ b/mullvad-jni/src/api.rs
@@ -20,7 +20,6 @@ pub fn api_endpoint_from_java(
     Some(mullvad_api::ApiEndpoint {
         host: Some(hostname),
         address,
-        disable_address_cache: disable_address_cache_from_java(env, endpoint_override),
         disable_tls: disable_tls_from_java(env, endpoint_override),
         force_direct: force_direct_from_java(env, endpoint_override),
     })
@@ -71,16 +70,8 @@ fn port_from_java(env: &JnixEnv<'_>, endpoint_override: JObject<'_>) -> u16 {
 }
 
 #[cfg(feature = "api-override")]
-fn disable_address_cache_from_java(env: &JnixEnv<'_>, endpoint_override: JObject<'_>) -> bool {
-    env.call_method(endpoint_override, "component3", "()Z", &[])
-        .expect("missing ApiEndpointOverride.disableAddressCache")
-        .z()
-        .expect("ApiEndpointOverride.disableAddressCache is not a bool")
-}
-
-#[cfg(feature = "api-override")]
 fn disable_tls_from_java(env: &JnixEnv<'_>, endpoint_override: JObject<'_>) -> bool {
-    env.call_method(endpoint_override, "component4", "()Z", &[])
+    env.call_method(endpoint_override, "component3", "()Z", &[])
         .expect("missing ApiEndpointOverride.disableTls")
         .z()
         .expect("ApiEndpointOverride.disableTls is not a bool")
@@ -88,7 +79,7 @@ fn disable_tls_from_java(env: &JnixEnv<'_>, endpoint_override: JObject<'_>) -> b
 
 #[cfg(feature = "api-override")]
 fn force_direct_from_java(env: &JnixEnv<'_>, endpoint_override: JObject<'_>) -> bool {
-    env.call_method(endpoint_override, "component5", "()Z", &[])
+    env.call_method(endpoint_override, "component4", "()Z", &[])
         .expect("missing ApiEndpointOverride.forceDirectConnection")
         .z()
         .expect("ApiEndpointOverride.forceDirectConnection is not a bool")

--- a/mullvad-jni/src/problem_report.rs
+++ b/mullvad-jni/src/problem_report.rs
@@ -6,6 +6,7 @@ use jnix::{
     },
     FromJava, JnixEnv,
 };
+use mullvad_api::ApiEndpoint;
 use std::path::Path;
 use talpid_types::ErrorExt;
 
@@ -44,6 +45,7 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemRepor
     userMessage: JString<'_>,
     outputPath: JString<'_>,
     cacheDirectory: JString<'_>,
+    endpoint: JObject<'_>,
 ) -> jboolean {
     let env = JnixEnv::from(env);
     let user_email = String::from_java(&env, userEmail);
@@ -52,12 +54,15 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemRepor
     let output_path = Path::new(&output_path_string);
     let cache_directory_string = String::from_java(&env, cacheDirectory);
     let cache_directory = Path::new(&cache_directory_string);
+    let api_endpoint =
+        crate::api::api_endpoint_from_java(&env, endpoint).unwrap_or(ApiEndpoint::from_env_vars());
 
     let send_result = mullvad_problem_report::send_problem_report(
         &user_email,
         &user_message,
         output_path,
         cache_directory,
+        api_endpoint,
     );
 
     match send_result {

--- a/mullvad-problem-report/src/lib.rs
+++ b/mullvad-problem-report/src/lib.rs
@@ -1,4 +1,4 @@
-use mullvad_api::proxy::ApiConnectionMode;
+use mullvad_api::{proxy::ApiConnectionMode, ApiEndpoint};
 use regex::Regex;
 use std::{
     borrow::Cow,
@@ -261,6 +261,7 @@ pub fn send_problem_report(
     user_message: &str,
     report_path: &Path,
     cache_dir: &Path,
+    endpoint: ApiEndpoint,
 ) -> Result<(), Error> {
     let report_content = normalize_newlines(
         read_file_lossy(report_path, REPORT_MAX_SIZE).map_err(|source| {
@@ -281,6 +282,7 @@ pub fn send_problem_report(
         user_message,
         &report_content,
         cache_dir,
+        &endpoint,
     ))
 }
 
@@ -289,9 +291,11 @@ async fn send_problem_report_inner(
     user_message: &str,
     report_content: &str,
     cache_dir: &Path,
+    endpoint: &ApiEndpoint,
 ) -> Result<(), Error> {
     let metadata = ProblemReport::parse_metadata(report_content).unwrap_or_else(metadata::collect);
     let api_runtime = mullvad_api::Runtime::with_cache(
+        endpoint,
         cache_dir,
         false,
         #[cfg(target_os = "android")]

--- a/mullvad-problem-report/src/main.rs
+++ b/mullvad-problem-report/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use mullvad_api::ApiEndpoint;
 use mullvad_problem_report::{collect_report, Error};
 use std::{
     env,
@@ -89,10 +90,16 @@ fn send_problem_report(
     report_path: &Path,
 ) -> Result<(), Error> {
     let cache_dir = mullvad_paths::get_cache_dir().map_err(Error::ObtainCacheDirectory)?;
-    mullvad_problem_report::send_problem_report(user_email, user_message, report_path, &cache_dir)
-        .inspect_err(|error| {
-            eprintln!("{}", error.display_chain());
-        })?;
+    mullvad_problem_report::send_problem_report(
+        user_email,
+        user_message,
+        report_path,
+        &cache_dir,
+        ApiEndpoint::from_env_vars(),
+    )
+    .inspect_err(|error| {
+        eprintln!("{}", error.display_chain());
+    })?;
 
     println!("Problem report sent");
     Ok(())

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::{path::PathBuf, process, str::FromStr, sync::LazyLock, time::Duration};
 
-use mullvad_api::{proxy::ApiConnectionMode, DEVICE_NOT_FOUND};
+use mullvad_api::{proxy::ApiConnectionMode, ApiEndpoint, DEVICE_NOT_FOUND};
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::version::ParsedAppVersion;
 use talpid_core::firewall::{self, Firewall};
@@ -152,9 +152,10 @@ async fn remove_device() -> Result<(), Error> {
         .await
         .map_err(Error::ReadDeviceCacheError)?;
     if let Some(device) = state.into_device() {
-        let api_runtime = mullvad_api::Runtime::with_cache(&cache_path, false)
-            .await
-            .map_err(Error::RpcInitializationError)?;
+        let api_runtime =
+            mullvad_api::Runtime::with_cache(&ApiEndpoint::from_env_vars(), &cache_path, false)
+                .await
+                .map_err(Error::RpcInitializationError)?;
 
         let connection_mode = ApiConnectionMode::try_from_cache(&cache_path).await;
         let proxy = mullvad_api::DevicesProxy::new(


### PR DESCRIPTION
This particular changeset started off with adding a unit test to see why the iOS end-to-end API client is failing. I fixed it and added a test to ensure it doesn't get broken again. Adding a test implied removing some _global state_, namely the global `ApiEndpoint`.  The test itself is using `httpmock` and exercising the FFI that the Swift test client is using.  I have tested these changes with various Android builds, will try out the app with stagemole later too. I am not entirely certain if removing the global state has made the code any more readable or better, but it certainly has improved the testability. 

This then bubbled over into refactoring the daemon parameters just one slight bit - I am not certain it is a change we need, and thus can drop the last commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7373)
<!-- Reviewable:end -->
