### PR TITLE
Fix bug where `block_on` was called from an async context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Add experimental support for Windows ARM64.
 
+### Fixed
+- Fix crash when Wireguard tunnel setup timed out.
+
 ## [2025.1] - 2025-01-02
 ### Fixed
 #### macOS

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -278,7 +278,13 @@ impl WireguardMonitor {
                     // timing out on Windows for 2024.9-beta1. These verbose data usage logs are
                     // a temporary measure to help us understand the issue. They can be removed
                     // if the issue is resolved.
-                    log_tunnel_data_usage(&config, &tunnel).await;
+                    if let Err(err) =
+                        tokio::task::spawn_blocking(move || log_tunnel_data_usage(&config, &tunnel))
+                            .await
+                    {
+                        log::error!("Failed to log tunnel data during setup phase");
+                        log::error!("{err}");
+                    }
                     return Err(e);
                 }
 
@@ -484,7 +490,13 @@ impl WireguardMonitor {
                     // timing out on Windows for 2024.9-beta1. These verbose data usage logs are
                     // a temporary measure to help us understand the issue. They can be removed
                     // if the issue is resolved.
-                    log_tunnel_data_usage(&config, &tunnel).await;
+                    if let Err(err) =
+                        tokio::task::spawn_blocking(move || log_tunnel_data_usage(&config, &tunnel))
+                            .await
+                    {
+                        log::error!("Failed to log tunnel data during setup phase");
+                        log::error!("{err}");
+                    }
                     return Err(e);
                 }
 
@@ -989,8 +1001,12 @@ impl WireguardMonitor {
     }
 }
 
-async fn log_tunnel_data_usage(config: &Config, tunnel: &Arc<AsyncMutex<Option<TunnelType>>>) {
-    let tunnel = tunnel.lock().await;
+/// Log the tunnel stats from the current tunnel.
+///
+/// This will log the amount of outgoing and incoming data to and from the exit (and entry) relay
+/// so far.
+fn log_tunnel_data_usage(config: &Config, tunnel: &Arc<AsyncMutex<Option<TunnelType>>>) {
+    let tunnel = tunnel.blocking_lock();
     let Some(tunnel) = &*tunnel else { return };
     let Ok(tunnel_stats) = tunnel.get_tunnel_stats() else {
         return;
@@ -1023,6 +1039,8 @@ enum CloseMsg {
 pub(crate) trait Tunnel: Send {
     fn get_interface_name(&self) -> String;
     fn stop(self: Box<Self>) -> std::result::Result<(), TunnelError>;
+    /// # Note
+    /// This function should *not* be called from within an async context.
     fn get_tunnel_stats(&self) -> std::result::Result<stats::StatsMap, TunnelError>;
     fn set_config<'a>(
         &'a mut self,


### PR DESCRIPTION
This PR fixes a regression introduced in the 2025.1 release. The fix is simple enough, simply call `log_tunnel_data_usage` from a thread where blocking is acceptable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7425)
<!-- Reviewable:end -->
