### PR TITLE
Refactor connection check to be async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,6 +4678,7 @@ dependencies = [
 name = "talpid-wireguard"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "bitflags 1.3.2",
  "byteorder",
  "chrono",

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+async-trait = "0.1"
 thiserror = { workspace = true }
 futures = { workspace = true }
 hex = "0.4"

--- a/talpid-wireguard/src/connectivity/constants.rs
+++ b/talpid-wireguard/src/connectivity/constants.rs
@@ -1,7 +1,5 @@
 use std::time::Duration;
 
-/// Sleep time used when initially establishing connectivity
-pub(crate) const DELAY_ON_INITIAL_SETUP: Duration = Duration::from_millis(50);
 /// Timeout for waiting on receiving traffic after sending outgoing traffic.  Once this timeout is
 /// hit, a ping will be sent every `SECONDS_PER_PING` until `PING_TIMEOUT` is reached, or traffic
 /// is received.

--- a/talpid-wireguard/src/connectivity/mock.rs
+++ b/talpid-wireguard/src/connectivity/mock.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::time::Instant;
+use tokio::time::Instant;
 
-use super::check::{ConnState, PingState, Timeout};
+use super::check::{CancelToken, ConnState, PingState};
 use super::pinger;
 use super::Check;
 
@@ -14,14 +14,14 @@ pub use crate::stats::{Stats, StatsMap};
 
 #[derive(Default)]
 pub(crate) struct MockPinger {
-    on_send_ping: Option<Box<dyn FnMut() + Send>>,
+    on_send_ping: Option<Box<dyn FnMut() + Send + Sync>>,
 }
 
 pub(crate) struct MockTunnel {
-    on_get_stats: Box<dyn Fn() -> Result<StatsMap, TunnelError> + Send>,
+    on_get_stats: Box<dyn Fn() -> Result<StatsMap, TunnelError> + Send + Sync>,
 }
 
-pub fn mock_checker(now: Instant, pinger: Box<dyn Pinger>) -> Check<Timeout> {
+pub fn mock_checker(now: Instant, pinger: Box<dyn Pinger>) -> (Check, CancelToken) {
     let conn_state = ConnState::new(now, Default::default());
     let ping_state = PingState::new_with(pinger);
     Check::mock(conn_state, ping_state)
@@ -47,7 +47,7 @@ pub fn connected_state(timestamp: Instant) -> ConnState {
 impl MockTunnel {
     const PEER: [u8; 32] = [0u8; 32];
 
-    pub fn new<F: Fn() -> Result<StatsMap, TunnelError> + Send + 'static>(f: F) -> Self {
+    pub fn new<F: Fn() -> Result<StatsMap, TunnelError> + Send + Sync + 'static>(f: F) -> Self {
         Self {
             on_get_stats: Box::new(f),
         }
@@ -97,6 +97,7 @@ impl MockTunnel {
     }
 }
 
+#[async_trait::async_trait]
 impl Tunnel for MockTunnel {
     fn get_interface_name(&self) -> String {
         "mock-tunnel".to_string()
@@ -106,7 +107,7 @@ impl Tunnel for MockTunnel {
         Ok(())
     }
 
-    fn get_tunnel_stats(&self) -> Result<StatsMap, TunnelError> {
+    async fn get_tunnel_stats(&self) -> Result<StatsMap, TunnelError> {
         (self.on_get_stats)()
     }
 
@@ -126,8 +127,9 @@ impl Tunnel for MockTunnel {
     }
 }
 
+#[async_trait::async_trait]
 impl Pinger for MockPinger {
-    fn send_icmp(&mut self) -> Result<(), pinger::Error> {
+    async fn send_icmp(&mut self) -> Result<(), pinger::Error> {
         if let Some(callback) = self.on_send_ping.as_mut() {
             (callback)();
         }

--- a/talpid-wireguard/src/connectivity/mod.rs
+++ b/talpid-wireguard/src/connectivity/mod.rs
@@ -7,7 +7,7 @@ mod monitor;
 mod pinger;
 
 #[cfg(target_os = "android")]
-pub use check::Cancellable;
-pub use check::Check;
+pub use check::CancelReceiver;
+pub use check::{CancelToken, Check};
 pub use error::Error;
 pub use monitor::Monitor;

--- a/talpid-wireguard/src/connectivity/monitor.rs
+++ b/talpid-wireguard/src/connectivity/monitor.rs
@@ -1,69 +1,73 @@
-use std::{
-    sync::Weak,
-    time::{Duration, Instant},
-};
+use std::{sync::Weak, time::Duration};
 
 use tokio::sync::Mutex;
+use tokio::time::{Instant, MissedTickBehavior};
 
 use crate::TunnelType;
 
-use super::check::{Cancellable, Check};
+use super::check::Check;
 use super::error::Error;
 
 /// Sleep time used when checking if an established connection is still working.
 const REGULAR_LOOP_SLEEP: Duration = Duration::from_secs(1);
 
+/// Reset the checker if the last check occurred this long ago
+const SUSPEND_TIMEOUT: Duration = Duration::from_secs(6);
+
 pub struct Monitor {
-    connectivity_check: Check<Cancellable>,
+    connectivity_check: Check,
 }
 
 impl Monitor {
-    pub fn init(connectivity_check: Check<Cancellable>) -> Self {
+    pub fn init(connectivity_check: Check) -> Self {
         Self { connectivity_check }
     }
 
-    pub fn run(self, tunnel_handle: Weak<Mutex<Option<TunnelType>>>) -> Result<(), Error> {
-        self.wait_loop(REGULAR_LOOP_SLEEP, tunnel_handle)
-    }
-
-    fn wait_loop(
+    pub async fn run(
         mut self,
-        iter_delay: Duration,
         tunnel_handle: Weak<Mutex<Option<TunnelType>>>,
     ) -> Result<(), Error> {
-        let mut last_iteration = Instant::now();
-        while !self.connectivity_check.should_shut_down(iter_delay) {
-            let mut current_iteration = Instant::now();
-            let time_slept = current_iteration - last_iteration;
-            if time_slept < (iter_delay * 2) {
-                let Some(tunnel) = tunnel_handle.upgrade() else {
-                    return Ok(());
-                };
-                let lock = tunnel.blocking_lock();
-                let Some(tunnel) = lock.as_ref() else {
-                    return Ok(());
-                };
+        let mut last_check = Instant::now();
 
-                if !self
-                    .connectivity_check
-                    .check_connectivity(Instant::now(), tunnel)?
-                {
-                    return Ok(());
-                }
-                drop(lock);
+        let mut interval = tokio::time::interval(REGULAR_LOOP_SLEEP);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-                let end = Instant::now();
-                if end - current_iteration > Duration::from_secs(1) {
-                    current_iteration = end;
-                }
-            } else {
-                // Loop was suspended for too long, so it's safer to assume that the host still has
-                // connectivity.
-                self.connectivity_check.reset(current_iteration);
+        loop {
+            if self.connectivity_check.should_shut_down() {
+                return Ok(());
             }
-            last_iteration = current_iteration;
+
+            let now = Instant::now();
+            let time_slept = now - last_check;
+            last_check = now;
+
+            if time_slept >= SUSPEND_TIMEOUT {
+                self.connectivity_check.reset(now).await;
+            } else if !self.tunnel_exists_and_is_connected(&tunnel_handle).await? {
+                return Ok(());
+            }
+
+            interval.tick().await;
         }
-        Ok(())
+    }
+
+    async fn tunnel_exists_and_is_connected(
+        &mut self,
+        tunnel_handle: &Weak<Mutex<Option<TunnelType>>>,
+    ) -> Result<bool, Error> {
+        let Some(tunnel) = tunnel_handle.upgrade() else {
+            // Tunnel closed
+            return Ok(false);
+        };
+        let lock = tunnel.lock().await;
+        let Some(tunnel) = lock.as_ref() else {
+            // Tunnel closed
+            return Ok(false);
+        };
+
+        self.connectivity_check
+            .check_connectivity(Instant::now(), tunnel)
+            .await
     }
 }
 
@@ -71,54 +75,52 @@ impl Monitor {
 mod test {
     use super::*;
 
-    // TODO: Port to async + tokio to reduce cost of testing?
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::mpsc;
     use std::sync::Arc;
     use std::time::Duration;
-    use std::time::Instant;
 
+    use tokio::sync::mpsc;
     use tokio::sync::Mutex;
 
     use crate::connectivity::constants::*;
     use crate::connectivity::mock::*;
 
-    #[test]
+    #[tokio::test(start_paused = true)]
     /// Verify that the connectivity monitor doesn't fail if the tunnel constantly sends traffic,
     /// and it shuts down properly.
-    fn test_wait_loop() {
-        use std::sync::mpsc;
-        let (result_tx, result_rx) = mpsc::channel();
+    async fn test_wait_loop() {
+        let (result_tx, mut result_rx) = mpsc::channel(1);
         let tunnel = MockTunnel::always_incrementing().boxed();
         let pinger = MockPinger::default();
         let (mut checker, stop_tx) = {
             let now = Instant::now();
             let start = now.checked_sub(Duration::from_secs(1)).unwrap();
-            mock_checker(start, Box::new(pinger)).with_cancellation()
+            mock_checker(start, Box::new(pinger))
         };
-        std::thread::spawn(move || {
-            let start_result = checker.establish_connectivity(&tunnel);
-            result_tx.send(start_result).unwrap();
+
+        tokio::spawn(async move {
+            let start_result = checker.establish_connectivity(&tunnel).await;
+            result_tx.send(start_result).await.unwrap();
             // Pointer dance
             let tunnel = Arc::new(Mutex::new(Some(tunnel)));
             let _tunnel = Arc::downgrade(&tunnel);
-            let result = Monitor::init(checker).run(_tunnel).map(|_| true);
-            result_tx.send(result).unwrap();
+            let result = Monitor::init(checker).run(_tunnel).await.map(|_| true);
+            result_tx.send(result).await.unwrap();
         });
 
-        std::thread::sleep(Duration::from_secs(1));
+        tokio::time::sleep(Duration::from_secs(1)).await;
         assert!(result_rx.try_recv().unwrap().unwrap());
-        stop_tx.send(()).unwrap();
-        std::thread::sleep(Duration::from_secs(1));
+        stop_tx.close();
+        tokio::time::sleep(Duration::from_secs(2)).await;
         assert!(result_rx.try_recv().unwrap().is_ok());
     }
 
-    #[test]
+    #[tokio::test(start_paused = true)]
     /// Verify that the connectivity monitor detects the tunnel timing out after no longer than
     /// `BYTES_RX_TIMEOUT` and `PING_TIMEOUT` combined.
-    fn test_wait_loop_timeout() {
-        let should_stop = Arc::new(AtomicBool::new(false));
-        let should_stop_inner = should_stop.clone();
+    async fn test_wait_loop_timeout() {
+        let stop_bytes_rx = Arc::new(AtomicBool::new(false));
+        let stop_bytes_rx_inner = stop_bytes_rx.clone();
 
         let mut map = StatsMap::new();
         map.insert(
@@ -133,7 +135,7 @@ mod test {
         let pinger = MockPinger::default();
         let tunnel = MockTunnel::new(move || {
             let mut tunnel_stats = tunnel_stats.lock().unwrap();
-            if !should_stop_inner.load(Ordering::SeqCst) {
+            if !stop_bytes_rx_inner.load(Ordering::SeqCst) {
                 for traffic in tunnel_stats.values_mut() {
                     traffic.rx_bytes += 1;
                 }
@@ -145,30 +147,41 @@ mod test {
         })
         .boxed();
 
-        let (result_tx, result_rx) = mpsc::channel();
+        let (result_tx, mut result_rx) = mpsc::channel(1);
 
-        std::thread::spawn(move || {
+        tokio::spawn(async move {
             let (mut checker, _cancellation_token) = {
                 let now = Instant::now();
                 let start = now.checked_sub(Duration::from_secs(1)).unwrap();
-                mock_checker(start, Box::new(pinger)).with_cancellation()
+                mock_checker(start, Box::new(pinger))
             };
-            let start_result = checker.establish_connectivity(&tunnel);
-            result_tx.send(start_result).unwrap();
+            let start_result = checker.establish_connectivity(&tunnel).await;
+            result_tx.send(start_result).await.unwrap();
             // Pointer dance
             let _tunnel = Arc::new(Mutex::new(Some(tunnel)));
             let tunnel = Arc::downgrade(&_tunnel);
-            let end_result = Monitor::init(checker).run(tunnel).map(|_| true);
-            result_tx.send(end_result).expect("Failed to send result");
+            let end_result = Monitor::init(checker).run(tunnel).await.map(|_| true);
+            result_tx
+                .send(end_result)
+                .await
+                .expect("Failed to send result");
         });
-        assert!(result_rx
-            .recv_timeout(Duration::from_secs(1))
-            .unwrap()
-            .unwrap());
-        should_stop.store(true, Ordering::SeqCst);
-        assert!(result_rx
-            .recv_timeout(BYTES_RX_TIMEOUT + PING_TIMEOUT + Duration::from_secs(2))
-            .unwrap()
-            .is_ok());
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), result_rx.recv())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap()
+        );
+        stop_bytes_rx.store(true, Ordering::SeqCst);
+        assert!(tokio::time::timeout(
+            BYTES_RX_TIMEOUT + PING_TIMEOUT + Duration::from_secs(2),
+            result_rx.recv()
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .is_ok());
     }
 }

--- a/talpid-wireguard/src/connectivity/pinger/mod.rs
+++ b/talpid-wireguard/src/connectivity/pinger/mod.rs
@@ -9,11 +9,12 @@ mod imp;
 pub use imp::Error;
 
 /// Trait for sending ICMP requests to get some traffic from a remote server
+#[async_trait::async_trait]
 pub trait Pinger: Send {
     /// Sends an ICMP packet
-    fn send_icmp(&mut self) -> Result<(), Error>;
+    async fn send_icmp(&mut self) -> Result<(), Error>;
     /// Clears all resources used by the pinger.
-    fn reset(&mut self) {}
+    async fn reset(&mut self) {}
 }
 
 /// Create a new pinger

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -226,6 +226,7 @@ async fn reconfigure_tunnel(
 
         let updated_tunnel = tunnel
             .set_config(&config)
+            .await
             .map_err(Error::TunnelError)
             .map_err(CloseMsg::SetupError)?;
 

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -145,7 +145,7 @@ pub struct WireguardMonitor {
     /// Callback to signal tunnel events
     event_hook: EventHook,
     close_msg_receiver: sync_mpsc::Receiver<CloseMsg>,
-    pinger_stop_sender: sync_mpsc::Sender<()>,
+    pinger_stop_sender: connectivity::CancelToken,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
 }
 
@@ -211,21 +211,22 @@ impl WireguardMonitor {
         let obfuscator = Arc::new(AsyncMutex::new(obfuscator));
 
         let gateway = config.ipv4_gateway;
-        let (mut connectivity_monitor, pinger_tx) = connectivity::Check::new(
+        let (cancel_token, cancel_receiver) = connectivity::CancelToken::new();
+        let mut connectivity_monitor = connectivity::Check::new(
             gateway,
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             iface_name.clone(),
             args.retry_attempt,
+            cancel_receiver,
         )
-        .map_err(Error::ConnectivityMonitorError)?
-        .with_cancellation();
+        .map_err(Error::ConnectivityMonitorError)?;
 
         let monitor = WireguardMonitor {
             runtime: args.runtime.clone(),
             tunnel: Arc::new(AsyncMutex::new(Some(tunnel))),
             event_hook: args.event_hook.clone(),
             close_msg_receiver: close_obfs_listener,
-            pinger_stop_sender: pinger_tx,
+            pinger_stop_sender: cancel_token,
             obfuscator,
         };
 
@@ -281,13 +282,7 @@ impl WireguardMonitor {
                     // timing out on Windows for 2024.9-beta1. These verbose data usage logs are
                     // a temporary measure to help us understand the issue. They can be removed
                     // if the issue is resolved.
-                    if let Err(err) =
-                        tokio::task::spawn_blocking(move || log_tunnel_data_usage(&config, &tunnel))
-                            .await
-                    {
-                        log::error!("Failed to log tunnel data during setup phase");
-                        log::error!("{err}");
-                    }
+                    log_tunnel_data_usage(&config, &tunnel).await;
                     return Err(e);
                 }
 
@@ -331,28 +326,26 @@ impl WireguardMonitor {
                 });
             }
 
-            let cloned_tunnel = Arc::clone(&tunnel);
-
-            let connectivity_check = tokio::task::spawn_blocking(move || {
-                let lock = cloned_tunnel.blocking_lock();
-                let tunnel = lock.as_ref().expect("The tunnel was dropped unexpectedly");
-                match connectivity_monitor.establish_connectivity(tunnel) {
-                    Ok(true) => Ok(connectivity_monitor),
-                    Ok(false) => {
-                        log::warn!("Timeout while checking tunnel connection");
-                        Err(CloseMsg::PingErr)
-                    }
-                    Err(error) => {
-                        log::error!(
-                            "{}",
-                            error.display_chain_with_msg("Failed to check tunnel connection")
-                        );
-                        Err(CloseMsg::PingErr)
-                    }
+            let lock = tunnel.lock().await;
+            let borrowed_tun = lock.as_ref().expect("The tunnel was dropped unexpectedly");
+            match connectivity_monitor
+                .establish_connectivity(borrowed_tun)
+                .await
+            {
+                Ok(true) => Ok(()),
+                Ok(false) => {
+                    log::warn!("Timeout while checking tunnel connection");
+                    Err(CloseMsg::PingErr)
                 }
-            })
-            .await
-            .unwrap()?;
+                Err(error) => {
+                    log::error!(
+                        "{}",
+                        error.display_chain_with_msg("Failed to check tunnel connection")
+                    );
+                    Err(CloseMsg::PingErr)
+                }
+            }?;
+            drop(lock);
 
             // Add any default route(s) that may exist.
             args.route_manager
@@ -364,19 +357,15 @@ impl WireguardMonitor {
             let metadata = Self::tunnel_metadata(&iface_name, &config);
             event_hook.on_event(TunnelEvent::Up(metadata)).await;
 
-            let monitored_tunnel = Arc::downgrade(&tunnel);
-            tokio::task::spawn_blocking(move || {
-                if let Err(error) =
-                    connectivity::Monitor::init(connectivity_check).run(monitored_tunnel)
-                {
-                    log::error!(
-                        "{}",
-                        error.display_chain_with_msg("Connectivity monitor failed")
-                    );
-                }
-            })
-            .await
-            .unwrap();
+            if let Err(error) = connectivity::Monitor::init(connectivity_monitor)
+                .run(Arc::downgrade(&tunnel))
+                .await
+            {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Connectivity monitor failed")
+                );
+            }
 
             Err::<Infallible, CloseMsg>(CloseMsg::PingErr)
         };
@@ -435,12 +424,15 @@ impl WireguardMonitor {
 
         let should_negotiate_ephemeral_peer = config.quantum_resistant || config.daita;
 
-        let (connectivity_check, pinger_tx) =
-            connectivity::Check::new(config.ipv4_gateway, args.retry_attempt)
-                .map_err(Error::ConnectivityMonitorError)?
-                .with_cancellation();
+        let (cancel_token, cancel_receiver) = connectivity::CancelToken::new();
+        let connectivity_check = connectivity::Check::new(
+            config.ipv4_gateway,
+            args.retry_attempt,
+            cancel_receiver.clone(),
+        )
+        .map_err(Error::ConnectivityMonitorError)?;
 
-        let tunnel = Self::open_wireguard_go_tunnel(
+        let tunnel = args.runtime.block_on(Self::open_wireguard_go_tunnel(
             &config,
             log_path,
             args.tun_provider.clone(),
@@ -448,8 +440,8 @@ impl WireguardMonitor {
             // that we only allows traffic to/from the gateway. This is only needed on Android
             // since we lack a firewall there.
             should_negotiate_ephemeral_peer,
-            connectivity_check,
-        )?;
+            cancel_receiver,
+        ))?;
 
         let iface_name = tunnel.get_interface_name();
         let tunnel = Arc::new(AsyncMutex::new(Some(tunnel)));
@@ -459,7 +451,7 @@ impl WireguardMonitor {
             tunnel: Arc::clone(&tunnel),
             event_hook: event_hook.clone(),
             close_msg_receiver: close_obfs_listener,
-            pinger_stop_sender: pinger_tx,
+            pinger_stop_sender: cancel_token,
             obfuscator: Arc::new(AsyncMutex::new(obfuscator)),
         };
 
@@ -492,13 +484,7 @@ impl WireguardMonitor {
                     // timing out on Windows for 2024.9-beta1. These verbose data usage logs are
                     // a temporary measure to help us understand the issue. They can be removed
                     // if the issue is resolved.
-                    if let Err(err) =
-                        tokio::task::spawn_blocking(move || log_tunnel_data_usage(&config, &tunnel))
-                            .await
-                    {
-                        log::error!("Failed to log tunnel data during setup phase");
-                        log::error!("{err}");
-                    }
+                    log_tunnel_data_usage(&config, &tunnel).await;
                     return Err(e);
                 }
 
@@ -514,29 +500,15 @@ impl WireguardMonitor {
             let metadata = Self::tunnel_metadata(&iface_name, &config);
             event_hook.on_event(TunnelEvent::Up(metadata)).await;
 
-            // HACK: The tunnel does not need the connectivity::Check anymore, so lets take it
-            let connectivity_check = {
-                let mut tunnel_lock = tunnel.lock().await;
-                let Some(tunnel) = tunnel_lock.as_mut() else {
-                    log::debug!("Tunnel is no longer running");
-                    return Err::<Infallible, CloseMsg>(CloseMsg::PingErr);
-                };
-                tunnel
-                    .take_checker()
-                    .expect("connectivity checker unexpectedly dropped")
-            };
-
-            tokio::task::spawn_blocking(move || {
-                let tunnel = Arc::downgrade(&tunnel);
-                if let Err(error) = connectivity::Monitor::init(connectivity_check).run(tunnel) {
-                    log::error!(
-                        "{}",
-                        error.display_chain_with_msg("Connectivity monitor failed")
-                    );
-                }
-            })
-            .await
-            .unwrap();
+            if let Err(error) = connectivity::Monitor::init(connectivity_check)
+                .run(Arc::downgrade(&tunnel))
+                .await
+            {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Connectivity monitor failed")
+                );
+            }
 
             Err::<Infallible, CloseMsg>(CloseMsg::PingErr)
         };
@@ -675,13 +647,18 @@ impl WireguardMonitor {
         if !*FORCE_USERSPACE_WIREGUARD {
             // If DAITA is enabled, wireguard-go has to be used.
             if config.daita {
-                let tunnel =
-                    Self::open_wireguard_go_tunnel(config, log_path, tun_provider).map(Box::new)?;
+                let tunnel = runtime
+                    .block_on(Self::open_wireguard_go_tunnel(
+                        config,
+                        log_path,
+                        tun_provider,
+                    ))
+                    .map(Box::new)?;
                 return Ok(tunnel);
             }
 
             if will_nm_manage_dns() {
-                match wireguard_kernel::NetworkManagerTunnel::new(runtime, config) {
+                match wireguard_kernel::NetworkManagerTunnel::new(runtime.clone(), config) {
                     Ok(tunnel) => {
                         log::debug!("Using NetworkManager to use kernel WireGuard implementation");
                         return Ok(Box::new(tunnel));
@@ -696,7 +673,7 @@ impl WireguardMonitor {
                     }
                 };
             } else {
-                match wireguard_kernel::NetlinkTunnel::new(runtime, config) {
+                match wireguard_kernel::NetlinkTunnel::new(runtime.clone(), config) {
                     Ok(tunnel) => {
                         log::debug!("Using kernel WireGuard implementation");
                         return Ok(Box::new(tunnel));
@@ -725,28 +702,28 @@ impl WireguardMonitor {
             #[cfg(target_os = "linux")]
             log::debug!("Using userspace WireGuard implementation");
 
-            let tunnel = Self::open_wireguard_go_tunnel(
-                config,
-                log_path,
-                tun_provider,
-                #[cfg(target_os = "android")]
-                gateway_only,
-            )
-            .map(Box::new)?;
+            let tunnel = runtime
+                .block_on(Self::open_wireguard_go_tunnel(
+                    config,
+                    log_path,
+                    tun_provider,
+                    #[cfg(target_os = "android")]
+                    gateway_only,
+                ))
+                .map(Box::new)?;
             Ok(tunnel)
         }
     }
 
     /// Configure and start a Wireguard-go tunnel.
     #[cfg(wireguard_go)]
-    fn open_wireguard_go_tunnel(
+    #[allow(clippy::unused_async)]
+    async fn open_wireguard_go_tunnel(
         config: &Config,
         log_path: Option<&Path>,
         tun_provider: Arc<Mutex<TunProvider>>,
         #[cfg(target_os = "android")] gateway_only: bool,
-        #[cfg(target_os = "android")] connectivity_check: connectivity::Check<
-            connectivity::Cancellable,
-        >,
+        #[cfg(target_os = "android")] cancel_receiver: connectivity::CancelReceiver,
     ) -> Result<WgGoTunnel> {
         let routes = config
             .get_tunnel_destinations()
@@ -781,8 +758,9 @@ impl WireguardMonitor {
                 log_path,
                 tun_provider,
                 routes,
-                connectivity_check,
+                cancel_receiver,
             )
+            .await
             .map_err(Error::TunnelError)?
         } else {
             WgGoTunnel::start_tunnel(
@@ -791,8 +769,9 @@ impl WireguardMonitor {
                 log_path,
                 tun_provider,
                 routes,
-                connectivity_check,
+                cancel_receiver,
             )
+            .await
             .map_err(Error::TunnelError)?
         };
 
@@ -811,7 +790,7 @@ impl WireguardMonitor {
             Err(_) => Ok(()),
         };
 
-        let _ = self.pinger_stop_sender.send(());
+        self.pinger_stop_sender.close();
 
         self.runtime
             .block_on(self.event_hook.on_event(TunnelEvent::Down));
@@ -997,10 +976,10 @@ impl WireguardMonitor {
 ///
 /// This will log the amount of outgoing and incoming data to and from the exit (and entry) relay
 /// so far.
-fn log_tunnel_data_usage(config: &Config, tunnel: &Arc<AsyncMutex<Option<TunnelType>>>) {
-    let tunnel = tunnel.blocking_lock();
+async fn log_tunnel_data_usage(config: &Config, tunnel: &Arc<AsyncMutex<Option<TunnelType>>>) {
+    let tunnel = tunnel.lock().await;
     let Some(tunnel) = &*tunnel else { return };
-    let Ok(tunnel_stats) = tunnel.get_tunnel_stats() else {
+    let Ok(tunnel_stats) = tunnel.get_tunnel_stats().await else {
         return;
     };
     if let Some(stats) = config
@@ -1028,12 +1007,11 @@ enum CloseMsg {
 }
 
 #[allow(unused)]
-pub(crate) trait Tunnel: Send {
+#[async_trait::async_trait]
+pub(crate) trait Tunnel: Send + Sync {
     fn get_interface_name(&self) -> String;
     fn stop(self: Box<Self>) -> std::result::Result<(), TunnelError>;
-    /// # Note
-    /// This function should *not* be called from within an async context.
-    fn get_tunnel_stats(&self) -> std::result::Result<stats::StatsMap, TunnelError>;
+    async fn get_tunnel_stats(&self) -> std::result::Result<stats::StatsMap, TunnelError>;
     fn set_config<'a>(
         &'a mut self,
         _config: Config,

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -1,7 +1,5 @@
 #[cfg(target_os = "android")]
 use super::config;
-#[cfg(target_os = "android")]
-use super::Error;
 use super::{
     stats::{Stats, StatsMap},
     Config, Tunnel, TunnelError,
@@ -106,32 +104,26 @@ impl WgGoTunnel {
         }
     }
 
-    pub fn set_config(self, config: &Config) -> Result<Self> {
+    pub async fn set_config(self, config: &Config) -> Result<Self> {
         let state = self.as_state();
         let log_path = state._logging_context.path.clone();
+        let cancel_receiver = state.cancel_receiver.clone();
         let tun_provider = Arc::clone(&state.tun_provider);
         let routes = config.get_tunnel_destinations();
 
         match self {
-            WgGoTunnel::Multihop(mut state) if !config.is_multihop() => {
-                let connectivity_checker = state
-                    .connectivity_checker
-                    .take()
-                    .expect("connectivity checker unexpectedly dropped");
+            WgGoTunnel::Multihop(state) if !config.is_multihop() => {
                 state.stop()?;
                 Self::start_tunnel(
                     config,
                     log_path.as_deref(),
                     tun_provider,
                     routes,
-                    connectivity_checker,
+                    cancel_receiver,
                 )
+                .await
             }
-            WgGoTunnel::Singlehop(mut state) if config.is_multihop() => {
-                let connectivity_checker = state
-                    .connectivity_checker
-                    .take()
-                    .expect("connectivity checker unexpectedly dropped");
+            WgGoTunnel::Singlehop(state) if config.is_multihop() => {
                 state.stop()?;
                 Self::start_multihop_tunnel(
                     config,
@@ -139,8 +131,9 @@ impl WgGoTunnel {
                     log_path.as_deref(),
                     tun_provider,
                     routes,
-                    connectivity_checker,
+                    cancel_receiver,
                 )
+                .await
             }
             WgGoTunnel::Singlehop(mut state) => {
                 state.set_config(config.clone())?;
@@ -170,13 +163,9 @@ pub(crate) struct WgGoTunnelState {
     tun_provider: Arc<Mutex<TunProvider>>,
     #[cfg(daita)]
     config: Config,
-    // HACK: Check is not Clone, so we have to pass this around ..
-    // This is conceptually the connection between this Tunnel and the currently running
-    // WireguardMonitor, and it is used to allow WireguardMonitor to cancel the setup of
-    // a new Tunnel during the "ensure_connectivity"  phase. This field should be removed
-    // as soon as we implement a better way to cancel Check asynchronously.
+    /// This is used to cancel the connectivity checks that occur when toggling multihop
     #[cfg(target_os = "android")]
-    connectivity_checker: Option<connectivity::Check<connectivity::Cancellable>>,
+    cancel_receiver: connectivity::CancelReceiver,
 }
 
 impl WgGoTunnelState {
@@ -295,12 +284,12 @@ impl WgGoTunnel {
 
 #[cfg(target_os = "android")]
 impl WgGoTunnel {
-    pub fn start_tunnel(
+    pub async fn start_tunnel(
         config: &Config,
         log_path: Option<&Path>,
         tun_provider: Arc<Mutex<TunProvider>>,
         routes: impl Iterator<Item = IpNetwork>,
-        mut connectivity_check: connectivity::Check<connectivity::Cancellable>,
+        cancel_receiver: connectivity::CancelReceiver,
     ) -> Result<Self> {
         let (mut tunnel_device, tunnel_fd) =
             Self::get_tunnel(Arc::clone(&tun_provider), config, routes)?;
@@ -325,7 +314,7 @@ impl WgGoTunnel {
         Self::bypass_tunnel_sockets(&handle, &mut tunnel_device)
             .map_err(TunnelError::BypassError)?;
 
-        let mut tunnel = WgGoTunnel::Singlehop(WgGoTunnelState {
+        let tunnel = WgGoTunnel::Singlehop(WgGoTunnelState {
             interface_name,
             tunnel_handle: handle,
             _tunnel_device: tunnel_device,
@@ -333,23 +322,22 @@ impl WgGoTunnel {
             tun_provider,
             #[cfg(daita)]
             config: config.clone(),
-            connectivity_checker: None,
+            cancel_receiver,
         });
 
         // HACK: Check if the tunnel is working by sending a ping in the tunnel.
-        tunnel.ensure_tunnel_is_running(&mut connectivity_check)?;
-        tunnel.as_state_mut().connectivity_checker = Some(connectivity_check);
+        tunnel.ensure_tunnel_is_running().await?;
 
         Ok(tunnel)
     }
 
-    pub fn start_multihop_tunnel(
+    pub async fn start_multihop_tunnel(
         config: &Config,
         exit_peer: &PeerConfig,
         log_path: Option<&Path>,
         tun_provider: Arc<Mutex<TunProvider>>,
         routes: impl Iterator<Item = IpNetwork>,
-        mut connectivity_check: connectivity::Check<connectivity::Cancellable>,
+        cancel_receiver: connectivity::CancelReceiver,
     ) -> Result<Self> {
         let (mut tunnel_device, tunnel_fd) =
             Self::get_tunnel(Arc::clone(&tun_provider), config, routes)?;
@@ -390,7 +378,7 @@ impl WgGoTunnel {
         Self::bypass_tunnel_sockets(&handle, &mut tunnel_device)
             .map_err(TunnelError::BypassError)?;
 
-        let mut tunnel = WgGoTunnel::Multihop(WgGoTunnelState {
+        let tunnel = WgGoTunnel::Multihop(WgGoTunnelState {
             interface_name,
             tunnel_handle: handle,
             _tunnel_device: tunnel_device,
@@ -398,12 +386,11 @@ impl WgGoTunnel {
             tun_provider,
             #[cfg(daita)]
             config: config.clone(),
-            connectivity_checker: None,
+            cancel_receiver: cancel_receiver.clone(),
         });
 
         // HACK: Check if the tunnel is working by sending a ping in the tunnel.
-        tunnel.ensure_tunnel_is_running(&mut connectivity_check)?;
-        tunnel.as_state_mut().connectivity_checker = Some(connectivity_check);
+        tunnel.ensure_tunnel_is_running().await?;
 
         Ok(tunnel)
     }
@@ -421,30 +408,34 @@ impl WgGoTunnel {
         Ok(())
     }
 
-    pub fn take_checker(&mut self) -> Option<connectivity::Check<connectivity::Cancellable>> {
-        self.as_state_mut().connectivity_checker.take()
-    }
-
     /// There is a brief period of time between setting up a Wireguard-go tunnel and the tunnel being ready to serve
     /// traffic. This function blocks until the tunnel starts to serve traffic or until [connectivity::Check] times out.
-    fn ensure_tunnel_is_running(
-        &self,
-        checker: &mut connectivity::Check<connectivity::Cancellable>,
-    ) -> Result<()> {
-        let connection_established = checker
+    async fn ensure_tunnel_is_running(&self) -> Result<()> {
+        let state = self.as_state();
+        let addr = state.config.ipv4_gateway;
+        let cancel_receiver = state.cancel_receiver.clone();
+        let mut check = connectivity::Check::new(addr, 0, cancel_receiver)
+            .map_err(|err| TunnelError::RecoverableStartWireguardError(Box::new(err)))?;
+
+        // TODO: retry attempt?
+
+        let connection_established = check
             .establish_connectivity(self)
+            .await
             .map_err(|e| TunnelError::RecoverableStartWireguardError(Box::new(e)))?;
 
         // Timed out
         if !connection_established {
             return Err(TunnelError::RecoverableStartWireguardError(Box::new(
-                Error::TimeoutError,
+                super::Error::TimeoutError,
             )));
         }
+
         Ok(())
     }
 }
 
+#[async_trait::async_trait]
 impl Tunnel for WgGoTunnel {
     fn get_interface_name(&self) -> String {
         self.as_state().interface_name.clone()
@@ -454,14 +445,16 @@ impl Tunnel for WgGoTunnel {
         self.into_state().stop()
     }
 
-    fn get_tunnel_stats(&self) -> Result<StatsMap> {
-        self.as_state()
-            .tunnel_handle
-            .get_config(|cstr| {
-                Stats::parse_config_str(cstr.to_str().expect("Go strings are always UTF-8"))
-            })
-            .ok_or(TunnelError::GetConfigError)?
-            .map_err(|error| TunnelError::StatsError(BoxedError::new(error)))
+    async fn get_tunnel_stats(&self) -> Result<StatsMap> {
+        tokio::task::block_in_place(|| {
+            self.as_state()
+                .tunnel_handle
+                .get_config(|cstr| {
+                    Stats::parse_config_str(cstr.to_str().expect("Go strings are always UTF-8"))
+                })
+                .ok_or(TunnelError::GetConfigError)?
+                .map_err(|error| TunnelError::StatsError(BoxedError::new(error)))
+        })
     }
 
     fn set_config(


### PR DESCRIPTION
This rewrites the pinger/connectivity checker, and some other pieces of `talpid-wireguard` to be async.

One benefit is that tests run faster, since we can mock time now. Running the tests for `talpid-wireguard` take about 1 ms instead of 20 seconds.

I only intend on making it *less* bad than before. There is still room for more refactoring. A lot of mixing of async/sync in places surrounding the `Tunnel` trait mixes sync and async, still.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7390)
<!-- Reviewable:end -->
