### PR TITLE
Implement send problem report using mullvad api ios 1117

### DIFF
--- a/ios/MullvadMockData/MullvadREST/APIProxy+Stubs.swift
+++ b/ios/MullvadMockData/MullvadREST/APIProxy+Stubs.swift
@@ -12,6 +12,14 @@ import MullvadTypes
 import WireGuardKitTypes
 
 struct APIProxyStub: APIQuerying {
+    func mullvadSendProblemReport(
+        _ body: REST.ProblemReportRequest,
+        retryStrategy: REST.RetryStrategy,
+        completionHandler: @escaping ProxyCompletionHandler<Void>
+    ) -> Cancellable {
+        AnyCancellable()
+    }
+
     func mullvadApiGetAddressList(
         retryStrategy: REST.RetryStrategy,
         completionHandler: @escaping ProxyCompletionHandler<[AnyIPEndpoint]>

--- a/ios/MullvadREST/APIRequest/APIRequest.swift
+++ b/ios/MullvadREST/APIRequest/APIRequest.swift
@@ -8,11 +8,14 @@
 
 public enum APIRequest: Codable, Sendable {
     case getAddressList(_ retryStrategy: REST.RetryStrategy)
+    case sendProblemReport(_ retryStrategy: REST.RetryStrategy, problemReportRequest: REST.ProblemReportRequest)
 
     var retryStrategy: REST.RetryStrategy {
-        switch self {
+        return switch self {
         case let .getAddressList(strategy):
-            return strategy
+            strategy
+        case let .sendProblemReport(strategy, _):
+            strategy
         }
     }
 }

--- a/ios/MullvadREST/ApiHandlers/MullvadApiRequestFactory.swift
+++ b/ios/MullvadREST/ApiHandlers/MullvadApiRequestFactory.swift
@@ -31,6 +31,13 @@ public struct MullvadApiRequestFactory: Sendable {
                     rawPointer,
                     retryStrategy.toRustStrategy()
                 ))
+            case let .sendProblemReport(retryStrategy, problemReportRequest):
+                MullvadApiCancellable(handle: mullvad_api_send_problem_report(
+                    apiContext.context,
+                    rawPointer,
+                    retryStrategy.toRustStrategy(),
+                    problemReportRequest.toRust()
+                ))
             }
         }
     }
