### PR TITLE
Backport "Fix excess opentun calls" to `prepare-android/2025.1`

### DIFF
--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -287,8 +287,13 @@ impl WgGoTunnel {
         tun_config.addresses = config.tunnel.addresses.clone();
         tun_config.ipv4_gateway = config.ipv4_gateway;
         tun_config.ipv6_gateway = config.ipv6_gateway;
-        tun_config.routes = routes.collect();
         tun_config.mtu = config.mtu;
+        tun_config.routes = if cfg!(target_os = "android") {
+            // Route everything into the tunnel and have wireguard-go act as a firewall.
+            vec!["0.0.0.0/0".parse().unwrap(), "::/0".parse().unwrap()]
+        } else {
+            routes.collect()
+        };
 
         for _ in 1..=MAX_PREPARE_TUN_ATTEMPTS {
             let tunnel_device = tun_provider


### PR DESCRIPTION
This PR simply backports https://github.com/mullvad/mullvadvpn-app/pull/7596 to the 2025.1 android release branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7618)
<!-- Reviewable:end -->
