### PR TITLE
Ios-1092 hide notification bar except in tunnel

### DIFF
--- a/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
+++ b/ios/MullvadVPN/Containers/Root/RootContainerViewController.swift
@@ -53,7 +53,7 @@ protocol RootContainment: Sendable {
 
 extension RootContainment {
     var prefersNotificationBarHidden: Bool {
-        false
+        true
     }
 
     var prefersDeviceInfoBarHidden: Bool {

--- a/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedController.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Completed/SetupAccountCompletedController.swift
@@ -32,10 +32,6 @@ class SetupAccountCompletedController: UIViewController, RootContainment {
         true
     }
 
-    var prefersNotificationBarHidden: Bool {
-        true
-    }
-
     weak var delegate: SetupAccountCompletedControllerDelegate?
 
     override func viewDidLoad() {

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeViewController.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeViewController.swift
@@ -35,10 +35,6 @@ class WelcomeViewController: UIViewController, RootContainment {
         false
     }
 
-    var prefersNotificationBarHidden: Bool {
-        true
-    }
-
     var prefersDeviceInfoBarHidden: Bool {
         true
     }

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
@@ -28,10 +28,6 @@ class DeviceManagementViewController: UIViewController, RootContainment {
         false
     }
 
-    var prefersNotificationBarHidden: Bool {
-        true
-    }
-
     override var preferredStatusBarStyle: UIStatusBarStyle {
         .lightContent
     }

--- a/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginViewController.swift
@@ -87,10 +87,6 @@ class LoginViewController: UIViewController, RootContainment {
         contentView.accountInputGroup.satisfiesMinimumTokenLengthRequirement
     }
 
-    var prefersNotificationBarHidden: Bool {
-        true
-    }
-
     var prefersDeviceInfoBarHidden: Bool {
         true
     }

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
@@ -44,10 +44,6 @@ class OutOfTimeViewController: UIViewController, RootContainment {
         false
     }
 
-    var prefersNotificationBarHidden: Bool {
-        true
-    }
-
     init(interactor: OutOfTimeInteractor, errorPresenter: PaymentAlertPresenter) {
         self.interactor = interactor
 

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/AddCreditSucceededViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/AddCreditSucceededViewController.swift
@@ -63,10 +63,6 @@ class AddCreditSucceededViewController: UIViewController, RootContainment {
         true
     }
 
-    var prefersNotificationBarHidden: Bool {
-        true
-    }
-
     weak var delegate: AddCreditSucceededViewControllerDelegate? {
         didSet {
             dismissButton.setTitle(delegate?.titleForAction(in: self), for: .normal)

--- a/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
+++ b/ios/MullvadVPN/View controllers/RedeemVoucher/RedeemVoucherViewController.swift
@@ -56,10 +56,6 @@ class RedeemVoucherViewController: UIViewController, UINavigationControllerDeleg
         true
     }
 
-    var prefersNotificationBarHidden: Bool {
-        true
-    }
-
     // MARK: - Life Cycle
 
     override func viewDidLoad() {

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -56,6 +56,10 @@ class TunnelViewController: UIViewController, RootContainment {
     var prefersHeaderBarHidden: Bool {
         false
     }
+    
+    var prefersNotificationBarHidden: Bool {
+        false
+    }
 
     init(interactor: TunnelViewControllerInteractor) {
         self.interactor = interactor


### PR DESCRIPTION
This flips the default of the `prefersNotificationBarHidden` setting that our RootContainmenr screens have, to hide the bar unless otherwise specified. The `TunnelViewController` (i.e., the main screen) is set to allow the notification bar to be displayed, with others hiding it. Most of them had explicit overrides to do this anyway, which are now deleted. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
