### PR TITLE
Update changelog with mention of bugfix for new users stuck after payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix `mullvad-cli` panicking if it tried to write to a closed pipe on Linux and macOS.
+- Fix bug where new users are not forwarded to the main view after payment.
 
 #### Windows
 - Fix error setting up tunnel when MTU was incorrectly set to a value below 1280 for IPv6.


### PR DESCRIPTION
Adds an entry in the changelog with a mention of the bugfix for new users stuck after payment.
This fix was merged in this PR:  https://github.com/mullvad/mullvadvpn-app/pull/7796

Checking Linear I also found the following issue which will be resolved by the same fix. Linking the Linear issue and related Github issue below:

Fixes: DES-1347
Fixes: https://github.com/mullvad/mullvadvpn-app/issues/7028

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7868)
<!-- Reviewable:end -->
