### PR TITLE
Hide loading spinner immediatly on connect

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -177,13 +177,9 @@ class TunnelViewController: UIViewController, RootContainment {
 
         case let .connected(tunnelRelays, _, _):
             let center = tunnelRelays.exit.location.geoCoordinate
-            mapViewController.setCenter(center, animated: animated) {
-                // Connection can change during animation, so make sure we're still connected before adding marker.
-                if case .connected = self.tunnelState {
-                    self.mapViewController.addLocationMarker(coordinate: center)
-                    self.activityIndicator.stopAnimating()
-                }
-            }
+            mapViewController.setCenter(center, animated: animated)
+            activityIndicator.stopAnimating()
+            mapViewController.addLocationMarker(coordinate: center)
 
         case .pendingReconnect:
             activityIndicator.startAnimating()


### PR DESCRIPTION
Earlier the spinner in the map view was visible until the map reached the connected location. Now the spinner disappears as soon as the connected state is reached.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7578)
<!-- Reviewable:end -->
