### PR TITLE
Set includeallnetworks to true in starttunneloperation and ios 945

### DIFF
--- a/ios/MullvadREST/Transport/Socks5/AnyIPEndpoint+Socks5.swift
+++ b/ios/MullvadREST/Transport/Socks5/AnyIPEndpoint+Socks5.swift
@@ -20,14 +20,4 @@ extension AnyIPEndpoint {
             .ipv6(endpoint)
         }
     }
-
-    /// Convert `AnyIPEndpoint` to `NWEndpoint`.
-    var nwEndpoint: NWEndpoint {
-        switch self {
-        case let .ipv4(endpoint):
-            .hostPort(host: .ipv4(endpoint.ip), port: NWEndpoint.Port(integerLiteral: endpoint.port))
-        case let .ipv6(endpoint):
-            .hostPort(host: .ipv6(endpoint.ip), port: NWEndpoint.Port(integerLiteral: endpoint.port))
-        }
-    }
 }

--- a/ios/MullvadSettings/TunnelSettings.swift
+++ b/ios/MullvadSettings/TunnelSettings.swift
@@ -36,30 +36,30 @@ public enum SchemaVersion: Int, Equatable, Sendable {
     /// V5 format with DAITA settings, stored as `TunnelSettingsV6`.
     case v6 = 6
 
-    /// V6 format with Local network sharing, stored as `TunnelSettingsV7`.
+    /// V6 format with a flag to enable LAN access, stored as `TunnelSettingsV7`.
     case v7 = 7
 
     var settingsType: any TunnelSettings.Type {
         switch self {
-        case .v1: return TunnelSettingsV1.self
-        case .v2: return TunnelSettingsV2.self
-        case .v3: return TunnelSettingsV3.self
-        case .v4: return TunnelSettingsV4.self
-        case .v5: return TunnelSettingsV5.self
-        case .v6: return TunnelSettingsV6.self
-        case .v7: return TunnelSettingsV7.self
+        case .v1: TunnelSettingsV1.self
+        case .v2: TunnelSettingsV2.self
+        case .v3: TunnelSettingsV3.self
+        case .v4: TunnelSettingsV4.self
+        case .v5: TunnelSettingsV5.self
+        case .v6: TunnelSettingsV6.self
+        case .v7: TunnelSettingsV7.self
         }
     }
 
     var nextVersion: Self {
         switch self {
-        case .v1: return .v2
-        case .v2: return .v3
-        case .v3: return .v4
-        case .v4: return .v5
-        case .v5: return .v6
-        case .v6: return .v7
-        case .v7: return .v7
+        case .v1: .v2
+        case .v2: .v3
+        case .v3: .v4
+        case .v4: .v5
+        case .v5: .v6
+        case .v6: .v7
+        case .v7: .v7
         }
     }
 

--- a/ios/MullvadSettings/TunnelSettingsV7.swift
+++ b/ios/MullvadSettings/TunnelSettingsV7.swift
@@ -1,8 +1,8 @@
 //
-//  TunnelSettingsV6 2.swift
-//  MullvadVPN
+//  TunnelSettingsV7.swift
+//  MullvadSettings
 //
-//  Created by Steffen Ernst on 2025-02-04.
+//  Created by Marco Nikic on 2025-01-31.
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 

--- a/ios/MullvadTypes/AnyIPEndpoint.swift
+++ b/ios/MullvadTypes/AnyIPEndpoint.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import protocol Network.IPAddress
+import Network
 
 public enum AnyIPEndpoint: Hashable, Equatable, Codable, CustomStringConvertible, @unchecked Sendable {
     case ipv4(IPv4Endpoint)
@@ -82,6 +82,16 @@ public enum AnyIPEndpoint: Hashable, Equatable, Codable, CustomStringConvertible
 
         default:
             return false
+        }
+    }
+
+    /// Convert `AnyIPEndpoint` to `NWEndpoint`.
+    public var nwEndpoint: NWEndpoint {
+        switch self {
+        case let .ipv4(endpoint):
+            .hostPort(host: .ipv4(endpoint.ip), port: NWEndpoint.Port(integerLiteral: endpoint.port))
+        case let .ipv6(endpoint):
+            .hostPort(host: .ipv6(endpoint.ip), port: NWEndpoint.Port(integerLiteral: endpoint.port))
         }
     }
 }

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -310,7 +310,6 @@
 		58C7A4492A863F490060C66F /* PacketTunnelCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58C7A4362A863F440060C66F /* PacketTunnelCore.framework */; };
 		58C7A44A2A863F490060C66F /* PacketTunnelCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 58C7A4362A863F440060C66F /* PacketTunnelCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		58C7A4512A863FB50060C66F /* PingerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58799A352A84FC9F007BE51F /* PingerProtocol.swift */; };
-		58C7A4552A863FB90060C66F /* TunnelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FC040927B3EE03001C21F0 /* TunnelMonitor.swift */; };
 		58C7A4562A863FB90060C66F /* DefaultPathObserverProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58225D252A84E8A10083D7F1 /* DefaultPathObserverProtocol.swift */; };
 		58C7A4572A863FB90060C66F /* TunnelDeviceInfoProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582403162A821FD700163DE8 /* TunnelDeviceInfoProtocol.swift */; };
 		58C7A4582A863FB90060C66F /* TunnelMonitorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7A42C2A85067A0060C66F /* TunnelMonitorProtocol.swift */; };
@@ -763,6 +762,7 @@
 		A9173C372C36CD2B00F6A08C /* MullvadTypes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D223D5294C8E5E0029F5F8 /* MullvadTypes.framework */; platformFilter = ios; };
 		A91D78E42B03C01600FCD5D3 /* MullvadSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58B2FDD32AA71D2A003EB5C6 /* MullvadSettings.framework */; };
 		A91EBEDA2C1337040004A84D /* RetryStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91EBED92C1337040004A84D /* RetryStrategyTests.swift */; };
+		A923D1212D5A40A80066C090 /* TunnelMonitorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A923D1202D5A40A80066C090 /* TunnelMonitorStateTests.swift */; };
 		A93181A12B727ED700E341D2 /* TunnelSettingsV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93181A02B727ED700E341D2 /* TunnelSettingsV4.swift */; };
 		A932D9EF2B5ADD0700999395 /* ProxyConfigurationTransportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A932D9EE2B5ADD0700999395 /* ProxyConfigurationTransportProvider.swift */; };
 		A932D9F32B5EB61100999395 /* HeadRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A932D9F22B5EB61100999395 /* HeadRequestTests.swift */; };
@@ -1982,7 +1982,6 @@
 		58FBFBE6291622580020E046 /* MullvadRESTTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MullvadRESTTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		58FBFBE8291622580020E046 /* ExponentialBackoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExponentialBackoffTests.swift; sourceTree = "<group>"; };
 		58FBFBF0291630700020E046 /* DurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationTests.swift; sourceTree = "<group>"; };
-		58FC040927B3EE03001C21F0 /* TunnelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitor.swift; sourceTree = "<group>"; };
 		58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Formatting.swift"; sourceTree = "<group>"; };
 		58FD5BF32428C67600112C88 /* InAppPurchaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseButton.swift; sourceTree = "<group>"; };
 		58FDF2D82A0BA11900C2B061 /* DeviceCheckOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceCheckOperation.swift; sourceTree = "<group>"; };
@@ -2274,6 +2273,7 @@
 		A91614D02B108D1B00F416EB /* TransportLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportLayer.swift; sourceTree = "<group>"; };
 		A917352029FAAA5200D5DCFD /* TransportStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportStrategyTests.swift; sourceTree = "<group>"; };
 		A91EBED92C1337040004A84D /* RetryStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryStrategyTests.swift; sourceTree = "<group>"; };
+		A923D1202D5A40A80066C090 /* TunnelMonitorStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitorStateTests.swift; sourceTree = "<group>"; };
 		A92962582B1F4FDB00DFB93B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A92ECC202A77FFAF0052F1B1 /* TunnelSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettings.swift; sourceTree = "<group>"; };
 		A92ECC232A7802520052F1B1 /* StoredAccountData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredAccountData.swift; sourceTree = "<group>"; };
@@ -3746,6 +3746,7 @@
 				5838321C2AC1C54600EA2071 /* TaskSleepTests.swift */,
 				58092E532A8B832E00C3CC72 /* TunnelMonitorTests.swift */,
 				F062B94C2C16E09700B6D47A /* TunnelSettingsManagerTests.swift */,
