### PR TITLE
Add pinned Rust version via rust-toolchain.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
 edition = "2021"
+# Keep in sync with `channel` in `rust-toolchain.toml`
 rust-version = "1.80.0"
 
 [workspace]

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -54,11 +54,13 @@ RUN dpkg --add-architecture arm64 && apt-get update -y && apt-get install -y \
 
 # === Rust ===
 
-# Install latest stable Rust toolchain for both x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu,
+ARG RUST_VERSION=stable
+
+# Install the Rust toolchain for both x86_64-unknown-linux-gnu and aarch64-unknown-linux-gnu,
 # plus x86_64-pc-windows-gnu for Windows cross-compilation/linting
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y \
-    --default-toolchain stable \
+    --default-toolchain $RUST_VERSION \
     --profile minimal \
     --component clippy \
     --target aarch64-unknown-linux-gnu \

--- a/building/build-and-publish-container-image.sh
+++ b/building/build-and-publish-container-image.sh
@@ -35,8 +35,11 @@ case ${1-:""} in
 esac
 full_container_name="$REGISTRY_HOST/$REGISTRY_ORG/$container_name"
 
+RUST_VERSION=$(rg -o "channel = \"(.*)\"" -r '$1' "$REPO_DIR/rust-toolchain.toml")
+
 log_header "Building $full_container_name tagged as '$tag' and 'latest'"
 podman build -f "$containerfile_path" "$container_context_dir" --no-cache \
+    --build-arg="RUST_VERSION=$RUST_VERSION" \
     -t "$full_container_name:$tag" \
     -t "$full_container_name:latest"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# Keep in sync with `rust-version` in `Cargo.toml`
+channel = "1.83.0"
+profile = "minimal"


### PR DESCRIPTION
As part of enabling reproducible builds we need to build a given commit with a pinned Rust version.

This commit adds a minimal rust-toolchain.toml file that specifies this version (this Rust version is enforced by rustup when invoking a cargo command).

In the container we extract the version that is specified in rust-toolchain.toml to ensure that the container is pre-built with the correct Rust version (so that when buildling in the container we do not need to download the right Rust version).

Related: #5680

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
