### PR TITLE
Move actions `debug.keystore` to secret

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -82,31 +82,6 @@ jobs:
     outputs:
       container_image: ${{ env.inner_container_image }}
 
-  generate-debug-keystore:
-    name: Generate debug keystore
-    needs: prepare
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate keystore
-        run: >-
-          keytool -genkey
-          -keystore debug.keystore
-          -storepass android
-          -alias androiddebugkey
-          -keypass android
-          -keyalg RSA
-          -keysize 2048
-          -validity 10000
-          -dname "CN=Android Debug,O=Android,C=US"
-
-      - name: Upload keystore
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-keystore
-          path: debug.keystore
-          if-no-files-found: error
-          retention-days: 7
-
   build-native:
     name: Build native # Used by wait for jobs.
     needs: prepare
@@ -227,7 +202,7 @@ jobs:
 
   build-app:
     name: Build app
-    needs: [prepare, generate-debug-keystore]
+    needs: [prepare]
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.prepare.outputs.container_image }}
@@ -242,10 +217,10 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: debug-keystore
-          path: /root/.android
+      - name: Prepare dummy debug keystore
+        run: |
+          echo "${{ secrets.ANDROID_DUMMY_DEBUG_KEYSTORE }}" | \
+            base64 -d > /root/.android/debug.keystore
 
       - name: Compile app
         uses: burrunan/gradle-cache-action@v1
@@ -322,7 +297,7 @@ jobs:
 
   build-instrumented-tests:
     name: Build instrumented test packages
-    needs: [prepare, generate-debug-keystore]
+    needs: [prepare]
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.prepare.outputs.container_image }}
@@ -349,10 +324,10 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: debug-keystore
-          path: /root/.android
+      - name: Prepare dummy debug keystore
+        run: |
+          echo "${{ secrets.ANDROID_DUMMY_DEBUG_KEYSTORE }}" | \
+            base64 -d > /root/.android/debug.keystore
 
       - name: Assemble instrumented test apk
         uses: burrunan/gradle-cache-action@v1


### PR DESCRIPTION
This PR aims to move the `debug.keystore` used in GitHub actions workflows for test and verification into a secret in order to simplify and speed up our workflow. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7555)
<!-- Reviewable:end -->
