### PR TITLE
Clarify documentation about TOCTOU attack on installer downloader

### DIFF
--- a/installer-downloader/src/temp.rs
+++ b/installer-downloader/src/temp.rs
@@ -13,9 +13,12 @@
 //! The downloader does not run as a privileged user, so we store downloads in a temporary
 //! directory that only the current user may access.
 //!
-//! This is potentially vulnerable to TOCTOU, ie replacing the file after its hash has been
-//! verified, but only by the current user. However, this would require asking the user to approve
-//! privilege escalation, just like the actual installer does.
+//! This is potentially vulnerable to TOCTOU, i.e. replacing the file after its hash has been
+//! verified but before it has been launched, leading to the installer downloader launching
+//! a malicious binary. However, this is considered outside the threat model of the installer
+//! downloader, since the attack can only be carried out by code running as the same user
+//! that runs the installer downloader. If such code is running, the attacker can just as well
+//! replace the installer downloader instead.
 
 use anyhow::Context;
 use async_trait::async_trait;


### PR DESCRIPTION
Further clarify why the potential same-user TOCTOU attack on the installer downloader on macOS is not in scope for our threat model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7889)
<!-- Reviewable:end -->
