### PR TITLE
Add locked to various cargo build invocations for desktop

### DIFF
--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build test framework
         working-directory: test
-        run: cargo build --release
+        run: cargo build --release --locked
 
   # Build the test runner + test manager at once.
   build-test-framework-macos:
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build test runner
         working-directory: test
-        run: cargo build
+        run: cargo build --locked
 
   # Build only the test-runner binary on Windows. Windows is not a supported host for test-manager.
   build-test-runner-windows:
@@ -112,4 +112,4 @@ jobs:
 
       - name: Build test runner
         working-directory: test
-        run: cargo build --release -p test-runner --target x86_64-pc-windows-gnu
+        run: cargo build --release --locked -p test-runner --target x86_64-pc-windows-gnu

--- a/desktop/packages/nseventforwarder/package.json
+++ b/desktop/packages/nseventforwarder/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "cargo-build": "tsc && cargo build",
     "build-debug": "npm run cargo-build && mkdir -p debug && cp ${CARGO_TARGET_DIR:-../../../target}/debug/libnseventforwarder.dylib debug/index.node",
-    "build-arm": "npm run cargo-build -- --release --target aarch64-apple-darwin && mkdir -p dist/darwin-arm64 && cp ${CARGO_TARGET_DIR:-../../../target}/aarch64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-arm64/index.node",
-    "build-x86": "npm run cargo-build -- --release --target x86_64-apple-darwin && mkdir -p dist/darwin-x64 && cp ${CARGO_TARGET_DIR:-../../../target}/x86_64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-x64/index.node",
+    "build-arm": "npm run cargo-build -- --release --locked --target aarch64-apple-darwin && mkdir -p dist/darwin-arm64 && cp ${CARGO_TARGET_DIR:-../../../target}/aarch64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-arm64/index.node",
+    "build-x86": "npm run cargo-build -- --release --locked --target x86_64-apple-darwin && mkdir -p dist/darwin-x64 && cp ${CARGO_TARGET_DIR:-../../../target}/x86_64-apple-darwin/release/libnseventforwarder.dylib dist/darwin-x64/index.node",
     "clean": "rm -rf debug; rm -rf dist",
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."

--- a/windows/nsis-plugins/src/cleanup/cleanup.vcxproj
+++ b/windows/nsis-plugins/src/cleanup/cleanup.vcxproj
@@ -106,7 +106,7 @@
       <ModuleDefinitionFile>cleanup.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Command "&amp; { Remove-Item Env:VSTEL_MSBuildProjectFullPath; cargo build --target i686-pc-windows-msvc --release -p mullvad-nsis }"
+      <Command>powershell.exe -Command "&amp; { Remove-Item Env:VSTEL_MSBuildProjectFullPath; cargo build --target i686-pc-windows-msvc --release --locked -p mullvad-nsis }"
 </Command>
       <Message>Build mullvad-nsis library</Message>
     </PreBuildEvent>

--- a/windows/nsis-plugins/src/log/log.vcxproj
+++ b/windows/nsis-plugins/src/log/log.vcxproj
@@ -106,7 +106,7 @@
       <ModuleDefinitionFile>log.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>powershell.exe -Command "&amp; { Remove-Item Env:VSTEL_MSBuildProjectFullPath; cargo build --target i686-pc-windows-msvc --release -p mullvad-nsis }"
+      <Command>powershell.exe -Command "&amp; { Remove-Item Env:VSTEL_MSBuildProjectFullPath; cargo build --target i686-pc-windows-msvc --release --locked -p mullvad-nsis }"
 </Command>
       <Message>Build mullvad-nsis library</Message>
     </PreBuildEvent>


### PR DESCRIPTION
We want to exit with an error if we try to produce a release build with an outdated lockfile. Such builds could be really hard to reproduce later, and is a supply chain risk. Being strict in CI is a good way of making sure we don't merge changes that require lockfile updates, but that were forgotten.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7524)
<!-- Reviewable:end -->
