### PR TITLE
Add setting for ian and update excludelocalnetwork flag from ios 246

### DIFF
--- a/ios/MullvadSettings/TunnelSettings.swift
+++ b/ios/MullvadSettings/TunnelSettings.swift
@@ -58,7 +58,7 @@ public enum SchemaVersion: Int, Equatable, Sendable {
         case .v3: return .v4
         case .v4: return .v5
         case .v5: return .v6
-        case .v6: return .v6
+        case .v6: return .v7
         case .v7: return .v7
         }
     }

--- a/ios/MullvadSettings/TunnelSettings.swift
+++ b/ios/MullvadSettings/TunnelSettings.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Alias to the latest version of the `TunnelSettings`.
-public typealias LatestTunnelSettings = TunnelSettingsV6
+public typealias LatestTunnelSettings = TunnelSettingsV7
 
 /// Protocol all TunnelSettings must adhere to, for upgrade purposes.
 public protocol TunnelSettings: Codable, Sendable {
@@ -36,6 +36,9 @@ public enum SchemaVersion: Int, Equatable, Sendable {
     /// V5 format with DAITA settings, stored as `TunnelSettingsV6`.
     case v6 = 6
 
+    /// V6 format with Local network sharing, stored as `TunnelSettingsV7`.
+    case v7 = 7
+
     var settingsType: any TunnelSettings.Type {
         switch self {
         case .v1: return TunnelSettingsV1.self
@@ -44,6 +47,7 @@ public enum SchemaVersion: Int, Equatable, Sendable {
         case .v4: return TunnelSettingsV4.self
         case .v5: return TunnelSettingsV5.self
         case .v6: return TunnelSettingsV6.self
+        case .v7: return TunnelSettingsV7.self
         }
     }
 
@@ -55,9 +59,10 @@ public enum SchemaVersion: Int, Equatable, Sendable {
         case .v4: return .v5
         case .v5: return .v6
         case .v6: return .v6
+        case .v7: return .v7
         }
     }
 
     /// Current schema version.
-    public static let current = SchemaVersion.v6
+    public static let current = SchemaVersion.v7
 }

--- a/ios/MullvadSettings/TunnelSettingsStrategy.swift
+++ b/ios/MullvadSettings/TunnelSettingsStrategy.swift
@@ -9,19 +9,42 @@
 import Foundation
 public protocol TunnelSettingsStrategyProtocol: Sendable {
     func shouldReconnectToNewRelay(oldSettings: LatestTunnelSettings, newSettings: LatestTunnelSettings) -> Bool
+    func getReconnectionStrategy(
+        oldSettings: LatestTunnelSettings,
+        newSettings: LatestTunnelSettings
+    ) -> TunnelSettingsReconnectionStrategy
 }
 
 public struct TunnelSettingsStrategy: TunnelSettingsStrategyProtocol, Sendable {
     public init() {}
+
     public func shouldReconnectToNewRelay(
         oldSettings: LatestTunnelSettings,
         newSettings: LatestTunnelSettings
     ) -> Bool {
+        getReconnectionStrategy(oldSettings: oldSettings, newSettings: newSettings) != .noReconnect
+    }
+
+    public func getReconnectionStrategy(
+        oldSettings: LatestTunnelSettings,
+        newSettings: LatestTunnelSettings
+    ) -> TunnelSettingsReconnectionStrategy {
+        if oldSettings.localNetworkSharing != newSettings.localNetworkSharing {
+            return .hardReconnect
+        }
         switch (oldSettings, newSettings) {
         case let (old, new) where old != new:
-            true
+            return .softReconnect
         default:
-            false
+            return .noReconnect
         }
     }
+}
+
+public enum TunnelSettingsReconnectionStrategy {
+    case noReconnect
+    case softReconnect
+//    This will fully disconnect and start a new connection
+//    Attention: This will leak traffic!!!
+    case hardReconnect
 }

--- a/ios/MullvadSettings/TunnelSettingsStrategy.swift
+++ b/ios/MullvadSettings/TunnelSettingsStrategy.swift
@@ -45,10 +45,11 @@ public struct TunnelSettingsStrategy: TunnelSettingsStrategyProtocol, Sendable {
     }
 }
 
+/// This enum representes reconnection strategies.
+/// > Warning: `hardReconnect` will disconnect and reconnect which
+/// > potentially leads to traffic leaking outside the tunnel.
 public enum TunnelSettingsReconnectionStrategy {
     case currentRelayReconnect
     case newRelayReconnect
-//    This will fully disconnect and start a new connection
-//    Attention: This will leak traffic!!!
     case hardReconnect
 }

