### PR TITLE
Re-use builds `test-manager` and `test-runner` accross target platforms

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -124,10 +124,22 @@ jobs:
       - name: Checkout submodules
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init --depth=1 dist-assets/binaries
-          git submodule update --init wireguard-go-rs/libwg/wireguard-go
+          git submodule update --init --depth=1
+      - uses: actions/cache@v4
+        id: cache-app-cargo-artifacts
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build app
-        run: ./build.sh
+        run: |
+          export CARGO_TARGET_DIR=target/
+          ./build.sh
       - name: Build test executable
         run: ./desktop/packages/mullvad-vpn/scripts/build-test-executable.sh
       - name: Upload app
@@ -166,9 +178,6 @@ jobs:
           name: mullvad-version-linux
           path: ./bin/mullvad-version
           if-no-files-found: error
-      - name: Clean up Cargo artifacts
-        run: |
-          cargo clean
 
   build-test-manager-linux:
     name: Build Test Manager
@@ -265,12 +274,12 @@ jobs:
         run: |
           ls -la ${{ github.workspace }}/bin
         shell: bash
-# - name: Download App
-#uses: actions/download-artifact@v4
-#if: ${{ needs.build-linux-app.result == 'success' }}
-        #with:
-          #name: linux-build
-          #path: ~/.cache/mullvad-test/packages
+      - name: Download App
+        uses: actions/download-artifact@v4
+        if: ${{ needs.build-linux-app.result == 'success' }}
+        with:
+          name: linux-build
+          path: ~/.cache/mullvad-test/packages
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Build app
         run: |
           export CARGO_TARGET_DIR=target/
-          ./build.sh
+          ./build.sh --optimize
       - name: Build test executable
         run: ./desktop/packages/mullvad-vpn/scripts/build-test-executable.sh
       - name: Upload app

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -146,7 +146,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.prepare-linux.outputs.container_image }}
-    continue-on-error: true
     steps:
       # Fix for HOME path overridden by GH runners when building in containers, see:
       # https://github.com/actions/runner/issues/863
@@ -174,10 +173,12 @@ jobs:
   build-test-manager-linux:
     name: Build Test Manager
     needs: prepare-linux
-    runs-on: [self-hosted, desktop-test, Linux]
+    # Note: libssl-dev is installed on the test server, so build test-manager there for the sake of simplicity
+    runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build test-manager
         run: ./test/scripts/container-run.sh cargo build --package test-manager --release
       - uses: actions/upload-artifact@v4
@@ -186,13 +187,39 @@ jobs:
           name: linux-test-manager-build
           path: |
             ./test/target/release/test-manager
+          if-no-files-found: error
       - name: Clean up Cargo artifacts
         run: |
           cargo clean
 
