### PR TITLE
Improve tapjacking prevention to not block other apps

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/ui/MainActivity.kt
@@ -83,7 +83,7 @@ class MainActivity : ComponentActivity(), AndroidScopeComponent {
         setContent { AppTheme { MullvadApp() } }
 
         // This is to protect against tapjacking attacks
-        window.decorView.filterTouchesWhenObscured = true
+        window.decorView.rootView.filterTouchesWhenObscured = true
 
         // Needs to be before we start the service, since we need to access the intent there
         lifecycleScope.launch { intents().collect(::handleIntent) }


### PR DESCRIPTION
Moved the tapjacking one step below in the view hierarchy. This is to allow full functionality for some other apps, while still preventing tapjacking attacks on affected Android versions.

This was tested using: https://github.com/carlospolop/Tapjacking-ExportedActivity

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7393)
<!-- Reviewable:end -->
