### PR TITLE
Fix `Display` implementation on `mullvad_version::Version`

### DIFF
--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -10,6 +10,7 @@ pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-versio
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Version {
+    /// The last two digits of the version's year
     pub year: String,
     pub incremental: String,
     /// A version can have an optional pre-stable type, e.g. alpha or beta. If `pre_stable`
@@ -226,5 +227,13 @@ mod tests {
     #[should_panic]
     fn test_panics_on_dev_without_commit_hash() {
         Version::parse("2021.1-dev");
+    }
+
+    #[test]
+    fn test_version_display() {
+        let version = "2024.8-beta1-dev-e5483d";
+        let parsed = Version::parse(version);
+
+        assert_eq!(format!("{parsed}"), version);
     }
 }

--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -60,7 +60,7 @@ impl Display for Version {
             dev,
         } = &self;
 
-        write!(f, "{year}.{incremental}")?;
+        write!(f, "20{year}.{incremental}")?;
 
         match pre_stable {
             Some(PreStableType::Alpha(version)) => write!(f, "-alpha{version}")?,


### PR DESCRIPTION
The formatted string was missing the "20" prefix, as the `year` field only includes the last two digits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7619)
<!-- Reviewable:end -->
