### PR TITLE
Do not block during ephemeral peer exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - (Linux and macOS only) Update to DAITA v2. The main difference is that many different machines are
   provided by relays instead of a bundled list. The bundled `maybenot_machines` file was removed.
+
+#### Windows
 - Test tunnel before ephemeral peer exchange. This is an attempt to fix timeout issues.
 
 ### Fixed

--- a/talpid-wireguard/build.rs
+++ b/talpid-wireguard/build.rs
@@ -19,7 +19,7 @@ fn main() {
     // This is useful after updating the WireGuard config, to force a WireGuard handshake. This
     // should reduce the number of PQ timeouts.
     println!("cargo::rustc-check-cfg=cfg(force_wireguard_handshake)");
-    if matches!(target_os.as_str(), "linux" | "macos" | "windows") {
+    if target_os.as_str() == "windows" {
         println!("cargo::rustc-cfg=force_wireguard_handshake");
     }
 }

--- a/talpid-wireguard/src/connectivity/mod.rs
+++ b/talpid-wireguard/src/connectivity/mod.rs
@@ -6,6 +6,8 @@ mod mock;
 mod monitor;
 mod pinger;
 
-pub use check::{Cancellable, Check};
+#[cfg(any(target_os = "android", force_wireguard_handshake))]
+pub use check::Cancellable;
+pub use check::Check;
 pub use error::Error;
 pub use monitor::Monitor;

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -121,7 +121,7 @@ async fn config_ephemeral_peers_inner(
     // NOTE: This one often fails with multihop on Windows, even though the handshake afterwards
     // succeeds. So we try anyway if it fails.
     #[cfg(force_wireguard_handshake)]
-    let _ = establish_tunnel_connection(tunnel, connectivity).await;
+    let _ = establish_tunnel_connection(tunnel, connectivity);
 
     let ephemeral_private_key = PrivateKey::new_from_random();
     let close_obfs_sender = close_obfs_sender.clone();
@@ -162,7 +162,7 @@ async fn config_ephemeral_peers_inner(
         .await?;
 
         #[cfg(force_wireguard_handshake)]
-        establish_tunnel_connection(tunnel, connectivity).await?;
+        establish_tunnel_connection(tunnel, connectivity)?;
 
         let entry_ephemeral_peer = request_ephemeral_peer(
             retry_attempt,
@@ -300,16 +300,17 @@ async fn reconfigure_tunnel(
 /// Ensure that the WireGuard tunnel works. This is useful after updating the WireGuard config, to
 /// force a WireGuard handshake. This should reduce the number of PQ timeouts.
 #[cfg(force_wireguard_handshake)]
-async fn establish_tunnel_connection(
+fn establish_tunnel_connection(
     tunnel: &Arc<AsyncMutex<Option<TunnelType>>>,
     connectivity: &mut connectivity::Check<connectivity::Cancellable>,
 ) -> Result<(), CloseMsg> {
     use talpid_types::ErrorExt;
 
-    let shared_tunnel = tunnel.lock().await;
-    let tunnel = shared_tunnel.as_ref().expect("tunnel was None");
-    let ping_result = connectivity.establish_connectivity(tunnel);
-    drop(shared_tunnel);
+    let ping_result = tokio::task::block_in_place(|| {
+        let shared_tunnel = tunnel.blocking_lock();
+        let tunnel = shared_tunnel.as_ref().expect("tunnel was None");
+        connectivity.establish_connectivity(tunnel)
+    });
 
     match ping_result {
         Ok(true) => Ok(()),


### PR DESCRIPTION
This is due to #7348. Previously, this could panic since some `Tunnel` implementations use `block_on`. This was due to a bug where a blocking function was called during ephemeral peer exchange.

Since `spawn_blocking` demands a static lifetime, the fix involves using `block_in_place`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7374)
<!-- Reviewable:end -->
