### PR TITLE
Remove `apisocks5` binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for DAITA V2.
 - Add back wireguard-go (userspace WireGuard) support.
 
+### Removed
+- Stop bundling https://github.com/mullvad/apisocks5 as a standalone binary.
+
 
 ## [2025.4] - 2025-02-12
 This release is identical to 2025.4-beta1

--- a/desktop/packages/mullvad-vpn/tasks/distribution.js
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.js
@@ -108,7 +108,6 @@ function newConfig() {
           to: '.',
         },
         { from: distAssets(path.join('binaries', '${env.TARGET_TRIPLE}', 'openvpn')), to: '.' },
-        { from: distAssets(path.join('binaries', '${env.TARGET_TRIPLE}', 'apisocks5')), to: '.' },
         { from: distAssets('uninstall_macos.sh'), to: './uninstall.sh' },
         { from: buildAssets('shell-completions/_mullvad'), to: '.' },
         { from: buildAssets('shell-completions/mullvad.fish'), to: '.' },
@@ -159,10 +158,6 @@ function newConfig() {
         // TODO: OpenVPN does not have an ARM64 build yet.
         { from: distAssets('binaries/x86_64-pc-windows-msvc/openvpn.exe'), to: '.' },
         {
-          from: distAssets(path.join('binaries', '${env.TARGET_SUBDIR}', 'apisocks5.exe')),
-          to: '.',
-        },
-        {
           from: distAssets(path.join('binaries', '${env.TARGET_SUBDIR}', 'wintun/wintun.dll')),
           to: '.',
         },
@@ -207,7 +202,6 @@ function newConfig() {
         },
         { from: distAssets(path.join('linux', 'apparmor_mullvad')), to: '.' },
         { from: distAssets(path.join('binaries', '${env.TARGET_TRIPLE}', 'openvpn')), to: '.' },
-        { from: distAssets(path.join('binaries', '${env.TARGET_TRIPLE}', 'apisocks5')), to: '.' },
       ],
     },
 


### PR DESCRIPTION
This PR stops bundling `apisocks5` with the app. `apisocks5` is no longer needed since Encrypted DNS proxy has been released as stable since [2025.1](https://github.com/mullvad/mullvadvpn-app/blob/main/CHANGELOG.md#20251---2025-01-02).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7690)
<!-- Reviewable:end -->