+				A923D1202D5A40A80066C090 /* TunnelMonitorStateTests.swift */,
 			);
 			path = PacketTunnelCoreTests;
 			sourceTree = "<group>";
@@ -4002,11 +4003,11 @@
 				58225D252A84E8A10083D7F1 /* DefaultPathObserverProtocol.swift */,
 				A95EEE372B722DFC00A8A39B /* PingStats.swift */,
 				582403162A821FD700163DE8 /* TunnelDeviceInfoProtocol.swift */,
-				58FC040927B3EE03001C21F0 /* TunnelMonitor.swift */,
 				58C7A42C2A85067A0060C66F /* TunnelMonitorProtocol.swift */,
 				A95EEE352B722CD600A8A39B /* TunnelMonitorState.swift */,
 				7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */,
 				58A3BDAF28A1821A00C8C2C6 /* WgStats.swift */,
+				A93A0BED2D4CEA7B001C9246 /* TunnelMonitor.swift */,
 			);
 			path = TunnelMonitor;
 			sourceTree = "<group>";
@@ -5989,7 +5990,6 @@
 				44DF8AC42BF20BD200869CA4 /* PacketTunnelActor+PostQuantum.swift in Sources */,
 				583832252AC318A100EA2071 /* PacketTunnelActor+ConnectionMonitoring.swift in Sources */,
 				F05919752C45194B00C301F3 /* EphemeralPeerKey.swift in Sources */,
-				58C7A4552A863FB90060C66F /* TunnelMonitor.swift in Sources */,
 				58C7AF182ABD84AB007EDD7A /* ProxyURLResponse.swift in Sources */,
 				58C7A4512A863FB50060C66F /* PingerProtocol.swift in Sources */,
 				583832292AC3DF1300EA2071 /* PacketTunnelActorCommand.swift in Sources */,
@@ -6004,6 +6004,7 @@
 				44B3C43A2BFE2C800079782C /* PacketTunnelActorReducer.swift in Sources */,
 				7A6B4F592AB8412E00123853 /* TunnelMonitorTimings.swift in Sources */,
 				A95EEE362B722CD600A8A39B /* TunnelMonitorState.swift in Sources */,
+				A93A0BEE2D4CEA7B001C9246 /* TunnelMonitor.swift in Sources */,
 				58FE25DB2AA72A8F003D1918 /* StartOptions.swift in Sources */,
 				A97D25AE2B0BB18100946B2D /* ProtocolObfuscator.swift in Sources */,
 				583832212AC3174700EA2071 /* PacketTunnelActor+NetworkReachability.swift in Sources */,
@@ -6042,6 +6043,7 @@
 				58FE25EE2AA7764E003D1918 /* TunnelAdapterDummy.swift in Sources */,
 				581F23AD2A8CF92100788AB6 /* DefaultPathObserverFake.swift in Sources */,
 				F07751582C50F149006E6A12 /* MultiHopEphemeralPeerExchangerTests.swift in Sources */,
+				A923D1212D5A40A80066C090 /* TunnelMonitorStateTests.swift in Sources */,
 				5838321B2AC1B18400EA2071 /* PacketTunnelActor+Mocks.swift in Sources */,
 				5838321D2AC1C54600EA2071 /* TaskSleepTests.swift in Sources */,
 				58092E542A8B832E00C3CC72 /* TunnelMonitorTests.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -772,6 +772,7 @@
 		A93969812CE606190032A7A0 /* Maybenot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9840BB32C69F78A0030F05E /* Maybenot.swift */; };
 		A95EEE362B722CD600A8A39B /* TunnelMonitorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95EEE352B722CD600A8A39B /* TunnelMonitorState.swift */; };
 		A95EEE382B722DFC00A8A39B /* PingStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95EEE372B722DFC00A8A39B /* PingStats.swift */; };
+		A96D0B432D671A4E00DD6C59 /* TunnelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96D0B422D671A4E00DD6C59 /* TunnelMonitor.swift */; };
 		A970C89D2B29E38C000A7684 /* Socks5UsernamePasswordCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A970C89C2B29E38C000A7684 /* Socks5UsernamePasswordCommand.swift */; };
 		A97275562CE36CAE00029F15 /* DaitaV2Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97275552CE36CAE00029F15 /* DaitaV2Parameters.swift */; };
 		A97D25AE2B0BB18100946B2D /* ProtocolObfuscator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97D25AD2B0BB18100946B2D /* ProtocolObfuscator.swift */; };
@@ -2291,6 +2292,7 @@
 		A948809A2BC9308D0090A44C /* EphemeralPeerExchangeActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralPeerExchangeActor.swift; sourceTree = "<group>"; };
 		A95EEE352B722CD600A8A39B /* TunnelMonitorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitorState.swift; sourceTree = "<group>"; };
 		A95EEE372B722DFC00A8A39B /* PingStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PingStats.swift; sourceTree = "<group>"; };
+		A96D0B422D671A4E00DD6C59 /* TunnelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelMonitor.swift; sourceTree = "<group>"; };
 		A970C89C2B29E38C000A7684 /* Socks5UsernamePasswordCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socks5UsernamePasswordCommand.swift; sourceTree = "<group>"; };
 		A97275552CE36CAE00029F15 /* DaitaV2Parameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaitaV2Parameters.swift; sourceTree = "<group>"; };
 		A97D25AD2B0BB18100946B2D /* ProtocolObfuscator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolObfuscator.swift; sourceTree = "<group>"; };
@@ -4003,11 +4005,11 @@
 				58225D252A84E8A10083D7F1 /* DefaultPathObserverProtocol.swift */,
 				A95EEE372B722DFC00A8A39B /* PingStats.swift */,
 				582403162A821FD700163DE8 /* TunnelDeviceInfoProtocol.swift */,
+				A96D0B422D671A4E00DD6C59 /* TunnelMonitor.swift */,
 				58C7A42C2A85067A0060C66F /* TunnelMonitorProtocol.swift */,
 				A95EEE352B722CD600A8A39B /* TunnelMonitorState.swift */,
 				7A6B4F582AB8412E00123853 /* TunnelMonitorTimings.swift */,
 				58A3BDAF28A1821A00C8C2C6 /* WgStats.swift */,
-				A93A0BED2D4CEA7B001C9246 /* TunnelMonitor.swift */,
 			);
 			path = TunnelMonitor;
 			sourceTree = "<group>";
@@ -5988,6 +5990,7 @@
 				587A5E522ADD7569003A70F1 /* ObservedState+Extensions.swift in Sources */,
 				58FE25E62AA738E8003D1918 /* TunnelAdapterProtocol.swift in Sources */,
 				44DF8AC42BF20BD200869CA4 /* PacketTunnelActor+PostQuantum.swift in Sources */,
+				A96D0B432D671A4E00DD6C59 /* TunnelMonitor.swift in Sources */,
 				583832252AC318A100EA2071 /* PacketTunnelActor+ConnectionMonitoring.swift in Sources */,
 				F05919752C45194B00C301F3 /* EphemeralPeerKey.swift in Sources */,
 				58C7AF182ABD84AB007EDD7A /* ProxyURLResponse.swift in Sources */,
@@ -6004,7 +6007,6 @@
 				44B3C43A2BFE2C800079782C /* PacketTunnelActorReducer.swift in Sources */,
 				7A6B4F592AB8412E00123853 /* TunnelMonitorTimings.swift in Sources */,
 				A95EEE362B722CD600A8A39B /* TunnelMonitorState.swift in Sources */,
-				A93A0BEE2D4CEA7B001C9246 /* TunnelMonitor.swift in Sources */,
 				58FE25DB2AA72A8F003D1918 /* StartOptions.swift in Sources */,
 				A97D25AE2B0BB18100946B2D /* ProtocolObfuscator.swift in Sources */,
 				583832212AC3174700EA2071 /* PacketTunnelActor+NetworkReachability.swift in Sources */,