@@ -38,4 +45,25 @@ public struct MullvadApiRequestFactory: Sendable {
 
 extension REST {
     public typealias MullvadApiRequestHandler = (((MullvadApiResponse) throws -> Void)?) -> MullvadApiCancellable
+}
+
+private extension REST.ProblemReportRequest {
+    func toRust() -> UnsafePointer<SwiftProblemReportRequest> {
+        let structPointer = UnsafeMutablePointer<SwiftProblemReportRequest>.allocate(capacity: 1)
+
+        let addressPointer = address.toUnsafePointer()
+        let messagePointer = message.toUnsafePointer()
+        let logPointer = log.toUnsafePointer()
+
+        structPointer.initialize(to: SwiftProblemReportRequest(
+            address: addressPointer,
+            address_len: UInt(address.utf8.count),
+            message: messagePointer,
+            message_len: UInt(message.utf8.count),
+            log: logPointer,
+            log_len: UInt(log.utf8.count)
+        ))
+
+        return UnsafePointer(structPointer)
+    }
 }

--- a/ios/MullvadREST/ApiHandlers/MullvadApiRequestFactory.swift
+++ b/ios/MullvadREST/ApiHandlers/MullvadApiRequestFactory.swift
@@ -24,20 +24,29 @@ public struct MullvadApiRequestFactory: Sendable {
 
             let rawPointer = Unmanaged.passRetained(pointerClass).toOpaque()
 
-            return switch request {
+            switch request {
             case let .getAddressList(retryStrategy):
-                MullvadApiCancellable(handle: mullvad_api_get_addresses(
-                    apiContext.context,
-                    rawPointer,
-                    retryStrategy.toRustStrategy()
-                ))
+                return MullvadApiCancellable(
+                    handle: mullvad_api_get_addresses(
+                        apiContext.context,
+                        rawPointer,
+                        retryStrategy.toRustStrategy()
+                    )
+                )
             case let .sendProblemReport(retryStrategy, problemReportRequest):
-                MullvadApiCancellable(handle: mullvad_api_send_problem_report(
-                    apiContext.context,
-                    rawPointer,
-                    retryStrategy.toRustStrategy(),
-                    problemReportRequest.toRust()
-                ))
+                let rustRequest = RustProblemReportRequest(from: problemReportRequest)
+
+                return MullvadApiCancellable(
+                    handle: mullvad_api_send_problem_report(
+                        apiContext.context,
+                        rawPointer,
+                        retryStrategy.toRustStrategy(),
+                        rustRequest.getPointer()
+                    ),
+                    deinitializer: {
+                        rustRequest.release()
+                    }
+                )
             }
         }
     }
@@ -45,25 +54,4 @@ public struct MullvadApiRequestFactory: Sendable {
 
 extension REST {
     public typealias MullvadApiRequestHandler = (((MullvadApiResponse) throws -> Void)?) -> MullvadApiCancellable
-}
-
-private extension REST.ProblemReportRequest {
-    func toRust() -> UnsafePointer<SwiftProblemReportRequest> {
-        let structPointer = UnsafeMutablePointer<SwiftProblemReportRequest>.allocate(capacity: 1)
-
-        let addressPointer = address.toUnsafePointer()
-        let messagePointer = message.toUnsafePointer()
-        let logPointer = log.toUnsafePointer()
-
-        structPointer.initialize(to: SwiftProblemReportRequest(
-            address: addressPointer,
-            address_len: UInt(address.utf8.count),
-            message: messagePointer,
-            message_len: UInt(message.utf8.count),
-            log: logPointer,
-            log_len: UInt(log.utf8.count)
-        ))
-
-        return UnsafePointer(structPointer)
-    }
 }

--- a/ios/MullvadREST/Extensions/String+UnsafePointer.swift
+++ b/ios/MullvadREST/Extensions/String+UnsafePointer.swift
@@ -1,0 +1,16 @@
+//
+//  String+UnsafePointer.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2025-03-19.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+import Foundation
+extension String {
+    func toUnsafePointer() -> UnsafePointer<UInt8>? {
+        guard let data = self.data(using: .utf8) else { return nil }
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: data.count)
+        data.copyBytes(to: buffer, count: data.count)
+        return UnsafePointer(buffer)
+    }
+}

--- a/ios/MullvadREST/Rust/RustProblemReportRequest.swift
+++ b/ios/MullvadREST/Rust/RustProblemReportRequest.swift
@@ -1,0 +1,52 @@
+//
+//  RustProblemReportRequest.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2025-03-21.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+import MullvadRustRuntimeProxy
+
+final public class RustProblemReportRequest {
+    private let rustPointer: UnsafeMutablePointer<SwiftProblemReportRequest>
+
+    public init(from request: REST.ProblemReportRequest) {
+        rustPointer = UnsafeMutablePointer<SwiftProblemReportRequest>.allocate(capacity: 1)
+
+        let addressPointer = request.address.toUnsafePointer()
+        let messagePointer = request.message.toUnsafePointer()
+        let logPointer = request.log.toUnsafePointer()
+
+        let metadataPointer = swift_map_new()
+
+        for (key, value) in request.metadata {
+            key.withCString { keyPtr in
+                value.withCString { valuePtr in
+                    swift_map_add(metadataPointer, keyPtr, valuePtr)
+                }
+            }
+        }
+
+        rustPointer.initialize(to: SwiftProblemReportRequest(
+            address: addressPointer,
+            address_len: UInt(request.address.utf8.count),
+            message: messagePointer,
+            message_len: UInt(request.message.utf8.count),
+            log: logPointer,
+            log_len: UInt(request.log.utf8.count),
+            meta_data: metadataPointer
+        ))
+    }
+
+    public func getPointer() -> UnsafePointer<SwiftProblemReportRequest> {
+        return UnsafePointer(rustPointer)
+    }
+
+    public func release() {
+        let metadataPointer = rustPointer.pointee.meta_data
+        swift_map_free(metadataPointer)
+
+        rustPointer.deinitialize(count: 1)
+        rustPointer.deallocate()
+    }
+}

--- a/ios/MullvadREST/Transport/APITransport.swift
+++ b/ios/MullvadREST/Transport/APITransport.swift
@@ -34,7 +34,7 @@ public final class APITransport: APITransportProtocol {
         let apiRequest = requestFactory.makeRequest(request)
 
         return apiRequest { response in
-            let error: APIError? = if response.statusCode != 200 {
+            let error: APIError? = if !response.success {
                 APIError(
                     statusCode: Int(response.statusCode),
                     errorDescription: response.errorDescription ?? "",

--- a/ios/MullvadRustRuntime/MullvadApiCancellable.swift
+++ b/ios/MullvadRustRuntime/MullvadApiCancellable.swift
@@ -10,12 +10,15 @@ import MullvadTypes
 
 public class MullvadApiCancellable: Cancellable {
     private let handle: SwiftCancelHandle
+    private let deinitializer: (() -> Void)?
 
-    public init(handle: consuming SwiftCancelHandle) {
+    public init(handle: consuming SwiftCancelHandle, deinitializer: (() -> Void)? = nil) {
         self.handle = handle
+        self.deinitializer = deinitializer
     }
 
     deinit {
+        deinitializer?()
         mullvad_api_cancel_task_drop(handle)
     }
 

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -53,6 +53,15 @@ typedef struct CompletionCookie {
   void *_0;
 } CompletionCookie;
 
+typedef struct SwiftProblemReportRequest {
+  const uint8_t *address;
+  uintptr_t address_len;
+  const uint8_t *message;
+  uintptr_t message_len;
+  const uint8_t *log;
+  uintptr_t log_len;
+} SwiftProblemReportRequest;
+
 typedef struct ProxyHandle {
   void *context;
   uint16_t port;
@@ -183,6 +192,11 @@ struct SwiftRetryStrategy mullvad_api_retry_strategy_exponential(uintptr_t max_r
                                                                  uint64_t initial_sec,
                                                                  uint32_t factor,
                                                                  uint64_t max_delay_sec);
+
+struct SwiftCancelHandle mullvad_api_send_problem_report(struct SwiftApiContext api_context,
+                                                         void *completion_cookie,
+                                                         struct SwiftRetryStrategy retry_strategy,
+                                                         const struct SwiftProblemReportRequest *request);
 
 /**
  * Initializes a valid pointer to an instance of `EncryptedDnsProxyState`.

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -24,6 +24,8 @@ typedef struct EncryptedDnsProxyState EncryptedDnsProxyState;
 
 typedef struct ExchangeCancelToken ExchangeCancelToken;
 
+typedef struct Map Map;
+
 typedef struct RequestCancelHandle RequestCancelHandle;
 
 typedef struct RetryStrategy RetryStrategy;
@@ -53,6 +55,10 @@ typedef struct CompletionCookie {
   void *_0;
 } CompletionCookie;
 
+typedef struct SwiftMap {
+  struct Map *inner;
+} SwiftMap;
+
 typedef struct SwiftProblemReportRequest {
   const uint8_t *address;
   uintptr_t address_len;
@@ -60,6 +66,7 @@ typedef struct SwiftProblemReportRequest {
   uintptr_t message_len;
   const uint8_t *log;
   uintptr_t log_len;
+  struct SwiftMap *meta_data;
 } SwiftProblemReportRequest;
 
 typedef struct ProxyHandle {
@@ -197,6 +204,14 @@ struct SwiftCancelHandle mullvad_api_send_problem_report(struct SwiftApiContext 
                                                          void *completion_cookie,
                                                          struct SwiftRetryStrategy retry_strategy,
                                                          const struct SwiftProblemReportRequest *request);
+
+struct SwiftMap *swift_map_new(void);
+
+void swift_map_add(struct SwiftMap *map, const char *key, const char *value);
+
+const char *swift_map_get(struct SwiftMap *map, const char *key);
+
+void swift_map_free(struct SwiftMap *map);
 
 /**
  * Initializes a valid pointer to an instance of `EncryptedDnsProxyState`.

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -970,6 +970,7 @@
 		F062000A2CB7EB42002E6DB9 /* CGSize+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06200092CB7EB42002E6DB9 /* CGSize+Helpers.swift */; };
 		F062000C2CB7EB5D002E6DB9 /* UIImage+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F062000B2CB7EB5D002E6DB9 /* UIImage+Helpers.swift */; };
 		F062B94D2C16E09700B6D47A /* TunnelSettingsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F062B94C2C16E09700B6D47A /* TunnelSettingsManagerTests.swift */; };
+		F0647C322D8AF1E800D2C489 /* String+UnsafePointer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0647C312D8AF1CD00D2C489 /* String+UnsafePointer.swift */; };
 		F072D3CF2C07122400906F64 /* SettingsUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F072D3CE2C07122400906F64 /* SettingsUpdaterTests.swift */; };
 		F072D3D22C071AD100906F64 /* ShadowsocksLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F072D3D12C071AD100906F64 /* ShadowsocksLoaderTests.swift */; };
 		F073FCB32C6617D70062EA1D /* TunnelStore+Stubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F073FCB22C6617D70062EA1D /* TunnelStore+Stubs.swift */; };
@@ -2392,6 +2393,7 @@
 		F06200092CB7EB42002E6DB9 /* CGSize+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Helpers.swift"; sourceTree = "<group>"; };
 		F062000B2CB7EB5D002E6DB9 /* UIImage+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Helpers.swift"; sourceTree = "<group>"; };
 		F062B94C2C16E09700B6D47A /* TunnelSettingsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettingsManagerTests.swift; sourceTree = "<group>"; };
+		F0647C312D8AF1CD00D2C489 /* String+UnsafePointer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+UnsafePointer.swift"; sourceTree = "<group>"; };
 		F072D3CE2C07122400906F64 /* SettingsUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUpdaterTests.swift; sourceTree = "<group>"; };
 		F072D3D12C071AD100906F64 /* ShadowsocksLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowsocksLoaderTests.swift; sourceTree = "<group>"; };
 		F073FCB22C6617D70062EA1D /* TunnelStore+Stubs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TunnelStore+Stubs.swift"; sourceTree = "<group>"; };
@@ -4291,6 +4293,7 @@
 		7AD63A422CDA661B00445268 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				F0647C312D8AF1CD00D2C489 /* String+UnsafePointer.swift */,
 				7AD63A432CDA662900445268 /* UInt+Counting.swift */,
 			);
 			path = Extensions;
@@ -5777,6 +5780,7 @@
 				F06045EA2B23217E00B2D37A /* ShadowsocksTransport.swift in Sources */,
 				06799AFC28F98EE300ACD94E /* AddressCache.swift in Sources */,
 				7ADCB2D82B6A6EB300C88F89 /* AnyRelay.swift in Sources */,
+				F0647C322D8AF1E800D2C489 /* String+UnsafePointer.swift in Sources */,
 				06799AF028F98E4800ACD94E /* REST.swift in Sources */,
 				06799ADF28F98E4800ACD94E /* RESTDevicesProxy.swift in Sources */,
 				06799ADA28F98E4800ACD94E /* RESTResponseHandler.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1074,6 +1074,7 @@
 		F0E8E4C32A602E0D00ED26A3 /* AccountDeletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E8E4C22A602E0D00ED26A3 /* AccountDeletionViewModel.swift */; };
 		F0E8E4C52A60499100ED26A3 /* AccountDeletionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E8E4C42A60499100ED26A3 /* AccountDeletionViewController.swift */; };
 		F0E8E4C92A604E7400ED26A3 /* AccountDeletionInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E8E4C82A604E7400ED26A3 /* AccountDeletionInteractor.swift */; };
