### PR TITLE
Add support for target dir in rustc remapping

### DIFF
--- a/building/rustc-remap-path-prefix.sh
+++ b/building/rustc-remap-path-prefix.sh
@@ -6,10 +6,18 @@
 
 set -eu
 
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 CARGO_HOME_PATH=${CARGO_HOME:-$HOME/.cargo}
 RUSTUP_HOME_PATH=${RUSTUP_HOME:-$HOME/.rustup}
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+CARGO_TARGET_DIR_PATH=${CARGO_TARGET_DIR:-$SOURCE_DIR/target}
 
-echo "--remap-path-prefix $CARGO_HOME_PATH=/CARGO_HOME \
+# The order is significant. Iterated over in reverse, so last argument is
+# treated as most significant. Since CARGO_TARGET_DIR_PATH might be located
+# under $SOURCE_DIR, it's important to keep it last.
+# See: https://github.com/rust-lang/rust/blob/55459598c250d985eb5f840306dfb59f267c03b6/compiler/rustc_span/src/source_map.rs#L1125-L1127
+echo "\
+--remap-path-prefix $CARGO_HOME_PATH=/CARGO_HOME \
 --remap-path-prefix $RUSTUP_HOME_PATH=/RUSTUP_HOME \
---remap-path-prefix $SOURCE_DIR=/SOURCE_DIR"
+--remap-path-prefix $SOURCE_DIR=/SOURCE_DIR \
+--remap-path-prefix $CARGO_TARGET_DIR_PATH=/CARGO_TARGET_DIR \
+" | xargs


### PR DESCRIPTION
This PR aims to add remapping support for `CARGO_TARGET_DIR` instead of relying on it existing under the project root. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7533)
<!-- Reviewable:end -->
