### PR TITLE
Split cell reuse identifiers to segregate subtitle cells

### DIFF
--- a/ios/MullvadVPN/View controllers/Settings/SettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCellFactory.swift
@@ -30,12 +30,13 @@ final class SettingsCellFactory: @preconcurrency CellFactoryProtocol, Sendable {
     func makeCell(for item: SettingsDataSource.Item, indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell
 
-        // Instantiate cell based on the specific item type
-        if item == .changelog {
-            cell = SettingsCell(style: .subtitle, reuseIdentifier: item.reuseIdentifier.rawValue)
-        } else {
-            cell = tableView.dequeueReusableCell(withIdentifier: item.reuseIdentifier.rawValue, for: indexPath)
-        }
+        cell = tableView
+            .dequeueReusableCell(
+                withIdentifier: item.reuseIdentifier.rawValue
+            ) ?? SettingsCell(
+                style: item.reuseIdentifier.cellStyle,
+                reuseIdentifier: item.reuseIdentifier.rawValue
+            )
 
         // Configure the cell with the common logic
         configureCell(cell, item: item, indexPath: indexPath)

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
@@ -11,11 +11,19 @@ import UIKit
 
 final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource.Section, SettingsDataSource.Item>,
     UITableViewDelegate {
-    enum CellReuseIdentifiers: String, CaseIterable {
+    enum CellReuseIdentifier: String, CaseIterable {
         case basic
+        case changelog
 
         var reusableViewClass: AnyClass {
             SettingsCell.self
+        }
+
+        var cellStyle: UITableViewCell.CellStyle {
+            switch self {
+            case .basic: .default
+            case .changelog: .subtitle
+            }
         }
     }
 
@@ -68,8 +76,11 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
             }
         }
 
-        var reuseIdentifier: CellReuseIdentifiers {
-            .basic
+        var reuseIdentifier: CellReuseIdentifier {
+            switch self {
+            case .changelog: .changelog
+            default: .basic
+            }
         }
     }
 
@@ -132,13 +143,6 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
     // MARK: - Private
 
     private func registerClasses() {
-        CellReuseIdentifiers.allCases.forEach { cellIdentifier in
-            tableView?.register(
-                cellIdentifier.reusableViewClass,
-                forCellReuseIdentifier: cellIdentifier.rawValue
-            )
-        }
-
         HeaderFooterReuseIdentifier.allCases.forEach { reuseIdentifier in
             tableView?.register(
                 reuseIdentifier.headerFooterClass,


### PR DESCRIPTION
Cells in the settings page would fluctuate on view appearance between subtitle and regular styles. This was due to all cells having the same reuse identifier, despite changelog cells being created with the `subtitle` style while others had the `default` style.  This change gives changelog cells their own reuse identifier, fixing this.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7585)
<!-- Reviewable:end -->
