### PR TITLE
 Add back missing app icon on Windows

### DIFF
--- a/desktop/packages/mullvad-vpn/tasks/distribution.js
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.js
@@ -133,7 +133,6 @@ function newConfig() {
 
     win: {
       target: [],
-      signAndEditExecutable: false,
       artifactName: 'MullvadVPN-${version}_${arch}.${ext}',
       publisherName: 'Mullvad VPN AB',
       extraResources: [


### PR DESCRIPTION
Enable the `signAndEditExecutable` electron-builder option, which allows electron-builder to add metadata to the produced binary / app installer. Without this option enabled, the electron app was missing the Mullvad app icon. This option was disabled by accident, and the default value is also true.

Here are the relevant electron-builder docs: https://www.electron.build/win.html#signandeditexecutable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7448)
<!-- Reviewable:end -->
