### PR TITLE
Forbid `implicit_clone` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ single_use_lifetimes = "warn"
 [workspace.lints.clippy]
 unused_async = "deny"
 undocumented_unsafe_blocks = "warn"
+implicit_clone = "warn"
 
 [workspace.dependencies]
 hickory-proto = "0.24.3"

--- a/mullvad-cli/src/cmds/proxies.rs
+++ b/mullvad-cli/src/cmds/proxies.rs
@@ -168,8 +168,8 @@ impl ProxyEditParams {
     pub fn merge_shadowsocks(self, shadowsocks: &Shadowsocks) -> Shadowsocks {
         let ip = self.ip.unwrap_or(shadowsocks.endpoint.ip());
         let port = self.port.unwrap_or(shadowsocks.endpoint.port());
-        let password = self.password.unwrap_or(shadowsocks.password.to_owned());
-        let cipher = self.cipher.unwrap_or(shadowsocks.cipher.to_owned());
+        let password = self.password.unwrap_or(shadowsocks.password.clone());
+        let cipher = self.cipher.unwrap_or(shadowsocks.cipher.clone());
         Shadowsocks::new((ip, port), cipher, password)
     }
 }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -809,7 +809,7 @@ impl Daemon {
             }
         });
         settings.register_change_listener(move |settings| {
-            let _ = param_gen_tx.unbounded_send(settings.tunnel_options.to_owned());
+            let _ = param_gen_tx.unbounded_send(settings.tunnel_options.clone());
         });
 
         // Register a listener for generic settings changes.

