### PR TITLE
Add helper function to check named pipe ownership to `windows-utils` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6145,6 +6145,8 @@ name = "windows-utils"
 version = "0.0.0"
 dependencies = [
  "neon",
+ "talpid-types",
+ "talpid-windows",
  "thiserror 2.0.9",
  "windows 0.59.0",
 ]

--- a/desktop/packages/windows-utils/Cargo.toml
+++ b/desktop/packages/windows-utils/Cargo.toml
@@ -19,3 +19,6 @@ path = "windows-utils-rs/lib.rs"
 neon = "1"
 windows = { version = "0.59.0", features = ["Win32", "Win32_UI", "Win32_UI_Shell", "Win32_System", "Win32_System_Com", "Win32_Storage_FileSystem"] }
 thiserror = { workspace = true }
+
+talpid-types = { path = "../../../talpid-types" }
+talpid-windows = { path = "../../../talpid-windows" }

--- a/desktop/packages/windows-utils/src/index.cts
+++ b/desktop/packages/windows-utils/src/index.cts
@@ -7,6 +7,7 @@ import * as addon from './load.cjs';
 // which otherwise by default are `any`.
 declare module './load.cjs' {
   function readShortcut(linkPath: string): string | null;
+  function pipeIsAdminOwned(pipePath: string): boolean;
 }
 
 /**
@@ -15,4 +16,12 @@ declare module './load.cjs' {
  */
 export function readShortcut(linkPath: string): string | null {
   return addon.readShortcut(linkPath);
+}
+
+/**
+ * Return whether a named pipe is owned by the admin or SYSTEM account.
+ * @param pipePath path to a named pipe.
+ */
+export function pipeIsAdminOwned(pipePath: string): boolean {
+  return addon.pipeIsAdminOwned(pipePath);
 }

--- a/desktop/packages/windows-utils/windows-utils-rs/fs.rs
+++ b/desktop/packages/windows-utils/windows-utils-rs/fs.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::path::Path;
+
+use neon::prelude::{Context, FunctionContext};
+use neon::result::JsResult;
+use neon::types::{JsString, JsValue, Value};
+
+use talpid_types::ErrorExt;
+
+#[derive(thiserror::Error, Debug)]
+enum Error {
+    /// Failed to open the provided file
+    #[error("Failed to open named pipe")]
+    OpenPipe(#[source] io::Error),
+
+    /// Failed to check pipe ownership (GetSecurityInfo)
+    #[error("Failed to check named pipe ownership (GetSecurityInfo failed)")]
+    CheckPermissions(#[source] io::Error),
+}
+
+pub fn pipe_is_admin_owned(mut cx: FunctionContext<'_>) -> JsResult<'_, JsValue> {
+    let link_path = cx.argument::<JsString>(0)?.value(&mut cx);
+
+    match pipe_is_admin_owned_inner(link_path) {
+        Ok(is_admin_owned) => Ok(cx.boolean(is_admin_owned).as_value(&mut cx)),
+        Err(err) => cx.throw_error(err.display_chain()),
+    }
+}
+
+fn pipe_is_admin_owned_inner<P: AsRef<Path>>(path: P) -> Result<bool, Error> {
+    let client = std::fs::File::options()
+        .read(true)
+        .open(path)
+        .map_err(Error::OpenPipe)?;
+
+    talpid_windows::fs::is_admin_owned(client).map_err(Error::CheckPermissions)
+}

--- a/desktop/packages/windows-utils/windows-utils-rs/lib.rs
+++ b/desktop/packages/windows-utils/windows-utils-rs/lib.rs
@@ -2,11 +2,13 @@
 
 use neon::{prelude::ModuleContext, result::NeonResult};
 
+mod fs;
 mod shortcut;
 
 #[neon::main]
 fn main(mut cx: ModuleContext<'_>) -> NeonResult<()> {
     cx.export_function("readShortcut", shortcut::read_shortcut)?;
+    cx.export_function("pipeIsAdminOwned", fs::pipe_is_admin_owned)?;
 
     Ok(())
 }

--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -30,3 +30,10 @@ features = [
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",
 ]
+
+[target.'cfg(windows)'.dev-dependencies.windows-sys]
+workspace = true
+features = [
+    "Win32_Storage",
+    "Win32_Storage_FileSystem"
+]

--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -23,6 +23,7 @@ features = [
     "Win32_Foundation",
     "Win32_Globalization",
     "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_IO",
     "Win32_Networking_WinSock",

--- a/talpid-windows/src/fs.rs
+++ b/talpid-windows/src/fs.rs
@@ -1,0 +1,47 @@
+use core::ffi::c_void;
+use std::io;
+use std::os::windows::io::AsRawHandle;
+use std::ptr;
+
+use windows_sys::Win32::{
+    Foundation::{LocalFree, ERROR_SUCCESS},
+    Security::{
+        Authorization::{GetSecurityInfo, SE_FILE_OBJECT},
+        IsWellKnownSid, WinBuiltinAdministratorsSid, WinLocalSystemSid, OWNER_SECURITY_INFORMATION,
+        SECURITY_DESCRIPTOR, SID,
+    },
+};
+
+/// Return whether a file handle is owned by either SYSTEM or the built-in administrators account
+pub fn is_admin_owned<T: AsRawHandle>(handle: T) -> io::Result<bool> {
+    let mut security_descriptor: *mut SECURITY_DESCRIPTOR = ptr::null_mut();
+    let mut owner: *mut SID = ptr::null_mut();
+
+    // SAFETY: `handle` is a valid handle
+    let result = unsafe {
+        GetSecurityInfo(
+            handle.as_raw_handle() as isize,
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            (&mut owner) as *mut *mut SID as *mut *mut c_void,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            (&mut security_descriptor) as *mut *mut SECURITY_DESCRIPTOR as *mut *mut c_void,
+        )
+    };
+
+    if result != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(result as i32));
+    }
+
+    // SAFETY: `owner` is valid since `security_descriptor` still is, and the well-known type is a valid argument
+    let is_system_owned = unsafe { IsWellKnownSid(owner as _, WinLocalSystemSid) != 0 };
+    // SAFETY: `owner` is valid since `security_descriptor` still is, and the well-known type is a valid argument
+    let is_admin_owned = unsafe { IsWellKnownSid(owner as _, WinBuiltinAdministratorsSid) != 0 };
+
+    // SAFETY: Since we no longer need the descriptor (or owner), it may be freed
+    unsafe { LocalFree(security_descriptor.cast()) };
+
+    Ok(is_system_owned || is_admin_owned)
+}

--- a/talpid-windows/src/lib.rs
+++ b/talpid-windows/src/lib.rs
@@ -3,6 +3,9 @@
 #![deny(missing_docs)]
 #![cfg(windows)]
 
+/// File system
+pub mod fs;
+
 /// I/O
 pub mod io;
 


### PR DESCRIPTION
The actual function was added to `talpid-windows` since the CLI will probably want to use this.

Fix DES-1889.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7846)
<!-- Reviewable:end -->
