### PR TITLE
Remove `duct` as a macOS dependency in `talpid-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4187,15 +4187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "subslice"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a8e4809a3bb02de01f1f7faf1ba01a83af9e8eabcd4d31dd6e413d14d56aae"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,7 +4315,6 @@ dependencies = [
  "resolv-conf",
  "serde",
  "serde_json",
- "subslice",
  "system-configuration",
  "talpid-dbus",
  "talpid-macos",

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -46,9 +46,7 @@ duct = "0.13"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 async-trait = "0.1"
-duct = "0.13"
 pfctl = "0.6.1"
-subslice = "0.2"
 system-configuration = "0.5.1"
 hickory-proto = { workspace = true }
 hickory-server = { workspace = true, features = ["resolver"] }


### PR DESCRIPTION
Just as the title says: Remove the use `duct` in the macOS firewall module in favor of using an equivalent function in the `pfctl` crate. This finally reverts https://github.com/mullvad/mullvadvpn-app/pull/3046 :tada:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7392)
<!-- Reviewable:end -->
