### PR TITLE
Fix tunnel protocol setting migration

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -442,7 +442,7 @@ mod windows {
 
 #[cfg(test)]
 mod test {
-    use mullvad_types::settings::Settings;
+    use mullvad_types::settings::{Settings, CURRENT_SETTINGS_VERSION};
 
     use crate::migrations::migrate_settings;
 
@@ -458,5 +458,15 @@ mod test {
             .unwrap();
 
         assert_eq!(default_settings, migrated_settings);
+    }
+
+    /// Ensure that the settings version is correct after running all migration code
+    #[tokio::test]
+    async fn test_all_migrations() {
+        const V1_SETTINGS: &str = include_str!("v1_settings.json");
+        let mut settings = serde_json::from_str(V1_SETTINGS).unwrap();
+        migrate_settings(None, &mut settings).await.unwrap();
+        let deserialized: Settings = serde_json::from_value(settings).unwrap();
+        assert_eq!(deserialized.settings_version, CURRENT_SETTINGS_VERSION);
     }
 }

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -46,6 +46,7 @@ use tokio::{
 mod account_history;
 mod device;
 mod v1;
+mod v10;
 mod v2;
 mod v3;
 mod v4;
@@ -206,6 +207,8 @@ async fn migrate_settings(
             settings: directories.settings_dir,
         }),
     )?;
+
+    v10::migrate(settings)?;
 
     Ok(migration_data)
 }

--- a/mullvad-daemon/src/migrations/v1.rs
+++ b/mullvad-daemon/src/migrations/v1.rs
@@ -118,46 +118,7 @@ mod test {
 }
 "#;
 