+		F0EEFBA22D8D61A9007FE4B3 /* RustProblemReportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EEFB9E2D8D60E1007FE4B3 /* RustProblemReportRequest.swift */; };
 		F0EF50D52A949F8E0031E8DF /* ChangeLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EF50D42A949F8E0031E8DF /* ChangeLogViewModel.swift */; };
 		F0F316192BF3572B0078DBCF /* RelaySelectorResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F316182BF3572B0078DBCF /* RelaySelectorResult.swift */; };
 		F0F3161B2BF358590078DBCF /* NoRelaysSatisfyingConstraintsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F3161A2BF358590078DBCF /* NoRelaysSatisfyingConstraintsError.swift */; };
@@ -2469,6 +2470,7 @@
 		F0E8E4C22A602E0D00ED26A3 /* AccountDeletionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletionViewModel.swift; sourceTree = "<group>"; };
 		F0E8E4C42A60499100ED26A3 /* AccountDeletionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletionViewController.swift; sourceTree = "<group>"; };
 		F0E8E4C82A604E7400ED26A3 /* AccountDeletionInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletionInteractor.swift; sourceTree = "<group>"; };
+		F0EEFB9E2D8D60E1007FE4B3 /* RustProblemReportRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustProblemReportRequest.swift; sourceTree = "<group>"; };
 		F0EF50D42A949F8E0031E8DF /* ChangeLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeLogViewModel.swift; sourceTree = "<group>"; };
 		F0F1EF8C2BE8FF0A00CED01D /* LaunchArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArguments.swift; sourceTree = "<group>"; };
 		F0F316182BF3572B0078DBCF /* RelaySelectorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelectorResult.swift; sourceTree = "<group>"; };
@@ -2688,6 +2690,7 @@
 				F0DC779F2B2222D20087F09D /* Relay */,
 				06FAE67B28F83CA50033DD93 /* REST.swift */,
 				F0DC77A12B2313330087F09D /* RetryStrategy */,
