### PR TITLE
Enable using two accounts for e2e tests

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -433,7 +433,7 @@ jobs:
   instrumented-e2e-tests:
     name: Run instrumented e2e tests
     # Temporary workaround for targeting the runner android-runner-v1
-    runs-on: [self-hosted, android-device, android-emulator]
+    runs-on: [self-hosted, android-device]
     needs: [prepare, build-app, build-instrumented-tests]
     if: >
       github.event_name == 'schedule' ||
@@ -443,6 +443,16 @@ jobs:
         include:
           - test-repeat: ${{ needs.prepare.outputs.E2E_TEST_REPEAT || 1 }}
     steps:
+      - name: Resolve unique runner test account secret name
+        if: needs.prepare.outputs.E2E_TEST_INFRA_FLAVOR == 'prod'
+        run: |
+          echo "RUNNER_SECRET_NAME=ANDROID_PROD_TEST_ACCOUNT_$(echo $RUNNER_NAME | tr '[:lower:]-' '[:upper:]_')" \
+          >> $GITHUB_ENV
+
+      - name: Resolve runner test account
+        if: needs.prepare.outputs.E2E_TEST_INFRA_FLAVOR == 'prod'
+        run: echo "RESOLVED_TEST_ACCOUNT=${{ secrets[env.RUNNER_SECRET_NAME] }}" >> $GITHUB_ENV
+
       - name: Prepare report dir
         if: ${{ matrix.test-repeat != 0 }}
         id: prepare-report-dir
@@ -486,8 +496,7 @@ jobs:
           INFRA_FLAVOR: "${{ needs.prepare.outputs.E2E_TEST_INFRA_FLAVOR }}"
           PARTNER_AUTH: |-
             ${{ needs.prepare.outputs.E2E_TEST_INFRA_FLAVOR == 'stagemole' && secrets.STAGEMOLE_PARTNER_AUTH || '' }}
-          VALID_TEST_ACCOUNT_NUMBER: |-
-            ${{ needs.prepare.outputs.E2E_TEST_INFRA_FLAVOR == 'prod' && secrets.ANDROID_PROD_TEST_ACCOUNT || '' }}
+          VALID_TEST_ACCOUNT_NUMBER: ${{ env.RESOLVED_TEST_ACCOUNT }}
           INVALID_TEST_ACCOUNT_NUMBER: '0000000000000000'
           ENABLE_HIGHLY_RATE_LIMITED_TESTS: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
           ENABLE_ACCESS_TO_LOCAL_API_TESTS: true


### PR DESCRIPTION
This PR aims to enable using two e2e test accounts on separate e2e test runners/devices. This approach can also easily be expanded to add more runner/device connected accounts.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7614)
<!-- Reviewable:end -->
