### PR TITLE
Update LegalCopyright year to 2025

### DIFF
--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -48,6 +48,6 @@ features = [
 [package.metadata.winres]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
-LegalCopyright = "(c) 2024 Mullvad VPN AB"
+LegalCopyright = "(c) 2025 Mullvad VPN AB"
 InternalName = "mullvad-cli"
 OriginalFilename = "mullvad.exe"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -97,6 +97,6 @@ features = [
 [package.metadata.winres]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
-LegalCopyright = "(c) 2024 Mullvad VPN AB"
+LegalCopyright = "(c) 2025 Mullvad VPN AB"
 InternalName = "mullvad-daemon"
 OriginalFilename = "mullvad-daemon.exe"

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -45,6 +45,6 @@ features = [
 [package.metadata.winres]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
-LegalCopyright = "(c) 2024 Mullvad VPN AB"
+LegalCopyright = "(c) 2025 Mullvad VPN AB"
 InternalName = "mullvad-problem-report"
 OriginalFilename = "mullvad-problem-report.exe"

--- a/talpid-openvpn-plugin/Cargo.toml
+++ b/talpid-openvpn-plugin/Cargo.toml
@@ -50,7 +50,7 @@ winapi = { version = "0.3", features = ["winerror"] }
 [package.metadata.winres]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
-LegalCopyright = "(c) 2024 Mullvad VPN AB"
+LegalCopyright = "(c) 2025 Mullvad VPN AB"
 InternalName = "talpid-openvpn-plugin"
 OriginalFilename = "talpid_openvpn_plugin.dll"
 

--- a/windows-installer/Cargo.toml
+++ b/windows-installer/Cargo.toml
@@ -24,6 +24,6 @@ mullvad-version = { path = "../mullvad-version" }
 [package.metadata.winres]
 ProductName = "Mullvad VPN"
 CompanyName = "Mullvad VPN AB"
-LegalCopyright = "(c) 2024 Mullvad VPN AB"
+LegalCopyright = "(c) 2025 Mullvad VPN AB"
 InternalName = "mullvad-installer"
 OriginalFilename = "MullvadVPN.exe"


### PR DESCRIPTION
This PR updates `LegalCopyright` year to 2025 for all applicable `mullvad-` & `talpid-` crates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7406)
<!-- Reviewable:end -->
