### PR TITLE
Fix daita settings view on ios 15

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -22,14 +22,13 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## Unreleased
+### Fixed
+- Broken DAITA settings view on iOS 15.
 
 ## [2025.1 - 2025-01-14]
 ### Added
 - Update to DAITA v2 - now machines are provided by relays dynamically instead
   of using bundled ones.
-
-### Fixed
-- Fix DAITA settings view on iOS 15.
 
 ## [2024.11 - 2024-12-12]
 ### Added

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -28,6 +28,9 @@ Line wrap the file at 100 chars.                                              Th
 - Update to DAITA v2 - now machines are provided by relays dynamically instead
   of using bundled ones.
 
+### Fixed
+- Fix DAITA settings view on iOS 15.
+
 ## [2024.11 - 2024-12-12]
 ### Added
 - Add WireGuard over Shadowsocks obfuscation. It can be enabled in "VPN settings". This will

--- a/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoContainerView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoContainerView.swift
@@ -16,16 +16,12 @@ struct SettingsInfoContainerView<Content: View>: View {
     }
 
     var body: some View {
-        ZStack {
-            List {
+        ScrollView {
+            VStack {
                 content
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color(.secondaryColor))
                     .padding(.top, UIMetrics.contentInsets.top)
                     .padding(.bottom, UIMetrics.contentInsets.bottom)
             }
-            .listStyle(.plain)
         }
         .background(Color(.secondaryColor))
     }

--- a/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
@@ -27,44 +27,42 @@ struct SettingsInfoView: View {
 
     var body: some View {
         ZStack {
-            // Renders (and hide) the content of each page, to push the view to the maximum possible size.
-            VStack {
-                ZStack {
-                    ForEach(viewModel.pages, id: \.self) { page in
-                        contentView(for: page)
-                    }
-                }
-                Spacer()
-                    .frame(height: pageIndicatorSpacing)
-            }
-            .hidden()
             TabView {
-                ForEach(viewModel.pages, id: \.self) { page in
-                    VStack {
-                        contentView(for: page)
-                        Spacer()
-                    }
-                    .padding(UIMetrics.SettingsInfoView.layoutMargins)
-                }
+                contentView()
             }
+            .padding(UIMetrics.SettingsInfoView.layoutMargins)
             .tabViewStyle(.page)
             .foregroundColor(Color(.primaryTextColor))
             .background {
                 Color(.secondaryColor)
             }
+            hiddenViewToStretchHeightInsideScrollView()
         }
     }
 
-    private func contentView(for page: SettingsInfoViewModelPage) -> some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Image(page.image)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-            Text(page.body)
-                .font(.subheadline)
-                .opacity(0.6)
-                // The following line is needed to not truncate the text when using xxl text size
-                .minimumScaleFactor(0.9)
+//    A TabView inside a Scrollview has no height. This hidden view stretches the TabView to have the size of the heighest page.
+    private func hiddenViewToStretchHeightInsideScrollView() -> some View {
+        return ZStack {
+            contentView()
+        }
+        .padding(UIMetrics.SettingsInfoView.layoutMargins)
+        .hidden()
+    }
+
+    private func contentView() -> some View {
+        ForEach(viewModel.pages, id: \.self) { page in
+            VStack {
+                VStack(alignment: .leading, spacing: 16) {
+                    Image(page.image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                    Text(page.body)
+                        .font(.subheadline)
+                        .opacity(0.6)
+                }
+                Spacer()
+            }
+            .padding(.bottom, pageIndicatorSpacing)
         }
     }
 }
@@ -104,4 +102,66 @@ struct SettingsInfoView: View {
             ),
         ]
     ))
