### PR TITLE
Fix syntax error in Apparmor profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ Line wrap the file at 100 chars.                                              Th
 ## [2025.5] - 2025-03-26
 This release is identical to 2025.5-beta1
 
+#### Linux
+- Fix syntax error in Apparmor profile.
+
 
 ## [2025.5-beta1] - 2025-03-11
 ### Added

--- a/dist-assets/linux/apparmor_mullvad
+++ b/dist-assets/linux/apparmor_mullvad
@@ -1,7 +1,7 @@
 abi <abi/4.0>,
 include <tunables/global>
 
-profile mullvad /opt/Mullvad\ VPN/mullvad-gui flags=(unconfined) {
+profile mullvad "/opt/Mullvad VPN/mullvad-gui" flags=(unconfined) {
   userns,
   # Site-specific additions and overrides. See local/README for details.
   include if exists <local/mullvad>


### PR DESCRIPTION
The executable path must be quoted instead of using an escape character.
See man apparmor.d(5), under "Unquoted Profile Name" - "Rules with embedded spaces or tabs must be quoted."

Before this commit, running `aa-enforce /opt/Mullvad\ VPN/mullvad-gui` (as root) returned an error:
```
ERROR: Syntax Error: Unknown line found in file /etc/apparmor.d/mullvad line 5:
    profile mullvad /opt/Mullvad\ VPN/mullvad-gui { userns,
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7876)
<!-- Reviewable:end -->
