### PR TITLE
Add rustc remap prefix helper crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,11 +1581,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3768,6 +3768,13 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "remap-path-prefix"
+version = "0.1.0"
+dependencies = [
+ "home",
+]
 
 [[package]]
 name = "resolv-conf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "remap-path-prefix"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "home",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "mullvad-types",
     "mullvad-types/intersection-derive",
     "mullvad-version",
+    "remap-path-prefix",
     "talpid-core",
     "talpid-dbus",
     "talpid-future",
@@ -53,6 +54,7 @@ default-members = [
     "mullvad-cli",
     "mullvad-daemon",
     "mullvad-version",
+    "remap-path-prefix",
 ]
 
 # Keep all lints in sync with `test/Cargo.toml`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ default-members = [
     "mullvad-cli",
     "mullvad-daemon",
     "mullvad-version",
-    "remap-path-prefix",
 ]
 
 # Keep all lints in sync with `test/Cargo.toml`

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -291,6 +291,11 @@ cargo {
             add("--locked")
         }
     }
+    exec = { spec, _ ->
+        val remaps = generateRemapArguments()
+        println("rustc path prefix remaps: $remaps")
+        spec.environment("RUSTFLAGS", remaps)
+    }
 }
 
 tasks.register<Exec>("generateRelayList") {

--- a/android/buildSrc/src/main/kotlin/Utils.kt
+++ b/android/buildSrc/src/main/kotlin/Utils.kt
@@ -14,7 +14,7 @@ fun Project.generateVersionName(localProperties: Properties): String {
 
 fun Project.generateRemapArguments(): String {
     return providers.exec {
-        commandLine("cargo", "run", "-q", "--bin", "remap-path-prefix")
+        commandLine("cargo", "run", "-p", "remap-path-prefix", "-q")
     }.standardOutput.asText.get().trim()
 }
 

--- a/android/buildSrc/src/main/kotlin/Utils.kt
+++ b/android/buildSrc/src/main/kotlin/Utils.kt
@@ -12,6 +12,12 @@ fun Project.generateVersionName(localProperties: Properties): String {
     return localProperties.getProperty("OVERRIDE_VERSION_NAME") ?: execVersionNameCargoCommand()
 }
 
+fun Project.generateRemapArguments(): String {
+    return providers.exec {
+        commandLine("cargo", "run", "-q", "--bin", "remap-path-prefix")
+    }.standardOutput.asText.get().trim()
+}
+
 private fun Project.execVersionCodeCargoCommand() =
     providers.exec {
         commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode")

--- a/remap-path-prefix/Cargo.toml
+++ b/remap-path-prefix/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
 name = "remap-path-prefix"
-version = "0.1.0"
-edition = "2021"
+description = """
+Computes the rustc flag `--remap-path-prefix` arguments that are needed
+to make the build artifacts reproducible.
+"""
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 home = "0.5.11"

--- a/remap-path-prefix/Cargo.toml
+++ b/remap-path-prefix/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "remap-path-prefix"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+home = "0.5.11"

--- a/remap-path-prefix/src/main.rs
+++ b/remap-path-prefix/src/main.rs
@@ -1,0 +1,21 @@
+fn main() {
+    match get_remap_path_prefix() {
+        Ok(prefix) => println!("{prefix}"),
+        Err(e) => {
+            eprintln!("error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn get_remap_path_prefix() -> Result<String, Box<dyn std::error::Error>> {
+    let cargo_home = home::cargo_home()?.display().to_string();
+    let rustup_home = home::rustup_home()?.display().to_string();
+
+    let source_dir = env!("CARGO_MANIFEST_DIR")
+        .split(concat!("/", env!("CARGO_PKG_NAME")))
+        .next()
+        .ok_or_else(|| "Could not find Cargo build dir.".to_string())?;
+
+    Ok(format!("--remap-path-prefix {cargo_home}=/CARGO_HOME --remap-path-prefix {rustup_home}=/RUSTUP_HOME --remap-path-prefix {source_dir}=/SOURCE_DIR"))
+}


### PR DESCRIPTION
Fixes: DROID-1747

This is needed for reproducible builds. This binary helper crate gets the file paths to the user's Cargo and Rustup home dirs, as well as the path to the Mullvad app source dir. These paths are then remapped to fixed values which is needed to make the build reproducible.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7508)
<!-- Reviewable:end -->