--- a/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
@@ -151,9 +151,12 @@ class MapConnectionStatusOperation: AsyncOperation, @unchecked Sendable {
     private func setTunnelDisconnectedStatus() {
         interactor.updateTunnelStatus { tunnelStatus in
             tunnelStatus = TunnelStatus()
-            tunnelStatus.state = pathStatus == .unsatisfied
-                ? .waitingForConnectivity(.noNetwork)
-                : .disconnected
+            let pathStatusIsUnsatisfied = pathStatus == .unsatisfied
+            let message = "pathStatusIsUnsatisfied: \(pathStatusIsUnsatisfied)"
+            print(message)
+            tunnelStatus.state = pathStatusIsUnsatisfied ? .waitingForConnectivity(.noNetwork) : .disconnected
+            let stateMessage = "Setting tunnelStatus.state to \(tunnelStatus.state)"
+            print(stateMessage)
         }
     }
 

--- a/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/MapConnectionStatusOperation.swift
@@ -152,11 +152,10 @@ class MapConnectionStatusOperation: AsyncOperation, @unchecked Sendable {
         interactor.updateTunnelStatus { tunnelStatus in
             tunnelStatus = TunnelStatus()
             let pathStatusIsUnsatisfied = pathStatus == .unsatisfied
-            let message = "pathStatusIsUnsatisfied: \(pathStatusIsUnsatisfied)"
-            print(message)
             tunnelStatus.state = pathStatusIsUnsatisfied ? .waitingForConnectivity(.noNetwork) : .disconnected
-            let stateMessage = "Setting tunnelStatus.state to \(tunnelStatus.state)"
-            print(stateMessage)
+            let stateMessage =
+                "pathStatusIsUnsatisfied: \(pathStatusIsUnsatisfied). Setting tunnelStatus.state to \(tunnelStatus.state)"
+            logger.debug("\(stateMessage)")
         }
     }
 

--- a/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/StartTunnelOperation.swift
@@ -19,13 +19,16 @@ class StartTunnelOperation: ResultOperation<Void>, @unchecked Sendable {
 
     private let interactor: TunnelInteractor
     private let logger = Logger(label: "StartTunnelOperation")
+    private let tunnelSettings: LatestTunnelSettings
 
     init(
         dispatchQueue: DispatchQueue,
         interactor: TunnelInteractor,
+        tunnelSettings: LatestTunnelSettings,
         completionHandler: @escaping CompletionHandler
     ) {
         self.interactor = interactor
+        self.tunnelSettings = tunnelSettings
 
         super.init(
             dispatchQueue: dispatchQueue,

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -223,6 +223,7 @@ final class TunnelManager: StorePaymentObserver, @unchecked Sendable {
         let operation = StartTunnelOperation(
             dispatchQueue: internalQueue,
             interactor: TunnelInteractorProxy(self),
+            tunnelSettings: settings,
             completionHandler: { [weak self] result in
                 guard let self else { return }
                 if let error = result.error {

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
@@ -18,6 +18,7 @@ class StartTunnelOperationTests: XCTestCase {
 
     let testQueue = DispatchQueue(label: "StartTunnelOperationTests.testQueue")
     let operationQueue = AsyncOperationQueue()
+    let tunnelSettings = LatestTunnelSettings()
 
     let loggedInDeviceState = DeviceState.loggedIn(
         StoredAccountData(
@@ -39,7 +40,7 @@ class StartTunnelOperationTests: XCTestCase {
     func makeInteractor(deviceState: DeviceState, tunnelState: TunnelState? = nil) -> MockTunnelInteractor {
         let interactor = MockTunnelInteractor(
             isConfigurationLoaded: true,
-            settings: LatestTunnelSettings(),
+            settings: tunnelSettings,
             deviceState: deviceState
         )
         if let tunnelState {
@@ -54,7 +55,8 @@ class StartTunnelOperationTests: XCTestCase {
         let expectation = expectation(description: "Start tunnel operation failed")
         let operation = StartTunnelOperation(
             dispatchQueue: testQueue,
-            interactor: makeInteractor(deviceState: .loggedOut)
+            interactor: makeInteractor(deviceState: .loggedOut),
+            tunnelSettings: tunnelSettings
         ) { result in
             guard case .failure = result else {
                 XCTFail("Operation returned \(result), not failure")
@@ -75,7 +77,8 @@ class StartTunnelOperationTests: XCTestCase {
 
         let operation = StartTunnelOperation(
             dispatchQueue: testQueue,
-            interactor: interactor
+            interactor: interactor,
+            tunnelSettings: tunnelSettings
         ) { _ in
             XCTAssertEqual(tunnelStatus.state, .disconnecting(.reconnect))
             expectation.fulfill()
@@ -89,7 +92,8 @@ class StartTunnelOperationTests: XCTestCase {
         let expectation = expectation(description: "Make tunnel provider and start tunnel")
         let operation = StartTunnelOperation(
             dispatchQueue: testQueue,
-            interactor: interactor
+            interactor: interactor,
+            tunnelSettings: tunnelSettings
         ) { _ in
             XCTAssertNotNil(interactor.tunnel)
             XCTAssertNotNil(interactor.tunnel?.startDate)

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelPathObserver.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelPathObserver.swift
@@ -7,50 +7,61 @@
 //
 
 import Combine
-import MullvadLogging
 import MullvadTypes
 import Network
 import NetworkExtension
 import PacketTunnelCore
 
-final class PacketTunnelPathObserver: DefaultPathObserverProtocol, Sendable {
+final class PacketTunnelPathObserver: DefaultPathObserverProtocol, @unchecked Sendable {
+    private weak var packetTunnelProvider: NEPacketTunnelProvider?
     private let eventQueue: DispatchQueue
     private let pathMonitor: NWPathMonitor
-    nonisolated(unsafe) let logger = Logger(label: "PacketTunnelPathObserver")
-    private let stateLock = NSLock()
 
-    nonisolated(unsafe) private var started = false
+    private var gatewayConnection: NWConnection?
 
     public var currentPathStatus: Network.NWPath.Status {
-        stateLock.withLock {
-            pathMonitor.currentPath.status
-        }
+        pathMonitor.currentPath.status
     }
 
-    init(eventQueue: DispatchQueue) {
+    init(packetTunnelProvider: NEPacketTunnelProvider, eventQueue: DispatchQueue) {
+        self.packetTunnelProvider = packetTunnelProvider
         self.eventQueue = eventQueue
 
         pathMonitor = NWPathMonitor(prohibitedInterfaceTypes: [.other])
     }
 
     func start(_ body: @escaping @Sendable (Network.NWPath.Status) -> Void) {
-        stateLock.withLock {
-            guard started == false else { return }
-            defer { started = true }
-            pathMonitor.pathUpdateHandler = { updatedPath in
-                body(updatedPath.status)
+        pathMonitor.pathUpdateHandler = { updatedPath in
+            var unsatisfiedReason = "<No value>"
+            if updatedPath.status == .unsatisfied {
+                unsatisfiedReason += updatedPath.unsatisfiedReasonDescription
             }
+            var interfaceDebug = ""
+            updatedPath.availableInterfaces.forEach { interfaceDebug += """
+                        \($0.customDebugDescription)
 
-            pathMonitor.start(queue: eventQueue)
+            """ }
+            let message = """
+            Path available interfaces: \(interfaceDebug)
+            Path status: \(updatedPath.status) Unsatisfied reason: \(unsatisfiedReason) Supports IPv4: \(
+                updatedPath
+                    .supportsIPv4
+            )
+            Supports IPv6: \(updatedPath.supportsIPv6) Supports DNS: \(updatedPath.supportsDNS) Is Constrained: \(
+                updatedPath
+                    .isConstrained
+            )
+            Is expensive: \(updatedPath.isExpensive) Gateways: \(updatedPath.gateways.map { $0.customDebugDescription })
+            """
+            print(message)
+            body(updatedPath.status)
         }
+
+        pathMonitor.start(queue: eventQueue)
     }
 
     func stop() {
-        stateLock.withLock {
-            guard started == true else { return }
-            defer { started = false }
-            pathMonitor.pathUpdateHandler = nil
-            pathMonitor.cancel()
-        }
+//        pathMonitor.pathUpdateHandler = nil
+//        pathMonitor.cancel()
     }
 }

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelPathObserver.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelPathObserver.swift
@@ -18,6 +18,7 @@ final class PacketTunnelPathObserver: DefaultPathObserverProtocol, @unchecked Se
     private let pathMonitor: NWPathMonitor
 
     private var gatewayConnection: NWConnection?
+    private var started = false
 
     public var currentPathStatus: Network.NWPath.Status {
         pathMonitor.currentPath.status
@@ -31,6 +32,8 @@ final class PacketTunnelPathObserver: DefaultPathObserverProtocol, @unchecked Se
     }
 
     func start(_ body: @escaping @Sendable (Network.NWPath.Status) -> Void) {
+        guard started == false else { return }
+        defer { started = true }
         pathMonitor.pathUpdateHandler = { updatedPath in
             var unsatisfiedReason = "<No value>"
             if updatedPath.status == .unsatisfied {
@@ -61,7 +64,9 @@ final class PacketTunnelPathObserver: DefaultPathObserverProtocol, @unchecked Se
     }
 
     func stop() {
-//        pathMonitor.pathUpdateHandler = nil
-//        pathMonitor.cancel()
+        guard started == true else { return }
+        defer { started = false }
+        pathMonitor.pathUpdateHandler = nil
+        pathMonitor.cancel()
     }
 }

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -68,8 +68,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
         let pinger = TunnelPinger(pingProvider: adapter.icmpPingProvider, replyQueue: internalQueue)
 
-        let tunnelMonitor = TunnelMonitor(
-            eventQueue: internalQueue,
+        let tunnelMonitor = TunnelMonitorActor(
             pinger: pinger,
             tunnelDeviceInfo: adapter,
             timings: TunnelMonitorTimings()
@@ -173,11 +172,13 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     }
 
     override func sleep() async {
-        actor.onSleep()
+        await actor.onSleep()
     }
 
     override func wake() {
-        actor.onWake()
+        Task {
+            await actor.onWake()
+        }
     }
 
     private func performSettingsMigration() {

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -68,7 +68,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
         let pinger = TunnelPinger(pingProvider: adapter.icmpPingProvider, replyQueue: internalQueue)
 
-        let tunnelMonitor = TunnelMonitorActor(
+        let tunnelMonitor = TunnelMonitor(
             pinger: pinger,
             tunnelDeviceInfo: adapter,
             timings: TunnelMonitorTimings()

--- a/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
+++ b/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
@@ -111,24 +111,14 @@ extension WgAdapter: TunnelDeviceInfoProtocol {
         return adapter.interfaceName
     }
 
-//    func getStats() throws -> WgStats {
-//        var result: String?
-//
-//        let dispatchGroup = DispatchGroup()
-//        dispatchGroup.enter()
-//        adapter.getRuntimeConfiguration { string in
-//            result = string
-//            dispatchGroup.leave()
-//        }
-//
-//        guard case .success = dispatchGroup.wait(wallTimeout: .now() + 1) else { throw StatsError.timeout }
-//        guard let result else { throw StatsError.nilValue }
-//        guard let newStats = WgStats(from: result) else { throw StatsError.parse }
-//
-//        return newStats
-//    }
-
+    /// Returns the number of bytes sent and read by the WireGuard device
+    ///
+    /// This methods gets the current WireGuard configuration
+    /// and parses the `rx_bytes` and `tx_bytes` found there if any.
+    /// - Returns: A structure containing the number of bytes read and sent by the WireGuard device
     func getStats() async throws -> WgStats {
+        /// Run `configurationTask` and `timeoutTask` in parallel.
+        /// Whichever finishes first cancels the other one
         let configurationTask = Task {
             let configuration = await getConfiguration()
             try Task.checkCancellation()

--- a/ios/PacketTunnelCore/Actor/NetworkPath+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/NetworkPath+NetworkReachability.swift
@@ -24,3 +24,64 @@ extension Network.NWPath.Status {
         }
     }
 }
+
+extension Network.NWPath {
+    public var unsatisfiedReasonDescription: String {
+        switch unsatisfiedReason {
+        case .cellularDenied: "User has disabled cellular"
+        case .localNetworkDenied: "User has disabled local network access"
+        case .notAvailable: "Not available, no reason given"
+        case .vpnInactive: "Required VPN, but no active VPN found"
+        case .wifiDenied: "User has disabled Wifi"
+        @unknown default: "Unknown situation"
+        }
+    }
+}
+
+extension NWInterface {
+    public var customDebugDescription: String {
+        "type: \(type) name: \(self.name) index: \(index)"
+    }
+}
+
+extension NWEndpoint.Host {
+    public var customDebugDescription: String {
+        switch self {
+        case let .ipv4(IPv4Address): "IPv4: \(IPv4Address)"
+        case let .ipv6(IPv6Address): "IPv6: \(IPv6Address)"
+        case let .name(name, interface): "named: \(name), \(interface?.customDebugDescription ?? "[No interface]")"
+        @unknown default: "Unknown host"
+        }
+    }
+}
+
+extension NWInterface.InterfaceType: @retroactive CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .cellular: "Cellular"
+        case .loopback: "Loopback"
+        case .other: "Other"
+        case .wifi: "Wifi"
+        case .wiredEthernet: "Wired Ethernet"
+        @unknown default: "Unknown interface type"
+        }
+    }
+}
+
+extension NWEndpoint {
+    public var customDebugDescription: String {
+        switch self {
+        case let .hostPort(host, port): "host: \(host.customDebugDescription) port: \(port)"
+        case let .opaque(endpoint): "opaque: \(endpoint.description)"
+        case let .url(url): "url: \(url)"
+        case let .service(
+            name,
+            type,
+            domain,
+            interface
+        ): "service named:\(name), type:\(type), domain:\(domain), interface:\(interface?.customDebugDescription ?? "[No interface]")"
+        case let .unix(path): "unix: \(path)"
+        @unknown default: "Unknown NWEndpoint type"
+        }
+    }
+}

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ConnectionMonitoring.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ConnectionMonitoring.swift
@@ -9,11 +9,14 @@
 import Foundation
 
 extension PacketTunnelActor {
-    /// Assign a closure receiving tunnel monitor events.
-    func setTunnelMonitorEventHandler() {
-        tunnelMonitor.onEvent = { [weak self] event in
-            /// Dispatch tunnel monitor events via command channel to guarantee the order of execution.
-            self?.eventChannel.send(.monitorEvent(event))
+    func listenForTunnelMonitorEvents() async {
+        tunnelMonitorTask?.cancel()
+
+        tunnelMonitorTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in self.tunnelMonitor.eventStream {
+                self.eventChannel.send(.monitorEvent(event))
+            }
         }
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -39,7 +39,7 @@ extension PacketTunnelActor {
      */
     func setErrorStateInternal(with reason: BlockedStateReason) async {
         // Tunnel monitor shouldn't run when in error state.
-        tunnelMonitor.stop()
+        await tunnelMonitor.stop()
 
         if let blockedState = makeBlockedState(reason: reason) {
             state = .error(blockedState)

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+NetworkReachability.swift
@@ -17,7 +17,6 @@ extension PacketTunnelActor {
      */
     func startDefaultPathObserver() {
         logger.trace("Start default path observer.")
-
         defaultPathObserver.start { [weak self] networkPath in
             self?.eventChannel.send(.networkReachability(networkPath))
         }
@@ -35,8 +34,8 @@ extension PacketTunnelActor {
 
      - Parameter networkPath: new default path
      */
-    func handleDefaultPathChange(_ networkPath: Network.NWPath.Status) {
-        tunnelMonitor.handleNetworkPathUpdate(networkPath)
+    func handleDefaultPathChange(_ networkPath: Network.NWPath.Status) async {
+        await tunnelMonitor.handleNetworkPathUpdate(networkPath)
 
         let newReachability = networkPath.networkReachability
 

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+PostQuantum.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+PostQuantum.swift
@@ -39,7 +39,7 @@ extension PacketTunnelActor {
         state = .connecting(connectionData)
 
         // Resume tunnel monitoring and use IPv4 gateway as a probe address.
-        tunnelMonitor.start(probeAddress: connectionData.selectedRelays.exit.endpoint.ipv4Gateway)
+        await tunnelMonitor.start(probeAddress: connectionData.selectedRelays.exit.endpoint.ipv4Gateway)
         // Restart default path observer and notify the observer with the current path that might have changed while
         // path observer was paused.
         startDefaultPathObserver()

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+SleepCycle.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+SleepCycle.swift
@@ -14,8 +14,9 @@ extension PacketTunnelActor {
 
      `NEPacketTunnelProvider` provides the corresponding lifecycle method.
      */
-    public nonisolated func onWake() {
-        tunnelMonitor.onWake()
+    public func onWake() async {
+        await tunnelMonitor.wake()
+//        tunnelMonitor.onWake()
     }
 
     /**
@@ -23,7 +24,8 @@ extension PacketTunnelActor {
 
      `NEPacketTunnelProvider` provides the corresponding lifecycle method.
      */
-    public nonisolated func onSleep() {
-        tunnelMonitor.onSleep()
+    public func onSleep() async {
+        await tunnelMonitor.sleep()
+//        tunnelMonitor.onSleep()
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+SleepCycle.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+SleepCycle.swift
@@ -16,7 +16,6 @@ extension PacketTunnelActor {
      */
     public func onWake() async {
         await tunnelMonitor.wake()
-//        tunnelMonitor.onWake()
     }
 
     /**
@@ -26,6 +25,5 @@ extension PacketTunnelActor {
      */
     public func onSleep() async {
         await tunnelMonitor.sleep()
-//        tunnelMonitor.onSleep()
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -198,8 +198,6 @@ extension PacketTunnelActor {
             fallthrough
 
         case .error:
-            stopDefaultPathObserver()
-
             do {
                 try await tunnelAdapter.stop()
             } catch {

--- a/ios/PacketTunnelCore/Pinger/PingerProtocol.swift
+++ b/ios/PacketTunnelCore/Pinger/PingerProtocol.swift
@@ -29,10 +29,10 @@ public struct PingerSendResult {
 }
 
 /// A type capable of sending and receving ICMP traffic.
-public protocol PingerProtocol {
-    var onReply: ((PingerReply) -> Void)? { get set }
+public protocol PingerProtocol: AnyObject, Sendable {
+    var onReply: (@Sendable (PingerReply) -> Void)? { get set }
 
-    func startPinging(destAddress: IPv4Address) throws
+    func startPinging(destAddress: IPv4Address)
     func stopPinging()
     func send() throws -> PingerSendResult
 }

--- a/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
+++ b/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
@@ -19,7 +19,7 @@ public final class TunnelPinger: PingerProtocol {
     private let replyQueue: DispatchQueue
     private var destAddress: IPv4Address?
     /// Always accessed from the `replyQueue` and is assigned once, on the main thread of the PacketTunnel. It is thread safe.
-    public var onReply: ((PingerReply) -> Void)?
+    public var onReply: (@Sendable (PingerReply) -> Void)?
     private var pingProvider: ICMPPingProvider
 
     private let logger: Logger
@@ -31,7 +31,7 @@ public final class TunnelPinger: PingerProtocol {
         self.logger = Logger(label: "TunnelPinger")
     }
 
-    public func startPinging(destAddress: IPv4Address) throws {
+    public func startPinging(destAddress: IPv4Address) {
         stateLock.withLock {
             self.destAddress = destAddress
         }
@@ -39,6 +39,7 @@ public final class TunnelPinger: PingerProtocol {
             while let self {
                 do {
                     let seq = try pingProvider.receiveICMP()
+                    print("received seq \(seq)")
 
                     replyQueue.async { [weak self] in
                         self?.stateLock.withLock {

--- a/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
+++ b/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
@@ -22,7 +22,7 @@ public final class TunnelPinger: PingerProtocol {
     public var onReply: (@Sendable (PingerReply) -> Void)?
     private var pingProvider: ICMPPingProvider
 
-    private let logger: Logger
+    nonisolated(unsafe) private let logger: Logger
 
     init(pingProvider: ICMPPingProvider, replyQueue: DispatchQueue) {
         self.pingProvider = pingProvider
@@ -39,7 +39,7 @@ public final class TunnelPinger: PingerProtocol {
             while let self {
                 do {
                     let seq = try pingProvider.receiveICMP()
-                    print("received seq \(seq)")
+                    logger.debug("received seq \(seq)")
 
                     replyQueue.async { [weak self] in
                         self?.stateLock.withLock {

--- a/ios/PacketTunnelCore/TunnelMonitor/PingStats.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/PingStats.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Ping statistics.
-struct PingStats {
+public struct PingStats {
     /// Dictionary holding sequence and corresponding date when echo request took place.
     var requests = [UInt16: Date]()
 
@@ -18,4 +18,10 @@ struct PingStats {
 
     /// Timestamp when last echo reply was received.
     var lastReplyDate: Date?
+
+    public init(requests: [UInt16: Date] = [UInt16: Date](), lastRequestDate: Date? = nil, lastReplyDate: Date? = nil) {
+        self.requests = requests
+        self.lastRequestDate = lastRequestDate
+        self.lastReplyDate = lastReplyDate
+    }
 }

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelDeviceInfoProtocol.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelDeviceInfoProtocol.swift
@@ -9,10 +9,13 @@
 import Foundation
 
 /// A type that can provide statistics and basic information about tunnel device.
-public protocol TunnelDeviceInfoProtocol {
+public protocol TunnelDeviceInfoProtocol: Sendable {
     /// Returns tunnel interface name (i.e utun0) if available.
     var interfaceName: String? { get }
 
     /// Returns tunnel statistics.
-    func getStats() throws -> WgStats
+    func getStats() async throws -> WgStats
+
+    /// Returns tunnel statistics.
+//    func getStats() throws -> WgStats
 }

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelDeviceInfoProtocol.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelDeviceInfoProtocol.swift
@@ -15,7 +15,4 @@ public protocol TunnelDeviceInfoProtocol: Sendable {
 
     /// Returns tunnel statistics.
     func getStats() async throws -> WgStats
-
-    /// Returns tunnel statistics.
-//    func getStats() throws -> WgStats
 }

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
@@ -269,7 +269,6 @@ public actor TunnelMonitorActor: TunnelMonitorProtocol {
     }
 
     #if DEBUG
-    /// Helper function used to help the state pass across the actor's isolation region
     internal func getState() -> TunnelMonitorState {
         TunnelMonitorState(
             connectionState: state.connectionState,

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorProtocol.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorProtocol.swift
@@ -20,25 +20,25 @@ public enum TunnelMonitorEvent: Sendable {
 }
 
 /// A type that can provide tunnel monitoring.
-public protocol TunnelMonitorProtocol: AnyObject, Sendable {
+public protocol TunnelMonitorProtocol: Sendable {
     /// Event handler that starts receiving events after the call to `start(probeAddress:)`.
-    var onEvent: ((TunnelMonitorEvent) -> Void)? { get set }
+    var eventStream: AsyncStream<TunnelMonitorEvent> { get }
 
     /// Start monitoring connection by pinging the given IP address.
     /// Normally we should only give an address of a tunnel gateway here which is reachable over tunnel interface.
-    func start(probeAddress: IPv4Address)
+    func start(probeAddress: IPv4Address) async
 
     /// Stop monitoring connection.
-    func stop()
+    func stop() async
 
     /// Restarts internal timers and gracefully handles transition from sleep to awake device state.
     /// Call this method when packet tunnel provider receives a wake event.
-    func onWake()
+    func wake() async
 
     /// Cancels internal timers and time dependent data in preparation for device sleep.
     /// Call this method when packet tunnel provider receives a sleep event.
-    func onSleep()
+    func sleep() async
 
     /// Handle changes in network path, eg. update connection state and monitoring.
-    func handleNetworkPathUpdate(_ networkPath: Network.NWPath.Status)
+    func handleNetworkPathUpdate(_ networkPath: Network.NWPath.Status) async
 }

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorState.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorState.swift
@@ -212,15 +212,15 @@ public struct TunnelMonitorState {
         return .ok
     }
 
-    mutating func reset(resetRetryAttempts: Bool) {
+    mutating func reset() {
         netStats = WgStats()
         lastSeenRx = nil
         lastSeenTx = nil
         pingStats = PingStats()
         isHeartbeatSuspended = false
+    }
 
-        if resetRetryAttempts {
-            retryAttempt = 0
-        }
+    mutating func resetRetryAttempts() {
+        retryAttempt = 0
     }
 }

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorState.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorState.swift
@@ -10,7 +10,7 @@ import Foundation
 import MullvadTypes
 
 /// Connection state.
-enum TunnelMonitorConnectionState {
+public enum TunnelMonitorConnectionState {
     /// Initialized and doing nothing.
     case stopped
 
@@ -45,9 +45,9 @@ enum ConnectionEvaluation {
 }
 
 /// Tunnel monitor state.
-struct TunnelMonitorState {
+public struct TunnelMonitorState {
     /// Current connection state.
-    var connectionState: TunnelMonitorConnectionState = .stopped
+    var connectionState: TunnelMonitorConnectionState
 
     /// Network counters.
     var netStats = WgStats()
@@ -68,10 +68,32 @@ struct TunnelMonitorState {
     var isHeartbeatSuspended = false
 
     /// Retry attempt.
-    var retryAttempt: UInt32 = 0
+    var retryAttempt: UInt32
 
     // Timings and timeouts.
     let timings: TunnelMonitorTimings
+
+    public init(
+        connectionState: TunnelMonitorConnectionState = .stopped,
+        netStats: WgStats = WgStats(),
+        pingStats: PingStats = PingStats(),
+        timeoutReference: Date = Date(),
+        lastSeenRx: Date? = nil,
+        lastSeenTx: Date? = nil,
+        isHeartbeatSuspended: Bool = false,
+        retryAttempt: UInt32 = 0,
+        timings: TunnelMonitorTimings
+    ) {
+        self.connectionState = connectionState
+        self.netStats = netStats
+        self.pingStats = pingStats
+        self.timeoutReference = timeoutReference
+        self.lastSeenRx = lastSeenRx
+        self.lastSeenTx = lastSeenTx
+        self.isHeartbeatSuspended = isHeartbeatSuspended
+        self.retryAttempt = retryAttempt
+        self.timings = timings
+    }
 
     func evaluateConnection(now: Date, pingTimeout: Duration) -> ConnectionEvaluation {
         switch connectionState {
@@ -156,7 +178,7 @@ struct TunnelMonitorState {
 
         let timeSinceLastPing = now.timeIntervalSince(lastRequestDate)
         if let lastReplyDate = pingStats.lastReplyDate,
-           lastRequestDate.timeIntervalSince(lastReplyDate) >= timings.heartbeatReplyTimeout,
+           lastReplyDate.timeIntervalSince(lastRequestDate) >= timings.heartbeatReplyTimeout,
            timeSinceLastPing >= timings.pingDelay, !isHeartbeatSuspended {
             return .retryHeartbeatPing
         }
@@ -188,5 +210,17 @@ struct TunnelMonitorState {
         }
 
         return .ok
+    }
+
+    mutating func reset(resetRetryAttempts: Bool) {
+        netStats = WgStats()
+        lastSeenRx = nil
+        lastSeenTx = nil
+        pingStats = PingStats()
+        isHeartbeatSuspended = false
+
+        if resetRetryAttempts {
+            retryAttempt = 0
+        }
     }
 }

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorTimings.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorTimings.swift
@@ -8,7 +8,7 @@
 
 import MullvadTypes
 
-public struct TunnelMonitorTimings {
+public struct TunnelMonitorTimings: Sendable {
     /// Interval for periodic heartbeat ping issued when traffic is flowing.
     /// Should help to detect connectivity issues on networks that drop traffic in one of directions,
     /// regardless if tx/rx counters are being updated.

--- a/ios/PacketTunnelCore/TunnelMonitor/WgStats.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/WgStats.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct WgStats {
+public struct WgStats: Sendable {
     public let bytesReceived: UInt64
     public let bytesSent: UInt64
 

--- a/ios/PacketTunnelCoreTests/Mocks/NetworkCounters.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/NetworkCounters.swift
@@ -18,7 +18,7 @@ protocol NetworkStatsReporting {
 }
 
 /// A type providing network statistics.
-protocol NetworkStatsProviding {
+protocol NetworkStatsProviding: Sendable {
     /// Returns number of bytes sent.
     var bytesSent: UInt64 { get }
 
@@ -27,10 +27,10 @@ protocol NetworkStatsProviding {
 }
 
 /// Class that holds network statistics (bytes sent and received) for a simulated network adapter.
-final class NetworkCounters: NetworkStatsProviding, NetworkStatsReporting {
+final class NetworkCounters: NetworkStatsProviding, NetworkStatsReporting, Sendable {
     private let stateLock = NSLock()
-    private var _bytesSent: UInt64 = 0
-    private var _bytesReceived: UInt64 = 0
+    nonisolated(unsafe) private var _bytesSent: UInt64 = 0
+    nonisolated(unsafe) private var _bytesReceived: UInt64 = 0
 
     var bytesSent: UInt64 {
         stateLock.withLock { _bytesSent }

--- a/ios/PacketTunnelCoreTests/Mocks/PingerMock.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/PingerMock.swift
@@ -12,15 +12,15 @@ import Network
 @testable import PacketTunnelCore
 
 /// Ping client mock that can be used to simulate network transmission errors and delays.
-class PingerMock: PingerProtocol {
+final class PingerMock: PingerProtocol, @unchecked Sendable {
     typealias OutcomeDecider = (IPv4Address, UInt16) -> Outcome
 
-    private let decideOutcome: OutcomeDecider
-    private let networkStatsReporting: NetworkStatsReporting
-    private let stateLock = NSLock()
-    private var state = State()
+    let decideOutcome: OutcomeDecider
+    let networkStatsReporting: NetworkStatsReporting
+    let stateLock = NSLock()
+    var state = State()
 
-    var onReply: ((PingerReply) -> Void)? {
+    var onReply: (@Sendable (PingerReply) -> Void)? {
         get {
             stateLock.withLock { state.onReply }
         }
@@ -34,7 +34,7 @@ class PingerMock: PingerProtocol {
         self.decideOutcome = decideOutcome
     }
 
-    func startPinging(destAddress: IPv4Address) throws {
+    func startPinging(destAddress: IPv4Address) {
         stateLock.withLock {
             state.destAddress = destAddress
             state.isSocketOpen = true
@@ -92,10 +92,10 @@ class PingerMock: PingerProtocol {
     // MARK: - Types
 
     /// Internal state
-    private struct State {
+    struct State {
         var sequenceId: UInt16 = 0
         var isSocketOpen = false
-        var onReply: ((PingerReply) -> Void)?
+        var onReply: (@Sendable (PingerReply) -> Void)?
         var destAddress: IPv4Address?
 
         mutating func incrementSequenceId() -> UInt16 {

--- a/ios/PacketTunnelCoreTests/TunnelMonitorStateTests.swift
+++ b/ios/PacketTunnelCoreTests/TunnelMonitorStateTests.swift
@@ -1,0 +1,206 @@
+//
+//  TunnelMonitorStateTests.swift
+//  PacketTunnelCoreTests
+//
+//  Created by Marco Nikic on 2025-02-10.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadTypes
+@testable import PacketTunnelCore
+import Testing
+
+struct TunnelMonitorStateTests {
+    var testDateComponents = DateComponents()
+    var defaultPingTimeout: Duration = .milliseconds(500)
+    var hearbeatReplyTimeout: Duration = .seconds(1)
+    var pingDelay: Duration = .seconds(1)
+
+    init() async throws {
+        testDateComponents.day = 10
+        testDateComponents.month = 2
+        testDateComponents.year = 2025
+        testDateComponents.hour = 10
+        testDateComponents.calendar = .current
+    }
+
+    @Test(arguments: [
+        TunnelMonitorConnectionState.stopped,
+        TunnelMonitorConnectionState.pendingStart,
+        TunnelMonitorConnectionState.recovering,
+        TunnelMonitorConnectionState
+            .waitingConnectivity,
+    ])
+    func connectionIsOk(initialState: TunnelMonitorConnectionState) async throws {
+        let state = createState(initialState)
+        #expect(state.evaluateConnection(now: .now, pingTimeout: .zero) == .ok)
+    }
+
+    @Test(arguments: [TunnelMonitorConnectionState.connecting, TunnelMonitorConnectionState.connected])
+    func timeoutWhenReplyComesAfterPingTimeoutIn(state: TunnelMonitorConnectionState) async throws {
+        var state = createState(state)
+
+        let now = try #require(testDateComponents.date)
+        let oneSecondAgo = try #require(testDateComponents.date?.addingTimeInterval(-1))
+
+        // Sent ping a second ago
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: oneSecondAgo)
+        // 0 latency reply
+        let timestamp = state.setPingReplyReceived(1, now: oneSecondAgo)
+        #expect(timestamp == oneSecondAgo)
+        #expect(state.evaluateConnection(now: now, pingTimeout: state.timings.pingTimeout) == .pingTimeout)
+    }
+
+    @Test(arguments: [TunnelMonitorConnectionState.connecting, TunnelMonitorConnectionState.connected])
+    func evaluateStateBeforeInitialPingIsSent(state: TunnelMonitorConnectionState) async throws {
+        let state = createState(state)
+        let now = try #require(testDateComponents.date)
+        #expect(state.evaluateConnection(now: now, pingTimeout: state.timings.pingTimeout) == .sendInitialPing)
+    }
+
+    @Test func evaluateConnectingStateAfterLastRequestWithoutReply() async throws {
+        var state = createState(.connecting)
+
+        let now = try #require(testDateComponents.date)
+        let nextPingDelay = state.timings.pingDelay + .seconds(1)
+        let oneSecondAgo = try #require(testDateComponents.date?.addingTimeInterval(-nextPingDelay.timeInterval))
+
+        // Sent ping a second ago
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: oneSecondAgo)
+
+        #expect(state.evaluateConnection(now: now, pingTimeout: .seconds(500)) == .sendNextPing)
+    }
+
+    @Test func retryHeartbeatPingWhenHeartbeatNotSuspended() async throws {
+        var state = createState(.connected)
+
+        // Send a ping and acknowledge it
+        let oneSecondAgo = try #require(testDateComponents.date?.addingTimeInterval(-1))
+        let now = try #require(testDateComponents.date)
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: oneSecondAgo)
+        _ = state.setPingReplyReceived(1, now: now)
+
+        #expect(state.evaluateConnection(now: now, pingTimeout: .hours(1)) == .retryHeartbeatPing)
+    }
+
+    @Test mutating func witnessTrafficFlowingAsExpected() async throws {
+        // Ignore heartbeat
+        hearbeatReplyTimeout = .hours(1)
+        var state = createState(.connected)
+
+        // Send a ping and acknowledge it
+        let oneSecondAgo = try #require(testDateComponents.date?.addingTimeInterval(-1))
+        let now = try #require(testDateComponents.date)
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: oneSecondAgo)
+        _ = state.setPingReplyReceived(1, now: now)
+
+        #expect(state.evaluateConnection(now: now, pingTimeout: .hours(1)) == .ok)
+    }
+
+    @Test func sendHeartbeatPingWhenConnected() async throws {
+        var state = createState(.connected)
+        state.isHeartbeatSuspended = true
+
+        // Send a ping and acknowledge it
+        let tenSecondAgo = try #require(testDateComponents.date?.addingTimeInterval(-10))
+        let now = try #require(testDateComponents.date)
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: tenSecondAgo)
+        _ = state.setPingReplyReceived(1, now: now)
+        let newNetStats = WgStats(bytesReceived: 100, bytesSent: 100)
+        state.updateNetStats(newStats: newNetStats, now: now)
+
+        #expect(state.evaluateConnection(now: now, pingTimeout: .hours(1)) == .sendHeartbeatPing)
+    }
+
+    @Test func suspendHeartbeatWhenTrafficIsWitnessed() async throws {
+        var state = createState(.connected)
+
+        // Send a ping and acknowledge it
+        let tenSecondAgo = try #require(testDateComponents.date?.addingTimeInterval(-10))
+        let now = try #require(testDateComponents.date)
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: tenSecondAgo)
+        _ = state.setPingReplyReceived(1, now: tenSecondAgo)
+
+        // Simulate traffic flowing between hearbeat inteval and traffic flow timeout
+        let newNetStats = WgStats(bytesReceived: 100, bytesSent: 100)
+        let sevenSecondAgo = try #require(testDateComponents.date?.addingTimeInterval(-7))
+        state.updateNetStats(newStats: newNetStats, now: sevenSecondAgo)
+
+        #expect(state.evaluateConnection(now: now, pingTimeout: .hours(1)) == .suspendHeartbeat)
+    }
+
+    @Test mutating func outboundTrafficTimeout() async throws {
+        hearbeatReplyTimeout = .hours(1)
+
+        var state = createState(.connected)
+        state.isHeartbeatSuspended = true
+        let now = try #require(testDateComponents.date)
+        let twoMinutesAgo = try #require(testDateComponents.date?.addingTimeInterval(-120))
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: twoMinutesAgo)
+
+        let newNetStats = WgStats(bytesReceived: 100, bytesSent: 100)
+        state.updateNetStats(newStats: newNetStats, now: twoMinutesAgo)
+
+        _ = state.setPingReplyReceived(1, now: now)
+
+        #expect(state.evaluateConnection(now: now, pingTimeout: .hours(1)) == .trafficTimeout)
+    }
+
+    @Test mutating func inboundTrafficTimeout() async throws {
+        hearbeatReplyTimeout = .hours(1)
+
+        var state = createState(.connected)
+        state.isHeartbeatSuspended = true
+        let now = try #require(testDateComponents.date)
+        let oneMinuteAgo = try #require(testDateComponents.date?.addingTimeInterval(-60))
+        let thirtySecondsAgo = try #require(testDateComponents.date?.addingTimeInterval(-30))
+        state.updatePingStats(sendResult: PingerSendResult(sequenceNumber: 1), now: oneMinuteAgo)
+
+        var newNetStats = WgStats(bytesReceived: 10, bytesSent: 10)
+        state.updateNetStats(newStats: newNetStats, now: oneMinuteAgo)
+
+        // Simulate bytes sent only, not received
+        newNetStats = WgStats(bytesReceived: 0, bytesSent: 20)
+        state.updateNetStats(newStats: newNetStats, now: thirtySecondsAgo)
+
+        _ = state.setPingReplyReceived(1, now: now)
+
+        #expect(state.evaluateConnection(now: now, pingTimeout: .hours(1)) == .inboundTrafficTimeout)
+    }
+
+    @Test(arguments: [
+        TunnelMonitorConnectionState.stopped,
+        TunnelMonitorConnectionState.connected,
+        TunnelMonitorConnectionState.pendingStart,
+        TunnelMonitorConnectionState.recovering,
+        TunnelMonitorConnectionState
+            .waitingConnectivity,
+    ])
+
+    func pingTimeoutIsUnalteredIn(state: TunnelMonitorConnectionState) async throws {
+        let state = createState(state)
+        #expect(state.getPingTimeout() == defaultPingTimeout)
+    }
+
+    func createState(_ initialState: TunnelMonitorConnectionState) -> TunnelMonitorState {
+        let timings = TunnelMonitorTimings(
+            heartbeatReplyTimeout: hearbeatReplyTimeout,
+            pingTimeout: defaultPingTimeout,
+            pingDelay: pingDelay,
+            initialEstablishTimeout: .milliseconds(50),
+            connectivityCheckInterval: .milliseconds(10)
+        )
+
+        return TunnelMonitorState(
+            connectionState: initialState,
+            netStats: WgStats(),
+            pingStats: PingStats(),
+            timeoutReference: Date(),
+            lastSeenRx: nil,
+            lastSeenTx: nil,
+            isHeartbeatSuspended: false,
+            retryAttempt: 0,
+            timings: timings
+        )
+    }
+}

--- a/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
+++ b/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
@@ -15,7 +15,7 @@ import XCTest
 final class TunnelMonitorTests: XCTestCase {
     let networkCounters = NetworkCounters()
 
-    func testShouldDetermineConnectionEstablished() throws {
+    func testConnectionEstablishedOnPingReply() async throws {
         let connectedExpectation = expectation(description: "Should report connected.")
         let connectionLostExpectation = expectation(description: "Should not report connection loss")
         connectionLostExpectation.isInverted = true
@@ -25,97 +25,110 @@ final class TunnelMonitorTests: XCTestCase {
         }
 
         let tunnelMonitor = createTunnelMonitor(pinger: pinger, timings: TunnelMonitorTimings())
+        await tunnelMonitor.start(probeAddress: .loopback)
 
-        tunnelMonitor.onEvent = { event in
-            switch event {
-            case .connectionEstablished:
-                connectedExpectation.fulfill()
-
-            case .connectionLost:
-                connectionLostExpectation.fulfill()
+        Task {
+            for await event in await tunnelMonitor.eventStream {
+                switch event {
+                case .connectionEstablished:
+                    connectedExpectation.fulfill()
+                case .connectionLost:
+                    connectionLostExpectation.fulfill()
+                }
             }
         }
 
-        tunnelMonitor.start(probeAddress: .loopback)
-
-        waitForExpectations(timeout: .UnitTest.invertedTimeout)
+        await fulfillment(of: [connectedExpectation, connectionLostExpectation], timeout: .UnitTest.invertedTimeout)
     }
 
-    func testInitialConnectionTimings() {
-        // Setup pinger so that it never receives any replies.
-        let pinger = PingerMock(networkStatsReporting: networkCounters) { _, _ in .ignore }
+    /// Verifies that the pinger is stopped when connectivity is not considered reachable,
+    /// and started again when connectivity becomes reachable
+    func testStartAndStopsMonitoringOnConnectivityUpdates() async {
+        let pinger = PingerMock(networkStatsReporting: networkCounters) { _, _ in
+            return .sendReply()
+        }
+
+        let tunnelMonitor = createTunnelMonitor(pinger: pinger, timings: TunnelMonitorTimings())
+
+        await tunnelMonitor.start(probeAddress: .loopback)
+
+        await tunnelMonitor.handleNetworkPathUpdate(.unsatisfied)
+        XCTAssertFalse(pinger.state.isSocketOpen)
+
+        await tunnelMonitor.handleNetworkPathUpdate(.satisfied)
+        XCTAssertTrue(pinger.state.isSocketOpen)
+    }
+
+    func testSendsConnectionLostEventOnPingTimeout() async {
+        let connectionLostExpectation = expectation(description: "Should report connection loss")
+
+        let pinger = PingerMock(networkStatsReporting: networkCounters) { _, _ in
+            return .sendReply(reply: .malformed, afterDelay: .milliseconds(10))
+        }
 
         let timings = TunnelMonitorTimings(
             pingTimeout: .milliseconds(300),
             initialEstablishTimeout: .milliseconds(100),
-            connectivityCheckInterval: .milliseconds(100)
+            connectivityCheckInterval: .milliseconds(50)
         )
 
         let tunnelMonitor = createTunnelMonitor(pinger: pinger, timings: timings)
 
-        var expectedTimings = [
-            timings.initialEstablishTimeout.milliseconds,
-            timings.initialEstablishTimeout.milliseconds * 2,
-            timings.pingTimeout.milliseconds,
-            timings.pingTimeout.milliseconds,
-        ]
-
-        // Calculate the amount of time necessary to perform the test.
-        var timeout = expectedTimings.reduce(0, +)
-        // Add leeway into the total amount of expected wait time.
-        timeout += timeout / 2
-
-        let expectation = expectation(description: "Should respect all timings.")
-        expectation.expectedFulfillmentCount = expectedTimings.count
-
-        // This date will be used to measure the amount of time elapsed between `.connectionLost` events.
-        var startDate = Date()
-
-        tunnelMonitor.onEvent = { [weak tunnelMonitor] event in
-            guard case .connectionLost = event else { return }
-
-            switch event {
-            case .connectionLost:
-                XCTAssertFalse(expectedTimings.isEmpty)
-
-                let expectedDuration = expectedTimings.removeFirst()
-                let leeway = expectedDuration / 2
-
-                // Compute amount of time elapsed between `.connectionLost` events.
-                let timeElapsed = Int(Date().timeIntervalSince(startDate) * 1000)
-
-                XCTAssertEqual(
-                    timeElapsed,
-                    expectedDuration,
-                    accuracy: leeway,
-                    "Expected to report connection loss after \(expectedDuration)-\(expectedDuration + leeway) ms, instead reported it after \(timeElapsed) ms."
-                )
-
-                expectation.fulfill()
-
-                if !expectedTimings.isEmpty {
-                    startDate = Date()
-
-                    // Continue monitoring by calling start() again.
-                    tunnelMonitor?.start(probeAddress: .loopback)
+        Task {
+            for await event in await tunnelMonitor.eventStream {
+                switch event {
+                case .connectionLost:
+                    connectionLostExpectation.fulfill()
+                default:
+                    break
                 }
-
-            case .connectionEstablished:
-                XCTFail("Connection should fail.")
             }
         }
 
-        // Start monitoring.
-        tunnelMonitor.start(probeAddress: .loopback)
+        await tunnelMonitor.start(probeAddress: .loopback)
 
-        waitForExpectations(timeout: TimeInterval(timeout) / 1000)
+        pinger.onReply?(.parseError(POSIXError(.ETIMEDOUT)))
+
+        await fulfillment(
+            of: [connectionLostExpectation],
+            timeout: .UnitTest.invertedTimeout,
+            enforceOrder: true
+        )
+    }
+
+    func testStopStopsPingingAndResetsPingCounter() async throws {
+        let pinger = PingerMock(networkStatsReporting: networkCounters) { _, _ in
+            return .sendReply(reply: .normal, afterDelay: .zero)
+        }
+
+        let timings = TunnelMonitorTimings(
+            pingTimeout: .milliseconds(300),
+            initialEstablishTimeout: .milliseconds(10),
+            connectivityCheckInterval: .milliseconds(50)
+        )
+
+        let tunnelMonitor = createTunnelMonitor(pinger: pinger, timings: timings)
+
+        await tunnelMonitor.start(probeAddress: .loopback)
+        XCTAssertTrue(pinger.state.isSocketOpen)
+
+        _ = try pinger.send()
+        try await Task.sleep(duration: .milliseconds(100))
+
+        var state = await tunnelMonitor.getState()
+        XCTAssertTrue(state.netStats.bytesReceived > 0)
+
+        await tunnelMonitor.stop()
+        XCTAssertFalse(pinger.state.isSocketOpen)
+        state = await tunnelMonitor.getState()
+        XCTAssertEqual(0, state.netStats.bytesReceived)
+        XCTAssertEqual(0, state.netStats.bytesSent)
     }
 }
 
 extension TunnelMonitorTests {
-    private func createTunnelMonitor(pinger: PingerProtocol, timings: TunnelMonitorTimings) -> TunnelMonitor {
-        return TunnelMonitor(
-            eventQueue: .main,
+    private func createTunnelMonitor(pinger: PingerProtocol, timings: TunnelMonitorTimings) -> TunnelMonitorActor {
+        return TunnelMonitorActor(
             pinger: pinger,
             tunnelDeviceInfo: TunnelDeviceInfoStub(networkStatsProviding: networkCounters),
             timings: timings

--- a/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
+++ b/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
@@ -127,8 +127,8 @@ final class TunnelMonitorTests: XCTestCase {
 }
 
 extension TunnelMonitorTests {
-    private func createTunnelMonitor(pinger: PingerProtocol, timings: TunnelMonitorTimings) -> TunnelMonitorActor {
-        return TunnelMonitorActor(
+    private func createTunnelMonitor(pinger: PingerProtocol, timings: TunnelMonitorTimings) -> TunnelMonitor {
+        return TunnelMonitor(
             pinger: pinger,
             tunnelDeviceInfo: TunnelDeviceInfoStub(networkStatsProviding: networkCounters),
             timings: timings


### PR DESCRIPTION
This PR does the following things:
- Turns `TunnelMonitor` into an `actor` 
- Adds massive amounts of logs that should give us more information about device connectivity in dire situations
- Adds tons of tests to `TunnelMonitorState` in order to simplify it in the future
- Also fixes bugs in `TunnelMonitorState` 
- Changes the `PacketTunnelPathObserver` to use `NWPathMonitor` instead of the deprecated `defaultPath` from `NEProvider`
- Changes the path monitored by `TunnelManager.swift` to prohibit interfaces of type `.other` 
- Adds lots of `CustomDebugStringDescription` convenience methods for improved debugging

## How to test this
- Play with airplane mode, both when the tunnel is up and down
- Try to switch from wifi to cellular connections back and forth
- Try plugging an ethernet adapter on your device ? (I haven't tried that but it would be interesting to know if it breaks things)
- Try this on an unstable connection

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7656)
<!-- Reviewable:end -->
