### PR TITLE
Track IPv6 connectivity on Android

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -34,6 +34,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Removed
 - Remove Google's resolvers from encrypted DNS proxy.
 
+### Fixed
+- Will no longer try to connect over IPv6 if IPv6 is not available.
+
 
 ## [android/2024.10-beta2] - 2024-12-20
 

--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/talpid/util/ConnectivityManagerUtilKtTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/talpid/util/ConnectivityManagerUtilKtTest.kt
@@ -1,11 +1,17 @@
 package net.mullvad.mullvadvpn.talpid.util
 
 import android.net.ConnectivityManager
+import android.net.LinkAddress
+import android.net.LinkProperties
 import android.net.Network
+import android.net.NetworkCapabilities
 import app.cash.turbine.test
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.verify
+import java.net.Inet4Address
+import java.net.Inet6Address
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -13,10 +19,11 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.test.runTest
+import net.mullvad.talpid.model.Connectivity
 import net.mullvad.talpid.util.NetworkEvent
+import net.mullvad.talpid.util.UnderlyingConnectivityStatusResolver
+import net.mullvad.talpid.util.defaultNetworkEvents
 import net.mullvad.talpid.util.hasInternetConnectivity
-import net.mullvad.talpid.util.networkEvents
-import net.mullvad.talpid.util.networksWithInternetConnectivity
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -31,19 +38,22 @@ class ConnectivityManagerUtilKtTest {
     /** User being online, the listener should emit once with `true` */
     @Test
     fun userIsOnline() = runTest {
-        val network = mockk<Network>()
-        every { connectivityManager.networksWithInternetConnectivity() } returns setOf(network)
-        every { connectivityManager.networkEvents(any()) } returns
+        val network = mockk<Network>(relaxed = true)
+        val linkProperties = mockLinkProperties(true, true)
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
+        every { connectivityManager.defaultNetworkEvents() } returns
             callbackFlow {
                 delay(100.milliseconds) // Simulate connectivity listener being a bit slow
                 send(NetworkEvent.Available(network))
+                delay(100.milliseconds) // Simulate connectivity listener being a bit slow
+                send(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
                 awaitClose {}
             }
 
-        connectivityManager.hasInternetConnectivity().test {
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
             // Since initial state and listener both return `true` within debounce we only see one
             // event
-            assertEquals(true, awaitItem())
+            assertEquals(Connectivity.Status(true, true), awaitItem())
             expectNoEvents()
         }
     }
@@ -51,12 +61,12 @@ class ConnectivityManagerUtilKtTest {
     /** User being offline, the listener should emit once with `false` */
     @Test
     fun userIsOffline() = runTest {
-        every { connectivityManager.networksWithInternetConnectivity() } returns setOf()
-        every { connectivityManager.networkEvents(any()) } returns callbackFlow { awaitClose {} }
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
+        every { connectivityManager.defaultNetworkEvents() } returns callbackFlow { awaitClose {} }
 
-        connectivityManager.hasInternetConnectivity().test {
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
             // Initially offline and no network events, so we should get a single `false` event
-            assertEquals(false, awaitItem())
+            assertEquals(Connectivity.Status(false, false), awaitItem())
             expectNoEvents()
         }
     }
@@ -64,19 +74,22 @@ class ConnectivityManagerUtilKtTest {
     /** User starting offline and then turning on a online after a while */
     @Test
     fun initiallyOfflineThenBecomingOnline() = runTest {
-        every { connectivityManager.networksWithInternetConnectivity() } returns emptySet()
-        every { connectivityManager.networkEvents(any()) } returns
+        val network = mockk<Network>()
+        val linkProperties = mockLinkProperties(true, true)
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
+        every { connectivityManager.defaultNetworkEvents() } returns
             callbackFlow {
                 // Simulate offline for a little while
                 delay(5.seconds)
                 // Then become online
                 send(NetworkEvent.Available(mockk()))
+                send(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
                 awaitClose {}
             }
 
-        connectivityManager.hasInternetConnectivity().test {
-            assertEquals(false, awaitItem())
-            assertEquals(true, awaitItem())
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
+            assertEquals(Connectivity.Status(false, false), awaitItem())
+            assertEquals(Connectivity.Status(true, true), awaitItem())
             expectNoEvents()
         }
     }
@@ -85,46 +98,23 @@ class ConnectivityManagerUtilKtTest {
     @Test
     fun initiallyOnlineAndThenTurningBecomingOffline() = runTest {
         val network = mockk<Network>()
-        every { connectivityManager.networksWithInternetConnectivity() } returns setOf(network)
-        every { connectivityManager.networkEvents(any()) } returns
+        val linkProperties = mockLinkProperties(true, true)
+
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
+        every { connectivityManager.defaultNetworkEvents() } returns
             callbackFlow {
                 // Starting as online
                 send(NetworkEvent.Available(network))
+                send(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
                 delay(5.seconds)
                 // Then becoming offline
                 send(NetworkEvent.Lost(network))
                 awaitClose {}
             }
 
-        connectivityManager.hasInternetConnectivity().test {
-            assertEquals(true, awaitItem())
-            assertEquals(false, awaitItem())
-            expectNoEvents()
-        }
-    }
-
-    /**
-     * User turning on Airplane mode as our connectivity listener starts so we never get any
-     * onAvailable event from our listener. Initial value will be `true`, followed by no
-     * `networkEvent` and then turning on network again after 5 seconds
-     */
-    @Test
-    fun incorrectInitialValueThenBecomingOnline() = runTest {
-        every { connectivityManager.networksWithInternetConnectivity() } returns setOf(mockk())
-        every { connectivityManager.networkEvents(any()) } returns
-            callbackFlow {
-                delay(5.seconds)
-                send(NetworkEvent.Available(mockk()))
-                awaitClose {}
-            }
-
-        connectivityManager.hasInternetConnectivity().test {
-            // Initial value is connected
-            assertEquals(true, awaitItem())
-            // Debounce time has passed, and we never received any network events, so we are offline
-            assertEquals(false, awaitItem())
-            // Network is back online
-            assertEquals(true, awaitItem())
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
+            assertEquals(Connectivity.Status(true, true), awaitItem())
+            assertEquals(Connectivity.Status(false, false), awaitItem())
             expectNoEvents()
         }
     }
@@ -133,26 +123,34 @@ class ConnectivityManagerUtilKtTest {
     @Test
     fun roamingFromCellularToWifi() = runTest {
         val wifiNetwork = mockk<Network>()
+        val wifiNetworkLinkProperties = mockLinkProperties(true, false)
         val cellularNetwork = mockk<Network>()
+        val cellularNetworkLinkProperties = mockLinkProperties(true, false)
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
 
-        every { connectivityManager.networksWithInternetConnectivity() } returns
-            setOf(cellularNetwork)
-        every { connectivityManager.networkEvents(any()) } returns
+        every { connectivityManager.defaultNetworkEvents() } returns
             callbackFlow {
                 send(NetworkEvent.Available(cellularNetwork))
+                send(
+                    NetworkEvent.LinkPropertiesChanged(
+                        cellularNetwork,
+                        cellularNetworkLinkProperties,
+                    )
+                )
                 delay(5.seconds)
                 // Turning on WiFi, we'll have duplicate networks until phone decides to turn of
                 // cellular
                 send(NetworkEvent.Available(wifiNetwork))
+                send(NetworkEvent.LinkPropertiesChanged(wifiNetwork, wifiNetworkLinkProperties))
                 delay(30.seconds)
                 // Phone turning off cellular network
                 send(NetworkEvent.Lost(cellularNetwork))
                 awaitClose {}
             }
 
-        connectivityManager.hasInternetConnectivity().test {
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
             // We should always only see us being online
-            assertEquals(true, awaitItem())
+            assertEquals(Connectivity.Status(ipv4 = true, ipv6 = false), awaitItem())
             expectNoEvents()
         }
     }
@@ -161,23 +159,32 @@ class ConnectivityManagerUtilKtTest {
     @Test
     fun roamingFromWifiToCellular() = runTest {
         val wifiNetwork = mockk<Network>()
+        val wifiNetworkLinkProperties = mockLinkProperties(true, false)
         val cellularNetwork = mockk<Network>()
+        val cellularNetworkLinkProperties = mockLinkProperties(true, false)
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
 
-        every { connectivityManager.networksWithInternetConnectivity() } returns setOf(wifiNetwork)
-        every { connectivityManager.networkEvents(any()) } returns
+        every { connectivityManager.defaultNetworkEvents() } returns
             callbackFlow {
                 send(NetworkEvent.Available(wifiNetwork))
+                send(NetworkEvent.LinkPropertiesChanged(wifiNetwork, wifiNetworkLinkProperties))
                 delay(5.seconds)
                 send(NetworkEvent.Lost(wifiNetwork))
                 // We will have no network for a little time until cellular chip is on.
                 delay(150.milliseconds)
                 send(NetworkEvent.Available(cellularNetwork))
+                send(
+                    NetworkEvent.LinkPropertiesChanged(
+                        cellularNetwork,
+                        cellularNetworkLinkProperties,
+                    )
+                )
                 awaitClose {}
             }
 
-        connectivityManager.hasInternetConnectivity().test {
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
             // We should always only see us being online, small offline state is caught by debounce
-            assertEquals(true, awaitItem())
+            assertEquals(Connectivity.Status(ipv4 = true, ipv6 = false), awaitItem())
             expectNoEvents()
         }
     }
@@ -186,30 +193,114 @@ class ConnectivityManagerUtilKtTest {
     @Test
     fun slowRoamingFromWifiToCellular() = runTest {
         val wifiNetwork = mockk<Network>()
+        val wifiNetworkLinkProperties = mockLinkProperties(false, true)
         val cellularNetwork = mockk<Network>()
+        val cellularNetworkLinkProperties = mockLinkProperties(false, true)
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
 
-        every { connectivityManager.networksWithInternetConnectivity() } returns setOf(wifiNetwork)
-        every { connectivityManager.networkEvents(any()) } returns
+        every { connectivityManager.defaultNetworkEvents() } returns
             callbackFlow {
                 send(NetworkEvent.Available(wifiNetwork))
+                send(NetworkEvent.LinkPropertiesChanged(wifiNetwork, wifiNetworkLinkProperties))
                 delay(5.seconds)
                 send(NetworkEvent.Lost(wifiNetwork))
                 // We will have no network for a little time until cellular chip is on.
                 delay(500.milliseconds)
                 send(NetworkEvent.Available(cellularNetwork))
+                send(
+                    NetworkEvent.LinkPropertiesChanged(
+                        cellularNetwork,
+                        cellularNetworkLinkProperties,
+                    )
+                )
                 awaitClose {}
             }
 
-        connectivityManager.hasInternetConnectivity().test {
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
             // Wifi is online
-            assertEquals(true, awaitItem())
+            assertEquals(Connectivity.Status(false, true), awaitItem())
             // We didn't get any network within debounce time, so we are offline
-            assertEquals(false, awaitItem())
+            assertEquals(Connectivity.Status(false, false), awaitItem())
             // Cellular network is online
-            assertEquals(true, awaitItem())
+            assertEquals(Connectivity.Status(false, true), awaitItem())
             expectNoEvents()
         }
     }
+
+    /** Switching between networks with different configurations. */
+    @Test
+    fun roamingFromWifiWithIpv6OnlyToWifiWithIpv4Only() = runTest {
+        val ipv6Network = mockk<Network>()
+        val ipv6NetworkLinkProperties = mockLinkProperties(false, true)
+        val ipv4Network = mockk<Network>()
+        val ipv4NetworkLinkProperties = mockLinkProperties(true, false)
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
+
+        every { connectivityManager.defaultNetworkEvents() } returns
+            callbackFlow {
+                send(NetworkEvent.Available(ipv6Network))
+                send(NetworkEvent.LinkPropertiesChanged(ipv6Network, ipv6NetworkLinkProperties))
+                delay(5.seconds)
+                send(NetworkEvent.Lost(ipv6Network))
+                delay(100.milliseconds)
+                send(NetworkEvent.Available(ipv4Network))
+                send(NetworkEvent.LinkPropertiesChanged(ipv4Network, ipv4NetworkLinkProperties))
+                awaitClose {}
+            }
+
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
+            // Ipv6 network is online
+            assertEquals(Connectivity.Status(false, true), awaitItem())
+            // Ipv4 network is online
+            assertEquals(Connectivity.Status(true, false), awaitItem())
+            expectNoEvents()
+        }
+    }
+
+    /** Vpn network should NOT check link properties but should rather use socket implementation */
+    @Test
+    fun checkVpnNetworkUsingSocketImplementation() = runTest {
+        val vpnNetwork = mockk<Network>()
+        val capabilities = mockk<NetworkCapabilities>()
+        every { capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN) } returns
+            false
+        val mockResolver = mockk<UnderlyingConnectivityStatusResolver>()
+        every { mockResolver.currentStatus() } returns Connectivity.Status(true, true)
+
+        every { connectivityManager.defaultNetworkEvents() } returns
+            callbackFlow {
+                send(NetworkEvent.Available(vpnNetwork))
+                send(NetworkEvent.CapabilitiesChanged(vpnNetwork, capabilities))
+                awaitClose {}
+            }
+
+        connectivityManager.hasInternetConnectivity(mockResolver).test {
+            // Network is online
+            assertEquals(Connectivity.Status(true, true), awaitItem())
+        }
+
+        verify(exactly = 1) { mockResolver.currentStatus() }
+    }
+
+    private fun mockLinkProperties(ipv4: Boolean, ipv6: Boolean) =
+        mockk<LinkProperties> {
+            val linkAddresses = buildList {
+                if (ipv4) {
+                    val linkIpv4Address: LinkAddress = mockk()
+                    val ipv4Address: Inet4Address = mockk()
+                    every { linkIpv4Address.address } returns ipv4Address
+                    add(linkIpv4Address)
+                }
+                if (ipv6) {
+                    val linkIpv6Address: LinkAddress = mockk()
+                    val ipv6Address: Inet6Address = mockk()
+                    every { linkIpv6Address.address } returns ipv6Address
+                    add(linkIpv6Address)
+                }
+            }
+
+            every { this@mockk.linkAddresses } returns linkAddresses
+        }
 
     companion object {
         private const val CONNECTIVITY_MANAGER_UTIL_CLASS =

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -26,6 +26,7 @@ import net.mullvad.talpid.model.CreateTunResult.OtherAlwaysOnApp
 import net.mullvad.talpid.model.CreateTunResult.OtherLegacyAlwaysOnVpn
 import net.mullvad.talpid.model.TunConfig
 import net.mullvad.talpid.util.TalpidSdkUtils.setMeteredIfSupported
+import net.mullvad.talpid.util.UnderlyingConnectivityStatusResolver
 
 open class TalpidVpnService : LifecycleVpnService() {
     private var activeTunStatus by
@@ -48,7 +49,11 @@ open class TalpidVpnService : LifecycleVpnService() {
     @CallSuper
     override fun onCreate() {
         super.onCreate()
-        connectivityListener = ConnectivityListener(getSystemService<ConnectivityManager>()!!)
+        connectivityListener =
+            ConnectivityListener(
+                getSystemService<ConnectivityManager>()!!,
+                UnderlyingConnectivityStatusResolver(::protect),
+            )
         connectivityListener.register(lifecycleScope)
     }
 

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/Connectivity.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/Connectivity.kt
@@ -1,0 +1,8 @@
+package net.mullvad.talpid.model
+
+sealed class Connectivity {
+    data class Status(val ipv4: Boolean, val ipv6: Boolean) : Connectivity()
+
+    // Required by jni
+    data object PresumeOnline : Connectivity()
+}

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/UnderlyingConnectivityStatusResolver.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/UnderlyingConnectivityStatusResolver.kt
@@ -1,0 +1,69 @@
+package net.mullvad.talpid.util
+
+import arrow.core.Either
+import arrow.core.raise.result
+import co.touchlab.kermit.Logger
+import java.net.DatagramSocket
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import net.mullvad.talpid.model.Connectivity
+
+/** This class is used to check the ip version of the underlying network when a VPN is active. */
+class UnderlyingConnectivityStatusResolver(
+    private val protect: (socket: DatagramSocket) -> Boolean
+) {
+    fun currentStatus(): Connectivity.Status =
+        Connectivity.Status(ipv4 = hasIPv4(), ipv6 = hasIPv6())
+
+    private fun hasIPv4(): Boolean =
+        hasIpVersion(Inet4Address.getByName(PUBLIC_IPV4_ADDRESS), protect)
+
+    private fun hasIPv6(): Boolean =
+        hasIpVersion(Inet6Address.getByName(PUBLIC_IPV6_ADDRESS), protect)
+
+    // Fake a connection to a public ip address using a UDP socket.
+    // We don't care about the result of the connection, only that it is possible to create.
+    // This is done this way since otherwise there is not way to check the availability of an ip
+    // version on the underlying network if the VPN is turned on.
+    // Since we are protecting the socket it will use the underlying network regardless
+    // if the VPN is turned on or not.
+    // If the ip version is not supported on the underlying network it will trigger a socket
+    // exception. Otherwise we assume it is available.
+    private fun hasIpVersion(
+        ip: InetAddress,
+        protect: (socket: DatagramSocket) -> Boolean,
+    ): Boolean =
+        result {
+                // Open socket
+                val socket = openSocket().bind()
+
+                val protected = protect(socket)
+
+                // Protect so we can get underlying network
+                if (!protected) {
+                    // We shouldn't be doing this if we don't have a VPN, then we should of checked
+                    // the network directly.
+                    Logger.w("Failed to protect socket")
+                }
+
+                // "Connect" to public ip to see IP version is available
+                val address = InetSocketAddress(ip, 1)
+                socket.connectSafe(address).bind()
+            }
+            .isSuccess
+
+    private fun openSocket(): Either<Throwable, DatagramSocket> =
+        Either.catch { DatagramSocket() }.onLeft { Logger.e("Could not open socket or bind port") }
+
+    private fun DatagramSocket.connectSafe(address: InetSocketAddress): Either<Throwable, Unit> =
+        Either.catch { connect(address.address, address.port) }
+            .onLeft { Logger.e("Socket could not be set up") }
+            .also { close() }
+
+    companion object {
+        private const val PUBLIC_IPV4_ADDRESS = "1.1.1.1"
+        private const val PUBLIC_IPV6_ADDRESS = "2606:4700:4700::1001"
+    }
+}

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -18,4 +18,6 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/talpid/ConnectivityListener",
     "net/mullvad/talpid/TalpidVpnService",
     "net/mullvad/mullvadvpn/lib/endpoint/ApiEndpointOverride",
+    "net/mullvad/talpid/model/Connectivity$Status",
+    "net/mullvad/talpid/model/Connectivity$PresumeOnline",
 ];


### PR DESCRIPTION
Exposes the availability of IPv4 and IPv6 to the daemon.

This is done by creating a dummy socket on the uderlying network.

This aligns android with other platforms.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7577)
<!-- Reviewable:end -->
