### PR TITLE
Add script to generate rustc --remap-path-prefix

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -292,9 +292,7 @@ cargo {
         }
     }
     exec = { spec, _ ->
-        val remaps = generateRemapArguments()
-        println("rustc path prefix remaps: $remaps")
-        spec.environment("RUSTFLAGS", remaps)
+        spec.environment("RUSTFLAGS", generateRemapArguments())
     }
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -291,6 +291,11 @@ cargo {
             add("--locked")
         }
     }
+    exec = { spec, _ ->
+        val remaps = generateRemapArguments()
+        println("rustc path prefix remaps: $remaps")
+        spec.environment("RUSTFLAGS", remaps)
+    }
 }
 
 tasks.register<Exec>("generateRelayList") {

--- a/android/buildSrc/src/main/kotlin/Utils.kt
+++ b/android/buildSrc/src/main/kotlin/Utils.kt
@@ -1,7 +1,5 @@
-import java.io.ByteArrayOutputStream
 import java.util.*
 import org.gradle.api.Project
-import org.gradle.process.ExecSpec
 
 fun Project.generateVersionCode(localProperties: Properties): Int {
     return localProperties.getProperty("OVERRIDE_VERSION_CODE")?.toIntOrNull()
@@ -12,12 +10,24 @@ fun Project.generateVersionName(localProperties: Properties): String {
     return localProperties.getProperty("OVERRIDE_VERSION_NAME") ?: execVersionNameCargoCommand()
 }
 
+fun Project.generateRemapArguments(): String {
+    val script = "${projectDir.parent}/../building/rustc-remap-path-prefix.sh"
+    return providers.exec { commandLine(script) }.standardOutput.asText.get().trim()
+}
+
 private fun Project.execVersionCodeCargoCommand() =
-    providers.exec {
-        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode")
-    }.standardOutput.asText.get().trim().toInt()
+    providers
+        .exec { commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode") }
+        .standardOutput
+        .asText
+        .get()
+        .trim()
+        .toInt()
 
 private fun Project.execVersionNameCargoCommand() =
-    providers.exec {
-        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName")
-    }.standardOutput.asText.get().trim()
+    providers
+        .exec { commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName") }
+        .standardOutput
+        .asText
+        .get()
+        .trim()

--- a/android/buildSrc/src/main/kotlin/Utils.kt
+++ b/android/buildSrc/src/main/kotlin/Utils.kt
@@ -16,18 +16,11 @@ fun Project.generateRemapArguments(): String {
 }
 
 private fun Project.execVersionCodeCargoCommand() =
-    providers
-        .exec { commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode") }
-        .standardOutput
-        .asText
-        .get()
-        .trim()
-        .toInt()
+    providers.exec {
+        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode")
+    }.standardOutput.asText.get().trim().toInt()
 
 private fun Project.execVersionNameCargoCommand() =
-    providers
-        .exec { commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName") }
-        .standardOutput
-        .asText
-        .get()
-        .trim()
+    providers.exec {
+        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName")
+    }.standardOutput.asText.get().trim()

--- a/building/rustc-remap-path-prefix.sh
+++ b/building/rustc-remap-path-prefix.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Returns the rustc `--remap-path-prefix` flags needed to replace file paths
+# that gets put in the build artifacts with fixed values in order to make
+# the build reproducible across different machines.
+
+set -eu
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+CARGO_HOME_PATH=${CARGO_HOME:-$HOME/.cargo}
+RUSTUP_HOME_PATH=${RUSTUP_HOME:-$HOME/.rustup}
+
+echo "--remap-path-prefix $CARGO_HOME_PATH=/CARGO_HOME \
+--remap-path-prefix $RUSTUP_HOME_PATH=/RUSTUP_HOME \
+--remap-path-prefix $SOURCE_DIR=/SOURCE_DIR"


### PR DESCRIPTION
This is needed for reproducible builds. The script  gets the file paths to the user's Cargo and Rustup home dirs, as well as the path to the Mullvad app source dir. These paths are then remapped to fixed values which is needed to make the build reproducible.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7512)
<!-- Reviewable:end -->
