### PR TITLE
Downgrade to tun 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Windows
 - Fix GUI crashing at launch on some systems by replacing Electron's shortcut parser.
 
+#### macOS
+- Fix routing issue caused by upgrading `tun`.
+
 
 ## [2025.3] - 2025-02-07
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,18 +183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,12 +205,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,12 +214,6 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -399,19 +375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,26 +397,6 @@ name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
-
-[[package]]
-name = "c2rust-bitfields"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367e5d1b30f28be590b6b3868da1578361d29d9bfac516d22f497d28ed7c9055"
-dependencies = [
- "c2rust-bitfields-derive",
-]
-
-[[package]]
-name = "c2rust-bitfields-derive"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a279db9c50c4024eeca1a763b6e0f033848ce74e83e47454bcf8a8a98f7b0b56"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "camellia"
@@ -677,15 +620,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1142,27 +1076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,16 +1206,6 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-lite"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -3218,12 +3121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,17 +3308,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs8"
@@ -4673,7 +4559,7 @@ dependencies = [
  "tokio",
  "tonic-build",
  "triggered",
- "tun 0.5.5",
+ "tun",
  "which",
  "widestring",
  "windows 0.58.0",
@@ -4827,7 +4713,7 @@ dependencies = [
  "talpid-windows",
  "thiserror 2.0.9",
  "tokio",
- "tun 0.7.10",
+ "tun",
  "windows-sys 0.52.0",
 ]
 
@@ -5346,27 +5232,6 @@ dependencies = [
  "thiserror 1.0.59",
  "tokio",
  "tokio-util 0.6.10",
-]
-
-[[package]]
-name = "tun"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5ea2466ffcdd0be0831f7d3981daa0b953586c0062f6d33398cb374689b090"
-dependencies = [
- "bytes",
- "cfg-if",
- "futures",
- "futures-core",
- "ipnet",
- "libc",
- "log",
- "nix 0.29.0",
- "thiserror 2.0.9",
- "tokio",
- "tokio-util 0.7.10",
- "windows-sys 0.59.0",
- "wintun-bindings",
 ]
 
 [[package]]
@@ -6200,38 +6065,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg2"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25225e44ce2ac6b72befed6416b0857cf8663f9963dba572c39473062f0e625"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "winres"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml 0.5.11",
-]
-
-[[package]]
-name = "wintun-bindings"
-version = "0.7.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e35d3911efde5ee25586385204127ff6a3f251477dcdd3b222775aaa4d95977"
-dependencies = [
- "blocking",
- "c2rust-bitfields",
- "futures",
- "libloading",
- "log",
- "thiserror 2.0.9",
- "windows-sys 0.59.0",
- "winreg2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ serde_json = "1.0.122"
 
 pnet_packet = "0.35.0"
 ipnetwork = "0.20"
-tun = { version = "0.7", features = ["async"] }
+tun = { version = "0.5.5", features = ["async"] }
 socket2 = "0.5.7"
 
 # Test dependencies

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -53,7 +53,7 @@ hickory-server = { workspace = true, features = ["resolver"] }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 pcap = { version = "2.1", features = ["capture-stream"] }
 pnet_packet = { workspace = true }
-tun = { version = "0.5.5", features = ["async"] }
+tun = { workspace = true, features = ["async"] }
 nix = { version = "0.28", features = ["socket", "signal"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/talpid-tunnel/src/tun_provider/unix.rs
+++ b/talpid-tunnel/src/tun_provider/unix.rs
@@ -5,7 +5,7 @@ use std::{
     os::unix::io::{AsRawFd, RawFd},
     process::Command,
 };
-use tun::{AbstractDevice, Configuration};
+use tun::{Configuration, Device};
 
 /// Errors that can occur while setting up a tunnel device.
 #[derive(Debug, thiserror::Error)]
@@ -115,7 +115,7 @@ impl TunnelDeviceBuilder {
     /// Set a custom name for this tunnel device.
     #[cfg(target_os = "linux")]
     pub fn name(&mut self, name: &str) -> &mut Self {
-        self.config.tun_name(name);
+        self.config.name(name);
         self
     }
 
@@ -123,7 +123,7 @@ impl TunnelDeviceBuilder {
     /// When enabled the first 4 bytes of each packet is a header with flags and protocol type.
     #[cfg(target_os = "linux")]
     pub fn enable_packet_information(&mut self) -> &mut Self {
-        self.config.platform_config(|config| {
+        self.config.platform(|config| {
             #[allow(deprecated)]
             // NOTE: This function does seemingly have an effect on Linux, despite what the deprecation
             // warning says.
@@ -135,7 +135,7 @@ impl TunnelDeviceBuilder {
 
 impl AsRawFd for TunnelDevice {
     fn as_raw_fd(&self) -> RawFd {
-        self.dev.as_raw_fd()
+        self.dev.get_ref().as_raw_fd()
     }
 }
 
@@ -143,7 +143,10 @@ impl TunnelDevice {
     fn set_ip(&mut self, ip: IpAddr) -> Result<(), Error> {
         match ip {
             IpAddr::V4(ipv4) => {
-                self.dev.set_address(ipv4.into()).map_err(Error::SetIpv4)?;
+                self.dev
+                    .get_mut()
+                    .set_address(ipv4)
+                    .map_err(Error::SetIpv4)?;
             }
 
             // NOTE: On MacOs, As of `tun 0.7`, `Device::set_address` accepts an `IpAddr` but
@@ -153,9 +156,9 @@ impl TunnelDevice {
             IpAddr::V6(ipv6) => {
                 // ifconfig <device> inet6 <ipv6 address> alias
                 let ipv6 = ipv6.to_string();
-                let device = self.dev.tun_name().unwrap(); // TODO: Do not unwrap!
+                let device = self.dev.get_ref().name();
                 Command::new("ifconfig")
-                    .args([&device, "inet6", &ipv6, "alias"])
+                    .args([device, "inet6", &ipv6, "alias"])
                     .output()
                     .map_err(Error::SetIpv6)?;
             }
@@ -166,9 +169,9 @@ impl TunnelDevice {
             IpAddr::V6(ipv6) => {
                 // ip -6 addr add <ipv6 address> dev <device>
                 let ipv6 = ipv6.to_string();
-                let device = self.dev.tun_name().unwrap(); // TODO: Do not unwrap!
+                let device = self.dev.get_ref().name();
                 Command::new("ip")
-                    .args(["-6", "addr", "add", &ipv6, "dev", &device])
+                    .args(["-6", "addr", "add", &ipv6, "dev", device])
                     .output()
                     .map_err(Error::SetIpv6)?;
             }
@@ -177,10 +180,10 @@ impl TunnelDevice {
     }
 
     fn set_up(&mut self, up: bool) -> Result<(), Error> {
-        self.dev.enabled(up).map_err(Error::ToggleDevice)
+        self.dev.get_mut().enabled(up).map_err(Error::ToggleDevice)
     }
 
     fn get_name(&self) -> Result<String, Error> {
-        self.dev.tun_name().map_err(Error::GetDeviceName)
+        Ok(self.dev.get_ref().name().to_owned())
     }
 }


### PR DESCRIPTION
`tun` tries to set up routes for us by running `route` commands, which we do not want. This PR fixes this by downgrading to 0.5. We need to make it possible to disable this behavior before upgrading to 0.7 again.

Related PR: https://github.com/mullvad/mullvadvpn-app/pull/7649

Close DES-1725

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7651)
<!-- Reviewable:end -->
