### PR TITLE
Update DAITA to v2 on Windows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -63,8 +63,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install libdbus-1-dev
 
+      - name: Install msbuild
+        if: matrix.os == 'windows-latest'
+        uses: microsoft/setup-msbuild@v1.0.2
+        with:
+          vs-version: 16
+
+      - name: Install latest zig
+        if: matrix.os == 'windows-latest'
+        uses: mlugg/setup-zig@v1
+
       - name: Install Go
-        if: matrix.os == 'linux-latest' || matrix.os == 'macos-latest'
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.3

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -185,6 +185,9 @@ jobs:
         with:
           vs-version: 16
 
+      - name: Install latest zig
+        uses: mlugg/setup-zig@v1
+
       - name: Build Windows modules
         if: steps.cache-windows-modules.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -130,7 +130,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout submodules
-        run: git submodule update --init --depth=1
+        run: |
+          git submodule update --init --depth=1
+          git submodule update --init --recursive --depth=1 wireguard-go-rs
 
       - name: Install Protoc
         # NOTE: ARM runner already has protoc

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -200,6 +200,8 @@ jobs:
           toolchain: stable
           target: i686-pc-windows-msvc
           default: true
+      - name: Install latest zig
+        uses: mlugg/setup-zig@v1
       - name: Install msbuild
         uses: microsoft/setup-msbuild@v1.0.2
         with:

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -114,6 +114,10 @@ jobs:
         with:
           vs-version: 16
 
+      - name: Install latest zig
+        if: matrix.os == 'windows-latest'
+        uses: mlugg/setup-zig@v1
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -103,10 +103,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout wireguard-go submodule
-        if: matrix.os == 'macos-latest'
         run: |
           git config --global --add safe.directory '*'
+          git submodule update --init --depth=1
           git submodule update --init --recursive --depth=1 wireguard-go-rs
+
+      - name: Install msbuild
+        if: matrix.os == 'windows-latest'
+        uses: microsoft/setup-msbuild@v1.0.2
+        with:
+          vs-version: 16
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /dist-assets/mullvad-setup.exe
 /dist-assets/mullvad-problem-report
 /dist-assets/mullvad-problem-report.exe
+/dist-assets/libwg.dll
+/dist-assets/maybenot_ffi.dll
 /dist-assets/libtalpid_openvpn_plugin.dylib
 /dist-assets/libtalpid_openvpn_plugin.so
 /dist-assets/talpid_openvpn_plugin.dll

--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -23,9 +23,8 @@ on your platform please submit an issue or a pull request.
 
     Install the `msi` hosted here: https://github.com/volta-cli/volta
 
