### PR TITLE
Avoid unnecessary calls to establish

### DIFF
--- a/android/app/src/test/kotlin/net/mullvad/talpid/TalpidVpnServiceFallbackDnsTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/talpid/TalpidVpnServiceFallbackDnsTest.kt
@@ -34,6 +34,9 @@ class TalpidVpnServiceFallbackDnsTest {
         every { talpidVpnService.prepareVpnSafe() } returns Prepared.right()
         builderMockk = mockk<VpnService.Builder>()
 
+        every { talpidVpnService getProperty "connectivityListener" } returns
+            mockk<ConnectivityListener>(relaxed = true)
+
         mockkConstructor(VpnService.Builder::class)
         every { anyConstructed<VpnService.Builder>().setMtu(any()) } returns builderMockk
         every { anyConstructed<VpnService.Builder>().setBlocking(any()) } returns builderMockk

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -2,21 +2,23 @@ package net.mullvad.talpid
 
 import android.net.ConnectivityManager
 import android.net.LinkProperties
-import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import co.touchlab.kermit.Logger
 import java.net.InetAddress
 import kotlin.collections.ArrayList
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.runBlocking
 import net.mullvad.talpid.model.NetworkState
 import net.mullvad.talpid.util.NetworkEvent
 import net.mullvad.talpid.util.RawNetworkState
@@ -56,7 +58,12 @@ class ConnectivityListener(private val connectivityManager: ConnectivityManager)
         _isConnected =
             hasInternetCapability()
                 .onEach { notifyConnectivityChange(it) }
-                .stateIn(scope, SharingStarted.Eagerly, false)
+                .stateIn(
+                    scope,
+                    SharingStarted.Eagerly,
+                    true, // Assume we have internet until we know otherwise
+                )
+    }
 
     /**
      * Invalidates the network state cache. E.g when the VPN is connected or disconnected, and we
@@ -70,35 +77,39 @@ class ConnectivityListener(private val connectivityManager: ConnectivityManager)
     private fun LinkProperties.dnsServersWithoutFallback(): List<InetAddress> =
         dnsServers.filter { it.hostAddress != TalpidVpnService.FALLBACK_DUMMY_DNS_SERVER }
 
-    private fun hasInternetCapability(): Flow<Boolean> {
-        val request =
-            NetworkRequest.Builder()
-                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
-                .build()
+    private val nonVPNNetworksRequest =
+        NetworkRequest.Builder().addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN).build()
 
+    private fun hasInternetCapability(): Flow<Boolean> {
+        @Suppress("DEPRECATION")
         return connectivityManager
-            .networkEvents(request)
-            .scan(setOf<Network>()) { networks, event ->
+            .networkEvents(nonVPNNetworksRequest)
+            .scan(
+                connectivityManager.allNetworks.associateWith {
+                    connectivityManager.getNetworkCapabilities(it)
+                }
+            ) { networks, event ->
                 when (event) {
-                    is NetworkEvent.Available -> {
-                        Logger.d("Network available ${event.network}")
-                        (networks + event.network).also {
-                            Logger.d("Number of networks: ${it.size}")
-                        }
-                    }
                     is NetworkEvent.Lost -> {
                         Logger.d("Network lost ${event.network}")
                         (networks - event.network).also {
                             Logger.d("Number of networks: ${it.size}")
                         }
                     }
+                    is NetworkEvent.CapabilitiesChanged -> {
+                        Logger.d("Network capabilities changed ${event.network}")
+                        (networks + (event.network to event.networkCapabilities)).also {
+                            Logger.d("Number of networks: ${it.size}")
+                        }
+                    }
                     else -> networks
                 }
             }
-            .map { it.isNotEmpty() }
-            .distinctUntilChanged()
+            .map { it.any { it.value.hasInternetCapability() } }
     }
+
+    private fun NetworkCapabilities?.hasInternetCapability(): Boolean =
+        this?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
 
     private fun RawNetworkState.toNetworkState(): NetworkState =
         NetworkState(

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -42,8 +42,6 @@ open class TalpidVpnService : LifecycleVpnService() {
             }
         }
 
-    private var currentTunConfig: TunConfig? = null
-
     // Used by JNI
     lateinit var connectivityListener: ConnectivityListener
 
@@ -56,12 +54,7 @@ open class TalpidVpnService : LifecycleVpnService() {
 
     // Used by JNI
     fun openTun(config: TunConfig): CreateTunResult =
-        synchronized(this) {
-            createTun(config).merge().also {
-                currentTunConfig = config
-                activeTunStatus = it
-            }
-        }
+        synchronized(this) { createTun(config).merge().also { activeTunStatus = it } }
 
     // Used by JNI
     fun closeTun(): Unit =

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -2,8 +2,6 @@ use futures::channel::{mpsc, oneshot};
 use futures::stream::Fuse;
 use futures::StreamExt;
 
-#[cfg(target_os = "android")]
-use talpid_tunnel::tun_provider::Error;
 use talpid_types::net::{AllowedClients, AllowedEndpoint, TunnelParameters};
 use talpid_types::tunnel::{ErrorStateCause, FirewallPolicyError};
 use talpid_types::{BoxedError, ErrorExt};
@@ -260,14 +258,7 @@ impl ConnectedState {
                 let consequence = if shared_values.set_allow_lan(allow_lan) {
                     #[cfg(target_os = "android")]
                     {
-                        if let Err(_err) = shared_values.restart_tunnel(false) {
-                            self.disconnect(
-                                shared_values,
-                                AfterDisconnect::Block(ErrorStateCause::StartTunnelError),
-                            )
-                        } else {
-                            self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                        }
+                        self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                     }
                     #[cfg(not(target_os = "android"))]
                     {
@@ -298,22 +289,7 @@ impl ConnectedState {
                 let consequence = if shared_values.set_dns_config(servers) {
                     #[cfg(target_os = "android")]
                     {
-                        if let Err(_err) = shared_values.restart_tunnel(false) {
-                            match _err {
-                                Error::InvalidDnsServers(ip_addrs) => self.disconnect(
-                                    shared_values,
-                                    AfterDisconnect::Block(ErrorStateCause::InvalidDnsServers(
-                                        ip_addrs,
-                                    )),
-                                ),
-                                _ => self.disconnect(
-                                    shared_values,
-                                    AfterDisconnect::Block(ErrorStateCause::StartTunnelError),
-                                ),
-                            }
-                        } else {
-                            self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                        }
+                        self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                     }
                     #[cfg(not(target_os = "android"))]
                     {
@@ -385,17 +361,8 @@ impl ConnectedState {
             #[cfg(target_os = "android")]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 if shared_values.set_excluded_paths(paths) {
-                    if let Err(err) = shared_values.restart_tunnel(false) {
-                        let _ =
-                            result_tx.send(Err(crate::split_tunnel::Error::SetExcludedApps(err)));
-                        self.disconnect(
-                            shared_values,
-                            AfterDisconnect::Block(ErrorStateCause::SplitTunnelError),
-                        )
-                    } else {
-                        let _ = result_tx.send(Ok(()));
-                        self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                    }
+                    let _ = result_tx.send(Ok(()));
+                    self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                 } else {
                     let _ = result_tx.send(Ok(()));
                     SameState(self)

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -114,6 +114,10 @@ impl ConnectingState {
                         ErrorStateCause::SetFirewallPolicyError(error),
                     )
                 } else {
+                    // HACK: On Android, DNS is part of creating the VPN interface, this call
+                    // ensures that the vpn_config is prepared with correct DNS servers in case they
+                    // previously set to something else, e.g. in the case of blocking. This call
+                    // should probably be part of start_tunnel call.
                     #[cfg(target_os = "android")]
                     {
                         shared_values.prepare_tun_config(false);

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -386,14 +386,7 @@ impl ConnectingState {
                 let consequence = if shared_values.set_allow_lan(allow_lan) {
                     #[cfg(target_os = "android")]
                     {
-                        if let Err(_err) = shared_values.restart_tunnel(false) {
-                            self.disconnect(
-                                shared_values,
-                                AfterDisconnect::Block(ErrorStateCause::StartTunnelError),
-                            )
-                        } else {
-                            self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                        }
+                        self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                     }
                     #[cfg(not(target_os = "android"))]
                     self.reset_firewall(shared_values)
@@ -427,14 +420,7 @@ impl ConnectingState {
                 let consequence = if shared_values.set_dns_config(servers) {
                     #[cfg(target_os = "android")]
                     {
-                        if let Err(_err) = shared_values.restart_tunnel(false) {
-                            self.disconnect(
-                                shared_values,
-                                AfterDisconnect::Block(ErrorStateCause::StartTunnelError),
-                            )
-                        } else {
-                            self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                        }
+                        self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                     }
                     #[cfg(not(target_os = "android"))]
                     SameState(self)
@@ -484,17 +470,8 @@ impl ConnectingState {
             #[cfg(target_os = "android")]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 if shared_values.set_excluded_paths(paths) {
-                    if let Err(err) = shared_values.restart_tunnel(false) {
-                        let _ =
-                            result_tx.send(Err(crate::split_tunnel::Error::SetExcludedApps(err)));
-                        self.disconnect(
-                            shared_values,
-                            AfterDisconnect::Block(ErrorStateCause::SplitTunnelError),
-                        )
-                    } else {
-                        let _ = result_tx.send(Ok(()));
-                        self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
-                    }
+                    let _ = result_tx.send(Ok(()));
+                    self.disconnect(shared_values, AfterDisconnect::Reconnect(0))
                 } else {
                     let _ = result_tx.send(Ok(()));
                     SameState(self)

--- a/talpid-routing/src/unix/android.rs
+++ b/talpid-routing/src/unix/android.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::ops::{ControlFlow, Not};
+use std::ops::ControlFlow;
 use std::sync::Mutex;
 
 use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -51,7 +51,7 @@ pub struct RouteManagerImpl {
     last_state: Option<NetworkState>,
 
     /// Clients waiting on response to [RouteManagerCommand::WaitForRoutes].
-    waiting_for_routes: Vec<oneshot::Sender<()>>,
+    waiting_for_routes: Vec<(oneshot::Sender<()>, Vec<Route>)>,
 }
 
 impl RouteManagerImpl {
@@ -64,7 +64,7 @@ impl RouteManagerImpl {
 
         // Try to poll for the current network state at startup.
         // This will most likely be null, but it covers the edge case where a NetworkState
-        // update has been emitted before we anyone starts to listen for route updates some
+        // update has been emitted before anyone starts to listen for route updates some
         // time in the future (when connecting).
         let last_state = match current_network_state(android_context) {
             Ok(initial_state) => initial_state,
@@ -105,12 +105,19 @@ impl RouteManagerImpl {
                     // update the last known NetworkState
                     self.last_state = network_state;
 
-                    if has_routes(self.last_state.as_ref()) {
-                        // notify waiting clients that routes exist
-                        for client in self.waiting_for_routes.drain(..) {
-                            let _ = client.send(());
-                        }
-                    }
+                    // notify waiting clients that routes exist
+                    self.waiting_for_routes = self
+                        .waiting_for_routes
+                        .into_iter()
+                        .filter_map(|(client, expected_routes)| {
+                            if has_routes(self.last_state.as_ref(), expected_routes.clone()) {
+                                let _ = client.send(());
+                                None
+                            } else {
+                                Some((client, expected_routes))
+                            }
+                        })
+                        .collect();
                 }
             }
         }
@@ -126,31 +133,42 @@ impl RouteManagerImpl {
                 let _ = tx.send(());
                 return ControlFlow::Break(());
             }
-            RouteManagerCommand::WaitForRoutes(response_tx) => {
+            RouteManagerCommand::WaitForRoutes(response_tx, expected_routes) => {
                 // check if routes have already been configured on the Android system.
                 // otherwise, register a listener for network state changes.
                 // routes may come in at any moment in the future.
-                if has_routes(self.last_state.as_ref()) {
+                if has_routes(self.last_state.as_ref(), expected_routes.clone()) {
                     let _ = response_tx.send(());
                 } else {
-                    self.waiting_for_routes.push(response_tx);
+                    self.waiting_for_routes.push((response_tx, expected_routes));
                 }
+            }
+            RouteManagerCommand::ClearRouteCache(tx) => {
+                self.clear_route_cache();
+                let _ = tx.send(());
             }
         }
 
         ControlFlow::Continue(())
     }
+
+    fn clear_route_cache(&mut self) {
+        self.last_state = None;
+    }
 }
 
-/// Check whether the [NetworkState] contains any routes.
+/// Check whether the [NetworkState] contains expected routes.
 ///
-/// Since we are the ones telling Android what routes to set, we make the assumption that:
-/// If any routes exist whatsoever, they are the the routes we specified.
-fn has_routes(state: Option<&NetworkState>) -> bool {
+/// Matches the routes reported from Android and checks if all the routes we expect to be there is
+/// present.
+fn has_routes(state: Option<&NetworkState>, expected_routes: Vec<Route>) -> bool {
     let Some(network_state) = state else {
         return false;
     };
-    configured_routes(network_state).is_empty().not()
+
+    let routes = configured_routes(network_state);
+
+    routes.is_superset(&HashSet::from_iter(expected_routes))
 }
 
 fn configured_routes(state: &NetworkState) -> HashSet<Route> {

--- a/talpid-routing/src/unix/mod.rs
+++ b/talpid-routing/src/unix/mod.rs
@@ -37,6 +37,8 @@ mod imp;
 #[path = "android.rs"]
 mod imp;
 
+#[cfg(target_os = "android")]
+use crate::Route;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub use imp::Error as PlatformError;
 
@@ -103,7 +105,8 @@ pub(crate) enum RouteManagerCommand {
 #[cfg(target_os = "android")]
 #[derive(Debug)]
 pub(crate) enum RouteManagerCommand {
-    WaitForRoutes(oneshot::Sender<()>),
+    ClearRouteCache(oneshot::Sender<()>),
+    WaitForRoutes(oneshot::Sender<()>, Vec<Route>),
     Shutdown(oneshot::Sender<()>),
 }
 
@@ -215,7 +218,7 @@ impl RouteManagerHandle {
     /// This function is guaranteed to *not* wait for longer than 2 seconds.
     /// Please, see the implementation of this function for further details.
     #[cfg(target_os = "android")]
-    pub async fn wait_for_routes(&self) -> Result<(), Error> {
+    pub async fn wait_for_routes(&self, expect_routes: Vec<Route>) -> Result<(), Error> {
         use std::time::Duration;
         use tokio::time::timeout;
         /// Maximum time to wait for routes to come up. The expected mean time is low (~200 ms), but
@@ -224,7 +227,7 @@ impl RouteManagerHandle {
 
         let (result_tx, result_rx) = oneshot::channel();
         self.tx
-            .unbounded_send(RouteManagerCommand::WaitForRoutes(result_tx))
+            .unbounded_send(RouteManagerCommand::WaitForRoutes(result_tx, expect_routes))
             .map_err(|_| Error::RouteManagerDown)?;
 
         timeout(WAIT_FOR_ROUTES_TIMEOUT, result_rx)
@@ -244,6 +247,17 @@ impl RouteManagerHandle {
     /// (Android) This is a noop since we don't directly control the routes on Android.
     #[cfg(target_os = "android")]
     pub fn clear_routes(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// (Android) Clear the cached routes
+    #[cfg(target_os = "android")]
+    pub async fn clear_route_cache(&self) -> Result<(), Error> {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.tx
+            .unbounded_send(RouteManagerCommand::ClearRouteCache(result_tx))
+            .map_err(|_| Error::RouteManagerDown)?;
+        let _ = result_rx.await;
         Ok(())
     }
 

--- a/talpid-tunnel/src/tun_provider/mod.rs
+++ b/talpid-tunnel/src/tun_provider/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "android")]
+use crate::tun_provider::imp::VpnServiceConfig;
 use cfg_if::cfg_if;
 use ipnetwork::IpNetwork;
 use std::{
@@ -72,6 +74,16 @@ impl TunConfig {
             servers.push(gateway.into());
         }
         servers
+    }
+
+    /// Routes to configure for the tunnel.
+    #[cfg(target_os = "android")]
+    pub fn real_routes(&self) -> Vec<IpNetwork> {
+        VpnServiceConfig::new(self.clone())
+            .routes
+            .iter()
+            .map(IpNetwork::from)
+            .collect()
     }
 }
 

--- a/talpid-wireguard/src/connectivity/check.rs
+++ b/talpid-wireguard/src/connectivity/check.rs
@@ -184,7 +184,17 @@ impl Check {
                 {
                     return Ok(true);
                 }
-                tokio::time::sleep(Duration::from_millis(20)).await;
+                // Calling get_stats has an unwanted effect of possibly causing segmentation fault,
+                // stacktrace hints towards Garbage Collector failing. The cause has yet not been
+                // determined, it could be because some dangling pointer, bug inside WG-go or
+                // something else. So for now we avoid spamming get_config too much since it lowers
+                // the risk of crash happening.
+                //
+                // The value was previously set to 20 ms, depending on when we called
+                // establish_connectivity, this caused the crash to reliably occur.
+                //
+                // Tracked by DROID-1825 (Investigate GO crash issue with runtime.GC())
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
         };
 


### PR DESCRIPTION
This PR prevent unwanted leaks when invoking establish, it minimizes calls to `VpnService.establish` and waits for android to report back on that new routes have been setup. It also clears DNS servers, to avoid reporting it incorrectly to the daemon when we know they will be invalid because of a call to `close` or `establish`

Fixes DROID-1793

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7703)
<!-- Reviewable:end -->
