### PR TITLE
Add ability to start the upgrade installer from electron

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/app-upgrade.ts
+++ b/desktop/packages/mullvad-vpn/src/main/app-upgrade.ts
@@ -1,7 +1,13 @@
+import { execFile } from 'child_process';
+import fs from 'fs/promises';
+import { promisify } from 'util';
+
 import { DaemonAppUpgradeEvent } from '../shared/daemon-rpc-types';
 import log from '../shared/logging';
 import { DaemonRpc, SubscriptionListener } from './daemon-rpc';
 import { IpcMainEventChannel } from './ipc-event-channel';
+
+const execFilePromise = promisify(execFile);
 
 export default class AppUpgrade {
   public constructor(private daemonRpc: DaemonRpc) {}
@@ -13,6 +19,17 @@ export default class AppUpgrade {
 
     IpcMainEventChannel.app.handleUpgradeAbort(() => {
       this.daemonRpc.appUpgradeAbort();
+    });
+
+    IpcMainEventChannel.app.handleUpgradeInstallerStart(async (verifiedInstallerPath: string) => {
+      try {
+        await this.startInstaller(verifiedInstallerPath);
+        IpcMainEventChannel.app.notifyUpgradeEvent?.({
+          type: 'APP_UPGRADE_STATUS_STARTED_INSTALLER',
+        });
+      } catch {
+        IpcMainEventChannel.app.notifyUpgradeError?.('START_INSTALLER_FAILED');
+      }
     });
   }
 
@@ -33,5 +50,26 @@ export default class AppUpgrade {
     this.daemonRpc.subscribeAppUpgradeEventListener(daemonAppUpgradeEventListener);
 
     return daemonAppUpgradeEventListener;
+  }
+
+  private async startInstaller(verifiedInstallerPath: string) {
+    await this.isInstallerExecutable(verifiedInstallerPath);
+    await this.executeInstaller(verifiedInstallerPath);
+  }
+
+  private async executeInstaller(verifiedInstallerPath: string) {
+    try {
+      await execFilePromise(verifiedInstallerPath);
+    } catch {
+      throw new Error(`Could not start installer at path: ${verifiedInstallerPath}`);
+    }
+  }
+
+  private async isInstallerExecutable(verifiedInstallerPath: string) {
+    try {
+      await fs.access(verifiedInstallerPath, fs.constants.X_OK);
+    } catch {
+      throw new Error(`An executable installer is not available at path: ${verifiedInstallerPath}`);
+    }
   }
 }

--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -405,6 +405,26 @@ export default class AppRenderer {
     IpcRendererEventChannel.app.upgrade();
   };
   public appUpgradeAbort = () => IpcRendererEventChannel.app.upgradeAbort();
+  public appUpgradeInstallerStart = () => {
+    const reduxState = this.reduxStore.getState();
+    const appUpgradeEvent = reduxState.appUpgrade.event;
+    const verifiedInstallerPath = reduxState.version.suggestedUpgrade?.verifiedInstallerPath;
+
+    // Ensure we have a the path to the verified installer and that we are not already trying
+    // to start the installer.
+    if (
+      verifiedInstallerPath &&
+      appUpgradeEvent?.type !== 'APP_UPGRADE_STATUS_STARTING_INSTALLER'
+    ) {
+      // Ensure we don't try to start the installer multiple times by setting the status
+      // as starting
+      this.reduxActions.appUpgrade.setAppUpgradeEvent({
+        type: 'APP_UPGRADE_STATUS_STARTING_INSTALLER',
+      });
+
+      IpcRendererEventChannel.app.upgradeInstallerStart(verifiedInstallerPath);
+    }
+  };
 
   public login = async (accountNumber: AccountNumber) => {
     const actions = this.reduxActions;

--- a/desktop/packages/mullvad-vpn/src/shared/app-upgrade.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/app-upgrade.ts
@@ -1,5 +1,17 @@
 import { DaemonAppUpgradeError, DaemonAppUpgradeEventStatus } from './daemon-rpc-types';
 
-export type AppUpgradeEvent = DaemonAppUpgradeEventStatus;
+export type AppUpgradeEventStatusStartingInstaller = {
+  type: 'APP_UPGRADE_STATUS_STARTING_INSTALLER';
+};
+
+export type AppUpgradeEventStatusStartedInstaller = {
+  type: 'APP_UPGRADE_STATUS_STARTED_INSTALLER';
+};
+
+export type AppUpgradeEventStatus =
+  | AppUpgradeEventStatusStartingInstaller
+  | AppUpgradeEventStatusStartedInstaller;
+
+export type AppUpgradeEvent = DaemonAppUpgradeEventStatus | AppUpgradeEventStatus;
 
 export type AppUpgradeError = DaemonAppUpgradeError | 'START_INSTALLER_FAILED';

--- a/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
@@ -169,6 +169,7 @@ export const ipcSchema = {
     upgradeAbort: send<void>(),
     upgradeEvent: notifyRenderer<AppUpgradeEvent>(),
     upgradeError: notifyRenderer<AppUpgradeError>(),
+    upgradeInstallerStart: send<string>(),
   },
   tunnel: {
     '': notifyRenderer<TunnelState>(),


### PR DESCRIPTION
Adds support for starting the verified installer. The installer can be started either manually or automatically.

- Manually from the Renderer via IPC: `IpcRendererEventChannel.app.upgradeInstallerStart`.
- Automatically if the window is focused and the verified installer becomes available after the user has initiated an app upgrade.