### PR TITLE
Add Boringtun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-tempfile"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +241,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -300,6 +324,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -353,6 +383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +429,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "boringtun"
+version = "0.6.0"
+source = "git+https://github.com/mullvad/boringtun?rev=a7e11fb46d4a#a7e11fb46d4ae65d4c7bf4efb9617548c072afa0"
+dependencies = [
+ "aead",
+ "base64 0.13.1",
+ "blake2",
+ "chacha20poly1305",
+ "eyre",
+ "hex",
+ "hmac",
+ "ip_network",
+ "ip_network_table",
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "parking_lot",
+ "rand_core 0.6.4",
+ "ring",
+ "socket2 0.4.10",
+ "thiserror 1.0.59",
+ "tokio",
+ "tracing",
+ "tun 0.7.13",
+ "typed-builder 0.20.1",
+ "untrusted",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +494,26 @@ name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+
+[[package]]
+name = "c2rust-bitfields"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367e5d1b30f28be590b6b3868da1578361d29d9bfac516d22f497d28ed7c9055"
+dependencies = [
+ "c2rust-bitfields-derive",
+]
+
+[[package]]
+name = "c2rust-bitfields-derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a279db9c50c4024eeca1a763b6e0f033848ce74e83e47454bcf8a8a98f7b0b56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "cacao"
@@ -647,10 +749,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.10"
+name = "concurrent-queue"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1180,6 +1291,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1467,16 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1821,7 +1973,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -1996,6 +2148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,12 +2293,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd11f3a29434026f5ff98c730b668ba74b1033637b8817940b54d040696133c"
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
+name = "ip_network_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4099b7cfc5c5e2fe8c5edf3f6f7adf7a714c9cc697534f63a5a5da30397cb2c0"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.8",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -2765,7 +2945,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-signal",
- "socket2",
+ "socket2 0.5.8",
  "talpid-core",
  "talpid-dbus",
  "talpid-future",
@@ -2878,7 +3058,7 @@ dependencies = [
  "pnet_packet 0.35.0",
  "reqwest",
  "serde",
- "socket2",
+ "socket2 0.5.8",
  "talpid-windows",
  "tokio",
  "windows-sys 0.52.0",
@@ -2923,10 +3103,10 @@ dependencies = [
  "rand 0.8.5",
  "rustls 0.23.18",
  "rustls-pemfile 2.1.3",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.9",
  "tokio",
- "typed-builder",
+ "typed-builder 0.21.0",
 ]
 
 [[package]]
@@ -3236,6 +3416,19 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -3581,6 +3774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,6 +3967,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -4113,7 +4323,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.18",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.9",
  "tokio",
  "tracing",
@@ -4150,7 +4360,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4789,7 +4999,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "shadowsocks-crypto",
- "socket2",
+ "socket2 0.5.8",
  "spin",
  "thiserror 1.0.59",
  "tokio",
@@ -4848,7 +5058,7 @@ dependencies = [
  "regex",
  "serde",
  "shadowsocks",
- "socket2",
+ "socket2 0.5.8",
  "spin",
  "thiserror 1.0.59",
  "tokio",
@@ -4943,6 +5153,16 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
@@ -4998,7 +5218,7 @@ dependencies = [
  "parking_lot",
  "pnet_packet 0.34.0",
  "rand 0.8.5",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 1.0.59",
  "tokio",
  "tracing",
@@ -5131,7 +5351,7 @@ dependencies = [
  "tokio",
  "tonic-build",
  "triggered",
- "tun",
+ "tun 0.5.5",
  "which",
  "widestring",
  "windows 0.58.0",
@@ -5178,7 +5398,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.29.0",
- "socket2",
+ "socket2 0.5.8",
  "talpid-types",
  "thiserror 2.0.9",
 ]
@@ -5287,7 +5507,8 @@ dependencies = [
  "talpid-windows",
  "thiserror 2.0.9",
  "tokio",
- "tun",
+ "tun 0.5.5",
+ "tun 0.7.13",
  "windows-sys 0.52.0",
 ]
 
@@ -5333,7 +5554,7 @@ name = "talpid-windows"
 version = "0.0.0"
 dependencies = [
  "futures",
- "socket2",
+ "socket2 0.5.8",
  "talpid-types",
  "thiserror 2.0.9",
  "windows-sys 0.52.0",
@@ -5345,6 +5566,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
+ "boringtun",
  "byteorder",
  "chrono",
  "futures",
@@ -5365,7 +5587,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rtnetlink",
- "socket2",
+ "socket2 0.5.8",
  "surge-ping",
  "talpid-dbus",
  "talpid-net",
@@ -5377,6 +5599,7 @@ dependencies = [
  "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
+ "tun 0.7.13",
  "tunnel-obfuscation",
  "widestring",
  "windows-sys 0.52.0",
@@ -5525,7 +5748,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -5597,7 +5820,7 @@ dependencies = [
  "log",
  "once_cell",
  "pin-project",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "windows-sys 0.52.0",
 ]
@@ -5694,7 +5917,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.3",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -5864,6 +6087,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tun"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298ac5c7f0076908d7a168c634bf4867b4a7d5725eb6356863f8640c6c35ef1"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "futures",
+ "futures-core",
+ "ipnet",
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "thiserror 2.0.9",
+ "tokio",
+ "tokio-util 0.7.10",
+ "windows-sys 0.59.0",
+ "wintun-bindings",
+]
+
+[[package]]
 name = "tunnel-obfuscation"
 version = "0.0.0"
 dependencies = [
@@ -5879,11 +6123,31 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
+dependencies = [
+ "typed-builder-macro 0.20.1",
+]
+
+[[package]]
+name = "typed-builder"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.21.0",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6749,12 +7013,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winres"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml 0.5.11",
+]
+
+[[package]]
+name = "wintun-bindings"
+version = "0.7.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a02981bed4592bcd271f9bfe154228ddbd2fd69e37a7d358da5d3a1251d696"
+dependencies = [
+ "blocking",
+ "c2rust-bitfields",
+ "futures",
+ "libloading",
+ "log",
+ "thiserror 2.0.9",
+ "windows-sys 0.59.0",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,10 +140,10 @@ strip = true
 
 # Selectively optimize packages where we know it makes a difference
 [profile.release.package]
+boringtun.opt-level = 3
 pqcrypto-hqc.opt-level = 3
 quinn-proto.opt-level = 3
 quinn-udp.opt-level = 3
 quinn.opt-level = 3
 mullvad-masque-proxy.opt-level = 3
 ring.opt-level = 3
-

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -247,6 +247,7 @@ junitPlatform {
 
 cargo {
     val isReleaseBuild = isReleaseBuild()
+    val enableBoringTun = getBooleanProperty("mullvad.app.build.boringtun.enable")
     val enableApiOverride = !isReleaseBuild || isDevBuild() || isAlphaBuild()
     module = repoRootPath
     libname = "mullvad-jni"
@@ -262,9 +263,15 @@ cargo {
     prebuiltToolchains = true
     targetDirectory = "$repoRootPath/target"
     features {
-        if (enableApiOverride) {
-            defaultAnd(arrayOf("api-override"))
+        val enabledFeatures = buildList {
+            if (enableApiOverride) {
+                add("api-override")
+            }
+            if (enableBoringTun) {
+                add("boringtun")
+            }
         }
+        defaultAnd(enabledFeatures.toTypedArray())
     }
     targetIncludes = arrayOf("libmullvad_jni.so")
     extraCargoBuildArguments = buildList {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -33,6 +33,9 @@ mullvad.app.build.cargo.cleanBuild=true
 # to be substantially larger.
 mullvad.app.build.keepDebugSymbols=false
 
+# Enable/Disable boringtun
+mullvad.app.build.boringtun.enable=false
+
 ## E2E tests ##
 
 # To run e2e tests you need to provide credentails for the enviroment you

--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -54,7 +54,7 @@ fi
 
 set -x
 exec "$CONTAINER_RUNNER" run --rm -it \
-    -v "$REPO_DIR:$REPO_MOUNT_TARGET:Z" \
+    -v "/$REPO_DIR:$REPO_MOUNT_TARGET:Z" \
     -v "$CARGO_TARGET_VOLUME_NAME:/cargo-target:Z" \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -13,6 +13,8 @@ workspace = true
 [features]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override"]
+boringtun = ["talpid-core/boringtun"]
+
 
 [dependencies]
 anyhow = { workspace = true }

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [features]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override", "mullvad-daemon/api-override"]
+boringtun = ["mullvad-daemon/boringtun"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+boringtun = ["talpid-wireguard/boringtun"]
+
 [dependencies]
 chrono = { workspace = true, features = ["clock"] }
 thiserror = { workspace = true }

--- a/talpid-core/src/tunnel/mod.rs
+++ b/talpid-core/src/tunnel/mod.rs
@@ -175,14 +175,11 @@ impl TunnelMonitor {
     }
 
     fn start_wireguard_tunnel(
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-        params: &wireguard_types::TunnelParameters,
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
         params: &wireguard_types::TunnelParameters,
         log: Option<path::PathBuf>,
         args: TunnelArgs<'_>,
     ) -> Result<Self> {
-        let monitor = talpid_wireguard::WireguardMonitor::start(params, log.as_deref(), args)?;
+        let monitor = talpid_wireguard::WireguardMonitor::start(params, args, log.as_deref())?;
         Ok(TunnelMonitor {
             monitor: InternalTunnelMonitor::Wireguard(monitor),
         })

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+boringtun = ["dep:tun07"]
+
 [dependencies]
 thiserror = { workspace = true }
 cfg-if = "1.0"
@@ -19,12 +22,17 @@ talpid-types = { path = "../talpid-types" }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+tun = { workspace = true } # use tun 0.5.5 for wireguard-go
+
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.5.1", features = ["derive"] }
 log = { workspace = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-tun = { workspace = true }
+[target.'cfg(not(target_os = "android"))'.dependencies]
+tun07 = { package = "tun", version = "0.7.11", optional = true, features = [
+  "async",
+] }
 
 [target.'cfg(windows)'.dependencies]
 talpid-windows = { path = "../talpid-windows" }
@@ -32,7 +40,7 @@ talpid-windows = { path = "../talpid-windows" }
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true
 features = [
-    "Win32_Foundation",
-    "Win32_Networking_WinSock",
-    "Win32_NetworkManagement_Ndis",
+  "Win32_Foundation",
+  "Win32_Networking_WinSock",
+  "Win32_NetworkManagement_Ndis",
 ]

--- a/talpid-tunnel/src/tun_provider/mod.rs
+++ b/talpid-tunnel/src/tun_provider/mod.rs
@@ -24,6 +24,14 @@ cfg_if! {
 
         pub type Tun = UnixTun;
         pub type TunProvider = UnixTunProvider;
+    } else if #[cfg(all(windows, feature = "boringtun"))] {
+        #[path = "windows.rs"]
+        mod imp;
+        use self::imp::{WindowsTun, WindowsTunProvider};
+        pub use self::imp::Error;
+
+        pub type Tun = WindowsTun;
+        pub type TunProvider = WindowsTunProvider;
     } else {
         mod stub;
         use self::stub::StubTunProvider;
@@ -39,6 +47,10 @@ pub struct TunConfig {
     /// Interface name to use.
     #[cfg(target_os = "linux")]
     pub name: Option<String>,
+
+    /// Whether to enable the packet_information option on the tun device.
+    #[cfg(target_os = "linux")]
+    pub packet_information: bool,
 
     /// IP addresses for the tunnel interface.
     pub addresses: Vec<IpAddr>,
@@ -95,6 +107,8 @@ pub fn blocking_config() -> TunConfig {
     TunConfig {
         #[cfg(target_os = "linux")]
         name: None,
+        #[cfg(target_os = "linux")]
+        packet_information: false,
         addresses: vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
         mtu: 1380,
         ipv4_gateway: Ipv4Addr::new(10, 64, 0, 1),

--- a/talpid-tunnel/src/tun_provider/stub.rs
+++ b/talpid-tunnel/src/tun_provider/stub.rs
@@ -1,7 +1,12 @@
 use super::TunConfig;
 
+#[derive(Debug, thiserror::Error)]
 /// Error stub.
-pub enum Error {}
+pub enum Error {
+    /// IO error
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+}
 
 /// Factory stub of tunnel devices.
 pub struct StubTunProvider;

--- a/talpid-tunnel/src/tun_provider/unix.rs
+++ b/talpid-tunnel/src/tun_provider/unix.rs
@@ -1,189 +1,393 @@
-use super::TunConfig;
-use std::{
-    net::IpAddr,
-    ops::Deref,
-    os::unix::io::{AsRawFd, RawFd},
-    process::Command,
-};
-use tun::{Configuration, Device};
+#[cfg(not(feature = "boringtun"))]
+pub use tun05_imp::{Error, UnixTun, UnixTunProvider};
+#[cfg(feature = "boringtun")]
+pub use tun07_imp::{Error, UnixTun, UnixTunProvider};
+#[cfg(not(feature = "boringtun"))]
+mod tun05_imp {
+    use std::{
+        net::IpAddr,
+        ops::Deref,
+        os::unix::io::{AsRawFd, RawFd},
+        process::Command,
+    };
+    use tun::{Configuration, Device};
 
-/// Errors that can occur while setting up a tunnel device.
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// Failed to set IPv4 address on tunnel device
-    #[error("Failed to set IPv4 address")]
-    SetIpv4(#[source] tun::Error),
+    use crate::tun_provider::TunConfig;
 
-    /// Failed to set IPv6 address on tunnel device
-    #[error("Failed to set IPv6 address")]
-    SetIpv6(#[source] std::io::Error),
+    /// Errors that can occur while setting up a tunnel device.
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        /// Failed to set IPv4 address on tunnel device
+        #[error("Failed to set IPv4 address")]
+        SetIpv4(#[source] tun::Error),
 
-    /// Unable to open a tunnel device
-    #[error("Unable to open a tunnel device")]
-    CreateDevice(#[source] tun::Error),
+        /// Failed to set IPv6 address on tunnel device
+        #[error("Failed to set IPv6 address")]
+        SetIpv6(#[source] std::io::Error),
 
-    /// Failed to enable/disable link device
-    #[error("Failed to enable/disable link device")]
-    ToggleDevice(#[source] tun::Error),
+        /// Unable to open a tunnel device
+        #[error("Unable to open a tunnel device")]
+        CreateDevice(#[source] tun::Error),
 
-    /// Failed to get device name
-    #[error("Failed to get tunnel device name")]
-    GetDeviceName(#[source] tun::Error),
-}
+        /// Failed to enable/disable link device
+        #[error("Failed to enable/disable link device")]
+        ToggleDevice(#[source] tun::Error),
 
-/// Factory of tunnel devices on Unix systems.
-pub struct UnixTunProvider {
-    config: TunConfig,
-}
-
-impl UnixTunProvider {
-    pub const fn new(config: TunConfig) -> Self {
-        UnixTunProvider { config }
+        /// Failed to get device name
+        #[error("Failed to get tunnel device name")]
+        GetDeviceName(#[source] tun::Error),
     }
 
-    /// Get the current tunnel config. Note that the tunnel must be recreated for any changes to
-    /// take effect.
-    pub fn config_mut(&mut self) -> &mut TunConfig {
-        &mut self.config
+    /// Factory of tunnel devices on Unix systems.
+    pub struct UnixTunProvider {
+        config: TunConfig,
     }
 
-    /// Open a tunnel using the current tunnel config.
-    pub fn open_tun(&mut self) -> Result<UnixTun, Error> {
-        let mut tunnel_device = {
-            #[allow(unused_mut)]
-            let mut builder = TunnelDeviceBuilder::default();
-            #[cfg(target_os = "linux")]
-            {
-                builder.enable_packet_information();
-                if let Some(ref name) = self.config.name {
-                    builder.name(name);
+    impl UnixTunProvider {
+        pub const fn new(config: TunConfig) -> Self {
+            UnixTunProvider { config }
+        }
+
+        /// Get the current tunnel config. Note that the tunnel must be recreated for any changes to
+        /// take effect.
+        pub fn config_mut(&mut self) -> &mut TunConfig {
+            &mut self.config
+        }
+
+        /// Open a tunnel using the current tunnel config.
+        pub fn open_tun(&mut self) -> Result<UnixTun, Error> {
+            let mut tunnel_device = {
+                #[allow(unused_mut)]
+                let mut builder = TunnelDeviceBuilder::default();
+                #[cfg(target_os = "linux")]
+                {
+                    builder.enable_packet_information();
+                    if let Some(ref name) = self.config.name {
+                        builder.name(name);
+                    }
+                }
+                builder.create()?
+            };
+
+            for ip in self.config.addresses.iter() {
+                tunnel_device.set_ip(*ip)?;
+            }
+
+            tunnel_device.set_up(true)?;
+
+            Ok(UnixTun(tunnel_device))
+        }
+    }
+
+    /// Generic tunnel device.
+    ///
+    /// Contains the file descriptor representing the device.
+    pub struct UnixTun(TunnelDevice);
+
+    impl UnixTun {
+        /// Retrieve the tunnel interface name.
+        pub fn interface_name(&self) -> Result<String, Error> {
+            self.get_name()
+        }
+    }
+
+    impl Deref for UnixTun {
+        type Target = TunnelDevice;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    /// A tunnel device
+    pub struct TunnelDevice {
+        dev: tun::AsyncDevice,
+    }
+
+    /// A tunnel device builder.
+    ///
+    /// Call [`Self::create`] to create [`TunnelDevice`] from the config.
+    #[derive(Default)]
+    pub struct TunnelDeviceBuilder {
+        config: Configuration,
+    }
+
+    impl TunnelDeviceBuilder {
+        /// Create a [`TunnelDevice`] from this builder.
+        pub fn create(self) -> Result<TunnelDevice, Error> {
+            let dev = tun::create_as_async(&self.config).map_err(Error::CreateDevice)?;
+            Ok(TunnelDevice { dev })
+        }
+
+        /// Set a custom name for this tunnel device.
+        #[cfg(target_os = "linux")]
+        pub fn name(&mut self, name: &str) -> &mut Self {
+            self.config.name(name);
+            self
+        }
+
+        /// Enable packet information.
+        /// When enabled the first 4 bytes of each packet is a header with flags and protocol type.
+        #[cfg(target_os = "linux")]
+        pub fn enable_packet_information(&mut self) -> &mut Self {
+            self.config.platform(|config| {
+                #[allow(deprecated)]
+                // NOTE: This function does seemingly have an effect on Linux, despite what the deprecation
+                // warning says.
+                config.packet_information(true);
+            });
+            self
+        }
+    }
+
+    impl AsRawFd for TunnelDevice {
+        fn as_raw_fd(&self) -> RawFd {
+            self.dev.get_ref().as_raw_fd()
+        }
+    }
+
+    impl TunnelDevice {
+        fn set_ip(&mut self, ip: IpAddr) -> Result<(), Error> {
+            match ip {
+                IpAddr::V4(ipv4) => {
+                    self.dev
+                        .get_mut()
+                        .set_address(ipv4)
+                        .map_err(Error::SetIpv4)?;
+                }
+
+                // NOTE: On MacOs, As of `tun 0.7`, `Device::set_address` accepts an `IpAddr` but
+                // only supports the `IpAddr::V4` address kind and panics if you pass it an
+                // `IpAddr::V6` value.
+                #[cfg(target_os = "macos")]
+                IpAddr::V6(ipv6) => {
+                    // ifconfig <device> inet6 <ipv6 address> alias
+                    let ipv6 = ipv6.to_string();
+                    let device = self.dev.get_ref().name();
+                    Command::new("ifconfig")
+                        .args([device, "inet6", &ipv6, "alias"])
+                        .output()
+                        .map_err(Error::SetIpv6)?;
+                }
+
+                // NOTE: On Linux, As of `tun 0.7`, `Device::set_address` throws an I/O error if you
+                // pass it an IPv6-address.
+                #[cfg(target_os = "linux")]
+                IpAddr::V6(ipv6) => {
+                    // ip -6 addr add <ipv6 address> dev <device>
+                    let ipv6 = ipv6.to_string();
+                    let device = self.dev.get_ref().name();
+                    Command::new("ip")
+                        .args(["-6", "addr", "add", &ipv6, "dev", device])
+                        .output()
+                        .map_err(Error::SetIpv6)?;
                 }
             }
-            builder.create()?
-        };
-
-        for ip in self.config.addresses.iter() {
-            tunnel_device.set_ip(*ip)?;
+            Ok(())
         }
 
-        tunnel_device.set_up(true)?;
-
-        Ok(UnixTun(tunnel_device))
-    }
-}
-
-/// Generic tunnel device.
-///
-/// Contains the file descriptor representing the device.
-pub struct UnixTun(TunnelDevice);
-
-impl UnixTun {
-    /// Retrieve the tunnel interface name.
-    pub fn interface_name(&self) -> Result<String, Error> {
-        self.get_name()
-    }
-}
-
-impl Deref for UnixTun {
-    type Target = TunnelDevice;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// A tunnel device
-pub struct TunnelDevice {
-    dev: tun::AsyncDevice,
-}
-
-/// A tunnel device builder.
-///
-/// Call [`Self::create`] to create [`TunnelDevice`] from the config.
-#[derive(Default)]
-pub struct TunnelDeviceBuilder {
-    config: Configuration,
-}
-
-impl TunnelDeviceBuilder {
-    /// Create a [`TunnelDevice`] from this builder.
-    pub fn create(self) -> Result<TunnelDevice, Error> {
-        let dev = tun::create_as_async(&self.config).map_err(Error::CreateDevice)?;
-        Ok(TunnelDevice { dev })
-    }
-
-    /// Set a custom name for this tunnel device.
-    #[cfg(target_os = "linux")]
-    pub fn name(&mut self, name: &str) -> &mut Self {
-        self.config.name(name);
-        self
-    }
-
-    /// Enable packet information.
-    /// When enabled the first 4 bytes of each packet is a header with flags and protocol type.
-    #[cfg(target_os = "linux")]
-    pub fn enable_packet_information(&mut self) -> &mut Self {
-        self.config.platform(|config| {
-            #[allow(deprecated)]
-            // NOTE: This function does seemingly have an effect on Linux, despite what the deprecation
-            // warning says.
-            config.packet_information(true);
-        });
-        self
-    }
-}
-
-impl AsRawFd for TunnelDevice {
-    fn as_raw_fd(&self) -> RawFd {
-        self.dev.get_ref().as_raw_fd()
-    }
-}
-
-impl TunnelDevice {
-    fn set_ip(&mut self, ip: IpAddr) -> Result<(), Error> {
-        match ip {
-            IpAddr::V4(ipv4) => {
-                self.dev
-                    .get_mut()
-                    .set_address(ipv4)
-                    .map_err(Error::SetIpv4)?;
-            }
-
-            // NOTE: On MacOs, As of `tun 0.7`, `Device::set_address` accepts an `IpAddr` but
-            // only supports the `IpAddr::V4` address kind and panics if you pass it an
-            // `IpAddr::V6` value.
-            #[cfg(target_os = "macos")]
-            IpAddr::V6(ipv6) => {
-                // ifconfig <device> inet6 <ipv6 address> alias
-                let ipv6 = ipv6.to_string();
-                let device = self.dev.get_ref().name();
-                Command::new("ifconfig")
-                    .args([device, "inet6", &ipv6, "alias"])
-                    .output()
-                    .map_err(Error::SetIpv6)?;
-            }
-
-            // NOTE: On Linux, As of `tun 0.7`, `Device::set_address` throws an I/O error if you
-            // pass it an IPv6-address.
-            #[cfg(target_os = "linux")]
-            IpAddr::V6(ipv6) => {
-                // ip -6 addr add <ipv6 address> dev <device>
-                let ipv6 = ipv6.to_string();
-                let device = self.dev.get_ref().name();
-                Command::new("ip")
-                    .args(["-6", "addr", "add", &ipv6, "dev", device])
-                    .output()
-                    .map_err(Error::SetIpv6)?;
-            }
+        fn set_up(&mut self, up: bool) -> Result<(), Error> {
+            self.dev.get_mut().enabled(up).map_err(Error::ToggleDevice)
         }
-        Ok(())
+
+        fn get_name(&self) -> Result<String, Error> {
+            Ok(self.dev.get_ref().name().to_owned())
+        }
+    }
+}
+
+#[cfg(feature = "boringtun")]
+mod tun07_imp {
+    use std::net::IpAddr;
+    use std::os::fd::{AsRawFd, RawFd};
+    use std::process::Command;
+
+    use std::ops::Deref;
+
+    use tun07::{AbstractDevice, AsyncDevice};
+
+    use crate::tun_provider::TunConfig;
+
+    /// Errors that can occur while setting up a tunnel device.
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        /// Failed to set IPv4 address on tunnel device
+        #[error("Failed to set IPv4 address")]
+        SetIpv4(#[source] tun07::Error),
+
+        /// Failed to set IPv6 address on tunnel device
+        #[error("Failed to set IPv6 address")]
+        SetIpv6(#[source] std::io::Error),
+
+        /// Unable to open a tunnel device
+        #[error("Unable to open a tunnel device")]
+        CreateDevice(#[source] tun07::Error),
+
+        /// Failed to enable/disable link device
+        #[error("Failed to enable/disable link device")]
+        ToggleDevice(#[source] tun07::Error),
+
+        /// Failed to get device name
+        #[error("Failed to get tunnel device name")]
+        GetDeviceName(#[source] tun07::Error),
     }
 
-    fn set_up(&mut self, up: bool) -> Result<(), Error> {
-        self.dev.get_mut().enabled(up).map_err(Error::ToggleDevice)
+    /// Factory of tunnel devices on Unix systems.
+    pub struct UnixTunProvider {
+        pub(crate) config: TunConfig,
     }
 
-    fn get_name(&self) -> Result<String, Error> {
-        Ok(self.dev.get_ref().name().to_owned())
+    impl UnixTunProvider {
+        pub const fn new(config: TunConfig) -> Self {
+            UnixTunProvider { config }
+        }
+
+        /// Get the current tunnel config. Note that the tunnel must be recreated for any changes to
+        /// take effect.
+        pub fn config_mut(&mut self) -> &mut TunConfig {
+            &mut self.config
+        }
+
+        /// Open a tunnel using the current tunnel config.
+        pub fn open_tun(&mut self) -> Result<UnixTun, Error> {
+            let mut tunnel_device = {
+                #[allow(unused_mut)]
+                let mut builder = TunnelDeviceBuilder::default();
+                #[cfg(target_os = "linux")]
+                {
+                    if self.config.packet_information {
+                        builder.enable_packet_information();
+                    }
+
+                    if let Some(ref name) = self.config.name {
+                        builder.name(name);
+                    }
+                }
+                builder.create()?
+            };
+
+            for ip in self.config.addresses.iter() {
+                tunnel_device.set_ip(*ip)?;
+            }
+
+            tunnel_device.set_up(true)?;
+
+            Ok(UnixTun(tunnel_device))
+        }
+    }
+
+    /// Generic tunnel device.
+    ///
+    /// Contains the file descriptor representing the device.
+    pub struct UnixTun(TunnelDevice);
+
+    impl UnixTun {
+        /// Retrieve the tunnel interface name.
+        pub fn interface_name(&self) -> Result<String, Error> {
+            self.get_name()
+        }
+
+        pub fn into_inner(self) -> TunnelDevice {
+            self.0
+        }
+    }
+
+    impl Deref for UnixTun {
+        type Target = TunnelDevice;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    /// A tunnel device
+    pub struct TunnelDevice {
+        pub(crate) dev: tun07::AsyncDevice,
+    }
+
+    /// A tunnel device builder.
+    ///
+    /// Call [`Self::create`] to create [`TunnelDevice`] from the config.
+    #[derive(Default)]
+    pub struct TunnelDeviceBuilder {
+        pub(crate) config: tun07::Configuration,
+    }
+
+    impl TunnelDeviceBuilder {
+        /// Create a [`TunnelDevice`] from this builder.
+        pub fn create(self) -> Result<TunnelDevice, Error> {
+            let dev = tun07::create_as_async(&self.config).map_err(Error::CreateDevice)?;
+            Ok(TunnelDevice { dev })
+        }
+
+        /// Set a custom name for this tunnel device.
+        #[cfg(target_os = "linux")]
+        pub fn name(&mut self, name: &str) -> &mut Self {
+            self.config.tun_name(name);
+            self
+        }
+
+        /// Enable packet information.
+        /// When enabled the first 4 bytes of each packet is a header with flags and protocol type.
+        #[cfg(target_os = "linux")]
+        pub fn enable_packet_information(&mut self) -> &mut Self {
+            self.config.platform_config(|config| {
+                #[allow(deprecated)]
+                // NOTE: This function does seemingly have an effect on Linux, despite what the deprecation
+                // warning says.
+                config.packet_information(true);
+            });
+            self
+        }
+    }
+
+    impl AsRawFd for TunnelDevice {
+        fn as_raw_fd(&self) -> RawFd {
+            self.dev.as_raw_fd()
+        }
+    }
+
+    impl TunnelDevice {
+        pub(crate) fn set_ip(&mut self, ip: IpAddr) -> Result<(), Error> {
+            match ip {
+                IpAddr::V4(ipv4) => {
+                    self.dev.set_address(ipv4.into()).map_err(Error::SetIpv4)?;
+                }
+
+                // NOTE: As of `tun 0.7`, `Device::set_address` accepts an `IpAddr` but
+                // only supports the `IpAddr::V4`.
+                // On MacOs, `Device::set_address` panics if you pass it an `IpAddr::V6` value.
+                // On Linux, `Device::set_address` throws an I/O error if you pass it an IPv6-address.
+                IpAddr::V6(ipv6) => {
+                    let ipv6 = ipv6.to_string();
+                    let device = self.get_name()?;
+                    // ifconfig <device> inet6 <ipv6 address> alias
+                    #[cfg(target_os = "macos")]
+                    Command::new("ifconfig")
+                        .args([&device, "inet6", &ipv6, "alias"])
+                        .output()
+                        .map_err(Error::SetIpv6)?;
+                    // ip -6 addr add <ipv6 address> dev <device>
+                    #[cfg(target_os = "linux")]
+                    Command::new("ip")
+                        .args(["-6", "addr", "add", &ipv6, "dev", &device])
+                        .output()
+                        .map_err(Error::SetIpv6)?;
+                }
+            }
+            Ok(())
+        }
+
+        pub(crate) fn set_up(&mut self, up: bool) -> Result<(), Error> {
+            self.dev.enabled(up).map_err(Error::ToggleDevice)
+        }
+
+        pub(crate) fn get_name(&self) -> Result<String, Error> {
+            self.dev.tun_name().map_err(Error::GetDeviceName)
+        }
+
+        pub fn into_inner(self) -> AsyncDevice {
+            self.dev
+        }
     }
 }

--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -1,0 +1,141 @@
+use super::TunConfig;
+use std::{io, net::IpAddr, ops::Deref};
+use tun07 as tun;
+use tun07::{AbstractDevice, AsyncDevice, Configuration};
+
+/// Errors that can occur while setting up a tunnel device.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failed to set IP address
+    #[error("Failed to set IPv4 address")]
+    SetIpv4(#[source] tun::Error),
+
+    /// Failed to set IP address
+    #[error("Failed to set IPv6 address")]
+    SetIpv6(#[source] io::Error),
+
+    /// Unable to open a tunnel device
+    #[error("Unable to open a tunnel device")]
+    CreateDevice(#[source] tun::Error),
+
+    /// Failed to enable/disable link device
+    #[error("Failed to enable/disable link device")]
+    ToggleDevice(#[source] tun::Error),
+
+    /// Failed to get device name
+    #[error("Failed to get tunnel device name")]
+    GetDeviceName(#[source] tun::Error),
+
+    /// IO error
+    #[error("IO error")]
+    Io(#[from] io::Error),
+}
+
+/// Factory of tunnel devices on Unix systems.
+pub struct WindowsTunProvider {
+    config: TunConfig,
+}
+
+impl WindowsTunProvider {
+    pub const fn new(config: TunConfig) -> Self {
+        WindowsTunProvider { config }
+    }
+
+    /// Get the current tunnel config. Note that the tunnel must be recreated for any changes to
+    /// take effect.
+    pub fn config_mut(&mut self) -> &mut TunConfig {
+        &mut self.config
+    }
+
+    /// Open a tunnel using the current tunnel config.
+    pub fn open_tun(&mut self) -> Result<WindowsTun, Error> {
+        let mut tunnel_device = {
+            #[allow(unused_mut)]
+            let mut builder = TunnelDeviceBuilder::default();
+            #[cfg(target_os = "linux")]
+            if let Some(ref name) = self.config.name {
+                builder.name(name);
+            }
+            builder.create()?
+        };
+
+        for ip in self.config.addresses.iter() {
+            tunnel_device.set_ip(*ip)?;
+        }
+
+        tunnel_device.set_up(true)?;
+
+        Ok(WindowsTun(tunnel_device))
+    }
+}
+
+/// Generic tunnel device.
+///
+/// Contains the file descriptor representing the device.
+pub struct WindowsTun(TunnelDevice);
+
+impl WindowsTun {
+    /// Retrieve the tunnel interface name.
+    pub fn interface_name(&self) -> Result<String, Error> {
+        self.get_name()
+    }
+
+    pub fn into_inner(self) -> AsyncDevice {
+        AsyncDevice::new(self.0.dev).unwrap()
+    }
+}
+
+impl Deref for WindowsTun {
+    type Target = TunnelDevice;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A tunnel device
+pub struct TunnelDevice {
+    dev: tun::Device,
+}
+
+/// A tunnel device builder.
+///
+/// Call [`Self::create`] to create [`TunnelDevice`] from the config.
+pub struct TunnelDeviceBuilder {
+    config: Configuration,
+}
+
+impl TunnelDeviceBuilder {
+    /// Create a [`TunnelDevice`] from this builder.
+    pub fn create(self) -> Result<TunnelDevice, Error> {
+        let dev = tun::create(&self.config).map_err(Error::CreateDevice)?;
+        Ok(TunnelDevice { dev })
+    }
+}
+
+impl Default for TunnelDeviceBuilder {
+    fn default() -> Self {
+        let config = Configuration::default();
+        Self { config }
+    }
+}
+
+impl TunnelDevice {
+    fn set_ip(&mut self, ip: IpAddr) -> Result<(), Error> {
+        match ip {
+            IpAddr::V4(ipv4) => self.dev.set_address(ipv4.into()).map_err(Error::SetIpv4),
+            IpAddr::V6(_ipv6) => {
+                // TODO
+                todo!("ipv6 not implemented");
+            }
+        }
+    }
+
+    fn set_up(&mut self, up: bool) -> Result<(), Error> {
+        self.dev.enabled(up).map_err(Error::ToggleDevice)
+    }
+
+    fn get_name(&self) -> Result<String, Error> {
+        self.dev.tun_name().map_err(Error::GetDeviceName)
+    }
+}

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+boringtun = ["dep:boringtun", "dep:tun07", "talpid-tunnel/boringtun"]
+
 [dependencies]
 async-trait = "0.1"
 thiserror = { workspace = true }
@@ -30,11 +33,20 @@ tunnel-obfuscation = { path = "../tunnel-obfuscation" }
 rand = "0.8.5"
 surge-ping = "0.8.0"
 rand_chacha = "0.3.1"
-wireguard-go-rs = { path = "../wireguard-go-rs"}
+wireguard-go-rs = { path = "../wireguard-go-rs" }
+tun07 = { package = "tun", version = "0.7.11", features = [
+  "async",
+], optional = true }
 byteorder = "1"
 internet-checksum = "0.2"
 socket2 = { workspace = true, features = ["all"] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
+
+[dependencies.boringtun]
+optional = true
+features = ["device"]
+git = "https://github.com/mullvad/boringtun"
+rev = "a7e11fb46d4a"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"
@@ -61,27 +73,27 @@ maybenot = "2.0.0"
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true
 features = [
-    "Win32_Foundation",
-    "Win32_Globalization",
-    "Win32_Security",
-    "Win32_System_Com",
-    "Win32_System_Diagnostics_ToolHelp",
-    "Win32_System_Ioctl",
-    "Win32_System_IO",
-    "Win32_System_LibraryLoader",
-    "Win32_System_ProcessStatus",
-    "Win32_System_Registry",
-    "Win32_System_Services",
-    "Win32_System_SystemServices",
-    "Win32_System_Threading",
-    "Win32_System_WindowsProgramming",
-    "Win32_Networking_WinSock",
-    "Win32_NetworkManagement_IpHelper",
-    "Win32_NetworkManagement_Ndis",
-    "Win32_UI_Shell",
-    "Win32_UI_WindowsAndMessaging",
+  "Win32_Foundation",
+  "Win32_Globalization",
+  "Win32_Security",
+  "Win32_System_Com",
+  "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_Ioctl",
+  "Win32_System_IO",
+  "Win32_System_LibraryLoader",
+  "Win32_System_ProcessStatus",
+  "Win32_System_Registry",
+  "Win32_System_Services",
+  "Win32_System_SystemServices",
+  "Win32_System_Threading",
+  "Win32_System_WindowsProgramming",
+  "Win32_Networking_WinSock",
+  "Win32_NetworkManagement_IpHelper",
+  "Win32_NetworkManagement_Ndis",
+  "Win32_UI_Shell",
+  "Win32_UI_WindowsAndMessaging",
 ]
 
 [dev-dependencies]
 proptest = { workspace = true }
-tokio = { workspace = true, features = [ "test-util" ] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/talpid-wireguard/build.rs
+++ b/talpid-wireguard/build.rs
@@ -6,9 +6,6 @@ fn main() {
     if target_os == "windows" {
         declare_libs_dir("../dist-assets/binaries");
     }
-    // Wireguard-Go can be used on all platforms
-    println!("cargo::rustc-check-cfg=cfg(wireguard_go)");
-    println!("cargo::rustc-cfg=wireguard_go");
 
     // Enable DAITA by default on desktop and android
     println!("cargo::rustc-check-cfg=cfg(daita)");

--- a/talpid-wireguard/src/boringtun/mod.rs
+++ b/talpid-wireguard/src/boringtun/mod.rs
@@ -1,0 +1,314 @@
+use crate::{
+    config::Config,
+    stats::{Stats, StatsMap},
+    Tunnel, TunnelError,
+};
+use boringtun::device::{
+    api::{command::*, ApiClient, ApiServer},
+    peer::AllowedIP,
+    DeviceConfig, DeviceHandle,
+};
+
+#[cfg(not(target_os = "android"))]
+use ipnetwork::IpNetwork;
+#[cfg(target_os = "android")]
+use std::os::fd::AsRawFd;
+use std::{
+    future::Future,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
+use talpid_tunnel::tun_provider::{self, Tun, TunProvider};
+use talpid_tunnel_config_client::DaitaSettings;
+use tun07::AbstractDevice;
+
+pub struct BoringTun {
+    device_handle: DeviceHandle,
+    config_tx: ApiClient,
+    config: Config,
+
+    /// Name of the tun interface.
+    interface_name: String,
+}
+
+/// Configure and start a boringtun tunnel.
+pub async fn open_boringtun_tunnel(
+    config: &Config,
+    tun_provider: Arc<Mutex<tun_provider::TunProvider>>,
+    #[cfg(target_os = "android")] route_manager_handle: talpid_routing::RouteManagerHandle,
+) -> super::Result<BoringTun> {
+    log::info!("BoringTun::start_tunnel");
+    let routes = config.get_tunnel_destinations();
+
+    log::info!("calling get_tunnel_for_userspace");
+    #[cfg(not(target_os = "android"))]
+    let async_tun = {
+        let tun = get_tunnel_for_userspace(tun_provider, config, routes)?;
+
+        #[cfg(unix)]
+        {
+            tun.into_inner().into_inner()
+        }
+        #[cfg(windows)]
+        {
+            tun.into_inner()
+        }
+    };
+
+    let (mut config_tx, config_rx) = ApiServer::new();
+
+    let boringtun_config = DeviceConfig {
+        n_threads: 4,
+        api: Some(config_rx),
+        on_bind: None,
+    };
+
+    #[cfg(target_os = "android")]
+    let mut boringtun_config = boringtun_config;
+
+    #[cfg(target_os = "android")]
+    let async_tun = {
+        let _ = routes; // TODO: do we need this?
+        let (mut tun, fd) = get_tunnel_for_userspace(Arc::clone(&tun_provider), config)?;
+        let is_new_tunnel = tun.is_new;
+
+        // TODO We should also wait for routes before sending any ping / connectivity check
+
+        // There is a brief period of time between setting up a Wireguard-go tunnel and the tunnel being ready to serve
+        // traffic. This function blocks until the tunnel starts to serve traffic or until [connectivity::Check] times out.
+        if is_new_tunnel {
+            let expected_routes = tun_provider.lock().unwrap().real_routes();
+
+            route_manager_handle
+                .clone()
+                .wait_for_routes(expected_routes)
+                .await
+                .map_err(crate::Error::SetupRoutingError)
+                .map_err(|e| TunnelError::RecoverableStartWireguardError(Box::new(e)))?;
+        }
+
+        let mut config = tun07::Configuration::default();
+        config.raw_fd(fd);
+
+        boringtun_config.on_bind = Some(Box::new(move |socket| {
+            tun.bypass(socket.as_raw_fd()).unwrap()
+        }));
+
+        let device = tun07::Device::new(&config).unwrap();
+        tun07::AsyncDevice::new(device).unwrap()
+    };
+
+    let interface_name = async_tun.deref().tun_name().unwrap();
+
+    log::info!("passing tunnel dev to boringtun");
+    let device_handle: DeviceHandle = DeviceHandle::new(async_tun, boringtun_config)
+        .await
+        .map_err(TunnelError::BoringTunDevice)?;
+
+    set_boringtun_config(&mut config_tx, config).await?;
+
+    log::info!(
+        "This tunnel was brought to you by...
+.........................................................
+..*...*.. .--.                    .---.         ..*....*.
+...*..... |   )         o           |           ......*..
+.*..*..*. |--:  .-. .--..  .--. .-..|.  . .--.  ...*.....
+...*..... |   )(   )|   |  |  |(   |||  | |  |  .*.....*.
+*.....*.. '--'  `-' ' -' `-'  `-`-`|'`--`-'  `- .....*...
+.........                       ._.'            ..*...*..
+..*...*.............................................*...."
+    );
+
+    Ok(BoringTun {
+        device_handle,
+        config: config.clone(),
+        config_tx,
+        interface_name,
+    })
+}
+
+#[async_trait::async_trait]
+impl Tunnel for BoringTun {
+    fn get_interface_name(&self) -> String {
+        self.interface_name.clone()
+    }
+
+    fn stop(self: Box<Self>) -> Result<(), TunnelError> {
+        log::info!("BoringTun::stop"); // remove me
+        tokio::runtime::Handle::current().block_on(self.device_handle.stop());
+        Ok(())
+    }
+
+    async fn get_tunnel_stats(&self) -> Result<StatsMap, TunnelError> {
+        let response = self
+            .config_tx
+            .send(Get::default())
+            .await
+            .expect("Failed to get peers");
+
+        let Response::Get(response) = response else {
+            return Err(TunnelError::GetConfigError);
+        };
+        Ok(StatsMap::from_iter(response.peers.into_iter().map(
+            |peer| {
+                (
+                    peer.peer.public_key.0,
+                    Stats {
+                        tx_bytes: peer.tx_bytes.unwrap_or_default(),
+                        rx_bytes: peer.rx_bytes.unwrap_or_default(),
+                    },
+                )
+            },
+        )))
+    }
+
+    fn set_config<'a>(
+        &'a mut self,
+        config: Config,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), TunnelError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.config = config;
+            set_boringtun_config(&mut self.config_tx, &self.config).await?;
+            Ok(())
+        })
+    }
+
+    fn start_daita(&mut self, _settings: DaitaSettings) -> Result<(), TunnelError> {
+        log::info!("Haha no");
+        Ok(())
+    }
+}
+
+async fn set_boringtun_config(
+    tx: &mut ApiClient,
+    config: &Config,
+) -> Result<(), crate::TunnelError> {
+    log::info!("configuring boringtun device");
+    let mut set_cmd = Set::builder()
+        .private_key(config.tunnel.private_key.to_bytes())
+        .listen_port(0u16)
+        .replace_peers()
+        .build();
+
+    #[cfg(target_os = "linux")]
+    {
+        set_cmd.fwmark = config.fwmark;
+    }
+
+    for peer in config.peers() {
+        let mut boring_peer = Peer::builder()
+            .public_key(*peer.public_key.as_bytes())
+            .endpoint(peer.endpoint)
+            .allowed_ip(
+                peer.allowed_ips
+                    .iter()
+                    .map(|net| AllowedIP {
+                        addr: net.ip(),
+                        cidr: net.prefix(),
+                    })
+                    .collect(),
+            )
+            .build();
+
+        if let Some(psk) = &peer.psk {
+            boring_peer.preshared_key = Some(SetUnset::Set((*psk.as_bytes()).into()));
+        }
+
+        let boring_peer = SetPeer::builder().peer(boring_peer).build();
+
+        set_cmd.peers.push(boring_peer);
+    }
+
+    tx.send(set_cmd).await.map_err(|err| {
+        log::error!("Failed to set boringtun config: {err:#}");
+        TunnelError::SetConfigError
+    })?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn get_tunnel_for_userspace(
+    tun_provider: Arc<Mutex<TunProvider>>,
+    config: &Config,
+    routes: impl Iterator<Item = IpNetwork>,
+) -> Result<Tun, crate::TunnelError> {
+    let mut tun_provider = tun_provider.lock().unwrap();
+
+    let tun_config = tun_provider.config_mut();
+    tun_config.addresses = config.tunnel.addresses.clone();
+    tun_config.ipv4_gateway = config.ipv4_gateway;
+    tun_config.ipv6_gateway = config.ipv6_gateway;
+    tun_config.mtu = config.mtu;
+
+    let _ = routes;
+
+    #[cfg(windows)]
+    tun_provider
+        .open_tun()
+        .map_err(TunnelError::SetupTunnelDevice)
+}
+
+#[cfg(all(not(target_os = "android"), unix))]
+fn get_tunnel_for_userspace(
+    tun_provider: Arc<Mutex<TunProvider>>,
+    config: &Config,
+    routes: impl Iterator<Item = IpNetwork>,
+) -> Result<Tun, crate::TunnelError> {
+    let mut tun_provider = tun_provider.lock().unwrap();
+
+    let tun_config = tun_provider.config_mut();
+    #[cfg(target_os = "linux")]
+    {
+        tun_config.name = Some(crate::config::MULLVAD_INTERFACE_NAME.to_string());
+        tun_config.packet_information = false;
+    }
+    tun_config.addresses = config.tunnel.addresses.clone();
+    tun_config.ipv4_gateway = config.ipv4_gateway;
+    tun_config.ipv6_gateway = config.ipv6_gateway;
+    tun_config.routes = routes.collect();
+    tun_config.mtu = config.mtu;
+
+    tun_provider
+        .open_tun()
+        .map_err(TunnelError::SetupTunnelDevice)
+}
+
+#[cfg(target_os = "android")]
+pub fn get_tunnel_for_userspace(
+    tun_provider: Arc<Mutex<TunProvider>>,
+    config: &Config,
+) -> Result<(Tun, std::os::fd::RawFd), TunnelError> {
+    let mut last_error = None;
+    let mut tun_provider = tun_provider.lock().unwrap();
+
+    let tun_config = tun_provider.config_mut();
+    tun_config.addresses = config.tunnel.addresses.clone();
+    tun_config.ipv4_gateway = config.ipv4_gateway;
+    tun_config.ipv6_gateway = config.ipv6_gateway;
+    tun_config.mtu = config.mtu;
+
+    // Route everything into the tunnel and have wireguard-go act as a firewall when
+    // blocking. These will not necessarily be the actual routes used by android. Those will
+    // be generated at a later stage e.g. if Local Network Sharing is enabled.
+    tun_config.routes = vec!["0.0.0.0/0".parse().unwrap(), "::/0".parse().unwrap()];
+
+    const MAX_PREPARE_TUN_ATTEMPTS: usize = 4;
+
+    for _ in 1..=MAX_PREPARE_TUN_ATTEMPTS {
+        let tunnel_device = tun_provider
+            .open_tun()
+            .map_err(TunnelError::SetupTunnelDevice)?;
+
+        match nix::unistd::dup(tunnel_device.as_raw_fd()) {
+            Ok(fd) => return Ok((tunnel_device, fd)),
+            #[cfg(not(target_os = "macos"))]
+            Err(error @ nix::errno::Errno::EBADFD) => last_error = Some(error),
+            Err(error @ nix::errno::Errno::EBADF) => last_error = Some(error),
+            Err(error) => return Err(TunnelError::FdDuplicationError(error)),
+        }
+    }
+
+    Err(TunnelError::FdDuplicationError(
+        last_error.expect("Should be collected in loop"),
+    ))
+}

--- a/talpid-wireguard/src/connectivity/mod.rs
+++ b/talpid-wireguard/src/connectivity/mod.rs
@@ -6,7 +6,7 @@ mod mock;
 mod monitor;
 mod pinger;
 
-#[cfg(target_os = "android")]
+#[cfg(all(target_os = "android", not(feature = "boringtun")))]
 pub use check::CancelReceiver;
 pub use check::{CancelToken, Check};
 pub use error::Error;

--- a/talpid-wireguard/src/connectivity/monitor.rs
+++ b/talpid-wireguard/src/connectivity/monitor.rs
@@ -1,12 +1,13 @@
 use std::{sync::Weak, time::Duration};
 
-use tokio::sync::Mutex;
-use tokio::time::{Instant, MissedTickBehavior};
+use tokio::{
+    sync::Mutex,
+    time::{Instant, MissedTickBehavior},
+};
 
 use crate::TunnelType;
 
-use super::check::Check;
-use super::error::Error;
+use super::{check::Check, error::Error};
 
 /// Sleep time used when checking if an established connection is still working.
 const REGULAR_LOOP_SLEEP: Duration = Duration::from_secs(1);
@@ -66,7 +67,7 @@ impl Monitor {
         };
 
         self.connectivity_check
-            .check_connectivity(Instant::now(), tunnel)
+            .check_connectivity(Instant::now(), tunnel.as_ref())
             .await
     }
 }
@@ -75,15 +76,17 @@ impl Monitor {
 mod test {
     use super::*;
 
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
-    use std::time::Duration;
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
 
-    use tokio::sync::mpsc;
-    use tokio::sync::Mutex;
+    use tokio::sync::{mpsc, Mutex};
 
-    use crate::connectivity::constants::*;
-    use crate::connectivity::mock::*;
+    use crate::connectivity::{constants::*, mock::*};
 
     #[tokio::test(start_paused = true)]
     /// Verify that the connectivity monitor doesn't fail if the tunnel constantly sends traffic,
@@ -99,7 +102,7 @@ mod test {
         };
 
         tokio::spawn(async move {
-            let start_result = checker.establish_connectivity(&tunnel).await;
+            let start_result = checker.establish_connectivity(tunnel.as_ref()).await;
             result_tx.send(start_result).await.unwrap();
             // Pointer dance
             let tunnel = Arc::new(Mutex::new(Some(tunnel)));
@@ -155,7 +158,7 @@ mod test {
                 let start = now.checked_sub(Duration::from_secs(1)).unwrap();
                 mock_checker(start, Box::new(pinger))
             };
-            let start_result = checker.establish_connectivity(&tunnel).await;
+            let start_result = checker.establish_connectivity(tunnel.as_ref()).await;
             result_tx.send(start_result).await.unwrap();
             // Pointer dance
             let _tunnel = Arc::new(Mutex::new(Some(tunnel)));

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -1,8 +1,6 @@
 //! This module takes care of obtaining ephemeral peers, updating the WireGuard configuration and
 //! restarting obfuscation and WG tunnels when necessary.
 
-#[cfg(target_os = "android")] // On Android, the Tunnel trait is not imported by default.
-use super::Tunnel;
 use super::{config::Config, obfuscation::ObfuscatorHandle, CloseMsg, Error, TunnelType};
 
 #[cfg(target_os = "android")]
@@ -207,15 +205,15 @@ async fn reconfigure_tunnel(
     }
     {
         let mut shared_tunnel = tunnel.lock().await;
-        let tunnel = shared_tunnel.take().expect("tunnel was None");
+        let mut tunnel = shared_tunnel.take().expect("tunnel was None");
 
-        let updated_tunnel = tunnel
-            .set_config(&config)
+        tunnel
+            .set_config(config.clone())
             .await
             .map_err(Error::TunnelError)
             .map_err(CloseMsg::SetupError)?;
 
-        *shared_tunnel = Some(updated_tunnel);
+        *shared_tunnel = Some(tunnel);
     }
     Ok(config)
 }

--- a/talpid-wireguard/src/logging.rs
+++ b/talpid-wireguard/src/logging.rs
@@ -1,3 +1,4 @@
+#![cfg(any(windows, not(feature = "boringtun")))]
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, fs, io::Write, path::Path, sync::LazyLock};
 
@@ -44,12 +45,12 @@ pub fn clean_up_logging(ordinal: u64) {
     state.map.remove(&ordinal);
 }
 
+#[allow(dead_code)]
 pub enum LogLevel {
-    #[cfg_attr(windows, allow(dead_code))]
     Verbose,
-    #[cfg_attr(wireguard_go, allow(dead_code))]
+    #[cfg_attr(not(feature = "boringtun"), allow(dead_code))]
     Info,
-    #[cfg_attr(wireguard_go, allow(dead_code))]
+    #[cfg_attr(not(feature = "boringtun"), allow(dead_code))]
     Warning,
     Error,
 }

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -440,7 +440,9 @@ impl WgNtTunnel {
             );
 
             match error {
-                Error::CreateTunnelDevice(error) => super::TunnelError::SetupTunnelDevice(error),
+                Error::CreateTunnelDevice(error) => super::TunnelError::SetupTunnelDevice(
+                    talpid_tunnel::tun_provider::Error::Io(error),
+                ),
                 _ => super::TunnelError::FatalStartWireguardError(Box::new(error)),
             }
         })


### PR DESCRIPTION
Test run (without `--features boringtun`, i.e. using `wireguard-go`): https://github.com/mullvad/mullvadvpn-app/actions/runs/15116240090.

## ToDo
- [x] Upgrade tun to 0.7.13
- [x] Fix TODOs
- [x] Make sure tun provider still works for wggo
- [x] Tun-provider windows? Should already exist on main?
- [x] Sanity-check boringtun dependency in cargo.toml
- [x] Check that feature-gate works on non-linux
- [x] Squash and rebase on main

## Known issues
Opening the tunnel device works the first time, but fails the second time with the following error on Windows
```
[2025-05-14 13:13:02.693][talpid_core::tunnel_state_machine::connecting_state][ERROR] Error: Failed to start tunnel
Caused by: Failed while listening for events from the Wireguard tunnel
Caused by: Tunnel failed
Caused by: Failed to create tunnel device
Caused by: Unable to open a tunnel device
Caused by: WintunStartSession failed "Failed to register rings: An attempt was made to perform an initialization operation when initialization has already been completed. (Code 0x000004DF)"
```
The error originates in the `wintun-bindings` crate: <https://github.com/tun2proxy/wintun-bindings/blob/.

And the following error on Linux
```
[2025-05-14 13:53:33.090][talpid_core::tunnel_state_machine::connecting_state][ERROR] Error: Failed to start tunnel
Caused by: Failed while listening for events from the Wireguard tunnel
Caused by: Tunnel failed
Caused by: Failed to create tunnel device
Caused by: Unable to open a tunnel device
Caused by: Device or resource busy (os error 16)
```` 

This prevents PQ from working.

See https://linear.app/mullvad/issue/DES-2161/opening-tunnel-device-fails-the-second-time.

### Windows

c65eb5f19d0bcdb4e128737b3bc5ca4ba434a3d1/src/adapter.rs#L180>.
- Loading `wintun.dll`, which is done on whenever a tunnel is created, takes ~15 seconds, as the `tun` crate verifies the signature of the file with no option to disable the behavior. See https://linear.app/mullvad/issue/DES-2160/stop-verifying-wintundll-signature-on-tunnel-creation.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7913)
<!-- Reviewable:end -->