+				F0EEFBA02D8D6133007FE4B3 /* Rust */,
 				F0DC77A02B2223290087F09D /* Transport */,
 			);
 			path = MullvadREST;
@@ -4479,16 +4482,16 @@
 		A992DA1E2C24709F00DE7CE5 /* MullvadRustRuntime */ = {
 			isa = PBXGroup;
 			children = (
-				A9D9A4D32C36E1EA004088DD /* mullvad_rust_runtime.h */,
-				A992DA1F2C24709F00DE7CE5 /* MullvadRustRuntime.h */,
 				014449942CA293B100C0C2F2 /* EncryptedDNSProxy.swift */,
 				A948809A2BC9308D0090A44C /* EphemeralPeerExchangeActor.swift */,
 				A9EB4F9C2B7FAB21002A2D7A /* EphemeralPeerNegotiator.swift */,
 				A9A557F42B7E3E5C0017ADA8 /* EphemeralPeerReceiver.swift */,
+				A9D9A4D32C36E1EA004088DD /* mullvad_rust_runtime.h */,
 				7A99D3702D56220E00891FF7 /* MullvadApiCancellable.swift */,
 				7A3215702D392F0B005DF395 /* MullvadApiCompletion.swift */,
 				7AB931232D43C2C2005FCEBA /* MullvadApiContext.swift */,
 				7AB931252D43D222005FCEBA /* MullvadApiResponse.swift */,
+				A992DA1F2C24709F00DE7CE5 /* MullvadRustRuntime.h */,
 				F0DDE40F2B220458006B57A7 /* ShadowSocksProxy.swift */,
 				584023212A406BF5007B27AC /* TunnelObfuscator.swift */,
 			);
@@ -4763,6 +4766,14 @@
 				F0E8E4C22A602E0D00ED26A3 /* AccountDeletionViewModel.swift */,
 			);
 			path = AccountDeletion;
