### PR TITLE
Move ErrorBoundary into Theme

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -293,16 +293,16 @@ export default class AppRenderer {
             <StyleSheetManager enableVendorPrefixes>
               <Lang>
                 <Router history={this.history.asHistory}>
-                  <ErrorBoundary>
-                    <ModalContainer>
-                      <KeyboardNavigation>
-                        <Theme>
+                  <Theme>
+                    <ErrorBoundary>
+                      <ModalContainer>
+                        <KeyboardNavigation>
                           <AppRouter />
-                        </Theme>
-                      </KeyboardNavigation>
-                      {window.env.platform === 'darwin' && <MacOsScrollbarDetection />}
-                    </ModalContainer>
-                  </ErrorBoundary>
+                        </KeyboardNavigation>
+                        {window.env.platform === 'darwin' && <MacOsScrollbarDetection />}
+                      </ModalContainer>
+                    </ErrorBoundary>
+                  </Theme>
                 </Router>
               </Lang>
             </StyleSheetManager>


### PR DESCRIPTION
The ErrorBoundary is currently outside of the Theme component which causes it to not have access to all css variables. This PR fixes the issue by wrapping the ErrorBoundary inside the Theme.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7505)
<!-- Reviewable:end -->
