### PR TITLE
Hide connection details view based on tunnel status

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
@@ -29,7 +29,7 @@ struct ConnectionView: View {
                 indicatorsViewModel: indicatorsViewModel,
                 isExpanded: $isExpanded
             )
-            .showIf(connectionViewModel.showConnectionDetails)
+            .showIf(connectionViewModel.showsConnectionDetails)
 
             ButtonPanel(viewModel: connectionViewModel, action: action)
                 .padding(.top, 16)
@@ -38,21 +38,13 @@ struct ConnectionView: View {
         .background(BlurView(style: .dark))
         .cornerRadius(12)
         .padding(EdgeInsets(top: 16, leading: 16, bottom: 24, trailing: 16))
-        .onReceive(connectionViewModel.$tunnelStatus) { _ in
-            // Only update expanded state when connections details should be hidden.
-            // This will contract the view on eg. disconnect, but leave it as-is on
-            // eg. connect.
-            if !connectionViewModel.showConnectionDetails {
-                isExpanded = false
-            }
-        }
     }
 }
 
 extension ConnectionView {
     var headerViewBottomPadding: CGFloat {
         let hasIndicators = !indicatorsViewModel.chips.isEmpty
-        let showConnectionDetails = connectionViewModel.showConnectionDetails
+        let showConnectionDetails = connectionViewModel.showsConnectionDetails
 
         return isExpanded
             ? showConnectionDetails ? 16 : 0

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewViewModel.swift
@@ -30,6 +30,7 @@ class ConnectionViewViewModel: ObservableObject {
     @Published private(set) var tunnelStatus: TunnelStatus
     @Published var outgoingConnectionInfo: OutgoingConnectionInfo?
     @Published var showsActivityIndicator = false
+    @Published var showsConnectionDetails = false
 
     @Published var relayConstraints: RelayConstraints
     let destinationDescriber: DestinationDescribing
@@ -72,24 +73,25 @@ class ConnectionViewViewModel: ObservableObject {
 
     func update(tunnelStatus: TunnelStatus) {
         self.tunnelStatus = tunnelStatus
+        self.showsConnectionDetails = shouldShowConnectionDetails(tunnelStatus)
 
         if !tunnelIsConnected {
             outgoingConnectionInfo = nil
         }
     }
-}
 
-extension ConnectionViewViewModel {
-    var showConnectionDetails: Bool {
+    private func shouldShowConnectionDetails(_ tunnelStatus: TunnelStatus) -> Bool {
         switch tunnelStatus.state {
-        case .connecting, .reconnecting, .waitingForConnectivity(.noConnection), .negotiatingEphemeralPeer,
+        case .connecting, .reconnecting, .negotiatingEphemeralPeer,
              .connected, .pendingReconnect:
             true
-        case .disconnecting, .disconnected, .waitingForConnectivity(.noNetwork), .error:
+        case .disconnecting, .disconnected, .waitingForConnectivity, .error:
             false
         }
     }
+}
 
+extension ConnectionViewViewModel {
     var textColorForSecureLabel: UIColor {
         switch tunnelStatus.state {
         case .connecting, .reconnecting, .waitingForConnectivity(.noConnection), .negotiatingEphemeralPeer,

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
@@ -47,7 +47,7 @@ extension ConnectionView {
                         .foregroundStyle(.white)
                         .accessibilityIdentifier(AccessibilityIdentifier.relayStatusCollapseButton.asString)
                 }
-                .showIf(viewModel.showConnectionDetails)
+                .showIf(viewModel.showsConnectionDetails)
             }
             .contentShape(Rectangle())
             .onTapGesture {


### PR DESCRIPTION
This PR toggles the visibility of the connection detail info base on tunnel state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7534)
<!-- Reviewable:end -->
