### PR TITLE
Move the spinner in front of the Connection View

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -134,8 +134,8 @@ class TunnelViewController: UIViewController, RootContainment {
         }
 
         addMapController()
-        addConnectionView()
         addActivityIndicator()
+        addConnectionView()
         updateMap(animated: false)
     }
 


### PR DESCRIPTION
This PR makes sure the Activity Indicator is in front of the Connection View when connecting to a relay.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7492)
<!-- Reviewable:end -->
