### PR TITLE
Implement detekt and ktfmt for buildSrc

### DIFF
--- a/.github/workflows/android-kotlin-format-check.yml
+++ b/.github/workflows/android-kotlin-format-check.yml
@@ -47,4 +47,4 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run ktfmt check
-        run: android/gradlew -p android ktfmtCheck
+        run: android/gradlew -p android ktfmtCheck :buildSrc:ktfmtCheck

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -117,6 +117,7 @@ allprojects {
             )
     }
 
+    // Should be the same as ktfmt config in buildSrc/build.gradle.kts
     configure<com.ncorti.ktfmt.gradle.KtfmtExtension> {
         kotlinLangStyle()
         maxWidth.set(100)

--- a/android/buildSrc/build.gradle.kts
+++ b/android/buildSrc/build.gradle.kts
@@ -1,5 +1,16 @@
-plugins { `kotlin-dsl` }
+plugins {
+    `kotlin-dsl`
+    alias(libs.plugins.ktfmt) apply true
+    alias(libs.plugins.detekt) apply true
+}
 
 repositories { maven("https://plugins.gradle.org/m2/") }
 
 kotlin { jvmToolchain(17) }
+
+// Should be the same as ktfmt config in project root build.gradle.kts
+ktfmt {
+    kotlinLangStyle()
+    maxWidth.set(100)
+    removeUnusedImports.set(true)
+}

--- a/android/buildSrc/settings.gradle.kts
+++ b/android/buildSrc/settings.gradle.kts
@@ -1,1 +1,9 @@
 rootProject.name = "buildSrc"
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/android/buildSrc/src/main/kotlin/BuildVariants.kt
+++ b/android/buildSrc/src/main/kotlin/BuildVariants.kt
@@ -44,11 +44,7 @@ val enabledAppVariantTriples =
         Triple(PLAY, DEVMOLE, DEBUG),
         Triple(PLAY, DEVMOLE, RELEASE),
         Triple(PLAY, STAGEMOLE, DEBUG),
-        Triple(PLAY, STAGEMOLE, RELEASE)
+        Triple(PLAY, STAGEMOLE, RELEASE),
     )
 
-val enabledE2eVariantTriples =
-    listOf(
-        Triple(OSS, PROD, DEBUG),
-        Triple(PLAY, STAGEMOLE, DEBUG)
-    )
+val enabledE2eVariantTriples = listOf(Triple(OSS, PROD, DEBUG), Triple(PLAY, STAGEMOLE, DEBUG))

--- a/android/buildSrc/src/main/kotlin/Extensions.kt
+++ b/android/buildSrc/src/main/kotlin/Extensions.kt
@@ -4,9 +4,10 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 fun String.isNonStableVersion(): Boolean {
     val nonStableQualifiers = listOf("alpha", "beta", "rc")
 
-    val isNonStable = nonStableQualifiers
-        .map { qualifier -> Regex("(?i).*[.-]$qualifier[.\\d-+]*") }
-        .any { it.matches(this) }
+    val isNonStable =
+        nonStableQualifiers
+            .map { qualifier -> Regex("(?i).*[.-]$qualifier[.\\d-+]*") }
+            .any { it.matches(this) }
 
     return isNonStable
 }

--- a/android/buildSrc/src/main/kotlin/Utils.kt
+++ b/android/buildSrc/src/main/kotlin/Utils.kt
@@ -33,11 +33,18 @@ fun Project.generateRemapArguments(): String {
 }
 
 private fun Project.execVersionCodeCargoCommand() =
-    providers.exec {
-        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode")
-    }.standardOutput.asText.get().trim().toInt()
+    providers
+        .exec { commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionCode") }
+        .standardOutput
+        .asText
+        .get()
+        .trim()
+        .toInt()
 
 private fun Project.execVersionNameCargoCommand() =
-    providers.exec {
-        commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName")
-    }.standardOutput.asText.get().trim()
+    providers
+        .exec { commandLine("cargo", "run", "-q", "--bin", "mullvad-version", "versionName") }
+        .standardOutput
+        .asText
+        .get()
+        .trim()


### PR DESCRIPTION
To format `buildSrc` it is required to run `:buildSrc:ktfmtFormat` separately.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7541)
<!-- Reviewable:end -->
