### PR TITLE
Take control over maybenot dependencies and verification

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Checkout wireguard-go-rs recursively
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Calculate native lib cache hash
         id: native-lib-cache-hash

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout submodules
         run: |
           git submodule update --init --depth=1 dist-assets/binaries
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Install build dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout wireguard-go submodule
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Clippy check
         env:

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git submodule update --init --depth=1 dist-assets/binaries
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       # The container image already has rustup and the pinned version of Rust
       - name: Install Rust toolchain
@@ -100,7 +100,7 @@ jobs:
       - name: Checkout wireguard-go submodule
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -131,7 +131,7 @@ jobs:
       - name: Checkout submodules
         run: |
           git submodule update --init --depth=1
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Install Protoc
         # NOTE: ARM runner already has protoc

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git submodule update --init --depth=1 dist-assets/binaries
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
       - name: Build app
         env:
           USE_MOLD: false
@@ -187,7 +187,7 @@ jobs:
           submodules: true
       - name: Checkout submodules
         run: |
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -274,7 +274,7 @@ jobs:
       - name: Checkout submodules
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
       - name: Install Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/ios-rust-ffi.yml
+++ b/.github/workflows/ios-rust-ffi.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Checkout wireguard-go-rs
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init wireguard-go-rs
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -17,4 +17,6 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@19ec1116569a47416e11a45848722b1af31a857b"  # v1.9.0
+    uses: "mullvad/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.0
+    with:
+      checkout-submodules: true

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -18,4 +18,6 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@19ec1116569a47416e11a45848722b1af31a857b"  # v1.9.0
+    uses: "mullvad/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.0
+    with:
+      checkout-submodules: true

--- a/.github/workflows/rust-unused-dependencies.yml
+++ b/.github/workflows/rust-unused-dependencies.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git submodule update --init --depth=1 dist-assets/binaries
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Install nightly Rust toolchain
         run: rustup override set $RUST_NIGHTLY_TOOLCHAIN
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout wireguard-go submodule
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Install nightly Rust
         run: |
@@ -106,7 +106,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           git submodule update --init --depth=1
-          git submodule update --init --recursive --depth=1 wireguard-go-rs
+          git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Install msbuild
         if: matrix.os == 'windows-latest'

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ cd mullvadvpn-app
 git submodule update --init
 ```
 
-On Android, Linux and macOS you also want to checkout the wireguard-go submodule recursively:
+On Android, Windows, Linux and macOS you also want to checkout the wireguard-go submodule:
 ```bash
-git submodule update --init --recursive --depth=1 wireguard-go-rs
+git submodule update --init wireguard-go-rs/libwg/wireguard-go
 ```
 Further details on why this is necessary can be found in the [wireguard-go-rs crate](./wireguard-go-rs/README.md).
 

--- a/android/BuildInstructions.md
+++ b/android/BuildInstructions.md
@@ -128,8 +128,6 @@ Linux distro:
 #### 5. Install and configure Rust toolchain
 
 - Get the latest **stable** Rust toolchain via [rustup.rs](https://rustup.rs/).
-  Also install `cbindgen` which is required to build `wireguard-go-rs`:
-  `cargo install --force cbindgen`
 
 - Configure Android cross-compilation targets and set up linker and archiver. This can be done by setting the following
 environment variables:

--- a/android/BuildInstructions.md
+++ b/android/BuildInstructions.md
@@ -155,7 +155,7 @@ environment variables:
   ```
 
 #### 6. Download wireguard-go-rs submodule
-Run the following command to download wireguard-go-rs submodule: `git submodule update --init --recursive --depth=1 wireguard-go-rs`
+Run the following command to download wireguard-go-rs submodule: `git submodule update --init wireguard-go-rs/libwg/wireguard-go`
 
 ### Debug build
 Run the following command to build a debug build:

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -117,11 +117,4 @@ RUN patch -p1 -f -N -r- -d /usr/local/go < /tmp/goruntime-boottime-over-monotoni
 # Add rust targets
 RUN rustup target add x86_64-linux-android i686-linux-android aarch64-linux-android armv7-linux-androideabi
 
-# Install cbindgen to address maybenot.h (checked in) sometimes needing to be
-# re-generated due to how `make` looks at last-modifications while git neither
-# stores nor consistently sets modification metadata on file checkout.
-# This is an intermediate solution that will be further improved as part of
-# issue: DROID-1328.
-RUN cargo install --force cbindgen --version "0.26.0" && rm -rf ~/.cargo/registry
-
 WORKDIR /build

--- a/android/docs/BuildInstructions.macos.md
+++ b/android/docs/BuildInstructions.macos.md
@@ -28,11 +28,6 @@ Finish the install of `rustup`:
 rustup-init
 ```
 
-Install `cbindgen` which is required to build `wireguard-go-rs`:
-```bash
-cargo install --force cbindgen
-```
-
 ## 2. Install SDK Tools and Android NDK Toolchain
 Open Android Studio -> Tools -> SDK Manager, and install `Android SDK Command-line Tools (latest)`.
 

--- a/android/docs/BuildInstructions.macos.md
+++ b/android/docs/BuildInstructions.macos.md
@@ -65,7 +65,7 @@ export CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$NDK_TOOLCHAIN_DIR/x86_64-linux
 wireguard-go-rs submodule need to be downloaded:
 
 ```bash
