### PR TITLE
Add route to obfuscator on relay (if applicable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Line wrap the file at 100 chars.                                              Th
 - Move changelog from a dialog to a separate view.
 - Reduce the setup time of PQ tunnels by pre-computing McEliece keys.
 
+### Fixed
+- (macOS and Windows only) Add the correct route when using obfuscation with Wireguard.
+
 
 ## [2025.2] - 2025-01-08
 ### Fixed

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -96,7 +96,7 @@ impl TunnelParameters {
         }
     }
 
-    // Returns the endpoint that will be connected to
+    /// Returns the endpoint that will be connected to
     pub fn get_next_hop_endpoint(&self) -> Endpoint {
         match self {
             TunnelParameters::OpenVpn(params) => params
@@ -104,24 +104,7 @@ impl TunnelParameters {
                 .as_ref()
                 .map(|proxy| proxy.get_remote_endpoint().endpoint)
                 .unwrap_or(params.config.endpoint),
-            TunnelParameters::Wireguard(params) => params
-                .obfuscation
-                .as_ref()
-                .map(Self::get_obfuscator_endpoint)
-                .unwrap_or_else(|| params.connection.get_endpoint()),
-        }
-    }
-
-    fn get_obfuscator_endpoint(obfuscator: &ObfuscatorConfig) -> Endpoint {
-        match obfuscator {
-            ObfuscatorConfig::Udp2Tcp { endpoint } => Endpoint {
-                address: *endpoint,
-                protocol: TransportProtocol::Tcp,
-            },
-            ObfuscatorConfig::Shadowsocks { endpoint } => Endpoint {
-                address: *endpoint,
-                protocol: TransportProtocol::Udp,
-            },
+            TunnelParameters::Wireguard(params) => params.get_next_hop_endpoint(),
         }
     }
 

--- a/talpid-types/src/net/obfuscation.rs
+++ b/talpid-types/src/net/obfuscation.rs
@@ -1,8 +1,25 @@
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
+use super::{Endpoint, TransportProtocol};
+
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Debug)]
 pub enum ObfuscatorConfig {
     Udp2Tcp { endpoint: SocketAddr },
     Shadowsocks { endpoint: SocketAddr },
+}
+
+impl ObfuscatorConfig {
+    pub fn get_obfuscator_endpoint(&self) -> Endpoint {
+        match self {
+            ObfuscatorConfig::Udp2Tcp { endpoint } => Endpoint {
+                address: *endpoint,
+                protocol: TransportProtocol::Tcp,
+            },
+            ObfuscatorConfig::Shadowsocks { endpoint } => Endpoint {
+                address: *endpoint,
+                protocol: TransportProtocol::Udp,
+            },
+        }
+    }
 }

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -19,6 +19,16 @@ pub struct TunnelParameters {
     pub obfuscation: Option<super::obfuscation::ObfuscatorConfig>,
 }
 
+impl TunnelParameters {
+    /// Returns the endpoint that will be connected to
+    pub fn get_next_hop_endpoint(&self) -> Endpoint {
+        self.obfuscation
+            .as_ref()
+            .map(|proxy| proxy.get_obfuscator_endpoint())
+            .unwrap_or_else(|| self.connection.get_endpoint())
+    }
+}
+
 /// Connection-specific configuration in [`TunnelParameters`].
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ConnectionConfig {

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -174,7 +174,7 @@ impl WireguardMonitor {
         let mut config = crate::config::Config::from_parameters(params, desired_mtu)
             .map_err(Error::WireguardConfigError)?;
 
-        let endpoint_addrs: Vec<IpAddr> = config.peers().map(|peer| peer.endpoint.ip()).collect();
+        let endpoint_addrs = [params.get_next_hop_endpoint().address.ip()];
 
         let (close_obfs_sender, close_obfs_listener) = sync_mpsc::channel();
         // Start obfuscation server and patch the WireGuard config to point the endpoint to it.


### PR DESCRIPTION
This PR fixes a bug where the wrong route(s) would be added when Shadowsocks obfuscation with extra in IPs where used. Previously, we would always add a route to the relay's public IP, but not to the obfuscator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7459)
<!-- Reviewable:end -->
