### PR TITLE
Add DAITAv2 on iOS

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -21,6 +21,11 @@ Line wrap the file at 100 chars.                                              Th
 * **Fixed**: for any bug fixes.
 * **Security**: in case of vulnerabilities.
 
+## Unreleased
+### Added
+- Update to DAITA v2 - now machines are provided by relays dynamically instead
+  of using bundled ones.
+
 ## [2024.11 - 2024-12-12]
 ### Added
 - Add WireGuard over Shadowsocks obfuscation. It can be enabled in "VPN settings". This will

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -27,6 +27,12 @@ typedef struct ProxyHandle {
   uint16_t port;
 } ProxyHandle;
 
+typedef struct DaitaParameters {
+  uint8_t *machines;
+  double max_padding_frac;
+  double max_blocking_frac;
+} DaitaParameters;
+
 typedef struct WgTcpConnectionFunctions {
   int32_t (*open_fn)(int32_t tunnelHandle, const char *address, uint64_t timeout);
   int32_t (*close_fn)(int32_t tunnelHandle, int32_t socketHandle);
@@ -89,6 +95,22 @@ int32_t encrypted_dns_proxy_start(struct EncryptedDnsProxyState *encrypted_dns_p
 int32_t encrypted_dns_proxy_stop(struct ProxyHandle *proxy_config);
 
 /**
+ * To be called when ephemeral peer exchange has finished. All parameters except
+ * `raw_packet_tunnel` are optional.
+ *
+ * # Safety:
+ * If the key exchange failed, all pointers except `raw_packet_tunnel` must be null. If the
+ * key exchange was successful, `raw_ephemeral_private_key` must be a valid pointer to 32
+ * bytes for the lifetime of this call. If PQ was enabled, `raw_preshared_key` must be a valid
+ * pointer to 32 bytes for the lifetime of this call. If DAITA was requested, the
+ * `daita_prameters` must point to a valid instance of `DaitaParameters`.
+ */
+extern void swift_ephemeral_peer_ready(const void *raw_packet_tunnel,
+                                       const uint8_t *raw_preshared_key,
+                                       const uint8_t *raw_ephemeral_private_key,
+                                       const struct DaitaParameters *daita_parameters);
+
+/**
  * Called by the Swift side to signal that the ephemeral peer exchange should be cancelled.
  * After this call, the cancel token is no longer valid.
  *
@@ -112,28 +134,17 @@ void drop_ephemeral_peer_exchange_token(struct ExchangeCancelToken *sender);
  * Entry point for requesting ephemeral peers on iOS.
  * The TCP connection must be created to go through the tunnel.
  * # Safety
- * `public_key` and `ephemeral_key` must be valid respective `PublicKey` and `PrivateKey` types.
- * They will not be valid after this function is called, and thus must be copied here.
- * `packet_tunnel` must be valid pointers to a packet tunnel, the packet tunnel pointer must
- * outlive the ephemeral peer exchange. `cancel_token` should be owned by the caller of this
- * function.
+ * `public_key` and `ephemeral_key` must be valid respective `PublicKey` and `PrivateKey` types,
+ * specifically, they must be valid pointers to 32 bytes. They will not be valid after this
+ * function is called, and thus must be copied here. `packet_tunnel` must be valid pointers to a
+ * packet tunnel, the packet tunnel pointer must outlive the ephemeral peer exchange.
+ * `cancel_token` should be owned by the caller of this function.
  */
 struct ExchangeCancelToken *request_ephemeral_peer(const uint8_t *public_key,
                                                    const uint8_t *ephemeral_key,
                                                    const void *packet_tunnel,
                                                    int32_t tunnel_handle,
                                                    struct EphemeralPeerParameters peer_parameters);
-
-/**
- * Called when the preshared post quantum key is ready,
- * or when a Daita peer has been successfully requested.
- * `raw_preshared_key` will be NULL if:
- * - The post quantum key negotiation failed
- * - A Daita peer has been requested without enabling post quantum keys.
- */
-extern void swift_ephemeral_peer_ready(const void *raw_packet_tunnel,
-                                       const uint8_t *raw_preshared_key,
-                                       const uint8_t *raw_ephemeral_private_key);
 
 /**
  * # Safety

--- a/ios/MullvadTypes/Protocols/DaitaV2Parameters.swift
+++ b/ios/MullvadTypes/Protocols/DaitaV2Parameters.swift
@@ -1,0 +1,31 @@
+//
+//  DaitaV2Parameters.swift
+//  MullvadTypes
+//
+//  Created by Marco Nikic on 2024-11-12.
+//  Copyright © 2024 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+public struct DaitaV2Parameters: Equatable {
+    public let machines: String
+    public let maximumEvents: UInt32
+    public let maximumActions: UInt32
+    public let maximumPadding: Double
+    public let maximumBlocking: Double
+
+    public init(
+        machines: String,
+        maximumEvents: UInt32,
+        maximumActions: UInt32,
+        maximumPadding: Double,
+        maximumBlocking: Double
+    ) {
+        self.machines = machines
+        self.maximumEvents = maximumEvents
+        self.maximumActions = maximumActions
+        self.maximumPadding = maximumPadding
+        self.maximumBlocking = maximumBlocking
+    }
+}

--- a/ios/MullvadTypes/Protocols/EphemeralPeerReceiver.swift
+++ b/ios/MullvadTypes/Protocols/EphemeralPeerReceiver.swift
@@ -29,19 +29,26 @@ public class EphemeralPeerReceiver: EphemeralPeerReceiving, TunnelProvider {
 
     // MARK: - EphemeralPeerReceiving
 
-    public func receivePostQuantumKey(_ key: PreSharedKey, ephemeralKey: PrivateKey) {
+    public func receivePostQuantumKey(
+        _ key: PreSharedKey,
+        ephemeralKey: PrivateKey,
+        daitaParameters: DaitaV2Parameters?
+    ) {
         let semaphore = DispatchSemaphore(value: 0)
         Task {
-            await keyReceiver.receivePostQuantumKey(key, ephemeralKey: ephemeralKey)
+            await keyReceiver.receivePostQuantumKey(key, ephemeralKey: ephemeralKey, daitaParameters: daitaParameters)
             semaphore.signal()
         }
         semaphore.wait()
     }
 
-    public func receiveEphemeralPeerPrivateKey(_ ephemeralPeerPrivateKey: PrivateKey) {
+    public func receiveEphemeralPeerPrivateKey(
+        _ ephemeralPeerPrivateKey: PrivateKey,
+        daitaParameters: DaitaV2Parameters?
+    ) {
         let semaphore = DispatchSemaphore(value: 0)
         Task {
-            await keyReceiver.receiveEphemeralPeerPrivateKey(ephemeralPeerPrivateKey)
+            await keyReceiver.receiveEphemeralPeerPrivateKey(ephemeralPeerPrivateKey, daitaParameters: daitaParameters)
             semaphore.signal()
         }
         semaphore.wait()

--- a/ios/MullvadTypes/Protocols/EphemeralPeerReceiving.swift
+++ b/ios/MullvadTypes/Protocols/EphemeralPeerReceiving.swift
@@ -15,11 +15,14 @@ public protocol EphemeralPeerReceiving {
     /// - Parameters:
     ///   - key: The preshared key used by the Ephemeral Peer
     ///   - ephemeralKey: The private key used by the Ephemeral Peer
-    func receivePostQuantumKey(_ key: PreSharedKey, ephemeralKey: PrivateKey) async
+    ///   - daitaParameters: DAITA parameters
+    func receivePostQuantumKey(_ key: PreSharedKey, ephemeralKey: PrivateKey, daitaParameters: DaitaV2Parameters?) async
 
     /// Called when successfully requesting an ephemeral peer with Daita enabled, and Post Quantum PSK disabled
-    /// - Parameter _:_ The private key used by the Ephemeral Peer
-    func receiveEphemeralPeerPrivateKey(_: PrivateKey) async
+    /// - Parameters:
+    ///     - _: The private key used by the Ephemeral Peer
+    ///     - daitaParameters: DAITA parameters
+    func receiveEphemeralPeerPrivateKey(_: PrivateKey, daitaParameters: DaitaV2Parameters?) async
 
     /// Called when an ephemeral peer could not be successfully negotiated
     func ephemeralPeerExchangeFailed()

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -739,18 +739,19 @@
 		A932D9F52B5EBB9D00999395 /* RESTTransportStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A932D9F42B5EBB9D00999395 /* RESTTransportStub.swift */; };
 		A935594C2B4C2DA900D5D524 /* APIAvailabilityTestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A935594B2B4C2DA900D5D524 /* APIAvailabilityTestRequest.swift */; };
 		A939661B2CAE6CE1008128CA /* MigrationManagerMultiProcessUpgradeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A939661A2CAE6CE1008128CA /* MigrationManagerMultiProcessUpgradeTests.swift */; };
