### PR TITLE
Upgrade `thiserror` to version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -496,7 +496,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.93",
+ "syn 2.0.89",
  "tempfile",
  "toml 0.8.19",
 ]
@@ -622,7 +622,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -814,7 +814,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -838,7 +838,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -930,7 +930,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -983,7 +983,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1052,7 +1052,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1875,7 +1875,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1979,7 +1979,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2487,7 +2487,7 @@ dependencies = [
  "shadowsocks",
  "talpid-time",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-socks",
@@ -2512,7 +2512,7 @@ dependencies = [
  "serde",
  "serde_json",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "windows-sys 0.52.0",
  "winres",
@@ -2556,7 +2556,7 @@ dependencies = [
  "talpid-time",
  "talpid-types",
  "talpid-windows",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
  "winapi",
@@ -2584,7 +2584,7 @@ version = "0.0.0"
 dependencies = [
  "nix 0.23.2",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -2633,7 +2633,7 @@ dependencies = [
  "rand 0.8.5",
  "talpid-tunnel",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
 ]
 
@@ -2652,7 +2652,7 @@ dependencies = [
  "prost 0.13.3",
  "prost-types 0.13.3",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tonic",
  "tonic-build",
@@ -2674,7 +2674,7 @@ version = "0.0.0"
 dependencies = [
  "log",
  "once_cell",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "widestring",
  "windows-sys 0.52.0",
 ]
@@ -2694,7 +2694,7 @@ dependencies = [
  "regex",
  "talpid-platform-metadata",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "uuid",
  "windows-sys 0.52.0",
@@ -2715,7 +2715,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -2733,7 +2733,7 @@ dependencies = [
  "talpid-core",
  "talpid-future",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
 ]
 
@@ -2750,7 +2750,7 @@ dependencies = [
  "regex",
  "serde",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "uuid",
 ]
 
@@ -2795,7 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6813fde79b646e47e7ad75f480aa80ef76a5d9599e2717407961531169ee38b"
 dependencies = [
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
  "syn-mid",
 ]
 
@@ -3287,7 +3287,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3378,7 +3378,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3438,7 +3438,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3504,7 +3504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3582,7 +3582,7 @@ dependencies = [
  "prost 0.12.4",
  "prost-types 0.12.4",
  "regex",
- "syn 2.0.93",
+ "syn 2.0.89",
  "tempfile",
 ]
 
@@ -3596,7 +3596,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3609,7 +3609,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4061,7 +4061,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4386,9 +4386,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4403,7 +4403,7 @@ checksum = "b5dc35bb08dd1ca3dfb09dce91fd2d13294d6711c88897d9a9d60acf39bce049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4426,7 +4426,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4492,7 +4492,7 @@ dependencies = [
  "talpid-types",
  "talpid-windows",
  "talpid-wireguard",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tonic-build",
  "triggered",
@@ -4514,7 +4514,7 @@ dependencies = [
  "dbus",
  "libc",
  "log",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
 ]
 
@@ -4562,7 +4562,7 @@ dependencies = [
  "talpid-tunnel",
  "talpid-types",
  "talpid-windows",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tonic",
  "tonic-build",
@@ -4586,7 +4586,7 @@ dependencies = [
  "parity-tokio-ipc",
  "prost 0.13.3",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tonic",
  "tonic-build",
@@ -4621,7 +4621,7 @@ dependencies = [
  "system-configuration",
  "talpid-types",
  "talpid-windows",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "widestring",
  "windows-sys 0.52.0",
@@ -4647,7 +4647,7 @@ dependencies = [
  "talpid-routing",
  "talpid-types",
  "talpid-windows",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tun 0.7.10",
  "windows-sys 0.52.0",
@@ -4683,7 +4683,7 @@ dependencies = [
  "jnix",
  "log",
  "serde",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "x25519-dalek",
  "zeroize",
 ]
@@ -4695,7 +4695,7 @@ dependencies = [
  "futures",
  "socket2",
  "talpid-types",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "windows-sys 0.52.0",
 ]
 
@@ -4734,7 +4734,7 @@ dependencies = [
  "talpid-tunnel-config-client",
  "talpid-types",
  "talpid-windows",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
  "tunnel-obfuscation",
@@ -4791,7 +4791,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4802,7 +4802,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4875,7 +4875,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5050,7 +5050,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5118,7 +5118,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5138,7 +5138,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "serde",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -5198,7 +5198,7 @@ dependencies = [
  "log",
  "nix 0.23.2",
  "shadowsocks",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "tokio",
  "udp-over-tcp",
 ]
@@ -5363,7 +5363,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -5385,7 +5385,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5491,7 +5491,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5513,7 +5513,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -5874,7 +5874,7 @@ dependencies = [
  "anyhow",
  "log",
  "maybenot-ffi",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
  "zeroize",
 ]
 
@@ -5937,7 +5937,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -5958,7 +5958,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -5979,7 +5979,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -6001,5 +6001,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.89",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ prost-types = "0.13.3"
 hyper-util = {version = "0.1.8", features = ["client", "client-legacy", "http2", "http1"]}
 
 env_logger = "0.10.0"
-thiserror = "1.0.57"
+thiserror = "2.0"
 log = "0.4"
 
 shadowsocks = "1.20.3"

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -191,7 +191,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -484,7 +484,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -656,7 +656,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -813,7 +813,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -826,7 +826,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -908,7 +908,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "log",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
  "tokio-stream",
 ]
@@ -1033,7 +1033,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1228,7 +1228,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
- "thiserror",
+ "thiserror 1.0.59",
  "tinyvec",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -1253,7 +1253,7 @@ dependencies = [
  "resolv-conf",
  "rustls 0.21.12",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
  "tokio-rustls 0.24.1",
  "tracing",
@@ -1561,7 +1561,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1655,7 +1655,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1741,7 +1741,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.59",
  "walkdir",
 ]
 
@@ -2051,7 +2051,7 @@ dependencies = [
  "shadowsocks",
  "talpid-time",
  "talpid-types",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-socks",
@@ -2096,7 +2096,7 @@ dependencies = [
  "prost 0.13.3",
  "prost-types 0.13.3",
  "talpid-types",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tonic",
  "tonic-build",
@@ -2109,7 +2109,7 @@ version = "0.0.0"
 dependencies = [
  "log",
  "once_cell",
- "thiserror",
+ "thiserror 2.0.3",
  "widestring",
  "windows-sys 0.52.0",
 ]
@@ -2127,7 +2127,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "talpid-types",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -2142,7 +2142,7 @@ dependencies = [
  "regex",
  "serde",
  "talpid-types",
- "thiserror",
+ "thiserror 2.0.3",
  "uuid",
 ]
 
@@ -2307,7 +2307,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.59",
 ]
 
 [[package]]
@@ -2455,7 +2455,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2478,7 +2478,7 @@ checksum = "122ee1f5a6843bec84fcbd5c6ba3622115337a6b8965b93a61aad347648f4e8d"
 dependencies = [
  "rand 0.8.5",
  "socket2 0.4.10",
- "thiserror",
+ "thiserror 1.0.59",
 ]
 
 [[package]]
@@ -2529,7 +2529,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2595,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2609,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2653,7 +2653,7 @@ dependencies = [
  "prost 0.12.4",
  "prost-types 0.12.4",
  "regex",
- "syn 2.0.60",
+ "syn 2.0.89",
  "tempfile",
 ]
 
@@ -2667,7 +2667,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2680,7 +2680,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2729,7 +2729,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.18",
  "socket2 0.5.6",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
  "tracing",
 ]
@@ -2746,7 +2746,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.18",
  "slab",
- "thiserror",
+ "thiserror 1.0.59",
  "tinyvec",
  "tracing",
 ]
@@ -2870,7 +2870,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom 0.2.14",
  "libredox",
- "thiserror",
+ "thiserror 1.0.59",
 ]
 
 [[package]]
@@ -3185,7 +3185,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3269,7 +3269,7 @@ dependencies = [
  "shadowsocks-crypto",
  "socket2 0.5.6",
  "spin",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
  "tokio-tfo",
  "url",
@@ -3371,7 +3371,7 @@ dependencies = [
  "fast-socks5",
  "futures",
  "log",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
 ]
 
@@ -3441,7 +3441,7 @@ dependencies = [
  "pnet_packet",
  "rand 0.8.5",
  "socket2 0.5.6",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
  "tracing",
 ]
@@ -3459,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3491,7 +3491,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3519,7 +3519,7 @@ dependencies = [
  "jnix",
  "log",
  "serde",
- "thiserror",
+ "thiserror 2.0.3",
  "x25519-dalek",
  "zeroize",
 ]
@@ -3531,7 +3531,7 @@ dependencies = [
  "futures",
  "socket2 0.5.6",
  "talpid-types",
- "thiserror",
+ "thiserror 2.0.3",
  "windows-sys 0.52.0",
 ]
 
@@ -3551,7 +3551,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tarpc-plugins",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -3623,7 +3623,7 @@ dependencies = [
  "tarpc",
  "test-rpc",
  "test_macro",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-serde",
  "tokio-serial",
@@ -3651,7 +3651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tarpc",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-serde",
@@ -3682,7 +3682,7 @@ dependencies = [
  "talpid-windows",
  "tarpc",
  "test-rpc",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-serde",
  "tokio-serial",
@@ -3708,7 +3708,16 @@ version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.59",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -3719,7 +3728,18 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3814,7 +3834,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3874,7 +3894,7 @@ checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
 dependencies = [
  "either",
  "futures-util",
- "thiserror",
+ "thiserror 1.0.59",
  "tokio",
 ]
 
@@ -3970,7 +3990,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4039,7 +4059,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4100,7 +4120,7 @@ checksum = "cbc25e23adc6cac7dd895ce2780f255902290fc39b00e1ae3c33e89f3d20fa66"
 dependencies = [
  "ioctl-sys",
  "libc",
- "thiserror",
+ "thiserror 1.0.59",
 ]
 
 [[package]]
@@ -4115,7 +4135,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0adf6ad32eb5b3cadff915f7b770faaac8f7ff0476633aa29eb0d9584d889d34"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.59",
 ]
 
 [[package]]
@@ -4249,7 +4269,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -4283,7 +4303,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4717,7 +4737,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -4738,7 +4758,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -4759,7 +4779,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4781,5 +4801,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.89",
 ]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -64,7 +64,7 @@ hyper-util = {version = "0.1.8", features = ["client", "client-legacy", "http2"]
 
 # Logging
 env_logger = "0.11.0"
-thiserror = "1.0.57"
+thiserror = "2.0"
 log = "0.4"
 colored = "2.0.0"
 


### PR DESCRIPTION
Simple bump of `thiserror` to version 2. We already have it in our tree, and it requires no modification to our code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7414)
<!-- Reviewable:end -->
