### PR TITLE
Add script which uploads metadata to CDN servers

### DIFF
--- a/desktop/scripts/release/4-make-release
+++ b/desktop/scripts/release/4-make-release
@@ -9,9 +9,14 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
-if [ $# -lt 1 ]; then
+if [ $# -lt 3 ]; then
     echo "Please provide the following arguments:"
-    echo "    $(basename "$0") <product version>"
+    echo "    $(basename "$0") \\"
+    echo "        <product version> \\"
+    echo "        <build server SSH destination> \\"
+    echo "        <metadata server SSH destination>"
+    echo ""
+    echo "Note that the metadata server SSH destination is part of the rsync command executed on the build server and will be checked against the SSH config of build@\$buildserver_host."
     exit 1
 fi
 
@@ -26,6 +31,8 @@ if ! gh auth status > /dev/null; then
 fi
 
 PRODUCT_VERSION=$1
+BUILDSERVER_HOST=$2
+CDN_HOST=$3
 
 ARTIFACT_DIR="./artifacts"
 URL_BASE="https://releases.mullvad.net/desktop/releases"
@@ -62,6 +69,7 @@ function download_and_verify {
 function publish_metadata {
     local platforms
     platforms=(windows macos linux)
+    local signed_dir="signed/"
 
     rm -rf currently_published/
 
@@ -70,7 +78,7 @@ function publish_metadata {
     echo ""
 
     echo ">>> Backing up released data"
-    cp -r signed/ currently_published/
+    cp -r $signed_dir currently_published/
     echo ""
 
     echo ">>> Replacing work/ directory with latest published data"
@@ -90,11 +98,11 @@ function publish_metadata {
     echo ""
 
     echo ">>> New metadata including $$PRODUCT_VERSION"
-    git diff --no-index -- currently_published/ signed/
+    git diff --no-index -- currently_published/ $signed_dir
     echo ""
 
     read -rp "Press enter to upload if the diff looks good "
-    # TODO: push metadata
+    ./publish-metadata-to-api $signed_dir "$BUILDSERVER_HOST" "$CDN_HOST"
 }
 
 function publish_release {

--- a/desktop/scripts/release/4-make-release
+++ b/desktop/scripts/release/4-make-release
@@ -98,7 +98,7 @@ function publish_metadata {
     echo ""
 
     echo ">>> New metadata including $$PRODUCT_VERSION"
-    git diff --no-index -- currently_published/ $signed_dir
+    git --no-pager diff --no-index -- currently_published/ $signed_dir || true
     echo ""
 
     read -rp "Press enter to upload if the diff looks good "

--- a/desktop/scripts/release/publish-metadata-to-api
+++ b/desktop/scripts/release/publish-metadata-to-api
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ $# -lt 3 ]; then
+    echo "Please provide the following arguments:"
+    echo "    $(basename "$0") \\"
+    echo "        <metadata directory> \\"
+    echo "        <build server SSH destination> \\"
+    echo "        <metadata server SSH destination>"
+    echo ""
+    echo "Note that the metadata server SSH destination is part of the rsync command executed on the build server and will be checked against the SSH config of build@\$buildserver_host."
+    exit 1
+fi
+
+LOCAL_METADATA_DIR=$1
+BUILD_SERVER_HOST=$2
+METADATA_SERVER_HOST=$3
+
+BUILDSERVER_TMP_DIR="/tmp/desktop-upload-release"
+BUILDSERVER_METADATA_DIR="$BUILDSERVER_TMP_DIR/metadata"
+METADATA_SERVER_METADATA_DIR="desktop/metadata"
+
+BUILDSERVER_BUILDUSER="build"
+
+RSYNC_OPTIONS=(-av --mkpath)
+METADATA_SERVER_RSYNC_OPTIONS=("${RSYNC_OPTIONS[@]}" '--rsh="ssh -p 1122"')
+
+function run_on_build_server {
+  # shellcheck disable=SC2029
+  ssh "$BUILD_SERVER_HOST" "$@"
+}
+
+function run_on_build_server_as_build_user {
+  run_on_build_server sudo -i -u "$BUILDSERVER_BUILDUSER" "$@"
+}
+
+function local_rsync {
+  rsync "${RSYNC_OPTIONS[@]}" "$@"
+}
+
+function buildserver_rsync {
+  run_on_build_server_as_build_user rsync "${METADATA_SERVER_RSYNC_OPTIONS[@]}" "$@"
+}
+
+function remove_buildserver_tmp_dir {
+  run_on_build_server rm -rf $BUILDSERVER_METADATA_DIR
+}
+
+# Clean up previous metadata dir on build server in case this failed the last time this script ran
+remove_buildserver_tmp_dir
+
+# Send the local metadata dir to the build server
+local_rsync "$LOCAL_METADATA_DIR" "$BUILD_SERVER_HOST":$BUILDSERVER_METADATA_DIR
+
+# Send the metadata on the buildserver to the cdn server
+buildserver_rsync $BUILDSERVER_METADATA_DIR "$METADATA_SERVER_HOST":"$(dirname "$METADATA_SERVER_METADATA_DIR")"
+
+# Remove intermediate tmp dir when done
+remove_buildserver_tmp_dir


### PR DESCRIPTION
This PR adds a script which uploads metadata to the CDN servers via the build server. It needs to be integrated in `desktop/scripts/release/4-make-release` and might need to upload artifacts as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7736)
<!-- Reviewable:end -->