+			sourceTree = "<group>";
+		};
+		F0EEFBA02D8D6133007FE4B3 /* Rust */ = {
+			isa = PBXGroup;
+			children = (
+				F0EEFB9E2D8D60E1007FE4B3 /* RustProblemReportRequest.swift */,
+			);
+			path = Rust;
 			sourceTree = "<group>";
 		};
 		F0EF50D12A8FA47E0031E8DF /* ChangeLog */ = {
@@ -5762,6 +5773,7 @@
 				F0B894EF2BF751C500817A42 /* RelayWithLocation.swift in Sources */,
 				F0DDE42C2B220A15006B57A7 /* Midpoint.swift in Sources */,
 				A90763C72B2858DC0045ADF0 /* CancellableChain.swift in Sources */,
+				F0EEFBA22D8D61A9007FE4B3 /* RustProblemReportRequest.swift in Sources */,
 				7AB9312F2D4A5D0A005FCEBA /* MullvadApiNetworkOperation.swift in Sources */,
 				06799AF128F98E4800ACD94E /* RESTAPIProxy.swift in Sources */,
 				F0DDE42A2B220A15006B57A7 /* Haversine.swift in Sources */,

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
@@ -80,13 +80,10 @@ final class ProblemReportInteractor: @unchecked Sendable {
             metadata: metadataDict
         )
 
-        _ = self.apiProxy.sendProblemReport(
-            request,
-            retryStrategy: .default
-        ) { result in
+        _ = self.apiProxy.mullvadSendProblemReport(request, retryStrategy: .default, completionHandler: { result in
             DispatchQueue.main.async {
                 completion(result)
             }
-        }
+        })
     }
 }

