### PR TITLE
Rename deserialize_and_verify_insecure

### DIFF
--- a/mullvad-update/meta/src/platform.rs
+++ b/mullvad-update/meta/src/platform.rs
@@ -192,7 +192,7 @@ impl Platform {
 
         // Read unsigned JSON data
         let data = fs::read(work_path).await?;
-        let mut response = format::SignedResponse::deserialize_and_verify_insecure(&data)?;
+        let mut response = format::SignedResponse::deserialize_insecure(&data)?;
 
         // Update the expiration date
         response.signed.metadata_expiry = chrono::Utc::now()
@@ -424,7 +424,7 @@ impl Platform {
             Err(error) => bail!("Failed to read {}: {error}", work_path.display()),
         };
         // Note: We don't need to verify the signature here
-        format::SignedResponse::deserialize_and_verify_insecure(&bytes)
+        format::SignedResponse::deserialize_insecure(&bytes)
     }
 }
 

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -20,7 +20,7 @@ impl SignedResponse {
 
     /// This method is used mostly for testing, and skips all verification.
     /// Own method to prevent accidental misuse.
-    pub fn deserialize_and_verify_insecure(bytes: &[u8]) -> Result<Self, anyhow::Error> {
+    pub fn deserialize_insecure(bytes: &[u8]) -> Result<Self, anyhow::Error> {
         let partial_data: PartialSignedResponse =
             serde_json::from_slice(bytes).context("Invalid version JSON")?;
         let signed = serde_json::from_value(partial_data.signed)
@@ -186,8 +186,8 @@ mod test {
 
         let bytes = serde_json::to_vec(&value).expect("serialize should succeed");
 
-        let response = SignedResponse::deserialize_and_verify_insecure(&bytes)
-            .expect("deserialization failed");
+        let response =
+            SignedResponse::deserialize_insecure(&bytes).expect("deserialization failed");
 
         let expected_key = VerifyingKey::from_hex(pubkey).unwrap();
         let expected_sig = Signature::from_hex(fakesig).unwrap();

--- a/mullvad-update/src/version.rs
+++ b/mullvad-update/src/version.rs
@@ -178,7 +178,7 @@ mod test {
     /// Test version info response handler (rollout 1, x86)
     #[test]
     fn test_version_info_parser_x86() -> anyhow::Result<()> {
-        let response = format::SignedResponse::deserialize_and_verify_insecure(include_bytes!(
+        let response = format::SignedResponse::deserialize_insecure(include_bytes!(
             "../test-version-response.json"
         ))?;
 
@@ -199,7 +199,7 @@ mod test {
     /// Test version info response handler (rollout 0.01, arm64)
     #[test]
     fn test_version_info_parser_arm64() -> anyhow::Result<()> {
-        let response = format::SignedResponse::deserialize_and_verify_insecure(include_bytes!(
+        let response = format::SignedResponse::deserialize_insecure(include_bytes!(
             "../test-version-response.json"
         ))?;
 


### PR DESCRIPTION
This method is awkwardly named. It's insecure exactly because it skips verification.

Fix DES-1945

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7908)
<!-- Reviewable:end -->
