### PR TITLE
Fix access method rotation after dns proxy failure

### DIFF
--- a/ios/MullvadRustRuntime/EncryptedDNSProxy.swift
+++ b/ios/MullvadRustRuntime/EncryptedDNSProxy.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MullvadRustRuntimeProxy
 
-enum EncryptedDnsProxyError: Error {
+public enum EncryptedDnsProxyError: Error {
     case start(err: Int32)
 }
 


### PR DESCRIPTION
The access method now rotates after encrypted dns failed.
Can be testes by blocking all traffic from a device and then trying log in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7678)
<!-- Reviewable:end -->
