### PR TITLE
Add an end to end test for UDP-over-TCP on port 80

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/DetailsView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/DetailsView.swift
@@ -42,7 +42,7 @@ extension ConnectionView {
                             connectionDetailRow(
                                 title: LocalizedStringKey("Out IPv6"),
                                 value: outAddressIpv6,
-                                accessibilityId: .connectionPanelOutAddressRow
+                                accessibilityId: .connectionPanelOutIpv6AddressRow
                             )
                         }
                     }

--- a/ios/MullvadVPNUITests/Networking/TrafficGenerator.swift
+++ b/ios/MullvadVPNUITests/Networking/TrafficGenerator.swift
@@ -27,7 +27,6 @@ class TrafficGenerator {
             port: NWEndpoint.Port(integerLiteral: UInt16(port)),
             using: params
         )
-        setupConnection()
         setupOtherHandlers()
     }
 
@@ -100,7 +99,13 @@ class TrafficGenerator {
         XCTWaiter().wait(for: [doneAttemptingConnectExpecation], timeout: 10.0)
     }
 
+    func stopConnection() {
+        connection.stateUpdateHandler = { @Sendable _ in }
+        connection.cancel()
+    }
+
     public func startGeneratingUDPTraffic(interval: TimeInterval) {
+        setupConnection()
         sendDataTimer.schedule(deadline: .now(), repeating: interval)
 
         sendDataTimer.setEventHandler {
@@ -125,7 +130,9 @@ class TrafficGenerator {
     }
 
     public func stopGeneratingUDPTraffic() {
+        sendDataTimer.setEventHandler(handler: {})
         sendDataTimer.cancel()
+        stopConnection()
     }
 }
 

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -71,6 +71,10 @@ class TunnelControlPage: Page {
         return connectionAttempts
     }
 
+    func getInIPv4AddressLabel() -> String {
+        app.staticTexts[AccessibilityIdentifier.connectionPanelInAddressRow].label.components(separatedBy: ":")[0]
+    }
+
     @discardableResult override init(_ app: XCUIApplication) {
         super.init(app)
 
@@ -121,7 +125,7 @@ class TunnelControlPage: Page {
     }
 
     @discardableResult func tapRelayStatusExpandCollapseButton() -> Self {
-        app.images[AccessibilityIdentifier.relayStatusCollapseButton].press(forDuration: .leastNonzeroMagnitude)
+        app.buttons[AccessibilityIdentifier.relayStatusCollapseButton].tap()
         return self
     }
 

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -76,34 +76,6 @@ class VPNSettingsPage: Page {
         return self
     }
 
-    // this button no longer exists
-    @discardableResult func tapUDPOverTCPPortExpandButton() -> Self {
-        cellExpandButton(AccessibilityIdentifier.udpOverTCPPortCell).tap()
-
-        return self
-    }
-
-    // this button no longer exists
-    @discardableResult func tapUDPOverTCPPortAutomaticCell() -> Self {
-        app.cells["\(AccessibilityIdentifier.wireGuardObfuscationPort)Automatic"]
-            .tap()
-        return self
-    }
-
-    // this button no longer exists
-    @discardableResult func tapUDPOverTCPPort80Cell() -> Self {
-        app.cells["\(AccessibilityIdentifier.wireGuardObfuscationPort)80"]
-            .tap()
-        return self
-    }
-
-    // this button no longer exists
-    @discardableResult func tapUDPOverTCPPort5001Cell() -> Self {
-        app.cells["\(AccessibilityIdentifier.wireGuardObfuscationPort)5001"]
-            .tap()
-        return self
-    }
-
     @discardableResult func tapQuantumResistantTunnelExpandButton() -> Self {
         cellExpandButton(AccessibilityIdentifier.quantumResistantTunnelCell).tap()
 


### PR DESCRIPTION
This PR adds an end to end test that connects to a relay using UDP-over-TCP obfuscation on port80.
The test also verifies using packet capture that the traffic sent to the relay during its course is happening exclusively on port 80 using a TCP connection.

The PR also fixes an innocent mistake in `DetailsView.swift` and makes the chevron icon accessibility tap action actually expand the connection details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7668)
<!-- Reviewable:end -->
