### PR TITLE
Allow maximum rotation interval to be set in CLI

### DIFF
--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -210,7 +210,7 @@ impl clap::builder::ValueParserFactory for RotationInterval {
     fn value_parser() -> Self::Parser {
         clap::builder::RangedU64ValueParser::new().range(
             (MIN_ROTATION_INTERVAL.as_secs() / 60 / 60)
-                ..(MAX_ROTATION_INTERVAL.as_secs() / 60 / 60),
+                ..=(MAX_ROTATION_INTERVAL.as_secs() / 60 / 60),
         )
     }
 }


### PR DESCRIPTION
As the interval wasn't inclusive, `MAX_ROTATION_INTERVAL - 1 hr` was the maximum value that could be set.

Close #7526

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7532)
<!-- Reviewable:end -->
