### PR TITLE
Disable `setup-zig` on Windows Arm

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -190,6 +190,11 @@ jobs:
         if: ${{ matrix.config.arch == 'x64' }}
         uses: mlugg/setup-zig@v1
 
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.3
+
       - name: Build Windows modules
         if: steps.cache-windows-modules.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -186,6 +186,8 @@ jobs:
           vs-version: 16
 
       - name: Install latest zig
+        # NOTE: This action doesn't support ARM64 for the time being (2025-01-27)
+        if: ${{ matrix.config.arch == 'x64' }}
         uses: mlugg/setup-zig@v1
 
       - name: Build Windows modules


### PR DESCRIPTION
Not supported at the moment. I've installed it on the runner itself for now.

Fix DES-1675

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7527)
<!-- Reviewable:end -->