+		A93969812CE606190032A7A0 /* Maybenot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9840BB32C69F78A0030F05E /* Maybenot.swift */; };
 		A94D691A2ABAD66700413DD4 /* WireGuardKitTypes in Frameworks */ = {isa = PBXBuildFile; productRef = 58FE25E22AA72AE9003D1918 /* WireGuardKitTypes */; };
 		A94D691B2ABAD66700413DD4 /* WireGuardKitTypes in Frameworks */ = {isa = PBXBuildFile; productRef = 58FE25E72AA7399D003D1918 /* WireGuardKitTypes */; };
 		A95EEE362B722CD600A8A39B /* TunnelMonitorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95EEE352B722CD600A8A39B /* TunnelMonitorState.swift */; };
 		A95EEE382B722DFC00A8A39B /* PingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95EEE372B722DFC00A8A39B /* PingStats.swift */; };
 		A970C89D2B29E38C000A7684 /* Socks5UsernamePasswordCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A970C89C2B29E38C000A7684 /* Socks5UsernamePasswordCommand.swift */; };
+		A97275562CE36CAE00029F15 /* DaitaV2Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97275552CE36CAE00029F15 /* DaitaV2Parameters.swift */; };
 		A97D25AE2B0BB18100946B2D /* ProtocolObfuscator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97D25AD2B0BB18100946B2D /* ProtocolObfuscator.swift */; };
 		A97D25B02B0BB5C400946B2D /* ProtocolObfuscationStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97D25AF2B0BB5C400946B2D /* ProtocolObfuscationStub.swift */; };
 		A97D25B22B0CB02D00946B2D /* ProtocolObfuscatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97D25B12B0CB02D00946B2D /* ProtocolObfuscatorTests.swift */; };
 		A97D25B42B0CB59300946B2D /* TunnelObfuscationStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97D25B32B0CB59300946B2D /* TunnelObfuscationStub.swift */; };
 		A97D30172AE6B5E90045C0E4 /* StoredWgKeyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97D30162AE6B5E90045C0E4 /* StoredWgKeyData.swift */; };
 		A97FF5502A0D2FFC00900996 /* NSFileCoordinator+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97FF54F2A0D2FFC00900996 /* NSFileCoordinator+Extensions.swift */; };
-		A9840BB42C69F78A0030F05E /* Maybenot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9840BB32C69F78A0030F05E /* Maybenot.swift */; };
 		A98502032B627B120061901E /* LocalNetworkProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98502022B627B120061901E /* LocalNetworkProbe.swift */; };
 		A988A3E22AFE54AC0008D2C7 /* AccountExpiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6F2FA62AFBB9AE006D0856 /* AccountExpiry.swift */; };
 		A988DF272ADE86ED00D807EF /* WireGuardObfuscationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A988DF252ADE86ED00D807EF /* WireGuardObfuscationSettings.swift */; };
