### PR TITLE
Add flag for debugging VPN with Local network sharing

### DIFF
--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -119,6 +119,12 @@ class StartTunnelOperation: ResultOperation<Void>, @unchecked Sendable {
         protocolConfig.providerBundleIdentifier = ApplicationTarget.packetTunnel.bundleIdentifier
         protocolConfig.serverAddress = ""
 
+        #if DEBUG
+        if #available(iOS 17.4, *) {
+            protocolConfig.excludeDeviceCommunication = true
+        }
+        #endif
+
         let alwaysOnRule = NEOnDemandRuleConnect()
         alwaysOnRule.interfaceTypeMatch = .any
 


### PR DESCRIPTION
This PR adds flags to the VPN configuration, allowing us to debug when local network sharing is active.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7601)
<!-- Reviewable:end -->