+}
+
+#Preview("Single inside Scrollview") {
+    ScrollView {
+        SettingsInfoView(viewModel: SettingsInfoViewModel(
+            pages: [
+                SettingsInfoViewModelPage(
+                    body: """
+                    Multihop routes your traffic into one WireGuard server and out another, making it \
+                    harder to trace. This results in increased latency but increases anonymity online.
+                    """,
+                    image: .multihopIllustration
+                ),
+            ]
+        ))
+    }
+}
+
+#Preview("Multiple inside Scrollview") {
+    ScrollView {
+        SettingsInfoView(viewModel: SettingsInfoViewModel(
+            pages: [
+                SettingsInfoViewModelPage(
+                    body: NSLocalizedString(
+                        "SETTINGS_INFO_DAITA_PAGE_1",
+                        tableName: "Settings",
+                        value: """
+                        DAITA (Defense against AI-guided Traffic Analysis) hides patterns in \
+                        your encrypted VPN traffic.
+
+                        By using sophisticated AI it’s possible to analyze the traffic of data \
+                        packets going in and out of your device (even if the traffic is encrypted).
+
+                        If an observer monitors these data packets, DAITA makes it significantly \
+                        harder for them to identify which websites you are visiting or with whom \
+                        you are communicating.
+                        """,
+                        comment: ""
+                    ),
+                    image: .daitaOffIllustration
+                ),
+                SettingsInfoViewModelPage(
+                    body: NSLocalizedString(
+                        "SETTINGS_INFO_DAITA_PAGE_2",
+                        tableName: "Settings",
+                        value: """
+                        DAITA does this by carefully adding network noise and making all network \
+                        packets the same size.
+
+                        Not all our servers are DAITA-enabled. Therefore, we use multihop \
+                        automatically to enable DAITA with any server.
+
+                        Attention: Be cautious if you have a limited data plan as this feature \
+                        will increase your network traffic.
+                        """,
+                        comment: ""
+                    ),
+                    image: .daitaOnIllustration
+                ),
+            ]
+        ))
+    }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
@@ -63,6 +63,8 @@ struct SettingsInfoView: View {
             Text(page.body)
                 .font(.subheadline)
                 .opacity(0.6)
+                // The following line is needed to not truncate the text when using xxl text size
+                .minimumScaleFactor(0.9)
         }
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
@@ -19,7 +19,6 @@ struct SettingsInfoViewModelPage: Hashable {
 
 struct SettingsInfoView: View {
     let viewModel: SettingsInfoViewModel
-    @State var height: CGFloat = 0
 
     // Extra spacing to allow for some room around the page indicators.
     var pageIndicatorSpacing: CGFloat {
@@ -27,23 +26,32 @@ struct SettingsInfoView: View {
     }
 
     var body: some View {
-        TabView {
-            ForEach(viewModel.pages, id: \.self) { page in
-                VStack {
-                    contentView(for: page)
-                    Spacer()
+        ZStack {
+            // Renders (and hide) the content of each page, to push the view to the maximum possible size.
+            VStack {
+                ZStack {
+                    ForEach(viewModel.pages, id: \.self) { page in
+                        contentView(for: page)
+                    }
                 }
-                .padding(UIMetrics.SettingsInfoView.layoutMargins)
+                Spacer()
+                    .frame(height: pageIndicatorSpacing)
             }
-        }
-        .frame(
-            height: height + pageIndicatorSpacing
-        )
-        .tabViewStyle(.page)
-        .foregroundColor(Color(.primaryTextColor))
-        .background {
-            Color(.secondaryColor)
-            preRenderViewSize()
+            .hidden()
+            TabView {
+                ForEach(viewModel.pages, id: \.self) { page in
+                    VStack {
+                        contentView(for: page)
+                        Spacer()
+                    }
+                    .padding(UIMetrics.SettingsInfoView.layoutMargins)
+                }
+            }
+            .tabViewStyle(.page)
+            .foregroundColor(Color(.primaryTextColor))
+            .background {
+                Color(.secondaryColor)
+            }
         }
     }
 
@@ -55,23 +63,6 @@ struct SettingsInfoView: View {
             Text(page.body)
                 .font(.subheadline)
                 .opacity(0.6)
-        }
-    }
-
-    // Renders the content of each page, determining the maximum height between them
-    // when laid out on screen. Since we only want this to update the real view
-    // this function should be called from a .background() and its contents hidden.
-    private func preRenderViewSize() -> some View {
-        ZStack {
-            ForEach(viewModel.pages, id: \.self) { page in
-                contentView(for: page)
-            }
-        }
-        .hidden()
-        .sizeOfView { size in
-            if size.height > height {
-                height = size.height
-            }
         }
     }
 }

--- a/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
@@ -46,6 +46,7 @@ struct SettingsInfoView: View {
             contentView()
         }
         .padding(UIMetrics.SettingsInfoView.layoutMargins)
+        .padding(.bottom, 1)
         .hidden()
     }
 


### PR DESCRIPTION
DAITA settings view was broken on iOS 15 devices due to SwiftUI List bug. This PR fixes the issue by using ScrollView instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7465)
<!-- Reviewable:end -->
