### PR TITLE
Fix crash in dispatch queue assertion with background tasks

### DIFF
--- a/ios/MullvadVPN/AddressCacheTracker/AddressCacheTracker.swift
+++ b/ios/MullvadVPN/AddressCacheTracker/AddressCacheTracker.swift
@@ -84,7 +84,7 @@ final class AddressCacheTracker: @unchecked Sendable {
         timer = nil
     }
 
-    func updateEndpoints(completionHandler: (@Sendable (Result<Bool, Error>) -> Void)? = nil) -> Cancellable {
+    func updateEndpoints(completionHandler: ((sending Result<Bool, Error>) -> Void)? = nil) -> Cancellable {
         let operation = ResultBlockOperation<Bool> { finish -> Cancellable in
             guard self.nextScheduleDate() <= Date() else {
                 finish(.success(false))

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -16,7 +16,7 @@ import UIKit
 protocol RelayCacheTrackerProtocol: Sendable {
     func startPeriodicUpdates()
     func stopPeriodicUpdates()
-    func updateRelays(completionHandler: (@Sendable (Result<RelaysFetchResult, Error>) -> Void)?) -> Cancellable
+    func updateRelays(completionHandler: ((sending Result<RelaysFetchResult, Error>) -> Void)?) -> Cancellable
     func getCachedRelays() throws -> CachedRelays
     func getNextUpdateDate() -> Date
     func addObserver(_ observer: RelayCacheTrackerObserver)
@@ -164,7 +164,7 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
         timerSource = nil
     }
 
-    func updateRelays(completionHandler: (@Sendable (Result<RelaysFetchResult, Error>) -> Void)? = nil)
+    func updateRelays(completionHandler: ((sending Result<RelaysFetchResult, Error>) -> Void)? = nil)
         -> Cancellable {
         let operation = ResultBlockOperation<RelaysFetchResult> { finish in
             let cachedRelays = try? self.getCachedRelays()

--- a/ios/MullvadVPN/TunnelManager/BackgroundTaskProvider.swift
+++ b/ios/MullvadVPN/TunnelManager/BackgroundTaskProvider.swift
@@ -14,18 +14,10 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 public protocol BackgroundTaskProviding: Sendable {
     var backgroundTimeRemaining: TimeInterval { get }
-    #if compiler(>=6)
-    nonisolated
-    func beginBackgroundTask(
+    nonisolated func beginBackgroundTask(
         withName taskName: String?,
         expirationHandler handler: (@MainActor @Sendable () -> Void)?
     ) -> UIBackgroundTaskIdentifier
-    #else
-    func beginBackgroundTask(
-        withName taskName: String?,
-        expirationHandler handler: (() -> Void)?
-    ) -> UIBackgroundTaskIdentifier
-    #endif
 
     func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier)
 }
@@ -40,22 +32,12 @@ public final class BackgroundTaskProvider: BackgroundTaskProviding {
         self.application = application
     }
 
-    #if compiler(>=6)
-    nonisolated
-    public func beginBackgroundTask(
+    nonisolated public func beginBackgroundTask(
         withName taskName: String?,
-        expirationHandler handler: (@MainActor @Sendable () -> Void)?
+        expirationHandler handler: (@MainActor @Sendable () -> Void)? = nil
     ) -> UIBackgroundTaskIdentifier {
         application.beginBackgroundTask(withName: taskName, expirationHandler: handler)
     }
-    #else
-    public func beginBackgroundTask(
-        withName taskName: String?,
-        expirationHandler handler: (() -> Void)?
-    ) -> UIBackgroundTaskIdentifier {
-        application.beginBackgroundTask(withName: taskName, expirationHandler: handler)
-    }
-    #endif
 
     public func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {
         application.endBackgroundTask(identifier)

--- a/ios/MullvadVPNTests/MullvadVPN/RelayCacheTracker/RelayCacheTracker+Stubs.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/RelayCacheTracker/RelayCacheTracker+Stubs.swift
@@ -15,7 +15,7 @@ struct RelayCacheTrackerStub: RelayCacheTrackerProtocol {
 
     func stopPeriodicUpdates() {}
 
-    func updateRelays(completionHandler: ((Result<RelaysFetchResult, Error>) -> Void)?) -> Cancellable {
+    func updateRelays(completionHandler: ((sending Result<RelaysFetchResult, Error>) -> Void)?) -> Cancellable {
         AnyCancellable()
     }
 

--- a/ios/Operations/ResultOperation.swift
+++ b/ios/Operations/ResultOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Base class for operations producing result.
 open class ResultOperation<Success: Sendable>: AsyncOperation, OutputOperation, @unchecked Sendable {
-    public typealias CompletionHandler = @Sendable (Result<Success, Error>) -> Void
+    public typealias CompletionHandler = (sending Result<Success, Error>) -> Void
 
     private let nslock = NSLock()
     private var _output: Success?
@@ -104,7 +104,7 @@ open class ResultOperation<Success: Sendable>: AsyncOperation, OutputOperation, 
         pendingFinish = true
 
         // Copy completion handler.
-        let completionHandler = _completionHandler
+        nonisolated(unsafe) let completionHandler = _completionHandler
 
         // Unset completion handler.
         _completionHandler = nil
@@ -118,8 +118,7 @@ open class ResultOperation<Success: Sendable>: AsyncOperation, OutputOperation, 
         let completionQueue = _completionQueue
         nslock.unlock()
 
-        let block: @Sendable () -> Void = {
-            // Call completion handler.
+        dispatchAsyncOn(completionQueue) {
             completionHandler?(result)
 
             var error: Error?
@@ -130,11 +129,13 @@ open class ResultOperation<Success: Sendable>: AsyncOperation, OutputOperation, 
             // Finish operation.
             super.finish(error: error)
         }
+    }
 
-        if let completionQueue {
-            completionQueue.async(execute: block)
-        } else {
+    private func dispatchAsyncOn(_ queue: DispatchQueue?, _ block: @escaping @Sendable () -> Void) {
+        guard let queue else {
             block()
+            return
         }
+        queue.async(execute: block)
     }
 }


### PR DESCRIPTION
This PR should fix the crash we've been encountering in the latest beta version of the app.
It does so by forcing the registered tasks completion handlers to run on the main thread of the application.
It also removes some of the `nonisolated(unsafe)` markers that were added in those completion handlers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7510)
<!-- Reviewable:end -->
