### PR TITLE
Fix router getting stuck under certain circumstances

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -627,6 +627,9 @@
 		7AB3BEB52BD7A6CB00E34384 /* LocationViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */; };
 		7AB4CCB92B69097E006037F5 /* IPOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4CCB82B69097E006037F5 /* IPOverrideTests.swift */; };
 		7AB4CCBB2B691BBB006037F5 /* IPOverrideInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4CCBA2B691BBB006037F5 /* IPOverrideInteractor.swift */; };
+		7AB931282D48FB8B005FCEBA /* DAITASettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB931272D48FB16005FCEBA /* DAITASettingsViewController.swift */; };
+		7AB9312A2D4A16BE005FCEBA /* MultihopViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB931292D4A16B8005FCEBA /* MultihopViewController.swift */; };
+		7AB9312C2D4A1732005FCEBA /* ChangeLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB9312B2D4A172C005FCEBA /* ChangeLogViewController.swift */; };
 		7ABCA5B32A9349F20044A708 /* Routing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A88DCCE2A8FABBE00D2FF0E /* Routing.framework */; };
 		7ABCA5B42A9349F20044A708 /* Routing.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7A88DCCE2A8FABBE00D2FF0E /* Routing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7ABCA5B72A9353C60044A708 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CAF9F72983D36800BE19F7 /* Coordinator.swift */; };
@@ -2025,6 +2028,9 @@
 		7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationViewControllerWrapper.swift; sourceTree = "<group>"; };
 		7AB4CCB82B69097E006037F5 /* IPOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideTests.swift; sourceTree = "<group>"; };
 		7AB4CCBA2B691BBB006037F5 /* IPOverrideInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideInteractor.swift; sourceTree = "<group>"; };
+		7AB931272D48FB16005FCEBA /* DAITASettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAITASettingsViewController.swift; sourceTree = "<group>"; };
+		7AB931292D4A16B8005FCEBA /* MultihopViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultihopViewController.swift; sourceTree = "<group>"; };
+		7AB9312B2D4A172C005FCEBA /* ChangeLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeLogViewController.swift; sourceTree = "<group>"; };
 		7ABE318C2A1CDD4500DF4963 /* UIFont+Weight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Weight.swift"; sourceTree = "<group>"; };
 		7ABFB09D2BA316220074A49E /* RelayConstraintsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayConstraintsTests.swift; sourceTree = "<group>"; };
 		7AC8A3AD2ABC6FBB00DC4939 /* SettingsHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
@@ -4085,6 +4091,7 @@
 			isa = PBXGroup;
 			children = (
 				7A8A19152CEF2696000BCB5B /* MultihopTunnelSettingsViewModel.swift */,
+				7AB931292D4A16B8005FCEBA /* MultihopViewController.swift */,
 				7A8A18F82CE34E9F000BCB5B /* SettingsMultihopView.swift */,
 			);
 			path = Multihop;
@@ -4107,6 +4114,7 @@
 			children = (
 				7A3215732D3E5A7B005DF395 /* DAITASettingsCoordinator.swift */,
 				F041BE4E2C983C2B0083EC28 /* DAITASettingsPromptItem.swift */,
+				7AB931272D48FB16005FCEBA /* DAITASettingsViewController.swift */,
 				7A8A19132CEF2527000BCB5B /* DAITATunnelSettingsViewModel.swift */,
 				7A8A19092CE5FFDF000BCB5B /* SettingsDAITAView.swift */,
 			);
@@ -4595,6 +4603,7 @@
 				F048BFA12D31842B00251CB9 /* ChangeLogModel.swift */,
 				F09C97222D3122E400ADE747 /* ChangeLogReader.swift */,
 				F09C97202D311D7A00ADE747 /* ChangeLogView.swift */,
+				7AB9312B2D4A172C005FCEBA /* ChangeLogViewController.swift */,
 				F0EF50D42A949F8E0031E8DF /* ChangeLogViewModel.swift */,
 			);
 			path = ChangeLog;
@@ -5920,6 +5929,7 @@
 				58E511E628DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift in Sources */,
 				58C76A0B2A338E4300100D75 /* BackgroundTask.swift in Sources */,
 				7A9CCCC32A96302800DD6A34 /* ApplicationCoordinator.swift in Sources */,
