### PR TITLE
Improve browser download script

### DIFF
--- a/ci/linux-repository-builder/build-linux-repositories.sh
+++ b/ci/linux-repository-builder/build-linux-repositories.sh
@@ -135,6 +135,10 @@ function rsync_repo {
     local remote_repo_dir=$2
 
     echo "Syncing to $repository_server_upload_domain:$remote_repo_dir"
+    # We have an issue where the rsync can fail due to the remote dir being locked (only one rsync at a time allowed)
+    # We suspect this is because of too fast subsequent invocations of rsync to the same target dir. With a hacky sleep
+    # we hope to avoid this issue for now.
+    sleep 10
     rsync -av --delete --mkpath --rsh='ssh -p 1122' \
         "$local_repo_dir"/ \
         build@"$repository_server_upload_domain":"$remote_repo_dir"

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -43,7 +43,7 @@ function main() {
     fi
 
     echo "[#] Verifying $PACKAGE_FILENAME signature"
-    if ! gpg --verify "$PACKAGE_FILENAME".asc; then
+    if ! gpg --verify "$PACKAGE_FILENAME".asc "$PACKAGE_FILENAME"; then
         echo "[!] Failed to verify signature"
         rm "$PACKAGE_FILENAME" "$PACKAGE_FILENAME.asc"
         exit 1

--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -39,6 +39,7 @@ function main() {
     echo "[#] Downloading $PACKAGE_FILENAME.asc"
     if ! wget --quiet "$SIGNATURE_URL"; then
         echo "[!] Failed to download $SIGNATURE_URL"
+        rm "$PACKAGE_FILENAME"
         exit 1
     fi
 
@@ -63,8 +64,6 @@ function main() {
         return
     fi
 
-    echo "[#] $PACKAGE_FILENAME has changed"
-    cp "$PACKAGE_FILENAME" "$WORKDIR/"
     # Leaving a file in `$TMP_DIR` is used as an indicator further down that something changed
 }
 
@@ -104,7 +103,13 @@ if [[ -z "$(ls -A "$TMP_DIR")" ]]; then
     exit
 fi
 
+echo ""
 echo "[#] New browser build(s) exist"
+for package in *; do
+    echo "[#] $package has changed"
+    mv "$package" "$WORKDIR/"
+done
+
 for repository in "${REPOSITORIES[@]}"; do
     inbox_dir="$NOTIFY_DIR/$repository"
 


### PR DESCRIPTION
Please review per commit. We hit two issues with the update of `mullvad-browser` yesterday.

The first issue was that `download-mullvad-browser.sh` first successfully downloaded the stable browser, saw that it was different, moved it into `WORKDIR/`. Then it went on to download the alpha. But downloading the alpha failed, so the script exited. On the subsequent run, 15 minutes later, the script could not see any update to the browser, so it skipped notifying the repository service altogether. This is because the script had already copied the new stable browser release into `WORKDIR/`, so on subsequent runs, the service saw that the browser was just the same. This fix saves the move of the browsers into `WORKDIR/` until the very end, after all downloading and verification has completed.

This also adds a hack to the repository generation script. I saw that it quite frequently exited with this error:

```
Mar 05 13:32:23 app-build-linux3 build-linux-repositories.sh[1716028]: Syncing to cdn.mullvad.net:deb/stable
Mar 05 13:32:23 app-build-linux3 build-linux-repositories.sh[1718307]: /usr/bin/rrsync error: Another instance of rrsync is already accessing this directory.
Mar 05 13:32:23 app-build-linux3 build-linux-repositories.sh[1718306]: rsync: connection unexpectedly closed (0 bytes received so far) [sender]
Mar 05 13:32:23 app-build-linux3 build-linux-repositories.sh[1718306]: rsync error: error in rsync protocol data stream (code 12) at io.c(231) [sender=3.2.7]
```

We don't run rsync in parallel anywhere in this script. So my suspicion is that the remote lock is not released immediately, but held for a while. So sleeping before all rsync invocations should hopefully mitigate this :see_no_evil: 

It could also be that the remote lock is global and we collide with our other artifact upload scripts :shrug: But since I always saw the failure occur on the same upload dir (`deb/stable`) this is not my primary suspect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7760)
<!-- Reviewable:end -->
