### PR TITLE
Filter by destination port before asserting

### DIFF
--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -194,12 +194,12 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapDisconnectButton()
         let capturedStreams = stopPacketCapture()
 
+        // The capture will contain several streams where `other_addr` contains the IP the device connected to
+        // One stream will be for the source port, the other for the destination port
         let streamFromPeeerToRelay = try XCTUnwrap(
-            capturedStreams
-                .filter { $0.destinationAddress == connectedToIPAddress }.first
+            capturedStreams.filter { $0.destinationAddress == connectedToIPAddress && $0.destinationPort == 80 }.first
         )
 
-        XCTAssertTrue(streamFromPeeerToRelay.destinationPort == 80)
         XCTAssertTrue(streamFromPeeerToRelay.transportProtocol == .TCP)
     }
 


### PR DESCRIPTION
This PR fixes the UDP over TCP port that uses capture traffic to guarantee that the correct stream is captured before asserting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7691)
<!-- Reviewable:end -->
