### PR TITLE
Stop overwriting daita params with 

### DIFF
--- a/ios/PacketTunnel/PostQuantum/MultiHopEphemeralPeerExchanger.swift
+++ b/ios/PacketTunnel/PostQuantum/MultiHopEphemeralPeerExchanger.swift
@@ -71,8 +71,8 @@ final class MultiHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
         _ ephemeralPeerPrivateKey: PrivateKey,
         daitaParameters: DaitaV2Parameters?
     ) async {
-        self.daitaParameters = daitaParameters
         if state == .negotiatingWithEntry {
+            self.daitaParameters = daitaParameters
             entryPeerKey = EphemeralPeerKey(ephemeralKey: ephemeralPeerPrivateKey)
             await negotiateBetweenEntryAndExit()
         } else if state == .negotiatingBetweenEntryAndExit {
@@ -86,8 +86,8 @@ final class MultiHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
         ephemeralKey: PrivateKey,
         daitaParameters: DaitaV2Parameters?
     ) async {
-        self.daitaParameters = daitaParameters
         if state == .negotiatingWithEntry {
+            self.daitaParameters = daitaParameters
             entryPeerKey = EphemeralPeerKey(preSharedKey: preSharedKey, ephemeralKey: ephemeralKey)
             await negotiateBetweenEntryAndExit()
         } else if state == .negotiatingBetweenEntryAndExit {
@@ -130,7 +130,7 @@ final class MultiHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
                 configuration: EphemeralPeerConfiguration(
                     privateKey: devicePrivateKey,
                     allowedIPs: defaultGatewayAddressRange,
-                    daitaParameters: self.daitaParameters
+                    daitaParameters: nil
                 )
             )
         ))
@@ -160,7 +160,7 @@ final class MultiHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
                     privateKey: exitPeerKey.ephemeralKey,
                     preSharedKey: exitPeerKey.preSharedKey,
                     allowedIPs: allTrafficRange,
-                    daitaParameters: self.daitaParameters
+                    daitaParameters: nil
                 )
             )
         ))


### PR DESCRIPTION
Our multihop peer exchanger was receiving 2 private keys, first with daita paremeters, and then 2nd time around with `nil` daita parameters. This then resulted in the peer exchanging pipeline overwriting the stored DAITA parameters. This changeset fixes that and adds a test to see that the daita parameters persist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7747)
<!-- Reviewable:end -->
