### PR TITLE
Fix testWireGuardOverTCPAutomatically and testConnectionRetryLogic

### DIFF
--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -126,6 +126,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
         // Should be two UDP connection attempts but sometimes only one is shown in the UI
         TunnelControlPage(app)
+            .tapRelayStatusExpandCollapseButton()
             .verifyConnectionAttemptsOrder()
             .tapCancelButton()
     }
@@ -252,6 +253,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
         // Should be two UDP connection attempts but sometimes only one is shown in the UI
         TunnelControlPage(app)
+            .tapRelayStatusExpandCollapseButton()
             .verifyConnectingOverTCPAfterUDPAttempts()
             .waitForConnectedLabel()
             .tapDisconnectButton()

--- a/ios/MullvadVPNUITests/tests.json
+++ b/ios/MullvadVPNUITests/tests.json
@@ -9,7 +9,8 @@
         ],
         "pr-merge-to-main": [
             "AccountTests/testLogin",
-            "AccountTests/testCreateAccount"
+            "AccountTests/testCreateAccount",
+            "RelayTests"
         ],
         "api-tests": [
             "AccountTests"


### PR DESCRIPTION
**Why this needs to be done**

The above tests are failing after merging feature indicator views, which is reason enough to fix them. 
https://github.com/mullvad/mullvadvpn-app/actions/runs/12871536677/job/35885195591

**What needs to be done**

The running theory is that these tests rely on the connection view being expanded, but you might need to do further investigation.

**Acceptance criteria**

- testWireGuardOverTCPAutomatically passes in CI
- testConnectionRetryLogic passes in CI

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7502)
<!-- Reviewable:end -->