--- a/mullvad-daemon/src/version_check.rs
+++ b/mullvad-daemon/src/version_check.rs
@@ -405,7 +405,7 @@ impl UpdateContext {
 
         async move {
             log::debug!("Writing version check cache to {}", cache_path.display());
-            let cached_app_version = CachedAppVersionInfo::from(last_app_version.to_owned());
+            let cached_app_version = CachedAppVersionInfo::from(last_app_version);
             let buf = serde_json::to_vec_pretty(&cached_app_version).map_err(Error::Serialize)?;
             tokio::fs::write(cache_path, buf)
                 .await

--- a/mullvad-relay-selector/src/relay_selector/parsed_relays.rs
+++ b/mullvad-relay-selector/src/relay_selector/parsed_relays.rs
@@ -150,10 +150,7 @@ impl ParsedRelays {
     fn parse_relay_list(relay_list: &RelayList, overrides: &[RelayOverride]) -> RelayList {
         let mut remaining_overrides = HashMap::new();
         for relay_override in overrides {
-            remaining_overrides.insert(
-                relay_override.hostname.to_owned(),
-                relay_override.to_owned(),
-            );
+            remaining_overrides.insert(relay_override.hostname.clone(), relay_override.to_owned());
         }
 
         let mut parsed_list = relay_list.clone();

--- a/mullvad-update/meta/src/platform.rs
+++ b/mullvad-update/meta/src/platform.rs
@@ -278,7 +278,7 @@ impl Platform {
         let new_release = format::Release {
             changelog: changes.to_owned(),
             version: version.clone(),
-            installers: installers.to_owned(),
+            installers,
             rollout,
         };
 

--- a/mullvad-version/build.rs
+++ b/mullvad-version/build.rs
@@ -62,7 +62,7 @@ fn get_product_version(target: Target) -> String {
     // Compute the expected tag name for the release named `product_version`
     let release_tag = match target {
         Target::Android => format!("android/{release_version}"),
-        Target::Desktop => release_version.to_owned(),
+        Target::Desktop => release_version.clone(),
     };
 
     format!("{release_version}{}", get_suffix(&release_tag))

--- a/talpid-core/src/split_tunnel/macos/default.rs
+++ b/talpid-core/src/split_tunnel/macos/default.rs
@@ -57,9 +57,9 @@ pub async fn get_default_interface(
             if v4_default.interface != v6_default.interface {
                 return Err(Error::DefaultInterfaceMismatch);
             }
-            v4_default.interface.to_owned()
+            v4_default.interface.clone()
         }
-        (Some(default), None) | (None, Some(default)) => default.interface.to_owned(),
+        (Some(default), None) | (None, Some(default)) => default.interface.clone(),
         (None, None) => return Err(Error::NoDefaultInterface),
     };
 

--- a/talpid-core/src/split_tunnel/macos/process.rs
+++ b/talpid-core/src/split_tunnel/macos/process.rs
@@ -332,7 +332,7 @@ impl ProcessStates {
 
             // Check if own path is excluded
             if paths.contains(&info.exec_path) && !new_exclude_paths.contains(&info.exec_path) {
-                new_exclude_paths.insert(info.exec_path.to_owned());
+                new_exclude_paths.insert(info.exec_path.clone());
             }
 
             info.excluded_by_paths = new_exclude_paths;
@@ -413,7 +413,7 @@ impl InnerProcessStates {
 
         // Exclude if path is excluded
         if self.exclude_paths.contains(&info.exec_path) {
-            info.excluded_by_paths.insert(info.exec_path.to_owned());
+            info.excluded_by_paths.insert(info.exec_path.clone());
             log::trace!("Excluding {pid} by path: {}", info.exec_path.display());
         }
     }

--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -446,7 +446,7 @@ impl SplitTunnel {
                                     error.display_chain_with_msg("Failed to update path monitor")
                                 );
                             }
-                            *monitored_paths_guard = paths.to_vec();
+                            *monitored_paths_guard = paths;
                         }
 
                         result

--- a/talpid-dbus/src/systemd_resolved.rs
+++ b/talpid-dbus/src/systemd_resolved.rs
@@ -261,7 +261,6 @@ impl SystemdResolved {
     }
 
     pub fn set_dns(&self, interface_index: u32, servers: Vec<IpAddr>) -> Result<DnsState> {
-        let set_servers = servers.to_vec();
         let link_object_path = self
             .fetch_link(interface_index)
             .map_err(|e| Error::GetLinkError(Box::new(e)))?;
@@ -269,7 +268,7 @@ impl SystemdResolved {
         Ok(DnsState {
             interface_path: link_object_path,
             interface_index,
-            set_servers,
+            set_servers: servers,
         })
     }
 

--- a/talpid-openvpn/src/wintun.rs
+++ b/talpid-openvpn/src/wintun.rs
@@ -108,7 +108,7 @@ impl WintunAdapter {
     }
 
     pub fn name(&self) -> U16CString {
-        self.name.to_owned()
+        self.name.clone()
     }
 
     pub fn luid(&self) -> NET_LUID_LH {

--- a/talpid-wireguard/src/wireguard_kernel/wg_message.rs
+++ b/talpid-wireguard/src/wireguard_kernel/wg_message.rs
@@ -707,73 +707,54 @@ mod test {
 
         let if_name = CString::new(b"wg-test".to_vec()).unwrap();
 
-        let peer_1 = PeerMessage(
-            [
-                PeerNla::PublicKey([
-                    32, 224, 68, 5, 23, 136, 103, 229, 206, 59, 34, 231, 215, 139, 214, 236, 80,
-                    81, 187, 7, 154, 197, 251, 36, 171, 156, 48, 73, 145, 47, 134, 54,
-                ]),
-                PeerNla::PresharedKey([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0,
-                ]),
-                LastHandshakeTime(TimeSpec::seconds(0)),
-                PersistentKeepaliveInterval(0),
-                TxBytes(0),
-                RxBytes(0),
-                ProtocolVersion(1),
-                Endpoint(InetAddr::from_std(&"192.168.40.1:9797".parse().unwrap())),
-                AllowedIps(
-                    [AllowedIpMessage(
-                        [
-                            CidrMask(32),
-                            AddressFamily(2),
-                            IpAddr(Ipv4Addr::new(192, 168, 39, 1).into()),
-                        ]
-                        .to_vec(),
-                    )]
-                    .to_vec()
-                    .to_vec(),
-                ),
-            ]
-            .to_vec(),
-        );
+        let peer_1 = PeerMessage(vec![
+            PeerNla::PublicKey([
+                32, 224, 68, 5, 23, 136, 103, 229, 206, 59, 34, 231, 215, 139, 214, 236, 80, 81,
+                187, 7, 154, 197, 251, 36, 171, 156, 48, 73, 145, 47, 134, 54,
+            ]),
+            PeerNla::PresharedKey([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ]),
+            LastHandshakeTime(TimeSpec::seconds(0)),
+            PersistentKeepaliveInterval(0),
+            TxBytes(0),
+            RxBytes(0),
+            ProtocolVersion(1),
+            Endpoint(InetAddr::from_std(&"192.168.40.1:9797".parse().unwrap())),
+            AllowedIps(vec![AllowedIpMessage(vec![
+                CidrMask(32),
+                AddressFamily(2),
+                IpAddr(Ipv4Addr::new(192, 168, 39, 1).into()),
+            ])]),
+        ]);
 
-        let peer_2 = PeerMessage(
-            [
-                PeerNla::PublicKey([
-                    244, 28, 206, 12, 79, 36, 88, 183, 194, 157, 54, 38, 54, 183, 127, 32, 142, 24,
-                    251, 158, 217, 56, 12, 146, 208, 21, 132, 157, 162, 68, 2, 44,
-                ]),
-                PresharedKey([
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0,
-                ]),
-                LastHandshakeTime(TimeSpec::seconds(0)),
-                PersistentKeepaliveInterval(0),
-                TxBytes(0),
-                RxBytes(0),
-                ProtocolVersion(1),
-                Endpoint(InetAddr::from_std(&"192.168.40.2:9797".parse().unwrap())),
-                AllowedIps(
-                    [AllowedIpMessage(
-                        [
-                            CidrMask(32),
-                            AddressFamily(2),
-                            IpAddr(Ipv4Addr::new(192, 168, 39, 2).into()),
-                        ]
-                        .to_vec(),
-                    )]
-                    .to_vec(),
-                ),
-            ]
-            .to_vec(),
-        );
+        let peer_2 = PeerMessage(vec![
+            PeerNla::PublicKey([
+                244, 28, 206, 12, 79, 36, 88, 183, 194, 157, 54, 38, 54, 183, 127, 32, 142, 24,
+                251, 158, 217, 56, 12, 146, 208, 21, 132, 157, 162, 68, 2, 44,
+            ]),
+            PresharedKey([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0,
+            ]),
+            LastHandshakeTime(TimeSpec::seconds(0)),
+            PersistentKeepaliveInterval(0),
+            TxBytes(0),
+            RxBytes(0),
+            ProtocolVersion(1),
+            Endpoint(InetAddr::from_std(&"192.168.40.2:9797".parse().unwrap())),
+            AllowedIps(vec![AllowedIpMessage(vec![
+                CidrMask(32),
+                AddressFamily(2),
+                IpAddr(Ipv4Addr::new(192, 168, 39, 2).into()),
+            ])]),
+        ]);
 
         DeviceMessage {
             command: WG_CMD_GET_DEVICE,
             message_type: 0,
-            nlas: [
+            nlas: vec![
                 ListenPort(51820),
                 Fwmark(0),
                 IfIndex(320),
@@ -786,9 +767,8 @@ mod test {
                     102, 218, 178, 222, 191, 21, 59, 83, 124, 180, 124, 41, 91, 10, 134, 199, 84,
                     186, 27, 218, 53, 216, 20, 93, 203, 82, 68, 74, 189, 142, 99, 59,
                 ]),
-                Peers([peer_1, peer_2].to_vec()),
-            ]
-            .to_vec(),
+                Peers(vec![peer_1, peer_2]),
+            ],
         }
     }
 
@@ -799,66 +779,46 @@ mod test {
 
         let if_name = CString::new("wg-test".to_string()).unwrap();
 
-        let peer_1 = PeerMessage(
-            [
-                PeerNla::PublicKey([
-                    32, 224, 68, 5, 23, 136, 103, 229, 206, 59, 34, 231, 215, 139, 214, 236, 80,
-                    81, 187, 7, 154, 197, 251, 36, 171, 156, 48, 73, 145, 47, 134, 54,
-                ]),
-                Endpoint(InetAddr::from_std(&"192.168.40.1:9797".parse().unwrap())),
-                PeerNla::Flags(WGPEER_F_REPLACE_ALLOWEDIPS),
-                AllowedIps(
-                    [AllowedIpMessage(
-                        [
-                            AddressFamily(2),
-                            IpAddr(Ipv4Addr::new(192, 168, 39, 1).into()),
-                            CidrMask(32),
-                        ]
-                        .to_vec(),
-                    )]
-                    .to_vec()
-                    .to_vec(),
-                ),
-            ]
-            .to_vec(),
-        );
+        let peer_1 = PeerMessage(vec![
+            PeerNla::PublicKey([
+                32, 224, 68, 5, 23, 136, 103, 229, 206, 59, 34, 231, 215, 139, 214, 236, 80, 81,
+                187, 7, 154, 197, 251, 36, 171, 156, 48, 73, 145, 47, 134, 54,
+            ]),
+            Endpoint(InetAddr::from_std(&"192.168.40.1:9797".parse().unwrap())),
+            PeerNla::Flags(WGPEER_F_REPLACE_ALLOWEDIPS),
+            AllowedIps(vec![AllowedIpMessage(vec![
+                AddressFamily(2),
+                IpAddr(Ipv4Addr::new(192, 168, 39, 1).into()),
+                CidrMask(32),
+            ])]),
+        ]);
 
-        let peer_2 = PeerMessage(
-            [
-                PeerNla::PublicKey([
-                    244, 28, 206, 12, 79, 36, 88, 183, 194, 157, 54, 38, 54, 183, 127, 32, 142, 24,
-                    251, 158, 217, 56, 12, 146, 208, 21, 132, 157, 162, 68, 2, 44,
-                ]),
-                Endpoint(InetAddr::from_std(&"192.168.40.2:9797".parse().unwrap())),
-                PeerNla::Flags(WGPEER_F_REPLACE_ALLOWEDIPS),
-                AllowedIps(
-                    [AllowedIpMessage(
-                        [
-                            AddressFamily(2),
-                            IpAddr(Ipv4Addr::new(192, 168, 39, 2).into()),
-                            CidrMask(32),
-                        ]
-                        .to_vec(),
-                    )]
-                    .to_vec(),
-                ),
-            ]
-            .to_vec(),
-        );
+        let peer_2 = PeerMessage(vec![
+            PeerNla::PublicKey([
+                244, 28, 206, 12, 79, 36, 88, 183, 194, 157, 54, 38, 54, 183, 127, 32, 142, 24,
+                251, 158, 217, 56, 12, 146, 208, 21, 132, 157, 162, 68, 2, 44,
+            ]),
+            Endpoint(InetAddr::from_std(&"192.168.40.2:9797".parse().unwrap())),
+            PeerNla::Flags(WGPEER_F_REPLACE_ALLOWEDIPS),
+            AllowedIps(vec![AllowedIpMessage(vec![
+                AddressFamily(2),
+                IpAddr(Ipv4Addr::new(192, 168, 39, 2).into()),
+                CidrMask(32),
+            ])]),
+        ]);
 
         DeviceMessage {
             command: WG_CMD_SET_DEVICE,
             message_type: 0,
-            nlas: [
+            nlas: vec![
                 IfName(if_name),
                 PrivateKey([
                     56, 71, 244, 173, 101, 223, 85, 22, 171, 175, 15, 39, 53, 180, 193, 198, 73,
                     55, 53, 59, 188, 26, 52, 74, 173, 179, 22, 213, 161, 71, 252, 125,
                 ]),
                 ListenPort(51820),
-                Peers([peer_1, peer_2].to_vec()),
-            ]
-            .to_vec(),
+                Peers(vec![peer_1, peer_2]),
+            ],
         }
     }
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -34,6 +34,7 @@ single_use_lifetimes = "warn"
 
 [workspace.lints.clippy]
 unused_async = "deny"
+implicit_clone = "warn"
 
 [workspace.dependencies]
 futures = "0.3"

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -568,7 +568,7 @@ pub async fn geoip_lookup_with_retries(rpc: &ServiceClient) -> Result<AmIMullvad
 
     loop {
         let result = rpc
-            .geoip_lookup(TEST_CONFIG.mullvad_host.to_owned())
+            .geoip_lookup(TEST_CONFIG.mullvad_host.clone())
             .await
             .map_err(Error::GeoipLookup);
 

--- a/test/test-manager/src/vm/network/macos.rs
+++ b/test/test-manager/src/vm/network/macos.rs
@@ -67,7 +67,7 @@ pub(crate) fn find_vm_bridge(guest_ip: &Ipv4Addr) -> Result<(String, Ipv4Addr)> 
             ipnetwork::Ipv4Network::with_netmask(address, netmask)
                 .ok()
                 .filter(|ip_v4_network| ip_v4_network.contains(*guest_ip))
-                .map(|_| (interface_name.to_owned(), address))
+                .map(|_| (interface_name.clone(), address))
         })
         .ok_or_else(|| anyhow!("Failed to identify bridge used by tart -- not running?"))
 }


### PR DESCRIPTION
I stumbled on this lint from the pedantic series of clippy lints. I found it to be quite valid thing to lint about. Sometimes it can just be seen as a stylistic choice between `to_owned` or `clone` maybe. But what the lint wants to communicate is that `to_owned` should be used when you have a `&str` and want a `String`. While if you have a `&String` and need a `String` you should clone it. Being more explicit with the intentions.

I don't think it hurts to enable. Will make the code slightly more consistent. I saw no "false positives" where this just caused annoying noise. But tell me what you think.

There are also two "trophy cases" here. You can see in one commit I'm able to completely get rid of cloning in two places. Not that it's going to affect our performance in any way at all, but nice with less cloning if it's completely unnecessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7835)
<!-- Reviewable:end -->
