### PR TITLE
Bundle a pre-generated relay list instead of generating one on android

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -104,49 +104,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  generate-relay-list:
-    name: Generate relay list # Used by wait for jobs.
-    needs: prepare
-    runs-on: ubuntu-latest
-    container:
-      image: ${{ needs.prepare.outputs.container_image }}
-    steps:
-      # Fix for HOME path overridden by GH runners when building in containers, see:
-      # https://github.com/actions/runner/issues/863
-      - name: Fix HOME path
-        run: echo "HOME=/root" >> $GITHUB_ENV
-
-      - name: Get date
-        id: get-date
-        shell: bash
-        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
-
-      - name: Cache
-        uses: actions/cache@v4
-        id: cache-relay-list
-        with:
-          path: android/app/build/extraAssets/relays.json
-          key: relay-list-${{ steps.get-date.outputs.date }}
-
-      - name: Checkout repository
-        if: steps.cache-relay-list.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Generate
-        if: steps.cache-relay-list.outputs.cache-hit != 'true'
-        shell: bash
-        run: ./android/gradlew -p android generateRelayList
-
-      - name: Upload
-        uses: actions/upload-artifact@v4
-        with:
-          name: relay-list
-          path: android/app/build/extraAssets/relays.json
-          if-no-files-found: error
-          retention-days: 7
-
   build-native:
     name: Build native # Used by wait for jobs.
     needs: prepare
@@ -311,10 +268,6 @@ jobs:
                 "workflowFile": "android-app.yml",
                 "jobMatchMode": "prefix",
                 "jobName": "Build native"
-              },
-              {
-                "workflowFile": "android-app.yml",
-                "jobName": "Generate relay list"
               }
             ]
 
@@ -323,11 +276,6 @@ jobs:
           pattern: native-libs-*
           path: android/app/build/rustJniLibs/android
           merge-multiple: true
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: relay-list
-          path: android/app/build/extraAssets
 
       - name: Build app
         uses: burrunan/gradle-cache-action@v1
@@ -410,7 +358,6 @@ jobs:
           arguments: |
             ${{ matrix.assemble-command }}
             -x cargoBuild
-            -x generateRelayList
             -x mergeOssProdDebugJniLibFolders
             -x mergePlayStagemoleDebugJniLibFolders
           gradle-version: wrapper

--- a/android/buildSrc/src/main/kotlin/Utils.kt
+++ b/android/buildSrc/src/main/kotlin/Utils.kt
@@ -1,6 +1,23 @@
 import java.util.*
 import org.gradle.api.Project
 
+// This is a hack and will not work correctly under all scenarios.
+// See DROID-1696 for how we can improve this.
+fun Project.isReleaseBuild() =
+    gradle.startParameter.getTaskNames().any {
+        it.contains("release", ignoreCase = true) || it.contains("fdroid", ignoreCase = true)
+    }
+
+fun Project.isAlphaBuild(localProperties: Properties): Boolean {
+    val versionName = generateVersionName(localProperties)
+    return versionName.contains("alpha")
+}
+
+fun Project.isDevBuild(localProperties: Properties): Boolean {
+    val versionName = generateVersionName(localProperties)
+    return versionName.contains("-dev-")
+}
+
 fun Project.generateVersionCode(localProperties: Properties): Int {
     return localProperties.getProperty("OVERRIDE_VERSION_CODE")?.toIntOrNull()
         ?: execVersionCodeCargoCommand()

--- a/android/scripts/update-lockfile.sh
+++ b/android/scripts/update-lockfile.sh
@@ -20,7 +20,6 @@ GRADLE_TASKS=(
     "lint"
 )
 EXCLUDED_GRADLE_TASKS=(
-    "-xgenerateRelayList"
     "-xcargoBuild"
 )
 

--- a/android/service/build.gradle.kts
+++ b/android/service/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -9,7 +11,16 @@ android {
     compileSdk = Versions.compileSdkVersion
     buildToolsVersion = Versions.buildToolsVersion
 
-    defaultConfig { minSdk = Versions.minSdkVersion }
+    defaultConfig {
+        minSdk = Versions.minSdkVersion
+        val localProperties = gradleLocalProperties(rootProject.projectDir, providers)
+        val shouldRequireBundleRelayFile = isReleaseBuild() && !isDevBuild(localProperties)
+        buildConfigField(
+            "Boolean",
+            "REQUIRE_BUNDLED_RELAY_FILE",
+            shouldRequireBundleRelayFile.toString(),
+        )
+    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/MullvadVpnService.kt
@@ -220,7 +220,10 @@ class MullvadVpnService : TalpidVpnService() {
     }
 
     private fun Context.prepareFiles() {
-        extractAndOverwriteIfAssetMoreRecent(RELAY_LIST_ASSET_NAME)
+        extractAndOverwriteIfAssetMoreRecent(
+            RELAY_LIST_ASSET_NAME,
+            BuildConfig.REQUIRE_BUNDLED_RELAY_FILE,
+        )
     }
 
     companion object {

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/util/ContextExtensions.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/util/ContextExtensions.kt
@@ -1,23 +1,31 @@
 package net.mullvad.mullvadvpn.service.util
 
 import android.content.Context
+import co.touchlab.kermit.Logger
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
 
-fun Context.extractAndOverwriteIfAssetMoreRecent(assetName: String) {
+fun Context.extractAndOverwriteIfAssetMoreRecent(assetName: String, requireAssetFile: Boolean) {
     val forceOverwriteIfMoreRecent = lastUpdatedTime() > File(filesDir, assetName).lastModified()
     val destination = File(filesDir, assetName)
 
     if (!destination.exists() || forceOverwriteIfMoreRecent) {
-        extractFile(assetName, destination)
+        extractFile(assetName, destination, requireAssetFile)
     }
 }
 
 private fun Context.lastUpdatedTime(): Long =
     packageManager.getPackageInfo(packageName, 0).lastUpdateTime
 
-private fun Context.extractFile(asset: String, destination: File) {
-    val destinationStream = FileOutputStream(destination)
-    assets.open(asset).copyTo(destinationStream)
-    destinationStream.close()
+private fun Context.extractFile(asset: String, destination: File, requireAssetFile: Boolean) {
+    if (assets.list("")?.contains(asset) == true) {
+        val destinationStream = FileOutputStream(destination)
+        assets.open(asset).copyTo(destinationStream)
+        destinationStream.close()
+    } else if (requireAssetFile) {
+        throw FileNotFoundException("Asset $asset not found")
+    } else {
+        Logger.i("Asset $asset not found")
+    }
 }

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -66,6 +66,15 @@ if [[ "$ANDROID" == "true" &&
     exit 1
 fi
 
+if [[ "$ANDROID" == "true" ]]; then
+    echo "Generate relays.json"
+    mkdir dist-assets/relays
+    cargo run -q -p mullvad-api --bin relay_list > dist-assets/relays/relays.json
+
+    git commit -S -m "Add relay list to bundle with $PRODUCT_VERSION" \
+        dist-assets/relays/relays.json
+fi
+
 if [[ "$DESKTOP" == "true" ]]; then
     echo "$PRODUCT_VERSION" > dist-assets/desktop-product-version.txt
     git commit -S -m "Update desktop app version to $PRODUCT_VERSION" \


### PR DESCRIPTION
For dev builds we rely on the app to download the relay list from the api. This will make the app behave a bit weird if it is not able to download the relay list

For release builds on release branches we will generate a relay list and commit it to the branch. This will then be used by the app and thus release builds will have a bundled `relays.json`.

This is required for reproducible builds.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7518)
<!-- Reviewable:end -->