--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -670,6 +670,21 @@ impl ProblemReportProxy {
         log: &str,
         metadata: &BTreeMap<String, String>,
     ) -> impl Future<Output = Result<(), rest::Error>> {
+        let future =         self.porblem_report_response(email, message, log, metadata);
+
+        async move {
+            future.await?;
+            Ok(())
+        }
+    }
+
+    pub fn porblem_report_response(
+        &self,
+        email: &str,
+        message: &str,
+        log: &str,
+        metadata: &BTreeMap<String, String>,
+    ) -> impl Future<Output = Result<rest::Response<Incoming>, rest::Error>> {
         #[derive(serde::Serialize)]
         struct ProblemReport {
             address: String,
@@ -692,8 +707,7 @@ impl ProblemReportProxy {
             let request = factory
                 .post_json(&format!("{APP_URL_PREFIX}/problem-report"), &report)?
                 .expected_status(&[StatusCode::NO_CONTENT]);
-            service.request(request).await?;
-            Ok(())
+            service.request(request).await
         }
     }
 }

--- a/mullvad-ios/src/api_client/mod.rs
+++ b/mullvad-ios/src/api_client/mod.rs
@@ -11,6 +11,7 @@ mod cancellation;
 mod completion;
 mod response;
 mod retry_strategy;
+mod  send_problem_report;
 
 #[repr(C)]
 pub struct SwiftApiContext(*const ApiContext);

--- a/mullvad-ios/src/api_client/response.rs
+++ b/mullvad-ios/src/api_client/response.rs
@@ -2,6 +2,7 @@ use std::{ffi::CString, ptr::null_mut};
 
 use mullvad_api::rest::{self, Response};
 
