### PR TITLE
Use a seperate lockfile for libmaybenot

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -17,4 +17,6 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@19ec1116569a47416e11a45848722b1af31a857b"  # v1.9.0
+    uses: "mullvad/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@aba27c138acfaad1a9fdf68fdd0fd78d3c974aaf"  # v1.9.0
+    with:
+      checkout-submodules: true

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -18,4 +18,6 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@19ec1116569a47416e11a45848722b1af31a857b"  # v1.9.0
+    uses: "mullvad/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@aba27c138acfaad1a9fdf68fdd0fd78d3c974aaf"  # v1.9.0
+    with:
+      checkout-submodules: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,13 +2324,6 @@ dependencies = [
 
 [[package]]
 name = "maybenot-ffi"
-version = "0.0.0"
-dependencies = [
- "maybenot-ffi 2.0.1",
-]
-
-[[package]]
-name = "maybenot-ffi"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c0111f55c83db74f51cdb1d8ffdad16149200d936d0a227fdfe5d579318ef78"
@@ -6111,7 +6104,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "log",
- "maybenot-ffi 0.0.0",
+ "maybenot-ffi",
  "thiserror 2.0.9",
  "windows-sys 0.52.0",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ members = [
     "tunnel-obfuscation",
     "wireguard-go-rs",
     "windows-installer",
-    # This crate lives in the wireguard-go submodule. We include it here to track its
-    # dependencies in our workspace lockfile.
-    "wireguard-go-rs/libwg/wireguard-go/maybenot-ffi",
 ]
 # Default members dictate what is built when running `cargo build` in the root directory.
 # This is set to a minimal set of packages to speed up the build process and avoid building

--- a/wireguard-go-rs/Cargo.toml
+++ b/wireguard-go-rs/Cargo.toml
@@ -18,7 +18,10 @@ zeroize = "1.8.1"
 # wireguard-go-rs nor its upstream dependants use it.
 # This is only here so that maybenot-ffi is built and its symbols are available to wireguard-go
 # at link time.
-maybenot-ffi = { path = "libwg/wireguard-go/maybenot-ffi" }
+# NOTE: for other platforms, maybenot-ffi is NOT declared here, but instead built directly from
+# wireguard-go-rs/libwg/wireguard-go/maybenot-ffi
+maybenot-ffi = "2.0.1"
+
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.52.0", features = ["Win32_Networking", "Win32_NetworkManagement", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock"] }

--- a/wireguard-go-rs/libwg/Android.mk
+++ b/wireguard-go-rs/libwg/Android.mk
@@ -26,7 +26,7 @@ default: $(DESTDIR)/libwg.so
 $(DESTDIR)/libwg.so:
 	mkdir -p $(DESTDIR)
 	# Build libmaybenot
-	make --directory wireguard-go libmaybenot.a LIBDEST="$(DESTDIR)" TARGET="$(TARGET)" CARGO_TARGET_DIR="$(CARGO_TARGET_DIR)"
+	make --directory wireguard-go/maybenot-ffi $(DESTDIR)/libmaybenot.a TARGET="$(TARGET)" CARGO_TARGET_DIR="$(CARGO_TARGET_DIR)"
 	# Build wireguard-go
 	go get -tags "linux android daita"
 	chmod -fR +w "$(GOPATH)/pkg/mod"


### PR DESCRIPTION
An experiment whereby we add a Cargo.lock to the `wireguard-go/maybenot-ffi` wrapper. To do this, we need to exclude maybenot-ffi from the workspace, but it allows us to lock its dependencies while working around the diamond-problem of having wireguard-go be included both directly, and through wireguard-apple.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7605)
<!-- Reviewable:end -->
