### PR TITLE
Fix kotlin formatting paths in ci

### DIFF
--- a/.github/workflows/android-kotlin-format-check.yml
+++ b/.github/workflows/android-kotlin-format-check.yml
@@ -2,7 +2,11 @@
 name: Android - Check kotlin formatting
 on:
   pull_request:
-    paths: [.github/workflows/android-kotlin-format-check.yml, android/**/*.kt]
+    paths:
+      - .github/workflows/android-kotlin-format-check.yml
+      - android/gradle/libs.versions.toml
+      - android/**/*.kt
+      - android/**/*.kts
   workflow_dispatch:
     inputs:
       override_container_image:

--- a/android/buildSrc/settings.gradle.kts
+++ b/android/buildSrc/settings.gradle.kts
@@ -1,9 +1,5 @@
 rootProject.name = "buildSrc"
 
 dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            from(files("../gradle/libs.versions.toml"))
-        }
-    }
+    versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
 }


### PR DESCRIPTION
This PR aims to fix the kotlin formatting workflow that runs in GH actions by adding the path for `*.kts` files.

Fixes: DROID-1815

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7683)
<!-- Reviewable:end -->
