### PR TITLE
Remove retry attempts from hickory resolver

### DIFF
--- a/mullvad-daemon/src/android_dns.rs
+++ b/mullvad-daemon/src/android_dns.rs
@@ -37,7 +37,9 @@ impl DnsResolver for AndroidDnsResolver {
         let group = NameServerConfigGroup::from_ips_clear(&ips, 53, false);
 
         let config = ResolverConfig::from_parts(None, vec![], group);
-        let resolver = TokioAsyncResolver::tokio(config, ResolverOpts::default());
+        let mut opts = ResolverOpts::default();
+        opts.attempts = 0;
+        let resolver = TokioAsyncResolver::tokio(config, opts);
 
         let lookup = resolver
             .lookup_ip(host)


### PR DESCRIPTION
We only want a single lookup attempt for `*.am.i.mullvad.net`, since we already have retry logic for these lookups, and `getaddrinfo` doesn't retry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7612)
<!-- Reviewable:end -->
