### PR TITLE
Set font size of dialog inputs to be title medium

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/RedeemVoucherDialog.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/dialog/RedeemVoucherDialog.kt
@@ -246,6 +246,7 @@ private fun EnterVoucherBody(
         keyboardType = KeyboardType.Password,
         placeholderText = stringResource(id = R.string.voucher_hint),
         visualTransformation = vouchersVisualTransformation(),
+        textStyle = MaterialTheme.typography.titleMedium,
         isDigitsOnlyAllowed = false,
         modifier = Modifier.testTag(VOUCHER_INPUT_TEST_TAG),
     )

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomListNameTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomListNameTextField.kt
@@ -49,6 +49,7 @@ fun CustomListNameTextField(
                 }
             },
         capitalization = KeyboardCapitalization.Words,
+        textStyle = MaterialTheme.typography.titleMedium,
         modifier =
             modifier.focusRequester(focusRequester).onFocusChanged { focusState ->
                 if (focusState.hasFocus) {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomPortTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomPortTextField.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.compose.textfield
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -26,5 +27,6 @@ fun CustomPortTextField(
         isEnabled = true,
         isValidValue = isValidValue,
         maxCharLength = maxCharLength,
+        textStyle = MaterialTheme.typography.titleMedium,
     )
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomTextField.kt
@@ -99,7 +99,7 @@ fun CustomTextField(
         },
         enabled = isEnabled,
         singleLine = true,
-        placeholder = placeholderText?.let { { Text(text = it) } },
+        placeholder = placeholderText?.let { { Text(text = it, style = textStyle) } },
         keyboardOptions = keyboardOptions,
         keyboardActions = KeyboardActions(onDone = { onSubmit(value) }),
         visualTransformation = visualTransformation,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/CustomTextField.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -23,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -48,6 +50,7 @@ fun CustomTextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     supportingText: @Composable (() -> Unit)? = null,
     colors: TextFieldColors = mullvadDarkTextFieldColors(),
+    textStyle: TextStyle = LocalTextStyle.current,
     capitalization: KeyboardCapitalization = KeyboardCapitalization.None,
     keyboardOptions: KeyboardOptions =
         KeyboardOptions(
@@ -101,6 +104,7 @@ fun CustomTextField(
         keyboardActions = KeyboardActions(onDone = { onSubmit(value) }),
         visualTransformation = visualTransformation,
         colors = colors,
+        textStyle = textStyle,
         isError = !isValidValue,
         modifier = modifier.clip(MaterialTheme.shapes.small).fillMaxWidth(),
         supportingText = supportingText,

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/DnsTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/DnsTextField.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.compose.textfield
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -28,5 +29,6 @@ fun DnsTextField(
         maxCharLength = Int.MAX_VALUE,
         isDigitsOnlyAllowed = false,
         isValidValue = isValidValue,
+        textStyle = MaterialTheme.typography.titleMedium,
     )
 }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/MtuTextField.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/compose/textfield/MtuTextField.kt
@@ -1,5 +1,6 @@
 package net.mullvad.mullvadvpn.compose.textfield
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
@@ -26,5 +27,6 @@ fun MtuTextField(
         maxCharLength = maxCharLength,
         isValidValue = isValidValue,
         isDigitsOnlyAllowed = true,
+        textStyle = MaterialTheme.typography.titleMedium,
     )
 }


### PR DESCRIPTION
They were using `bodyMedium` and that was changed to the default value.
This PR set it explicitly to `titleMedium` to make it look like it was before the change of `bodyMedium`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7633)
<!-- Reviewable:end -->
