### PR TITLE
Update screenshot tests to use correct iPad models

### DIFF
--- a/ios/Snapfile
+++ b/ios/Snapfile
@@ -5,8 +5,8 @@ devices([
   "iPhone SE (3rd generation)",
   "iPhone 15 Pro",
   "iPhone 15 Pro Max",
-  "iPad Pro (11-inch) (4th generation)",
-  "iPad Pro (12.9-inch) (6th generation)"
+  "iPad Pro 11-inch (M4)",
+  "iPad Pro 13-inch (M4)"
 ])
 
 languages([


### PR DESCRIPTION
Screenshot tests fail due to using the wrong iPad models. We should use `iPad Pro (11-inch) (M4)` and `iPad Pro (13-inch) (M4)`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7503)
<!-- Reviewable:end -->