+
 #[repr(C)]
 pub struct SwiftMullvadApiResponse {
     body: *mut u8,

--- a/mullvad-ios/src/api_client/send_problem_report.rs
+++ b/mullvad-ios/src/api_client/send_problem_report.rs
@@ -1,0 +1,124 @@
+use mullvad_api::{
+    rest::{self, MullvadRestHandle},
+    ProblemReportProxy,
+};
+use talpid_future::retry::retry_future;
+
+use super::{
+    cancellation::{RequestCancelHandle, SwiftCancelHandle},
+    completion::{CompletionCookie, SwiftCompletionHandler},
+    response::SwiftMullvadApiResponse,
+    retry_strategy::{RetryStrategy, SwiftRetryStrategy},
+    SwiftApiContext,
+};
+
+use mullvad_api::rest::Error;
+use std::{collections::BTreeMap};
+use std::slice;
+use tokio::task::JoinHandle;
+
+#[no_mangle]
+pub unsafe extern "C" fn mullvad_api_send_problem_report(
+    api_context: SwiftApiContext,
+    completion_cookie: *mut libc::c_void,
+    retry_strategy: SwiftRetryStrategy,
+    request: *const SwiftProblemReportRequest,
+) -> SwiftCancelHandle {
+    let completion_handler = SwiftCompletionHandler::new(CompletionCookie(completion_cookie));
+    let completion = completion_handler.clone();
+
+    let Ok(tokio_handle) = crate::mullvad_ios_runtime() else {
+        completion_handler.finish(SwiftMullvadApiResponse::no_tokio_runtime());
+        return SwiftCancelHandle::empty();
+    };
+
+    let api_context = api_context.into_rust_context();
+    let retry_strategy = unsafe { retry_strategy.into_rust() };
+
+    let problem_report_request = match unsafe { ProblemReportRequest::from_swift_parameters(request) } {
+        Some(req) => req,
+        None => {
+            let err = Error::ApiError(rest::StatusCode::BAD_REQUEST, "Failed to send problem report: invalid address, message, or log data.".to_string());
+            log::error!("{err:?}");
+            completion.finish(SwiftMullvadApiResponse::rest_error(err));
+            return SwiftCancelHandle::empty();
+        }
+    };
+
+    let task: JoinHandle<()> = tokio_handle.spawn(async move {
+        match mullvad_api_send_problem_report_inner(
+            api_context.rest_handle(),
+            retry_strategy,
+            problem_report_request,
+        )
+        .await
+        {
+            Ok(response) => completion.finish(response),
+            Err(err) => {
+                log::error!("{err:?}");
+                completion.finish(SwiftMullvadApiResponse::rest_error(err));
+            }
+        }
+    });
+
+    RequestCancelHandle::new(task, completion_handler.clone()).into_swift()
+}
+
+async fn mullvad_api_send_problem_report_inner(
+    rest_client: MullvadRestHandle,
+    retry_strategy: RetryStrategy,
+    problem_report_request: ProblemReportRequest,
+) -> Result<SwiftMullvadApiResponse, rest::Error> {
+    let api = ProblemReportProxy::new(rest_client);
+    let empty_metadata: BTreeMap<String, String> = BTreeMap::new();
+
+    let future_factory = || api.porblem_report_response(&problem_report_request.address, &problem_report_request.message, &(String::from_utf8_lossy(&problem_report_request.log)), &empty_metadata);
+
+    let should_retry = |result: &Result<_, rest::Error>| match result {
+        Err(err) => err.is_network_error(),
+        Ok(_) => false,
+    };
+
+    let response = retry_future(future_factory, should_retry, retry_strategy.delays()).await?;
+    SwiftMullvadApiResponse::with_body(response).await
+
+}
+
+#[repr(C)]
+pub struct SwiftProblemReportRequest {
+    address: *const u8,
+    address_len: usize,
+    message: *const u8,
+    message_len: usize,
+    log: *const u8,
+    log_len: usize,
+}
+
+struct ProblemReportRequest {
+    address: String,
+    message: String,
+    log: Vec<u8>,
+}
+
+
+unsafe impl Send for SwiftProblemReportRequest {}
+
+impl ProblemReportRequest {
+    unsafe fn from_swift_parameters(request: *const SwiftProblemReportRequest) -> Option<Self> {
+        if request.is_null() {
+            return None;
+        }
+
+        let request = &*request; // Dereference the pointer
+
+        let address_slice = slice::from_raw_parts(request.address, request.address_len);
+        let message_slice = slice::from_raw_parts(request.message, request.message_len);
+        let log_slice = slice::from_raw_parts(request.log, request.log_len);
+
+        let address = String::from_utf8(address_slice.to_vec()).ok()?;
+        let message = String::from_utf8(message_slice.to_vec()).ok()?;
+        let log = log_slice.to_vec();
+
+        Some(Self { address, message, log })
+    }
+}

--- a/mullvad-ios/src/api_client/send_problem_report.rs
+++ b/mullvad-ios/src/api_client/send_problem_report.rs
@@ -3,6 +3,8 @@ use mullvad_api::{
     ProblemReportProxy,
 };
 use talpid_future::retry::retry_future;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 
 use super::{
     cancellation::{RequestCancelHandle, SwiftCancelHandle},
@@ -70,9 +72,8 @@ async fn mullvad_api_send_problem_report_inner(
     problem_report_request: ProblemReportRequest,
 ) -> Result<SwiftMullvadApiResponse, rest::Error> {
     let api = ProblemReportProxy::new(rest_client);
-    let empty_metadata: BTreeMap<String, String> = BTreeMap::new();
 
-    let future_factory = || api.porblem_report_response(&problem_report_request.address, &problem_report_request.message, &(String::from_utf8_lossy(&problem_report_request.log)), &empty_metadata);
+    let future_factory = || api.porblem_report_response(&problem_report_request.address, &problem_report_request.message, &(String::from_utf8_lossy(&problem_report_request.log)), &problem_report_request.meta_data);
 
     let should_retry = |result: &Result<_, rest::Error>| match result {
         Err(err) => err.is_network_error(),
@@ -92,12 +93,14 @@ pub struct SwiftProblemReportRequest {
     message_len: usize,
     log: *const u8,
     log_len: usize,
+    meta_data : *mut SwiftMap,
 }
 
 struct ProblemReportRequest {
     address: String,
     message: String,
     log: Vec<u8>,
+    meta_data: BTreeMap<String, String>,
 }
 
 
@@ -119,6 +122,95 @@ impl ProblemReportRequest {
         let message = String::from_utf8(message_slice.to_vec()).ok()?;
         let log = log_slice.to_vec();
 
-        Some(Self { address, message, log })
+        let meta_data = if request.meta_data.is_null() {
+            BTreeMap::new() // Default empty map
+        } else {
+            let swift_map = &*request.meta_data;
+            let mut converted_map = BTreeMap::new();
+
+            if let Some(inner) = swift_map.inner.as_ref() {
+                for (key, value) in &inner.0 {
+                    converted_map.insert(key.clone(), value.clone());
+                }
+            }
+
+            converted_map
+        };
+
+        Some(Self { address, message, log, meta_data })
+    }
+}
+
+
+
+
+#[repr(C)]
+pub struct SwiftMap {
+    inner: *mut Map,
+}
+
+struct Map(BTreeMap<String, String>);
+
+impl Map {
+    fn new() -> Self {
+        Map(BTreeMap::new())
+    }
+
+    unsafe fn add(&mut self, key: *const c_char, value: *const c_char) {
+        let key = CStr::from_ptr(key).to_string_lossy().into_owned();
+        let value = CStr::from_ptr(value).to_string_lossy().into_owned();
+        self.0.insert(key, value);
+    }
+
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(|s| s.as_str())
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn swift_map_new() -> *mut SwiftMap {
+    let map = Box::new(Map::new());
+    let swift_map = Box::new(SwiftMap {
+        inner: Box::into_raw(map),
+    });
+    Box::into_raw(swift_map)
+}
+
+#[no_mangle]
+pub extern "C" fn swift_map_add(map: *mut SwiftMap, key: *const c_char, value: *const c_char) {
+    if let Some(map) = unsafe { map.as_mut() } {
+        if let Some(inner) = unsafe { map.inner.as_mut() } {
+            unsafe { inner.add(key, value) };
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn swift_map_get(map: *mut SwiftMap, key: *const c_char) -> *const c_char {
+    if let Some(map) = unsafe { map.as_mut() } {
+        if let Some(inner) = unsafe { map.inner.as_ref() } {
+            let key = unsafe { CStr::from_ptr(key).to_str().unwrap() };
+            if let Some(value) = inner.get(key) {
+                return CString::new(value).unwrap().into_raw();
+            }
+        }
+    }
+    std::ptr::null()
+}
+
+#[no_mangle]
+pub extern "C" fn swift_map_free(map: *mut SwiftMap) {
+    if map.is_null() {
+        return;
+    }
+
+    unsafe {
+        // Free the inner map first
+        if let Some(inner) = (*map).inner.as_mut() {
+            drop(Box::from_raw(inner));
+        }
+
+        // Free the SwiftMap struct itself
+        drop(Box::from_raw(map));
     }
 }


### PR DESCRIPTION
this PR introduces the ability to use `SendProblemReport` from `Rust` into `Swift`. 