### PR TITLE
Treat fdroid builds the same as release builds

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -333,7 +333,9 @@ if (
 // This is a hack and will not work correctly under all scenarios.
 // See DROID-1696 for how we can improve this.
 fun isReleaseBuild() =
-    gradle.startParameter.getTaskNames().any { it.contains("release", ignoreCase = true) }
+    gradle.startParameter.getTaskNames().any {
+        it.contains("release", ignoreCase = true) || it.contains("fdroid", ignoreCase = true)
+    }
 
 fun isAlphaOrDevBuild(): Boolean {
     val localProperties = gradleLocalProperties(rootProject.projectDir, providers)


### PR DESCRIPTION
Fdroid builds should be the same as release build when it comes to bulding cargo, eg. setting the --release flag. This is currently not true as we only check for "release" in gradle tasks and the task we use to build for fdroid `createOssProdFdroidDist[Apk/Bundle]` does not contain this keyword.

This is a stop-gap measure that just treats "fdroid" the same "release" until we can figure out a better solution for release builds.

The longterm solution is tracked in DROID-1696.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7531)
<!-- Reviewable:end -->