@@ -2120,6 +2121,7 @@
 		A95EEE352B722CD600A8A39B /* TunnelMonitorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitorState.swift; sourceTree = "<group>"; };
 		A95EEE372B722DFC00A8A39B /* PingStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingStats.swift; sourceTree = "<group>"; };
 		A970C89C2B29E38C000A7684 /* Socks5UsernamePasswordCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socks5UsernamePasswordCommand.swift; sourceTree = "<group>"; };
+		A97275552CE36CAE00029F15 /* DaitaV2Parameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaitaV2Parameters.swift; sourceTree = "<group>"; };
 		A97D25AD2B0BB18100946B2D /* ProtocolObfuscator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolObfuscator.swift; sourceTree = "<group>"; };
 		A97D25AF2B0BB5C400946B2D /* ProtocolObfuscationStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolObfuscationStub.swift; sourceTree = "<group>"; };
 		A97D25B12B0CB02D00946B2D /* ProtocolObfuscatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolObfuscatorTests.swift; sourceTree = "<group>"; };
@@ -2714,6 +2716,7 @@
 				449EBA252B975B9700DFA4EB /* EphemeralPeerReceiving.swift */,
 				A90C48662C36BC2600DCB94C /* EphemeralPeerReceiver.swift */,
 				A90C48682C36BF3900DCB94C /* TunnelProvider.swift */,
