### PR TITLE
Fix `mullvad-cli` panicking if writing to a closed pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 - Remove "Any" option for tunnel protocol. The default is now WireGuard.
 
 ### Fixed
+- Fix `mullvad-cli` panicking if it tried to write to a closed pipe on Linux and macOS.
+
 #### macOS
 - Fix routing issue caused by upgrading `tun`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "mullvad-types",
  "mullvad-version",
  "natord",
+ "nix 0.29.0",
  "serde",
  "serde_json",
  "talpid-types",

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 
 [target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 clap_complete = { version = "4.4.8" }
+nix = { version = "0.29.0", features = ["signal"] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"


### PR DESCRIPTION
This PR fixes https://github.com/mullvad/mullvadvpn-app/issues/7689. I've provided sources to the problem and suggested solution as comments in the code. Please have a look.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7802)
<!-- Reviewable:end -->
