### PR TITLE
Remove most `default-members` to speed up builds and reduce duplication

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -75,8 +75,8 @@ jobs:
           RUSTFLAGS: --deny warnings
         run: |
           source env.sh
-          time cargo clippy --locked --all-targets --no-default-features
-          time cargo clippy --locked --all-targets --all-features
+          time cargo clippy --workspace --locked --all-targets --no-default-features
+          time cargo clippy --workspace --locked --all-targets --all-features
 
   clippy-check-android:
     name: Clippy linting, Android

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ members = [
     "mullvad-api",
     "mullvad-cli",
     "mullvad-daemon",
+    "mullvad-encrypted-dns-proxy",
     "mullvad-exclude",
     "mullvad-fs",
     "mullvad-ios",
     "mullvad-jni",
     "mullvad-management-interface",
     "mullvad-nsis",
-    "mullvad-encrypted-dns-proxy",
     "mullvad-paths",
     "mullvad-problem-report",
     "mullvad-relay-selector",
@@ -45,44 +45,14 @@ members = [
     "wireguard-go-rs",
     "windows-installer",
 ]
-# The default members may exclude packages that cannot be built for all targets, or that do not always
-# need to be built
+# Default members dictate what is built when running `cargo build` in the root directory.
+# This is set to a minimal set of packages to speed up the build process and avoid building
+# crates which might not compile without additional input, such as the `windows-installer` crate.
+# To build or test everything, add `--workspace` to your cargo commands.
 default-members = [
-    "android/translations-converter",
-    "desktop/packages/nseventforwarder",
-    "mullvad-api",
     "mullvad-cli",
     "mullvad-daemon",
-    "mullvad-exclude",
-    "mullvad-fs",
-    "mullvad-ios",
-    "mullvad-jni",
-    "mullvad-management-interface",
-    "mullvad-nsis",
-    "mullvad-encrypted-dns-proxy",
-    "mullvad-paths",
-    "mullvad-problem-report",
-    "mullvad-relay-selector",
-    "mullvad-setup",
-    "mullvad-types",
-    "mullvad-types/intersection-derive",
     "mullvad-version",
-    "talpid-core",
-    "talpid-dbus",
-    "talpid-future",
-    "talpid-macos",
-    "talpid-net",
-    "talpid-openvpn",
-    "talpid-openvpn-plugin",
-    "talpid-platform-metadata",
-    "talpid-routing",
-    "talpid-time",
-    "talpid-tunnel",
-    "talpid-tunnel-config-client",
-    "talpid-windows",
-    "talpid-wireguard",
-    "tunnel-obfuscation",
-    "wireguard-go-rs",
 ]
 
 # Keep all lints in sync with `test/Cargo.toml`

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -299,7 +299,7 @@ tasks.register<Exec>("generateRelayList") {
 
     onlyIf { isReleaseBuild() || !relayListPath.exists() }
 
-    commandLine("cargo", "run", "--bin", "relay_list")
+    commandLine("cargo", "run", "-p", "mullvad-api", "--bin", "relay_list")
 
     doLast {
         val output = standardOutput as ByteArrayOutputStream

--- a/build.sh
+++ b/build.sh
@@ -361,7 +361,7 @@ else
 fi
 
 log_info "Updating relays.json..."
-cargo run --bin relay_list "${CARGO_ARGS[@]}" > build/relays.json
+cargo run -p mullvad-api --bin relay_list "${CARGO_ARGS[@]}" > build/relays.json
 
 
 log_header "Installing JavaScript dependencies"

--- a/ci/check-rust.sh
+++ b/ci/check-rust.sh
@@ -4,9 +4,12 @@ set -eux
 
 export RUSTFLAGS="--deny warnings"
 
+# Excluding windows-installer because it builds an actual full installer
+# at the build step, which is not desired in a CI environment.
+
 # Build Rust crates
 source env.sh
-time cargo build --locked --verbose
+time cargo build --workspace --exclude windows-installer --locked --verbose
 
 # Test Rust crates
-time cargo test --locked --verbose
+time cargo test --workspace --exclude windows-installer --locked --verbose


### PR DESCRIPTION
We included almost every crate in `default-members`. All crates except `windows-installer` which could not build without specific inputs as to what installers to include (it built a full universal installer, bundling arch specific installers at build time). This list had a lot of duplication and seems like a bit of a mess to maintain.

Since our workspace also contained virtually everything, a simple `cargo build` built everything, which might not be desired from a build time perspective. This PR reduce the `default-members` to some "sane default" bare minimum. It includes `mullvad-daemon` and `mullvad-cli` because those are the main binaries, and anyone building this project is most likely after those binaries. It also includes `mullvad-version` since we have a ton of invocations to `cargo run --bin mullvad-version`, and that does not work if the crate is not a default crate. We could also update all those invocations to add an extra `-p mullvad-version` to solve the issue. But I felt like the version computation binary was central enough to be included as a default crate :shrug: 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7494)
<!-- Reviewable:end -->
