### PR TITLE
Fix typo in Wireguard obfuscation info text

### DIFF
--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -2179,8 +2179,10 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr ""
 
+#. Describes what WireGuard obfuscation does, how it works and when
+#. it would be useful to enable it.
 msgctxt "wireguard-settings-view"
-msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connect would be blocked."
+msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr ""
 
 msgctxt "wireguard-settings-view"
@@ -2573,6 +2575,9 @@ msgid "No result for \"%s\", please try a different search"
 msgstr ""
 
 msgid "Not found"
+msgstr ""
+
+msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connect would be blocked."
 msgstr ""
 
 msgid "Overrides active"

--- a/desktop/packages/mullvad-vpn/src/renderer/components/WireguardSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/WireguardSettings.tsx
@@ -245,10 +245,14 @@ function ObfuscationSettings() {
           title={messages.pgettext('wireguard-settings-view', 'Obfuscation')}
           details={
             <ModalMessage>
-              {messages.pgettext(
-                'wireguard-settings-view',
-                'Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connect would be blocked.',
-              )}
+              {
+                // TRANSLATORS: Describes what WireGuard obfuscation does, how it works and when
+                // TRANSLATORS: it would be useful to enable it.
+                messages.pgettext(
+                  'wireguard-settings-view',
+                  'Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked.',
+                )
+              }
             </ModalMessage>
           }
           items={obfuscationTypeItems}


### PR DESCRIPTION
Fixes typo in Wireguard obfuscation info text. Note that the typo is still present in the android app and as such the old translation is still present in the `messages.pot` file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7704)
<!-- Reviewable:end -->
