### PR TITLE
Bump wireguard-apple

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -9647,7 +9647,7 @@
 			repositoryURL = "https://github.com/mullvad/wireguard-apple.git";
 			requirement = {
 				kind = revision;
-				revision = f6c6af02d3a9168589b8c109b4826b7f224fcf73;
+				revision = f19338dafd349fd6ddb1c1032b5705d362f56d2b;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MullvadVPN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mullvad/wireguard-apple.git",
       "state" : {
-        "revision" : "f6c6af02d3a9168589b8c109b4826b7f224fcf73"
+        "revision" : "f19338dafd349fd6ddb1c1032b5705d362f56d2b"
       }
     }
   ],


### PR DESCRIPTION
This bumps wireguard-apple so that we have the latest changes, which hopefully improves the amount of go crashes we're seeing. And there's a stray xcodeproj change removing the last reference to `ProductState.swift`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7540)
<!-- Reviewable:end -->
