### PR TITLE
Improve information in 4-make-release script

### DIFF
--- a/desktop/scripts/release/4-make-release
+++ b/desktop/scripts/release/4-make-release
@@ -148,10 +148,14 @@ function publish_release {
 
     body+="\n$changelog"
 
+    echo ""
     echo ">>> Creating GitHub release"
     # shellcheck disable=SC2059
     # shellcheck disable=SC2046
     printf "$body" | gh release create "${release_flags[@]}" "$PRODUCT_VERSION" $(printf "%s " "$ARTIFACT_DIR"/*)
+
+    echo ""
+    echo "The above URL contains the text \"untagged\", but don't worry it is tagged properly and everything will look correct once it's published."
 }
 
 download_and_verify


### PR DESCRIPTION
This PR adds a bit of text to the output of the `4-make-release` script. This addresses confusion that occured the first time it was used to publish a release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7807)
<!-- Reviewable:end -->
