### PR TITLE
Open pinned window on bottom right if tray position is unknown

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/window-controller.ts
+++ b/desktop/packages/mullvad-vpn/src/main/window-controller.ts
@@ -83,8 +83,8 @@ class AttachedToTrayWindowPositioning implements IWindowPositioning {
         break;
 
       case 'none':
-        x = workArea.x + (workArea.width - windowBounds.width) * 0.5;
-        y = workArea.y + (workArea.height - windowBounds.height) * 0.5;
+        x = workArea.x + (workArea.width - windowBounds.width);
+        y = workArea.y + (workArea.height - windowBounds.height);
         break;
     }
 


### PR DESCRIPTION
Platform: Windows

When the taskbar is hidden the tray icon's position can't be established the pinned window is opened in the center of the screen as the fallback position. This PR changes the fallback position to be the lower right of the screen instead of the center of the screen.

Adds feature requested in discussion in #5114.

Note that even though the application can be pinned/unpinned on both Windows and Mac OS, the tray position can only be `'none'` on Windows, as on Mac OS the tray position is always statically set to `'top'` and as such will not be affected by this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7711)
<!-- Reviewable:end -->
