### PR TITLE
Update Direct only pop up design

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITASettingsPromptItem.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITASettingsPromptItem.swift
@@ -23,7 +23,7 @@ enum DAITASettingsPromptItem: CustomStringConvertible {
             case .daita:
                 "DAITA"
             case .directOnly:
-                "direct only"
+                "Direct only"
             }
         }
     }

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsViewControllerFactory.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsViewControllerFactory.swift
@@ -142,7 +142,7 @@ struct SettingsViewControllerFactory {
         let presentation = AlertPresentation(
             id: "settings-daita-prompt",
             accessibilityIdentifier: .daitaPromptAlert,
-            icon: .info,
+            icon: .warning,
             message: NSLocalizedString(
                 "SETTINGS_DAITA_ENABLE_TEXT",
                 tableName: "DAITA",
@@ -154,7 +154,7 @@ struct SettingsViewControllerFactory {
                     title: String(format: NSLocalizedString(
                         "SETTINGS_DAITA_ENABLE_OK_ACTION",
                         tableName: "DAITA",
-                        value: "Enable %@",
+                        value: "Enable \"%@\"",
                         comment: ""
                     ), item.title),
                     style: .default,
@@ -165,7 +165,7 @@ struct SettingsViewControllerFactory {
                     title: NSLocalizedString(
                         "SETTINGS_DAITA_ENABLE_CANCEL_ACTION",
                         tableName: "DAITA",
-                        value: "Back",
+                        value: "Cancel",
                         comment: ""
                     ),
                     style: .default,


### PR DESCRIPTION
This PR updates the copyright text and replaces the info icon with a warning icon in the popup displayed when a user enables 'Direct Only' while the selected location does not support Daita.
<table style="width: 100%; max-width: 828px; table-layout: fixed; border-collapse: collapse; text-align: center;">
    <tr>
        <th style="width: 50%; padding: 10px; font-size: 18px; font-family: Arial, sans-serif; background-color: #f2f2f2;">
            Before
        </th>
        <th style="width: 50%; padding: 10px; font-size: 18px; font-family: Arial, sans-serif; background-color: #f2f2f2;">
            After
        </th>
    </tr>
    <tr>
        <td style="width: 50%; text-align: center; padding: 10px;">
            <img src="https://github.com/user-attachments/assets/30f25146-ffa5-4907-ab3f-61f3a36b4e37" alt="Image 1" style="max-width: 100%; height: auto;">
        </td>
        <td style="width: 50%; text-align: center; padding: 10px;">
            <img src="https://github.com/user-attachments/assets/658583b3-2f51-4fce-9530-05daff71f487" alt="Image 2" style="max-width: 100%; height: auto;">
        </td>
    </tr>
</table>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7442)
<!-- Reviewable:end -->

![Simulator Screenshot - iPhone 15 - 2025-01-13 at 10 50 48]()


