### PR TITLE
Fix ending up in blocked state when disabling split tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - (macOS and Windows only) Add the correct route when using obfuscation with Wireguard.
 
+#### macOS
+- Fix daemon ending up in blocked state if the user toggled split tunneling without having granted
+  Full Disk Access to `mullvad-daemon`. This could only ever be accomplished from the CLI.
+
 
 ## [2025.2] - 2025-01-08
 ### Fixed

--- a/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
@@ -46,7 +46,7 @@ interface IProps {
 }
 
 export default function NotificationArea(props: IProps) {
-  const { showFullDiskAccessSettings, reconnectTunnel } = useAppContext();
+  const { showFullDiskAccessSettings } = useAppContext();
 
   const account = useSelector((state: IReduxState) => state.account);
   const locale = useSelector((state: IReduxState) => state.userInterface.locale);
@@ -80,8 +80,7 @@ export default function NotificationArea(props: IProps) {
   const disableSplitTunneling = useCallback(async () => {
     setIsModalOpen(false);
     await setSplitTunnelingState(false);
-    await reconnectTunnel();
-  }, [reconnectTunnel, setSplitTunnelingState]);
+  }, [setSplitTunnelingState]);
 
   const notificationProviders: InAppNotificationProvider[] = [
     new ConnectingNotificationProvider({ tunnelState }),

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1021,7 +1021,7 @@ impl Daemon {
             TunnelStateTransition::Disconnected => TunnelState::Disconnected { location: None },
             TunnelStateTransition::Connecting(endpoint) => {
                 let feature_indicators = compute_feature_indicators(
-                    &self.settings.to_settings(),
+                    self.settings.settings(),
                     &endpoint,
                     self.parameters_generator.last_relay_was_overridden().await,
                 );
@@ -1033,7 +1033,7 @@ impl Daemon {
             }
             TunnelStateTransition::Connected(endpoint) => {
                 let feature_indicators = compute_feature_indicators(
-                    &self.settings.to_settings(),
+                    self.settings.settings(),
                     &endpoint,
                     self.parameters_generator.last_relay_was_overridden().await,
                 );
@@ -1199,7 +1199,7 @@ impl Daemon {
                     .active_features()
                     .any(|f| matches!(&f, FeatureIndicator::ServerIpOverride));
                 let new_feature_indicators =
-                    compute_feature_indicators(&self.settings.to_settings(), endpoint, ip_override);
+                    compute_feature_indicators(self.settings.settings(), endpoint, ip_override);
                 // Update and broadcast the new feature indicators if they have changed
                 if *feature_indicators != new_feature_indicators {
                     // Make sure to update the daemon's actual tunnel state. Otherwise, feature
@@ -1541,7 +1541,7 @@ impl Daemon {
         let save_result = match update {
             ExcludedPathsUpdate::SetState(state) => {
                 let split_tunnel_was_enabled =
-                    self.settings.to_settings().split_tunnel.enable_exclusions;
+                    self.settings.settings().split_tunnel.enable_exclusions;
                 let save_result = self
                     .settings
                     .update(move |settings| settings.split_tunnel.enable_exclusions = state)
@@ -2533,7 +2533,7 @@ impl Daemon {
         {
             Ok(settings_changed) => {
                 if settings_changed {
-                    let settings = self.settings.to_settings();
+                    let settings = self.settings.settings();
                     let resolvers =
                         dns::addresses_from_options(&settings.tunnel_options.dns_options);
                     self.send_tunnel_command(TunnelCommand::Dns(

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -248,6 +248,10 @@ impl SettingsPersister {
         Ok(())
     }
 
+    pub const fn settings(&self) -> &Settings {
+        &self.settings
+    }
+
     pub fn to_settings(&self) -> Settings {
         self.settings.clone()
     }


### PR DESCRIPTION
Fix daemon ending up in blocked state if the user toggled split tunneling without having granted Full Disk Access to `mullvad-daemon`. This could only ever be accomplished from the CLI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7473)
<!-- Reviewable:end -->
