### PR TITLE
Add `waitForIdle` to device list test

### DIFF
--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
@@ -52,6 +52,9 @@ class TooManyDevicesMockApiTest : MockApiTest() {
         device.findObjectWithTimeout(By.text("Continue with login").hasParent(By.enabled((false))))
 
         // Act
+        // Wait until the application is idle to avoid skipping input events that are filtered out
+        // depending on lifecycle state (dropUnlessResumed).
+        device.waitForIdle()
         app.attemptToRemoveDevice()
 
         // Assert that a device was removed


### PR DESCRIPTION
Wait until the application is idle to avoid skipping input events in the device list screen test that are filtered out depending on lifecycle state (`dropUnlessResumed`).

It's unclear whether this will help so the goal here is to merge it and observe future test runs due to how rare the issue has been.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7748)
<!-- Reviewable:end -->
