### PR TITLE
Trim surrounding whitespace in checksum files in `buildserver-upload.sh`

### DIFF
--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -45,7 +45,9 @@ while true; do
             upload_path="$platform/releases"
         fi
 
-        readarray -t files < <(cut -f 2- -d ' ' < "$checksums_path" | sed 's/^\*\(.*\)/\1/')
+        # Read all files listed in the checksum file at $checksums_path into an array.
+        # sed is used to trim surrounding whitespace and asterisks from filenames.
+        readarray -t files < <(cut -f 2- -d ' ' < "$checksums_path" | sed 's/^[ \t\*]*\(.*\)[ \t]*$/\1/')
         for filename in "${files[@]}"; do
             file="$checksums_dir/$filename"
 


### PR DESCRIPTION
Some `.sha256` include extra whitespace for whatever reason. This PR trims surrounding whitespace for all filenames.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7857)
<!-- Reviewable:end -->