-git submodule update --init --recursive --depth=1 wireguard-go-rs
+git submodule update --init wireguard-go-rs/libwg/wireguard-go
 ```
 
 ## 4. Debug build

--- a/ci/buildserver-build-android.sh
+++ b/ci/buildserver-build-android.sh
@@ -65,7 +65,7 @@ function checkout_ref {
     git reset --hard
     git checkout "$ref"
     git submodule update
-    git submodule update --init --recursive --depth=1 wireguard-go-rs || true
+    git submodule update --init wireguard-go-rs/libwg/wireguard-go || true
     git clean -df
 }
 

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -159,7 +159,7 @@ function checkout_ref {
     git reset --hard
     git checkout "$ref"
     git submodule update
-    git submodule update --init --recursive --depth=1 wireguard-go-rs || true
+    git submodule update --init wireguard-go-rs/libwg/wireguard-go || true
     git clean -df
 }
 

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -12,10 +12,13 @@ thiserror.workspace = true
 log.workspace = true
 zeroize = "1.8.1"
 
-# The app does not depend on maybenot-ffi itself, but adds it as a dependency to expose FFI symbols to wireguard-go.
-# This is done, instead of using the makefile in wireguard-go to build maybenot-ffi into its archive, to prevent
-# name clashes induced by link-time optimization.
-# NOTE: the version of maybenot-ffi below must be the same as the version checked into the wireguard-go submodule
+# On platforms where maybenot and wireguard-go can be built statically (Linux and macOS) we use
+# this hack to include it. The hack is that we depend on this crate here even if neither
+# wireguard-go-rs nor its upstream dependants use it.
+# This is only here so that maybenot-ffi is built and its symbols are available to wireguard-go
+# at link time.
+# NOTE: for other platforms, maybenot-ffi is NOT declared here, but instead built directly from
+# wireguard-go-rs/libwg/wireguard-go/maybenot-ffi
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 maybenot-ffi = "2.0.1"
 

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -268,11 +268,16 @@ fn build_shared_maybenot_lib(out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
     tmp_build_dir = tmp_build_dir.join("target");
 
     build_command
-        .current_dir("./libwg/wireguard-go/maybenot/crates/maybenot-ffi")
+        .current_dir("./libwg/wireguard-go/maybenot-ffi")
         .env("RUSTFLAGS", "-C metadata=maybenot-ffi -Ctarget-feature=+crt-static")
-        // Set temporary target dir to prevent deadlock
+        // Set temporary target dir to prevent deadlock, since we are invoking cargo from within
+        // another cargo process.
         .env("CARGO_TARGET_DIR", &tmp_build_dir)
-        .arg("build")
+        .arg("rustc")
+        // Build a shared library to consume from another language (go)
+        .arg("--crate-type=cdylib")
+        // Always respect lockfiles
+        .args(["--locked"])
         .args(["--profile", profile])
         .args(["--target", &target_triple]);
 

--- a/wireguard-go-rs/libwg/Android.mk
+++ b/wireguard-go-rs/libwg/Android.mk
@@ -3,7 +3,8 @@
 # Copyright © 2017-2019 WireGuard LLC. All Rights Reserved.
 
 DESTDIR ?= $(OUT_DIR)
-CARGO_TARGET_DIR ?=
+# Default to the workspace root if not set
+CARGO_TARGET_DIR ?= $(CURDIR)/../../target
 TARGET ?=
 
 NDK_GO_ARCH_MAP_x86 := 386
@@ -25,7 +26,7 @@ default: $(DESTDIR)/libwg.so
 $(DESTDIR)/libwg.so:
 	mkdir -p $(DESTDIR)
 	# Build libmaybenot
-	make --directory wireguard-go libmaybenot.a LIBDEST="$(DESTDIR)" TARGET="$(TARGET)" CARGO_TARGET_DIR="$(CARGO_TARGET_DIR)"
+	make --directory wireguard-go/maybenot-ffi $(DESTDIR)/libmaybenot.a TARGET="$(TARGET)" CARGO_TARGET_DIR="$(CARGO_TARGET_DIR)"
 	# Build wireguard-go
 	go get -tags "linux android daita"
 	chmod -fR +w "$(GOPATH)/pkg/mod"

--- a/wireguard-go-rs/src/lib.rs
+++ b/wireguard-go-rs/src/lib.rs
@@ -29,7 +29,8 @@ pub type LoggingContext = u64;
 pub type LoggingCallback =
     unsafe extern "system" fn(level: WgLogLevel, msg: *const c_char, context: LoggingContext);
 
-// Make symbols from maybenot-ffi visible to wireguard-go
+// Make symbols from maybenot-ffi visible to wireguard-go, on the platforms where
+// wireguard-go is statically linked into this crate.
 #[cfg(all(daita, any(target_os = "linux", target_os = "macos")))]
 use maybenot_ffi as _;
 


### PR DESCRIPTION
This PR is a sibling-PR to https://github.com/mullvad/wireguard-go/pull/22.

This switches to a version of the `wireguard-go` submodule where `maybenot-ffi` is not included and built as a submodule. Instead there is a local crate in `wireguard-go` that acts as a simple wrapper around `maybenot-ffi`, with helper files to build it for static linking. This allows us to include the wrapper (and transitively all its dependencies) in our main workspace and track all dependency versions and checksums here. This simplifies dependency management, reproducible builds and supply chain security checks.

This PR is going to be colliding a bit with DAITA v2 for Windows (#7457), we have to discuss which one to get merged first.

Fixes DES-1360 and DES-1645

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7515)
<!-- Reviewable:end -->
