### PR TITLE
Update README indicating wireguard over shadowsocks availability on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the current state of the latest code in git, not necessarily any existing releas
 | [DAITA]                       |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
 | WireGuard multihop            |    ✓    |   ✓   |   ✓   |         |  ✓  |
 | WireGuard over TCP            |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| WireGuard over Shadowsocks    |    ✓    |   ✓   |   ✓   |    ✓    |     |
+| WireGuard over Shadowsocks    |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
 | OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |
 | Split tunneling               |    ✓    |   ✓   |   ✓   |    ✓    |     |
 | Custom DNS server             |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |


### PR DESCRIPTION
This PR updates the README file to indicate that Wireguard over Shadowsocks is available on iOS.

Much thanks goes to @tunadreno for pointing out that we had missed that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7431)
<!-- Reviewable:end -->
