### PR TITLE
Add `mullvad-problem-report` to default workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
 # This is set to a minimal set of packages to speed up the build process and avoid building
 # crates which might not compile without additional input, such as the `windows-installer` crate.
 # To build or test everything, add `--workspace` to your cargo commands.
-default-members = ["mullvad-cli", "mullvad-daemon", "mullvad-version"]
+default-members = ["mullvad-cli", "mullvad-daemon", "mullvad-version", "mullvad-problem-report"]
 
 # Keep all lints in sync with `test/Cargo.toml`
 [workspace.lints.rust]


### PR DESCRIPTION
When connecting, a firewall exception is made to the current relay for `mullvad-problem-report.exe`. The daemon expects this binary to be located in the same folder as itself, else it fails and enters the error state. As of 379e4539120dd4aebdc30d7195f9b61cee09b24b, `mullvad-problem-report` is no longer built by default (when running e.g. `cargo build`), so running the local build of the daemon from the target folder will fail unless the problem report tool is manually built prior. We should add it to the workspace default members so it automatically builds again, to improve the developer experience.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7745)
<!-- Reviewable:end -->
