### PR TITLE
Move DAITA warning to first page & update text

### DIFF
--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -2127,7 +2127,7 @@ msgid "%(wireguard)s settings"
 msgstr ""
 
 msgctxt "wireguard-settings-view"
-msgid "Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with %(wireguard)s."
+msgid "Attention: This increases network traffic and will also negatively affect speed, latency, and battery usage. Use with caution on limited plans. Only works with %(wireguard)s."
 msgstr ""
 
 msgctxt "wireguard-settings-view"

--- a/desktop/packages/mullvad-vpn/src/renderer/components/DaitaSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/DaitaSettings.tsx
@@ -73,6 +73,10 @@ export default function DaitaSettings() {
                         <StyledHeaderSubTitle>
                           {sprintf(
                             messages.pgettext(
+                              // TRANSLATORS: Information to the user what the DAITA setting does.
+                              // TRANSLATORS: Available placeholders:
+                              // TRANSLATORS: %(daita)s - Will be replaced with DAITA
+                              // TRANSLATORS: %(daitaFull)s - Will be replaced with Defence against AI-guided Traffic Analysis
                               'wireguard-settings-view',
                               '%(daita)s (%(daitaFull)s) hides patterns in your encrypted VPN traffic.',
                             ),
@@ -81,6 +85,7 @@ export default function DaitaSettings() {
                         </StyledHeaderSubTitle>
                         <StyledHeaderSubTitle>
                           {messages.pgettext(
+                            // TRANSLATORS: Information to the user on the background why the DAITA setting exists.
                             'wireguard-settings-view',
                             'By using sophisticated AI it’s possible to analyze the traffic of data packets going in and out of your device (even if the traffic is encrypted).',
                           )}
@@ -95,6 +100,7 @@ export default function DaitaSettings() {
                         <StyledHeaderSubTitle>
                           {sprintf(
                             messages.pgettext(
+                              // TRANSLATORS: Information to the user on the background why the DAITA setting exists.
                               'wireguard-settings-view',
                               'If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating.',
                             ),
@@ -104,6 +110,9 @@ export default function DaitaSettings() {
                         <StyledHeaderSubTitle>
                           {sprintf(
                             messages.pgettext(
+                              // TRANSLATORS: Information to the user what the DAITA setting does.
+                              // TRANSLATORS: Available placeholders:
+                              // TRANSLATORS: %(daita)s - Will be replaced with DAITA
                               'wireguard-settings-view',
                               '%(daita)s does this by carefully adding network noise and making all network packets the same size.',
                             ),
@@ -113,6 +122,12 @@ export default function DaitaSettings() {
                         <StyledHeaderSubTitle>
                           {sprintf(
                             messages.pgettext(
+                              // TRANSLATORS: Information to the user that DAITA is not available
+                              // TRANSLATORS: on all servers, however in the background the multihop
+                              // TRANSLATORS: feature is used automatically which enables the use
+                              // TRANSLATORS: of DAITA with any server.
+                              // TRANSLATORS: Available placeholders:
+                              // TRANSLATORS: %(daita)s - Will be replaced with DAITA
                               'wireguard-settings-view',
                               'Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server.',
                             ),

--- a/desktop/packages/mullvad-vpn/src/renderer/components/DaitaSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/DaitaSettings.tsx
@@ -62,6 +62,15 @@ export default function DaitaSettings() {
                           {sprintf(
                             messages.pgettext(
                               'wireguard-settings-view',
+                              'Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with %(wireguard)s.',
+                            ),
+                            { wireguard: strings.wireguard },
+                          )}
+                        </StyledHeaderSubTitle>
+                        <StyledHeaderSubTitle>
+                          {sprintf(
+                            messages.pgettext(
+                              'wireguard-settings-view',
                               '%(daita)s (%(daitaFull)s) hides patterns in your encrypted VPN traffic.',
                             ),
                             { daita: strings.daita, daitaFull: strings.daitaFull },
@@ -73,6 +82,13 @@ export default function DaitaSettings() {
                             'By using sophisticated AI it’s possible to analyze the traffic of data packets going in and out of your device (even if the traffic is encrypted).',
                           )}
                         </StyledHeaderSubTitle>
+                      </Flex>
+                    </React.Fragment>,
+                    <React.Fragment key="with-daita">
+                      <StyledIllustration
+                        src={`${PATH_PREFIX}assets/images/daita-on-illustration.svg`}
+                      />
+                      <Flex $flexDirection="column" $gap={Spacings.spacing5}>
                         <StyledHeaderSubTitle>
                           {sprintf(
                             messages.pgettext(
@@ -82,13 +98,6 @@ export default function DaitaSettings() {
                             { daita: strings.daita },
                           )}
                         </StyledHeaderSubTitle>
-                      </Flex>
-                    </React.Fragment>,
-                    <React.Fragment key="with-daita">
-                      <StyledIllustration
-                        src={`${PATH_PREFIX}assets/images/daita-on-illustration.svg`}
-                      />
-                      <Flex $flexDirection="column" $gap={Spacings.spacing5}>
                         <StyledHeaderSubTitle>
                           {sprintf(
                             messages.pgettext(
@@ -105,15 +114,6 @@ export default function DaitaSettings() {
                               'Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server.',
                             ),
                             { daita: strings.daita },
-                          )}
-                        </StyledHeaderSubTitle>
-                        <StyledHeaderSubTitle>
-                          {sprintf(
-                            messages.pgettext(
-                              'wireguard-settings-view',
-                              'Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with %(wireguard)s.',
-                            ),
-                            { wireguard: strings.wireguard },
                           )}
                         </StyledHeaderSubTitle>
                       </Flex>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/DaitaSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/DaitaSettings.tsx
@@ -61,8 +61,11 @@ export default function DaitaSettings() {
                         <StyledHeaderSubTitle>
                           {sprintf(
                             messages.pgettext(
+                              // TRANSLATORS: Information to the user that with this setting enabled
+                              // TRANSLATORS: their network and device's battery life will be
+                              // TRANSLATORS: affected negatively.
                               'wireguard-settings-view',
-                              'Attention: Be cautious if you have a limited data plan as this feature will increase your network traffic. This feature can only be used with %(wireguard)s.',
+                              'Attention: This increases network traffic and will also negatively affect speed, latency, and battery usage. Use with caution on limited plans. Only works with %(wireguard)s.',
                             ),
                             { wireguard: strings.wireguard },
                           )}


### PR DESCRIPTION
DAITA warning has been moved to the top of the first carousel page in the DAITA submenu. This change is due to users not noticing that DAITA increases network usage and on limited plans one might very quickly reach the plan's cap.

The DAITA warning has also been updated to make it clear that network speed, latency and the device's battery life will be affected when the setting is enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7746)
<!-- Reviewable:end -->
