### PR TITLE
Fix NavigationHeader text overflow

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/organisms/navigation-header/NavigationHeader.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/organisms/navigation-header/NavigationHeader.tsx
@@ -24,6 +24,7 @@ export const StyledContent = styled.div({
   placeContent: 'center',
   minHeight: '32px',
   height: '32px',
+  gap: Spacings.spacing1,
 });
 
 const NavigationHeader = ({ titleVisible, children, ...props }: NavigationHeaderProps) => {

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/organisms/navigation-header/components/NavigationHeaderTitle.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/organisms/navigation-header/components/NavigationHeaderTitle.tsx
@@ -10,6 +10,9 @@ export interface NavigationHeaderTitleProps {
 export const StyledText = styled(TitleMedium)<{ $visible?: boolean }>(({ $visible = true }) => ({
   opacity: $visible ? 1 : 0,
   transition: 'opacity 250ms ease-in-out',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 }));
 
 export const NavigationHeaderTitle = ({ children }: NavigationHeaderTitleProps) => {


### PR DESCRIPTION
Currently really long text in the NavigationHeader causes it to wrap weirdly, this can for example be seen in the user interface menu with the language set to swedish. This is fixed in this PR by removing the overflow.