### PR TITLE
Use a sendable closure for task expiry

### DIFF
--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -280,11 +280,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             using: .main
         ) { [self] task in
 
-            let handle = relayCacheTracker.updateRelays { result in
+            nonisolated(unsafe) let handle = relayCacheTracker.updateRelays { result in
                 task.setTaskCompleted(success: result.isSuccess)
             }
 
-            task.expirationHandler = {
+            task.expirationHandler = { @Sendable in
                 handle.cancel()
             }
 
@@ -303,12 +303,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             forTaskWithIdentifier: BackgroundTask.privateKeyRotation.identifier,
             using: .main
         ) { [self] task in
-            let handle = tunnelManager.rotatePrivateKey { [self] error in
+            nonisolated(unsafe) let handle = tunnelManager.rotatePrivateKey { [self] error in
                 scheduleKeyRotationTask()
                 task.setTaskCompleted(success: error == nil)
             }
 
-            task.expirationHandler = {
+            task.expirationHandler = { @Sendable in
                 handle.cancel()
             }
         }
@@ -325,12 +325,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             forTaskWithIdentifier: BackgroundTask.addressCacheUpdate.identifier,
             using: .main
         ) { [self] task in
-            let handle = addressCacheTracker.updateEndpoints { [self] result in
+            nonisolated(unsafe) let handle = addressCacheTracker.updateEndpoints { [self] result in
                 scheduleAddressCacheUpdateTask()
                 task.setTaskCompleted(success: result.isSuccess)
             }
 
-            task.expirationHandler = {
+            task.expirationHandler = { @Sendable in
                 handle.cancel()
             }
         }


### PR DESCRIPTION
Even though the signature for `expirationHandler` has no meniton of sendability and there's a distinct lack of documentation about where exactly the expiration handler would be invoked, whatever is invoked there is checked at runtime to be dispatched on the main thread. Unless it's marked as sendable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7556)
<!-- Reviewable:end -->
