### PR TITLE
Fix memory leak in libwg_windows.go

### DIFF
--- a/wireguard-go-rs/libwg/libwg_windows.go
+++ b/wireguard-go-rs/libwg/libwg_windows.go
@@ -112,7 +112,9 @@ func wgTurnOn(cIfaceName *C.char, cIfaceNameOut *C.char, cIfaceNameOutSize C.siz
 			device.Close()
 			return ERROR_GENERAL_FAILURE
 		}
-		C.strcpy(cIfaceNameOut, C.CString(actualInterfaceName))
+		cName := C.CString(actualInterfaceName)
+		C.strcpy(cIfaceNameOut, cName)
+		C.free(unsafe.Pointer(cName))
 	}
 	if cLuidOut != nil {
 		*cLuidOut = C.uint64_t(nativeTun.LUID())


### PR DESCRIPTION
`C.CString` allocates a new string, but there was no corresponding call to `C.free`. This is recent: It slipped in with https://github.com/mullvad/mullvadvpn-app/commit/654de1cd2d3cdde6a3c26fe0cf5f26a4b0d1a89c

I'm sure there's a way to do this without allocating, but this seemed like the simplest approach.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7529)
<!-- Reviewable:end -->
