### PR TITLE
Improve tunnel state test

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -34,4 +34,4 @@ jobs:
           # This action defaults to 50 char subjects, but 72 is fine.
           max-subject-line-length: '72'
           # The action's wordlist is a bit short. Add more accepted verbs
-          additional-verbs: 'tidy, wrap, obfuscate, bias, prohibit, forbid, revert'
+          additional-verbs: 'tidy, wrap, obfuscate, bias, prohibit, forbid, revert, slim'

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+import { exec as execAsync } from 'child_process';
+import { Page } from 'playwright';
+import { promisify } from 'util';
+
+import { expectConnected } from '../../shared/tunnel-state';
+import { startInstalledApp } from '../installed-utils';
+
+const exec = promisify(execAsync);
+
+// This test expects the daemon to be logged into an account that has time left, have OpenVPN
+// selected and to be disconnected.
+
+let page: Page;
+
+test.beforeAll(async () => {
+  ({ page } = await startInstalledApp());
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test('App should show correct tunnel protocol', async () => {
+  await page.getByText('Connect', { exact: true }).click();
+  await expectConnected(page);
+  await page.getByTestId('connection-panel-chevron').click();
+
+  const tunnelProtocol = page.getByTestId('tunnel-protocol');
+  await expect(tunnelProtocol).toHaveText('OpenVPN');
+});
+
+test('App should show correct OpenVPN transport protocol and port', async () => {
+  const inData = page.getByTestId('in-ip');
+
+  await expect(inData).toContainText(new RegExp(':[0-9]+'));
+  await expect(inData).toContainText(new RegExp('(TCP|UDP)$'));
+  await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1195');
+  await expectConnected(page);
+  await page.getByTestId('connection-panel-chevron').click();
+  await expect(inData).toContainText(new RegExp(':1195'));
+
+  await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1300');
+  await expectConnected(page);
+  await page.getByTestId('connection-panel-chevron').click();
+  await expect(inData).toContainText(new RegExp(':1300'));
+
+  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port any');
+  await expectConnected(page);
+  await page.getByTestId('connection-panel-chevron').click();
+  await expect(inData).toContainText(new RegExp(':[0-9]+'));
+  await expect(inData).toContainText(new RegExp('TCP$'));
+
+  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port 80');
+  await expectConnected(page);
+  await page.getByTestId('connection-panel-chevron').click();
+  await expect(inData).toContainText(new RegExp(':80'));
+
+  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port 443');
+  await expectConnected(page);
+  await page.getByTestId('connection-panel-chevron').click();
+  await expect(inData).toContainText(new RegExp(':443'));
+
+  await exec('mullvad relay set tunnel openvpn --transport-protocol any');
+});
+
+test('App should show bridge mode', async () => {
+  await exec('mullvad bridge set state on');
+  await expectConnected(page);
+  const relay = page.getByTestId('hostname-line');
+  await expect(relay).toHaveText(new RegExp(' via ', 'i'));
+});

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
@@ -35,10 +35,6 @@ test('App should show correct OpenVPN transport protocol and port', async () => 
 
   await expect(inData).toContainText(new RegExp(':[0-9]+'));
   await expect(inData).toContainText(new RegExp('(TCP|UDP)$'));
-  await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1195');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(inData).toContainText(new RegExp(':1195'));
 
   await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1300');
   await expectConnected(page);
@@ -55,11 +51,6 @@ test('App should show correct OpenVPN transport protocol and port', async () => 
   await expectConnected(page);
   await page.getByTestId('connection-panel-chevron').click();
   await expect(inData).toContainText(new RegExp(':80'));
-
-  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port 443');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(inData).toContainText(new RegExp(':443'));
 
   await exec('mullvad relay set tunnel openvpn --transport-protocol any');
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -34,7 +34,7 @@ test('App should connect', async () => {
   await expectConnected(page);
 
   const relay = page.getByTestId('hostname-line');
-  const inIp = page.locator(':text("In") + span');
+  const inIp = page.getByText('In', { exact: true }).locator('+ span');
   // If IPv6 is enabled, there will be two "Out" IPs, one for IPv4 and one for IPv6
   // Selecting the first resolves to the IPv4 address regardless of the IP setting
   const outIp = page.locator(':text("Out") + div > span').first();

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -95,61 +95,6 @@ test('App should connect with Shadowsocks', async () => {
   await expectConnected(page);
 });
 
-test('App should show correct tunnel protocol', async () => {
-  const tunnelProtocol = page.getByTestId('tunnel-protocol');
-  await expect(tunnelProtocol).toHaveText('WireGuard');
-
-  await exec('mullvad relay set tunnel-protocol openvpn');
-  await exec('mullvad relay set location se');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(tunnelProtocol).toHaveText('OpenVPN');
-});
-
-test('App should show correct OpenVPN transport protocol and port', async () => {
-  const inData = page.getByTestId('in-ip');
-
-  await expect(inData).toContainText(new RegExp(':[0-9]+'));
-  await expect(inData).toContainText(new RegExp('(TCP|UDP)$'));
-  await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1195');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(inData).toContainText(new RegExp(':1195'));
-
-  await exec('mullvad relay set tunnel openvpn --transport-protocol udp --port 1300');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(inData).toContainText(new RegExp(':1300'));
-
-  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port any');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(inData).toContainText(new RegExp(':[0-9]+'));
-  await expect(inData).toContainText(new RegExp('TCP$'));
-
-  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port 80');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(inData).toContainText(new RegExp(':80'));
-
-  await exec('mullvad relay set tunnel openvpn --transport-protocol tcp --port 443');
-  await expectConnected(page);
-  await page.getByTestId('connection-panel-chevron').click();
-  await expect(inData).toContainText(new RegExp(':443'));
-
-  await exec('mullvad relay set tunnel openvpn --transport-protocol any');
-});
-
-test('App should show bridge mode', async () => {
-  await exec('mullvad bridge set state on');
-  await expectConnected(page);
-  const relay = page.getByTestId('hostname-line');
-  await expect(relay).toHaveText(new RegExp(' via ', 'i'));
-  await exec('mullvad bridge set state off');
-
-  await exec('mullvad relay set tunnel-protocol wireguard');
-});
-
 test('App should enter blocked state', async () => {
   await exec('mullvad debug block-connection');
   await expectError(page);

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -101,7 +101,7 @@ pub async fn test_ui_tunnel_settings(
 
     let ui_result = run_test_env(
         &rpc,
-        &["tunnel-state.spec"],
+        &["state-dependent/tunnel-state.spec"],
         [
             ("HOSTNAME", entry.hostname.as_str()),
             ("IN_IP", &entry.ipv4_addr_in.to_string()),
@@ -115,6 +115,22 @@ pub async fn test_ui_tunnel_settings(
     .unwrap();
     assert!(ui_result.success());
 
+    Ok(())
+}
+
+/// Test how various tunnel settings for OpenVPN are handled and displayed by the GUI
+#[test_function]
+pub async fn test_ui_openvpn_tunnel_settings(
+    _: TestContext,
+    rpc: ServiceClient,
+    mut mullvad_client: MullvadProxyClient,
+) -> anyhow::Result<()> {
+    // openvpn-tunnel-state.spec precondition: OpenVPN needs to be selected
+    let query = RelayQueryBuilder::new().openvpn().build();
+    helpers::apply_settings_from_relay_query(&mut mullvad_client, query).await?;
+
+    let ui_result = run_test(&rpc, &["openvpn-tunnel-state.spec"]).await?;
+    assert!(ui_result.success());
     Ok(())
 }
 


### PR DESCRIPTION
This PR improves the tunnel state test by:
* Splitting out OpenVPN specific tests to a separate file
* Removes some redundant OpenVPN tests
* Better matches the "In" label in the connection panel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7615)
<!-- Reviewable:end -->
