### PR TITLE
Add setup-rust script and git hook

### DIFF
--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -9,6 +9,15 @@ on your platform please submit an issue or a pull request.
 ## All platforms
 
 - Get the latest **stable** Rust toolchain via [rustup.rs](https://rustup.rs/).
+  - Install default targets and components needed for desktop
+    ```bash
+    ./scripts/setup-rust desktop
+     ```
+  - (Optional) Run the following to install a git `post-checkout` hook that will automatically
+    run the `setup-rust` script when the Rust version specified in the `rust-toolchain.toml` file changes:
+    ```bash
+    .scripts/setup-rust install-hook
+    ```
 
 - You need Node.js and npm. You can find the exact versions in the `volta` section of
   `desktop/package.json`. The toolchain is managed by volta.

--- a/android/BuildInstructions.md
+++ b/android/BuildInstructions.md
@@ -151,7 +151,13 @@ environment variables:
 
 - Install Android targets
   ```bash
-  rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+  ./scripts/setup-rust android
+  ```
+
+- (Optional) Run the following to install a git `post-checkout` hook that will automatically
+  run the `setup-rust` script when the Rust version specified in the `rust-toolchain.toml` file changes:
+  ```bash
+  .scripts/setup-rust install-hook
   ```
 
 #### 6. Download wireguard-go-rs submodule

--- a/ios/BuildInstructions.md
+++ b/ios/BuildInstructions.md
@@ -10,8 +10,16 @@ Rust should be installed via [rustup](https://rustup.rs). Once rust is
 installed, do not forget to install the iOS targets:
 
 ```bash
-rustup target install aarch64-apple-ios aarch64-apple-ios-sim
+./scripts/setup-rust ios
 ```
+
+(Optional) Run the following to install a git `post-checkout` hook that will automatically
+run the `setup-rust` script when the Rust version specified in the `rust-toolchain.toml` file changes:
+
+```bash
+.scripts/setup-rust install-hook
+```
+
 You only need to install the ARM simulator target, which matches the current Apple Silicon architecture.
 
 Once both rust and go are installed, ensure they are available in your path.

--- a/scripts/setup-rust
+++ b/scripts/setup-rust
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Installs the default toolchains and components for different platforms.
+# To use this script rustup must be installed first.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+source scripts/utils/log
+
+ANDROID_TARGETS="x86_64-linux-android i686-linux-android aarch64-linux-android armv7-linux-androideabi"
+ANDROID_COMPONENTS="rust-analyzer"
+
+DESKTOP_TARGETS="x86_64-pc-windows-msvc x86_64-pc-windows-gnu i686-pc-windows-msvc"
+DESKTOP_COMPONENTS="rust-analyzer"
+
+IOS_TARGETS="aarch64-apple-ios-sim aarch64-apple-ios x86_64-apple-ios"
+IOS_COMPONENTS="rust-analyzer"
+
+function main {
+    if [[ $# -eq 0 ]]; then
+        print_usage
+        exit 1
+    fi
+
+    case "$1" in
+    "android")
+        setup "Android" "$ANDROID_TARGETS" "$ANDROID_COMPONENTS"
+        ;;
+    "desktop")
+        setup "Desktop" "$DESKTOP_TARGETS" "$DESKTOP_COMPONENTS"
+        ;;
+    "ios")
+        setup "Android" "$IOS_TARGETS" "$IOS_COMPONENTS"
+        ;;
+    "install-hook")
+        install_hook
+        ;;
+    "--help")
+        print_usage
+        exit 0
+        ;;
+    *)
+        log_error "Invalid argument: \`$1\`"
+        print_usage
+        exit 1
+        ;;
+    esac
+}
+
+function print_usage {
+    log "Setup default Rust targets and components for different platforms"
+    log ""
+    log "Usage: setup-rust android|desktop|ios|install-hook"
+    log "  android                    Run Android-specific setup"
+    log "  desktop                    Run Desktop-specific setup"
+    log "  ios                        Run iOS-specific setup"
+    log "  install-hook               Copies the setup-rust-post-checkout file to .git/hooks/post-checkout"
+}
+
+function setup {
+    local platform=$1
+    local targets=$2
+    local components=$3
+
+    log "Installing default Rust targets/components"
+    log "platform: $platform"
+    log "targets: $targets"
+    log "components: $components"
+    # shellcheck disable=SC2086
+    rustup target add $targets
+    # shellcheck disable=SC2086
+    rustup component add $components
+}
+
+function install_hook {
+    local hook=$SCRIPT_DIR/../.git/hooks/post-checkout
+    if [[ -f "$hook" ]]; then
+        log_error "$(realpath "$hook") file already exists - will not overwrite"
+        exit 1
+    else
+        cp "$SCRIPT_DIR/setup-rust-post-checkout" "$hook"
+        chmod +x "$hook"
+        log "Hook installed. You must now set the environment variable MULLVAD_SETUP_PLATFORM to "
+        log "\`android\`, \`desktop\` or \`ios\` in your shell environment."
+    fi
+}
+
+# Run script
+main "$@"

--- a/scripts/setup-rust-post-checkout
+++ b/scripts/setup-rust-post-checkout
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# To install the hook copy this file to `.git/hooks/post-checkout` or run
+# scripts/setup-rust install_hook
+
+set -u
+
+# Set to "android", "desktop", or "ios".
+MULLVAD_SETUP_PLATFORM="${MULLVAD_SETUP_PLATFORM:-}"
+
+SETUP_RUST_SCRIPT="scripts/setup-rust"
+
+if [[ ! -f "$SETUP_RUST_SCRIPT" ]]; then
+    exit 0
+fi
+
+if [[ -z ${MULLVAD_SETUP_PLATFORM+x} ]]; then
+    echo "MULLVAD_SETUP_PLATFORM is not set, must be set to " >&2
+    echo "\`android\`, \`desktop\` or \`ios\`" >&2
+    exit 1
+fi
+
+git diff-tree --exit-code "$1".."$2" --quiet -- rust-toolchain.toml
+
+# Exit code 1 means there was a change, 0 means no change.
+if [[ $? -eq 1 ]]; then
+    $SETUP_RUST_SCRIPT "$MULLVAD_SETUP_PLATFORM"
+fi


### PR DESCRIPTION
The setup-rust helper script installs the default targets and components that each platform needs with rustup.

The setup-rust-post-checkout script is a git hook (needs to be copied to .git/hooks/post-checkout, which can be done manually or by running `setup-rust install-hook`) that detects when the rust-toolchain.toml file has changed and installs the default targets/components (and/or extra targets/components that the user has specified in the hook script).

So say we have a new desktop developer and they are setting up their environment. They could run the following:
`scripts/setup-rust desktop && scripts/setup-rust install-hook desktop` after which things Should Just Work.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7636)
<!-- Reviewable:end -->