--- a/ios/MullvadSettings/TunnelSettingsStrategy.swift
+++ b/ios/MullvadSettings/TunnelSettingsStrategy.swift
@@ -29,7 +29,8 @@ public struct TunnelSettingsStrategy: TunnelSettingsStrategyProtocol, Sendable {
         oldSettings: LatestTunnelSettings,
         newSettings: LatestTunnelSettings
     ) -> TunnelSettingsReconnectionStrategy {
-        if oldSettings.localNetworkSharing != newSettings.localNetworkSharing {
+        if oldSettings.localNetworkSharing != newSettings.localNetworkSharing ||
+            oldSettings.includeAllNetworks != newSettings.includeAllNetworks {
             return .hardReconnect
         }
         switch (oldSettings, newSettings) {

--- a/ios/MullvadSettings/TunnelSettingsStrategy.swift
+++ b/ios/MullvadSettings/TunnelSettingsStrategy.swift
@@ -22,7 +22,10 @@ public struct TunnelSettingsStrategy: TunnelSettingsStrategyProtocol, Sendable {
         oldSettings: LatestTunnelSettings,
         newSettings: LatestTunnelSettings
     ) -> Bool {
-        getReconnectionStrategy(oldSettings: oldSettings, newSettings: newSettings) != .noReconnect
+        getReconnectionStrategy(
+            oldSettings: oldSettings,
+            newSettings: newSettings
+        ) != .currentRelayReconnect
     }
 
     public func getReconnectionStrategy(
@@ -35,16 +38,16 @@ public struct TunnelSettingsStrategy: TunnelSettingsStrategyProtocol, Sendable {
         }
         switch (oldSettings, newSettings) {
         case let (old, new) where old != new:
-            return .softReconnect
+            return .newRelayReconnect
         default:
-            return .noReconnect
+            return .currentRelayReconnect
         }
     }
 }
 
 public enum TunnelSettingsReconnectionStrategy {
-    case noReconnect
-    case softReconnect
+    case currentRelayReconnect
+    case newRelayReconnect
 //    This will fully disconnect and start a new connection
 //    Attention: This will leak traffic!!!
     case hardReconnect

--- a/ios/MullvadSettings/TunnelSettingsUpdate.swift
+++ b/ios/MullvadSettings/TunnelSettingsUpdate.swift
@@ -11,6 +11,7 @@ import MullvadTypes
 
 public enum TunnelSettingsUpdate: Sendable {
     case localNetworkSharing(Bool)
+    case includeAllNetworks(Bool)
     case dnsSettings(DNSSettings)
     case obfuscation(WireGuardObfuscationSettings)
     case relayConstraints(RelayConstraints)
@@ -24,6 +25,8 @@ extension TunnelSettingsUpdate {
         switch self {
         case let .localNetworkSharing(enabled):
             settings.localNetworkSharing = enabled
+        case let .includeAllNetworks(enabled):
+            settings.includeAllNetworks = enabled
         case let .dnsSettings(newDNSSettings):
             settings.dnsSettings = newDNSSettings
         case let .obfuscation(newObfuscationSettings):
@@ -42,6 +45,7 @@ extension TunnelSettingsUpdate {
     public var subjectName: String {
         switch self {
         case .localNetworkSharing: "Local network sharing"
+        case .includeAllNetworks: "Include all networks"
         case .dnsSettings: "DNS settings"
         case .obfuscation: "obfuscation settings"
         case .relayConstraints: "relay constraints"

--- a/ios/MullvadSettings/TunnelSettingsUpdate.swift
+++ b/ios/MullvadSettings/TunnelSettingsUpdate.swift
@@ -10,6 +10,7 @@ import Foundation
 import MullvadTypes
 
 public enum TunnelSettingsUpdate: Sendable {
+    case localNetworkSharing(Bool)
     case dnsSettings(DNSSettings)
     case obfuscation(WireGuardObfuscationSettings)
     case relayConstraints(RelayConstraints)
@@ -21,6 +22,8 @@ public enum TunnelSettingsUpdate: Sendable {
 extension TunnelSettingsUpdate {
     public func apply(to settings: inout LatestTunnelSettings) {
         switch self {
+        case let .localNetworkSharing(enabled):
+            settings.localNetworkSharing = enabled
         case let .dnsSettings(newDNSSettings):
             settings.dnsSettings = newDNSSettings
         case let .obfuscation(newObfuscationSettings):
@@ -38,6 +41,7 @@ extension TunnelSettingsUpdate {
 
     public var subjectName: String {
         switch self {
+        case .localNetworkSharing: "Local network sharing"
         case .dnsSettings: "DNS settings"
         case .obfuscation: "obfuscation settings"
         case .relayConstraints: "relay constraints"

--- a/ios/MullvadSettings/TunnelSettingsV6.swift
+++ b/ios/MullvadSettings/TunnelSettingsV6.swift
@@ -52,7 +52,8 @@ public struct TunnelSettingsV6: Codable, Equatable, TunnelSettings, Sendable {
             tunnelQuantumResistance: tunnelQuantumResistance,
             tunnelMultihopState: tunnelMultihopState,
             daita: daita,
-            localNetworkSharing: false
+            localNetworkSharing: false,
+            includeAllNetworks: false
         )
     }
 }

--- a/ios/MullvadSettings/TunnelSettingsV6.swift
+++ b/ios/MullvadSettings/TunnelSettingsV6.swift
@@ -45,12 +45,14 @@ public struct TunnelSettingsV6: Codable, Equatable, TunnelSettings, Sendable {
     }
 
     public func upgradeToNextVersion() -> any TunnelSettings {
-        TunnelSettingsV7(relayConstraints: relayConstraints,
-                         dnsSettings: dnsSettings,
-                         wireGuardObfuscation: wireGuardObfuscation,
-                         tunnelQuantumResistance: tunnelQuantumResistance,
-                         tunnelMultihopState: tunnelMultihopState,
-                         daita: daita,
-                         localNetworkSharing: false)
+        TunnelSettingsV7(
+            relayConstraints: relayConstraints,
+            dnsSettings: dnsSettings,
+            wireGuardObfuscation: wireGuardObfuscation,
+            tunnelQuantumResistance: tunnelQuantumResistance,
+            tunnelMultihopState: tunnelMultihopState,
+            daita: daita,
+            localNetworkSharing: false
+        )
     }
 }

--- a/ios/MullvadSettings/TunnelSettingsV7.swift
+++ b/ios/MullvadSettings/TunnelSettingsV7.swift
@@ -27,9 +27,12 @@ public struct TunnelSettingsV7: Codable, Equatable, TunnelSettings, Sendable {
 
     /// DAITA settings.
     public var daita: DAITASettings
-    
+
     /// Local networks sharing.
     public var localNetworkSharing: Bool
+
+    /// Forces the system to route most traffic through the tunnel
+    public var includeAllNetworks: Bool
 
     public init(
         relayConstraints: RelayConstraints = RelayConstraints(),
@@ -38,7 +41,8 @@ public struct TunnelSettingsV7: Codable, Equatable, TunnelSettings, Sendable {
         tunnelQuantumResistance: TunnelQuantumResistance = .automatic,
         tunnelMultihopState: MultihopState = .off,
         daita: DAITASettings = DAITASettings(),
-        localNetworkSharing: Bool = false
+        localNetworkSharing: Bool = false,
+        includeAllNetworks: Bool = false
     ) {
         self.relayConstraints = relayConstraints
         self.dnsSettings = dnsSettings
@@ -47,6 +51,7 @@ public struct TunnelSettingsV7: Codable, Equatable, TunnelSettings, Sendable {
         self.tunnelMultihopState = tunnelMultihopState
         self.daita = daita
         self.localNetworkSharing = localNetworkSharing
+        self.includeAllNetworks = includeAllNetworks
     }
 
     public func upgradeToNextVersion() -> any TunnelSettings {

--- a/ios/MullvadSettings/TunnelSettingsV7.swift
+++ b/ios/MullvadSettings/TunnelSettingsV7.swift
@@ -1,15 +1,16 @@
 //
-//  TunnelSettingsV6.swift
-//  MullvadSettings
+//  TunnelSettingsV6 2.swift
+//  MullvadVPN
 //
-//  Created by Mojgan on 2024-08-08.
+//  Created by Steffen Ernst on 2025-02-04.
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
+
 
 import Foundation
 import MullvadTypes
 
-public struct TunnelSettingsV6: Codable, Equatable, TunnelSettings, Sendable {
+public struct TunnelSettingsV7: Codable, Equatable, TunnelSettings, Sendable {
     /// Relay constraints.
     public var relayConstraints: RelayConstraints
 
@@ -27,6 +28,9 @@ public struct TunnelSettingsV6: Codable, Equatable, TunnelSettings, Sendable {
 
     /// DAITA settings.
     public var daita: DAITASettings
+    
+    /// Local networks sharing.
+    public var localNetworkSharing: Bool
 
     public init(
         relayConstraints: RelayConstraints = RelayConstraints(),
@@ -34,7 +38,8 @@ public struct TunnelSettingsV6: Codable, Equatable, TunnelSettings, Sendable {
         wireGuardObfuscation: WireGuardObfuscationSettings = WireGuardObfuscationSettings(),
         tunnelQuantumResistance: TunnelQuantumResistance = .automatic,
         tunnelMultihopState: MultihopState = .off,
-        daita: DAITASettings = DAITASettings()
+        daita: DAITASettings = DAITASettings(),
+        localNetworkSharing: Bool = false
     ) {
         self.relayConstraints = relayConstraints
         self.dnsSettings = dnsSettings
@@ -42,15 +47,10 @@ public struct TunnelSettingsV6: Codable, Equatable, TunnelSettings, Sendable {
         self.tunnelQuantumResistance = tunnelQuantumResistance
         self.tunnelMultihopState = tunnelMultihopState
         self.daita = daita
+        self.localNetworkSharing = localNetworkSharing
     }
 
     public func upgradeToNextVersion() -> any TunnelSettings {
-        TunnelSettingsV7(relayConstraints: relayConstraints,
-                         dnsSettings: dnsSettings,
-                         wireGuardObfuscation: wireGuardObfuscation,
-                         tunnelQuantumResistance: tunnelQuantumResistance,
-                         tunnelMultihopState: tunnelMultihopState,
-                         daita: daita,
-                         localNetworkSharing: false)
+        self
     }
 }

--- a/ios/MullvadSettings/TunnelSettingsV7.swift
+++ b/ios/MullvadSettings/TunnelSettingsV7.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-
 import Foundation
 import MullvadTypes
 

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1064,6 +1064,7 @@
 		F0FADDEC2BE90AB0000D0B02 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F1EF8C2BE8FF0A00CED01D /* LaunchArguments.swift */; };
 		F910A4312D4A1B41002FF3BB /* InAppPurchaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A4302D4A1B3B002FF3BB /* InAppPurchaseCoordinator.swift */; };
 		F910A43A2D4A283D002FF3BB /* InAppPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A4392D4A2839002FF3BB /* InAppPurchaseViewController.swift */; };
+		F910A8572D523812002FF3BB /* TunnelSettingsV7.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A8562D523812002FF3BB /* TunnelSettingsV7.swift */; };
 		F95C1C252D3E5E8E00EBE769 /* UIAlertController+InAppPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95C1C242D3E5E7A00EBE769 /* UIAlertController+InAppPurchase.swift */; };
 		F910A4012D3FF23A002FF3BB /* View+Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A4002D3FF22E002FF3BB /* View+Modifier.swift */; };
 		F998EFF82D359C4600D88D01 /* SKProduct+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */; };
@@ -2329,6 +2330,7 @@
 		F0F316182BF3572B0078DBCF /* RelaySelectorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelectorResult.swift; sourceTree = "<group>"; };
 		F0F3161A2BF358590078DBCF /* NoRelaysSatisfyingConstraintsError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoRelaysSatisfyingConstraintsError.swift; sourceTree = "<group>"; };
 		F0FBD98E2C4A60CC00EE5323 /* KeyExchangingResultStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyExchangingResultStub.swift; sourceTree = "<group>"; };
+		F910A8562D523812002FF3BB /* TunnelSettingsV7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettingsV7.swift; sourceTree = "<group>"; };
 		F910A4002D3FF22E002FF3BB /* View+Modifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Modifier.swift"; sourceTree = "<group>"; };
 		F95C1C242D3E5E7A00EBE769 /* UIAlertController+InAppPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+InAppPurchase.swift"; sourceTree = "<group>"; };
 		F910A4302D4A1B3B002FF3BB /* InAppPurchaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseCoordinator.swift; sourceTree = "<group>"; };
@@ -3548,6 +3550,7 @@
 				A93181A02B727ED700E341D2 /* TunnelSettingsV4.swift */,
 				F0E61CA82BF2911D000C4A95 /* TunnelSettingsV5.swift */,
 				F0C13FE52C64FB3400BD087D /* TunnelSettingsV6.swift */,
+				F910A8562D523812002FF3BB /* TunnelSettingsV7.swift */,
 				A988DF252ADE86ED00D807EF /* WireGuardObfuscationSettings.swift */,
 			);
 			path = MullvadSettings;
@@ -5799,6 +5802,7 @@
 				58B2FDDE2AA71D5C003EB5C6 /* Migration.swift in Sources */,
 				F05769BB2C6661EE00D9778B /* TunnelSettingsStrategy.swift in Sources */,
 				F0D7FF8F2B31DF5900E0FDE5 /* AccessMethodRepository.swift in Sources */,
+				F910A8572D523812002FF3BB /* TunnelSettingsV7.swift in Sources */,
 				58B2FDE12AA71D5C003EB5C6 /* TunnelSettingsV1.swift in Sources */,
 				449872E12B7BBC5400094DDC /* TunnelSettingsUpdate.swift in Sources */,
 				58B2FDE72AA71D5C003EB5C6 /* SettingsStore.swift in Sources */,

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -175,6 +175,7 @@ public enum AccessibilityIdentifier: Equatable {
     case statusImageView
 
     // DNS settings
+    case localNetworkSharing
     case dnsSettings
     case ipOverrides
     case wireGuardCustomPort

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -176,6 +176,7 @@ public enum AccessibilityIdentifier: Equatable {
     case statusImageView
 
     // DNS settings
+    case includeAllNetworks
     case localNetworkSharing
     case dnsSettings
     case ipOverrides

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -61,6 +61,7 @@ public enum AccessibilityIdentifier: Equatable {
     case relayFilterChipCloseButton
     case openPortSelectorMenuButton
     case cancelPurchaseListButton
+    case acceptLocalNetworkSharingButton
     // Cells
     case deviceCell
     case accessMethodProtocolSelectionCell

--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -9,6 +9,7 @@
 import Foundation
 import MullvadLogging
 import MullvadREST
+import MullvadSettings
 import NetworkExtension
 import Operations
 import PacketTunnelCore
@@ -48,7 +49,7 @@ class StartTunnelOperation: ResultOperation<Void>, @unchecked Sendable {
 
             finish(result: .success(()))
 
-        case .disconnected, .pendingReconnect:
+        case .disconnected, .pendingReconnect, .waitingForConnectivity:
             makeTunnelProviderAndStartTunnel { error in
                 self.finish(result: error.map { .failure($0) } ?? .success(()))
             }
@@ -106,28 +107,11 @@ class StartTunnelOperation: ResultOperation<Void>, @unchecked Sendable {
     ) {
         let persistentTunnels = interactor.getPersistentTunnels()
         let tunnel = persistentTunnels.first ?? interactor.createNewTunnel()
-        let configuration = Self.makeTunnelConfiguration()
+        let configuration = TunnelConfiguration(excludeLocalNetworks: interactor.settings.localNetworkSharing)
 
         tunnel.setConfiguration(configuration)
         tunnel.saveToPreferences { error in
             completionHandler(error.map { .failure($0) } ?? .success(tunnel))
         }
-    }
-
-    private class func makeTunnelConfiguration() -> TunnelConfiguration {
-        let protocolConfig = NETunnelProviderProtocol()
-        protocolConfig.providerBundleIdentifier = ApplicationTarget.packetTunnel.bundleIdentifier
-        protocolConfig.serverAddress = ""
-
-        let alwaysOnRule = NEOnDemandRuleConnect()
-        alwaysOnRule.interfaceTypeMatch = .any
-
-        return TunnelConfiguration(
-            isEnabled: true,
-            localizedDescription: "WireGuard",
-            protocolConfiguration: protocolConfig,
-            onDemandRules: [alwaysOnRule],
-            isOnDemandEnabled: true
-        )
     }
 }

--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -107,7 +107,10 @@ class StartTunnelOperation: ResultOperation<Void>, @unchecked Sendable {
     ) {
         let persistentTunnels = interactor.getPersistentTunnels()
         let tunnel = persistentTunnels.first ?? interactor.createNewTunnel()
-        let configuration = TunnelConfiguration(excludeLocalNetworks: interactor.settings.localNetworkSharing)
+        let configuration = TunnelConfiguration(
+            includeAllNetworks: interactor.settings.includeAllNetworks,
+            excludeLocalNetworks: interactor.settings.localNetworkSharing
+        )
 
         tunnel.setConfiguration(configuration)
         tunnel.saveToPreferences { error in

--- a/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StopTunnelOperation.swift
@@ -11,6 +11,7 @@ import Operations
 
 class StopTunnelOperation: ResultOperation<Void>, @unchecked Sendable {
     private let interactor: TunnelInteractor
+    var isOnDemandEnabled = false
 
     init(
         dispatchQueue: DispatchQueue,
@@ -50,8 +51,7 @@ class StopTunnelOperation: ResultOperation<Void>, @unchecked Sendable {
             return
         }
 
-        // Disable on-demand when stopping the tunnel to prevent it from coming back up
-        tunnel.isOnDemandEnabled = false
+        tunnel.isOnDemandEnabled = isOnDemandEnabled
 
         tunnel.saveToPreferences { error in
             self.dispatchQueue.async {

--- a/ios/MullvadVPN/TunnelManager/TunnelConfiguration.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelConfiguration.swift
@@ -16,11 +16,13 @@ struct TunnelConfiguration {
     var onDemandRules: [NEOnDemandRule]
     var isOnDemandEnabled: Bool
 
-    init(excludeLocalNetworks: Bool, isOnDemandEnabled: Bool = true) {
+    init(includeAllNetworks: Bool, excludeLocalNetworks: Bool, isOnDemandEnabled: Bool = true) {
         let protocolConfig = NETunnelProviderProtocol()
         protocolConfig.providerBundleIdentifier = ApplicationTarget.packetTunnel.bundleIdentifier
         protocolConfig.serverAddress = ""
-        protocolConfig.includeAllNetworks = true
+        #if DEBUG
+        protocolConfig.includeAllNetworks = includeAllNetworks
+        #endif
         protocolConfig.excludeLocalNetworks = excludeLocalNetworks
 
         let alwaysOnRule = NEOnDemandRuleConnect()

--- a/ios/MullvadVPN/TunnelManager/TunnelConfiguration.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelConfiguration.swift
@@ -16,6 +16,23 @@ struct TunnelConfiguration {
     var onDemandRules: [NEOnDemandRule]
     var isOnDemandEnabled: Bool
 
+    init(excludeLocalNetworks: Bool, isOnDemandEnabled: Bool = true) {
+        let protocolConfig = NETunnelProviderProtocol()
+        protocolConfig.providerBundleIdentifier = ApplicationTarget.packetTunnel.bundleIdentifier
+        protocolConfig.serverAddress = ""
+        protocolConfig.includeAllNetworks = true
+        protocolConfig.excludeLocalNetworks = excludeLocalNetworks
+
+        let alwaysOnRule = NEOnDemandRuleConnect()
+        alwaysOnRule.interfaceTypeMatch = .any
+
+        isEnabled = true
+        localizedDescription = "WireGuard"
+        protocolConfiguration = protocolConfig
+        onDemandRules = [alwaysOnRule]
+        self.isOnDemandEnabled = isOnDemandEnabled
+    }
+
     func apply(to manager: TunnelProviderManagerType) {
         manager.isEnabled = isEnabled
         manager.localizedDescription = localizedDescription

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -976,9 +976,9 @@ final class TunnelManager: StorePaymentObserver, @unchecked Sendable {
                 newSettings: updatedSettings
             )
             switch reconnectionStrategy {
-            case .noReconnect:
+            case .currentRelayReconnect:
                 self.reconnectTunnel(selectNewRelay: false)
-            case .softReconnect:
+            case .newRelayReconnect:
                 self.reconnectTunnel(selectNewRelay: true)
             case .hardReconnect:
                 self.reapplyTunnelConfiguration()

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -16,6 +16,7 @@ protocol VPNSettingsCellEventHandler {
     func selectCustomPortEntry(_ port: UInt16) -> Bool
     func selectObfuscationState(_ state: WireGuardObfuscationState)
     func switchMultihop(_ state: MultihopState)
+    func setLocalNetworkSettings(_ enabled: Bool, onCancel: @escaping () -> Void)
 }
 
 @MainActor
@@ -32,7 +33,6 @@ final class VPNSettingsCellFactory: @preconcurrency CellFactoryProtocol {
 
     func makeCell(for item: VPNSettingsDataSource.Item, indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: item.reuseIdentifier.rawValue, for: indexPath)
-
         configureCell(cell, item: item, indexPath: indexPath)
 
         return cell
@@ -42,6 +42,24 @@ final class VPNSettingsCellFactory: @preconcurrency CellFactoryProtocol {
     func configureCell(_ cell: UITableViewCell, item: VPNSettingsDataSource.Item, indexPath: IndexPath) {
         (cell as? SettingsCell)?.detailTitleLabel.accessibilityIdentifier = nil
         switch item {
+        case .localNetworkSharing:
+            guard let cell = cell as? SettingsSwitchCell else { return }
+            cell.infoButtonHandler = { self.delegate?.showInfo(for: .localNetworkSharing) }
+            cell.action = { enable in
+                self.delegate?.setLocalNetworkSettings(enable) {
+                    cell.setOn(self.viewModel.localNetworkSharing, animated: true)
+                }
+            }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "LOCAL_NETWORK_SHARING_CELL_LABEL",
+                tableName: "VPNSettings",
+                value: "Local network sharing",
+                comment: ""
+            )
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
+            cell.setOn(viewModel.localNetworkSharing, animated: true)
+
         case .dnsSettings:
             guard let cell = cell as? SettingsCell else { return }
 

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -294,6 +294,16 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         }
     }
 
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        let item = itemIdentifier(for: indexPath)
+
+        switch item {
+        case .includeAllNetworks, .localNetworkSharing:
+            return nil
+        default: return indexPath
+        }
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let item = itemIdentifier(for: indexPath)
 

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSourceDelegate.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSourceDelegate.swift
@@ -22,4 +22,5 @@ protocol VPNSettingsDataSourceDelegate: AnyObject {
     func showIPOverrides()
     func didSelectWireGuardPort(_ port: UInt16?)
     func humanReadablePortRepresentation() -> String
+    func showLocalNetworkSharingWarning(_ enable: Bool, completion: @escaping (Bool) -> Void)
 }

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
@@ -26,7 +26,6 @@ enum VPNSettingsInfoButtonItem: CustomStringConvertible {
                 tableName: "LocalNetworkSharing",
                 value: """
                 This feature allows access to other devices on the local network, such as for sharing, printing, streaming, etc.
-
                 It does this by allowing network communication outside the tunnel to local multicast and broadcast ranges as well as to and from these private IP ranges:
                 10.0.0.0/8
                 172.16.0.0/12
@@ -34,7 +33,6 @@ enum VPNSettingsInfoButtonItem: CustomStringConvertible {
                 169.254.0.0/16
                 fe80::/10
                 fc00::/7
-
                 Attention: toggling “Local network sharing” requires restarting the VPN connection.
                 """,
                 comment: ""

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 enum VPNSettingsInfoButtonItem: CustomStringConvertible {
+    case localNetworkSharing
     case contentBlockers
     case blockMalware
     case wireGuardPorts(String)
@@ -19,6 +20,25 @@ enum VPNSettingsInfoButtonItem: CustomStringConvertible {
 
     var description: String {
         switch self {
+        case .localNetworkSharing:
+            NSLocalizedString(
+                "VPN_SETTINGS_LOCAL_NETWORK_SHARING",
+                tableName: "LocalNetworkSharing",
+                value: """
+                This feature allows access to other devices on the local network, such as for sharing, printing, streaming, etc.
+
+                It does this by allowing network communication outside the tunnel to local multicast and broadcast ranges as well as to and from these private IP ranges:
+                10.0.0.0/8
+                172.16.0.0/12
+                192.168.0.0/16
+                169.254.0.0/16
+                fe80::/10
+                fc00::/7
+
+                Attention: toggling “Local network sharing” requires restarting the VPN connection.
+                """,
+                comment: ""
+            )
         case .contentBlockers:
             NSLocalizedString(
                 "VPN_SETTINGS_CONTENT_BLOCKERS_GENERAL",

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsInfoButtonItem.swift
@@ -26,13 +26,6 @@ enum VPNSettingsInfoButtonItem: CustomStringConvertible {
                 tableName: "LocalNetworkSharing",
                 value: """
                 This feature allows access to other devices on the local network, such as for sharing, printing, streaming, etc.
-                It does this by allowing network communication outside the tunnel to local multicast and broadcast ranges as well as to and from these private IP ranges:
-                10.0.0.0/8
-                172.16.0.0/12
-                192.168.0.0/16
-                169.254.0.0/16
-                fe80::/10
-                fc00::/7
                 Attention: toggling “Local network sharing” requires restarting the VPN connection.
                 """,
                 comment: ""

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
@@ -161,7 +161,8 @@ extension VPNSettingsViewController: @preconcurrency VPNSettingsDataSourceDelega
     }
 
     func showLocalNetworkSharingWarning(_ enable: Bool, completion: @escaping (Bool) -> Void) {
-        if interactor.tunnelManager.tunnelStatus.state.isSecured && interactor.tunnelManager.tunnelStatus.observedState.connectionState?.isNetworkReachable ?? false {
+        if interactor.tunnelManager.tunnelStatus.state.isSecured && interactor.tunnelManager.tunnelStatus.observedState
+            .connectionState?.isNetworkReachable ?? false {
             let description = NSLocalizedString(
                 "VPN_SETTINGS_LOCAL_NETWORK_SHARING_WARNING",
                 tableName: "LocalNetworkSharing",

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
@@ -161,7 +161,7 @@ extension VPNSettingsViewController: @preconcurrency VPNSettingsDataSourceDelega
     }
 
     func showLocalNetworkSharingWarning(_ enable: Bool, completion: @escaping (Bool) -> Void) {
-        if interactor.tunnelManager.tunnelStatus.state.isSecured {
+        if interactor.tunnelManager.tunnelStatus.state.isSecured && interactor.tunnelManager.tunnelStatus.observedState.connectionState?.isNetworkReachable ?? false {
             let description = NSLocalizedString(
                 "VPN_SETTINGS_LOCAL_NETWORK_SHARING_WARNING",
                 tableName: "LocalNetworkSharing",
@@ -172,7 +172,6 @@ extension VPNSettingsViewController: @preconcurrency VPNSettingsDataSourceDelega
                         : "Disabling"
                 ) “Local network sharing” requires restarting the VPN connection, which will disconnect you and briefly expose your traffic. 
                 To prevent this, manually enable Airplane Mode and turn off Wi-Fi before continuing. 
-
                 Would you like to continue to enable “Local network sharing”?
                 """,
                 comment: ""

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
@@ -161,8 +161,7 @@ extension VPNSettingsViewController: @preconcurrency VPNSettingsDataSourceDelega
     }
 
     func showLocalNetworkSharingWarning(_ enable: Bool, completion: @escaping (Bool) -> Void) {
-        if interactor.tunnelManager.tunnelStatus.state.isSecured && interactor.tunnelManager.tunnelStatus.observedState
-            .connectionState?.isNetworkReachable ?? false {
+        if interactor.tunnelManager.tunnelStatus.state.isSecured {
             let description = NSLocalizedString(
                 "VPN_SETTINGS_LOCAL_NETWORK_SHARING_WARNING",
                 tableName: "LocalNetworkSharing",

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
@@ -191,7 +191,10 @@ extension VPNSettingsViewController: @preconcurrency VPNSettingsDataSourceDelega
                             comment: ""
                         ),
                         style: .destructive,
-                        handler: { completion(true) }
+                        accessibilityId: .acceptLocalNetworkSharingButton,
+                        handler: {
+                            completion(true)
+                        }
                     ),
                     AlertAction(
                         title: NSLocalizedString(

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewController.swift
@@ -159,4 +159,56 @@ extension VPNSettingsViewController: @preconcurrency VPNSettingsDataSourceDelega
     func didSelectWireGuardPort(_ port: UInt16?) {
         interactor.setPort(port)
     }
+
+    func showLocalNetworkSharingWarning(_ enable: Bool, completion: @escaping (Bool) -> Void) {
+        if interactor.tunnelManager.tunnelStatus.state.isSecured {
+            let description = NSLocalizedString(
+                "VPN_SETTINGS_LOCAL_NETWORK_SHARING_WARNING",
+                tableName: "LocalNetworkSharing",
+                value: """
+                \(
+                    enable
+                        ? "Enabling"
+                        : "Disabling"
+                ) “Local network sharing” requires restarting the VPN connection, which will disconnect you and briefly expose your traffic. 
+                To prevent this, manually enable Airplane Mode and turn off Wi-Fi before continuing. 
+
+                Would you like to continue to enable “Local network sharing”?
+                """,
+                comment: ""
+            )
+
+            let presentation = AlertPresentation(
+                id: "vpn-settings-local-network-sharing-warning",
+                icon: .info,
+                message: description,
+                buttons: [
+                    AlertAction(
+                        title: NSLocalizedString(
+                            "VPN_SETTINGS_LOCAL_NETWORK_SHARING_OK_ACTION",
+                            tableName: "ContentBlockers",
+                            value: "Yes, continue",
+                            comment: ""
+                        ),
+                        style: .destructive,
+                        handler: { completion(true) }
+                    ),
+                    AlertAction(
+                        title: NSLocalizedString(
+                            "VPN_SETTINGS_LOCAL_NETWORK_SHARING_CANCEL_ACTION",
+                            tableName: "ContentBlockers",
+                            value: "Cancel",
+                            comment: ""
+                        ),
+                        style: .default,
+                        handler: { completion(false) }
+                    ),
+                ]
+            )
+
+            alertPresenter.showAlert(presentation: presentation, animated: true)
+        } else {
+            completion(true)
+        }
+    }
 }

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewModel.swift
@@ -103,6 +103,8 @@ struct VPNSettingsViewModel: Equatable {
     private(set) var quantumResistance: TunnelQuantumResistance
     private(set) var multihopState: MultihopState
 
+    private(set) var localNetworkSharing: Bool
+
     static let defaultWireGuardPorts: [UInt16] = [51820, 53]
 
     var enabledBlockersCount: Int {
@@ -195,6 +197,10 @@ struct VPNSettingsViewModel: Equatable {
         multihopState = newState
     }
 
+    mutating func setLocalNetworkSharing(_ newState: Bool) {
+        localNetworkSharing = newState
+    }
+
     /// Precondition for enabling Custom DNS.
     var customDNSPrecondition: CustomDNSPrecondition {
         if blockAdvertising || blockTracking || blockMalware ||
@@ -252,6 +258,8 @@ struct VPNSettingsViewModel: Equatable {
 
         quantumResistance = tunnelSettings.tunnelQuantumResistance
         multihopState = tunnelSettings.tunnelMultihopState
+
+        localNetworkSharing = tunnelSettings.localNetworkSharing
     }
 
     /// Produce merged view model, keeping entry `identifier` for matching DNS entries and

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsViewModel.swift
@@ -103,6 +103,7 @@ struct VPNSettingsViewModel: Equatable {
     private(set) var quantumResistance: TunnelQuantumResistance
     private(set) var multihopState: MultihopState
 
+    private(set) var includeAllNetworks: Bool
     private(set) var localNetworkSharing: Bool
 
     static let defaultWireGuardPorts: [UInt16] = [51820, 53]
@@ -197,6 +198,10 @@ struct VPNSettingsViewModel: Equatable {
         multihopState = newState
     }
 
+    mutating func setIncludeAllNetworks(_ newState: Bool) {
+        includeAllNetworks = newState
+    }
+
     mutating func setLocalNetworkSharing(_ newState: Bool) {
         localNetworkSharing = newState
     }
@@ -259,6 +264,7 @@ struct VPNSettingsViewModel: Equatable {
         quantumResistance = tunnelSettings.tunnelQuantumResistance
         multihopState = tunnelSettings.tunnelMultihopState
 
+        includeAllNetworks = tunnelSettings.includeAllNetworks
         localNetworkSharing = tunnelSettings.localNetworkSharing
     }
 

--- a/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
@@ -128,6 +128,33 @@ final class MigrationManagerTests: XCTestCase {
         wait(for: [failedMigrationExpectation], timeout: .UnitTest.timeout)
     }
 
+    func testSuccessfulMigrationFromV6ToLatest() throws {
+        var settingsV6 = TunnelSettingsV6()
+        let relayConstraints = RelayConstraints(
+            exitLocations: .only(UserSelectedRelays(locations: [.city("jp", "osa")]))
+        )
+
+        settingsV6.relayConstraints = relayConstraints
+        settingsV6.tunnelQuantumResistance = .off
+        settingsV6.wireGuardObfuscation = WireGuardObfuscationSettings(
+            state: .off,
+            udpOverTcpPort: .automatic
+        )
+        settingsV6.tunnelMultihopState = .off
+        settingsV6.daita = .init(daitaState: .on)
+
+        try migrateToLatest(settingsV6, version: .v6)
+
+        // Once the migration is done, settings should have been updated to the latest available version
+        // Verify that the old settings are still valid
+        let latestSettings = try SettingsManager.readSettings()
+        XCTAssertEqual(settingsV6.relayConstraints, latestSettings.relayConstraints)
+        XCTAssertEqual(settingsV6.tunnelQuantumResistance, latestSettings.tunnelQuantumResistance)
+        XCTAssertEqual(settingsV6.wireGuardObfuscation, latestSettings.wireGuardObfuscation)
+        XCTAssertEqual(settingsV6.tunnelMultihopState, latestSettings.tunnelMultihopState)
+        XCTAssertEqual(settingsV6.daita, latestSettings.daita)
+    }
+
     func testSuccessfulMigrationFromV5ToLatest() throws {
         var settingsV5 = TunnelSettingsV5()
         let relayConstraints = RelayConstraints(

--- a/ios/MullvadVPNTests/MullvadSettings/TunnelSettingsUpdateTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/TunnelSettingsUpdateTests.swift
@@ -101,4 +101,32 @@ final class TunnelSettingsUpdateTests: XCTestCase {
         // Then:
         XCTAssertEqual(settings.daita, daitaSettings)
     }
+
+    func testApplyIAN() {
+        // Given:
+        let includeAllNetworks = true
+        var settings = LatestTunnelSettings()
+
+        // When:
+        let update = TunnelSettingsUpdate.includeAllNetworks(includeAllNetworks)
+        update.apply(to: &settings)
+
+        // Then:
+        XCTAssertEqual(settings.includeAllNetworks, includeAllNetworks)
+    }
+
+    func testApplyLocalNetworkSharing() {
+        // Given:
+        let localNetworkSharing = true
+        var settings = LatestTunnelSettings()
+
+        // When:
+        let update = TunnelSettingsUpdate.localNetworkSharing(
+            localNetworkSharing
+        )
+        update.apply(to: &settings)
+
+        // Then:
+        XCTAssertEqual(settings.localNetworkSharing, localNetworkSharing)
+    }
 }

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelSettingsStrategyTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelSettingsStrategyTests.swift
@@ -104,4 +104,30 @@ final class TunnelSettingsStrategyTests: XCTestCase {
             newSettings: updatedSettings
         ))
     }
+
+    func testHardReconnectWhenIncludeAllNetworksChange() {
+        let currentSettings = LatestTunnelSettings()
+        var updatedSettings = currentSettings
+        TunnelSettingsUpdate.includeAllNetworks(true)
+            .apply(to: &updatedSettings)
+
+        let tunnelSettingsStrategy = TunnelSettingsStrategy()
+        XCTAssertEqual(tunnelSettingsStrategy.getReconnectionStrategy(
+            oldSettings: currentSettings,
+            newSettings: updatedSettings
+        ), .hardReconnect)
+    }
+
+    func testHardReconnectWhenLocalNetworkSharingChange() {
+        let currentSettings = LatestTunnelSettings()
+        var updatedSettings = currentSettings
+        TunnelSettingsUpdate.localNetworkSharing(true)
+            .apply(to: &updatedSettings)
+
+        let tunnelSettingsStrategy = TunnelSettingsStrategy()
+        XCTAssertEqual(tunnelSettingsStrategy.getReconnectionStrategy(
+            oldSettings: currentSettings,
+            newSettings: updatedSettings
+        ), .hardReconnect)
+    }
 }

--- a/ios/MullvadVPNUITests/Networking/Networking.swift
+++ b/ios/MullvadVPNUITests/Networking/Networking.swift
@@ -265,4 +265,22 @@ class Networking {
             XCTFail("Request to connection check API failed - timeout")
         }
     }
+
+    public static func verifyCanAccessLocalNetwork() throws {
+        let apiIPAddress = "192.168.105.1"
+        let apiPort = "80"
+        XCTAssertTrue(
+            try canConnectSocket(host: apiIPAddress, port: apiPort),
+            "Failed to verify that local network can be accessed"
+        )
+    }
+
+    public static func verifyCannotAccessLocalNetwork() throws {
+        let apiIPAddress = "192.168.105.1"
+        let apiPort = "80"
+        XCTAssertFalse(
+            try canConnectSocket(host: apiIPAddress, port: apiPort),
+            "Failed to verify that local network cannot be accessed"
+        )
+    }
 }

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -53,6 +53,16 @@ class VPNSettingsPage: Page {
         return self
     }
 
+    @discardableResult func tapLocalNetworkSharingSwitch() -> Self {
+        app.cells[AccessibilityIdentifier.localNetworkSharing]
+            .switches[AccessibilityIdentifier.customSwitch]
+            .tap()
+        app.buttons[AccessibilityIdentifier.acceptLocalNetworkSharingButton]
+            .tap()
+
+        return self
+    }
+
     @discardableResult func tapWireGuardPortsExpandButton() -> Self {
         cellExpandButton(AccessibilityIdentifier.wireGuardPortsCell).tap()
         return self


### PR DESCRIPTION
Add toggles for includeAllNetwork and excludeLocalNetwork in VPN Settings in debug builds. IAN kept false by default since there are issues with app updates when the tunnel is active with IAN enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7655)
<!-- Reviewable:end -->
