### PR TITLE
Add StoreKit2 button

### DIFF
--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -38,6 +38,7 @@ public enum AccessibilityIdentifier: Equatable {
     case loginTextFieldButton
     case logoutButton
     case purchaseButton
+    case storekit2Button
     case redeemVoucherButton
     case restorePurchasesButton
     case secureConnectionButton

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -521,7 +521,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, RootContainerViewCo
         let accountInteractor = AccountInteractor(
             storePaymentManager: storePaymentManager,
             tunnelManager: tunnelManager,
-            accountsProxy: accountsProxy
+            accountsProxy: accountsProxy,
+            apiProxy: apiProxy
         )
 
         let coordinator = AccountCoordinator(

--- a/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
@@ -15,6 +15,18 @@ class AccountContentView: UIView {
         return button
     }()
 
+    let storeKit2Button: AppButton = {
+        let button = AppButton(style: .success)
+        button.setTitle(NSLocalizedString(
+            "BUY_SUBSCRIPTION_STOREKIT_2",
+            tableName: "Account",
+            value: "Make a purchase with StoreKit2",
+            comment: ""
+        ), for: .normal)
+        button.setAccessibilityIdentifier(.storekit2Button)
+        return button
+    }()
+
     let redeemVoucherButton: AppButton = {
         let button = AppButton(style: .success)
         button.setAccessibilityIdentifier(.redeemVoucherButton)
@@ -85,6 +97,7 @@ class AccountContentView: UIView {
         var arrangedSubviews = [UIView]()
         #if DEBUG
         arrangedSubviews.append(redeemVoucherButton)
+        arrangedSubviews.append(storeKit2Button)
         #endif
         arrangedSubviews.append(contentsOf: [
             purchaseButton,

--- a/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
@@ -144,6 +144,8 @@ class AccountViewController: UIViewController {
         contentView.logoutButton.addTarget(self, action: #selector(logOut), for: .touchUpInside)
 
         contentView.deleteButton.addTarget(self, action: #selector(deleteAccount), for: .touchUpInside)
+
+        contentView.storeKit2Button.addTarget(self, action: #selector(handleStoreKit2Purchase), for: .touchUpInside)
     }
 
     private func requestStoreProducts() {
@@ -202,6 +204,7 @@ class AccountViewController: UIViewController {
         contentView.logoutButton.isEnabled = isInteractionEnabled
         contentView.redeemVoucherButton.isEnabled = isInteractionEnabled
         contentView.deleteButton.isEnabled = isInteractionEnabled
+        contentView.storeKit2Button.isEnabled = isInteractionEnabled
         navigationItem.rightBarButtonItem?.isEnabled = isInteractionEnabled
 
         view.isUserInteractionEnabled = isInteractionEnabled
@@ -293,4 +296,68 @@ class AccountViewController: UIViewController {
             setPaymentState(.none, animated: true)
         }
     }
+
+    @objc private func handleStoreKit2Purchase() {
+        guard let accountData = interactor.deviceState.accountData else {
+            return
+        }
+        guard case let .received(oldProduct) = productState,
+              let accountData = interactor.deviceState.accountData
+        else {
+            return
+        }
+
+        setPaymentState(.makingStoreKit2Purchase, animated: true)
+
+        Task {
+            do {
+                let product = try await Product.products(for: [oldProduct.productIdentifier]).first!
+                let result = try await product.purchase()
+
+                switch result {
+                case let .success(verification):
+                    let transaction = try checkVerified(verification)
+                    await sendReceiptToAPI(accountNumber: accountData.identifier, receipt: verification)
+                    await transaction.finish()
+
+                case .userCancelled:
+                    print("User cancelled the purchase")
+                case .pending:
+                    print("Purchase is pending")
+                @unknown default:
+                    print("Unknown purchase result")
+                }
+            } catch {
+                print("Error: \(error)")
+                errorPresenter.showAlertForStoreKitError(error, context: .purchase)
+            }
+
+            setPaymentState(.none, animated: true)
+        }
+    }
+
+    private func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified:
+            throw StoreKit2Error.verificationFailed
+        case let .verified(safe):
+            return safe
+        }
+    }
+
+    private func sendReceiptToAPI(accountNumber: String, receipt: VerificationResult<Transaction>) async {
+        do {
+            // Accessing unsafe payload data because n
+            let receiptData = receipt.unsafePayloadValue
+            try await interactor.sendStoreKitReceipt(receipt, for: accountNumber)
+            print("Receipt sent successfully")
+        } catch {
+            print("Error sending receipt: \(error)")
+            errorPresenter.showAlertForStoreKitError(error, context: .purchase)
+        }
+    }
+}
+
+private enum StoreKit2Error: Error {
+    case verificationFailed
 }

--- a/ios/MullvadVPN/View controllers/Account/PaymentAlertPresenter.swift
+++ b/ios/MullvadVPN/View controllers/Account/PaymentAlertPresenter.swift
@@ -36,6 +36,30 @@ struct PaymentAlertPresenter {
         presenter.showAlert(presentation: presentation, animated: true)
     }
 
+    func showAlertForStoreKitError(
+        _ error: any Error,
+        context: REST.CreateApplePaymentResponse.Context,
+        completion: (() -> Void)? = nil
+    ) {
+        let presentation = AlertPresentation(
+            id: "payment-error-alert",
+            title: context.errorTitle,
+            message: "\(error)",
+            buttons: [
+                AlertAction(
+                    title: okButtonTextForKey("PAYMENT_ERROR_ALERT_OK_ACTION"),
+                    style: .default,
+                    handler: {
+                        completion?()
+                    }
+                ),
+            ]
+        )
+
+        let presenter = AlertPresenter(context: alertContext)
+        presenter.showAlert(presentation: presentation, animated: true)
+    }
+
     func showAlertForResponse(
         _ response: REST.CreateApplePaymentResponse,
         context: REST.CreateApplePaymentResponse.Context,

--- a/ios/MullvadVPN/View controllers/Account/PaymentState.swift
+++ b/ios/MullvadVPN/View controllers/Account/PaymentState.swift
@@ -12,13 +12,14 @@ import StoreKit
 enum PaymentState: Equatable {
     case none
     case makingPayment(SKPayment)
+    case makingStoreKit2Purchase
     case restoringPurchases
 
     var allowsViewInteraction: Bool {
         switch self {
         case .none:
             return true
-        case .restoringPurchases, .makingPayment:
+        case .restoringPurchases, .makingPayment, .makingStoreKit2Purchase:
             return false
         }
     }


### PR DESCRIPTION
To aid with developing the server side changes for StoreKit2, I've added a button that generates a StoreKit2 receipt and sends it to the same endpoint on to our API. The button is only added in debug builds.  Since this is a _manager is let loose on the codebase they do not understand_, please do review these changes diligently.  XCode will complain about us not listening to transactions succeeding out-of-band - this is to be expected and we will fix this once we move to StoreKit2 properly - the changes I'm introducing here are not intended to be used in production.