### PR TITLE
Restore osv scanner vuln ignore that is still required

### DIFF
--- a/android/gradle/osv-scanner.toml
+++ b/android/gradle/osv-scanner.toml
@@ -66,3 +66,12 @@ reason = "No impact since the app doesn't process externally crafted XML."
 id = "CVE-2024-47535" # GHSA-xq3w-v528-46rv
 ignoreUntil = 2025-02-13
 reason = "Only impacting Windows."
+
+# Several vulns related to bouncy castle that is only being used by lint.
+# These are not used directly in the app.
+[[PackageOverrides]]
+name = "org.bouncycastle:bcprov-jdk18on"
+ecosystem = "Maven"
+ignore = true
+effectiveUntil = 2025-05-02
+reason = "Used by lint and not the app directly."


### PR DESCRIPTION
Actually manually ran a scheduled scan this time:
https://github.com/mullvad/mullvadvpn-app/actions/runs/13130795543/job/36635362299

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7588)
<!-- Reviewable:end -->
