### PR TITLE
Make Multihop feature chip appear if settings or current state say so

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -145,6 +145,10 @@ enum TunnelState: Equatable, CustomStringConvertible, Sendable {
             nil
         }
     }
+
+    var isMultihop: Bool {
+        relays?.entry != nil
+    }
 }
 
 /// A enum that describes the action to perform after disconnect.

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
@@ -52,8 +52,9 @@ struct QuantumResistanceFeature: ChipFeature {
 
 struct MultihopFeature: ChipFeature {
     let settings: LatestTunnelSettings
+    let state: TunnelState
     var isEnabled: Bool {
-        settings.tunnelMultihopState.isEnabled
+        settings.tunnelMultihopState.isEnabled || state.isMultihop
     }
 
     var name: String {

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
@@ -29,7 +29,7 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
             let features: [ChipFeature] = [
                 DaitaFeature(settings: tunnelSettings),
                 QuantumResistanceFeature(settings: tunnelSettings),
-                MultihopFeature(settings: tunnelSettings),
+                MultihopFeature(settings: tunnelSettings, state: tunnelState),
                 ObfuscationFeature(settings: tunnelSettings),
                 DNSFeature(settings: tunnelSettings),
                 IPOverrideFeature(overrides: ipOverrides),


### PR DESCRIPTION
The Multihop feature chip has been modified to appear if the settings enable multihop, or if the current tunnel state is multihop (i.e., if this has been enabled due to DAITA)

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7815)
<!-- Reviewable:end -->