+  build-test-runner-binaries-linux:
+    name: Build Test Runner Binaries
+    needs: prepare-linux
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.prepare-linux.outputs.container_image }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build binaries
+        run: |
+          # Move test runner binaries to a known location. This is needed in the coming `upload-artifact` step.
+          mkdir bin
+          test/scripts/build/test-runner.sh linux
+          mv -t ./bin/ \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/test-runner" \
+            "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/connection-checker"
+      - uses: actions/upload-artifact@v4
+        if: '!cancelled()'
+        with:
+          name: linux-test-runner-binaries
+          path: bin/*
+          if-no-files-found: error
+
   e2e-test-linux:
     name: Linux end-to-end tests
-    needs: [prepare-matrices, build-linux-app, build-mullvad-version-linux, build-test-manager-linux]
+    # yamllint disable-line rule:line-length
+    needs: [prepare-matrices, build-linux-app, build-mullvad-version-linux, build-test-manager-linux, build-test-runner-binaries-linux]
     if: |
       !cancelled() &&
       needs.prepare-matrices.outputs.linux_matrix != '[]' &&
@@ -224,15 +251,26 @@ jobs:
         with:
           name: mullvad-version-linux
           path: ${{ github.workspace }}/bin
-      - name: Check binaries
-        run: ls -la ${{ github.workspace }}/bin
-        shell: bash
-      - name: Download App
+      - name: Download Test Runner binaries
         uses: actions/download-artifact@v4
-        if: ${{ needs.build-linux-app.result == 'success' }}
+        if: ${{ needs.build-test-runner-binaries-linux.result == 'success' }}
         with:
-          name: linux-build
-          path: ~/.cache/mullvad-test/packages
+          name: linux-test-runner-binaries
+          path: ${{ github.workspace }}/bin
+      - name: chmod binaries
+        run: |
+          chmod +x ${{ github.workspace }}/bin/*
+        shell: bash
+      - name: Check binaries
+        run: |
+          ls -la ${{ github.workspace }}/bin
+        shell: bash
+# - name: Download App
+#uses: actions/download-artifact@v4
+#if: ${{ needs.build-linux-app.result == 'success' }}
+        #with:
+          #name: linux-build
+          #path: ~/.cache/mullvad-test/packages
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
@@ -241,7 +279,8 @@ jobs:
           export TEST_DIST_DIR="${{ github.workspace }}/bin/"
           git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
-          # TEST_DIST_DIR
+          ls -la "$TEST_DIST_DIR"
+          ${{ github.workspace }}/bin/mullvad-version
           ./test/scripts/run/ci.sh ${{ matrix.os }}
       - name: Upload test report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -457,25 +457,38 @@ jobs:
     name: Result matrix
     needs: [e2e-test-linux, e2e-test-windows, e2e-test-macos]
     if: '!cancelled()'
-    runs-on: [self-hosted, desktop-test, Linux]
-    timeout-minutes: 240
-    strategy:
-      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.prepare-linux.outputs.container_image }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - name: Download test report
+        uses: actions/download-artifact@v4
         with:
-          path: ./test/.ci-logs/artifacts
+          pattern: '*_report'
+          merge-multiple: true
+      - name: Create binaries directory
+        shell: bash -ieo pipefail {0}
+        run: |
+          mkdir "${{ github.workspace }}/bin"
+      - name: Download report compiler
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-test-manager-build
+          path: ${{ github.workspace }}/bin
+      - name: chmod binaries
+        run: |
+          chmod +x ${{ github.workspace }}/bin/*
+      - name: Check binaries
+        run: |
+          ls -la ${{ github.workspace }}/bin
+        shell: bash
       - name: Generate test result matrix
         shell: bash -ieo pipefail {0}
         run: |
-          cd test
-          # "Unpack" the downloaded report artifacts: https://github.com/actions/download-artifact/issues/141
-          cp ./.ci-logs/artifacts/*_report/*_report ./.ci-logs/
-          cargo run --bin test-manager format-test-reports ./.ci-logs/*_report \
-            | tee summary.html >> $GITHUB_STEP_SUMMARY
+          ${{ github.workspace }}/bin/test-manager \
+          format-test-reports ${{ github.workspace }}/*_report \
+          | tee summary.html >> $GITHUB_STEP_SUMMARY
       - uses: actions/upload-artifact@v4
         with:
           name: summary.html
-          path: test/summary.html
+          path: summary.html

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -154,7 +154,8 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.prepare-matrices.outputs.linux_matrix) }}
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download App
+        uses: actions/download-artifact@v4
         if: ${{ needs.build-linux.result == 'success' }}
         with:
           name: linux-build
@@ -167,7 +168,8 @@ jobs:
           git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
-      - uses: actions/upload-artifact@v4
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
         if: '!cancelled()'
         with:
           name: ${{ matrix.os }}_report
@@ -242,7 +244,8 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.prepare-matrices.outputs.windows_matrix) }}
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download App
+        uses: actions/download-artifact@v4
         if: ${{ needs.build-windows.result == 'success' }}
         with:
           name: windows-build
@@ -255,7 +258,8 @@ jobs:
           git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
-      - uses: actions/upload-artifact@v4
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
         if: '!cancelled()'
         with:
           name: ${{ matrix.os }}_report
@@ -314,7 +318,8 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.prepare-matrices.outputs.macos_matrix) }}
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Download App
+        uses: actions/download-artifact@v4
         if: ${{ needs.build-macos.result == 'success' }}
         with:
           name: macos-build
@@ -327,7 +332,8 @@ jobs:
           git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
           ./test/scripts/ci-runtests.sh ${{ matrix.os }}
-      - uses: actions/upload-artifact@v4
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
         if: '!cancelled()'
         with:
           name: ${{ matrix.os }}_report

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -126,8 +126,6 @@ jobs:
           git submodule update --init --depth=1 dist-assets/binaries
           git submodule update --init wireguard-go-rs/libwg/wireguard-go
       - name: Build app
-        env:
-          USE_MOLD: false
         run: ./build.sh
       - name: Build test executable
         run: ./desktop/packages/mullvad-vpn/scripts/build-test-executable.sh

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -106,8 +106,9 @@ jobs:
           echo "inner_container_image=$(cat ./building/linux-container-image.txt)" >> $GITHUB_ENV
     outputs:
       container_image: ${{ env.inner_container_image }}
-  build-linux:
-    name: Build Linux
+
+  build-linux-app:
+    name: Build Linux App
     needs: prepare-linux
     runs-on: ubuntu-latest
     container:
@@ -129,7 +130,8 @@ jobs:
         run: ./build.sh
       - name: Build test executable
         run: ./desktop/packages/mullvad-vpn/scripts/build-test-executable.sh
-      - uses: actions/upload-artifact@v4
+      - name: Upload app
+        uses: actions/upload-artifact@v4
         if: '!cancelled()'
         with:
           name: linux-build
@@ -138,9 +140,59 @@ jobs:
             ./dist/*.deb
             ./dist/app-e2e-*
 
+  build-mullvad-version-linux:
+    name: Build mullvad-version
+    needs: prepare-linux
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.prepare-linux.outputs.container_image }}
+    continue-on-error: true
+    steps:
+      # Fix for HOME path overridden by GH runners when building in containers, see:
+      # https://github.com/actions/runner/issues/863
+      - name: Fix HOME path
+        run: echo "HOME=/root" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build mullvad-version
+        run: |
+          cargo build --package mullvad-version --release
+          # Move `mullvad-version` to a known location. This is needed in the coming `upload-artifact` step.
+          mkdir bin
+          mv -t ./bin/ "$CARGO_TARGET_DIR/release/mullvad-version"
+        shell: bash
+      - name: Upload mullvad-version
+        uses: actions/upload-artifact@v4
+        with:
+          name: mullvad-version-linux
+          path: ./bin/mullvad-version
+          if-no-files-found: error
+      - name: Clean up Cargo artifacts
+        run: |
+          cargo clean
+
+  build-test-manager-linux:
+    name: Build Test Manager
+    needs: prepare-linux
+    runs-on: [self-hosted, desktop-test, Linux]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build test-manager
+        run: ./test/scripts/container-run.sh cargo build --package test-manager --release
+      - uses: actions/upload-artifact@v4
+        if: '!cancelled()'
+        with:
+          name: linux-test-manager-build
+          path: |
+            ./test/target/release/test-manager
+      - name: Clean up Cargo artifacts
+        run: |
+          cargo clean
+
   e2e-test-linux:
     name: Linux end-to-end tests
-    needs: [prepare-matrices, build-linux]
+    needs: [prepare-matrices, build-linux-app, build-mullvad-version-linux, build-test-manager-linux]
     if: |
       !cancelled() &&
       needs.prepare-matrices.outputs.linux_matrix != '[]' &&
@@ -152,20 +204,45 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.prepare-matrices.outputs.linux_matrix) }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Create binaries directory & add to PATH
+        shell: bash -ieo pipefail {0}
+        run: |
+          # Put all binaries in a known folder: test-runner, connection-checker, mullvad-version
+          mkdir "${{ github.workspace }}/bin"
+          echo "${{ github.workspace }}/bin/" >> "$GITHUB_PATH"
+      - name: Download Test Manager
+        uses: actions/download-artifact@v4
+        if: ${{ needs.build-test-manager-linux.result == 'success' }}
+        with:
+          name: linux-test-manager-build
+          path: ${{ github.workspace }}/bin
+      - name: Download mullvad-version
+        uses: actions/download-artifact@v4
+        if: ${{ needs.build-test-manager-linux.result == 'success' }}
+        with:
+          name: mullvad-version-linux
+          path: ${{ github.workspace }}/bin
+      - name: Check binaries
+        run: ls -la ${{ github.workspace }}/bin
+        shell: bash
       - name: Download App
         uses: actions/download-artifact@v4
-        if: ${{ needs.build-linux.result == 'success' }}
+        if: ${{ needs.build-linux-app.result == 'success' }}
         with:
           name: linux-build
           path: ~/.cache/mullvad-test/packages
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Run end-to-end tests
         shell: bash -ieo pipefail {0}
         run: |
+          # A directory with all the binaries is required to run test-manager.
+          # The test scripts which runs in CI expects this folder to be available as the `TEST_DIST_DIR` variable.
+          export TEST_DIST_DIR="${{ github.workspace }}/bin/"
           git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
-          ./test/scripts/ci-runtests.sh ${{ matrix.os }}
+          # TEST_DIST_DIR
+          ./test/scripts/run/ci.sh ${{ matrix.os }}
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: '!cancelled()'

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -308,11 +308,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Checkout submodules
         run: |
-          git submodule update --init wireguard-go-rs/libwg/wireguard-go
+          git config --global --add safe.directory '*'
+          git submodule update --init --depth=1
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
@@ -401,7 +400,7 @@ jobs:
       - name: Checkout submodules
         run: |
           git config --global --add safe.directory '*'
-          git submodule update --init wireguard-go-rs/libwg/wireguard-go
+          git submodule update --init --depth=1
       - name: Install Go
         uses: actions/setup-go@v3
         with:

--- a/test/README.md
+++ b/test/README.md
@@ -107,33 +107,33 @@ Next: build the `test-runner`
 
 ### Building the test runner
 
-Building the `test-runner` binary is done with the `build-runner.sh` script.
+Building the `test-runner` binary is done with the `build/test-runner.sh` script.
 Currently, only `x86_64` platforms are supported for Windows/Linux and `ARM64` (Apple Silicon) for macOS.
 
 For example, building `test-runner` for Windows would look like this:
 
 ``` bash
-./scripts/container-run.sh ./scripts/build-runner.sh windows
+./scripts/container-run.sh ./scripts/build/test-runner.sh windows
 ```
 
 #### Linux
 Using `podman` is the recommended way to build the `test-runner`. See the [Linux section under Prerequisities](#prerequisites) for more details.
 
 ``` bash
-./scripts/container-run.sh ./scripts/build-runner.sh linux
+./scripts/container-run.sh ./scripts/build/test-runner.sh linux
 ```
 
 #### macOS
 
 ``` bash
-./scripts/build-runner.sh macos
+./scripts/build/test-runner.sh macos
 ```
 
 #### Windows
 The `test-runner` binary for Windows may be cross-compiled from a Linux host.
 
 ``` bash
-./scripts/container-run.sh ./scripts/build-runner.sh windows
+./scripts/container-run.sh ./scripts/build/test-runner.sh windows
 ```
 
 ### Running the tests
@@ -164,6 +164,6 @@ cargo run --bin test-manager run-tests --vm macos-ventura \
     --app-package-to-upgrade-from 2023.2
 ```
 
-## Note on `scripts/ci-runtests.sh`
+## Note on `scripts/run/ci.sh`
 
-`scripts/ci-runtests.sh` is the script that GitHub actions uses to invokes the `test-manager`, with similar functionality as `test-by-version.sh`. Note that account numbers are read (newline-delimited) from the path specified by the environment variable `ACCOUNT_TOKENS`. Round robin is used to select an account for each VM.
+`scripts/run/ci.sh` is the script that GitHub actions uses to invokes the `test-manager`, with similar functionality as `test-by-version.sh`. Note that account numbers are read (newline-delimited) from the path specified by the environment variable `ACCOUNT_TOKENS`. Round robin is used to select an account for each VM.

--- a/test/scripts/build.sh
+++ b/test/scripts/build.sh
@@ -13,11 +13,11 @@ REPO_ROOT="$SCRIPT_DIR/../.."
 build_linux() {
     mkdir -p "$TEST_FRAMEWORK_ROOT/dist"
     # Build the test manager
-    "$SCRIPT_DIR/build-manager.sh" linux
+    "$SCRIPT_DIR/build/test-manager.sh" linux
     cp "$TEST_FRAMEWORK_ROOT/target/release/test-manager" "$TEST_FRAMEWORK_ROOT/dist/"
 
     # Build the test runner
-    "$SCRIPT_DIR/build-runner.sh" linux
+    "$SCRIPT_DIR/build/test-runner.sh" linux
     cp "$TEST_FRAMEWORK_ROOT/target/x86_64-unknown-linux-gnu/release/test-runner" "$TEST_FRAMEWORK_ROOT/dist/"
     cp "$TEST_FRAMEWORK_ROOT/target/x86_64-unknown-linux-gnu/release/connection-checker" "$TEST_FRAMEWORK_ROOT/dist/"
 

--- a/test/scripts/build/runner-image.sh
+++ b/test/scripts/build/runner-image.sh
@@ -4,6 +4,9 @@
 
 set -eu
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEST_FRAMEWORK_ROOT="$SCRIPT_DIR/../.."
+
 TEST_RUNNER_IMAGE_SIZE_MB=5000
 
 case $TARGET in
@@ -20,10 +23,8 @@ echo "************************************************************"
 echo "* Preparing test runner image: $TARGET"
 echo "************************************************************"
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-mkdir -p "${SCRIPT_DIR}/../testrunner-images/"
-TEST_RUNNER_IMAGE_PATH="${SCRIPT_DIR}/../testrunner-images/${TEST_RUNNER_IMAGE_FILENAME}"
+mkdir -p "${TEST_FRAMEWORK_REPO}/testrunner-images"
+TEST_RUNNER_IMAGE_PATH="${TEST_FRAMEWORK_REPO}/testrunner-images/${TEST_RUNNER_IMAGE_FILENAME}"
 
 case $TARGET in
 
@@ -32,8 +33,8 @@ case $TARGET in
         mformat -F -i "${TEST_RUNNER_IMAGE_PATH}" "::"
         mcopy \
             -i "${TEST_RUNNER_IMAGE_PATH}" \
-            "${SCRIPT_DIR}/../target/$TARGET/release/test-runner.exe" \
-            "${SCRIPT_DIR}/../target/$TARGET/release/connection-checker.exe" \
+            "${TEST_FRAMEWORK_ROOT}/target/$TARGET/release/test-runner.exe" \
+            "${TEST_FRAMEWORK_ROOT}/target/$TARGET/release/connection-checker.exe" \
             "${PACKAGE_DIR}/"*.exe \
             "::"
         mdir -i "${TEST_RUNNER_IMAGE_PATH}"

--- a/test/scripts/build/test-manager.sh
+++ b/test/scripts/build/test-manager.sh
@@ -4,7 +4,7 @@ set -eu
 
 # Build `test-manager`
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-TEST_FRAMEWORK_ROOT="$SCRIPT_DIR/.."
+TEST_FRAMEWORK_ROOT="$SCRIPT_DIR/../.."
 REPO_DIR="$TEST_FRAMEWORK_ROOT/.."
 
 # shellcheck disable=SC1091

--- a/test/scripts/build/test-runner.sh
+++ b/test/scripts/build/test-runner.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TEST_FRAMEWORK_ROOT="$SCRIPT_DIR/../.."
 REPO_DIR="$TEST_FRAMEWORK_ROOT/.."
 
-cd "$SCRIPT_DIR"
+pushd "$SCRIPT_DIR"
 
 # shellcheck disable=SC1091
 source "$REPO_DIR/scripts/utils/log"
@@ -39,3 +39,20 @@ cargo build \
 if [[ $TARGET == x86_64-pc-windows-gnu ]]; then
     TARGET="$TARGET" ./runner-image.sh
 fi
+
+popd
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        # Optionally move binaries to some known location
+        --output)
+            ARTIFACTS_DIR="$TEST_FRAMEWORK_ROOT/target/$TARGET/release"
+            mv -t "$1" "$ARTIFACTS_DIR/test-runner" "$ARTIFACTS_DIR/connection-checker"
+            ;;
+        *)
+            log_error "Unknown parameter: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done

--- a/test/scripts/build/test-runner.sh
+++ b/test/scripts/build/test-runner.sh
@@ -3,7 +3,9 @@
 set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_DIR="$SCRIPT_DIR/../.."
+TEST_FRAMEWORK_ROOT="$SCRIPT_DIR/../.."
+REPO_DIR="$TEST_FRAMEWORK_ROOT/.."
+
 cd "$SCRIPT_DIR"
 
 # shellcheck disable=SC1091
@@ -35,5 +37,5 @@ cargo build \
 
 # Only build runner image for Windows
 if [[ $TARGET == x86_64-pc-windows-gnu ]]; then
-    TARGET="$TARGET" ./build-runner-image.sh
+    TARGET="$TARGET" ./runner-image.sh
 fi

--- a/test/scripts/run/ci.sh
+++ b/test/scripts/run/ci.sh
@@ -65,14 +65,6 @@ nice_time download_e2e_executable "$CURRENT_VERSION" "$TEST_OS"
 # TODO: This should def be it's own step in the GitHub actions workflow
 
 echo "**********************************"
-echo "* Building test manager"
-echo "**********************************"
-
-cargo build -p test-manager
-
-# TODO: This should def be it's own step in the GitHub actions workflow
-
-echo "**********************************"
 echo "* Running tests"
 echo "**********************************"
 

--- a/test/scripts/utils/download.sh
+++ b/test/scripts/utils/download.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEST_FRAMEWORK_ROOT="$SCRIPT_DIR/../.."
+REPO_ROOT="$TEST_FRAMEWORK_ROOT/.."
+
+export BUILD_RELEASE_REPOSITORY="https://releases.mullvad.net/desktop/releases"
+export BUILD_DEV_REPOSITORY="https://releases.mullvad.net/desktop/builds"
+
+function executable_not_found_in_dist_error {
+    1>&2 echo "Executable \"$1\" not found in specified dist dir. Exiting."
+    exit 1
+}
+
+# Returns the directory of the lib.sh script
+function get_test_utils_dir {
+    echo "$SCRIPT_DIR"
+}
+
+# Infer stable version from GitHub repo
+RELEASES=$(curl -sf https://api.github.com/repos/mullvad/mullvadvpn-app/releases | jq -r '[.[] | select(((.tag_name|(startswith("android") or startswith("ios"))) | not))]')
+LATEST_STABLE_RELEASE=$(jq -r '[.[] | select(.prerelease==false)] | .[0].tag_name' <<<"$RELEASES")
+
+function get_current_version {
+    local app_dir
+    app_dir="$REPO_ROOT"
+    if [ -n "${TEST_DIST_DIR+x}" ]; then
+        if [ ! -x "${TEST_DIST_DIR%/}/mullvad-version" ]; then
+            executable_not_found_in_dist_error mullvad-version
+        fi
+        "${TEST_DIST_DIR%/}/mullvad-version"
+    else
+        cargo run -q --manifest-path="$app_dir/Cargo.toml" --bin mullvad-version
+    fi
+}
+
+CURRENT_VERSION=$(get_current_version)
+commit=$(git rev-parse HEAD^\{commit\})
+commit=${commit:0:6}
+
+TAG=$(git describe --exact-match HEAD 2>/dev/null || echo "")
+
+if [[ -n "$TAG" && ${CURRENT_VERSION} =~ -dev- ]]; then
+    # Remove disallowed version characters from the tag
+    CURRENT_VERSION+="+${TAG//[^0-9a-z_-]/}"
+fi
+
+export CURRENT_VERSION
+export LATEST_STABLE_RELEASE
+
+function print_available_releases {
+    for release in $(jq -r '.[].tag_name' <<<"$RELEASES"); do
+        echo "$release"
+    done
+}
+
+function get_package_dir {
+    local package_dir
+    if [[ -n "${PACKAGE_DIR+x}" ]]; then
+        # Resolve the package dir to an absolute path since cargo must be invoked from the test directory
+        package_dir=$(realpath "$PACKAGE_DIR")
+    elif [[ ("$(uname -s)" == "Darwin") ]]; then
+        package_dir="$HOME/Library/Caches/mullvad-test/packages"
+    elif [[ ("$(uname -s)" == "Linux") ]]; then
+        package_dir="$HOME/.cache/mullvad-test/packages"
+    else
+        echo "Unsupported OS" 1>&2
+        exit 1
+    fi
+
+    mkdir -p "$package_dir" || exit 1
+    # Clean up old packages
+    find "$package_dir" -type f -mtime +5 -delete || true
+
+    echo "$package_dir"
+    return 0
+}
+
+function nice_time {
+    SECONDS=0
+    if "$@"; then
+        result=0
+    else
+        result=$?
+    fi
+    s=$SECONDS
+    echo "\"$*\" completed in $((s / 60))m:$((s % 60))s"
+    return $result
+}
+# Matches $1 with a build version string and sets the following exported variables:
+# - BUILD_VERSION: The version part of the build string (e.g., "2024.3-beta1-dev-").
+# - COMMIT_HASH: The commit hash part of the build string (e.g., "abcdef").
+# - TAG: The tag part of the build string (e.g., "+tag").
+function parse_build_version {
+    if [[ "$1" =~ (^[0-9.]+(-beta[0-9]+)?-dev-)([0-9a-z]+)(\+[0-9a-z|-]+)?$ ]]; then
+        BUILD_VERSION="${BASH_REMATCH[1]}"
+        COMMIT_HASH="${BASH_REMATCH[3]}"
+        TAG="${BASH_REMATCH[4]}"
+        return 0
+    fi
+    return 1
+}
+
+# Returns 0 if $1 is a development build.
+function is_dev_version {
+    if [[ "$1" == *"-dev-"* ]]; then
+        return 0
+    fi
+    return 1
+}
+
+function get_app_filename {
+    local version=$1
+    local os=$2
+    if is_dev_version "$version"; then
+        parse_build_version "$version"
+        version="${BUILD_VERSION}${COMMIT_HASH}${TAG:-}"
+    fi
+    case $os in
+    debian* | ubuntu*)
+        echo "MullvadVPN-${version}_amd64.deb"
+        ;;
+    fedora*)
+        echo "MullvadVPN-${version}_x86_64.rpm"
+        ;;
+    windows*)
+        echo "MullvadVPN-${version}.exe"
+        ;;
+    macos*)
+        echo "MullvadVPN-${version}.pkg"
+        ;;
+    *)
+        echo "Unsupported target: $os" 1>&2
+        return 1
+        ;;
+    esac
+}
+
+function download_app_package {
+    local version=$1
+    local os=$2
+    local package_repo=""
+
+    if is_dev_version "$version"; then
+        package_repo="${BUILD_DEV_REPOSITORY}"
+    else
+        package_repo="${BUILD_RELEASE_REPOSITORY}"
+    fi
+
+    local filename
+    filename=$(get_app_filename "$version" "$os")
+    local url="${package_repo}/$version/$filename"
+
+    local package_dir
+    package_dir=$(get_package_dir)
+    if [[ ! -f "$package_dir/$filename" ]]; then
+        echo "Downloading build for $version ($os) from $url"
+        if ! curl -sf -o "$package_dir/$filename" "$url"; then
+            echo "Failed to download package from $url (hint: build may not exist, check the url)" 1>&2
+            exit 1
+        fi
+    else
+        echo "App package for version $version ($os) already exists at $package_dir/$filename, skipping download"
+    fi
+}
+
+function get_e2e_filename {
+    local version=$1
+    local os=$2
+    if is_dev_version "$version"; then
+        parse_build_version "$version"
+        version="${BUILD_VERSION}${COMMIT_HASH}"
+    fi
+    case $os in
+    debian* | ubuntu* | fedora*)
+        echo "app-e2e-tests-${version}-x86_64-unknown-linux-gnu"
+        ;;
+    windows*)
+        echo "app-e2e-tests-${version}-x86_64-pc-windows-msvc.exe"
+        ;;
+    macos*)
+        echo "app-e2e-tests-${version}-aarch64-apple-darwin"
+        ;;
+    *)
+        echo "Unsupported target: $os" 1>&2
+        return 1
+        ;;
+    esac
+}
+
+function download_e2e_executable {
+    local version=${1:?Error: version not set}
+    local os=${2:?Error: os not set}
+    local package_repo
+
+    if is_dev_version "$version"; then
+        package_repo="${BUILD_DEV_REPOSITORY}"
+    else
+        package_repo="${BUILD_RELEASE_REPOSITORY}"
+    fi
+
+    local filename
+    filename=$(get_e2e_filename "$version" "$os")
+    local url="${package_repo}/$version/additional-files/$filename"
+
+    local package_dir
+    package_dir=$(get_package_dir)
+    if [[ ! -f "$package_dir/$filename" ]]; then
+        echo "Downloading e2e executable for $version ($os) from $url"
+        if ! curl -sf -o "$package_dir/$filename" "$url"; then
+            echo "Failed to download package from $url (hint: build may not exist, check the url)" 1>&2
+            exit 1
+        fi
+    else
+        echo "GUI e2e executable for version $version ($os) already exists at $package_dir/$filename, skipping download"
+    fi
+}

--- a/test/scripts/utils/lib.sh
+++ b/test/scripts/utils/lib.sh
@@ -230,7 +230,8 @@ function run_tests_for_os {
         test_manager="${TEST_DIST_DIR%/}/test-manager"
         runner_dir_flag=("--runner-dir" "$TEST_DIST_DIR")
     else
-        test_manager="cargo run --bin test-manager"
+        # Assume test-manager is in path.
+        test_manager="$(which test-manager)"
         runner_dir_flag=()
     fi
 

--- a/test/test-by-version.sh
+++ b/test/test-by-version.sh
@@ -21,8 +21,8 @@ usage() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# shellcheck source=test/scripts/test-utils.sh
-source "scripts/test-utils.sh"
+# shellcheck source=test/scripts/utils/lib.sh
+source "scripts/utils/lib.sh"
 
 if [[ ("$*" == "--help") || "$*" == "-h" ]]; then
     usage


### PR DESCRIPTION
This PR changes the desktop end-to-end test workflow to build the `test-manager` and `test-runner` binaries before running the tests. The binaries are then re-used in the step running the test cases, which means that we don't spend time rebuilding stuff for every target platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7674)
<!-- Reviewable:end -->
