### PR TITLE
Use padded chevron image to follow figma design

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
@@ -41,9 +41,9 @@ extension ConnectionView {
 
                 Group {
                     Spacer()
-                    Image(.iconChevron)
+                    Image(.iconChevronUp)
                         .renderingMode(.template)
-                        .rotationEffect(isExpanded ? .degrees(-90) : .degrees(90))
+                        .rotationEffect(isExpanded ? .degrees(180) : .degrees(0))
                         .foregroundStyle(.white)
                         .accessibilityIdentifier(AccessibilityIdentifier.relayStatusCollapseButton.asString)
                 }


### PR DESCRIPTION
The chevron in the connection view was a little squeezed to one side. Now it follows the figma design

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7476)
<!-- Reviewable:end -->
