### PR TITLE
Stop checking out submodules when running scheduled osv-scanner CI

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -20,4 +20,4 @@ jobs:
     # yamllint disable rule:line-length
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.2 + submodule patch
     with:
-      checkout-submodules: true
+      checkout-submodules: false


### PR DESCRIPTION
I'm disabling scanning of submodules for osv-scanner, since it is currently too noisy. Our submodules get false positives (unrelated golang CVEs) all the time. Getting rid of them is a pain since we would need to fix/ignore them in the submodule and then bump the submodule. This creates a lot of churn just to silence this tool.

This is not optimal since there *can* be real vulnerabilities, and we would miss them easier this way. But this is not worse than where we were a couple of months back, before we even had the submodule scanning at least.

I left the submodule scanning on in the PR version of this CI job. There it's not as problematic. If a PR does something to a submodule so that a new CVE is introduced, we want to know.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7912)
<!-- Reviewable:end -->
