### PR TITLE
Remove Google's resolvers from encrypted DNS proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix daemon ending up in blocked state if the user toggled split tunneling without having granted
   Full Disk Access to `mullvad-daemon`. This could only ever be accomplished from the CLI.
 
+### Removed
+- Remove Google's resolvers from encrypted DNS proxy.
+
 
 ## [2025.2] - 2025-01-08
 ### Fixed

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -22,7 +22,8 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
-
+### Removed
+- Remove Google's resolvers from encrypted DNS proxy.
 
 ## [android/2024.10-beta2] - 2024-12-20
 

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -24,9 +24,13 @@ Line wrap the file at 100 chars.                                              Th
 ## Unreleased
 ### Fixed
 - Broken DAITA settings view on iOS 15.
+
 ### Changed
 - Move changelog to settings and add an in-app notification banner for app update.
 - Add different themes for app icons
+
+### Removed
+- Remove Google's resolvers from encrypted DNS proxy.
 
 ## [2025.1 - 2025-01-14]
 ### Added

--- a/mullvad-encrypted-dns-proxy/src/config_resolver.rs
+++ b/mullvad-encrypted-dns-proxy/src/config_resolver.rs
@@ -48,10 +48,6 @@ pub fn default_resolvers() -> Vec<Nameserver> {
             addr: vec!["1.1.1.1".parse().unwrap(), "1.0.0.1".parse().unwrap()],
         },
         Nameserver {
-            name: "dns.google".to_owned(),
-            addr: vec!["8.8.8.8".parse().unwrap(), "8.8.4.4".parse().unwrap()],
-        },
-        Nameserver {
             name: "dns.quad9.net".to_owned(),
             addr: vec![
                 "9.9.9.9".parse().unwrap(),


### PR DESCRIPTION
What is says on the tin - remove Google's resolvers from `mullvad-encrypted-dns-proxy`.  Maybe the changelog should say _stop using_ Google's resolvers?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7539)
<!-- Reviewable:end -->
