### PR TITLE
Only set IPv6 MTU if IPv6 is enabled for wireguard-nt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 - Fix `mullvad-cli` panicking if it tried to write to a closed pipe on Linux and macOS.
 
+#### Windows
+- Fix error setting up tunnel when MTU was incorrectly set to a value below 1280 for IPv6.
+
 
 ## [2025.5-beta1] - 2025-03-11
 ### Added

--- a/talpid-openvpn/src/wintun.rs
+++ b/talpid-openvpn/src/wintun.rs
@@ -98,7 +98,7 @@ impl WintunAdapter {
 
     pub fn prepare_interface(&self) {
         if let Err(error) =
-            talpid_tunnel::network_interface::initialize_interfaces(self.luid(), None)
+            talpid_tunnel::network_interface::initialize_interfaces(self.luid(), None, None)
         {
             log::error!(
                 "{}",

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -311,7 +311,8 @@ impl WgGoTunnel {
                 .map_err(|e| BoxedError::new(TunnelError::SetupIpInterfaces(e)))?;
             log::debug!("Waiting for tunnel IP interfaces: Done");
 
-            if let Err(error) = talpid_tunnel::network_interface::initialize_interfaces(luid, None)
+            if let Err(error) =
+                talpid_tunnel::network_interface::initialize_interfaces(luid, None, None)
             {
                 log::error!(
                     "{}",

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -543,8 +543,12 @@ async fn setup_ip_listener(device: Arc<WgNtAdapter>, mtu: u32, has_ipv6: bool) -
         .map_err(Error::IpInterfaces)?;
     log::debug!("Waiting for tunnel IP interfaces: Done");
 
-    talpid_tunnel::network_interface::initialize_interfaces(luid, Some(mtu))
-        .map_err(Error::SetTunnelMtu)?;
+    talpid_tunnel::network_interface::initialize_interfaces(
+        luid,
+        Some(mtu),
+        has_ipv6.then_some(mtu),
+    )
+    .map_err(Error::SetTunnelMtu)?;
 
     device
         .set_state(WgAdapterState::Up)


### PR DESCRIPTION
Previously, this caused an error if an MTU below 1280 was set.

Fix DES-1870.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7832)
<!-- Reviewable:end -->
