### PR TITLE
Compile win-shortcuts only on windows in dev mode

### DIFF
--- a/desktop/packages/mullvad-vpn/tasks/scripts.js
+++ b/desktop/packages/mullvad-vpn/tasks/scripts.js
@@ -118,7 +118,11 @@ function buildNseventforwarder(callback) {
 }
 
 function buildWinShortcuts(callback) {
-  exec('npm -w win-shortcuts run build-debug', (err) => callback(err));
+  if (process.platform === 'win32') {
+    exec('npm -w win-shortcuts run build-debug', (err) => callback(err));
+  } else {
+    callback();
+  }
 }
 
 compileScripts.displayName = 'compile-scripts';


### PR DESCRIPTION
This PR ensures that the `win-shortucts` module is only compiled on Windows when running `npm run develop`.
