### PR TITLE
Silence `CVE-2024-45336` and `CVE-2024-45341` in osv-scanner

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -28,3 +28,15 @@ reason = "wireguard-go does not use the affected code"
 id = "GHSA-w32m-9786-jp63" # GO-2024-3333
 ignoreUntil = 2025-03-19
 reason = "wireguard-go does not use the affected code"
+
+# Sensitive headers incorrectly sent after cross-domain redirect in net/http
+[[IgnoredVulns]]
+id = "CVE-2024-45336" # GO-2025-3420
+ignoreUntil = 2025-04-28
+reason = "wireguard-go does not use the affected code"
+
+# Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
+[[IgnoredVulns]]
+id = "CVE-2024-45341" # GO-2025-3373
+ignoreUntil = 2025-04-28
+reason = "wireguard-go does not use the affected code"


### PR DESCRIPTION
This PR silences [`CVE-2024-45336`](https://osv.dev/vulnerability/GO-2025-3420) and [`CVE-2024-45341`](https://osv.dev/vulnerability/GO-2025-3373) which are both vulnerabilities found in the go standard library. The affected functions are not used in `wireguard-go`, so we are unaffected. Upgrading to `go 1.24` (when it is released) will allow us to un-silence these CVEs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7538)
<!-- Reviewable:end -->
