### PR TITLE
Update misleading documentation regarding random temp dir

### DIFF
--- a/installer-downloader/src/temp.rs
+++ b/installer-downloader/src/temp.rs
@@ -11,10 +11,11 @@
 //! # macOS
 //!
 //! The downloader does not run as a privileged user, so we store downloads in a temporary
-//! directory.
+//! directory that only the current user may access.
 //!
-//! This is vulnerable to TOCTOU, ie replacing the file after its hash has been verified, but only
-//! by the current user. Using a random directory name mitigates this issue.
+//! This is potentially vulnerable to TOCTOU, ie replacing the file after its hash has been
+//! verified, but only by the current user. However, this would require asking the user to approve
+//! privilege escalation, just like the actual installer does.
 
 use anyhow::Context;
 use async_trait::async_trait;


### PR DESCRIPTION
The previous comment implied that it fixed ("mitigated") the underlying issue.

Fix DES-1914.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7858)
<!-- Reviewable:end -->
