### PR TITLE
Add `mullvad-browser-alpha` to our linux repositories

### DIFF
--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -2,9 +2,7 @@
 
 set -eu
 
-# TODO: Uncomment when alpha is to be released
-# BROWSER_RELEASES=("alpha" "stable")
-BROWSER_RELEASES=("stable")
+BROWSER_RELEASES=("stable" "alpha")
 REPOSITORIES=("stable" "beta")
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
There are alpha builds of the Mullvad Browser now, and we want them in our Linux repositories. It is only needed in the production environment, and it should be available on both the stable and beta repositories.

This PR is related to #7686, which would be good to have merged also, because it makes it easier to print and debug the repository content.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7687)
<!-- Reviewable:end -->
