### PR TITLE
Add `2025.5` changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Line wrap the file at 100 chars.                                              Th
 - Fix BSOD caused by routing loop in wireguard-nt.
 
 
+## [2025.5] - 2025-03-26
+This release is identical to 2025.5-beta1
+
+
 ## [2025.5-beta1] - 2025-03-11
 ### Added
 #### Windows


### PR DESCRIPTION
This PR backports the changelog from the `2025.5` release to `main` :tada:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7905)
<!-- Reviewable:end -->
