### PR TITLE
Urlsession retry strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "oslog",
  "serde_json",
  "shadowsocks-service",
+ "talpid-future",
  "talpid-tunnel-config-client",
  "talpid-types",
  "tokio",

--- a/ios/MullvadREST/ApiHandlers/MullvadApiRequestFactory.swift
+++ b/ios/MullvadREST/ApiHandlers/MullvadApiRequestFactory.swift
@@ -10,7 +10,7 @@ import MullvadRustRuntime
 import MullvadTypes
 
 enum MullvadApiRequest {
-    case getAddressList
+    case getAddressList(retryStrategy: REST.RetryStrategy)
 }
 
 struct MullvadApiRequestFactory {
@@ -25,8 +25,12 @@ struct MullvadApiRequestFactory {
             let rawPointer = Unmanaged.passRetained(pointerClass).toOpaque()
 
             return switch request {
-            case .getAddressList:
-                MullvadApiCancellable(handle: mullvad_api_get_addresses(apiContext.context, rawPointer))
+            case let .getAddressList(retryStrategy):
+                MullvadApiCancellable(handle: mullvad_api_get_addresses(
+                    apiContext.context,
+                    rawPointer,
+                    retryStrategy.toRustStrategy()
+                ))
             }
         }
     }

--- a/ios/MullvadREST/ApiHandlers/RESTAPIProxy.swift
+++ b/ios/MullvadREST/ApiHandlers/RESTAPIProxy.swift
@@ -66,7 +66,7 @@ extension REST {
             retryStrategy: REST.RetryStrategy,
             completionHandler: @escaping @Sendable ProxyCompletionHandler<[AnyIPEndpoint]>
         ) -> Cancellable {
-            let requestHandler = mullvadApiRequestFactory.makeRequest(.getAddressList)
+            let requestHandler = mullvadApiRequestFactory.makeRequest(.getAddressList(retryStrategy: retryStrategy))
 
             let responseHandler = rustResponseHandler(
                 decoding: [AnyIPEndpoint].self,
@@ -76,7 +76,6 @@ extension REST {
             let networkOperation = MullvadApiNetworkOperation(
                 name: "get-api-addrs",
                 dispatchQueue: dispatchQueue,
-                retryStrategy: retryStrategy,
                 requestHandler: requestHandler,
                 responseDecoder: responseDecoder,
                 responseHandler: responseHandler,

--- a/ios/MullvadREST/RetryStrategy/RetryStrategy.swift
+++ b/ios/MullvadREST/RetryStrategy/RetryStrategy.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MullvadRustRuntime
 import MullvadTypes
 
 extension REST {
@@ -19,6 +20,23 @@ extension REST {
             self.maxRetryCount = maxRetryCount
             self.delay = delay
             self.applyJitter = applyJitter
+        }
+
+        /// The return value of this function *must* be passed to a Rust FFI function that will consume it, otherwise it will leak.
+        public func toRustStrategy() -> SwiftRetryStrategy {
+            switch delay {
+            case .never:
+                return mullvad_api_retry_strategy_never()
+            case let .constant(duration):
+                return mullvad_api_retry_strategy_constant(UInt(maxRetryCount), UInt64(duration.seconds))
+            case let .exponentialBackoff(initial, multiplier, maxDelay):
+                return mullvad_api_retry_strategy_exponential(
+                    UInt(maxRetryCount),
+                    UInt64(initial.seconds),
+                    UInt32(multiplier),
+                    UInt64(maxDelay.seconds)
+                )
+            }
         }
 
         public func makeDelayIterator() -> AnyIterator<Duration> {

--- a/ios/MullvadRustRuntime/MullvadApiResponse.swift
+++ b/ios/MullvadRustRuntime/MullvadApiResponse.swift
@@ -45,10 +45,6 @@ public class MullvadApiResponse {
         }
     }
 
-    public var shouldRetry: Bool {
-        response.should_retry
-    }
-
     public var success: Bool {
         response.success
     }

--- a/ios/MullvadTypes/Duration+Extensions.swift
+++ b/ios/MullvadTypes/Duration+Extensions.swift
@@ -14,6 +14,10 @@ extension Duration {
         return timeInterval.isFinite
     }
 
+    public var seconds: Int64 {
+        return components.seconds
+    }
+
     public var timeInterval: TimeInterval {
         return TimeInterval(components.seconds) + (TimeInterval(components.attoseconds) * 1e-18)
     }

--- a/mullvad-ios/Cargo.toml
+++ b/mullvad-ios/Cargo.toml
@@ -24,6 +24,7 @@ hyper-util = { workspace = true }
 tower = { workspace = true }
 tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 oslog = "0.2"
+talpid-future = { path = "../talpid-future" }
 talpid-types = { path = "../talpid-types" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }

--- a/mullvad-ios/src/api_client/mod.rs
+++ b/mullvad-ios/src/api_client/mod.rs
@@ -10,6 +10,7 @@ mod api;
 mod cancellation;
 mod completion;
 mod response;
+mod retry_strategy;
 
 #[repr(C)]
 pub struct SwiftApiContext(*const ApiContext);

--- a/mullvad-ios/src/api_client/response.rs
+++ b/mullvad-ios/src/api_client/response.rs
@@ -10,8 +10,6 @@ pub struct SwiftMullvadApiResponse {
     error_description: *mut u8,
     server_response_code: *mut u8,
     success: bool,
-    should_retry: bool,
-    retry_after: u64,
 }
 impl SwiftMullvadApiResponse {
     pub async fn with_body(response: Response<hyper::body::Incoming>) -> Result<Self, rest::Error> {
@@ -28,8 +26,6 @@ impl SwiftMullvadApiResponse {
             error_description: null_mut(),
             server_response_code: null_mut(),
             success: true,
-            should_retry: false,
-            retry_after: 0,
         })
     }
 
@@ -44,7 +40,6 @@ impl SwiftMullvadApiResponse {
                 .unwrap_or(null_mut())
         };
 
-        let should_retry = err.is_network_error();
         let error_description = to_cstr_pointer(err.to_string());
         let (status_code, server_response_code): (u16, _) =
             if let rest::Error::ApiError(status_code, error_code) = err {
@@ -60,34 +55,28 @@ impl SwiftMullvadApiResponse {
             error_description,
             server_response_code,
             success: false,
-            should_retry,
-            retry_after: 0,
         }
     }
 
     pub fn cancelled() -> Self {
         Self {
             success: false,
-            should_retry: false,
             error_description: c"Request was cancelled".to_owned().into_raw().cast(),
             body: null_mut(),
             body_size: 0,
             status_code: 0,
             server_response_code: null_mut(),
-            retry_after: 0,
         }
     }
 
     pub fn no_tokio_runtime() -> Self {
         Self {
             success: false,
-            should_retry: false,
             error_description: c"Failed to get Tokio runtime".to_owned().into_raw().cast(),
             body: null_mut(),
             body_size: 0,
             status_code: 0,
             server_response_code: null_mut(),
-            retry_after: 0,
         }
     }
 }

--- a/mullvad-ios/src/api_client/retry_strategy.rs
+++ b/mullvad-ios/src/api_client/retry_strategy.rs
@@ -1,0 +1,99 @@
+use std::time::Duration;
+
+use talpid_future::retry::{ConstantInterval, ExponentialBackoff, Jittered};
+
+#[repr(C)]
+pub struct SwiftRetryStrategy(*mut RetryStrategy);
+
+impl SwiftRetryStrategy {
+    /// # Safety
+    /// The pointer must be a pointing to a valid instance of a `Box<RetryStrategy>`.
+    pub unsafe fn into_rust(self) -> RetryStrategy {
+        *Box::from_raw(self.0)
+    }
+}
+
+pub struct RetryStrategy {
+    delays: RetryDelay,
+    max_retries: usize,
+}
+
+impl RetryStrategy {
+    pub fn delays(self) -> impl Iterator<Item = Duration> + Send {
+        let Self {
+            delays,
+            max_retries,
+        } = self;
+
+        let delays: Box<dyn Iterator<Item = Duration> + Send> = match delays {
+            RetryDelay::Never => Box::new(std::iter::empty()),
+            RetryDelay::Constant(constant_delays) => Box::new(constant_delays.take(max_retries)),
+            RetryDelay::Exponential(exponential_delays) => {
+                Box::new(exponential_delays.take(max_retries))
+            }
+        };
+
+        Jittered::jitter(delays)
+    }
+}
+
+#[repr(C)]
+pub enum RetryDelay {
+    Never,
+    Constant(ConstantInterval),
+    Exponential(ExponentialBackoff),
+}
+
+/// Creates a retry strategy that never retries after failure.
+/// The result needs to be consumed.
+#[no_mangle]
+pub extern "C" fn mullvad_api_retry_strategy_never() -> SwiftRetryStrategy {
+    let retry_strategy = RetryStrategy {
+        delays: RetryDelay::Never,
+        max_retries: 0,
+    };
+
+    let ptr = Box::into_raw(Box::new(retry_strategy));
+    SwiftRetryStrategy(ptr)
+}
+
+/// Creates a retry strategy that retries `max_retries` times with a constant delay of `delay_sec`.
+/// The result needs to be consumed.
+#[no_mangle]
+pub extern "C" fn mullvad_api_retry_strategy_constant(
+    max_retries: usize,
+    delay_sec: u64,
+) -> SwiftRetryStrategy {
+    let interval = Duration::from_secs(delay_sec);
+    let retry_strategy = RetryStrategy {
+        delays: RetryDelay::Constant(ConstantInterval::new(interval, Some(max_retries))),
+        max_retries: 0,
+    };
+    let ptr = Box::into_raw(Box::new(retry_strategy));
+
+    SwiftRetryStrategy(ptr)
+}
+
+/// Creates a retry strategy that retries `max_retries` times with a exponantially increating delay.
+/// The delay will never exceed `max_delay_sec`
+/// The result needs to be consumed.
+#[no_mangle]
+pub extern "C" fn mullvad_api_retry_strategy_exponential(
+    max_retries: usize,
+    initial_sec: u64,
+    factor: u32,
+    max_delay_sec: u64,
+) -> SwiftRetryStrategy {
+    let initial_delay = Duration::from_secs(initial_sec);
+
+    let backoff = ExponentialBackoff::new(initial_delay, factor)
+        .max_delay(Some(Duration::from_secs(max_delay_sec)));
+
+    let retry_strategy = RetryStrategy {
+        delays: RetryDelay::Exponential(backoff),
+        max_retries,
+    };
+
+    let ptr = Box::into_raw(Box::new(retry_strategy));
+    SwiftRetryStrategy(ptr)
+}


### PR DESCRIPTION
Adding the ability to retry api calls to Rust. It uses the same retry strategy as the previous URLSession calls.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7708)
<!-- Reviewable:end -->
