### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,15 +2274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,7 +2535,7 @@ dependencies = [
  "mullvad-types",
  "mullvad-version",
  "nix 0.23.2",
- "objc",
+ "objc2",
  "regex",
  "serde",
  "serde_json",
@@ -2987,20 +2978,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
- "objc_exception",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "objc2"
@@ -3093,15 +3077,6 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "objc2-metal",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -62,7 +62,7 @@ simple-signal = "1.1"
 talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(target_os="macos")'.dependencies]
-objc = { version = "0.2.7", features = ["exception", "verify_message"] }
+objc2 = { version = "0.5.2", features = ["exception"] }
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"

--- a/talpid-core/src/split_tunnel/macos/process.rs
+++ b/talpid-core/src/split_tunnel/macos/process.rs
@@ -567,7 +567,7 @@ mod test {
             msg.contains('\n'),
             "Message does not contain a newline!! Make sure to add a newline to '{msg}'"
         );
-        let (stdout_read, mut stdout_write) = simplex(msg.as_bytes().len());
+        let (stdout_read, mut stdout_write) = simplex(msg.len());
         //  "print" to "stdout" after `duration`.
         tokio::spawn(async move {
             tokio::time::sleep(lag).await;

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -159,12 +159,12 @@ impl SocksAuth {
     /// assert!(too_long_username.is_err());
     /// ```
     pub fn new(username: String, password: String) -> Result<Self, Error> {
-        if !(1..=255).contains(&password.as_bytes().len()) {
+        if !(1..=255).contains(&password.len()) {
             return Err(Error::InvalidSocksAuthValues(
                 "Password length should between 1 and 255 bytes",
             ));
         }
-        if !(1..=255).contains(&username.as_bytes().len()) {
+        if !(1..=255).contains(&username.len()) {
             return Err(Error::InvalidSocksAuthValues(
                 "Username length should between 1 and 255 bytes",
             ));


### PR DESCRIPTION
This PR fixes recent `clippy` complaints that are currently hindering CI to become green: [1](https://github.com/mullvad/mullvadvpn-app/actions/runs/12751740545/job/35539516074?pr=7459), [2](https://github.com/mullvad/mullvadvpn-app/actions/runs/12751740538/job/35539516292?pr=7459).

The warning stemming from the `objc` crate is tricky to fix by keeping `objc`, as we would have to convert it to a git dependency.. See https://github.com/SSheldon/rust-objc/issues/125 for details on that. What I instead did was to convert the little code we had that used `objc` to the much more well-maintained [`objc2`](https://docs.rs/objc2/) crate which does not generate these `clippy` warnings. We already have it in our tree because of `nseventforwarder`, so this change even reduced the total amount of dependencies we have! I see this as an absolute win.