### PR TITLE
Use the user facing term "Automatic" instead of "Any" in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Line wrap the file at 100 chars.                                              Th
 - Rename `win-shortcuts` native module to `windows-utils`.
 
 ### Removed
-- Remove "Any" option for tunnel protocol. The default is now WireGuard.
+- Remove "Automatic" option for tunnel protocol. The default is now WireGuard.
 
 ### Fixed
 - Fix `mullvad-cli` panicking if it tried to write to a closed pipe on Linux and macOS.


### PR DESCRIPTION
:pick: The user facing option is/was called "Automatic". This change is made to prevent confusion in the next beta release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7888)
<!-- Reviewable:end -->
