### PR TITLE
Implement changes to suggestedUpgrade in Electron

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/version.ts
+++ b/desktop/packages/mullvad-vpn/src/main/version.ts
@@ -81,7 +81,7 @@ export default class Version {
 
     const suggestedIsBeta =
       latestVersionInfo.suggestedUpgrade !== undefined &&
-      IS_BETA.test(latestVersionInfo.suggestedUpgrade);
+      IS_BETA.test(latestVersionInfo.suggestedUpgrade.version);
 
     const upgradeVersion = {
       ...latestVersionInfo,

--- a/desktop/packages/mullvad-vpn/src/main/version.ts
+++ b/desktop/packages/mullvad-vpn/src/main/version.ts
@@ -95,7 +95,6 @@ export default class Version {
       new UnsupportedVersionNotificationProvider({
         supported: latestVersionInfo.supported,
         consistent: this.currentVersionData.isConsistent,
-        suggestedUpgrade: latestVersionInfo.suggestedUpgrade,
         suggestedIsBeta,
       }),
       new UpdateAvailableNotificationProvider({

--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -588,7 +588,7 @@ export default class AppRenderer {
 
   public setDismissedUpgrade = (): void => {
     IpcRendererEventChannel.upgradeVersion.dismissedUpgrade(
-      this.reduxStore.getState().version.suggestedUpgrade ?? '',
+      this.reduxStore.getState().version.suggestedUpgrade?.version ?? '',
     );
   };
 

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/version/reducers.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/version/reducers.ts
@@ -1,10 +1,11 @@
+import { AppVersionInfoSuggestedUpgrade } from '../../../shared/daemon-rpc-types';
 import { ReduxAction } from '../store';
 
 export interface IVersionReduxState {
   current: string;
   supported: boolean;
   isBeta: boolean;
-  suggestedUpgrade?: string;
+  suggestedUpgrade?: AppVersionInfoSuggestedUpgrade;
   suggestedIsBeta?: boolean;
   consistent: boolean;
 }

--- a/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
@@ -381,9 +381,15 @@ export interface IDnsOptions {
   };
 }
 
+export type AppVersionInfoSuggestedUpgrade = {
+  changelog?: string;
+  verifiedInstallerPath?: string;
+  version: string;
+};
+
 export interface IAppVersionInfo {
   supported: boolean;
-  suggestedUpgrade?: string;
+  suggestedUpgrade?: AppVersionInfoSuggestedUpgrade;
   suggestedIsBeta?: boolean;
 }
 

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
@@ -12,7 +12,6 @@ import {
 interface UnsupportedVersionNotificationContext {
   supported: boolean;
   consistent: boolean;
-  suggestedUpgrade?: string;
   suggestedIsBeta?: boolean;
 }
 

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/update-available.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/update-available.ts
@@ -1,6 +1,7 @@
 import { sprintf } from 'sprintf-js';
 
 import { messages } from '../../shared/gettext';
+import { AppVersionInfoSuggestedUpgrade } from '../daemon-rpc-types';
 import { getDownloadUrl } from '../version';
 import {
   InAppNotification,
@@ -12,7 +13,7 @@ import {
 } from './notification';
 
 interface UpdateAvailableNotificationContext {
-  suggestedUpgrade?: string;
+  suggestedUpgrade?: AppVersionInfoSuggestedUpgrade;
   suggestedIsBeta?: boolean;
 }
 
@@ -22,7 +23,7 @@ export class UpdateAvailableNotificationProvider
   public constructor(private context: UpdateAvailableNotificationContext) {}
 
   public mayDisplay() {
-    return this.context.suggestedUpgrade ? true : false;
+    return this.context.suggestedUpgrade?.version ? true : false;
   }
 
   public getInAppNotification(): InAppNotification {
@@ -62,7 +63,7 @@ export class UpdateAvailableNotificationProvider
         // TRANSLATORS: Available placeholders:
         // TRANSLATORS: %(version)s - The version number of the new beta version.
         messages.pgettext('in-app-notifications', 'Try out the newest beta version (%(version)s).'),
-        { version: this.context.suggestedUpgrade },
+        { version: this.context.suggestedUpgrade?.version },
       );
     } else {
       // TRANSLATORS: The in-app banner displayed to the user when the app update is available.
@@ -84,7 +85,7 @@ export class UpdateAvailableNotificationProvider
           'notifications',
           'Beta update available. Try out the newest beta version (%(version)s).',
         ),
-        { version: this.context.suggestedUpgrade },
+        { version: this.context.suggestedUpgrade?.version },
       );
     } else {
       return messages.pgettext(

--- a/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
@@ -51,7 +51,6 @@ describe('System notifications', () => {
     const notification = new UnsupportedVersionNotificationProvider({
       supported: false,
       consistent: true,
-      suggestedUpgrade: '2100.1',
       suggestedIsBeta: false,
     });
 
@@ -88,7 +87,6 @@ describe('System notifications', () => {
     const notification = new UnsupportedVersionNotificationProvider({
       supported: false,
       consistent: true,
-      suggestedUpgrade: '2100.1',
       suggestedIsBeta: false,
     });
 
@@ -105,7 +103,6 @@ describe('System notifications', () => {
     const notification = new UnsupportedVersionNotificationProvider({
       supported: false,
       consistent: true,
-      suggestedUpgrade: '2100.1',
       suggestedIsBeta: false,
     });
 

--- a/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
@@ -68,7 +68,9 @@ describe('System notifications', () => {
     const controller1 = createController();
     const controller2 = createController();
     const notification = new UpdateAvailableNotificationProvider({
-      suggestedUpgrade: '2100.1',
+      suggestedUpgrade: {
+        version: '2100.1',
+      },
       suggestedIsBeta: false,
     });
 


### PR DESCRIPTION
When the `AppVersionInfo.suggestedUpgrade` property is updated, due to the changes in [DES-1811](https://linear.app/mullvad/issue/DES-1811/create-specification-for-communication-between-electron-and-the-daemon) we need to make some changes in the code to handle the new format.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7881)
<!-- Reviewable:end -->
