### PR TITLE
Fix excess `createTun` calls with multihop and PQ/DAITA

### DIFF
--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -361,8 +361,13 @@ impl WgGoTunnel {
         tun_config.addresses = config.tunnel.addresses.clone();
         tun_config.ipv4_gateway = config.ipv4_gateway;
         tun_config.ipv6_gateway = config.ipv6_gateway;
-        tun_config.routes = routes.collect();
         tun_config.mtu = config.mtu;
+        tun_config.routes = if cfg!(target_os = "android") {
+            // Route everything into the tunnel and have wireguard-go act as a firewall.
+            vec!["0.0.0.0/0".parse().unwrap(), "::/0".parse().unwrap()]
+        } else {
+            routes.collect()
+        };
 
         for _ in 1..=MAX_PREPARE_TUN_ATTEMPTS {
             let tunnel_device = tun_provider


### PR DESCRIPTION
This PR removes a lot of excess calls to `openTun` during the tunnel setup by re-using the same tunnel FD while restarting wireguard-go. This is accomplished by not changing the routes in the tunnel configuration, as Kotlin will avoid _actually_ calling `createTun` if the configuration doesn't change across calls to `openTun`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7596)
<!-- Reviewable:end -->
