### PR TITLE
Build and cache relay list per configuration excluding Release

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -100,4 +100,6 @@ ios/convert-assets.rb --additional-assets
 
 ## Cached relays
 
-The script `relays-prebuild.sh` runs on each Xcode build and updates the cached relay list whenever there *IS NO* relay file. To get a fresh relay file on demand, simply remove `MullvadREST/Assets/relays.json` and build the Xcode project.
+The script `relays-prebuild.sh` runs on each Xcode build and will download and cache a list of relays if it is not already present for a given configuration.
+The cached list for a given configuration will always override the current relays file.
+To get a fresh relay file on demand, issue a `clean` command to Xcode and re-build the project.

--- a/ios/relays-prebuild.sh
+++ b/ios/relays-prebuild.sh
@@ -7,13 +7,27 @@ fi
 
 RELAYS_FILE="$PROJECT_DIR/MullvadREST/Assets/relays.json"
 
+# Do not download the file for release builds, a different script will take care of that.
+if [ "$CONFIGURATION" == "Release" ]; then
+  # Fail loudly if the required file is not already present.
+  if [ ! -f "$RELAYS_FILE" ]; then
+    echo "No file found at $RELAYS_FILE"
+    exit 1
+  fi
+  return 0
+fi
+
+BACKUP_FILE="$CONFIGURATION_TEMP_DIR/relays.json"
+
 if [ "$CONFIGURATION" == "Staging" ]; then
   API_ENDPOINT="api.stagemole.eu"
 else
   API_ENDPOINT="api.mullvad.net"
 fi
 
-if [ ! -f "$RELAYS_FILE" ]; then
-  echo "Download relays file"
-  curl https://"$API_ENDPOINT"/app/v1/relays -s -o "$RELAYS_FILE"
+if [ ! -f "$BACKUP_FILE" ]; then
+  echo "Downloading relays file for $CONFIGURATION"
+  curl https://"$API_ENDPOINT"/app/v1/relays -s -o "$BACKUP_FILE"
 fi
+
+cp "$BACKUP_FILE" "$RELAYS_FILE"


### PR DESCRIPTION
This PR changes the `relays-prebuild.sh` script to :
- Cache a relay list per configuration
- Automatically switch the `relays.json` file to the correct configuration
- Not download the relays list when the build scheme specifies a `Release` build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7797)
<!-- Reviewable:end -->
