### PR TITLE
Fix enum variant lint error

### DIFF
--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -19,7 +19,7 @@ fn main() -> anyhow::Result<()> {
 
     match target_os.as_str() {
         "linux" => build_static_lib(Os::Linux, true)?,
-        "macos" => build_static_lib(Os::MacOs, true)?,
+        "macos" => build_static_lib(Os::Macos, true)?,
         "android" => build_android_dynamic_lib(true)?,
         // building wireguard-go-rs for windows is not implemented
         _ => {}
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<()> {
 
 #[derive(PartialEq, Eq)]
 enum Os {
-    MacOs,
+    Macos,
     Linux,
 }
 
@@ -67,7 +67,7 @@ fn host_os() -> anyhow::Result<Os> {
     if cfg!(target_os = "linux") {
         Ok(Os::Linux)
     } else if cfg!(target_os = "macos") {
-        Ok(Os::MacOs)
+        Ok(Os::Macos)
     } else {
         bail!("Unsupported host OS")
     }
@@ -123,7 +123,7 @@ fn build_static_lib(target_os: Os, daita: bool) -> anyhow::Result<()> {
                 };
             }
         }
-        Os::MacOs => {
+        Os::Macos => {
             go_build.env("GOOS", "darwin");
 
             if cross_compiling {


### PR DESCRIPTION
See https://github.com/mullvad/mullvadvpn-app/actions/runs/12792796100/job/35664092183?pr=7457.

```
error: variant name ends with the enum's name
```

This error doesn't make any sense in this case, but renaming it was nicer than disabling the warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7469)
<!-- Reviewable:end -->
