### PR TITLE
Print public key when running 'meta generate-key'

### DIFF
--- a/mullvad-update/meta/src/main.rs
+++ b/mullvad-update/meta/src/main.rs
@@ -119,7 +119,9 @@ async fn main() -> anyhow::Result<()> {
 
     match opt {
         Opt::GenerateKey => {
-            println!("{}", key::SecretKey::generate());
+            let secret = key::SecretKey::generate();
+            println!("Secret key: {secret}");
+            println!("Public key: {}", secret.pubkey());
             Ok(())
         }
         Opt::CreateMetadataFile { platforms } => {

--- a/mullvad-update/src/format/key.rs
+++ b/mullvad-update/src/format/key.rs
@@ -79,6 +79,12 @@ impl Serialize for SecretKey {
 #[cfg_attr(test, derive(Clone))]
 pub struct VerifyingKey(pub ed25519_dalek::VerifyingKey);
 
+impl fmt::Display for VerifyingKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0.as_bytes()))
+    }
+}
+
 impl VerifyingKey {
     pub fn from_hex(s: &str) -> anyhow::Result<Self> {
         let bytes = bytes_from_hex::<{ ed25519_dalek::PUBLIC_KEY_LENGTH }>(s)?;


### PR DESCRIPTION
The only way to retrieve the pubkey currently is by signing something. The PR prints it during generation for convenience.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7880)
<!-- Reviewable:end -->