-- (Not Windows) Install Go (ideally version `1.21`) by following the [official
-  instructions](https://golang.org/doc/install).  Newer versions may work
-  too.
+- Install Go (ideally version `1.21`) by following the [official instructions](https://golang.org/doc/install).
+  Newer versions may work too.
 
 - Install a protobuf compiler (version 3.15 and up), it can be installed on most major Linux distros
   via the package name `protobuf-compiler`, `protobuf` on macOS via Homebrew, and on Windows
@@ -95,6 +94,8 @@ The host has to have the following installed:
 
 - `bash` installed as well as a few base unix utilities, including `sed` and `tail`.
   You are recommended to use [Git for Windows].
+
+- `zig` installed and available in `%PATH%`. The latest official release should be fine: https://ziglang.org/download/.
 
 - `msbuild.exe` available in `%PATH%`. If you installed Visual Studio Community edition, the
   binary can be found under:

--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -95,7 +95,7 @@ The host has to have the following installed:
 - `bash` installed as well as a few base unix utilities, including `sed` and `tail`.
   You are recommended to use [Git for Windows].
 
-- `zig` installed and available in `%PATH%`. The latest official release should be fine: https://ziglang.org/download/.
+- `zig` installed and available in `%PATH%`. 0.14 or later is recommended: https://ziglang.org/download/.
 
 - `msbuild.exe` available in `%PATH%`. If you installed Visual Studio Community edition, the
   binary can be found under:

--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -154,7 +154,7 @@ In addition to the above requirements:
   the Electron app:
 
   ```
-  pushd gui
+  pushd desktop/packages/mullvad-vpn
   npm install --target_arch=x64 grpc-tools
   popd
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 #### Windows
 - Add support for Windows ARM64.
+- Add support for DAITA V2.
+- Add back wireguard-go (userspace WireGuard) support.
 
 ### Changed
 - (Linux and macOS only) Update to DAITA v2. The main difference is that many different machines are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5851,6 +5851,7 @@ dependencies = [
  "log",
  "maybenot-ffi",
  "thiserror 2.0.9",
+ "windows-sys 0.52.0",
  "zeroize",
 ]
 

--- a/build.sh
+++ b/build.sh
@@ -265,6 +265,8 @@ function build {
             mullvad-problem-report.exe
             talpid_openvpn_plugin.dll
             mullvad-setup.exe
+            libwg.dll
+            maybenot_ffi.dll
         )
     fi
 

--- a/desktop/packages/mullvad-vpn/tasks/distribution.js
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.js
@@ -177,6 +177,8 @@ function newConfig() {
           ),
           to: '.',
         },
+        { from: distAssets(path.join('${env.DIST_SUBDIR}', 'libwg.dll')), to: '.' },
+        { from: distAssets(path.join('${env.DIST_SUBDIR}', 'maybenot_ffi.dll')), to: '.' },
         { from: distAssets('maybenot_machines'), to: '.' },
       ],
     },

--- a/desktop/packages/mullvad-vpn/tasks/distribution.js
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.js
@@ -179,7 +179,6 @@ function newConfig() {
         },
         { from: distAssets(path.join('${env.DIST_SUBDIR}', 'libwg.dll')), to: '.' },
         { from: distAssets(path.join('${env.DIST_SUBDIR}', 'maybenot_ffi.dll')), to: '.' },
-        { from: distAssets('maybenot_machines'), to: '.' },
       ],
     },
 

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -22,7 +22,6 @@ mod proto {
     tonic::include_proto!("ephemeralpeer");
 }
 
-#[cfg(unix)]
 const DAITA_VERSION: u32 = 2;
 
 #[derive(Debug)]
@@ -88,7 +87,6 @@ pub const CONFIG_SERVICE_PORT: u16 = 1337;
 
 pub struct EphemeralPeer {
     pub psk: Option<PresharedKey>,
-    #[cfg(unix)]
     pub daita: Option<DaitaSettings>,
 }
 
@@ -141,15 +139,7 @@ pub async fn request_ephemeral_peer_with(
             wg_parent_pubkey: parent_pubkey.as_bytes().to_vec(),
             wg_ephemeral_peer_pubkey: ephemeral_pubkey.as_bytes().to_vec(),
             post_quantum: pq_request,
-            #[cfg(windows)]
-            daita: Some(proto::DaitaRequestV1 {
-                activate_daita: enable_daita,
-            }),
-            #[cfg(windows)]
-            daita_v2: None,
-            #[cfg(unix)]
             daita: None,
-            #[cfg(unix)]
             daita_v2: enable_daita.then(|| proto::DaitaRequestV2 {
                 level: i32::from(proto::DaitaLevel::LevelDefault),
                 platform: i32::from(get_platform()),
@@ -204,29 +194,21 @@ pub async fn request_ephemeral_peer_with(
         None
     };
 
-    #[cfg(unix)]
-    {
-        let daita = response.daita.map(|daita| DaitaSettings {
-            client_machines: daita.client_machines,
-            max_padding_frac: daita.max_padding_frac,
-            max_blocking_frac: daita.max_blocking_frac,
-        });
-        if daita.is_none() && enable_daita {
-            return Err(Error::MissingDaitaResponse);
-        }
-        Ok(EphemeralPeer { psk, daita })
+    let daita = response.daita.map(|daita| DaitaSettings {
+        client_machines: daita.client_machines,
+        max_padding_frac: daita.max_padding_frac,
+        max_blocking_frac: daita.max_blocking_frac,
+    });
+    if daita.is_none() && enable_daita {
+        return Err(Error::MissingDaitaResponse);
     }
-
-    #[cfg(windows)]
-    {
-        Ok(EphemeralPeer { psk })
-    }
+    Ok(EphemeralPeer { psk, daita })
 }
 
-#[cfg(unix)]
 const fn get_platform() -> proto::DaitaPlatform {
     use proto::DaitaPlatform;
     const PLATFORM: DaitaPlatform = if cfg!(target_os = "windows") {
+        // FIXME: wggo
         DaitaPlatform::WindowsNative
     } else if cfg!(target_os = "linux") {
         DaitaPlatform::LinuxWgGo

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -213,7 +213,7 @@ const fn get_platform() -> proto::DaitaPlatform {
     use proto::DaitaPlatform;
     const PLATFORM: DaitaPlatform = if cfg!(target_os = "windows") {
         // FIXME: wggo
-        DaitaPlatform::WindowsNative
+        DaitaPlatform::LinuxWgGo
     } else if cfg!(target_os = "linux") {
         DaitaPlatform::LinuxWgGo
     } else if cfg!(target_os = "macos") {

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -140,10 +140,14 @@ pub async fn request_ephemeral_peer_with(
             wg_ephemeral_peer_pubkey: ephemeral_pubkey.as_bytes().to_vec(),
             post_quantum: pq_request,
             daita: None,
-            daita_v2: enable_daita.then(|| proto::DaitaRequestV2 {
-                level: i32::from(proto::DaitaLevel::LevelDefault),
-                platform: i32::from(get_platform()),
-                version: DAITA_VERSION,
+            daita_v2: enable_daita.then(|| {
+                let platform = get_platform();
+                log::trace!("DAITA v2 platform: {platform:?}");
+                proto::DaitaRequestV2 {
+                    level: i32::from(proto::DaitaLevel::LevelDefault),
+                    platform: i32::from(platform),
+                    version: DAITA_VERSION,
+                }
             }),
         })
         .await

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -30,8 +30,6 @@ tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 rand = "0.8.5"
 surge-ping = "0.8.0"
 rand_chacha = "0.3.1"
-
-[target.'cfg(not(windows))'.dependencies]
 wireguard-go-rs = { path = "../wireguard-go-rs"}
 
 [target.'cfg(target_os="android")'.dependencies]

--- a/talpid-wireguard/build.rs
+++ b/talpid-wireguard/build.rs
@@ -6,11 +6,10 @@ fn main() {
     if target_os == "windows" {
         declare_libs_dir("../dist-assets/binaries");
     }
-    // Wireguard-Go can be used on all platforms except Windows
+    // Wireguard-Go can be used on all platforms
     println!("cargo::rustc-check-cfg=cfg(wireguard_go)");
-    if matches!(target_os.as_str(), "linux" | "macos" | "android") {
-        println!("cargo::rustc-cfg=wireguard_go");
-    }
+    println!("cargo::rustc-cfg=wireguard_go");
+
     // Enable DAITA by default on desktop and android
     println!("cargo::rustc-check-cfg=cfg(daita)");
     println!("cargo::rustc-cfg=daita");

--- a/talpid-wireguard/src/connectivity/mock.rs
+++ b/talpid-wireguard/src/connectivity/mock.rs
@@ -121,7 +121,7 @@ impl Tunnel for MockTunnel {
     #[cfg(daita)]
     fn start_daita(
         &mut self,
-        #[cfg(not(target_os = "windows"))] _: talpid_tunnel_config_client::DaitaSettings,
+        _: talpid_tunnel_config_client::DaitaSettings,
     ) -> std::result::Result<(), TunnelError> {
         Ok(())
     }

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -148,7 +148,6 @@ async fn config_ephemeral_peers_inner(
     }
 
     config.exit_peer_mut().psk = exit_ephemeral_peer.psk;
-    #[cfg(daita)]
     if config.daita {
         log::trace!("Enabling constant packet size for entry peer");
         config.entry_peer.constant_packet_size = true;
@@ -166,7 +165,6 @@ async fn config_ephemeral_peers_inner(
     )
     .await?;
 
-    #[cfg(daita)]
     if config.daita {
         let Some(daita) = daita else {
             unreachable!("missing DAITA settings");

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -110,7 +110,6 @@ async fn config_ephemeral_peers_inner(
     )
     .await?;
 
-    #[cfg(not(target_os = "windows"))]
     let mut daita = exit_ephemeral_peer.daita;
 
     log::debug!("Retrieved ephemeral peer");
@@ -169,7 +168,6 @@ async fn config_ephemeral_peers_inner(
 
     #[cfg(daita)]
     if config.daita {
-        #[cfg(not(target_os = "windows"))]
         let Some(daita) = daita
         else {
             unreachable!("missing DAITA settings");
@@ -178,15 +176,8 @@ async fn config_ephemeral_peers_inner(
         // Start local DAITA machines
         let mut tunnel = tunnel.lock().await;
         if let Some(tunnel) = tunnel.as_mut() {
-            #[cfg(not(target_os = "windows"))]
             tunnel
                 .start_daita(daita)
-                .map_err(Error::TunnelError)
-                .map_err(CloseMsg::SetupError)?;
-
-            #[cfg(target_os = "windows")]
-            tunnel
-                .start_daita()
                 .map_err(Error::TunnelError)
                 .map_err(CloseMsg::SetupError)?;
         }

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -168,8 +168,7 @@ async fn config_ephemeral_peers_inner(
 
     #[cfg(daita)]
     if config.daita {
-        let Some(daita) = daita
-        else {
+        let Some(daita) = daita else {
             unreachable!("missing DAITA settings");
         };
 

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -145,10 +145,7 @@ async fn config_ephemeral_peers_inner(
         log::debug!("Successfully exchanged PSK with entry peer");
 
         config.entry_peer.psk = entry_ephemeral_peer.psk;
-        #[cfg(not(target_os = "windows"))]
-        {
-            daita = entry_ephemeral_peer.daita;
-        }
+        daita = entry_ephemeral_peer.daita;
     }
 
     config.exit_peer_mut().psk = exit_ephemeral_peer.psk;

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     pin::Pin,
     sync::{mpsc as sync_mpsc, Arc, Mutex},
 };
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use std::{env, sync::LazyLock};
 #[cfg(not(target_os = "android"))]
 use talpid_routing::{self, RequiredRoute};
@@ -149,7 +149,7 @@ pub struct WireguardMonitor {
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 /// Overrides the preference for the kernel module for WireGuard.
 static FORCE_USERSPACE_WIREGUARD: LazyLock<bool> = LazyLock::new(|| {
     env::var("TALPID_FORCE_USERSPACE_WIREGUARD")
@@ -693,7 +693,7 @@ impl WireguardMonitor {
         {
             #[cfg(wireguard_go)]
             {
-                let use_userspace_wg = config.daita;
+                let use_userspace_wg = config.daita || *FORCE_USERSPACE_WIREGUARD;
                 if use_userspace_wg {
                     log::debug!("Using userspace WireGuard implementation");
                     let tunnel = runtime

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -697,14 +697,15 @@ impl WireguardMonitor {
                 let use_userspace_wg = config.daita;
                 if use_userspace_wg {
                     log::debug!("Using userspace WireGuard implementation");
-                    let tunnel = runtime.block_on(Self::open_wireguard_go_tunnel(
-                        runtime,
-                        config,
-                        log_path,
-                        setup_done_tx,
-                        route_manager,
-                    ))
-                    .map(Box::new)?;
+                    let tunnel = runtime
+                        .block_on(Self::open_wireguard_go_tunnel(
+                            runtime,
+                            config,
+                            log_path,
+                            setup_done_tx,
+                            route_manager,
+                        ))
+                        .map(Box::new)?;
                     return Ok(tunnel);
                 }
             }
@@ -755,8 +756,9 @@ impl WireguardMonitor {
             .map_err(Error::TunnelError)?;
 
         #[cfg(target_os = "windows")]
-        let tunnel = WgGoTunnel::start_tunnel(runtime, config, log_path, route_manager, setup_done_tx)
-            .map_err(Error::TunnelError)?;
+        let tunnel =
+            WgGoTunnel::start_tunnel(runtime, config, log_path, route_manager, setup_done_tx)
+                .map_err(Error::TunnelError)?;
 
         // Android uses multihop implemented in Mullvad's wireguard-go fork. When negotiating
         // with an ephemeral peer, this multihop strategy require us to restart the tunnel

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -299,7 +299,6 @@ impl WireguardMonitor {
                 let config = config.clone();
                 let iface_name = iface_name.clone();
                 tokio::task::spawn(async move {
-                    #[cfg(daita)]
                     if config.daita {
                         // TODO: For now, we assume the MTU during the tunnel lifetime.
                         // We could instead poke maybenot whenever we detect changes to it.
@@ -1039,7 +1038,6 @@ pub(crate) trait Tunnel: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = std::result::Result<(), TunnelError>> + Send + 'a>>;
     #[cfg(daita)]
     /// A [`Tunnel`] capable of using DAITA.
-    #[cfg(daita)]
     fn start_daita(&mut self, settings: DaitaSettings) -> std::result::Result<(), TunnelError>;
 }
 

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -692,6 +692,23 @@ impl WireguardMonitor {
 
         #[cfg(target_os = "windows")]
         {
+            #[cfg(wireguard_go)]
+            {
+                let use_userspace_wg = config.daita;
+                if use_userspace_wg {
+                    log::debug!("Using userspace WireGuard implementation");
+                    let tunnel = Self::open_wireguard_go_tunnel(
+                        runtime,
+                        config,
+                        log_path,
+                        setup_done_tx,
+                        route_manager,
+                    )
+                    .map(Box::new)?;
+                    return Ok(tunnel);
+                }
+            }
+
             wireguard_nt::WgNtTunnel::start_tunnel(config, log_path, resource_dir, setup_done_tx)
                 .map(|tun| Box::new(tun) as Box<dyn Tunnel + 'static>)
                 .map_err(Error::TunnelError)

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -28,7 +28,7 @@ use talpid_tunnel::{
     tun_provider::TunProvider, EventHook, TunnelArgs, TunnelEvent, TunnelMetadata,
 };
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(daita)]
 use talpid_tunnel_config_client::DaitaSettings;
 use talpid_types::{
     net::{wireguard::TunnelParameters, AllowedTunnelTraffic, Endpoint, TransportProtocol},
@@ -714,7 +714,7 @@ impl WireguardMonitor {
                 .map_err(Error::TunnelError)
         }
 
-        #[cfg(wireguard_go)]
+        #[cfg(all(wireguard_go, not(target_os = "windows")))]
         {
             #[cfg(target_os = "linux")]
             log::debug!("Using userspace WireGuard implementation");
@@ -738,23 +738,23 @@ impl WireguardMonitor {
     async fn open_wireguard_go_tunnel(
         config: &Config,
         log_path: Option<&Path>,
-        tun_provider: Arc<Mutex<TunProvider>>,
+        #[cfg(unix)] tun_provider: Arc<Mutex<TunProvider>>,
+        #[cfg(windows)] setup_done_tx: mpsc::Sender<std::result::Result<(), BoxedError>>,
         #[cfg(target_os = "android")] gateway_only: bool,
         #[cfg(target_os = "android")] cancel_receiver: connectivity::CancelReceiver,
     ) -> Result<WgGoTunnel> {
+        #[cfg(unix)]
         let routes = config
             .get_tunnel_destinations()
             .flat_map(Self::replace_default_prefixes);
 
-        #[cfg(not(target_os = "android"))]
-        let tunnel = WgGoTunnel::start_tunnel(
-            #[allow(clippy::needless_borrow)]
-            &config,
-            log_path,
-            tun_provider,
-            routes,
-        )
-        .map_err(Error::TunnelError)?;
+        #[cfg(all(unix, not(target_os = "android")))]
+        let tunnel = WgGoTunnel::start_tunnel(config, log_path, tun_provider, routes)
+            .map_err(Error::TunnelError)?;
+
+        #[cfg(target_os = "windows")]
+        let tunnel = WgGoTunnel::start_tunnel(config, log_path, setup_done_tx)
+            .map_err(Error::TunnelError)?;
 
         // Android uses multihop implemented in Mullvad's wireguard-go fork. When negotiating
         // with an ephemeral peer, this multihop strategy require us to restart the tunnel
@@ -1035,10 +1035,8 @@ pub(crate) trait Tunnel: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = std::result::Result<(), TunnelError>> + Send + 'a>>;
     #[cfg(daita)]
     /// A [`Tunnel`] capable of using DAITA.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(daita)]
     fn start_daita(&mut self, settings: DaitaSettings) -> std::result::Result<(), TunnelError>;
-    #[cfg(target_os = "windows")]
-    fn start_daita(&mut self) -> std::result::Result<(), TunnelError>;
 }
 
 /// Errors to be returned from WireGuard implementations, namely implementers of the Tunnel trait

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -698,7 +698,6 @@ impl WireguardMonitor {
                     log::debug!("Using userspace WireGuard implementation");
                     let tunnel = runtime
                         .block_on(Self::open_wireguard_go_tunnel(
-                            runtime,
                             config,
                             log_path,
                             setup_done_tx,
@@ -736,7 +735,6 @@ impl WireguardMonitor {
     #[cfg(wireguard_go)]
     #[allow(clippy::unused_async)]
     async fn open_wireguard_go_tunnel(
-        #[cfg(windows)] runtime: tokio::runtime::Handle,
         config: &Config,
         log_path: Option<&Path>,
         #[cfg(unix)] tun_provider: Arc<Mutex<TunProvider>>,
@@ -755,9 +753,9 @@ impl WireguardMonitor {
             .map_err(Error::TunnelError)?;
 
         #[cfg(target_os = "windows")]
-        let tunnel =
-            WgGoTunnel::start_tunnel(runtime, config, log_path, route_manager, setup_done_tx)
-                .map_err(Error::TunnelError)?;
+        let tunnel = WgGoTunnel::start_tunnel(config, log_path, route_manager, setup_done_tx)
+            .await
+            .map_err(Error::TunnelError)?;
 
         // Android uses multihop implemented in Mullvad's wireguard-go fork. When negotiating
         // with an ephemeral peer, this multihop strategy require us to restart the tunnel

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -9,15 +9,18 @@ use crate::config::MULLVAD_INTERFACE_NAME;
 #[cfg(target_os = "android")]
 use crate::connectivity;
 use crate::logging::{clean_up_logging, initialize_logging};
+#[cfg(unix)]
 use ipnetwork::IpNetwork;
 #[cfg(daita)]
 use std::ffi::CString;
+#[cfg(unix)]
+use std::sync::{Arc, Mutex};
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::{
     future::Future,
-    os::unix::io::{AsRawFd, RawFd},
     path::{Path, PathBuf},
     pin::Pin,
-    sync::{Arc, Mutex},
 };
 #[cfg(target_os = "android")]
 use talpid_tunnel::tun_provider::Error as TunProviderError;
@@ -27,6 +30,7 @@ use talpid_tunnel_config_client::DaitaSettings;
 use talpid_types::net::wireguard::PeerConfig;
 use talpid_types::BoxedError;
 
+#[cfg(unix)]
 const MAX_PREPARE_TUN_ATTEMPTS: usize = 4;
 
 /// Maximum number of events that can be stored in the underlying buffer

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -221,7 +221,7 @@ impl WgGoTunnelState {
 }
 
 impl WgGoTunnel {
-    #[cfg(all(not(target_os = "android"), unix))]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn start_tunnel(
         config: &Config,
         log_path: Option<&Path>,

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -24,7 +24,9 @@ use std::{
 };
 #[cfg(target_os = "android")]
 use talpid_tunnel::tun_provider::Error as TunProviderError;
+#[cfg(not(target_os = "windows"))]
 use talpid_tunnel::tun_provider::{Tun, TunProvider};
+#[cfg(daita)]
 use talpid_tunnel_config_client::DaitaSettings;
 #[cfg(target_os = "android")]
 use talpid_types::net::wireguard::PeerConfig;
@@ -165,6 +167,7 @@ pub(crate) struct WgGoTunnelState {
     tunnel_handle: wireguard_go_rs::Tunnel,
     // holding on to the tunnel device and the log file ensures that the associated file handles
     // live long enough and get closed when the tunnel is stopped
+    #[cfg(unix)]
     _tunnel_device: Tun,
     // context that maps to fs::File instance and stores the file path, used with logging callback
     _logging_context: LoggingContext,
@@ -214,7 +217,7 @@ impl WgGoTunnelState {
 }
 
 impl WgGoTunnel {
-    #[cfg(not(target_os = "android"))]
+    #[cfg(all(not(target_os = "android"), unix))]
     pub fn start_tunnel(
         config: &Config,
         log_path: Option<&Path>,
@@ -252,6 +255,69 @@ impl WgGoTunnel {
         }))
     }
 
+    #[cfg(target_os = "windows")]
+    pub fn start_tunnel(
+        config: &Config,
+        log_path: Option<&Path>,
+        mut setup_done_tx: futures::channel::mpsc::Sender<std::result::Result<(), BoxedError>>,
+    ) -> Result<Self> {
+        use futures::SinkExt;
+        use talpid_types::ErrorExt;
+
+        let wg_config_str = config.to_userspace_format();
+        let logging_context = initialize_logging(log_path)
+            .map(|ordinal| LoggingContext::new(ordinal, log_path.map(Path::to_owned)))
+            .map_err(TunnelError::LoggingError)?;
+
+        // TODO: default route clalback
+
+        let handle = wireguard_go_rs::Tunnel::turn_on(
+            c"Mullvad",
+            config.mtu,
+            &wg_config_str,
+            Some(logging::wg_go_logging_callback),
+            logging_context.ordinal,
+        )
+        .map_err(|e| TunnelError::FatalStartWireguardError(Box::new(e)))?;
+
+        let has_ipv6 = config.ipv6_gateway.is_some();
+
+        let luid = handle.luid().to_owned();
+
+        let setup_task = async move {
+            log::debug!("Waiting for tunnel IP interfaces to arrive");
+            talpid_windows::net::wait_for_interfaces(luid, true, has_ipv6)
+                .await
+                .map_err(|e| BoxedError::new(TunnelError::SetupIpInterfaces(e)))?;
+            log::debug!("Waiting for tunnel IP interfaces: Done");
+
+            if let Err(error) = talpid_tunnel::network_interface::initialize_interfaces(luid, None)
+            {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Failed to set tunnel interface metric"),
+                );
+            }
+
+            Ok(())
+        };
+
+        tokio::spawn(async move {
+            let _ = setup_done_tx.send(setup_task.await).await;
+        });
+
+        let interface_name = handle.name();
+
+        Ok(WgGoTunnel(WgGoTunnelState {
+            interface_name: interface_name.to_owned(),
+            tunnel_handle: handle,
+            _logging_context: logging_context,
+            #[cfg(daita)]
+            config: config.clone(),
+        }))
+    }
+
+    #[cfg(unix)]
     fn get_tunnel(
         tun_provider: Arc<Mutex<TunProvider>>,
         config: &Config,

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -14,9 +14,9 @@ use ipnetwork::IpNetwork;
 #[cfg(daita)]
 use std::ffi::CString;
 #[cfg(unix)]
-use std::sync::{Arc, Mutex};
-#[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(unix)]
+use std::sync::{Arc, Mutex};
 use std::{
     future::Future,
     path::{Path, PathBuf},
@@ -275,13 +275,12 @@ impl WgGoTunnel {
             .map(|ordinal| LoggingContext::new(ordinal, log_path.map(Path::to_owned)))
             .map_err(TunnelError::LoggingError)?;
 
-        let socket_update_cb = runtime
-            .block_on(
-                route_manager.add_default_route_change_callback(Box::new(
+        let socket_update_cb =
+            runtime
+                .block_on(route_manager.add_default_route_change_callback(Box::new(
                     Self::default_route_changed_callback,
-                )),
-            )
-            .ok();
+                )))
+                .ok();
         if socket_update_cb.is_none() {
             log::warn!("Failed to register default route callback");
         }

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -337,37 +337,14 @@ impl WgGoTunnel {
     #[cfg(target_os = "windows")]
     fn default_route_changed_callback(
         event_type: talpid_routing::EventType<'_>,
-        address_family: talpid_windows::net::AddressFamily,
+        _family: talpid_windows::net::AddressFamily,
     ) {
         use talpid_routing::EventType::*;
-
-        let iface_idx: u32 = match event_type {
-            Updated(default_route) => {
-                let iface_luid = default_route.iface;
-                match talpid_windows::net::index_from_luid(&iface_luid) {
-                    Ok(idx) => idx,
-                    Err(err) => {
-                        log::error!(
-                            "Failed to convert interface LUID to interface index: {}",
-                            err,
-                        );
-                        return;
-                    },
-                }
-            }
-            // if there is no new default route, specify 0 as the interface index
-            Removed => 0,
+        match event_type {
+            // if there is no new default route, or if the route was removed, update the bind
+            Updated(_) | Removed => wireguard_go_rs::update_bind(),
             // ignore interface updates that don't affect the interface to use
-            UpdatedDetails(_) => return,
-        };
-
-        match address_family {
-            talpid_windows::net::AddressFamily::Ipv4 => {
-                wireguard_go_rs::rebind_tunnel_socket_v4(iface_idx);
-            }
-            talpid_windows::net::AddressFamily::Ipv6 => {
-                wireguard_go_rs::rebind_tunnel_socket_v6(iface_idx);
-            }
+            UpdatedDetails(_) => (),
         }
     }
 

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -548,15 +548,14 @@ impl Tunnel for WgGoTunnel {
     }
 
     async fn get_tunnel_stats(&self) -> Result<StatsMap> {
-        tokio::task::block_in_place(|| {
-            self.as_state()
-                .tunnel_handle
-                .get_config(|cstr| {
-                    Stats::parse_config_str(cstr.to_str().expect("Go strings are always UTF-8"))
-                })
-                .ok_or(TunnelError::GetConfigError)?
-                .map_err(|error| TunnelError::StatsError(BoxedError::new(error)))
-        })
+        // NOTE: wireguard-go might perform blocking I/O, but it's most likely not a problem
+        self.as_state()
+            .tunnel_handle
+            .get_config(|cstr| {
+                Stats::parse_config_str(cstr.to_str().expect("Go strings are always UTF-8"))
+            })
+            .ok_or(TunnelError::GetConfigError)?
+            .map_err(|error| TunnelError::StatsError(BoxedError::new(error)))
     }
 
     fn set_config(

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -1104,7 +1104,10 @@ impl Tunnel for WgNtTunnel {
     }
 
     #[cfg(daita)]
-    fn start_daita(&mut self, _: talpid_tunnel_config_client::DaitaSettings) -> std::result::Result<(), crate::TunnelError> {
+    fn start_daita(
+        &mut self,
+        _: talpid_tunnel_config_client::DaitaSettings,
+    ) -> std::result::Result<(), crate::TunnelError> {
         self.spawn_machinist().map_err(|error| {
             log::error!(
                 "{}",

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -1104,7 +1104,7 @@ impl Tunnel for WgNtTunnel {
     }
 
     #[cfg(daita)]
-    fn start_daita(&mut self) -> std::result::Result<(), crate::TunnelError> {
+    fn start_daita(&mut self, _: talpid_tunnel_config_client::DaitaSettings) -> std::result::Result<(), crate::TunnelError> {
         self.spawn_machinist().map_err(|error| {
             log::error!(
                 "{}",

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -20,4 +20,4 @@ zeroize = "1.8.1"
 maybenot-ffi = "2.0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.52.0", features = ["Win32_NetworkManagement_Ndis"] }
+windows-sys = { version = "0.52.0", features = ["Win32_Networking", "Win32_NetworkManagement", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock"] }

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -16,6 +16,7 @@ zeroize = "1.8.1"
 # This is done, instead of using the makefile in wireguard-go to build maybenot-ffi into its archive, to prevent
 # name clashes induced by link-time optimization.
 # NOTE: the version of maybenot-ffi below must be the same as the version checked into the wireguard-go submodule
+[target.'cfg(unix)'.dependencies]
 maybenot-ffi = "2.0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -16,7 +16,7 @@ zeroize = "1.8.1"
 # This is done, instead of using the makefile in wireguard-go to build maybenot-ffi into its archive, to prevent
 # name clashes induced by link-time optimization.
 # NOTE: the version of maybenot-ffi below must be the same as the version checked into the wireguard-go submodule
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 maybenot-ffi = "2.0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -7,14 +7,16 @@ license.workspace = true
 [build-dependencies]
 anyhow = "1.0"
 
-[target.'cfg(unix)'.dependencies]
+[dependencies]
 thiserror.workspace = true
 log.workspace = true
 zeroize = "1.8.1"
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
 # The app does not depend on maybenot-ffi itself, but adds it as a dependency to expose FFI symbols to wireguard-go.
 # This is done, instead of using the makefile in wireguard-go to build maybenot-ffi into its archive, to prevent
 # name clashes induced by link-time optimization.
 # NOTE: the version of maybenot-ffi below must be the same as the version checked into the wireguard-go submodule
 maybenot-ffi = "2.0.1"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.52.0", features = ["Win32_NetworkManagement_Ndis"] }

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -278,9 +278,10 @@ fn find_lib_exe() -> anyhow::Result<PathBuf> {
     // Find lib.exe relative to msbuild.exe, in ../../../../ relative to msbuild
     let search_path = msbuild_exe
         .ancestors()
-        .nth(3)
+        .nth(4)
         .context("Unexpected msbuild.exe path")?;
 
+    // TODO: Make this arch agnostic (host AND target)
     let path_is_lib_exe = |file: &Path| file.ends_with("Hostx64/x64/lib.exe");
 
     find_file(search_path, &path_is_lib_exe)?.context("No lib.exe relative to msbuild.exe")

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -266,9 +266,9 @@ fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
         ("maybenot_ffi.dll", "maybenot_ffi.dll"),
         ("maybenot_ffi.dll.lib", "maybenot.lib"),
     ] {
+        let src = artifacts_dir.join(src_filename);
         let dest = out_dir.as_ref().join(dest_filename);
-        fs::copy(artifacts_dir.join(src_filename), &dest)
-            .with_context(|| format!("Failed to copy {src_filename}"))?;
+        fs::copy(&src, &dest).with_context(|| format!("Failed to copy {src_filename}",))?;
     }
 
     Ok(())

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -79,14 +79,15 @@ const fn host_os() -> Os {
     HOST
 }
 
-fn host_arch() -> anyhow::Result<Arch> {
-    if cfg!(target_arch = "x86_64") {
-        Ok(Arch::Amd64)
+const fn host_arch() -> Arch {
+    const ARCH: Arch = if cfg!(target_arch = "x86_64") {
+        Arch::Amd64
     } else if cfg!(target_arch = "aarch64") {
-        Ok(Arch::Arm64)
+        Arch::Arm64
     } else {
-        bail!("Unsupported host architecture")
-    }
+        panic!("Unsupported host architecture")
+    };
+    ARCH
 }
 
 /// Compile libwg as a library and place it in `OUT_DIR`.
@@ -105,7 +106,7 @@ fn build_desktop_lib(target_os: Os) -> anyhow::Result<()> {
     go_build.env("CGO_ENABLED", "1").current_dir("./libwg");
 
     // are we cross compiling?
-    let cross_compiling = host_os() != target_os || host_arch()? != target_arch;
+    let cross_compiling = host_os() != target_os || host_arch() != target_arch;
 
     match target_arch {
         Arch::Amd64 => go_build.env("GOARCH", "amd64"),

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -255,6 +255,7 @@ fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
         // Set temporary target dir to prevent deadlock
         .env("CARGO_TARGET_DIR", &tmp_build_dir)
         .arg("build")
+        .args(["--profile", &profile])
         .args(["--target", &target_triple]);
 
     exec(build_command)?;

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -153,6 +153,8 @@ fn build_desktop_lib(target_os: Os) -> anyhow::Result<()> {
                     go_build.env("CC", "zig cc -target aarch64-windows");
                 }
             }
+
+            go_build.env("CGO_LDFLAGS", format!("-L{}", target_dir.to_str().unwrap()));
         }
         Os::Linux => {
             let out_file = format!("{out_dir}/libwg.a");
@@ -252,12 +254,12 @@ fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
     let artifacts_dir = tmp_build_dir.join(target_triple).join(profile);
 
     // Copy library to actual target dir
-    for filename in ["maybenot_ffi.dll", "maybenot_ffi.lib"] {
-        fs::copy(
-            artifacts_dir.join(filename),
-            out_dir.as_ref().join(filename),
-        )
-        .with_context(|| format!("Failed to copy {filename}"))?;
+    for (src, dest) in [
+        ("maybenot_ffi.dll", "maybenot.dll"),
+        ("maybenot_ffi.dll.lib", "maybenot.lib"),
+    ] {
+        fs::copy(artifacts_dir.join(src), out_dir.as_ref().join(dest))
+            .with_context(|| format!("Failed to copy {src}"))?;
     }
 
     Ok(())

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -233,7 +233,11 @@ fn build_desktop_lib(target_os: Os) -> anyhow::Result<()> {
 // Build dynamically library for maybenot
 fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
     let target_triple = env::var("TARGET").context("Missing 'TARGET'")?;
-    let profile = env::var("PROFILE").context("Missing 'PROFILE'")?;
+    let profile_category = env::var("PROFILE").context("Missing 'PROFILE'")?;
+    let profile = match profile_category.as_str() {
+        "release" => "release",
+        _ => "dev",
+    };
 
     let mut build_command = Command::new("cargo");
 
@@ -255,12 +259,12 @@ fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
         // Set temporary target dir to prevent deadlock
         .env("CARGO_TARGET_DIR", &tmp_build_dir)
         .arg("build")
-        .args(["--profile", &profile])
+        .args(["--profile", profile])
         .args(["--target", &target_triple]);
 
     exec(build_command)?;
 
-    let artifacts_dir = tmp_build_dir.join(target_triple).join(profile);
+    let artifacts_dir = tmp_build_dir.join(target_triple).join(profile_category);
 
     // Copy library to desired target dir
     for (src_filename, dest_filename) in [

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -294,7 +294,6 @@ fn find_file(
         let path = entry.path();
         if path.is_dir() {
             if let Some(result) = find_file(&path, condition)? {
-                // TODO: distinguish between err and no result
                 return Ok(Some(result));
             }
         }
@@ -313,7 +312,7 @@ fn find_msbuild_exe() -> anyhow::Result<PathBuf> {
         .context("msbuild.exe not found in PATH")
 }
 
-/// Generate exports.def from wireguard-go source
+/// Generate lib from export
 fn generate_lib_from_exports_def(arch: Arch, exports_path: impl AsRef<Path>) -> anyhow::Result<()> {
     let lib_path = exports_path
         .as_ref()

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -263,7 +263,7 @@ fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
 
     // Copy library to desired target dir
     for (src_filename, dest_filename) in [
-        ("maybenot_ffi.dll", "maybenot.dll"),
+        ("maybenot_ffi.dll", "maybenot_ffi.dll"),
         ("maybenot_ffi.dll.lib", "maybenot.lib"),
     ] {
         let dest = out_dir.as_ref().join(dest_filename);

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -233,8 +233,8 @@ fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
 
     // Strip \\?\ prefix. Note that doing this directly on Path/PathBuf fails
     let path_str = tmp_build_dir.to_str().unwrap();
-    if path_str.starts_with(r"\\?\") {
-        tmp_build_dir = PathBuf::from(&path_str[4..]);
+    if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+        tmp_build_dir = PathBuf::from(stripped);
     }
 
     tmp_build_dir = tmp_build_dir.join("target");

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -64,18 +64,19 @@ impl AndroidTarget {
     }
 }
 
-fn host_os() -> anyhow::Result<Os> {
+const fn host_os() -> Os {
     // this ugliness is a limitation of rust, where we can't directly
     // access the target triple of the build script.
-    if cfg!(target_os = "windows") {
-        Ok(Os::Windows)
+    const HOST: Os = if cfg!(target_os = "windows") {
+        Os::Windows
     } else if cfg!(target_os = "linux") {
-        Ok(Os::Linux)
+        Os::Linux
     } else if cfg!(target_os = "macos") {
-        Ok(Os::Macos)
+        Os::Macos
     } else {
-        bail!("Unsupported host OS")
-    }
+        panic!("Unsupported host OS")
+    };
+    HOST
 }
 
 fn host_arch() -> anyhow::Result<Arch> {
@@ -104,7 +105,7 @@ fn build_desktop_lib(target_os: Os) -> anyhow::Result<()> {
     go_build.env("CGO_ENABLED", "1").current_dir("./libwg");
 
     // are we cross compiling?
-    let cross_compiling = host_os()? != target_os || host_arch()? != target_arch;
+    let cross_compiling = host_os() != target_os || host_arch()? != target_arch;
 
     match target_arch {
         Arch::Amd64 => go_build.env("GOARCH", "amd64"),

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -20,10 +20,10 @@ fn main() -> anyhow::Result<()> {
     println!("cargo::rerun-if-changed=libwg");
 
     match target_os.as_str() {
-        "windows" => build_desktop_lib(Os::Windows, true)?,
-        "linux" => build_desktop_lib(Os::Linux, true)?,
-        "macos" => build_desktop_lib(Os::Macos, true)?,
-        "android" => build_android_dynamic_lib(true)?,
+        "windows" => build_desktop_lib(Os::Windows)?,
+        "linux" => build_desktop_lib(Os::Linux)?,
+        "macos" => build_desktop_lib(Os::Macos)?,
+        "android" => build_android_dynamic_lib()?,
         _ => {}
     }
 
@@ -33,7 +33,7 @@ fn main() -> anyhow::Result<()> {
 #[derive(PartialEq, Eq, Clone, Copy)]
 enum Os {
     Windows,
-    MacOs,
+    Macos,
     Linux,
 }
 
@@ -89,7 +89,7 @@ fn host_arch() -> anyhow::Result<Arch> {
 }
 
 /// Compile libwg as a library and place it in `OUT_DIR`.
-fn build_desktop_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
+fn build_desktop_lib(target_os: Os) -> anyhow::Result<()> {
     let out_dir = env::var("OUT_DIR").context("Missing OUT_DIR")?;
     let target_arch =
         env::var("CARGO_CFG_TARGET_ARCH").context("Missing 'CARGO_CFG_TARGET_ARCH")?;
@@ -118,9 +118,8 @@ fn build_desktop_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
                 .nth(3)
                 .context("Failed to find target dir")?;
 
-            if daita {
-                build_shared_maybenot_lib(target_dir).context("Failed to build maybenot")?;
-            }
+            // building maybenot is required for DAITA - wireguard-go will link to it at runtime.
+            build_shared_maybenot_lib(target_dir).context("Failed to build maybenot")?;
 
             let dll_path = target_dir.join("libwg.dll");
 
@@ -134,7 +133,7 @@ fn build_desktop_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
                 .args(["build", "-v"])
                 .arg("-o")
                 .arg(&dll_path)
-                .args(if daita { &["--tags", "daita"][..] } else { &[] });
+                .args(["--tags", "daita"]);
             // Build dynamic lib
             go_build.args(["-buildmode", "c-shared"]);
 
@@ -159,7 +158,7 @@ fn build_desktop_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
             let out_file = format!("{out_dir}/libwg.a");
             go_build
                 .args(["build", "-v", "-o", &out_file])
-                .args(if daita { &["--tags", "daita"][..] } else { &[] });
+                .args(["--tags", "daita"]);
 
             // Build static lib
             go_build.args(["-buildmode", "c-archive"]);
@@ -181,7 +180,7 @@ fn build_desktop_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
             let out_file = format!("{out_dir}/libwg.a");
             go_build
                 .args(["build", "-v", "-o", &out_file])
-                .args(if daita { &["--tags", "daita"][..] } else { &[] });
+                .args(["--tags", "daita"]);
 
             // Build static lib
             go_build.args(["-buildmode", "c-archive"]);
@@ -215,10 +214,8 @@ fn build_desktop_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
 
     exec(go_build)?;
 
-    // if daita is enabled, also enable the corresponding rust feature flag
-    if daita {
-        println!(r#"cargo::rustc-cfg=daita"#);
-    }
+    // Enable the DAITA (rust) feature flag
+    println!(r#"cargo::rustc-cfg=daita"#);
 
     Ok(())
 }
@@ -400,7 +397,7 @@ fn gather_exports(go_src_path: impl AsRef<Path>) -> anyhow::Result<Vec<String>> 
 
 /// Compile libwg as a dynamic library for android and place it in [`android_output_path`].
 // NOTE: We use dynamic linking as Go cannot produce static binaries specifically for Android.
-fn build_android_dynamic_lib(daita: bool) -> anyhow::Result<()> {
+fn build_android_dynamic_lib() -> anyhow::Result<()> {
     let out_dir = env::var("OUT_DIR").context("Missing OUT_DIR")?;
     let target_triple = env::var("TARGET").context("Missing 'TARGET'")?;
     let target = AndroidTarget::from_str(&target_triple)?;
@@ -451,10 +448,8 @@ fn build_android_dynamic_lib(daita: bool) -> anyhow::Result<()> {
     println!("cargo::rustc-link-search={}", android_output_path.display());
     println!("cargo::rustc-link-lib=dylib=wg");
 
-    // If daita is enabled, also enable the corresponding rust feature flag
-    if daita {
-        println!(r#"cargo::rustc-cfg=daita"#);
-    }
+    // Enable the DAITA (rust) feature flag
+    println!(r#"cargo::rustc-cfg=daita"#);
 
     Ok(())
 }

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -1,6 +1,8 @@
 use std::{
     borrow::BorrowMut,
     env,
+    fs::{self, File},
+    io::{BufRead, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
     process::Command,
     str,
@@ -18,23 +20,24 @@ fn main() -> anyhow::Result<()> {
     println!("cargo::rerun-if-changed=libwg");
 
     match target_os.as_str() {
-        "linux" => build_static_lib(Os::Linux, true)?,
-        "macos" => build_static_lib(Os::Macos, true)?,
+        "windows" => build_desktop_lib(Os::Windows, true)?,
+        "linux" => build_desktop_lib(Os::Linux, true)?,
+        "macos" => build_desktop_lib(Os::Macos, true)?,
         "android" => build_android_dynamic_lib(true)?,
-        // building wireguard-go-rs for windows is not implemented
         _ => {}
     }
 
     Ok(())
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 enum Os {
-    Macos,
+    Windows,
+    MacOs,
     Linux,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 enum Arch {
     Amd64,
     Arm64,
@@ -64,7 +67,9 @@ impl AndroidTarget {
 fn host_os() -> anyhow::Result<Os> {
     // this ugliness is a limitation of rust, where we can't directly
     // access the target triple of the build script.
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "windows") {
+        Ok(Os::Windows)
+    } else if cfg!(target_os = "linux") {
         Ok(Os::Linux)
     } else if cfg!(target_os = "macos") {
         Ok(Os::Macos)
@@ -83,8 +88,8 @@ fn host_arch() -> anyhow::Result<Arch> {
     }
 }
 
-/// Compile libwg as a static library and place it in `OUT_DIR`.
-fn build_static_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
+/// Compile libwg as a library and place it in `OUT_DIR`.
+fn build_desktop_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
     let out_dir = env::var("OUT_DIR").context("Missing OUT_DIR")?;
     let target_arch =
         env::var("CARGO_CFG_TARGET_ARCH").context("Missing 'CARGO_CFG_TARGET_ARCH")?;
@@ -95,14 +100,8 @@ fn build_static_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
         _ => bail!("Unsupported architecture: {target_arch}"),
     };
 
-    let out_file = format!("{out_dir}/libwg.a");
     let mut go_build = Command::new("go");
-    go_build
-        .args(["build", "-v", "-o", &out_file])
-        .args(["-buildmode", "c-archive"])
-        .args(if daita { &["--tags", "daita"][..] } else { &[] })
-        .env("CGO_ENABLED", "1")
-        .current_dir("./libwg");
+    go_build.env("CGO_ENABLED", "1").current_dir("./libwg");
 
     // are we cross compiling?
     let cross_compiling = host_os()? != target_os || host_arch()? != target_arch;
@@ -113,7 +112,58 @@ fn build_static_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
     };
 
     match target_os {
+        Os::Windows => {
+            let target_dir = Path::new(&out_dir)
+                .ancestors()
+                .nth(3)
+                .context("Failed to find target dir")?;
+
+            if daita {
+                build_shared_maybenot_lib(target_dir).context("Failed to build maybenot")?;
+            }
+
+            let dll_path = target_dir.join("libwg.dll");
+
+            println!("cargo::rerun-if-changed={}", dll_path.display());
+            println!(
+                "cargo::rerun-if-changed={}",
+                target_dir.join("libwg.lib").display()
+            );
+
+            go_build
+                .args(["build", "-v"])
+                .arg("-o")
+                .arg(&dll_path)
+                .args(if daita { &["--tags", "daita"][..] } else { &[] });
+            // Build dynamic lib
+            go_build.args(["-buildmode", "c-shared"]);
+
+            go_build.env("GOOS", "windows");
+
+            generate_windows_lib(target_arch, target_dir)?;
+
+            println!("cargo::rustc-link-search={}", target_dir.to_str().unwrap());
+            println!("cargo::rustc-link-lib=dylib=libwg");
+
+            // Build using zig
+            match target_arch {
+                Arch::Amd64 => {
+                    go_build.env("CC", "zig cc -target x86_64-windows");
+                }
+                Arch::Arm64 => {
+                    go_build.env("CC", "zig cc -target aarch64-windows");
+                }
+            }
+        }
         Os::Linux => {
+            let out_file = format!("{out_dir}/libwg.a");
+            go_build
+                .args(["build", "-v", "-o", &out_file])
+                .args(if daita { &["--tags", "daita"][..] } else { &[] });
+
+            // Build static lib
+            go_build.args(["-buildmode", "c-archive"]);
+
             go_build.env("GOOS", "linux");
 
             if cross_compiling {
@@ -122,8 +172,20 @@ fn build_static_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
                     Arch::Amd64 => bail!("cross-compiling to linux x86_64 is not implemented"),
                 };
             }
+
+            // make sure to link to the resulting binary
+            println!("cargo::rustc-link-search={out_dir}");
+            println!("cargo::rustc-link-lib=static=wg");
         }
         Os::Macos => {
+            let out_file = format!("{out_dir}/libwg.a");
+            go_build
+                .args(["build", "-v", "-o", &out_file])
+                .args(if daita { &["--tags", "daita"][..] } else { &[] });
+
+            // Build static lib
+            go_build.args(["-buildmode", "c-archive"]);
+
             go_build.env("GOOS", "darwin");
 
             if cross_compiling {
@@ -144,14 +206,14 @@ fn build_static_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
                 go_build.env("CGO_LDFLAGS", format!("-isysroot {sdkroot} -arch {c_arch}"));
                 go_build.env("LD_LIBRARY_PATH", format!("{sdkroot}/usr/lib"));
             }
+
+            // make sure to link to the resulting binary
+            println!("cargo::rustc-link-search={out_dir}");
+            println!("cargo::rustc-link-lib=static=wg");
         }
     }
 
     exec(go_build)?;
-
-    // make sure to link to the resulting binary
-    println!("cargo::rustc-link-search={out_dir}");
-    println!("cargo::rustc-link-lib=static=wg");
 
     // if daita is enabled, also enable the corresponding rust feature flag
     if daita {
@@ -159,6 +221,181 @@ fn build_static_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+// Build dynamically library for maybenot
+fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
+    let target_triple = env::var("TARGET").context("Missing 'TARGET'")?;
+    let profile = env::var("PROFILE").context("Missing 'PROFILE'")?;
+
+    let mut build_command = Command::new("cargo");
+
+    std::fs::create_dir_all("../build")?;
+
+    let mut tmp_build_dir = Path::new("../build").canonicalize()?;
+
+    // Strip \\?\ prefix. Note that doing this directly on Path/PathBuf fails
+    let path_str = tmp_build_dir.to_str().unwrap();
+    if path_str.starts_with(r"\\?\") {
+        tmp_build_dir = PathBuf::from(&path_str[4..]);
+    }
+
+    tmp_build_dir = tmp_build_dir.join("target");
+
+    build_command
+        .current_dir("./libwg/wireguard-go/maybenot/crates/maybenot-ffi")
+        .env("RUSTFLAGS", "-C metadata=maybenot-ffi -Ctarget-feature=+crt-static")
+        // Set temporary target dir to prevent deadlock
+        .env("CARGO_TARGET_DIR", &tmp_build_dir)
+        .arg("build")
+        .args(["--target", &target_triple]);
+
+    exec(build_command)?;
+
+    let artifacts_dir = tmp_build_dir.join(target_triple).join(profile);
+
+    // Copy library to actual target dir
+    for filename in ["maybenot_ffi.dll", "maybenot_ffi.lib"] {
+        fs::copy(
+            artifacts_dir.join(filename),
+            out_dir.as_ref().join(filename),
+        )
+        .with_context(|| format!("Failed to copy {filename}"))?;
+    }
+
+    Ok(())
+}
+
+/// Generate a library for the exported functions. Required for linking.
+/// This requires `lib.exe` in the path.
+fn generate_windows_lib(arch: Arch, out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
+    let exports_def_path = out_dir.as_ref().join("exports.def");
+    generate_exports_def(&exports_def_path).context("Failed to generate exports.def")?;
+    generate_lib_from_exports_def(arch, &exports_def_path)
+        .context("Failed to generate lib from exports.def")
+}
+
+fn find_lib_exe() -> anyhow::Result<PathBuf> {
+    let msbuild_exe = find_msbuild_exe()?;
+
+    // Find lib.exe relative to msbuild.exe, in ../../../../ relative to msbuild
+    let search_path = msbuild_exe
+        .ancestors()
+        .nth(3)
+        .context("Unexpected msbuild.exe path")?;
+
+    let path_is_lib_exe = |file: &Path| file.ends_with("Hostx64/x64/lib.exe");
+
+    find_file(search_path, &path_is_lib_exe)?.context("No lib.exe relative to msbuild.exe")
+}
+
+/// Recursively search for file until 'condition' returns true
+fn find_file(
+    dir: impl AsRef<Path>,
+    condition: &impl Fn(&Path) -> bool,
+) -> anyhow::Result<Option<PathBuf>> {
+    for path in std::fs::read_dir(dir).context("Failed to read dir")? {
+        let entry = path.context("Failed to read dir entry")?;
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(result) = find_file(&path, condition)? {
+                // TODO: distinguish between err and no result
+                return Ok(Some(result));
+            }
+        }
+        if condition(&path) {
+            return Ok(Some(path.to_owned()));
+        }
+    }
+    Ok(None)
+}
+
+/// Find msbuild.exe in PATH
+fn find_msbuild_exe() -> anyhow::Result<PathBuf> {
+    let path = std::env::var_os("PATH").context("Missing PATH var")?;
+    std::env::split_paths(&path)
+        .find(|path| path.join("msbuild.exe").exists())
+        .context("msbuild.exe not found in PATH")
+}
+
+/// Generate exports.def from wireguard-go source
+fn generate_lib_from_exports_def(arch: Arch, exports_path: impl AsRef<Path>) -> anyhow::Result<()> {
+    let lib_path = exports_path
+        .as_ref()
+        .parent()
+        .context("Missing parent")?
+        .join("libwg.lib");
+    let path = exports_path.as_ref().to_str().context("Non-UTF8 path")?;
+
+    let lib_exe = find_lib_exe()?;
+
+    let mut lib_exe = Command::new(lib_exe);
+    lib_exe.args([
+        format!("/def:{path}"),
+        format!("/out:{}", lib_path.to_str().context("Non-UTF8 lib path")?),
+    ]);
+
+    match arch {
+        Arch::Amd64 => {
+            lib_exe.arg("/machine:X64");
+        }
+        Arch::Arm64 => {
+            lib_exe.arg("/machine:ARM64");
+        }
+    }
+
+    exec(lib_exe)?;
+
+    Ok(())
+}
+
+/// Generate exports.def from wireguard-go source
+fn generate_exports_def(exports_path: impl AsRef<Path>) -> anyhow::Result<()> {
+    let file = File::create(exports_path).context("Failed to create file")?;
+    let mut file = BufWriter::new(file);
+
+    writeln!(file, "LIBRARY libwg").context("Write LIBRARY statement")?;
+    writeln!(file, "EXPORTS").context("Write EXPORTS statement")?;
+
+    let mut libwg_exports = vec![];
+    for path in &[
+        "./libwg/libwg.go",
+        "./libwg/libwg_windows.go",
+        "./libwg/libwg_daita.go",
+    ] {
+        libwg_exports.extend(gather_exports(path).context("Failed to find exports")?);
+    }
+
+    for export in libwg_exports {
+        writeln!(file, "\t{export}").context("Failed to output exported function")?;
+    }
+
+    Ok(())
+}
+
+/// Return functions exported from .go file
+fn gather_exports(go_src_path: impl AsRef<Path>) -> anyhow::Result<Vec<String>> {
+    let go_src_path = go_src_path.as_ref();
+    let mut exports = vec![];
+    let file = File::open(go_src_path)
+        .with_context(|| format!("Failed to open go source: {}", go_src_path.display()))?;
+
+    for line in BufReader::new(file).lines() {
+        let line = line.context("Failed to read line in go src")?;
+        let mut words = line.split_whitespace();
+
+        // Is this an export?
+        let Some("//export") = words.next() else {
+            continue;
+        };
+
+        let exported_func = words
+            .next()
+            .with_context(|| format!("Invalid export on line: {line}"))?;
+        exports.push(exported_func.to_owned());
+    }
+
+    Ok(exports)
 }
 
 /// Compile libwg as a dynamic library for android and place it in [`android_output_path`].

--- a/wireguard-go-rs/libwg/README.md
+++ b/wireguard-go-rs/libwg/README.md
@@ -7,6 +7,7 @@ It currently offers support for the following platforms:
 - Linux
 - macOS
 - Android
+- Windows
 
 # Organization
 
@@ -15,6 +16,8 @@ It currently offers support for the following platforms:
 `libwg_default.go` has default implementations for Linux-based systems.
 
 `libwg_android.go` has code specifically for Android.
+
+`libwg_windows.go` has code specifically for Windows.
 
 # Usage
 

--- a/wireguard-go-rs/libwg/libwg.go
+++ b/wireguard-go-rs/libwg/libwg.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2025 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard-go-rs/libwg/libwg_android.go
+++ b/wireguard-go-rs/libwg/libwg_android.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2025 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard-go-rs/libwg/libwg_android.go
+++ b/wireguard-go-rs/libwg/libwg_android.go
@@ -1,3 +1,6 @@
+//go:build android
+// +build android
+
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.

--- a/wireguard-go-rs/libwg/libwg_daita.go
+++ b/wireguard-go-rs/libwg/libwg_daita.go
@@ -3,7 +3,7 @@
 
 /* SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (C) 2024 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2025 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard-go-rs/libwg/libwg_default.go
+++ b/wireguard-go-rs/libwg/libwg_default.go
@@ -5,7 +5,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2025 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard-go-rs/libwg/libwg_windows.go
+++ b/wireguard-go-rs/libwg/libwg_windows.go
@@ -8,6 +8,7 @@ package main
 
 // #include <stdlib.h>
 // #include <stdint.h>
+// #include <string.h>
 import "C"
 
 import (
@@ -31,11 +32,8 @@ type LogSink = unsafe.Pointer
 type LogContext = C.uint64_t
 
 //export wgTurnOn
-func wgTurnOn(cIfaceName *C.char, cIfaceNameOut **C.char, cLuidOut *C.uint64_t, mtu C.uint16_t, cSettings *C.char, logSink LogSink, logContext LogContext) C.int32_t {
+func wgTurnOn(cIfaceName *C.char, cIfaceNameOut *C.char, cIfaceNameOutSize C.size_t, cLuidOut *C.uint64_t, mtu C.uint16_t, cSettings *C.char, logSink LogSink, logContext LogContext) C.int32_t {
 	logger := logging.NewLogger(logSink, logging.LogContext(logContext))
-	if cIfaceNameOut != nil {
-		*cIfaceNameOut = nil
-	}
 
 	if cIfaceName == nil {
 		logger.Errorf("cIfaceName is null\n")
@@ -60,7 +58,7 @@ func wgTurnOn(cIfaceName *C.char, cIfaceNameOut **C.char, cLuidOut *C.uint64_t, 
 
 	tun.WintunTunnelType = "Mullvad"
 
-	wintun, err := tun.CreateTUNWithRequestedGUID(ifaceName, &networkId, mtu)
+	wintun, err := tun.CreateTUNWithRequestedGUID(ifaceName, &networkId, int(mtu))
 	if err != nil {
 		logger.Errorf("Failed to create tunnel\n")
 		logger.Errorf("%s\n", err)
@@ -106,10 +104,15 @@ func wgTurnOn(cIfaceName *C.char, cIfaceNameOut **C.char, cLuidOut *C.uint64_t, 
 	}
 
 	if cIfaceNameOut != nil {
-		*cIfaceNameOut = C.CString(actualInterfaceName)
+		if int(cIfaceNameOutSize) <= len(actualInterfaceName) {
+			logger.Errorf("Interface name buffer too small\n")
+			device.Close()
+			return ERROR_GENERAL_FAILURE
+		}
+		C.strcpy(cIfaceNameOut, C.CString(actualInterfaceName))
 	}
 	if cLuidOut != nil {
-		*cLuidOut = nativeTun.LUID()
+		*cLuidOut = C.uint64_t(nativeTun.LUID())
 	}
 
 	return C.int32_t(handle)

--- a/wireguard-go-rs/libwg/libwg_windows.go
+++ b/wireguard-go-rs/libwg/libwg_windows.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2024 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2025 Mullvad VPN AB. All Rights Reserved.
  */
 
 package main

--- a/wireguard-go-rs/libwg/libwg_windows.go
+++ b/wireguard-go-rs/libwg/libwg_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.

--- a/wireguard-go-rs/libwg/libwg_windows.go
+++ b/wireguard-go-rs/libwg/libwg_windows.go
@@ -118,24 +118,9 @@ func wgTurnOn(cIfaceName *C.char, cIfaceNameOut *C.char, cIfaceNameOutSize C.siz
 	return C.int32_t(handle)
 }
 
-//export wgRebindTunnelSocket
-func wgRebindTunnelSocket(family uint16, interfaceIndex uint32) {
+//export wgUpdateBind
+func wgUpdateBind() {
 	tunnels.ForEach(func(tunnel tunnelcontainer.Context) {
-		blackhole := (interfaceIndex == 0)
-		bind := tunnel.Device.Bind().(conn.BindSocketToInterface)
-
-		if family == windows.AF_INET {
-			tunnel.Logger.Verbosef("Binding v4 socket to interface %d (blackhole=%v)\n", interfaceIndex, blackhole)
-			err := bind.BindSocketToInterface4(interfaceIndex, blackhole)
-			if err != nil {
-				tunnel.Logger.Verbosef("%s\n", err)
-			}
-		} else if family == windows.AF_INET6 {
-			tunnel.Logger.Verbosef("Binding v6 socket to interface %d (blackhole=%v)\n", interfaceIndex, blackhole)
-			err := bind.BindSocketToInterface6(interfaceIndex, blackhole)
-			if err != nil {
-				tunnel.Logger.Verbosef("%s\n", err)
-			}
-		}
+		tunnel.Device.BindUpdate()
 	})
 }

--- a/wireguard-go-rs/libwg/libwg_windows.go
+++ b/wireguard-go-rs/libwg/libwg_windows.go
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ * Copyright (C) 2024 Mullvad VPN AB. All Rights Reserved.
+ */
+
+package main
+
+// #include <stdlib.h>
+// #include <stdint.h>
+import "C"
+
+import (
+	"bufio"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun"
+
+	"github.com/mullvad/mullvadvpn-app/wireguard/libwg/logging"
+	"github.com/mullvad/mullvadvpn-app/wireguard/libwg/tunnelcontainer"
+)
+
+// Redefined here because otherwise the compiler doesn't realize it's a type alias for a type that's safe to export.
+// Taken from the contained logging package.
+type LogSink = unsafe.Pointer
+type LogContext = C.uint64_t
+
+//export wgTurnOn
+func wgTurnOn(cIfaceName *C.char, cIfaceNameOut **C.char, cLuidOut *C.uint64_t, mtu C.uint16_t, cSettings *C.char, logSink LogSink, logContext LogContext) C.int32_t {
+	logger := logging.NewLogger(logSink, logging.LogContext(logContext))
+	if cIfaceNameOut != nil {
+		*cIfaceNameOut = nil
+	}
+
+	if cIfaceName == nil {
+		logger.Errorf("cIfaceName is null\n")
+		return ERROR_GENERAL_FAILURE
+	}
+
+	if cSettings == nil {
+		logger.Errorf("cSettings is null\n")
+		return ERROR_GENERAL_FAILURE
+	}
+
+	settings := C.GoString(cSettings)
+	ifaceName := C.GoString(cIfaceName)
+
+	// {AFE43773-E1F8-4EBB-8536-576AB86AFE9A}
+	networkId := windows.GUID{
+		Data1: 0xafe43773,
+		Data2: 0xe1f8,
+		Data3: 0x4ebb,
+		Data4: [8]byte{0x85, 0x36, 0x57, 0x6a, 0xb8, 0x6a, 0xfe, 0x9a},
+	}
+
+	tun.WintunTunnelType = "Mullvad"
+
+	wintun, err := tun.CreateTUNWithRequestedGUID(ifaceName, &networkId, mtu)
+	if err != nil {
+		logger.Errorf("Failed to create tunnel\n")
+		logger.Errorf("%s\n", err)
+		return ERROR_INTERMITTENT_FAILURE
+	}
+
+	nativeTun := wintun.(*tun.NativeTun)
+
+	actualInterfaceName, err := nativeTun.Name()
+	if err != nil {
+		nativeTun.Close()
+		logger.Errorf("Failed to determine name of wintun adapter\n")
+		return ERROR_GENERAL_FAILURE
+	}
+	if actualInterfaceName != ifaceName {
+		// WireGuard picked a different name for the adapter than the one we expected.
+		// This indicates there is already an adapter with the name we intended to use.
+		logger.Verbosef("Failed to create adapter with specific name\n")
+	}
+
+	device := device.NewDevice(wintun, conn.NewDefaultBind(), logger)
+
+	setError := device.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
+	if setError != nil {
+		logger.Errorf("Failed to set device configuration\n")
+		logger.Errorf("%s\n", setError)
+		device.Close()
+		return ERROR_GENERAL_FAILURE
+	}
+
+	device.Up()
+
+	context := tunnelcontainer.Context{
+		Device: device,
+		Logger: logger,
+	}
+
+	handle, err := tunnels.Insert(context)
+	if err != nil {
+		logger.Errorf("%s\n", err)
+		device.Close()
+		return ERROR_GENERAL_FAILURE
+	}
+
+	if cIfaceNameOut != nil {
+		*cIfaceNameOut = C.CString(actualInterfaceName)
+	}
+	if cLuidOut != nil {
+		*cLuidOut = nativeTun.LUID()
+	}
+
+	return C.int32_t(handle)
+}
+
+//export wgRebindTunnelSocket
+func wgRebindTunnelSocket(family uint16, interfaceIndex uint32) {
+	tunnels.ForEach(func(tunnel tunnelcontainer.Context) {
+		blackhole := (interfaceIndex == 0)
+		bind := tunnel.Device.Bind().(conn.BindSocketToInterface)
+
+		if family == windows.AF_INET {
+			tunnel.Logger.Verbosef("Binding v4 socket to interface %d (blackhole=%v)\n", interfaceIndex, blackhole)
+			err := bind.BindSocketToInterface4(interfaceIndex, blackhole)
+			if err != nil {
+				tunnel.Logger.Verbosef("%s\n", err)
+			}
+		} else if family == windows.AF_INET6 {
+			tunnel.Logger.Verbosef("Binding v6 socket to interface %d (blackhole=%v)\n", interfaceIndex, blackhole)
+			err := bind.BindSocketToInterface6(interfaceIndex, blackhole)
+			if err != nil {
+				tunnel.Logger.Verbosef("%s\n", err)
+			}
+		}
+	})
+}

--- a/wireguard-go-rs/libwg/logging/logging.go
+++ b/wireguard-go-rs/libwg/logging/logging.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2021 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2025 Mullvad VPN AB. All Rights Reserved.
  */
 
 package logging

--- a/wireguard-go-rs/libwg/tunnelcontainer/tunnelcontainer.go
+++ b/wireguard-go-rs/libwg/tunnelcontainer/tunnelcontainer.go
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0
  *
  * Copyright (C) 2017-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
- * Copyright (C) 2020 Mullvad VPN AB. All Rights Reserved.
+ * Copyright (C) 2025 Mullvad VPN AB. All Rights Reserved.
  */
 
 package tunnelcontainer

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -30,7 +30,7 @@ pub type LoggingCallback =
     unsafe extern "system" fn(level: WgLogLevel, msg: *const c_char, context: LoggingContext);
 
 // Make symbols from maybenot-ffi visible to wireguard-go
-#[cfg(all(daita, unix))]
+#[cfg(all(daita, any(target_os = "linux", target_os = "macos")))]
 use maybenot_ffi as _;
 
 /// A wireguard-go tunnel

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -304,6 +304,22 @@ impl Drop for Tunnel {
     }
 }
 
+/// Rebind WireGuard IPv4 endpoint sockets to use the given interface
+#[cfg(target_os = "windows")]
+pub fn rebind_tunnel_socket_v4(interface_index: u32) {
+    use windows_sys::Win32::Networking::WinSock::AF_INET;
+    // SAFETY: Passing an invalid interface is safe
+    unsafe { ffi::wgRebindTunnelSocket(AF_INET, interface_index) }
+}
+
+/// Rebind WireGuard IPv6 endpoint sockets to use the given interface
+#[cfg(target_os = "windows")]
+pub fn rebind_tunnel_socket_v6(interface_index: u32) {
+    use windows_sys::Win32::Networking::WinSock::AF_INET6;
+    // SAFETY: Passing an invalid interface is safe
+    unsafe { ffi::wgRebindTunnelSocket(AF_INET6, interface_index) }
+}
+
 fn result_from_code(code: i32) -> Result<(), Error> {
     // NOTE: must be kept in sync with enum definition
     Err(match code {
@@ -434,5 +450,9 @@ mod ffi {
         /// Get the file descriptor of the tunnel IPv6 socket.
         #[cfg(target_os = "android")]
         pub fn wgGetSocketV6(handle: i32) -> Fd;
+
+        /// Rebind tunnel socket endpoint sockets
+        #[cfg(target_os = "windows")]
+        pub fn wgRebindTunnelSocket(family: u16, index: u32);
     }
 }

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -32,7 +32,7 @@ pub type LoggingCallback =
     unsafe extern "system" fn(level: WgLogLevel, msg: *const c_char, context: LoggingContext);
 
 // Make symbols from maybenot-ffi visible to wireguard-go
-#[cfg(daita)]
+#[cfg(all(daita, unix))]
 use maybenot_ffi as _;
 
 /// A wireguard-go tunnel
@@ -301,25 +301,6 @@ impl Drop for Tunnel {
         if let Err(e) = result_from_code(code) {
             log::error!("Failed to stop wireguard-go tunnel,oerror_code={code} ({e:?})")
         }
-    }
-}
-
-/// Check whether `machines` contains a valid, LF-separated maybenot machines. Return an error
-/// otherwise.
-pub fn validate_maybenot_machines(machines: &CStr) -> Result<(), Error> {
-    use maybenot_ffi::MaybenotResult;
-
-    let mut framework = MaybeUninit::uninit();
-    // SAFETY: `machines` is a null-terminated string, and `&mut framework` is a valid pointer
-    let result =
-        unsafe { maybenot_ffi::maybenot_start(machines.as_ptr(), 0.0, 0.0, &mut framework) };
-
-    if result as u32 == MaybenotResult::Ok as u32 {
-        // SAFETY: `maybenot_start` succeeded, so `framework` points to a valid framework
-        unsafe { maybenot_ffi::maybenot_stop(framework.assume_init()) };
-        Ok(())
-    } else {
-        Err(Error::Other)
     }
 }
 

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -304,20 +304,11 @@ impl Drop for Tunnel {
     }
 }
 
-/// Rebind WireGuard IPv4 endpoint sockets to use the given interface
+/// Rebind WireGuard endpoint sockets. When the default interface changes, this needs to be called
+/// so that the UDP socket can be rebound to use the new interface
 #[cfg(target_os = "windows")]
-pub fn rebind_tunnel_socket_v4(interface_index: u32) {
-    use windows_sys::Win32::Networking::WinSock::AF_INET;
-    // SAFETY: Passing an invalid interface is safe
-    unsafe { ffi::wgRebindTunnelSocket(AF_INET, interface_index) }
-}
-
-/// Rebind WireGuard IPv6 endpoint sockets to use the given interface
-#[cfg(target_os = "windows")]
-pub fn rebind_tunnel_socket_v6(interface_index: u32) {
-    use windows_sys::Win32::Networking::WinSock::AF_INET6;
-    // SAFETY: Passing an invalid interface is safe
-    unsafe { ffi::wgRebindTunnelSocket(AF_INET6, interface_index) }
+pub fn update_bind() {
+    unsafe { ffi::wgUpdateBind() }
 }
 
 fn result_from_code(code: i32) -> Result<(), Error> {
@@ -451,8 +442,8 @@ mod ffi {
         #[cfg(target_os = "android")]
         pub fn wgGetSocketV6(handle: i32) -> Fd;
 
-        /// Rebind tunnel socket endpoint sockets
+        /// Rebind endpoint sockets
         #[cfg(target_os = "windows")]
-        pub fn wgRebindTunnelSocket(family: u16, index: u32);
+        pub fn wgUpdateBind();
     }
 }

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -6,18 +6,23 @@
 //!
 //! The [`Tunnel`] type provides a safe Rust wrapper around the C FFI.
 
-#![cfg(unix)]
-
+#[cfg(target_os = "windows")]
+use core::mem::MaybeUninit;
 use core::{
     ffi::{c_char, CStr},
-    mem::{ManuallyDrop, MaybeUninit},
+    mem::ManuallyDrop,
     slice,
 };
+#[cfg(target_os = "windows")]
+use std::ffi::CString;
 use util::OnDrop;
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::NetworkManagement::Ndis::NET_LUID_LH;
 use zeroize::Zeroize;
 
 mod util;
 
+#[cfg(unix)]
 pub type Fd = std::os::unix::io::RawFd;
 
 pub type WgLogLevel = u32;
@@ -34,6 +39,11 @@ use maybenot_ffi as _;
 pub struct Tunnel {
     /// wireguard-go handle to the tunnel.
     handle: i32,
+
+    #[cfg(target_os = "windows")]
+    assigned_name: CString,
+    #[cfg(target_os = "windows")]
+    luid: NET_LUID_LH,
 }
 
 // NOTE: Must be kept in sync with libwg.go
@@ -73,6 +83,7 @@ impl Tunnel {
     /// The `logging_callback` let's you provide a Rust function that receives any logging output
     /// from wireguard-go. `logging_context` is a value that will be passed to each invocation of
     /// `logging_callback`.
+    #[cfg(not(target_os = "windows"))]
     pub fn turn_on(
         #[cfg(not(target_os = "android"))] mtu: isize,
         settings: &CStr,
@@ -96,6 +107,51 @@ impl Tunnel {
         Ok(Tunnel { handle: code })
     }
 
+    /// Creates a new wireguard tunnel, uses the specific interface name, and file descriptors
+    /// for the tunnel device and logging.
+    ///
+    /// The `logging_callback` let's you provide a Rust function that receives any logging output
+    /// from wireguard-go. `logging_context` is a value that will be passed to each invocation of
+    /// `logging_callback`.
+    #[cfg(target_os = "windows")]
+    pub fn turn_on(
+        interface_name: &CStr,
+        mtu: u16,
+        settings: &CStr,
+        logging_callback: Option<LoggingCallback>,
+        logging_context: LoggingContext,
+    ) -> Result<Self, Error> {
+        // FIXME: use reasonable length
+        let mut assigned_name = [0u8; 128];
+        let mut luid = MaybeUninit::uninit();
+
+        // SAFETY: pointers are valid for the the lifetime of this function
+        let code = unsafe {
+            ffi::wgTurnOn(
+                interface_name.as_ptr(),
+                assigned_name.as_mut_ptr() as *mut i8,
+                assigned_name.len(),
+                // SAFETY: This is a union of a u64 and `NET_LUID_LH_0`
+                luid.as_mut_ptr() as *mut u64,
+                mtu,
+                settings.as_ptr(),
+                logging_callback,
+                logging_context,
+            )
+        };
+
+        result_from_code(code)?;
+
+        let assigned_name = CStr::from_bytes_until_nul(&assigned_name).unwrap();
+
+        Ok(Tunnel {
+            handle: code,
+            assigned_name: assigned_name.to_owned(),
+            // SAFETY: wgTurnOn succeeded and the LUID is guaranteed to be intialized by wgTurnOn
+            luid: unsafe { luid.assume_init() },
+        })
+    }
+
     /// Stop the wireguard tunnel. This also happens automatically if the [`Tunnel`] is dropped.
     pub fn turn_off(self) -> Result<(), Error> {
         // we manually turn off the tunnel here, so wrap it in ManuallyDrop to prevent the Drop
@@ -103,6 +159,18 @@ impl Tunnel {
         let code = unsafe { ffi::wgTurnOff(self.handle) };
         let _ = ManuallyDrop::new(self);
         result_from_code(code)
+    }
+
+    /// Tunnel interface name
+    #[cfg(target_os = "windows")]
+    pub fn name(&self) -> &str {
+        self.assigned_name.to_str().expect("non-UTF8 name")
+    }
+
+    /// Tunnel interface LUID
+    #[cfg(target_os = "windows")]
+    pub fn luid(&self) -> &NET_LUID_LH {
+        &self.luid
     }
 
     /// Special function for android multihop since that behavior is different from desktop
@@ -276,7 +344,9 @@ impl Error {
 }
 
 mod ffi {
-    use super::{Fd, LoggingCallback, LoggingContext};
+    #[cfg(not(target_os = "windows"))]
+    use super::Fd;
+    use super::{LoggingCallback, LoggingContext};
     use core::ffi::{c_char, c_void};
 
     extern "C" {
@@ -286,10 +356,31 @@ mod ffi {
         ///
         /// Positive return values are tunnel handles for this specific wireguard tunnel instance.
         /// Negative return values signify errors.
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
         pub fn wgTurnOn(
-            #[cfg(not(target_os = "android"))] mtu: isize,
+            mtu: isize,
             settings: *const c_char,
             fd: Fd,
+            logging_callback: Option<LoggingCallback>,
+            logging_context: LoggingContext,
+        ) -> i32;
+
+        #[cfg(target_os = "android")]
+        pub fn wgTurnOn(
+            settings: *const c_char,
+            fd: Fd,
+            logging_callback: Option<LoggingCallback>,
+            logging_context: LoggingContext,
+        ) -> i32;
+
+        #[cfg(target_os = "windows")]
+        pub fn wgTurnOn(
+            desired_name: *const c_char,
+            assigned_name: *mut c_char,
+            assigned_name_size: usize,
+            assigned_luid: *mut u64,
+            mtu: u16,
+            settings: *const c_char,
             logging_callback: Option<LoggingCallback>,
             logging_context: LoggingContext,
         ) -> i32;

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -6,13 +6,11 @@
 //!
 //! The [`Tunnel`] type provides a safe Rust wrapper around the C FFI.
 
+use core::ffi::{c_char, CStr};
+use core::mem::ManuallyDrop;
 #[cfg(target_os = "windows")]
 use core::mem::MaybeUninit;
-use core::{
-    ffi::{c_char, CStr},
-    mem::ManuallyDrop,
-    slice,
-};
+use core::slice;
 #[cfg(target_os = "windows")]
 use std::ffi::CString;
 use util::OnDrop;


### PR DESCRIPTION
This PR updates Windows DAITA to v2 by reintroducing wireguard-go.

# WIP

- [x] Sign and pack DLLs
- [x] Update build instructions
- [x] Make sure multihop handles network changes correctly. `wgRebindTunnelSocket` seems to affect all peers rather than only the entry.
- [x] Remove maybenot_machines (only from installer, since wgnt hasn't yet been removed)
- [x] Update changelog
- [x] Push tag, verify that dlls are signed
- [x] Set DAITA platform to wg-go for windows (currently not included)
- [x] Prepare build server before merging
- [x] Benchmarks

# Out of scope for this PR
- Remove wireguard-nt code for DAITA
- Use the multihop implementation of wireguard-go instead of WireguardNT

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7457)
<!-- Reviewable:end -->
