### PR TITLE
Fix clipped feature indicators

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct ChipView: View {
     let item: ChipModel
+    private let borderWidth: CGFloat = 1
+
     var body: some View {
         Text(item.name)
             .font(.subheadline)
@@ -21,12 +23,13 @@ struct ChipView: View {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(
                         UIColor.primaryColor.color,
-                        lineWidth: 1
+                        lineWidth: borderWidth
                     )
                     .background(
                         RoundedRectangle(cornerRadius: 8)
                             .fill(UIColor.secondaryColor.color)
                     )
+                    .padding(borderWidth)
             )
     }
 }


### PR DESCRIPTION
The feature indicators were slightly clipped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7474)
<!-- Reviewable:end -->
