### PR TITLE
Simplify version parsing tests

### DIFF
--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -164,6 +164,11 @@ impl FromStr for Version {
 mod tests {
     use super::*;
 
+    // Helper to parse a version string
+    fn parse(version: &str) -> Version {
+        version.parse().unwrap()
+    }
+
     #[test]
     fn test_version_ordering() {
         // Test year comparison
@@ -220,70 +225,87 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let version = "2021.34";
-        let parsed = parse(version);
-        assert_eq!(parsed.year, 2021);
-        assert_eq!(parsed.incremental, 34);
-        assert_eq!(alpha(&parsed), None);
-        assert_eq!(beta(&parsed), None);
-        assert_eq!(parsed.dev, None);
-        assert!(is_stable(&parsed));
+        assert_eq!(
+            parse("2021.34"),
+            Version {
+                year: 2021,
+                incremental: 34,
+                pre_stable: None,
+                dev: None,
+            }
+        );
     }
 
     #[test]
     fn test_parse_with_alpha() {
-        let version = "2023.1-alpha77";
-        let parsed = parse(version);
-        assert_eq!(parsed.year, 2023);
-        assert_eq!(parsed.incremental, 1);
-        assert_eq!(alpha(&parsed), Some(77));
-        assert_eq!(beta(&parsed), None);
-        assert_eq!(parsed.dev, None);
-        assert!(!is_stable(&parsed));
+        assert_eq!(
+            parse("2023.1-alpha77"),
+            Version {
+                year: 2023,
+                incremental: 1,
+                pre_stable: Some(PreStableType::Alpha(77)),
+                dev: None,
+            }
+        );
 
-        let version = "2021.34-alpha777";
-        let parsed = parse(version);
-        assert_eq!(alpha(&parsed), Some(777));
+        assert_eq!(
+            parse("2021.34-alpha777"),
+            Version {
+                year: 2021,
+                incremental: 34,
+                pre_stable: Some(PreStableType::Alpha(777)),
+                dev: None,
+            }
+        );
     }
 
     #[test]
     fn test_parse_with_beta() {
-        let version = "2021.34-beta5";
-        let parsed = parse(version);
-        assert_eq!(parsed.year, 2021);
-        assert_eq!(parsed.incremental, 34);
-        assert_eq!(alpha(&parsed), None);
-        assert_eq!(beta(&parsed), Some(5));
-        assert_eq!(parsed.dev, None);
-        assert!(!is_stable(&parsed));
+        assert_eq!(
+            parse("2021.34-beta5"),
+            Version {
+                year: 2021,
+                incremental: 34,
+                pre_stable: Some(PreStableType::Beta(5)),
+                dev: None,
+            }
+        );
 
-        let version = "2021.34-beta453";
-        let parsed = parse(version);
-        assert_eq!(beta(&parsed), Some(453));
+        assert_eq!(
+            parse("2021.34-beta453"),
+            Version {
+                year: 2021,
+                incremental: 34,
+                pre_stable: Some(PreStableType::Beta(453)),
+                dev: None,
+            }
+        );
     }
 
     #[test]
     fn test_parse_with_dev() {
-        let version = "2021.34-dev-0b60e4d87";
-        let parsed = parse(version);
-        assert_eq!(parsed.year, 2021);
-        assert_eq!(parsed.incremental, 34);
-        assert!(!is_stable(&parsed));
-        assert_eq!(parsed.dev, Some("0b60e4d87".to_string()));
-        assert_eq!(alpha(&parsed), None);
-        assert_eq!(beta(&parsed), None);
+        assert_eq!(
+            parse("2021.34-dev-0b60e4d87"),
+            Version {
+                year: 2021,
+                incremental: 34,
+                pre_stable: None,
+                dev: Some("0b60e4d87".to_string()),
+            }
+        );
     }
 
     #[test]
     fn test_parse_both_beta_and_dev() {
-        let version = "2024.8-beta1-dev-e5483d";
-        let parsed = parse(version);
-        assert_eq!(parsed.year, 2024);
-        assert_eq!(parsed.incremental, 8);
-        assert_eq!(alpha(&parsed), None);
-        assert_eq!(beta(&parsed), Some(1));
-        assert_eq!(parsed.dev, Some("e5483d".to_string()));
-        assert!(!is_stable(&parsed));
+        assert_eq!(
+            parse("2024.8-beta1-dev-e5483d"),
+            Version {
+                year: 2024,
+                incremental: 8,
+                pre_stable: Some(PreStableType::Beta(1)),
+                dev: Some("e5483d".to_string()),
+            }
+        );
     }
 
     #[test]
@@ -318,10 +340,6 @@ mod tests {
         assert!("2021.1-dev".parse::<Version>().is_err())
     }
 
-    fn parse(version: &str) -> Version {
-        version.parse().unwrap()
-    }
-
     #[test]
     fn test_version_display() {
         let version = "2024.8-beta1-dev-e5483d";
@@ -343,23 +361,5 @@ mod tests {
         let parsed: Version = version.parse().unwrap();
 
         assert_eq!(format!("{parsed}"), version);
-    }
-
-    fn alpha(version: &Version) -> Option<u32> {
-        match version.pre_stable {
-            Some(PreStableType::Alpha(alpha)) => Some(alpha),
-            _ => None,
-        }
-    }
-
-    fn beta(version: &Version) -> Option<u32> {
-        match version.pre_stable {
-            Some(PreStableType::Beta(beta)) => Some(beta),
-            _ => None,
-        }
-    }
-
-    fn is_stable(version: &Version) -> bool {
-        version.pre_stable.is_none() && !version.is_dev()
     }
 }

--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -216,7 +216,7 @@ mod tests {
 
         // Exactly the same version are equal, but has no ordering
         assert_eq!(v1, v1);
-        assert!(v1.partial_cmp(&v2).is_none());
+        assert!(v1.partial_cmp(&v1).is_none());
 
         // Equal down to the dev suffix are not equal, and has no ordering
         assert_ne!(v1, v2);

--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -342,24 +342,15 @@ mod tests {
 
     #[test]
     fn test_version_display() {
-        let version = "2024.8-beta1-dev-e5483d";
-        let parsed: Version = version.parse().unwrap();
+        let assert_same_display = |version: &str| {
+            let parsed = Version::from_str(version).unwrap();
+            assert_eq!(parsed.to_string(), version);
+        };
 
-        assert_eq!(format!("{parsed}"), version);
-
-        let version = "2024.8-beta1";
-        let parsed: Version = version.parse().unwrap();
-
-        assert_eq!(format!("{parsed}"), version);
-
-        let version = "2024.8-alpha77-dev-85483d";
-        let parsed: Version = version.parse().unwrap();
-
-        assert_eq!(format!("{parsed}"), version);
-
-        let version = "2024.12";
-        let parsed: Version = version.parse().unwrap();
-
-        assert_eq!(format!("{parsed}"), version);
+        assert_same_display("2024.8-beta1-dev-e5483d");
+        assert_same_display("2024.8-beta1");
+        assert_same_display("2024.8-alpha77-dev-85483d");
+        assert_same_display("2024.12");
+        assert_same_display("2045.2-dev-123");
     }
 }


### PR DESCRIPTION
Follow up to your PR #7600 

I saw some potential simplifications of the tests. Please tell me what you think of this version of testing stuff!

I also found a minor error in the `test_version_ordering_and_equality_dev` test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7688)
<!-- Reviewable:end -->
