### PR TITLE
Fix bug in nightly osv-scanner CI job

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -17,6 +17,6 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "mullvad/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.0
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.2 + submodule patch
     with:
       checkout-submodules: true

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -18,6 +18,6 @@ jobs:
       actions: read
 
     # yamllint disable rule:line-length
-    uses: "mullvad/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.0
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.2 + submodule patch
     with:
       checkout-submodules: true


### PR DESCRIPTION
Fixes bug introduced in https://github.com/mullvad/mullvadvpn-app/pull/7515.

When we patched the CI job to allow checking out git submodules, I accidentally copy-pasted the wrong workflow yaml file. This made the nightly scheduled scan use the PR workflow. This workflow does not work in this setting, and it always just reported green status

Moving back to consuming the workflow from google instead of our fork again, since the PR with the needed changes have been merged upstream

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7786)
<!-- Reviewable:end -->
