### PR TITLE
Log as soon as the logger is up

### DIFF
--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -41,6 +41,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     override init() {
         Self.configureLogging()
         providerLogger = Logger(label: "PacketTunnelProvider")
+        providerLogger.info("Starting new packet tunnel")
 
         let containerURL = ApplicationConfiguration.containerURL
         let addressCache = REST.AddressCache(canWriteToCache: false, cacheDirectory: containerURL)


### PR DESCRIPTION
Going by Eskimo's recommendations, let's log an entry as soon as our logger is configured.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7663)
<!-- Reviewable:end -->
