### PR TITLE
Ensure locales are loaded from the correct path

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/load-translations.ts
+++ b/desktop/packages/mullvad-vpn/src/main/load-translations.ts
@@ -6,7 +6,8 @@ import path from 'path';
 import log from '../shared/logging';
 
 const SOURCE_LANGUAGE = 'en';
-const LOCALES_DIR = path.resolve(__dirname, '../locales');
+const PATH_PREFIX = process.env.NODE_ENV === 'development' ? '../' : '';
+const LOCALES_DIR = path.resolve(__dirname, `${PATH_PREFIX}locales`);
 
 export function loadTranslations(
   currentLocale: string,


### PR DESCRIPTION
Due to the vite migration the path to load resources from is different between the production and development environments. This change ensures that the same fix which is already applied to geo files and images is applied to locales.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7819)
<!-- Reviewable:end -->
