### PR TITLE
Fix `desktop-e2e.yml` workflow

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -267,10 +267,6 @@ jobs:
         run: |
           chmod +x ${{ github.workspace }}/bin/*
         shell: bash
-      - name: Check binaries
-        run: |
-          ls -la ${{ github.workspace }}/bin
-        shell: bash
       - name: Download App
         uses: actions/download-artifact@v4
         if: ${{ needs.build-linux-app.result == 'success' }}
@@ -483,9 +479,6 @@ jobs:
       - name: chmod binaries
         run: |
           chmod +x ${{ github.workspace }}/bin/*
-      - name: Check binaries
-        run: |
-          ls -la ${{ github.workspace }}/bin
         shell: bash
       - name: Generate test result matrix
         shell: bash -ieo pipefail {0}

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -110,6 +110,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.prepare-linux.outputs.container_image }}
+    if: |
+      !cancelled() &&
+      needs.prepare-matrices.outputs.linux_matrix != '[]' &&
+      needs.prepare-matrices.outputs.linux_matrix != ''
     continue-on-error: true
     steps:
       # Fix for HOME path overridden by GH runners when building in containers, see:
@@ -155,6 +159,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.prepare-linux.outputs.container_image }}
+    if: |
+      !cancelled() &&
+      needs.prepare-matrices.outputs.linux_matrix != '[]' &&
+      needs.prepare-matrices.outputs.linux_matrix != ''
     steps:
       # Fix for HOME path overridden by GH runners when building in containers, see:
       # https://github.com/actions/runner/issues/863
@@ -181,6 +189,10 @@ jobs:
     needs: prepare-linux
     # Note: libssl-dev is installed on the test server, so build test-manager there for the sake of simplicity
     runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
+    if: |
+      !cancelled() &&
+      needs.prepare-matrices.outputs.linux_matrix != '[]' &&
+      needs.prepare-matrices.outputs.linux_matrix != ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -204,6 +216,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.prepare-linux.outputs.container_image }}
+    if: |
+      !cancelled() &&
+      needs.prepare-matrices.outputs.linux_matrix != '[]' &&
+      needs.prepare-matrices.outputs.linux_matrix != ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -253,7 +253,6 @@ jobs:
           path: ${{ github.workspace }}/bin
       - name: Download mullvad-version
         uses: actions/download-artifact@v4
-        if: ${{ needs.build-test-manager-linux.result == 'success' }}
         with:
           name: mullvad-version-linux
           path: ${{ github.workspace }}/bin

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -379,7 +379,7 @@ jobs:
         run: |
           git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
-          ./test/scripts/ci-runtests.sh ${{ matrix.os }}
+          ./test/scripts/run/ci.sh ${{ matrix.os }}
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: '!cancelled()'
@@ -453,7 +453,7 @@ jobs:
         run: |
           git fetch --tags --prune-tags --force
           export TEST_FILTERS="${{ github.event.inputs.tests }}"
-          ./test/scripts/ci-runtests.sh ${{ matrix.os }}
+          ./test/scripts/run/ci.sh ${{ matrix.os }}
       - name: Upload test report
         uses: actions/upload-artifact@v4
         if: '!cancelled()'

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -89,9 +89,6 @@ jobs:
   prepare-linux:
     name: Prepare Linux build container
     needs: prepare-matrices
-    if: |
-      needs.prepare-matrices.outputs.linux_matrix != '[]' &&
-      !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/test/scripts/build/runner-image.sh
+++ b/test/scripts/build/runner-image.sh
@@ -23,8 +23,8 @@ echo "************************************************************"
 echo "* Preparing test runner image: $TARGET"
 echo "************************************************************"
 
-mkdir -p "${TEST_FRAMEWORK_REPO}/testrunner-images"
-TEST_RUNNER_IMAGE_PATH="${TEST_FRAMEWORK_REPO}/testrunner-images/${TEST_RUNNER_IMAGE_FILENAME}"
+mkdir -p "${TEST_FRAMEWORK_ROOT}/testrunner-images"
+TEST_RUNNER_IMAGE_PATH="${TEST_FRAMEWORK_ROOT}/testrunner-images/${TEST_RUNNER_IMAGE_FILENAME}"
 
 case $TARGET in
 

--- a/test/scripts/utils/lib.sh
+++ b/test/scripts/utils/lib.sh
@@ -230,8 +230,8 @@ function run_tests_for_os {
         test_manager="${TEST_DIST_DIR%/}/test-manager"
         runner_dir_flag=("--runner-dir" "$TEST_DIST_DIR")
     else
-        # Assume test-manager is in path.
-        test_manager="$(which test-manager)"
+        # Build & run test-manager
+        test_manager="cargo run --bin test-manager"
         runner_dir_flag=()
     fi
 

--- a/test/test-by-version.sh
+++ b/test/test-by-version.sh
@@ -59,6 +59,9 @@ echo "**********************************"
 echo "* Downloading app packages"
 echo "**********************************"
 
+# shellcheck source=test/scripts/utils/download.sh
+source "scripts/utils/download.sh"
+
 download_app_package "$APP_VERSION" "$TEST_OS"
 download_e2e_executable "$APP_VERSION" "$TEST_OS"
 


### PR DESCRIPTION
This PR fixes some regressions introduced in https://github.com/mullvad/mullvadvpn-app/pull/7674:

- Windows and macOS invoking the wrong script
- The Linux container used in some workflow steps was not always available/prepared
- Build step was gated on the wrong condition for some binaries
- `test-manager` was wrongly assumed to be in `$PATH`
- Test binaries (for linux) were always built, regardless if the tested platform was Linux or not

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7744)
<!-- Reviewable:end -->