-    const V1_SETTINGS: &str = r#"
-{
-  "account_token": "1234",
-  "relay_settings": {
-    "normal": {
-      "location": {
-        "only": {
-          "country": "se"
-        }
-      },
-      "tunnel": {
-        "only": {
-          "openvpn": {
-            "port": {
-              "only": 53
-            },
-            "protocol": {
-              "only": "udp"
-            }
-          }
-        }
-      }
-    }
-  },
-  "allow_lan": true,
-  "block_when_disconnected": false,
-  "auto_connect": false,
-  "tunnel_options": {
-    "openvpn": {
-      "mssfix": null
-    },
-    "wireguard": {
-      "mtu": null
-    },
-    "generic": {
-      "enable_ipv6": false
-    }
-  }
-}
-"#;
+    const V1_SETTINGS: &str = include_str!("v1_settings.json");
 
     const V1_SETTINGS_2019V3: &str = r#"
 {

--- a/mullvad-daemon/src/migrations/v10.rs
+++ b/mullvad-daemon/src/migrations/v10.rs
@@ -1,0 +1,554 @@
+use super::{Error, Result};
+use mullvad_types::settings::SettingsVersion;
+use talpid_types::net::TunnelType;
+
+/// Automatic tunnel protocol has been removed. If the tunnel protocol is set to `any`, it will be
+/// migrated to `wireguard`, unless the location is an openvpn relay, in which case it will be
+/// migrated to `openvpn`.
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !(version(settings) == Some(SettingsVersion::V10)) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to v11");
+
+    migrate_tunnel_type(settings)?;
+
+    settings["settings_version"] = serde_json::json!(SettingsVersion::V11);
+
+    Ok(())
+}
+
+fn version(settings: &serde_json::Value) -> Option<SettingsVersion> {
+    settings
+        .get("settings_version")
+        .and_then(|version| serde_json::from_value(version.clone()).ok())
+}
+
+fn relay_settings(settings: &mut serde_json::Value) -> Option<&mut serde_json::Value> {
+    settings.get_mut("relay_settings")?.get_mut("normal")
+}
+
+fn migrate_tunnel_type(settings: &mut serde_json::Value) -> Result<()> {
+    let Some(ref mut normal) = relay_settings(settings) else {
+        return Ok(());
+    };
+    match normal.get_mut("tunnel_protocol") {
+        // Migrate tunnel protocol "any"
+        Some(serde_json::Value::String(s)) if s == "any" => {
+            // If openvpn is selected, migrate to openvpn tunnel type
+            // Otherwise, select wireguard
+            let hostname = normal
+                .get_mut("location")
+                .and_then(|location| location.get_mut("only"))
+                .and_then(|only| only.get_mut("location"))
+                .and_then(|only| only.get_mut("hostname").cloned());
+
+            let protocol = if let Some(serde_json::Value::String(s)) = hostname {
+                if s.split('-').any(|token| token == "ovpn") {
+                    TunnelType::OpenVpn
+                } else {
+                    TunnelType::Wireguard
+                }
+            } else {
+                TunnelType::Wireguard
+            };
+
+            normal["tunnel_protocol"] = serde_json::json!(protocol);
+        }
+        // Migrate '"only": { "tunnel_protocol": $tunnel_protocol }'
+        // to '"tunnel_protocol": $tunnel_protocol'
+        Some(serde_json::Value::Object(ref mut constraint)) => {
+            if let Some(tunnel_type) = constraint.get("only") {
+                let tunnel_type: TunnelType = serde_json::from_value(tunnel_type.clone())
+                    .map_err(|_| Error::InvalidSettingsContent)?;
+                normal["tunnel_protocol"] = serde_json::json!(tunnel_type);
+            } else {
+                return Err(Error::InvalidSettingsContent);
+            }
+        }
+        Some(_) => {
+            return Err(Error::InvalidSettingsContent);
+        }
+        // Unexpected result. Do nothing.
+        None => (),
+    }
+    Ok(())
+}
+#[cfg(test)]
+mod test {
+    use mullvad_types::settings::SettingsVersion;
+
+    use super::{migrate, version};
+
+    /// Tunnel protocol "any" is migrated to wireguard
+    #[test]
+    fn test_v10_to_v11_migration() {
+        // TODO: Also test the case where the location is not an openvpn relay and the tunnel type
+        // is any
+        let mut old_settings = serde_json::from_str(V10_SETTINGS).unwrap();
+
+        assert_eq!(version(&old_settings), Some(SettingsVersion::V10));
+        migrate(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = serde_json::from_str(V11_SETTINGS).unwrap();
+        assert_eq!(version(&new_settings), Some(SettingsVersion::V11));
+
+        eprintln!(
+            "old_settings: {}",
+            serde_json::to_string_pretty(&old_settings).unwrap()
+        );
+        eprintln!(
+            "new_settings: {}",
+            serde_json::to_string_pretty(&new_settings).unwrap()
+        );
+        assert_eq!(&old_settings, &new_settings);
+    }
+
+    /// Tunnel protocol "any" is migrated to openvpn, since the location is an openvpn relay
+    #[test]
+    fn test_v10_to_v11_migration_openvpn_location() {
+        // TODO: Also test the case where the location is not an openvpn relay and the tunnel type
+        // is any
+        let mut old_settings = serde_json::from_str(V10_SETTINGS_OPENVPN_LOCATION).unwrap();
+
+        assert_eq!(version(&old_settings), Some(SettingsVersion::V10));
+        migrate(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value =
+            serde_json::from_str(V11_SETTINGS_OPENVPN_LOCATION).unwrap();
+        assert_eq!(version(&new_settings), Some(SettingsVersion::V11));
+
+        eprintln!(
+            "old_settings: {}",
+            serde_json::to_string_pretty(&old_settings).unwrap()
+        );
+        eprintln!(
+            "new_settings: {}",
+            serde_json::to_string_pretty(&new_settings).unwrap()
+        );
+        assert_eq!(&old_settings, &new_settings);
+    }
+
+    /// Tunnel protocol is set to any, but the location is not an openvpn relay
+    pub const V10_SETTINGS: &str = r#"
+        {
+          "relay_settings": {
+            "normal": {
+              "location": {
+                "only": {
+                  "location": {
+                    "country": "se"
+                  }
+                }
+              },
+              "providers": "any",
+              "ownership": "any",
+              "tunnel_protocol": "any",
+              "wireguard_constraints": {
+                "port": "any",
+                "ip_version": "any",
+                "use_multihop": false,
+                "entry_location": {
+                  "only": {
+                    "location": {
+                      "country": "se"
+                    }
+                  }
+                }
+              },
+              "openvpn_constraints": {
+                "port": "any"
+              }
+            }
+          },
+          "bridge_settings": {
+            "bridge_type": "normal",
+            "normal": {
+              "location": "any",
+              "providers": "any",
+              "ownership": "any"
+            },
+            "custom": null
+          },
+          "obfuscation_settings": {
+            "selected_obfuscation": "auto",
+            "udp2tcp": {
+              "port": "any"
+            }
+          },
+          "bridge_state": "auto",
+          "custom_lists": {
+            "custom_lists": []
+          },
+          "api_access_methods": {
+            "direct": {
+              "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+              "name": "Direct",
+              "enabled": true,
+              "access_method": {
+                "built_in": "direct"
+              }
+            },
+            "mullvad_bridges": {
+              "id": "92135711-534d-4950-963d-93e446a792e4",
+              "name": "Mullvad Bridges",
+              "enabled": true,
+              "access_method": {
+                "built_in": "bridge"
+              }
+            },
+            "custom": []
+          },
+          "allow_lan": false,
+          "block_when_disconnected": false,
+          "auto_connect": false,
+          "tunnel_options": {
+            "openvpn": {
+              "mssfix": null
+            },
+            "wireguard": {
+              "mtu": null,
+              "quantum_resistant": "auto",
+              "rotation_interval": null
+            },
+            "generic": {
+              "enable_ipv6": false
+            },
+            "dns_options": {
+              "state": "default",
+              "default_options": {
+                "block_ads": false,
+                "block_trackers": false,
+                "block_malware": false,
+                "block_adult_content": false,
+                "block_gambling": false,
+                "block_social_media": false
+              },
+              "custom_options": {
+                "addresses": []
+              }
+            }
+          },
+          "relay_overrides": [],
+          "show_beta_releases": true,
+          "settings_version": 10
+        }
+        "#;
+
+    /// Tunnel protocol is migrated to wireguard
+    pub const V11_SETTINGS: &str = r#"
+        {
+          "relay_settings": {
+            "normal": {
+              "location": {
+                "only": {
+                  "location": {
+                    "country": "se"
+                  }
+                }
+              },
+              "providers": "any",
+              "ownership": "any",
+              "tunnel_protocol": "wireguard",
+              "wireguard_constraints": {
+                "port": "any",
+                "ip_version": "any",
+                "use_multihop": false,
+                "entry_location": {
+                  "only": {
+                    "location": {
+                      "country": "se"
+                    }
+                  }
+                }
+              },
+              "openvpn_constraints": {
+                "port": "any"
+              }
+            }
+          },
+          "bridge_settings": {
+            "bridge_type": "normal",
+            "normal": {
+              "location": "any",
+              "providers": "any",
+              "ownership": "any"
+            },
+            "custom": null
+          },
+          "obfuscation_settings": {
+            "selected_obfuscation": "auto",
+            "udp2tcp": {
+              "port": "any"
+            }
+          },
+          "bridge_state": "auto",
+          "custom_lists": {
+            "custom_lists": []
+          },
+          "api_access_methods": {
+            "direct": {
+              "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+              "name": "Direct",
+              "enabled": true,
+              "access_method": {
+                "built_in": "direct"
+              }
+            },
+            "mullvad_bridges": {
+              "id": "92135711-534d-4950-963d-93e446a792e4",
+              "name": "Mullvad Bridges",
+              "enabled": true,
+              "access_method": {
+                "built_in": "bridge"
+              }
+            },
+            "custom": []
+          },
+          "allow_lan": false,
+          "block_when_disconnected": false,
+          "auto_connect": false,
+          "tunnel_options": {
+            "openvpn": {
+              "mssfix": null
+            },
+            "wireguard": {
+              "mtu": null,
+              "quantum_resistant": "auto",
+              "rotation_interval": null
+            },
+            "generic": {
+              "enable_ipv6": false
+            },
+            "dns_options": {
+              "state": "default",
+              "default_options": {
+                "block_ads": false,
+                "block_trackers": false,
+                "block_malware": false,
+                "block_adult_content": false,
+                "block_gambling": false,
+                "block_social_media": false
+              },
+              "custom_options": {
+                "addresses": []
+              }
+            }
+          },
+          "relay_overrides": [],
+          "show_beta_releases": true,
+          "settings_version": 11
+        }
+        "#;
+
+    /// This settings blob contains no constraint for tunnel type
+    pub const V10_SETTINGS_OPENVPN_LOCATION: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "hostname": "at-vie-ovpn-001"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "any",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "92135711-534d-4950-963d-93e446a792e4",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "settings_version": 10
+}
+"#;
+
+    /// This settings blob does not contain an "any" tunnel type
+    pub const V11_SETTINGS_OPENVPN_LOCATION: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "hostname": "at-vie-ovpn-001"
+          }
+        }
+      },
+      "providers": "any",
+      "ownership": "any",
+      "tunnel_protocol": "openvpn",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "use_multihop": false,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "bridge_settings": {
+    "bridge_type": "normal",
+    "normal": {
+      "location": "any",
+      "providers": "any",
+      "ownership": "any"
+    },
+    "custom": null
+  },
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "udp2tcp": {
+      "port": "any"
+    }
+  },
+  "bridge_state": "auto",
+  "custom_lists": {
+    "custom_lists": []
+  },
+  "api_access_methods": {
+    "direct": {
+      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
+      "name": "Direct",
+      "enabled": true,
+      "access_method": {
+        "built_in": "direct"
+      }
+    },
+    "mullvad_bridges": {
+      "id": "92135711-534d-4950-963d-93e446a792e4",
+      "name": "Mullvad Bridges",
+      "enabled": true,
+      "access_method": {
+        "built_in": "bridge"
+      }
+    },
+    "custom": []
+  },
+  "allow_lan": false,
+  "block_when_disconnected": false,
+  "auto_connect": false,
+  "tunnel_options": {
+    "openvpn": {
+      "mssfix": null
+    },
+    "wireguard": {
+      "mtu": null,
+      "quantum_resistant": "auto",
+      "rotation_interval": null
+    },
+    "generic": {
+      "enable_ipv6": false
+    },
+    "dns_options": {
+      "state": "default",
+      "default_options": {
+        "block_ads": false,
+        "block_trackers": false,
+        "block_malware": false,
+        "block_adult_content": false,
+        "block_gambling": false,
+        "block_social_media": false
+      },
+      "custom_options": {
+        "addresses": []
+      }
+    }
+  },
+  "relay_overrides": [],
+  "show_beta_releases": true,
+  "settings_version": 11
+}
+"#;
+}

