### PR TITLE
Fix saving scroll and expanded state to correct location object

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/NavigationScrollbars.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/NavigationScrollbars.tsx
@@ -17,6 +17,7 @@ export const NavigationScrollbars = React.forwardRef(function NavigationScrollba
   forwardedRef?: React.Ref<CustomScrollbarsRef>,
 ) {
   const history = useHistory();
+  const location = useRef(history.location);
   const { setNavigationHistory } = useAppContext();
   const { onScroll } = useContext(NavigationScrollContext);
 
@@ -25,7 +26,7 @@ export const NavigationScrollbars = React.forwardRef(function NavigationScrollba
 
   const beforeunload = useEffectEvent(() => {
     if (ref.current) {
-      history.recordScrollPosition(ref.current.getScrollPosition());
+      location.current.state.scrollPosition = ref.current.getScrollPosition();
       setNavigationHistory(history.asObject);
     }
   });
@@ -44,7 +45,7 @@ export const NavigationScrollbars = React.forwardRef(function NavigationScrollba
 
   const onUnmount = useEffectEvent(() => {
     if (history.action === 'PUSH' && ref.current) {
-      history.recordScrollPosition(ref.current.getScrollPosition());
+      location.current.state.scrollPosition = ref.current.getScrollPosition();
       setNavigationHistory(history.asObject);
     }
   });

--- a/desktop/packages/mullvad-vpn/src/renderer/components/cell/Section.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/cell/Section.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '../../context';
@@ -66,13 +66,14 @@ export function ExpandableSection(props: ExpandableSectionProps) {
   const { expandableId, expandedInitially, sectionTitle, ...otherProps } = props;
 
   const history = useHistory();
+  const location = useRef(history.location);
   const { setNavigationHistory } = useAppContext();
   const expandedValue =
     history.location.state.expandedSections[props.expandableId] ?? !!expandedInitially;
   const [expanded, , , toggleExpanded] = useBoolean(expandedValue);
 
   const updateHistory = useEffectEvent((expanded: boolean) => {
-    history.recordSectionExpandedState(props.expandableId, expanded);
+    location.current.state.expandedSections[props.expandableId] = expanded;
     setNavigationHistory(history.asObject);
   });
 

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/history.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/history.tsx
@@ -82,14 +82,6 @@ export default class History {
     return history;
   }
 
-  public recordScrollPosition(position: [number, number]) {
-    this.location.state.scrollPosition = position;
-  }
-
-  public recordSectionExpandedState(id: string, expanded: boolean) {
-    this.location.state.expandedSections[id] = expanded;
-  }
-
   public get location(): Location<LocationState> {
     return this.entries[this.index];
   }


### PR DESCRIPTION
This PR fixes the saving of the scroll position and section expanded state when navigating. When navigating back the previous scroll position should still apply for users not to lose context. This regressed in [This PR](https://github.com/mullvad/mullvadvpn-app/pull/6972) where the state was saved to the new location instead of the previous one when navigating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7462)
<!-- Reviewable:end -->
