### PR TITLE
Fix the issue in smart routing when selecting one to many relays

### DIFF
--- a/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
+++ b/ios/MullvadREST/Relay/MultihopDecisionFlow.swift
@@ -92,11 +92,6 @@ struct OneToMany: MultihopDecisionFlow {
             )
         }
 
-        guard !daitaAutomaticRouting else {
-            return try ManyToOne(next: next, relayPicker: relayPicker)
-                .pick(entryCandidates: entryCandidates, exitCandidates: exitCandidates, daitaAutomaticRouting: true)
-        }
-
         let entryMatch = try multihopPicker.findBestMatch(from: entryCandidates, useObfuscatedPortIfAvailable: true)
         let exitMatch = try multihopPicker.exclude(
             relay: entryMatch,

--- a/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/MultihopDecisionFlowTests.swift
@@ -112,14 +112,22 @@ class MultihopDecisionFlowTests: XCTestCase {
         let entryCandidates = [seSto2]
         let exitCandidates = [seSto2, seSto6]
 
-        let selectedRelays = try oneToMany.pick(
+        let selectedRelaysWithoutSmartRouting = try oneToMany.pick(
             entryCandidates: entryCandidates,
             exitCandidates: exitCandidates,
             daitaAutomaticRouting: false
         )
 
-        XCTAssertEqual(selectedRelays.entry?.hostname, "se2-wireguard")
-        XCTAssertEqual(selectedRelays.exit.hostname, "se6-wireguard")
+        XCTAssertEqual(selectedRelaysWithoutSmartRouting.entry?.hostname, "se2-wireguard")
+        XCTAssertEqual(selectedRelaysWithoutSmartRouting.exit.hostname, "se6-wireguard")
+
+        let selectedRelaysWithSmartRouting = try XCTUnwrap(oneToMany.pick(
+            entryCandidates: [seSto2],
+            exitCandidates: [seSto2, seSto6],
+            daitaAutomaticRouting: true
+        ))
+        XCTAssertEqual(selectedRelaysWithSmartRouting.entry?.hostname, "se2-wireguard")
+        XCTAssertEqual(selectedRelaysWithSmartRouting.exit.hostname, "se6-wireguard")
     }
 
     func testManyToOnePick() throws {


### PR DESCRIPTION
This PR fixes an issue where, if Daita with smart routing is enabled and the user selects a location without a Daita relay, the app goes into a blocked state instead of attempting to find a relay server from the remaining available relays.

You can reproduce this issue on main by following these steps:

1. Set the provider to Tzulo in the Filter view and apply.
2. Select Canada → The app goes into a blocked state, even though a `Daita` relay is available in USA.
3. Select USA → The VPN successfully connects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7820)
<!-- Reviewable:end -->
