### PR TITLE
Avoid using an unavailable ip version to connect to a relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix `mullvad-cli` panicking if it tried to write to a closed pipe on Linux and macOS.
 - Fix bug where new users are not forwarded to the main view after payment.
+- Will no longer try to connect over IPv4 if IPv4 is not available.
 
 #### Windows
 - Fix error setting up tunnel when MTU was incorrectly set to a value below 1280 for IPv6.

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -37,7 +37,7 @@ Line wrap the file at 100 chars.                                              Th
 - Remove Google's resolvers from encrypted DNS proxy.
 
 ### Fixed
-- Will no longer try to connect over IPv6 if IPv6 is not available.
+- Will no longer try to connect using an IP version if that IP version is not available.
 
 
 ## [android/2025.1-beta1] - 2025-03-05

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/ConnectivityListener.kt
@@ -66,7 +66,7 @@ class ConnectivityListener(
         _isConnected =
             connectivityManager
                 .hasInternetConnectivity(resolver)
-                .onEach { notifyConnectivityChange(it.ipv4, it.ipv6) }
+                .onEach { notifyConnectivityChange(it) }
                 .stateIn(
                     scope + Dispatchers.IO,
                     SharingStarted.Eagerly,
@@ -99,7 +99,7 @@ class ConnectivityListener(
             linkProperties?.dnsServersWithoutFallback(),
         )
 
-    private external fun notifyConnectivityChange(isIPv4: Boolean, isIPv6: Boolean)
+    private external fun notifyConnectivityChange(connectivity: Connectivity)
 
     private external fun notifyDefaultNetworkChange(networkState: NetworkState?)
 }

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/Connectivity.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/Connectivity.kt
@@ -1,8 +1,30 @@
 package net.mullvad.talpid.model
 
+import android.net.LinkAddress
+import java.net.Inet4Address
+import java.net.Inet6Address
+
 sealed class Connectivity {
-    data class Status(val ipv4: Boolean, val ipv6: Boolean) : Connectivity()
+    data class Online(val ipAvailability: IpAvailability) : Connectivity()
+
+    data object Offline : Connectivity()
 
     // Required by jni
     data object PresumeOnline : Connectivity()
+
+    companion object {
+        fun fromIpAvailability(ipv4: Boolean, ipv6: Boolean) =
+            when {
+                ipv4 && ipv6 -> Online(IpAvailability.Ipv4AndIpv6)
+                ipv4 -> Online(IpAvailability.Ipv4)
+                ipv6 -> Online(IpAvailability.Ipv6)
+                else -> Offline
+            }
+
+        fun fromLinkAddresses(linkAddresses: List<LinkAddress>): Connectivity {
+            val ipv4 = linkAddresses.any { it.address is Inet4Address }
+            val ipv6 = linkAddresses.any { it.address is Inet6Address }
+            return fromIpAvailability(ipv4, ipv6)
+        }
+    }
 }

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/IpAvailability.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/IpAvailability.kt
@@ -1,0 +1,7 @@
+package net.mullvad.talpid.model
+
+enum class IpAvailability {
+    Ipv4,
+    Ipv6,
+    Ipv4AndIpv6,
+}

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/UnderlyingConnectivityStatusResolver.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/UnderlyingConnectivityStatusResolver.kt
@@ -14,8 +14,8 @@ import net.mullvad.talpid.model.Connectivity
 class UnderlyingConnectivityStatusResolver(
     private val protect: (socket: DatagramSocket) -> Boolean
 ) {
-    fun currentStatus(): Connectivity.Status =
-        Connectivity.Status(ipv4 = hasIpv4(), ipv6 = hasIpv6())
+    fun currentStatus(): Connectivity =
+        Connectivity.fromIpAvailability(ipv4 = hasIpv4(), ipv6 = hasIpv6())
 
     private fun hasIpv4(): Boolean =
         hasIpVersion(Inet4Address.getByName(PUBLIC_IPV4_ADDRESS), protect)

--- a/mullvad-jni/src/classes.rs
+++ b/mullvad-jni/src/classes.rs
@@ -18,6 +18,8 @@ pub const CLASSES: &[&str] = &[
     "net/mullvad/talpid/ConnectivityListener",
     "net/mullvad/talpid/TalpidVpnService",
     "net/mullvad/mullvadvpn/lib/endpoint/ApiEndpointOverride",
-    "net/mullvad/talpid/model/Connectivity$Status",
+    "net/mullvad/talpid/model/Connectivity$Online",
+    "net/mullvad/talpid/model/Connectivity$Offline",
     "net/mullvad/talpid/model/Connectivity$PresumeOnline",
+    "net/mullvad/talpid/model/IpAvailability",
 ];

--- a/mullvad-relay-selector/src/error.rs
+++ b/mullvad-relay-selector/src/error.rs
@@ -36,6 +36,9 @@ pub enum Error {
 
     #[error("Invalid bridge settings")]
     InvalidBridgeSettings(#[from] MissingCustomBridgeSettings),
+
+    #[error("The requested IP version is not available")]
+    IpVersionUnavailable,
 }
 
 /// Special type which only shows up in [`Error`]. This error variant signals that no valid

--- a/mullvad-relay-selector/src/lib.rs
+++ b/mullvad-relay-selector/src/lib.rs
@@ -11,6 +11,5 @@ pub use error::Error;
 pub use relay_selector::{
     detailer, matcher, matcher::filter_matching_relay_list, query, relays::WireguardConfig,
     AdditionalRelayConstraints, AdditionalWireguardConstraints, GetRelay, RelaySelector,
-    RuntimeParameters, SelectedBridge, SelectedObfuscator, SelectorConfig, OPENVPN_RETRY_ORDER,
-    WIREGUARD_RETRY_ORDER,
+    SelectedBridge, SelectedObfuscator, SelectorConfig, OPENVPN_RETRY_ORDER, WIREGUARD_RETRY_ORDER,
 };

--- a/talpid-core/src/offline/linux.rs
+++ b/talpid-core/src/offline/linux.rs
@@ -82,7 +82,7 @@ async fn check_connectivity(handle: &RouteManagerHandle, fwmark: Option<u32>) ->
         route_exists(PUBLIC_INTERNET_ADDRESS_V4).await,
         route_exists(PUBLIC_INTERNET_ADDRESS_V6).await,
     ) {
-        (Ok(ipv4), Ok(ipv6)) => Connectivity::Status { ipv4, ipv6 },
+        (Ok(ipv4), Ok(ipv6)) => Connectivity::new(ipv4, ipv6),
         // If we fail to retrieve the IPv4 route, always assume we're connected
         (Err(err), _) => {
             log::error!(
@@ -99,7 +99,7 @@ async fn check_connectivity(handle: &RouteManagerHandle, fwmark: Option<u32>) ->
                     "Failed to infer offline state for IPv6. Assuming it's unavailable"
                 )
             );
-            Connectivity::Status { ipv4, ipv6: false }
+            Connectivity::new(ipv4, false)
         }
     }
 }

