### PR TITLE
Use regex-lite for mullvad-version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,7 +2698,7 @@ dependencies = [
 name = "mullvad-version"
 version = "0.0.0"
 dependencies = [
- "regex",
+ "regex-lite",
 ]
 
 [[package]]
@@ -3799,6 +3799,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ name = "mullvad-version"
 version = "0.0.0"
 dependencies = [
  "regex-lite",
+ "serde",
 ]
 
 [[package]]

--- a/mullvad-version/Cargo.toml
+++ b/mullvad-version/Cargo.toml
@@ -18,3 +18,4 @@ workspace = true
 
 [dependencies]
 regex-lite = "0.1"
+serde = { workspace = true, optional = true }

--- a/mullvad-version/Cargo.toml
+++ b/mullvad-version/Cargo.toml
@@ -17,4 +17,4 @@ workspace = true
 
 
 [dependencies]
-regex = "1.6.0"
+regex-lite = "0.1"

--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use regex::Regex;
+use regex_lite::Regex;
 
 /// The Mullvad VPN app product version
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));

--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -160,6 +160,27 @@ impl FromStr for Version {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -2141,7 +2141,7 @@ dependencies = [
 name = "mullvad-version"
 version = "0.0.0"
 dependencies = [
- "regex",
+ "regex-lite",
 ]
 
 [[package]]
@@ -2852,6 +2852,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"


### PR DESCRIPTION
* Implement `Serialize` and `Deserialize` for `mullvad_version::Version` (optionally). This will be used for updates (#7583)
* Use `regex-lite` instead of `regex` for `mullvad-version`. This is slower but compiles faster and is smaller than `regex`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7707)
<!-- Reviewable:end -->
