### PR TITLE
Document mounting issue for the testing framework

### DIFF
--- a/test/docs/BUILD_OS_IMAGE.md
+++ b/test/docs/BUILD_OS_IMAGE.md
@@ -218,6 +218,15 @@ Windows Defender ocasionally kills the `test-runner` because it believes it to b
 Now you are done! If the VM was configured correctly, `test-manager` will be able to run the test suite using the new OS image.
 Now you should [add your new VM to the test-manager config](./test-manager/README.md#configuring-test-manager)
 
+## Notes on editing Windows VM images
+
+When editing the VM image, never shut it down with the test runner volume mounted (i.e. `E:`). When
+Windows is shut down with the disk mounted, it will be unable to remount it correctly when the image
+is replaced.
+
+To get around this behavior, remove the disk from your VM config before starting it with
+`--keep-changes`.
+
 # macOS 🚧
 
 _Instructions for building an OS image based on macOS are still under construction._


### PR DESCRIPTION
It turns out that shutting down the VM with the test runner image mounted results in a weird state. I've added this to the documentation.

This explains why the Windows 11 VM was failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7590)
<!-- Reviewable:end -->
