### PR TITLE
Unsilence `RUSTSEC-2024-0384` in osv-scanner & cargo-deny

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "windows-sys 0.52.0",
 ]
 
@@ -1248,7 +1248,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rand 0.8.5",
  "resolv-conf",
  "rustls 0.21.12",
@@ -1641,15 +1641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "intersection-derive"
 version = "0.0.0"
 dependencies = [
@@ -1760,7 +1751,7 @@ dependencies = [
  "jni",
  "jnix-macros",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1838,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
 dependencies = [
  "cc",
  "libc",
@@ -2359,37 +2350,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2400,7 +2366,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -2842,15 +2808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3396,14 +3353,14 @@ dependencies = [
 
 [[package]]
 name = "ssh2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fe461910559f6d5604c3731d00d2aafc4a83d1665922e280f42f9a168d5455"
+checksum = "2f84d13b3b8a0d4e91a2629911e951db1bb8671512f5c09d7d4ba34500ba68c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "libc",
  "libssh2-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3437,7 +3394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbf95ce4c7c5b311d2ce3f088af2b93edef0f09727fa50fbe03c7a979afce77"
 dependencies = [
  "hex",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pnet_packet",
  "rand 0.8.5",
  "socket2 0.5.8",
@@ -3819,7 +3776,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.0.2",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.8",

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -20,10 +20,6 @@ yanked = "deny"
 ignore = [
     # Ignored audit issues. This list should be kept short, and effort should be
     # put into removing items from the list.
-
-    # RUSTSEC-2024-0384 - `instant` is unmaintained.
-    # `ssh2 0.9.4` uses `instant`.
-    "RUSTSEC-2024-0384",
 ]
 
 

--- a/test/osv-scanner.toml
+++ b/test/osv-scanner.toml
@@ -1,14 +1,3 @@
 # See repository root `osv-scanner.toml` for instructions and rules for this file.
 #
 # Keep this file in sync with test/deny.toml
-
-# `instant` is unmaintained.
-[[IgnoredVulns]]
-id = "RUSTSEC-2024-0384"
-ignoreUntil = 2025-02-11
-reason = """
-There is no reported vulnerability in the `instant` crate, but it is unmaintained and the author suggest switching to
-a fork instead of depending on `instant`. In our tree it is `ssh2` that currently depend on `instant` through an old
-version of `parking_lot`, preventing us from upgrading to a fixed version. This ignore can be removed when
-https://github.com/alexcrichton/ssh2-rs/issues/338 is resolved.
-"""

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -60,7 +60,7 @@ mullvad-types = { path = "../../mullvad-types" }
 mullvad-version = { path = "../../mullvad-version" }
 talpid-types = { path = "../../talpid-types" }
 
-ssh2 = "0.9.4"
+ssh2 = "0.9.5"
 
 nix = { workspace = true }
 socket2 = { workspace = true }


### PR DESCRIPTION
Since `ssh2 0.9.5` was released this weekend, we no longer have to silence `RUSTSEC-2024-0384` in osv-scanner nor cargo-deny! :tada:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7572)
<!-- Reviewable:end -->
