### PR TITLE
Fix users getting stuck on welcome screen

### DIFF
--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -402,6 +402,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
     }
 
     private func presentWelcome(animated: Bool, completion: @escaping (Coordinator) -> Void) {
+        appPreferences.isShownOnboarding = true
+
         let coordinator = WelcomeCoordinator(
             navigationController: navigationContainer,
             storePaymentManager: storePaymentManager,
@@ -410,7 +412,6 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
         )
         coordinator.didFinish = { [weak self] in
             guard let self else { return }
-            appPreferences.isShownOnboarding = true
             router.dismiss(.welcome, animated: false)
             continueFlow(animated: false)
         }


### PR DESCRIPTION
**Why this needs to be done**

Reproduce:

- Create new account
- Purchase time in welcome view
- Close app (do not click Start using the app
- Start app again
- Now the user is back on the Welcome view and needs to purchase more time to continue.

It can be solved by logging out and back in, but this is not a good first experience.

**What needs to be done**

`isShownOnboarding` in AppPreferences should be set to true as soon as the user has been past the Welcome view.

~~Check if the user has time before presenting WelcomeView.~~

Acceptance criteria

Reproducing the above steps should lead the user to the main view instead of back to the welcome view.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7726)
<!-- Reviewable:end -->
