### PR TITLE
Decouple DNS server info from content-blockers UI expansion

### DIFF
--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSDataSource.swift
@@ -563,17 +563,13 @@ final class CustomDNSDataSource: UITableViewDiffableDataSource<
     ) -> NSDiffableDataSourceSnapshot<Section, Item> {
         var snapshot = snapshot
 
-        if snapshot.itemIdentifiers(inSection: .contentBlockers).isEmpty {
+        if viewModel.customDNSPrecondition == .satisfied {
             snapshot.deleteItems([.dnsServerInfo])
         } else {
-            if viewModel.customDNSPrecondition == .satisfied {
-                snapshot.deleteItems([.dnsServerInfo])
+            if snapshot.itemIdentifiers(inSection: .customDNS).contains(.dnsServerInfo) {
+                snapshot.reloadItems([.dnsServerInfo])
             } else {
-                if snapshot.itemIdentifiers(inSection: .customDNS).contains(.dnsServerInfo) {
-                    snapshot.reloadItems([.dnsServerInfo])
-                } else {
-                    snapshot.appendItems([.dnsServerInfo], toSection: .customDNS)
-                }
+                snapshot.appendItems([.dnsServerInfo], toSection: .customDNS)
             }
         }
 
@@ -618,10 +614,8 @@ final class CustomDNSDataSource: UITableViewDiffableDataSource<
 
             if headerView.isExpanded {
                 snapshot.deleteItems(Item.contentBlockers)
-                snapshot.deleteItems([.dnsServerInfo])
             } else {
                 snapshot.appendItems(Item.contentBlockers, toSection: .contentBlockers)
-                snapshot.appendItems([.dnsServerInfo])
             }
 
             headerView.isExpanded.toggle()


### PR DESCRIPTION
With this change, the explanatory message for custom DNS in the DNS Settings will always be visible when the switch is disabled, as opposed to being hidden when the content blockers list is collapsed. 

This closes IOS-1051.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7791)
<!-- Reviewable:end -->
