### PR TITLE
Improve single relay custom list blocked handling and presentation

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/select-location/custom-list-helpers.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/select-location/custom-list-helpers.ts
@@ -9,7 +9,12 @@ import {
   usePreventDueToCustomBridgeSelected,
   useSelectedLocation,
 } from './RelayListContext';
-import { isCustomListDisabled, isExpanded, isSelected } from './select-location-helpers';
+import {
+  formatRowName,
+  isCustomListDisabled,
+  isExpanded,
+  isSelected,
+} from './select-location-helpers';
 import {
   CitySpecification,
   CountrySpecification,
@@ -73,7 +78,7 @@ function prepareCustomList(
 
   const disabledReason = isCustomListDisabled(location, locations, disabledLocation);
   return {
-    label: list.name,
+    label: formatRowName(list.name, location, disabledReason),
     list,
     location,
     active: disabledReason !== DisabledReason.inactive,

--- a/desktop/packages/mullvad-vpn/src/renderer/components/select-location/select-location-helpers.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/select-location/select-location-helpers.ts
@@ -128,7 +128,7 @@ export function isCityDisabled(
   disabledLocation?: { location: RelayLocation; reason: DisabledReason },
 ): DisabledReason | undefined {
   const relaysDisabled = city.relays.map((relay) =>
-    isRelayDisabled(relay, { ...location, hostname: relay.hostname }),
+    isRelayDisabled(relay, { ...location, hostname: relay.hostname }, disabledLocation),
   );
   if (relaysDisabled.every((status) => status === DisabledReason.inactive)) {
     return DisabledReason.inactive;

--- a/desktop/packages/mullvad-vpn/src/renderer/components/select-location/select-location-helpers.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/select-location/select-location-helpers.ts
@@ -162,7 +162,7 @@ export function isCountryDisabled(
   disabledLocation?: { location: RelayLocation; reason: DisabledReason },
 ): DisabledReason | undefined {
   const citiesDisabled = country.cities.map((city) =>
-    isCityDisabled(city, { ...location, city: city.code }),
+    isCityDisabled(city, { ...location, city: city.code }, disabledLocation),
   );
   if (citiesDisabled.every((status) => status === DisabledReason.inactive)) {
     return DisabledReason.inactive;


### PR DESCRIPTION
If multihop is enabled and the user has a custom list consisting of a single relay then the list will be disabled in the other view if used as Entry or Exit. However, its label will not display the `(Entry)` or `(Exit)` suffix. Additionally, the single relay in the custom list is not disabled in the other view if the user has expanded the custom list and selected the single relay inside it manually.

Improvements:

- In single relay custom lists the relay is disabled if the custom list has already been used as Entry or Exit.
- Add blocked reason suffix in label for custom lists.

Fixes: DES-1348

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7702)
<!-- Reviewable:end -->