+				7AB9312A2D4A16BE005FCEBA /* MultihopViewController.swift in Sources */,
 				5864AF0729C78843005B0CD9 /* SettingsCellFactory.swift in Sources */,
 				F0ADC3742CD3C47400A1AD97 /* ChipFlowLayout.swift in Sources */,
 				587B75412668FD7800DEF7E9 /* AccountExpirySystemNotificationProvider.swift in Sources */,
@@ -6080,6 +6090,7 @@
 				7A0EAE9A2D01B41500D3EB8B /* MainButtonStyle.swift in Sources */,
 				58CEB3022AFD365600E6E088 /* SwitchCellContentConfiguration.swift in Sources */,
 				7AA130A12D01B1E200640DF9 /* SplitMainButton.swift in Sources */,
+				7AB931282D48FB8B005FCEBA /* DAITASettingsViewController.swift in Sources */,
 				7AA1309F2D007B2500640DF9 /* VisualEffectView.swift in Sources */,
 				7A9CCCB52A96302800DD6A34 /* AddCreditSucceededCoordinator.swift in Sources */,
 				7A0C0F632A979C4A0058EFCE /* Coordinator+Router.swift in Sources */,
@@ -6266,6 +6277,7 @@
 				A9C342C12ACC37E30045F00E /* TunnelStatusBlockObserver.swift in Sources */,
 				587425C12299833500CA2045 /* RootContainerViewController.swift in Sources */,
 				7AB3BEB52BD7A6CB00E34384 /* LocationViewControllerWrapper.swift in Sources */,
+				7AB9312C2D4A1732005FCEBA /* ChangeLogViewController.swift in Sources */,
 				F09D04BD2AEBB7C5003D4F89 /* OutgoingConnectionService.swift in Sources */,
 				58FF9FF42B07C61B00E4C97D /* AccessMethodValidationError.swift in Sources */,
 				5896AE84246D5889005B36CB /* CustomDateComponentsFormatting.swift in Sources */,

--- a/ios/MullvadVPN/Classes/AppRoutes.swift
+++ b/ios/MullvadVPN/Classes/AppRoutes.swift
@@ -42,30 +42,6 @@ enum AppRouteGroup: AppRouteGroupProtocol {
      Alert group. Alert id should match the id of the alert being contained.
      */
     case alert(_ alertId: String)
-
-    var isModal: Bool {
-        switch self {
-        case .primary:
-            return false
-
-        case .selectLocation, .account, .settings, .changelog, .alert:
-            return true
-        }
-    }
-
-    var modalLevel: Int {
-        switch self {
-        case .primary:
-            return 0
-        case .account, .selectLocation, .changelog:
-            return 1
-        case .settings:
-            return 2
-        case .alert:
-            // Alerts should always be topmost.
-            return .max
-        }
-    }
 }
 
 /**
@@ -107,15 +83,6 @@ enum AppRoute: AppRouteProtocol {
      Routes that are part of primary horizontal navigation group.
      */
     case tos, login, main, revoked, outOfTime, welcome
