### PR TITLE
Deserialize canonical JSON after verifying it

### DIFF
--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -106,7 +106,9 @@ pub(super) fn deserialize_and_verify(
 
     Ok(PartialSignedResponse {
         signatures: partial_data.signatures,
-        signed: partial_data.signed,
+        // Serialize back in case something was lost during deserialization
+        signed: serde_json::from_slice(&canon_data)
+            .context("Failed to serialize canonical JSON")?,
     })
 }
 


### PR DESCRIPTION
This reverts 147a28c9e0244c0c4ca24fdd30f720616f2fb3b1 as recommended by the audit.

Fix DES-1915.