### PR TITLE
IOS-1052/IOS-1055 SingleChoiceList wonkiness fixes

### DIFF
--- a/ios/MullvadVPN/View controllers/Settings/SwiftUI components/SingleChoiceList.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SwiftUI components/SingleChoiceList.swift
@@ -347,6 +347,7 @@ struct SingleChoiceList<Value>: View where Value: Equatable {
                         switch opt.value {
                         case let .literal(v):
                             literalRow(v)
+                                .listRowSeparator(.hidden)
                         case let .custom(
                             label,
                             prompt,
@@ -364,8 +365,10 @@ struct SingleChoiceList<Value>: View where Value: Equatable {
                                 toValue: toValue,
                                 fromValue: fromValue
                             )
+                            .listRowSeparator(.hidden)
                             if let legend {
                                 subtitleRow(legend)
+                                    .listRowSeparator(.hidden)
                             }
                         }
                     }

--- a/ios/MullvadVPN/View controllers/Settings/SwiftUI components/SingleChoiceList.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SwiftUI components/SingleChoiceList.swift
@@ -59,6 +59,8 @@ struct SingleChoiceList<Value>: View where Value: Equatable {
     let tableAccessibilityIdentifier: String
     let itemDescription: (Value) -> String
     let customFieldMode: CustomFieldMode
+    // a latch to keep the custom field selected through changes of focus until the user taps elsewhere
+    @State var customFieldSelected = false
 
     /// The configuration for the field for a custom value row
     enum CustomFieldMode {
@@ -206,7 +208,7 @@ struct SingleChoiceList<Value>: View where Value: Equatable {
     // Construct a literal row for a specific literal value
     private func literalRow(_ item: Value) -> some View {
         row(
-            isSelected: value.wrappedValue == item && !customValueIsFocused
+            isSelected: value.wrappedValue == item && !customFieldSelected
         ) {
             Text(verbatim: itemDescription(item))
             Spacer()
@@ -215,6 +217,7 @@ struct SingleChoiceList<Value>: View where Value: Equatable {
             value.wrappedValue = item
             customValueIsFocused = false
             customValueInput = ""
+            customFieldSelected = false
         }
     }
 
@@ -229,7 +232,7 @@ struct SingleChoiceList<Value>: View where Value: Equatable {
         fromValue: @escaping (Value) -> String?
     ) -> some View {
         row(
-            isSelected: value.wrappedValue == toValue(customValueInput) || customValueIsFocused
+            isSelected: value.wrappedValue == toValue(customValueInput) || customFieldSelected
         ) {
             Text(label)
             Spacer()
@@ -304,6 +307,7 @@ struct SingleChoiceList<Value>: View where Value: Equatable {
             }
         }
         .onTapGesture {
+            customFieldSelected = true
             if let v = toValue(customValueInput) {
                 value.wrappedValue = v
             } else {


### PR DESCRIPTION
This fixes IOS-1052 and IOS-1055. The former by separating the logic behind row selection from input field focus, the latter by removing system list item separators that somehow were still around.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7613)
<!-- Reviewable:end -->
