### PR TITLE
Use thread rng to generate ed25519 secret

### DIFF
--- a/mullvad-update/src/format/key.rs
+++ b/mullvad-update/src/format/key.rs
@@ -16,8 +16,7 @@ impl SecretKey {
     /// Generate a new secret ed25519 key
     #[cfg(feature = "sign")]
     pub fn generate() -> Self {
-        // Using OsRng is suggested by the docs
-        let key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
         SecretKey(key)
     }
 


### PR DESCRIPTION
`ThreadRng` uses chacha12, seeded by `OsRng`. This might be slightly better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7851)
<!-- Reviewable:end -->
