### PR TITLE
Update electron to 33.4.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -2031,9 +2031,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
+      "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -5375,11 +5375,12 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.2.1.tgz",
-      "integrity": "sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==",
+      "version": "33.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.0.tgz",
+      "integrity": "sha512-AO+Q/ygWwKKs+JtNEFgfS5ntjG3TA2HX7s4IEbiYi6lktaocuLP2oScG1/mmKRuUWoOcow2RRsf995L2mM4bvQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -14672,7 +14673,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
         "cross-env": "^7.0.3",
-        "electron": "33.2.1",
+        "electron": "33.4.0",
         "electron-builder": "^24.13.3",
         "electron-devtools-installer": "^3.2.0",
         "eslint-plugin-react": "^7.36.1",
@@ -16270,9 +16271,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
-      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "version": "20.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
+      "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
       "requires": {
         "undici-types": "~6.19.2"
       }
@@ -18933,9 +18934,9 @@
       }
     },
     "electron": {
-      "version": "33.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.2.1.tgz",
-      "integrity": "sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==",
+      "version": "33.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.0.tgz",
+      "integrity": "sha512-AO+Q/ygWwKKs+JtNEFgfS5ntjG3TA2HX7s4IEbiYi6lktaocuLP2oScG1/mmKRuUWoOcow2RRsf995L2mM4bvQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -22551,7 +22552,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-spies": "^1.0.0",
         "cross-env": "^7.0.3",
-        "electron": "33.2.1",
+        "electron": "33.4.0",
         "electron-builder": "^24.13.3",
         "electron-devtools-installer": "^3.2.0",
         "eslint-plugin-react": "^7.36.1",

--- a/desktop/packages/mullvad-vpn/package.json
+++ b/desktop/packages/mullvad-vpn/package.json
@@ -52,7 +52,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "cross-env": "^7.0.3",
-    "electron": "33.2.1",
+    "electron": "33.4.0",
     "electron-builder": "^24.13.3",
     "electron-devtools-installer": "^3.2.0",
     "eslint-plugin-react": "^7.36.1",


### PR DESCRIPTION
This PR bumps electron to a new patch version in order to fix a bug where the app would crash on launch due to the `shell.readShortcutLink` electron API crashing when parsing some app shortcuts on Windows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7611)
<!-- Reviewable:end -->
