### PR TITLE
Update `print-package-versions` script for Linux repositories

### DIFF
--- a/desktop/scripts/release/print-package-versions
+++ b/desktop/scripts/release/print-package-versions
@@ -88,6 +88,6 @@ if [[ $rpm == "true" ]]; then
 
     bash -c "podman run --rm -it fedora:latest sh -c \
         \"dnf install -y 'dnf-command(config-manager)' $silent_stdout; \
-        dnf config-manager --add-repo $repository_server_public_url/rpm/$release_channel/mullvad.repo $silent_stdout; \
+        dnf config-manager addrepo --from-repofile=$repository_server_public_url/rpm/$release_channel/mullvad.repo $silent_stdout; \
         dnf list --refresh mullvad-vpn mullvad-browser $silent_stderr | grep -E 'mullvad-(vpn|browser)'\" $silent_stderr"
 fi

--- a/desktop/scripts/release/print-package-versions
+++ b/desktop/scripts/release/print-package-versions
@@ -72,7 +72,7 @@ if [[ $deb == "true" ]]; then
         log_header "deb"
     fi
 
-    bash -c " podman run --rm -it debian:latest sh -c \
+    bash -c " podman run --rm -it debian:12 sh -c \
         \"apt update $silent_stderr $silent_stdout; \
         apt install -y curl $silent_stderr $silent_stdout; \
         curl -fsSLo /usr/share/keyrings/mullvad-keyring.asc $repository_server_public_url/deb/mullvad-keyring.asc; \
@@ -86,7 +86,7 @@ if [[ $rpm == "true" ]]; then
         log_header "rpm"
     fi
 
-    bash -c "podman run --rm -it fedora:latest sh -c \
+    bash -c "podman run --rm -it fedora:41 sh -c \
         \"dnf install -y 'dnf-command(config-manager)' $silent_stderr $silent_stdout; \
         dnf config-manager addrepo --from-repofile=$repository_server_public_url/rpm/$release_channel/mullvad.repo $silent_stderr; \
         dnf list --refresh mullvad-* $silent_stderr | grep 'x86_64'\" $silent_stderr"

--- a/desktop/scripts/release/print-package-versions
+++ b/desktop/scripts/release/print-package-versions
@@ -87,7 +87,7 @@ if [[ $rpm == "true" ]]; then
     fi
 
     bash -c "podman run --rm -it fedora:latest sh -c \
-        \"dnf install -y 'dnf-command(config-manager)' $silent_stdout; \
-        dnf config-manager addrepo --from-repofile=$repository_server_public_url/rpm/$release_channel/mullvad.repo $silent_stdout; \
+        \"dnf install -y 'dnf-command(config-manager)' $silent_stderr $silent_stdout; \
+        dnf config-manager addrepo --from-repofile=$repository_server_public_url/rpm/$release_channel/mullvad.repo $silent_stderr; \
         dnf list --refresh mullvad-vpn mullvad-browser $silent_stderr | grep -E 'mullvad-(vpn|browser)'\" $silent_stderr"
 fi

--- a/desktop/scripts/release/print-package-versions
+++ b/desktop/scripts/release/print-package-versions
@@ -78,7 +78,7 @@ if [[ $deb == "true" ]]; then
         curl -fsSLo /usr/share/keyrings/mullvad-keyring.asc $repository_server_public_url/deb/mullvad-keyring.asc; \
         echo \\\"deb [signed-by=/usr/share/keyrings/mullvad-keyring.asc arch=amd64] $repository_server_public_url/deb/$release_channel bookworm main\\\" > /etc/apt/sources.list.d/mullvad.list; \
         apt update $silent_stderr $silent_stdout; \
-        apt list mullvad-vpn mullvad-browser $silent_stderr | grep -E 'mullvad-(vpn|browser)'\" $silent_stderr"
+        apt list mullvad-* $silent_stderr | grep 'amd64'\" $silent_stderr"
 fi
 
 if [[ $rpm == "true" ]]; then
@@ -89,5 +89,5 @@ if [[ $rpm == "true" ]]; then
     bash -c "podman run --rm -it fedora:latest sh -c \
         \"dnf install -y 'dnf-command(config-manager)' $silent_stderr $silent_stdout; \
         dnf config-manager addrepo --from-repofile=$repository_server_public_url/rpm/$release_channel/mullvad.repo $silent_stderr; \
-        dnf list --refresh mullvad-vpn mullvad-browser $silent_stderr | grep -E 'mullvad-(vpn|browser)'\" $silent_stderr"
+        dnf list --refresh mullvad-* $silent_stderr | grep 'x86_64'\" $silent_stderr"
 fi


### PR DESCRIPTION
The original issue I fixed here is that the script was not compatible with Fedora 41, which my `fedora:latest` image pointed to. It needed the newer argument format to add repositories.

I then realized the script became very noisy. Seems like Fedora 41 print more stuff to stdout/stderr. So I had to update parts of the silencing code.

I then wanted to prepare for the `mullvad-browser-alpha` package soon being added. So I list and show all packages having `mullvad-` in its name instead of just the vpn and browser.

Lastly, I pinned the container images to fixed releases, to avoid things breaking in the future because `latest` is a moving target.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7686)
<!-- Reviewable:end -->
