### PR TITLE
Fix crash when pressing create new account button ios 1019

### DIFF
--- a/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountViewController.swift
@@ -161,6 +161,8 @@ class AccountViewController: UIViewController, @unchecked Sendable {
             let productState: ProductState = completion.value?.products.first
                 .map { .received($0) } ?? .failed
 
+            /// `@MainActor` isolation is safe here because
+            /// `ProductsRequestOperation` sets its `completionQueue` to `.main`
             MainActor.assumeIsolated {
                 self?.setProductState(productState, animated: true)
             }

--- a/ios/MullvadVPN/View controllers/Account/PaymentAlertPresenter.swift
+++ b/ios/MullvadVPN/View controllers/Account/PaymentAlertPresenter.swift
@@ -16,7 +16,7 @@ struct PaymentAlertPresenter {
     func showAlertForError(
         _ error: StorePaymentManagerError,
         context: REST.CreateApplePaymentResponse.Context,
-        completion: (@Sendable () -> Void)? = nil
+        completion: (@MainActor @Sendable () -> Void)? = nil
     ) {
         let presentation = AlertPresentation(
             id: "payment-error-alert",
@@ -64,7 +64,7 @@ struct PaymentAlertPresenter {
     func showAlertForResponse(
         _ response: REST.CreateApplePaymentResponse,
         context: REST.CreateApplePaymentResponse.Context,
-        completion: (@Sendable () -> Void)? = nil
+        completion: (@MainActor @Sendable () -> Void)? = nil
     ) {
         guard case .noTimeAdded = response else {
             completion?()

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
@@ -116,6 +116,8 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
         contentView.isEditing = false
         interactor.redeemVoucher(code: code, completion: { [weak self] result in
             guard let self else { return }
+            /// Safe to assume `@MainActor` isolation because
+            /// `TunnelManager.redeemVoucher` sets the `RedeemVoucherOperation`'s `completionQueue` to `.main`
             MainActor.assumeIsolated {
                 switch result {
                 case let .success(value):

--- a/ios/Operations/BackgroundObserver.swift
+++ b/ios/Operations/BackgroundObserver.swift
@@ -26,13 +26,9 @@ public final class BackgroundObserver: OperationObserver {
     }
 
     public func didAttach(to operation: Operation) {
-        #if swift(>=6)
         let expirationHandler = cancelUponExpiration
             ? { @MainActor in operation.cancel() } as? @MainActor @Sendable () -> Void
             : nil
-        #else
-        let expirationHandler = cancelUponExpiration ? { operation.cancel() } : nil
-        #endif
 
         taskIdentifier = backgroundTaskProvider.beginBackgroundTask(
             withName: name,

--- a/ios/Routing/Router/ApplicationRouter.swift
+++ b/ios/Routing/Router/ApplicationRouter.swift
@@ -158,9 +158,8 @@ public final class ApplicationRouter<RouteType: AppRouteProtocol>: Sendable {
             let context = RoutePresentationContext(route: route, isAnimated: animated, metadata: metadata)
 
             delegate.applicationRouter(self, presentWithContext: context, animated: animated) { coordinator in
-                /*
-                 Synchronize router when modal controllers are removed by swipe.
-                 */
+                /// Synchronize router when modal controllers are removed by swipe.
+                /// The delegate (`ApplicationCoordinator`) is `@MainActor` by virtue of being a `Coordinator`
                 MainActor.assumeIsolated {
                     if let presentable = coordinator as? Presentable {
                         presentable.onInteractiveDismissal { [weak self] coordinator in


### PR DESCRIPTION
This PR revisits main actor isolation in the application and adds comments where necessary.
It also fixes a crash where we wrongly assumed that a callback was ran on the main actor.