-
-    var isExclusive: Bool {
-        switch self {
-        case .account, .settings, .alert:
-            return true
-        default:
-            return false
-        }
-    }
 
     var supportsSubNavigation: Bool {
         if case .settings = self {

--- a/ios/MullvadVPN/Coordinators/ChangeLogCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ChangeLogCoordinator.swift
@@ -32,8 +32,7 @@ final class ChangeLogCoordinator: Coordinator, Presentable, SettingsChildCoordin
     }
 
     func start(animated: Bool) {
-        let changeLogViewController = UIHostingController(rootView: ChangeLogView(viewModel: viewModel))
-        changeLogViewController.view.setAccessibilityIdentifier(.changeLogAlert)
+        let changeLogViewController = ChangeLogViewController(rootView: ChangeLogView(viewModel: viewModel))
         changeLogViewController.navigationItem.title = NSLocalizedString(
             "whats_new_title",
             tableName: "Changelog",

--- a/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LocationCoordinator.swift
@@ -258,10 +258,12 @@ extension LocationCoordinator: @preconcurrency LocationViewControllerWrapperDele
     }
 
     func navigateToFilter() {
-        let coordinator = makeRelayFilterCoordinator(forModalPresentation: true)
-        coordinator.start()
+        applicationRouter?.present(.settings(nil))
 
-        presentChild(coordinator, animated: true)
+//        let coordinator = makeRelayFilterCoordinator(forModalPresentation: true)
+//        coordinator.start()
+//
+//        presentChild(coordinator, animated: true)
     }
 
     func navigateToCustomLists(nodes: [LocationNode]) {

--- a/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITASettingsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITASettingsCoordinator.swift
@@ -50,14 +50,13 @@ class DAITASettingsCoordinator: Coordinator, SettingsChildCoordinator, Presentab
             )
         }
 
-        let host = UIHostingController(rootView: view)
+        let host = DAITASettingsViewController(rootView: view)
         host.title = NSLocalizedString(
             "NAVIGATION_TITLE_DAITA",
             tableName: "Settings",
             value: "DAITA",
             comment: ""
         )
-        host.view.setAccessibilityIdentifier(.daitaView)
         customiseNavigation(on: host)
 
         navigationController.pushViewController(host, animated: animated)

--- a/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITASettingsViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITASettingsViewController.swift
@@ -1,0 +1,20 @@
+//
+//  DAITAViewController.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2025-01-28.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+import SwiftUI
+
+class DAITASettingsViewController: UIHostingController<SettingsDAITAView<DAITATunnelSettingsViewModel>> {
+    override init(rootView: SettingsDAITAView<DAITATunnelSettingsViewModel>) {
+        super.init(rootView: rootView)
+        view.setAccessibilityIdentifier(.daitaView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/ios/MullvadVPN/Coordinators/Settings/DAITASettingsViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DAITASettingsViewController.swift
@@ -1,0 +1,7 @@
+//
+//  DAITAViewController.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2025-01-28.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//

--- a/ios/MullvadVPN/Coordinators/Settings/Multihop/MultihopViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Multihop/MultihopViewController.swift
@@ -1,0 +1,20 @@
+//
+//  MultihopViewController.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2025-01-29.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+import SwiftUI
+
+class MultihopViewController: UIHostingController<SettingsMultihopView<MultihopTunnelSettingsViewModel>> {
+    override init(rootView: SettingsMultihopView<MultihopTunnelSettingsViewModel>) {
+        super.init(rootView: rootView)
+        view.setAccessibilityIdentifier(.multihopView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsCoordinator.swift
@@ -270,6 +270,12 @@ final class SettingsCoordinator: Coordinator, Presentable, Presenting, SettingsV
             return .problemReport
         case is ListAccessMethodViewController:
             return .apiAccess
+        case is DAITASettingsViewController:
+            return .daita
+        case is MultihopViewController:
+            return .multihop
+        case is ChangeLogViewController:
+            return .changelog
         default:
             return nil
         }

--- a/ios/MullvadVPN/Coordinators/Settings/SettingsViewControllerFactory.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/SettingsViewControllerFactory.swift
@@ -109,16 +109,15 @@ struct SettingsViewControllerFactory {
         let viewModel = MultihopTunnelSettingsViewModel(tunnelManager: interactorFactory.tunnelManager)
         let view = SettingsMultihopView(tunnelViewModel: viewModel)
 
-        let host = UIHostingController(rootView: view)
-        host.title = NSLocalizedString(
+        let viewController = MultihopViewController(rootView: view)
+        viewController.title = NSLocalizedString(
             "NAVIGATION_TITLE_MULTIHOP",
             tableName: "Settings",
             value: "Multihop",
             comment: ""
         )
-        host.view.setAccessibilityIdentifier(.multihopView)
 
-        return .viewController(host)
+        return .viewController(viewController)
     }
 
     private func makeDAITASettingsCoordinator() -> MakeChildResult {

--- a/ios/MullvadVPN/View controllers/Alert/AlertPresenter.swift
+++ b/ios/MullvadVPN/View controllers/Alert/AlertPresenter.swift
@@ -23,7 +23,7 @@ struct AlertPresenter {
     }
 
     func dismissAlert(presentation: AlertPresentation, animated: Bool) {
-        context?.applicationRouter?.dismiss(.alert(presentation.id), animated: animated)
+        context?.applicationRouter?.dismiss(route: .alert(presentation.id), animated: animated)
     }
 }
 

--- a/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogViewController.swift
+++ b/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogViewController.swift
@@ -1,0 +1,20 @@
+//
+//  ChangeLogViewController.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2025-01-29.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+import SwiftUI
+
+class ChangeLogViewController: UIHostingController<ChangeLogView<ChangeLogViewModel>> {
+    override init(rootView: ChangeLogView<ChangeLogViewModel>) {
+        super.init(rootView: rootView)
+        view.setAccessibilityIdentifier(.changeLogAlert)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/ios/Routing/Router/AppRouteProtocol.swift
+++ b/ios/Routing/Router/AppRouteProtocol.swift
@@ -11,46 +11,13 @@ import Foundation
 /**
  Formal protocol describing a group of routes.
  */
-public protocol AppRouteGroupProtocol: Comparable, Equatable, Hashable, Sendable {
-    /**
-     Returns `true` if group is presented modally, otherwise `false` if group is a part of root view
-     controller.
-     */
-    var isModal: Bool { get }
-
-    /**
-     Defines a modal level that's used for restricting modal presentation.
-
-     A group with higher modal level can be presented above a group with lower level but not the other way around. For example, if a modal group is represented by
-     `UIAlertController`, it should have the highest level (i.e `Int.max`) to prevent other modals from being presented above it, however it enables alert
-     controller to be presented above any other modal.
-     */
-    var modalLevel: Int { get }
-}
-
-/**
- Default implementation of `Comparable` for `AppRouteGroupProtocol` which compares `modalLevel` of both sides.
- */
-extension AppRouteGroupProtocol {
-    public static func < (lhs: Self, rhs: Self) -> Bool {
-        lhs.modalLevel < rhs.modalLevel
-    }
-
-    public static func <= (lhs: Self, rhs: Self) -> Bool {
-        lhs.modalLevel <= rhs.modalLevel
-    }
-}
+public protocol AppRouteGroupProtocol: Comparable, Equatable, Hashable, Sendable {}
 
 /**
  Formal protocol describing a single route.
  */
 public protocol AppRouteProtocol: Equatable, Hashable, Sendable {
     associatedtype RouteGroupType: AppRouteGroupProtocol
-
-    /**
-     Returns `true` when only one route of a kind can be displayed.
-     */
-    var isExclusive: Bool { get }
 
     /**
      Returns `true` if the route supports sub-navigation.

--- a/ios/Routing/Router/ApplicationRouter.swift
+++ b/ios/Routing/Router/ApplicationRouter.swift
@@ -14,36 +14,19 @@ import UIKit
  Main application router.
  */
 @MainActor
-public final class ApplicationRouter<RouteType: AppRouteProtocol>: Sendable {
+public final class ApplicationRouter<RouteType: AppRouteProtocol> {
     nonisolated(unsafe) private let logger = Logger(label: "ApplicationRouter")
 
-    private(set) var modalStack: [RouteType.RouteGroupType] = []
     private(set) var presentedRoutes: [RouteType.RouteGroupType: [PresentedRoute<RouteType>]] = [:]
-
-    private var pendingRoutes = [PendingRoute<RouteType>]()
-    private var isProcessingPendingRoutes = false
-
     private unowned let delegate: any ApplicationRouterDelegate<RouteType>
 
-    /**
-     Designated initializer.
-
-     Delegate object is unonwed and the caller has to guarantee that the router does not outlive it.
-     */
+    /// Designated initializer.
+    /// Delegate object is unonwed and the caller has to guarantee that the router does not outlive it.
     public init(_ delegate: some ApplicationRouterDelegate<RouteType>) {
         self.delegate = delegate
     }
 
-    /**
-     Returns `true` is the given route group is currently being presented.
-     */
-    public func isPresenting(group: RouteType.RouteGroupType) -> Bool {
-        modalStack.contains(group)
-    }
-
-    /**
-     Returns `true` if is the given route  is currently being presented.
-     */
+    /// Returns `true` if is the given route is currently being presented.
     public func isPresenting(route: RouteType) -> Bool {
         guard let presentedRoute = presentedRoutes[route.routeGroup] else {
             return false
@@ -51,115 +34,96 @@ public final class ApplicationRouter<RouteType: AppRouteProtocol>: Sendable {
         return presentedRoute.contains(where: { $0.route == route })
     }
 
-    /**
-     Enqueue route for presetnation.
-     */
+    /// Returns `true` is the given route group is currently being presented.
+    public func isPresenting(group: RouteType.RouteGroupType) -> Bool {
+        presentedRoutes[group] != nil
+    }
+
+    /// Presents route.
     public func present(_ route: RouteType, animated: Bool = true, metadata: Any? = nil) {
-        enqueue(PendingRoute(
-            operation: .present(route),
-            animated: animated,
-            metadata: metadata
-        ))
-    }
-
-    /**
-     Enqueue dismissal of the route.
-     */
-    public func dismiss(_ route: RouteType, animated: Bool = true) {
-        enqueue(PendingRoute(
-            operation: .dismiss(.singleRoute(route)),
-            animated: animated
-        ))
-    }
-
-    /**
-     Enqueue dismissal of a group of routes.
-     */
-    public func dismissAll(_ group: RouteType.RouteGroupType, animated: Bool = true) {
-        enqueue(PendingRoute(
-            operation: .dismiss(.group(group)),
-            animated: animated
-        ))
-    }
-
-    private func enqueue(_ pendingRoute: PendingRoute<RouteType>) {
-        logger.debug("\(pendingRoute.operation).")
-
-        pendingRoutes.append(pendingRoute)
-
-        if !isProcessingPendingRoutes {
-            processPendingRoutes()
+        // Pass sub-route for routes supporting sub-navigation.
+        if route.supportsSubNavigation, let presentedRoute = presentedRoutes[route.routeGroup]?.first {
+            presentSubRoute(route, on: presentedRoute, animated: animated)
+        } else {
+            presentRoute(route, animated: animated, metadata: metadata)
         }
     }
 
-    private func presentRoute(
-        _ route: RouteType,
-        animated: Bool,
-        metadata: Any?,
-        completion: @escaping @Sendable @MainActor (PendingPresentationResult) -> Void
-    ) {
-        /**
-         Pass sub-route for routes supporting sub-navigation.
-         */
-        if route.supportsSubNavigation, modalStack.contains(route.routeGroup),
-           var presentedRoute = presentedRoutes[route.routeGroup]?.first {
-            let context = RouteSubnavigationContext(
-                presentedRoute: presentedRoute,
-                route: route,
-                isAnimated: animated
-            )
+    /// Dismisses route.
+    public func dismiss(route: RouteType, animated: Bool = true) {
+        var routes = presentedRoutes[route.routeGroup] ?? []
 
-            presentedRoute.route = route
-            presentedRoutes[route.routeGroup] = [presentedRoute]
+        // Find the index of route to pop.
+        guard let index = routes.lastIndex(where: { $0.route == route }) else {
+            return
+        }
 
-            delegate.applicationRouter(self, handleSubNavigationWithContext: context) {
-                completion(.success)
+        // Check if dismissing the last route.
+        let isLastRoute = routes.count == 1
+
+        let context = RouteDismissalContext(
+            dismissedRoutes: [routes[index]],
+            isClosing: isLastRoute,
+            isAnimated: animated
+        )
+
+        // Consult with delegate whether the route should still be dismissed.
+        guard delegate.applicationRouter(self, shouldDismissWithContext: context) else {
+            return
+        }
+
+        if isLastRoute {
+            presentedRoutes.removeValue(forKey: route.routeGroup)
+        } else {
+            routes.remove(at: index)
+            presentedRoutes[route.routeGroup] = routes
+        }
+
+        delegate.applicationRouter(self, dismissWithContext: context) { [weak self] in
+            MainActor.assumeIsolated {
+                self?.logger.debug("Dismissed route: \(route)")
             }
+        }
+    }
 
+    // Dismisses route group.
+    public func dismiss(group: RouteType.RouteGroupType, animated: Bool = true) {
+        let dismissedRoutes = presentedRoutes[group] ?? []
+
+        guard !dismissedRoutes.isEmpty else {
             return
         }
 
-        /**
-         Drop duplicate exclusive routes.
-         */
-        if route.isExclusive, modalStack.contains(route.routeGroup) {
-            completion(.drop)
+        let context = RouteDismissalContext(
+            dismissedRoutes: dismissedRoutes,
+            isClosing: true,
+            isAnimated: animated
+        )
+
+        // Consult with delegate whether the route should still be dismissed.
+        guard delegate.applicationRouter(self, shouldDismissWithContext: context) else {
             return
         }
 
-        /**
-         Drop if the last presented route within the group is the same.
-         */
-        if !route.isExclusive, presentedRoutes[route.routeGroup]?.last?.route == route {
-            completion(.drop)
-            return
-        }
+        presentedRoutes.removeValue(forKey: group)
 
-        /**
-         Check if route can be presented above the last route in the modal stack.
-         */
-        if let
-            // Get current modal route.
-            lastRouteGroup = modalStack.last,
-            // Check if incoming route is modal.
-            route.routeGroup.isModal,
-            // Check whether incoming route can be presented on top of current.
-            (lastRouteGroup > route.routeGroup) ||
-            // OR, check whether incoming exclusive route can be presented on top of current.
-            (lastRouteGroup >= route.routeGroup && route.isExclusive) {
-            completion(.blockedByModalContext)
-            return
+        delegate.applicationRouter(self, dismissWithContext: context) { [weak self] in
+            MainActor.assumeIsolated {
+                self?.logger.debug("Dismissed route group: \(group)")
+            }
         }
+    }
 
-        /**
-         Consult with delegate whether the route should still be presented.
-         */
+    private func presentRoute(_ route: RouteType, animated: Bool, metadata: Any?) {
+        // Consult with delegate whether the route should still be presented.
         if delegate.applicationRouter(self, shouldPresent: route) {
             let context = RoutePresentationContext(route: route, isAnimated: animated, metadata: metadata)
 
-            delegate.applicationRouter(self, presentWithContext: context, animated: animated) { coordinator in
-                /// Synchronize router when modal controllers are removed by swipe.
-                /// The delegate (`ApplicationCoordinator`) is `@MainActor` by virtue of being a `Coordinator`
+            delegate.applicationRouter(
+                self,
+                presentWithContext: context,
+                animated: animated
+            ) { [weak self] coordinator in
                 MainActor.assumeIsolated {
                     if let presentable = coordinator as? Presentable {
                         presentable.onInteractiveDismissal { [weak self] coordinator in
@@ -169,188 +133,38 @@ public final class ApplicationRouter<RouteType: AppRouteProtocol>: Sendable {
                         }
                     }
 
-                    self.addPresentedRoute(PresentedRoute(route: route, coordinator: coordinator))
+                    let group = route.routeGroup
+                    var routes = self?.presentedRoutes[group] ?? []
 
-                    completion(.success)
+                    routes.append(PresentedRoute(route: route, coordinator: coordinator))
+                    self?.presentedRoutes[group] = routes
+
+                    self?.logger.debug("Presented route: \(route)")
                 }
             }
-        } else {
-            completion(.drop)
         }
     }
 
-    private func dismissGroup(
-        _ dismissGroup: RouteType.RouteGroupType,
-        animated: Bool,
-        completion: @escaping @Sendable (PendingDismissalResult) -> Void
-    ) {
-        /**
-         Check if routes corresponding to the group requested for dismissal are present.
-         */
-        guard modalStack.contains(dismissGroup) else {
-            completion(.drop)
-            return
-        }
+    private func presentSubRoute(_ route: RouteType, on presentedRoute: PresentedRoute<RouteType>, animated: Bool) {
+        var presentedRoute = presentedRoute
 
-        /**
-         Check if the group can be dismissed and it's not blocked by another group presented above.
-         */
-        if modalStack.last != dismissGroup, dismissGroup.isModal {
-            completion(.blockedByModalAbove)
-            return
-        }
-
-        let dismissedRoutes = presentedRoutes[dismissGroup] ?? []
-        assert(!dismissedRoutes.isEmpty)
-
-        let context = RouteDismissalContext(
-            dismissedRoutes: dismissedRoutes,
-            isClosing: true,
+        let context = RouteSubnavigationContext(
+            presentedRoute: presentedRoute,
+            route: route,
             isAnimated: animated
         )
 
-        /**
-         Consult with delegate whether the route should still be dismissed.
-         */
-        guard delegate.applicationRouter(self, shouldDismissWithContext: context) else {
-            completion(.drop)
-            return
-        }
+        presentedRoute.route = route
+        presentedRoutes[route.routeGroup] = [presentedRoute]
 
-        presentedRoutes.removeValue(forKey: dismissGroup)
-        modalStack.removeAll { $0 == dismissGroup }
-
-        delegate.applicationRouter(self, dismissWithContext: context) {
-            completion(.success)
-        }
-    }
-
-    private func dismissRoute(
-        _ dismissRoute: RouteType,
-        animated: Bool,
-        completion: @escaping @Sendable (PendingDismissalResult) -> Void
-    ) {
-        var routes = presentedRoutes[dismissRoute.routeGroup] ?? []
-
-        // Find the index of route to pop.
-        guard let index = routes.lastIndex(where: { $0.route == dismissRoute }) else {
-            completion(.drop)
-            return
-        }
-
-        // Check if dismissing the last route in horizontal navigation group.
-        let isLastRoute = routes.count == 1
-
-        // Check if the route can be dismissed and there is no other modal above.
-        if let lastModalGroup = modalStack.last,
-           lastModalGroup != dismissRoute.routeGroup,
-           dismissRoute.routeGroup.isModal,
-           isLastRoute {
-            completion(.blockedByModalAbove)
-            return
-        }
-
-        let context = RouteDismissalContext(
-            dismissedRoutes: [routes[index]],
-            isClosing: isLastRoute,
-            isAnimated: animated
-        )
-
-        /**
-         Consult with delegate whether the route should still be dismissed.
-         */
-        guard delegate.applicationRouter(self, shouldDismissWithContext: context) else {
-            completion(.drop)
-            return
-        }
-
-        if isLastRoute {
-            presentedRoutes.removeValue(forKey: dismissRoute.routeGroup)
-            modalStack.removeAll { $0 == dismissRoute.routeGroup }
-        } else {
-            routes.remove(at: index)
-            presentedRoutes[dismissRoute.routeGroup] = routes
-        }
-
-        delegate.applicationRouter(self, dismissWithContext: context) {
-            completion(.success)
-        }
-    }
-
-    private func processPendingRoutes(skipRouteGroups: Set<RouteType.RouteGroupType> = []) {
-        isProcessingPendingRoutes = true
-
-        let pendingRoute = pendingRoutes.first { pendingRoute in
-            !skipRouteGroups.contains(pendingRoute.operation.routeGroup)
-        }
-
-        guard let pendingRoute else {
-            isProcessingPendingRoutes = false
-            return
-        }
-
-        switch pendingRoute.operation {
-        case let .present(route):
-            presentRoute(route, animated: pendingRoute.animated, metadata: pendingRoute.metadata) { result in
-                switch result {
-                case .success, .drop:
-                    self.finishPendingRoute(pendingRoute)
-
-                case .blockedByModalContext:
-                    /**
-                     Present next route if this one is not ready to be presented.
-                     */
-                    self.processPendingRoutes(
-                        skipRouteGroups: skipRouteGroups.union([route.routeGroup])
-                    )
-                }
-            }
-
-        case let .dismiss(dismissMatch):
-            handleDismissal(dismissMatch, animated: pendingRoute.animated) { result in
-                MainActor.assumeIsolated {
-                    switch result {
-                    case .success, .drop:
-                        self.finishPendingRoute(pendingRoute)
-
-                    case .blockedByModalAbove:
-                        /**
-                         If router cannot dismiss modal because there is one above,
-                         try walking down the queue and see if there is a dismissal request that could
-                         resolve that.
-                         */
-                        self.processPendingRoutes(
-                            skipRouteGroups: skipRouteGroups.union([dismissMatch.routeGroup])
-                        )
-                    }
-                }
+        delegate.applicationRouter(self, handleSubNavigationWithContext: context) { [weak self] in
+            MainActor.assumeIsolated {
+                self?.logger.debug("Presented sub route: \(route)")
             }
         }
     }
 
-    private func handleDismissal(
-        _ dismissMatch: DismissMatch<RouteType>,
-        animated: Bool,
-        completion: @escaping @Sendable (PendingDismissalResult) -> Void
-    ) {
-        switch dismissMatch {
-        case let .singleRoute(route):
-            dismissRoute(route, animated: animated, completion: completion)
-
-        case let .group(group):
-            dismissGroup(group, animated: animated, completion: completion)
-        }
-    }
-
-    private func finishPendingRoute(_ pendingRoute: PendingRoute<RouteType>) {
-        if let index = pendingRoutes.firstIndex(of: pendingRoute) {
-            pendingRoutes.remove(at: index)
-        }
-
-        processPendingRoutes()
-    }
-
-    private func handleInteractiveDismissal(route: RouteType, coordinator: Coordinator) {
+    internal func handleInteractiveDismissal(route: RouteType, coordinator: Coordinator) {
         var routes = presentedRoutes[route.routeGroup] ?? []
 
         routes.removeAll { presentedRoute in
@@ -359,34 +173,10 @@ public final class ApplicationRouter<RouteType: AppRouteProtocol>: Sendable {
 
         if routes.isEmpty {
             presentedRoutes.removeValue(forKey: route.routeGroup)
-            modalStack.removeAll { $0 == route.routeGroup }
         } else {
             presentedRoutes[route.routeGroup] = routes
         }
 
-        if !isProcessingPendingRoutes {
-            processPendingRoutes()
-        }
-    }
-
-    private func addPresentedRoute(_ presented: PresentedRoute<RouteType>) {
-        let group = presented.route.routeGroup
-        var routes = presentedRoutes[group] ?? []
-
-        if presented.route.isExclusive {
-            routes = [presented]
-        } else {
-            routes.append(presented)
-        }
-
-        presentedRoutes[group] = routes
-
-        if !modalStack.contains(group) {
-            if group.isModal {
-                modalStack.append(group)
-            } else {
-                modalStack.insert(group, at: 0)
-            }
-        }
+        logger.debug("Dismissed route: \(route)")
     }
 }

--- a/ios/Routing/Router/ApplicationRouterDelegate.swift
+++ b/ios/Routing/Router/ApplicationRouterDelegate.swift
@@ -11,6 +11,7 @@ import Foundation
 /**
  Application router delegate
  */
+@MainActor
 public protocol ApplicationRouterDelegate<RouteType>: AnyObject, Sendable {
     associatedtype RouteType: AppRouteProtocol
 
@@ -57,6 +58,6 @@ public protocol ApplicationRouterDelegate<RouteType>: AnyObject, Sendable {
     func applicationRouter(
         _ router: ApplicationRouter<RouteType>,
         handleSubNavigationWithContext context: RouteSubnavigationContext<RouteType>,
-        completion: @escaping @Sendable @MainActor () -> Void
+        completion: @MainActor @escaping @Sendable () -> Void
     )
 }

--- a/ios/RoutingTests/RouterBlockDelegate.swift
+++ b/ios/RoutingTests/RouterBlockDelegate.swift
@@ -49,10 +49,8 @@ final class RouterBlockDelegate<RouteType: AppRouteProtocol>: ApplicationRouterD
     func applicationRouter(
         _ router: ApplicationRouter<RouteType>,
         handleSubNavigationWithContext context: RouteSubnavigationContext<RouteType>,
-        completion: @escaping @Sendable @MainActor () -> Void
+        completion: @MainActor @escaping @Sendable () -> Void
     ) {
-        MainActor.assumeIsolated {
-            handleSubnavigation?(context, completion) ?? completion()
-        }
+        handleSubnavigation?(context, completion) ?? completion()
     }
 }


### PR DESCRIPTION
Somehow, Emīls manages to get the router to get stuck, which results in no button in the connect view navigating to any other view. 

Jon believes we could just remove the queue from the router, that would remove the blocking behavior. It seems that the the router is just not removing work from the queue, seemingly being stuck.

This PR removes route validation and queueing, making the router simpler and easier to work with.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7536)
<!-- Reviewable:end -->
