### PR TITLE
Remove direct winapi dependency from mullvad-daemon exception handling

### DIFF
--- a/mullvad-daemon/src/exception_logging/win.rs
+++ b/mullvad-daemon/src/exception_logging/win.rs
@@ -211,11 +211,13 @@ unsafe extern "system" fn logging_exception_filter(info_ptr: *const EXCEPTION_PO
 
 #[cfg(target_arch = "aarch64")]
 fn get_context_info(context: &CONTEXT) -> String {
-    use winapi::um::winnt::{CONTEXT_CONTROL, CONTEXT_FLOATING_POINT, CONTEXT_INTEGER};
+    use windows_sys::Win32::System::Diagnostics::Debug::{
+        CONTEXT_CONTROL_ARM64, CONTEXT_FLOATING_POINT_ARM64, CONTEXT_INTEGER_ARM64,
+    };
 
     let mut context_str = "Context:\n".to_string();
 
-    if context.ContextFlags & CONTEXT_CONTROL != 0 {
+    if context.ContextFlags & CONTEXT_CONTROL_ARM64 != 0 {
         writeln!(
             &mut context_str,
             "\n\tFp: {:#x?}\n \
@@ -232,7 +234,7 @@ fn get_context_info(context: &CONTEXT) -> String {
         .unwrap();
     }
 
-    if context.ContextFlags & CONTEXT_INTEGER != 0 {
+    if context.ContextFlags & CONTEXT_INTEGER_ARM64 != 0 {
         context_str.push('\n');
         for x in 0..=28 {
             writeln!(&mut context_str, "\tX{}: {:#x?}", x, unsafe {
@@ -241,7 +243,7 @@ fn get_context_info(context: &CONTEXT) -> String {
             .unwrap();
         }
     }
-    if context.ContextFlags & CONTEXT_FLOATING_POINT != 0 {
+    if context.ContextFlags & CONTEXT_FLOATING_POINT_ARM64 != 0 {
         writeln!(
             &mut context_str,
             "\n\tFpcr: {:#x?}\n \
@@ -262,11 +264,13 @@ fn get_context_info(context: &CONTEXT) -> String {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn get_context_info(context: &CONTEXT) -> String {
-    use winapi::um::winnt::{CONTEXT_CONTROL, CONTEXT_INTEGER, CONTEXT_SEGMENTS};
+    use windows_sys::Win32::System::Diagnostics::Debug::{
+        CONTEXT_CONTROL_AMD64, CONTEXT_INTEGER_AMD64, CONTEXT_SEGMENTS_AMD64,
+    };
 
     let mut context_str = "Context:\n".to_string();
 
-    if context.ContextFlags & CONTEXT_CONTROL != 0 {
+    if context.ContextFlags & CONTEXT_CONTROL_AMD64 != 0 {
         writeln!(
             &mut context_str,
             "\n\tSegSs: {:#x?}\n \
@@ -279,7 +283,7 @@ fn get_context_info(context: &CONTEXT) -> String {
         .unwrap();
     }
 
-    if context.ContextFlags & CONTEXT_INTEGER != 0 {
+    if context.ContextFlags & CONTEXT_INTEGER_AMD64 != 0 {
         writeln!(
             &mut context_str,
             "\n\tRax: {:#x?}\n \
@@ -316,7 +320,7 @@ fn get_context_info(context: &CONTEXT) -> String {
         .unwrap();
     }
 
-    if context.ContextFlags & CONTEXT_SEGMENTS != 0 {
+    if context.ContextFlags & CONTEXT_SEGMENTS_AMD64 != 0 {
         writeln!(
             &mut context_str,
             "\n\tSegDs: {:#x?}\n \

--- a/mullvad-daemon/src/exception_logging/win.rs
+++ b/mullvad-daemon/src/exception_logging/win.rs
@@ -262,7 +262,7 @@ fn get_context_info(context: &CONTEXT) -> String {
     context_str
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 fn get_context_info(context: &CONTEXT) -> String {
     use windows_sys::Win32::System::Diagnostics::Debug::{
         CONTEXT_CONTROL_AMD64, CONTEXT_INTEGER_AMD64, CONTEXT_SEGMENTS_AMD64,


### PR DESCRIPTION
We still pull in `winapi` as a transitive dependency via a bunch of crates. But this PR at least tries to remove the last usage of it as a direct dependency. This makes very little difference in practice, but is a step towards only using a single binding for the Windows API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7382)
<!-- Reviewable:end -->
