### PR TITLE
Tighten signature verification in `download-release-artifacts`

### DIFF
--- a/desktop/scripts/release/download-release-artifacts
+++ b/desktop/scripts/release/download-release-artifacts
@@ -21,9 +21,6 @@ URL_BASE="https://releases.mullvad.net/desktop/releases"
 
 mkdir -p $ARTIFACT_DIR
 
-# Find GnuPG command to use. Prefer gpg2
-gpg_cmd=$(command -v gpg2 || command -v gpg)
-
 for ext in .exe _arm64.exe _x64.exe _amd64.deb _arm64.deb _x86_64.rpm _aarch64.rpm .pkg; do
     pkg_filename="MullvadVPN-${PRODUCT_VERSION}${ext}"
     pkg_path="$ARTIFACT_DIR/$pkg_filename"
@@ -45,7 +42,8 @@ for ext in .exe _arm64.exe _x64.exe _amd64.deb _arm64.deb _x86_64.rpm _aarch64.r
 
     echo ""
     echo ">>> Verifying integrity of $pkg_filename"
-    if ! $gpg_cmd --verify "$pkg_path.asc" "$pkg_path"; then
+    # We prefer sq for PGP key verification (sequoia-sq in the fedora repos).
+    if ! sq verify --signer-file="mullvad-code-signing-key.asc" --signature-file="$pkg_path.asc" "$pkg_path"; then
         echo ""
         echo "!!! INTEGRITY CHECKING FAILED !!!"
         rm "$pkg_path" "$pkg_path.asc"


### PR DESCRIPTION
Make it harder to accidentally trust signatures from a key different from the Mullvad Code signing key by explicitly setting the the allowed signer key. For this purpose, we will switch to using `sequoia-sq` for verifying downloaded artifacts in `download-release-artifacts` script. With `sequoia-sq` it is possible to specify a detached signer file with `sq verify --signer-file`.

This is in response to finding `3.1` in the audit of `installer-downloader` that was given to us last week.