--- a/talpid-core/src/offline/macos.rs
+++ b/talpid-core/src/offline/macos.rs
@@ -52,10 +52,7 @@ struct ConnectivityInner {
 
 impl ConnectivityInner {
     fn into_connectivity(self) -> Connectivity {
-        Connectivity::Status {
-            ipv4: self.ipv4,
-            ipv6: self.ipv6,
-        }
+        Connectivity::new(self.ipv4, self.ipv6)
     }
 
     fn is_online(&self) -> bool {

--- a/talpid-core/src/offline/windows.rs
+++ b/talpid-core/src/offline/windows.rs
@@ -230,15 +230,9 @@ impl ConnectivityInner {
     /// `ipv4` and `ipv6` availability to `false`.
     fn into_connectivity(self) -> Connectivity {
         if self.suspended {
-            Connectivity::Status {
-                ipv4: false,
-                ipv6: false,
-            }
+            Connectivity::Offline
         } else {
-            Connectivity::Status {
-                ipv4: self.ipv4,
-                ipv6: self.ipv6,
-            }
+            Connectivity::new(self.ipv4, self.ipv6)
         }
     }
 

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -9,7 +9,9 @@ use futures::{FutureExt, StreamExt};
 use talpid_routing::RouteManagerHandle;
 use talpid_tunnel::tun_provider::TunProvider;
 use talpid_tunnel::{EventHook, TunnelArgs, TunnelEvent, TunnelMetadata};
-use talpid_types::net::{AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, TunnelParameters};
+use talpid_types::net::{
+    AllowedClients, AllowedEndpoint, AllowedTunnelTraffic, IpAvailability, TunnelParameters,
+};
 use talpid_types::tunnel::{ErrorStateCause, FirewallPolicyError};
 use talpid_types::ErrorExt;
 
@@ -73,19 +75,24 @@ impl ConnectingState {
                 });
         }
 
-        if shared_values.connectivity.is_offline() {
-            // FIXME: Temporary: Nudge route manager to update the default interface
-            #[cfg(target_os = "macos")]
-            {
-                log::debug!("Poking route manager to update default routes");
-                let _ = shared_values.route_manager.refresh_routes();
+        let ip_availability = match shared_values.connectivity {
+            talpid_types::net::Connectivity::Offline => {
+                // FIXME: Temporary: Nudge route manager to update the default interface
+                #[cfg(target_os = "macos")]
+                {
+                    log::debug!("Poking route manager to update default routes");
+                    let _ = shared_values.route_manager.refresh_routes();
+                }
+                return ErrorState::enter(shared_values, ErrorStateCause::IsOffline);
             }
-            return ErrorState::enter(shared_values, ErrorStateCause::IsOffline);
-        }
+            talpid_types::net::Connectivity::PresumeOnline => IpAvailability::Ipv4,
+            talpid_types::net::Connectivity::Online(ip_availability) => ip_availability,
+        };
+
         match shared_values.runtime.block_on(
             shared_values
                 .tunnel_parameters_generator
-                .generate(retry_attempt, shared_values.connectivity.has_ipv6()),
+                .generate(retry_attempt, ip_availability),
         ) {
             Err(err) => {
                 ErrorState::enter(shared_values, ErrorStateCause::TunnelParameterError(err))

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -46,7 +46,7 @@ use std::{
 #[cfg(target_os = "android")]
 use talpid_types::{android::AndroidContext, ErrorExt};
 use talpid_types::{
-    net::{AllowedEndpoint, Connectivity, TunnelParameters},
+    net::{AllowedEndpoint, Connectivity, IpAvailability, TunnelParameters},
     tunnel::{ErrorStateCause, ParameterGenerationError, TunnelStateTransition},
 };
 
@@ -452,7 +452,7 @@ pub trait TunnelParametersGenerator: Send + 'static {
     fn generate(
         &mut self,
         retry_attempt: u32,
-        ipv6: bool,
+        ip_availability: IpAvailability,
     ) -> Pin<Box<dyn Future<Output = Result<TunnelParameters, ParameterGenerationError>>>>;
 }
 


### PR DESCRIPTION
This PR tries to do two things:

1. Throw an error if the user device IP setting does not align with the available ip version on the network
2. Prevent the app from trying to connect using an unavailable ip version.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7777)
<!-- Reviewable:end -->