+				A97275552CE36CAE00029F15 /* DaitaV2Parameters.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -4721,7 +4724,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58C7A44B2A863F4A0060C66F /* Build configuration list for PBXNativeTarget "PacketTunnelCore" */;
 			buildPhases = (
-				A9840BB22C69F7290030F05E /* Import maybenot_machines */,
 				58C7A4312A863F440060C66F /* Headers */,
 				58C7A4322A863F440060C66F /* Sources */,
 				58C7A4332A863F440060C66F /* Frameworks */,
@@ -4973,6 +4975,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A992DA252C24709F00DE7CE5 /* Build configuration list for PBXNativeTarget "MullvadRustRuntime" */;
 			buildPhases = (
+				A93969802CE603110032A7A0 /* Import maybenot_machines */,
 				A992DA2A2C2470B300DE7CE5 /* Build MullvadRustRuntime */,
 				A992DA182C24709F00DE7CE5 /* Headers */,
 				A992DA192C24709F00DE7CE5 /* Sources */,
@@ -5351,7 +5354,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif which swiftlint > /dev/null; then\n  swiftlint PacketTunnel/**/*.swift\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		A9840BB22C69F7290030F05E /* Import maybenot_machines */ = {
+		A93969802CE603110032A7A0 /* Import maybenot_machines */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -5367,7 +5370,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "MAYBENOT_MACHINES=`cat ${SRCROOT}/../dist-assets/maybenot_machines`\ncat > ${SRCROOT}/PacketTunnelCore/Daita/Maybenot.swift << EOF\n// swiftlint:disable line_length\n// This is an autogenerated file, do not edit\npublic struct Maybenot {\n    public let machines=\"\"\"\n$MAYBENOT_MACHINES\n\"\"\"\n    public let maximumEvents: UInt32 = 1000\n    public let maximumActions: UInt32 = 1000\n}\n// swiftlint:enable line_length\nEOF\n";
+			shellScript = "MAYBENOT_MACHINES=`cat ${SRCROOT}/../dist-assets/maybenot_machines`\ncat > ${SRCROOT}/PacketTunnelCore/Daita/Maybenot.swift << EOF\n// swiftlint:disable line_length\n// This is an autogenerated file, do not edit\npublic struct Maybenot {\n    public let machines=\"\"\"\n$MAYBENOT_MACHINES\n\"\"\"\n    public let maximumEvents: UInt32 = 2048\n    public let maximumActions: UInt32 = 1024\n    public let maximumPadding: Double = 1.0\n    public let maximumBlocking: Double = 1.0\n}\n// swiftlint:enable line_length\nEOF\n";
 		};
 		A992DA2A2C2470B300DE7CE5 /* Build MullvadRustRuntime */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -5775,7 +5778,6 @@
 				583832272AC3193600EA2071 /* PacketTunnelActor+SleepCycle.swift in Sources */,
 				58FE25DC2AA72A8F003D1918 /* AnyTask.swift in Sources */,
 				F04AF92D2C466013004A8314 /* EphemeralPeerNegotiationState.swift in Sources */,
-				A9840BB42C69F78A0030F05E /* Maybenot.swift in Sources */,
 				58FE25D92AA72A8F003D1918 /* AutoCancellingTask.swift in Sources */,
 				58FE25E12AA72A9B003D1918 /* SettingsReaderProtocol.swift in Sources */,
 				58C7A4582A863FB90060C66F /* TunnelMonitorProtocol.swift in Sources */,
@@ -6313,6 +6315,7 @@
 				58D22412294C90210029F5F8 /* RelayConstraint.swift in Sources */,
 				7A7AD14F2BF21EF200B30B3C /* NameInputFormatter.swift in Sources */,
 				58D22413294C90210029F5F8 /* RelayConstraints.swift in Sources */,
+				A97275562CE36CAE00029F15 /* DaitaV2Parameters.swift in Sources */,
 				7AF9BE8C2A321D1F00DBFEDB /* RelayFilter.swift in Sources */,
 				58D22414294C90210029F5F8 /* RelayLocation.swift in Sources */,
 				581DA2732A1E227D0046ED47 /* RESTTypes.swift in Sources */,
@@ -6447,6 +6450,7 @@
 				A9D9A4BB2C36D397004088DD /* EphemeralPeerNegotiator.swift in Sources */,
 				A9D9A4B22C36D12D004088DD /* TunnelObfuscator.swift in Sources */,
 				A9173C322C36CCDD00F6A08C /* EphemeralPeerReceiver.swift in Sources */,
+				A93969812CE606190032A7A0 /* Maybenot.swift in Sources */,
 				F05919802C45515200C301F3 /* EphemeralPeerExchangeActor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9512,7 +9516,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = 4499596651b4fe8a162e587c75a01615168f29a6;
+				revision = f6c6af02d3a9168589b8c109b4826b7f224fcf73;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "4499596651b4fe8a162e587c75a01615168f29a6"
+        "revision" : "f6c6af02d3a9168589b8c109b4826b7f224fcf73"
       }
     }
   ],

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -376,12 +376,26 @@ extension PacketTunnelProvider {
 }
 
 extension PacketTunnelProvider: EphemeralPeerReceiving {
-    func receivePostQuantumKey(_ key: PreSharedKey, ephemeralKey: PrivateKey) async {
-        await ephemeralPeerExchangingPipeline.receivePostQuantumKey(key, ephemeralKey: ephemeralKey)
+    func receivePostQuantumKey(
+        _ key: PreSharedKey,
+        ephemeralKey: PrivateKey,
+        daitaParameters: MullvadTypes.DaitaV2Parameters?
+    ) async {
+        await ephemeralPeerExchangingPipeline.receivePostQuantumKey(
+            key,
+            ephemeralKey: ephemeralKey,
+            daitaParameters: daitaParameters
+        )
     }
 
-    public func receiveEphemeralPeerPrivateKey(_ ephemeralPeerPrivateKey: PrivateKey) async {
-        await ephemeralPeerExchangingPipeline.receiveEphemeralPeerPrivateKey(ephemeralPeerPrivateKey)
+    public func receiveEphemeralPeerPrivateKey(
+        _ ephemeralPeerPrivateKey: PrivateKey,
+        daitaParameters: MullvadTypes.DaitaV2Parameters?
+    ) async {
+        await ephemeralPeerExchangingPipeline.receiveEphemeralPeerPrivateKey(
+            ephemeralPeerPrivateKey,
+            daitaParameters: daitaParameters
+        )
     }
 
     func ephemeralPeerExchangeFailed() {

--- a/ios/PacketTunnel/PostQuantum/EphemeralPeerExchangingPipeline.swift
+++ b/ios/PacketTunnel/PostQuantum/EphemeralPeerExchangingPipeline.swift
@@ -8,6 +8,7 @@
 
 import MullvadRustRuntime
 import MullvadSettings
+import MullvadTypes
 import PacketTunnelCore
 import WireGuardKitTypes
 
@@ -59,11 +60,25 @@ final public class EphemeralPeerExchangingPipeline {
         await ephemeralPeerExchanger.start()
     }
 
-    public func receivePostQuantumKey(_ key: PreSharedKey, ephemeralKey: PrivateKey) async {
-        await ephemeralPeerExchanger.receivePostQuantumKey(key, ephemeralKey: ephemeralKey)
+    public func receivePostQuantumKey(
+        _ key: PreSharedKey,
+        ephemeralKey: PrivateKey,
+        daitaParameters: DaitaV2Parameters?
+    ) async {
+        await ephemeralPeerExchanger.receivePostQuantumKey(
+            key,
+            ephemeralKey: ephemeralKey,
+            daitaParameters: daitaParameters
+        )
     }
 
-    public func receiveEphemeralPeerPrivateKey(_ ephemeralPeerPrivateKey: PrivateKey) async {
-        await ephemeralPeerExchanger.receiveEphemeralPeerPrivateKey(ephemeralPeerPrivateKey)
+    public func receiveEphemeralPeerPrivateKey(
+        _ ephemeralPeerPrivateKey: PrivateKey,
+        daitaParameters: DaitaV2Parameters?
+    ) async {
+        await ephemeralPeerExchanger.receiveEphemeralPeerPrivateKey(
+            ephemeralPeerPrivateKey,
+            daitaParameters: daitaParameters
+        )
     }
 }

--- a/ios/PacketTunnel/PostQuantum/SingleHopEphemeralPeerExchanger.swift
+++ b/ios/PacketTunnel/PostQuantum/SingleHopEphemeralPeerExchanger.swift
@@ -45,7 +45,8 @@ struct SingleHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
             relay: exit,
             configuration: EphemeralPeerConfiguration(
                 privateKey: devicePrivateKey,
-                allowedIPs: [IPAddressRange(from: "\(LocalNetworkIPs.gatewayAddress.rawValue)/32")!]
+                allowedIPs: [IPAddressRange(from: "\(LocalNetworkIPs.gatewayAddress.rawValue)/32")!],
+                daitaParameters: nil
             )
         )))
         keyExchanger.startNegotiation(
@@ -55,7 +56,7 @@ struct SingleHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
         )
     }
 
-    public func receiveEphemeralPeerPrivateKey(_ ephemeralKey: PrivateKey) async {
+    public func receiveEphemeralPeerPrivateKey(_ ephemeralKey: PrivateKey, daitaParameters: DaitaV2Parameters?) async {
         await onUpdateConfiguration(.single(EphemeralPeerRelayConfiguration(
             relay: exit,
             configuration: EphemeralPeerConfiguration(
@@ -64,7 +65,8 @@ struct SingleHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
                 allowedIPs: [
                     IPAddressRange(from: "\(LocalNetworkIPs.defaultRouteIpV4.rawValue)/0")!,
                     IPAddressRange(from: "\(LocalNetworkIPs.defaultRouteIpV6.rawValue)/0")!,
-                ]
+                ],
+                daitaParameters: daitaParameters
             )
         )))
         self.onFinish()
@@ -72,7 +74,8 @@ struct SingleHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
 
     func receivePostQuantumKey(
         _ preSharedKey: WireGuardKitTypes.PreSharedKey,
-        ephemeralKey: WireGuardKitTypes.PrivateKey
+        ephemeralKey: WireGuardKitTypes.PrivateKey,
+        daitaParameters: DaitaV2Parameters?
     ) async {
         await onUpdateConfiguration(.single(EphemeralPeerRelayConfiguration(
             relay: exit,
@@ -82,7 +85,8 @@ struct SingleHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
                 allowedIPs: [
                     IPAddressRange(from: "\(LocalNetworkIPs.defaultRouteIpV4.rawValue)/0")!,
                     IPAddressRange(from: "\(LocalNetworkIPs.defaultRouteIpV6.rawValue)/0")!,
-                ]
+                ],
+                daitaParameters: daitaParameters
             )
         )))
         self.onFinish()

--- a/ios/PacketTunnelCore/Actor/EphemeralPeerNegotiationState.swift
+++ b/ios/PacketTunnelCore/Actor/EphemeralPeerNegotiationState.swift
@@ -7,6 +7,7 @@
 //
 
 import MullvadREST
+import MullvadTypes
 import WireGuardKitTypes
 
 public enum EphemeralPeerNegotiationState: Equatable {
@@ -43,11 +44,18 @@ public struct EphemeralPeerConfiguration: Equatable, CustomDebugStringConvertibl
     public let privateKey: PrivateKey
     public let preSharedKey: PreSharedKey?
     public let allowedIPs: [IPAddressRange]
+    public let daitaParameters: DaitaV2Parameters?
 
-    public init(privateKey: PrivateKey, preSharedKey: PreSharedKey? = nil, allowedIPs: [IPAddressRange]) {
+    public init(
+        privateKey: PrivateKey,
+        preSharedKey: PreSharedKey? = nil,
+        allowedIPs: [IPAddressRange],
+        daitaParameters: DaitaV2Parameters?
+    ) {
         self.privateKey = privateKey
         self.preSharedKey = preSharedKey
         self.allowedIPs = allowedIPs
+        self.daitaParameters = daitaParameters
     }
 
     public var debugDescription: String {

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -307,20 +307,11 @@ extension PacketTunnelActor {
             startDefaultPathObserver(notifyObserverWithCurrentPath: true)
         }
 
-        var daitaConfiguration: DaitaConfiguration?
-        if settings.daita.daitaState.isEnabled {
-            let maybeNot = Maybenot()
-            daitaConfiguration = DaitaConfiguration(
-                machines: maybeNot.machines,
-                maxEvents: maybeNot.maximumEvents,
-                maxActions: maybeNot.maximumActions
-            )
-        }
-
+        // Daita parameters are gotten from an ephemeral peer
         try await tunnelAdapter.startMultihop(
             entryConfiguration: configuration.entryConfiguration,
             exitConfiguration: configuration.exitConfiguration,
-            daita: daitaConfiguration
+            daita: nil
         )
 
         // Resume tunnel monitoring and use IPv4 gateway as a probe address.

--- a/ios/PacketTunnelCore/Actor/Protocols/EphemeralPeerExchangingProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/EphemeralPeerExchangingProtocol.swift
@@ -6,10 +6,15 @@
 //  Copyright © 2024 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadTypes
 import WireGuardKitTypes
 
 public protocol EphemeralPeerExchangingProtocol {
     func start() async
-    func receivePostQuantumKey(_ preSharedKey: PreSharedKey, ephemeralKey: PrivateKey) async
-    func receiveEphemeralPeerPrivateKey(_: PrivateKey) async
+    func receivePostQuantumKey(
+        _ preSharedKey: PreSharedKey,
+        ephemeralKey: PrivateKey,
+        daitaParameters: DaitaV2Parameters?
+    ) async
+    func receiveEphemeralPeerPrivateKey(_: PrivateKey, daitaParameters: DaitaV2Parameters?) async
 }

--- a/ios/PacketTunnelCore/Daita/Maybenot.swift
+++ b/ios/PacketTunnelCore/Daita/Maybenot.swift
@@ -7,7 +7,9 @@ public struct Maybenot {
 02eNqFjDkOgDAMBL056PkEJTVdvsY/+URKmojDmwiBUDyStbJ35DLuy5anWRrlqLTDcA0AkTXVkDt01ZAHwLFwludZeMsLLILlRRax4+lKcnrnl/8HJzqIIG0=
 02eNpdjr0LQVEYxt9zGES5o4myKVksFM45lEHKx0LJYDAZ5C+QRTHIaGETViYDKYPp3ijFYLj3KkmGK2WwuVwiv3rrrafnA1Jm16ijKBQ+6NRDGPJ2E0Xe6YnAD0hFD9nm/ObIHumlv4imZ3Mm8DwvtaxB0Jy1IUex0pYIIB30lhuCYkYvwW6nQFSV41R1L8vkmwlgEOONVvEaYt1SwLhdhxn8gdBgEfXU7RFmzeR9YtPPxrbqOVkLsd29XJhIJfbqRomGheLcYUWeFgxQodrq9wcP1E88/w==
 """
-    public let maximumEvents: UInt32 = 1000
-    public let maximumActions: UInt32 = 1000
+    public let maximumEvents: UInt32 = 2048
+    public let maximumActions: UInt32 = 1024
+    public let maximumPadding: Double = 1.0
+    public let maximumBlocking: Double = 1.0
 }
 // swiftlint:enable line_length

--- a/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
+++ b/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
@@ -77,9 +77,14 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        keyExchangeActor.delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, privateKey in
-            await postQuantumKeyExchangingPipeline.receivePostQuantumKey(preSharedKey, ephemeralKey: privateKey)
-        })
+        keyExchangeActor
+            .delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, privateKey, daita in
+                await postQuantumKeyExchangingPipeline.receivePostQuantumKey(
+                    preSharedKey,
+                    ephemeralKey: privateKey,
+                    daitaParameters: daita
+                )
+            })
 
         let connectionState = stubConnectionState(enableMultiHop: false, enablePostQuantum: true, enableDaita: false)
         await postQuantumKeyExchangingPipeline.startNegotiation(connectionState, privateKey: PrivateKey())
@@ -107,9 +112,13 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        keyExchangeActor.delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { privateKey in
-            await postQuantumKeyExchangingPipeline.receiveEphemeralPeerPrivateKey(privateKey)
-        })
+        keyExchangeActor
+            .delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { privateKey, daitaParameters in
+                await postQuantumKeyExchangingPipeline.receiveEphemeralPeerPrivateKey(
+                    privateKey,
+                    daitaParameters: daitaParameters
+                )
+            })
 
         let connectionState = stubConnectionState(enableMultiHop: false, enablePostQuantum: false, enableDaita: true)
         await postQuantumKeyExchangingPipeline.startNegotiation(connectionState, privateKey: PrivateKey())
@@ -137,9 +146,14 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        keyExchangeActor.delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, privateKey in
-            await postQuantumKeyExchangingPipeline.receivePostQuantumKey(preSharedKey, ephemeralKey: privateKey)
-        })
+        keyExchangeActor
+            .delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, privateKey, daita in
+                await postQuantumKeyExchangingPipeline.receivePostQuantumKey(
+                    preSharedKey,
+                    ephemeralKey: privateKey,
+                    daitaParameters: daita
+                )
+            })
 
         let connectionState = stubConnectionState(enableMultiHop: true, enablePostQuantum: true, enableDaita: false)
         await postQuantumKeyExchangingPipeline.startNegotiation(connectionState, privateKey: PrivateKey())
@@ -167,8 +181,8 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        keyExchangeActor.delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { privateKey in
-            await postQuantumKeyExchangingPipeline.receiveEphemeralPeerPrivateKey(privateKey)
+        keyExchangeActor.delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { privateKey, daita in
+            await postQuantumKeyExchangingPipeline.receiveEphemeralPeerPrivateKey(privateKey, daitaParameters: daita)
         })
 
         let connectionState = stubConnectionState(enableMultiHop: true, enablePostQuantum: false, enableDaita: true)

--- a/ios/PacketTunnelCoreTests/Mocks/EphemeralPeerExchangeActorStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/EphemeralPeerExchangeActorStub.swift
@@ -19,12 +19,25 @@ final class EphemeralPeerExchangeActorStub: EphemeralPeerExchangeActorProtocol {
     var delegate: EphemeralPeerReceiving?
 
     func startNegotiation(with privateKey: PrivateKey, enablePostQuantum: Bool, enableDaita: Bool) {
+        let daita = enableDaita
+            ? DaitaV2Parameters(
+                machines: "test",
+                maximumEvents: 1,
+                maximumActions: 1,
+                maximumPadding: 1.0,
+                maximumBlocking: 1.0
+            )
+            : nil
         switch result {
         case let .success((preSharedKey, ephemeralKey)):
             if enablePostQuantum {
-                Task { await delegate?.receivePostQuantumKey(preSharedKey, ephemeralKey: ephemeralKey) }
+                Task { await delegate?.receivePostQuantumKey(
+                    preSharedKey,
+                    ephemeralKey: ephemeralKey,
+                    daitaParameters: daita
+                ) }
             } else {
-                Task { await delegate?.receiveEphemeralPeerPrivateKey(ephemeralKey) }
+                Task { await delegate?.receiveEphemeralPeerPrivateKey(ephemeralKey, daitaParameters: daita) }
             }
         case .failure:
             delegate?.ephemeralPeerExchangeFailed()

--- a/ios/PacketTunnelCoreTests/Mocks/KeyExchangingResultStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/KeyExchangingResultStub.swift
@@ -12,15 +12,22 @@
 
 struct KeyExchangingResultStub: EphemeralPeerReceiving {
     var onFailure: (() -> Void)?
-    var onReceivePostQuantumKey: ((PreSharedKey, PrivateKey) async -> Void)?
-    var onReceiveEphemeralPeerPrivateKey: ((PrivateKey) async -> Void)?
+    var onReceivePostQuantumKey: ((PreSharedKey, PrivateKey, DaitaV2Parameters?) async -> Void)?
+    var onReceiveEphemeralPeerPrivateKey: ((PrivateKey, DaitaV2Parameters?) async -> Void)?
 
-    func receivePostQuantumKey(_ key: PreSharedKey, ephemeralKey: PrivateKey) async {
-        await onReceivePostQuantumKey?(key, ephemeralKey)
+    func receivePostQuantumKey(
+        _ key: PreSharedKey,
+        ephemeralKey: PrivateKey,
+        daitaParameters: DaitaV2Parameters?
+    ) async {
+        await onReceivePostQuantumKey?(key, ephemeralKey, daitaParameters)
     }
 
-    public func receiveEphemeralPeerPrivateKey(_ ephemeralPeerPrivateKey: PrivateKey) async {
-        await onReceiveEphemeralPeerPrivateKey?(ephemeralPeerPrivateKey)
+    public func receiveEphemeralPeerPrivateKey(
+        _ ephemeralPeerPrivateKey: PrivateKey,
+        daitaParameters daitaParamters: MullvadTypes.DaitaV2Parameters?
+    ) async {
+        await onReceiveEphemeralPeerPrivateKey?(ephemeralPeerPrivateKey, daitaParamters)
     }
 
     func ephemeralPeerExchangeFailed() {

--- a/ios/PacketTunnelCoreTests/MultiHopEphemeralPeerExchangerTests.swift
+++ b/ios/PacketTunnelCoreTests/MultiHopEphemeralPeerExchangerTests.swift
@@ -123,9 +123,14 @@ final class MultiHopEphemeralPeerExchangerTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        peerExchangeActor.delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, ephemeralKey in
-            await multiHopPeerExchanger.receivePostQuantumKey(preSharedKey, ephemeralKey: ephemeralKey)
-        })
+        peerExchangeActor
+            .delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, ephemeralKey, daita in
+                await multiHopPeerExchanger.receivePostQuantumKey(
+                    preSharedKey,
+                    ephemeralKey: ephemeralKey,
+                    daitaParameters: daita
+                )
+            })
         await multiHopPeerExchanger.start()
 
         wait(
@@ -161,8 +166,8 @@ final class MultiHopEphemeralPeerExchangerTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        peerExchangeActor.delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { ephemeralKey in
-            await multiHopPeerExchanger.receiveEphemeralPeerPrivateKey(ephemeralKey)
+        peerExchangeActor.delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { ephemeralKey, daita in
+            await multiHopPeerExchanger.receiveEphemeralPeerPrivateKey(ephemeralKey, daitaParameters: daita)
         })
         await multiHopPeerExchanger.start()
 

--- a/ios/PacketTunnelCoreTests/SingleHopEphemeralPeerExchangerTests.swift
+++ b/ios/PacketTunnelCoreTests/SingleHopEphemeralPeerExchangerTests.swift
@@ -100,9 +100,14 @@ final class SingleHopEphemeralPeerExchangerTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        keyExchangeActor.delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, ephemeralKey in
-            await singleHopPostQuantumKeyExchanging.receivePostQuantumKey(preSharedKey, ephemeralKey: ephemeralKey)
-        })
+        keyExchangeActor
+            .delegate = KeyExchangingResultStub(onReceivePostQuantumKey: { preSharedKey, ephemeralKey, daita in
+                await singleHopPostQuantumKeyExchanging.receivePostQuantumKey(
+                    preSharedKey,
+                    ephemeralKey: ephemeralKey,
+                    daitaParameters: daita
+                )
+            })
         await singleHopPostQuantumKeyExchanging.start()
 
         wait(
@@ -137,8 +142,8 @@ final class SingleHopEphemeralPeerExchangerTests: XCTestCase {
             negotiationSuccessful.fulfill()
         }
 
-        peerExchangeActor.delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { ephemeralKey in
-            await multiHopPeerExchanger.receiveEphemeralPeerPrivateKey(ephemeralKey)
+        peerExchangeActor.delegate = KeyExchangingResultStub(onReceiveEphemeralPeerPrivateKey: { ephemeralKey, daita in
+            await multiHopPeerExchanger.receiveEphemeralPeerPrivateKey(ephemeralKey, daitaParameters: daita)
         })
         await multiHopPeerExchanger.start()
 

--- a/mullvad-ios/src/ephemeral_peer_proxy/ios_tcp_connection.rs
+++ b/mullvad-ios/src/ephemeral_peer_proxy/ios_tcp_connection.rs
@@ -1,4 +1,3 @@
-use libc::c_void;
 use std::{
     ffi::CStr,
     future::Future,
@@ -69,20 +68,6 @@ impl WgTcpConnectionFunctions {
             .expect("Cannot send a buffer larger than 2GiB");
         unsafe { (self.send_fn)(tunnel_handle, socket_handle, ptr.cast(), len) }
     }
-}
-
-extern "C" {
-    /// Called when the preshared post quantum key is ready,
-    /// or when a Daita peer has been successfully requested.
-    /// `raw_preshared_key` will be NULL if:
-    /// - The post quantum key negotiation failed
-    /// - A Daita peer has been requested without enabling post quantum keys.
-    pub fn swift_ephemeral_peer_ready(
-        raw_packet_tunnel: *const c_void,
-        raw_preshared_key: *const u8,
-        raw_ephemeral_private_key: *const u8,
-    );
-
 }
 
 #[derive(Clone)]

--- a/mullvad-ios/src/ephemeral_peer_proxy/mod.rs
+++ b/mullvad-ios/src/ephemeral_peer_proxy/mod.rs
@@ -2,11 +2,11 @@
 pub mod ios_tcp_connection;
 pub mod peer_exchange;
 
-use ios_tcp_connection::swift_ephemeral_peer_ready;
 use libc::c_void;
 use peer_exchange::EphemeralPeerExchange;
 
-use std::{ptr, sync::Once};
+use std::{ffi::CString, ptr, sync::Once};
+use talpid_tunnel_config_client::DaitaSettings;
 static INIT_LOGGING: Once = Once::new();
 
 #[derive(Clone)]
@@ -17,17 +17,39 @@ pub struct PacketTunnelBridge {
 
 impl PacketTunnelBridge {
     fn fail_exchange(self) {
-        unsafe { swift_ephemeral_peer_ready(self.packet_tunnel, ptr::null(), ptr::null()) };
+        // # Safety
+        // Call is safe as long as the `packet_tunnel` pointer is valid. Since a valid instance of
+        // `PacketTunnelBridge` requires the packet tunnel pointer to be valid, it is assumed this
+        // call is safe.
+        unsafe {
+            swift_ephemeral_peer_ready(self.packet_tunnel, ptr::null(), ptr::null(), ptr::null())
+        };
     }
 
-    fn succeed_exchange(self, ephemeral_key: [u8; 32], preshared_key: Option<[u8; 32]>) {
+    fn succeed_exchange(
+        self,
+        ephemeral_key: [u8; 32],
+        preshared_key: Option<[u8; 32]>,
+        daita: Option<DaitaParameters>,
+    ) {
         let ephemeral_ptr = ephemeral_key.as_ptr();
         let preshared_ptr = preshared_key
             .as_ref()
             .map(|key| key.as_ptr())
             .unwrap_or(ptr::null());
 
-        unsafe { swift_ephemeral_peer_ready(self.packet_tunnel, preshared_ptr, ephemeral_ptr) };
+        let daita_ptr = daita
+            .as_ref()
+            .map(|params| params as *const _)
+            .unwrap_or(ptr::null());
+        // # Safety
+        // The `packet_tunnel` pointer must be valid, much like the call in `fail_exchange`, but
+        // since the other arguments here are non-null, these pointers (`preshared_ptr`,
+        // `ephmerela_ptr` and `daita_ptr`) have to be valid too. Since they point to local
+        // variables or are null, the pointer values will be valid for the lifetime of the call.
+        unsafe {
+            swift_ephemeral_peer_ready(self.packet_tunnel, preshared_ptr, ephemeral_ptr, daita_ptr)
+        };
     }
 }
 
@@ -40,6 +62,54 @@ pub struct EphemeralPeerParameters {
     pub enable_post_quantum: bool,
     pub enable_daita: bool,
     pub funcs: ios_tcp_connection::WgTcpConnectionFunctions,
+}
+
+#[repr(C)]
+pub struct DaitaParameters {
+    pub machines: *mut u8,
+    pub max_padding_frac: f64,
+    pub max_blocking_frac: f64,
+}
+
+impl DaitaParameters {
+    fn new(settings: DaitaSettings) -> Option<Self> {
+        let machines_string = settings.client_machines.join("\n");
+        let machines = CString::new(machines_string).ok()?.into_raw().cast();
+        Some(Self {
+            machines,
+            max_padding_frac: settings.max_padding_frac,
+            max_blocking_frac: settings.max_blocking_frac,
+        })
+    }
+}
+
+impl Drop for DaitaParameters {
+    fn drop(&mut self) {
+        // # Safety
+        // `machines` pointer must be a valid pointer to a CString. This can be achieved by
+        // ensuring that `DaitaParameters` are constructed via `DaitaParameters::new` and the
+        // `machines` pointer is never written to.
+        let _ = unsafe { CString::from_raw(self.machines.cast()) };
+    }
+}
+
+extern "C" {
+    /// To be called when ephemeral peer exchange has finished. All parameters except
+    /// `raw_packet_tunnel` are optional.
+    ///
+    /// # Safety:
+    /// If the key exchange failed, all pointers except `raw_packet_tunnel` must be null. If the
+    /// key exchange was successful, `raw_ephemeral_private_key` must be a valid pointer to 32
+    /// bytes for the lifetime of this call. If PQ was enabled, `raw_preshared_key` must be a valid
+    /// pointer to 32 bytes for the lifetime of this call. If DAITA was requested, the
+    /// `daita_prameters` must point to a valid instance of `DaitaParameters`.
+    pub fn swift_ephemeral_peer_ready(
+        raw_packet_tunnel: *const c_void,
+        raw_preshared_key: *const u8,
+        raw_ephemeral_private_key: *const u8,
+        daita_parameters: *const DaitaParameters,
+    );
+
 }
 
 /// Called by the Swift side to signal that the ephemeral peer exchange should be cancelled.
@@ -73,11 +143,11 @@ pub unsafe extern "C" fn drop_ephemeral_peer_exchange_token(
 /// Entry point for requesting ephemeral peers on iOS.
 /// The TCP connection must be created to go through the tunnel.
 /// # Safety
-/// `public_key` and `ephemeral_key` must be valid respective `PublicKey` and `PrivateKey` types.
-/// They will not be valid after this function is called, and thus must be copied here.
-/// `packet_tunnel` must be valid pointers to a packet tunnel, the packet tunnel pointer must
-/// outlive the ephemeral peer exchange. `cancel_token` should be owned by the caller of this
-/// function.
+/// `public_key` and `ephemeral_key` must be valid respective `PublicKey` and `PrivateKey` types,
+/// specifically, they must be valid pointers to 32 bytes. They will not be valid after this
+/// function is called, and thus must be copied here. `packet_tunnel` must be valid pointers to a
+/// packet tunnel, the packet tunnel pointer must outlive the ephemeral peer exchange.
+/// `cancel_token` should be owned by the caller of this function.
 #[no_mangle]
 pub unsafe extern "C" fn request_ephemeral_peer(
     public_key: *const u8,
@@ -92,7 +162,11 @@ pub unsafe extern "C" fn request_ephemeral_peer(
             .init();
     });
 
+    // # Safety
+    // `public_key` pointer must be a valid pointer to 32 unsigned bytes.
     let pub_key: [u8; 32] = unsafe { ptr::read(public_key as *const [u8; 32]) };
+    // # Safety
+    // `ephemeral_key` pointer must be a valid pointer to 32 unsigned bytes.
     let eph_key: [u8; 32] = unsafe { ptr::read(ephemeral_key as *const [u8; 32]) };
 
     let handle = match crate::mullvad_ios_runtime() {

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -22,7 +22,7 @@ mod proto {
     tonic::include_proto!("ephemeralpeer");
 }
 
-#[cfg(all(unix, not(target_os = "ios")))]
+#[cfg(unix)]
 const DAITA_VERSION: u32 = 2;
 
 #[derive(Debug)]
@@ -88,7 +88,7 @@ pub const CONFIG_SERVICE_PORT: u16 = 1337;
 
 pub struct EphemeralPeer {
     pub psk: Option<PresharedKey>,
-    #[cfg(all(unix, not(target_os = "ios")))]
+    #[cfg(unix)]
     pub daita: Option<DaitaSettings>,
 }
 
@@ -141,15 +141,15 @@ pub async fn request_ephemeral_peer_with(
             wg_parent_pubkey: parent_pubkey.as_bytes().to_vec(),
             wg_ephemeral_peer_pubkey: ephemeral_pubkey.as_bytes().to_vec(),
             post_quantum: pq_request,
-            #[cfg(any(windows, target_os = "ios"))]
+            #[cfg(windows)]
             daita: Some(proto::DaitaRequestV1 {
                 activate_daita: enable_daita,
             }),
-            #[cfg(any(windows, target_os = "ios"))]
+            #[cfg(windows)]
             daita_v2: None,
-            #[cfg(all(unix, not(target_os = "ios")))]
+            #[cfg(unix)]
             daita: None,
-            #[cfg(all(unix, not(target_os = "ios")))]
+            #[cfg(unix)]
             daita_v2: enable_daita.then(|| proto::DaitaRequestV2 {
                 level: i32::from(proto::DaitaLevel::LevelDefault),
                 platform: i32::from(get_platform()),
@@ -204,7 +204,7 @@ pub async fn request_ephemeral_peer_with(
         None
     };
 
-    #[cfg(all(unix, not(target_os = "ios")))]
+    #[cfg(unix)]
     {
         let daita = response.daita.map(|daita| DaitaSettings {
             client_machines: daita.client_machines,
@@ -217,13 +217,13 @@ pub async fn request_ephemeral_peer_with(
         Ok(EphemeralPeer { psk, daita })
     }
 
-    #[cfg(any(windows, target_os = "ios"))]
+    #[cfg(windows)]
     {
         Ok(EphemeralPeer { psk })
     }
 }
 
-#[cfg(all(unix, not(target_os = "ios")))]
+#[cfg(unix)]
 const fn get_platform() -> proto::DaitaPlatform {
     use proto::DaitaPlatform;
     const PLATFORM: DaitaPlatform = if cfg!(target_os = "windows") {


### PR DESCRIPTION
On the back of @buggmagnet and @dlon work, I've gone and rebased things and touched everything up. These changes enable DAITAv2 on iOS. It seems to work :shrug:.

These changes depend on https://github.com/mullvad/wireguard-apple/pull/34 being merged first. 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7387)
<!-- Reviewable:end -->
