### PR TITLE
Fix logic keeping users on expired route even after time has been added

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -765,10 +765,7 @@ export default class AppRenderer {
         return RoutePath.deviceRevoked;
       } else if (!this.isLoggedIn()) {
         return RoutePath.login;
-      } else if (
-        loginState.type === 'ok' &&
-        (loginState.expiredState === 'expired' || loginState.method === 'new_account')
-      ) {
+      } else if (loginState.type === 'ok' && loginState.expiredState === 'expired') {
         return RoutePath.expired;
       } else if (loginState.type === 'ok' && loginState.expiredState === 'time_added') {
         return RoutePath.timeAdded;


### PR DESCRIPTION
When a user creates an account in the app and
then adds time to the account outside of the app
the user should then be shown the
`"/main/time-added"` route.

Whenever an account is created in the app, it's
`expiredStatus` is set immediately to `"expired"`,
which makes the app show the `"/main/expired"`
route. When time is added to the account its
`expiredStatus` changes to `"time_added"` and this
should show the `"/main/time-added"` route.

However, due to an overly broad condition
in the logic to determine when the
`"/main/expired"` route should be shown, this
caused the `"main/time-added"` route to never be
shown, as the overly broad condition effectively
prevented the logic to determine when to show the
`"/main/time-added"` route from ever being called.

This overly broad condition erroneously targeted
all new accounts created from within the app and
prevented the transition to the `"/main/time-added"`
route.

To fix the problem we update the logic regarding
when to show the `"/main/expired"` route to not
check if the account is new, as it is enough to
only check if the account is logged in and that
its `expiredStatus` is `"expired"`.

This change allows the logic to determine when
the `"/main/time-added"` route should be shown to
be called and as such can allow the route to be
shown after time has been added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7796)
<!-- Reviewable:end -->
