### PR TITLE
Fix regressions for non-Linux platforms in E2E desktop workflow

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -184,15 +184,14 @@ jobs:
           path: ./bin/mullvad-version
           if-no-files-found: error
 
+  # This step should always be run because the `test-manager` binary is used to compile the
+  # result matrix at the end! If that functionality is ever split out from the `test-manager`,
+  # this step may be conditionally run.
   build-test-manager-linux:
     name: Build Test Manager
     needs: prepare-linux
     # Note: libssl-dev is installed on the test server, so build test-manager there for the sake of simplicity
     runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
-    if: |
-      !cancelled() &&
-      needs.prepare-matrices.outputs.linux_matrix != '[]' &&
-      needs.prepare-matrices.outputs.linux_matrix != ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes an issue with the `desktop-e2e.yml` GHA workflow where the `test-manager` binary wouldn't be built if no tested platforms were Linux. However, it always needs to be built because it will be used in the very last workflow step where the test matrix is compiled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7801)
<!-- Reviewable:end -->
