### PR TITLE
Fix borked unit test

### DIFF
--- a/ios/MullvadRustRuntimeTests/MullvadPostQuantum+Stubs.swift
+++ b/ios/MullvadRustRuntimeTests/MullvadPostQuantum+Stubs.swift
@@ -31,8 +31,8 @@ class TunnelProviderStub: TunnelProvider {
         0
     }
 
-    func wgFunctions() -> MullvadTypes.WgFuncPointers {
-        return MullvadTypes.WgFuncPointers(
+    func wgFunctions() -> MullvadTypes.WgFunctionPointers {
+        return MullvadTypes.WgFunctionPointers(
             open: { _, _, _ in return 0 },
             close: { _, _ in return 0 },
             receive: { _, _, _, _ in return 0 },


### PR DESCRIPTION
When adding last changes to IAN to use real names instead of abbreviations of runes, I forgot to extend those changes to the unit tests too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7391)
<!-- Reviewable:end -->
