### PR TITLE
Silence security advisory `GO-2024-3333` in osv-scanner

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -16,3 +16,15 @@ reason = "wireguard-go does not use the affected code"
 id = "CVE-2024-34155" # GO-2024-3105
 ignoreUntil = 2025-03-18
 reason = "wireguard-go does not use the affected code"
+
+# Denial of service in HTML Parse function in go/net/html
+[[IgnoredVulns]]
+id = "CVE-2024-45338" # GO-2024-3333
+ignoreUntil = 2025-03-19
+reason = "wireguard-go does not use the affected code"
+
+# Denial of service in HTML Parse function in go/net/html
+[[IgnoredVulns]]
+id = "GHSA-w32m-9786-jp63" # GO-2024-3333
+ignoreUntil = 2025-03-19
+reason = "wireguard-go does not use the affected code"


### PR DESCRIPTION
This PR silences yet another security advisory in the go standard library. We are unaffected by the vulnerability itself since we never parse HTML in any of our go code. As stated in https://github.com/mullvad/mullvadvpn-app/pull/7361, we could look into bumping our version of go when the fix has been released, but we don't need to worry about it atm.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7375)
<!-- Reviewable:end -->
