### PR TITLE
[`osv-scanner`] Silence CVEs in `libwg`

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -46,3 +46,9 @@ reason = "wireguard-go does not use the affected code"
 id = "CVE-2025-22869" # GO-2025-3487
 ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
+
+# Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec. We don't deploy to PowerPC.
+[[IgnoredVulns]]
+id = "CVE-2025-22866" # GO-2025-3447
+ignoreUntil = 2025-06-12
+reason = "wireguard-go does not use the affected code"

--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -40,3 +40,9 @@ reason = "wireguard-go does not use the affected code"
 id = "CVE-2024-45341" # GO-2025-3373
 ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
+
+# Denial of service in golang.org/x/crypto (for SSH server implementations)
+[[IgnoredVulns]]
+id = "CVE-2025-22869" # GO-2025-3487
+ignoreUntil = 2025-06-12
+reason = "wireguard-go does not use the affected code"

--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -2,41 +2,41 @@
 # Stack exhaustion in Decoder.Decode in encoding/gob
 [[IgnoredVulns]]
 id = "CVE-2024-34156" # GO-2024-3106
-ignoreUntil = 2025-03-18
+ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
 
 # Stack exhaustion in Parse in go/build/constraint
 [[IgnoredVulns]]
 id = "CVE-2024-34158" # GO-2024-3107
-ignoreUntil = 2025-03-18
+ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
 
 # Stack exhaustion in all Parse functions in go/parser
 [[IgnoredVulns]]
 id = "CVE-2024-34155" # GO-2024-3105
-ignoreUntil = 2025-03-18
+ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
 
 # Denial of service in HTML Parse function in go/net/html
 [[IgnoredVulns]]
 id = "CVE-2024-45338" # GO-2024-3333
-ignoreUntil = 2025-03-19
+ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
 
 # Denial of service in HTML Parse function in go/net/html
 [[IgnoredVulns]]
 id = "GHSA-w32m-9786-jp63" # GO-2024-3333
-ignoreUntil = 2025-03-19
+ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
 
 # Sensitive headers incorrectly sent after cross-domain redirect in net/http
 [[IgnoredVulns]]
 id = "CVE-2024-45336" # GO-2025-3420
-ignoreUntil = 2025-04-28
+ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
 
 # Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
 [[IgnoredVulns]]
 id = "CVE-2024-45341" # GO-2025-3373
-ignoreUntil = 2025-04-28
+ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"


### PR DESCRIPTION
Another day, yet more CVEs in go libs.

This PR renews the `ignoredUntil` date for a bunch of already-silenced-CVEs for another 3 months. It also silences new CVEs as needed. As usual, we aren't affected by these CVEs in practice, since `wireguard-go` either doesn't use the affected functions or we don't deploy to the affected CPU architectures.

## New CVEs
- `GO-2025-3487` - Potential denial of service in `golang.org/x/crypto` (for SSH server implementations)
- `GO-2025-3447` - Timing sidechannel for P-256 on ppc64le in `crypto/internal/nistec`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7799)
<!-- Reviewable:end -->
