### PR TITLE
Cleanup talpid tunnel `unix` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,7 +4644,6 @@ dependencies = [
  "ipnetwork",
  "jnix",
  "log",
- "nix 0.23.2",
  "talpid-routing",
  "talpid-types",
  "talpid-windows",
@@ -5178,11 +5177,15 @@ checksum = "5b5ea2466ffcdd0be0831f7d3981daa0b953586c0062f6d33398cb374689b090"
 dependencies = [
  "bytes",
  "cfg-if",
+ "futures",
+ "futures-core",
  "ipnet",
  "libc",
  "log",
  "nix 0.29.0",
  "thiserror 2.0.9",
+ "tokio",
+ "tokio-util 0.7.10",
  "windows-sys 0.59.0",
  "wintun-bindings",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ serde = "1.0.204"
 serde_json = "1.0.122"
 
 ipnetwork = "0.20"
+tun = { version = "0.7", features = ["async"] }
 
 # Test dependencies
 proptest = "1.4"

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -24,8 +24,7 @@ jnix = { version = "0.5.1", features = ["derive"] }
 log = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-tun = "0.7"
-nix = "0.23"
+tun = { version = "0.7", features = ["async"] }
 
 [target.'cfg(windows)'.dependencies]
 talpid-windows = { path = "../talpid-windows" }

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -24,7 +24,7 @@ jnix = { version = "0.5.1", features = ["derive"] }
 log = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-tun = { version = "0.7", features = ["async"] }
+tun = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 talpid-windows = { path = "../talpid-windows" }

--- a/talpid-tunnel/src/tun_provider/mod.rs
+++ b/talpid-tunnel/src/tun_provider/mod.rs
@@ -35,6 +35,7 @@ cfg_if! {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TunConfig {
     /// Interface name to use.
+    #[cfg(target_os = "linux")]
     pub name: Option<String>,
 
     /// IP addresses for the tunnel interface.
@@ -80,6 +81,7 @@ impl TunConfig {
 /// Android to route all traffic inside the tunnel.
 pub fn blocking_config() -> TunConfig {
     TunConfig {
+        #[cfg(target_os = "linux")]
         name: None,
         addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
         mtu: 1380,

--- a/talpid-tunnel/src/tun_provider/unix.rs
+++ b/talpid-tunnel/src/tun_provider/unix.rs
@@ -66,10 +66,11 @@ impl UnixTunProvider {
             #[allow(unused_mut)]
             let mut builder = TunnelDeviceBuilder::default();
             #[cfg(target_os = "linux")]
-            builder.enable_packet_information();
-            #[cfg(target_os = "linux")]
-            if let Some(ref name) = self.config.name {
-                builder.name(name);
+            {
+                builder.enable_packet_information();
+                if let Some(ref name) = self.config.name {
+                    builder.name(name);
+                }
             }
             builder.create()?
         };

--- a/talpid-tunnel/src/tun_provider/unix.rs
+++ b/talpid-tunnel/src/tun_provider/unix.rs
@@ -112,6 +112,7 @@ pub struct TunnelDevice {
 /// A tunnel device builder.
 ///
 /// Call [`Self::create`] to create [`TunnelDevice`] from the config.
+#[derive(Default)]
 pub struct TunnelDeviceBuilder {
     config: Configuration,
 }
@@ -149,13 +150,6 @@ impl TunnelDeviceBuilder {
             config.packet_information(true);
         });
         self
-    }
-}
-
-impl Default for TunnelDeviceBuilder {
-    fn default() -> Self {
-        let config = Configuration::default();
-        Self { config }
     }
 }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/mullvad/mullvadvpn-app/pull/7410 which just cleans up code in the `talpid-tunnel` by leveraging the `async` feature of `tun`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7411)
<!-- Reviewable:end -->