--- a/mullvad-daemon/src/migrations/v10.rs
+++ b/mullvad-daemon/src/migrations/v10.rs
@@ -30,9 +30,13 @@ fn relay_settings(settings: &mut serde_json::Value) -> Option<&mut serde_json::V
 }
 
 fn migrate_tunnel_type(settings: &mut serde_json::Value) -> Result<()> {
-    let Some(ref mut normal) = relay_settings(settings) else {
-        return Ok(());
-    };
+    if let Some(ref mut normal) = relay_settings(settings) {
+        migrate_tunnel_type_inner(normal)?;
+    }
+    Ok(())
+}
+
+fn migrate_tunnel_type_inner(normal: &mut serde_json::Value) -> Result<()> {
     match normal.get_mut("tunnel_protocol") {
         // Migrate tunnel protocol "any"
         Some(serde_json::Value::String(s)) if s == "any" => {
@@ -72,483 +76,96 @@ fn migrate_tunnel_type(settings: &mut serde_json::Value) -> Result<()> {
         }
         // Unexpected result. Do nothing.
         None => (),
-    }
+    };
     Ok(())
 }
 #[cfg(test)]
 mod test {
-    use mullvad_types::settings::SettingsVersion;
+    use serde_json::json;
 
-    use super::{migrate, version};
+    use crate::migrations::v10::migrate_tunnel_type_inner;
 
     /// Tunnel protocol "any" is migrated to wireguard
     #[test]
     fn test_v10_to_v11_migration() {
-        // TODO: Also test the case where the location is not an openvpn relay and the tunnel type
-        // is any
-        let mut old_settings = serde_json::from_str(V10_SETTINGS).unwrap();
-
-        assert_eq!(version(&old_settings), Some(SettingsVersion::V10));
-        migrate(&mut old_settings).unwrap();
-        let new_settings: serde_json::Value = serde_json::from_str(V11_SETTINGS).unwrap();
-        assert_eq!(version(&new_settings), Some(SettingsVersion::V11));
-
-        eprintln!(
-            "old_settings: {}",
-            serde_json::to_string_pretty(&old_settings).unwrap()
-        );
-        eprintln!(
-            "new_settings: {}",
-            serde_json::to_string_pretty(&new_settings).unwrap()
-        );
+        let mut old_settings = json!({
+            "tunnel_protocol": "any",
+            "location": {
+                "only": {
+                    "location": {
+                        "country": "se"
+                    }
+                }
+            }
+        });
+        migrate_tunnel_type_inner(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = json!({
+            "tunnel_protocol": "wireguard",
+            "location": {
+                "only": {
+                    "location": {
+                        "country": "se"
+                    }
+                }
+            }
+        });
         assert_eq!(&old_settings, &new_settings);
     }
 
     /// Tunnel protocol "any" is migrated to openvpn, since the location is an openvpn relay
     #[test]
     fn test_v10_to_v11_migration_openvpn_location() {
-        // TODO: Also test the case where the location is not an openvpn relay and the tunnel type
-        // is any
-        let mut old_settings = serde_json::from_str(V10_SETTINGS_OPENVPN_LOCATION).unwrap();
-
-        assert_eq!(version(&old_settings), Some(SettingsVersion::V10));
-        migrate(&mut old_settings).unwrap();
-        let new_settings: serde_json::Value =
-            serde_json::from_str(V11_SETTINGS_OPENVPN_LOCATION).unwrap();
-        assert_eq!(version(&new_settings), Some(SettingsVersion::V11));
-
-        eprintln!(
-            "old_settings: {}",
-            serde_json::to_string_pretty(&old_settings).unwrap()
-        );
-        eprintln!(
-            "new_settings: {}",
-            serde_json::to_string_pretty(&new_settings).unwrap()
-        );
+        let mut old_settings = json!({
+            "tunnel_protocol": "any",
+            "location": {
+                "only": {
+                    "location": {
+                        "hostname": "at-vie-ovpn-001"
+                    }
+                }
+            }
+        });
+        migrate_tunnel_type_inner(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = json!({
+            "tunnel_protocol": "openvpn",
+            "location": {
+                "only": {
+                    "location": {
+                        "hostname": "at-vie-ovpn-001"
+                    }
+                }
+            }
+        });
         assert_eq!(&old_settings, &new_settings);
     }
 
-    /// Tunnel protocol is set to any, but the location is not an openvpn relay
-    pub const V10_SETTINGS: &str = r#"
-        {
-          "relay_settings": {
-            "normal": {
-              "location": {
-                "only": {
-                  "location": {
-                    "country": "se"
-                  }
-                }
-              },
-              "providers": "any",
-              "ownership": "any",
-              "tunnel_protocol": "any",
-              "wireguard_constraints": {
-                "port": "any",
-                "ip_version": "any",
-                "use_multihop": false,
-                "entry_location": {
-                  "only": {
-                    "location": {
-                      "country": "se"
-                    }
-                  }
-                }
-              },
-              "openvpn_constraints": {
-                "port": "any"
-              }
-            }
-          },
-          "bridge_settings": {
-            "bridge_type": "normal",
-            "normal": {
-              "location": "any",
-              "providers": "any",
-              "ownership": "any"
+    /// Tunnel protocol '"only" = { "tunnel_protocol" = '$tunnel_protocol' } is migrated to
+    /// '"tunnel_protocol" = '$tunnel_protocol'
+    #[test]
+    fn test_v10_to_v11_migration_only_protocol() {
+        let mut old_settings = json!({
+            "tunnel_protocol": {
+                "only": "wireguard"
             },
-            "custom": null
-          },
-          "obfuscation_settings": {
-            "selected_obfuscation": "auto",
-            "udp2tcp": {
-              "port": "any"
-            }
-          },
-          "bridge_state": "auto",
-          "custom_lists": {
-            "custom_lists": []
-          },
-          "api_access_methods": {
-            "direct": {
-              "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
-              "name": "Direct",
-              "enabled": true,
-              "access_method": {
-                "built_in": "direct"
-              }
-            },
-            "mullvad_bridges": {
-              "id": "92135711-534d-4950-963d-93e446a792e4",
-              "name": "Mullvad Bridges",
-              "enabled": true,
-              "access_method": {
-                "built_in": "bridge"
-              }
-            },
-            "custom": []
-          },
-          "allow_lan": false,
-          "block_when_disconnected": false,
-          "auto_connect": false,
-          "tunnel_options": {
-            "openvpn": {
-              "mssfix": null
-            },
-            "wireguard": {
-              "mtu": null,
-              "quantum_resistant": "auto",
-              "rotation_interval": null
-            },
-            "generic": {
-              "enable_ipv6": false
-            },
-            "dns_options": {
-              "state": "default",
-              "default_options": {
-                "block_ads": false,
-                "block_trackers": false,
-                "block_malware": false,
-                "block_adult_content": false,
-                "block_gambling": false,
-                "block_social_media": false
-              },
-              "custom_options": {
-                "addresses": []
-              }
-            }
-          },
-          "relay_overrides": [],
-          "show_beta_releases": true,
-          "settings_version": 10
-        }
-        "#;
-
-    /// Tunnel protocol is migrated to wireguard
-    pub const V11_SETTINGS: &str = r#"
-        {
-          "relay_settings": {
-            "normal": {
-              "location": {
-                "only": {
-                  "location": {
-                    "country": "se"
-                  }
-                }
-              },
-              "providers": "any",
-              "ownership": "any",
-              "tunnel_protocol": "wireguard",
-              "wireguard_constraints": {
-                "port": "any",
-                "ip_version": "any",
-                "use_multihop": false,
-                "entry_location": {
-                  "only": {
-                    "location": {
-                      "country": "se"
-                    }
-                  }
-                }
-              },
-              "openvpn_constraints": {
-                "port": "any"
-              }
-            }
-          },
-          "bridge_settings": {
-            "bridge_type": "normal",
-            "normal": {
-              "location": "any",
-              "providers": "any",
-              "ownership": "any"
-            },
-            "custom": null
-          },
-          "obfuscation_settings": {
-            "selected_obfuscation": "auto",
-            "udp2tcp": {
-              "port": "any"
-            }
-          },
-          "bridge_state": "auto",
-          "custom_lists": {
-            "custom_lists": []
-          },
-          "api_access_methods": {
-            "direct": {
-              "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
-              "name": "Direct",
-              "enabled": true,
-              "access_method": {
-                "built_in": "direct"
-              }
-            },
-            "mullvad_bridges": {
-              "id": "92135711-534d-4950-963d-93e446a792e4",
-              "name": "Mullvad Bridges",
-              "enabled": true,
-              "access_method": {
-                "built_in": "bridge"
-              }
-            },
-            "custom": []
-          },
-          "allow_lan": false,
-          "block_when_disconnected": false,
-          "auto_connect": false,
-          "tunnel_options": {
-            "openvpn": {
-              "mssfix": null
-            },
-            "wireguard": {
-              "mtu": null,
-              "quantum_resistant": "auto",
-              "rotation_interval": null
-            },
-            "generic": {
-              "enable_ipv6": false
-            },
-            "dns_options": {
-              "state": "default",
-              "default_options": {
-                "block_ads": false,
-                "block_trackers": false,
-                "block_malware": false,
-                "block_adult_content": false,
-                "block_gambling": false,
-                "block_social_media": false
-              },
-              "custom_options": {
-                "addresses": []
-              }
-            }
-          },
-          "relay_overrides": [],
-          "show_beta_releases": true,
-          "settings_version": 11
-        }
-        "#;
-
-    /// This settings blob contains no constraint for tunnel type
-    pub const V10_SETTINGS_OPENVPN_LOCATION: &str = r#"
-{
-  "relay_settings": {
-    "normal": {
-      "location": {
-        "only": {
-          "location": {
-            "hostname": "at-vie-ovpn-001"
-          }
-        }
-      },
-      "providers": "any",
-      "ownership": "any",
-      "tunnel_protocol": "any",
-      "wireguard_constraints": {
-        "port": "any",
-        "ip_version": "any",
-        "use_multihop": false,
-        "entry_location": {
-          "only": {
             "location": {
-              "country": "se"
+                "only": {
+                    "location": {
+                        "country": "se"
+                    }
+                }
             }
-          }
-        }
-      },
-      "openvpn_constraints": {
-        "port": "any"
-      }
-    }
-  },
-  "bridge_settings": {
-    "bridge_type": "normal",
-    "normal": {
-      "location": "any",
-      "providers": "any",
-      "ownership": "any"
-    },
-    "custom": null
-  },
-  "obfuscation_settings": {
-    "selected_obfuscation": "auto",
-    "udp2tcp": {
-      "port": "any"
-    }
-  },
-  "bridge_state": "auto",
-  "custom_lists": {
-    "custom_lists": []
-  },
-  "api_access_methods": {
-    "direct": {
-      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
-      "name": "Direct",
-      "enabled": true,
-      "access_method": {
-        "built_in": "direct"
-      }
-    },
-    "mullvad_bridges": {
-      "id": "92135711-534d-4950-963d-93e446a792e4",
-      "name": "Mullvad Bridges",
-      "enabled": true,
-      "access_method": {
-        "built_in": "bridge"
-      }
-    },
-    "custom": []
-  },
-  "allow_lan": false,
-  "block_when_disconnected": false,
-  "auto_connect": false,
-  "tunnel_options": {
-    "openvpn": {
-      "mssfix": null
-    },
-    "wireguard": {
-      "mtu": null,
-      "quantum_resistant": "auto",
-      "rotation_interval": null
-    },
-    "generic": {
-      "enable_ipv6": false
-    },
-    "dns_options": {
-      "state": "default",
-      "default_options": {
-        "block_ads": false,
-        "block_trackers": false,
-        "block_malware": false,
-        "block_adult_content": false,
-        "block_gambling": false,
-        "block_social_media": false
-      },
-      "custom_options": {
-        "addresses": []
-      }
-    }
-  },
-  "relay_overrides": [],
-  "show_beta_releases": true,
-  "settings_version": 10
-}
-"#;
-
-    /// This settings blob does not contain an "any" tunnel type
-    pub const V11_SETTINGS_OPENVPN_LOCATION: &str = r#"
-{
-  "relay_settings": {
-    "normal": {
-      "location": {
-        "only": {
-          "location": {
-            "hostname": "at-vie-ovpn-001"
-          }
-        }
-      },
-      "providers": "any",
-      "ownership": "any",
-      "tunnel_protocol": "openvpn",
-      "wireguard_constraints": {
-        "port": "any",
-        "ip_version": "any",
-        "use_multihop": false,
-        "entry_location": {
-          "only": {
+        });
+        migrate_tunnel_type_inner(&mut old_settings).unwrap();
+        let new_settings: serde_json::Value = json!({
+            "tunnel_protocol": "wireguard",
             "location": {
-              "country": "se"
+                "only": {
+                    "location": {
+                        "country": "se"
+                    }
+                }
             }
-          }
-        }
-      },
-      "openvpn_constraints": {
-        "port": "any"
-      }
+        });
+        assert_eq!(&old_settings, &new_settings);
     }
-  },
-  "bridge_settings": {
-    "bridge_type": "normal",
-    "normal": {
-      "location": "any",
-      "providers": "any",
-      "ownership": "any"
-    },
-    "custom": null
-  },
-  "obfuscation_settings": {
-    "selected_obfuscation": "auto",
-    "udp2tcp": {
-      "port": "any"
-    }
-  },
-  "bridge_state": "auto",
-  "custom_lists": {
-    "custom_lists": []
-  },
-  "api_access_methods": {
-    "direct": {
-      "id": "d81121bf-c942-4ca4-971f-8ea6581bc915",
-      "name": "Direct",
-      "enabled": true,
-      "access_method": {
-        "built_in": "direct"
-      }
-    },
-    "mullvad_bridges": {
-      "id": "92135711-534d-4950-963d-93e446a792e4",
-      "name": "Mullvad Bridges",
-      "enabled": true,
-      "access_method": {
-        "built_in": "bridge"
-      }
-    },
-    "custom": []
-  },
-  "allow_lan": false,
-  "block_when_disconnected": false,
-  "auto_connect": false,
-  "tunnel_options": {
-    "openvpn": {
-      "mssfix": null
-    },
-    "wireguard": {
-      "mtu": null,
-      "quantum_resistant": "auto",
-      "rotation_interval": null
-    },
-    "generic": {
-      "enable_ipv6": false
-    },
-    "dns_options": {
-      "state": "default",
-      "default_options": {
-        "block_ads": false,
-        "block_trackers": false,
-        "block_malware": false,
-        "block_adult_content": false,
-        "block_gambling": false,
-        "block_social_media": false
-      },
-      "custom_options": {
-        "addresses": []
-      }
-    }
-  },
-  "relay_overrides": [],
-  "show_beta_releases": true,
-  "settings_version": 11
-}
-"#;
 }

--- a/mullvad-daemon/src/migrations/v1_settings.json
+++ b/mullvad-daemon/src/migrations/v1_settings.json
@@ -1,0 +1,38 @@
+{
+    "account_token": "1234",
+    "relay_settings": {
+      "normal": {
+        "location": {
+          "only": {
+            "country": "se"
+          }
+        },
+        "tunnel": {
+          "only": {
+            "openvpn": {
+              "port": {
+                "only": 53
+              },
+              "protocol": {
+                "only": "udp"
+              }
+            }
+          }
+        }
+      }
+    },
+    "allow_lan": true,
+    "block_when_disconnected": false,
+    "auto_connect": false,
+    "tunnel_options": {
+      "openvpn": {
+        "mssfix": null
+      },
+      "wireguard": {
+        "mtu": null
+      },
+      "generic": {
+        "enable_ipv6": false
+      }
+    }
+}

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -20,7 +20,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V10;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V11;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -34,6 +34,7 @@ pub enum SettingsVersion {
     V8 = 8,
     V9 = 9,
     V10 = 10,
+    V11 = 11,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -51,6 +52,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V8 as u32 => Ok(SettingsVersion::V8),
             v if v == SettingsVersion::V9 as u32 => Ok(SettingsVersion::V9),
             v if v == SettingsVersion::V10 as u32 => Ok(SettingsVersion::V10),
+            v if v == SettingsVersion::V11 as u32 => Ok(SettingsVersion::V11),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),


### PR DESCRIPTION
The tunnel protocol migration (any -> wireguard) was incorrectly added to the V9 -> V10 migration, even though V10 was the current settings version, causing it to be missed for users already on V10. This PR bumps the current setting version to V11 and moves the tunnel protocol change to the new V10 -> V11 migration.

Also simply tests and improve their coverage by using the `json!` macro to test all the affected sub-setting json objects individually.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7776)
<!-- Reviewable:end -->
