### PR TITLE
Add reusable AppUpgrade hooks

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
@@ -1,0 +1,7 @@
+export * from './useAppUpgradeDownloadProgressValue';
+export * from './useAppUpgradeEventType';
+export * from './useHasAppUpgradeError';
+export * from './useHasAppUpgradeEvent';
+export * from './useHasAppUpgradeVerifiedInstallerPath';
+export * from './useIsAppUpgradeInProgress';
+export * from './useShouldAppUpgradeInstallManually';

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/constants.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/constants.ts
@@ -1,0 +1,2 @@
+export const DOWNLOAD_COMPLETE_VALUE = 100;
+export const FALLBACK_VALUE = 0;

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useGetValueDownloadProgress';
+export * from './useGetValueError';

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/hooks/useGetValueDownloadProgress.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/hooks/useGetValueDownloadProgress.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+import { useAppUpgradeEvent } from '../../../redux/hooks';
+import { FALLBACK_VALUE } from '../constants';
+
+export const useGetValueDownloadProgress = () => {
+  const { appUpgradeEvent } = useAppUpgradeEvent();
+
+  const getValueDownloadProgress = useCallback(() => {
+    if (appUpgradeEvent?.type === 'APP_UPGRADE_STATUS_DOWNLOAD_PROGRESS') {
+      const { progress } = appUpgradeEvent;
+
+      return progress;
+    }
+
+    return FALLBACK_VALUE;
+  }, [appUpgradeEvent]);
+
+  return getValueDownloadProgress;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/hooks/useGetValueError.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/hooks/useGetValueError.ts
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+
+import { useAppUpgradeError } from '../../../redux/hooks';
+import { DOWNLOAD_COMPLETE_VALUE, FALLBACK_VALUE } from '../constants';
+
+export const useGetValueError = () => {
+  const { appUpgradeError } = useAppUpgradeError();
+
+  const getValueError = useCallback(() => {
+    if (appUpgradeError === 'START_INSTALLER_FAILED' || appUpgradeError === 'VERIFICATION_FAILED') {
+      return DOWNLOAD_COMPLETE_VALUE;
+    }
+
+    return FALLBACK_VALUE;
+  }, [appUpgradeError]);
+
+  return getValueError;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/index.ts
@@ -1,0 +1,1 @@
+export * from './useAppUpgradeDownloadProgressValue';

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/useAppUpgradeDownloadProgressValue.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/useAppUpgradeDownloadProgressValue.ts
@@ -1,0 +1,33 @@
+import { useAppUpgradeEventType } from '../useAppUpgradeEventType';
+import { useHasAppUpgradeError } from '../useHasAppUpgradeError';
+import { useHasAppUpgradeVerifiedInstallerPath } from '../useHasAppUpgradeVerifiedInstallerPath';
+import { DOWNLOAD_COMPLETE_VALUE, FALLBACK_VALUE } from './constants';
+import { useGetValueDownloadProgress, useGetValueError } from './hooks';
+
+export const useAppUpgradeDownloadProgressValue = () => {
+  const appUpgradeEventType = useAppUpgradeEventType();
+  const getValueDownloadProgress = useGetValueDownloadProgress();
+  const getValueError = useGetValueError();
+  const hasAppUpgradeError = useHasAppUpgradeError();
+  const hasAppUpgradeVerifiedInstallerPath = useHasAppUpgradeVerifiedInstallerPath();
+
+  if (hasAppUpgradeError) {
+    return getValueError();
+  }
+
+  if (hasAppUpgradeVerifiedInstallerPath) {
+    return DOWNLOAD_COMPLETE_VALUE;
+  }
+
+  switch (appUpgradeEventType) {
+    case 'APP_UPGRADE_STATUS_DOWNLOAD_PROGRESS':
+      return getValueDownloadProgress();
+    case 'APP_UPGRADE_STATUS_STARTED_INSTALLER':
+    case 'APP_UPGRADE_STATUS_STARTING_INSTALLER':
+    case 'APP_UPGRADE_STATUS_VERIFIED_INSTALLER':
+    case 'APP_UPGRADE_STATUS_VERIFYING_INSTALLER':
+      return DOWNLOAD_COMPLETE_VALUE;
+    default:
+      return FALLBACK_VALUE;
+  }
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeEventType.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeEventType.ts
@@ -1,0 +1,9 @@
+import { useAppUpgradeEvent } from '../redux/hooks';
+
+export const useAppUpgradeEventType = () => {
+  const { appUpgradeEvent } = useAppUpgradeEvent();
+
+  const appUpgradeEventType = appUpgradeEvent?.type;
+
+  return appUpgradeEventType;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useHasAppUpgradeError.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useHasAppUpgradeError.ts
@@ -1,0 +1,9 @@
+import { useAppUpgradeError } from '../redux/hooks';
+
+export const useHasAppUpgradeError = () => {
+  const { appUpgradeError } = useAppUpgradeError();
+
+  const hasAppUpgradeError = appUpgradeError !== undefined;
+
+  return hasAppUpgradeError;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useHasAppUpgradeEvent.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useHasAppUpgradeEvent.ts
@@ -1,0 +1,9 @@
+import { useAppUpgradeEvent } from '../redux/hooks';
+
+export const useHasAppUpgradeEvent = () => {
+  const { appUpgradeEvent } = useAppUpgradeEvent();
+
+  const hasAppUpgradeEvent = appUpgradeEvent !== undefined;
+
+  return hasAppUpgradeEvent;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useHasAppUpgradeVerifiedInstallerPath.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useHasAppUpgradeVerifiedInstallerPath.ts
@@ -1,0 +1,9 @@
+import { useVersionSuggestedUpgrade } from '../redux/hooks';
+
+export const useHasAppUpgradeVerifiedInstallerPath = () => {
+  const { suggestedUpgrade } = useVersionSuggestedUpgrade();
+
+  const hasVerifiedInstallerPath = suggestedUpgrade?.verifiedInstallerPath !== undefined;
+
+  return hasVerifiedInstallerPath;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useIsAppUpgradeInProgress.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useIsAppUpgradeInProgress.ts
@@ -1,0 +1,23 @@
+import { useAppUpgradeEventType } from './useAppUpgradeEventType';
+import { useHasAppUpgradeError } from './useHasAppUpgradeError';
+
+export const useIsAppUpgradeInProgress = () => {
+  const appUpgradeEventType = useAppUpgradeEventType();
+  const hasAppUpgradeError = useHasAppUpgradeError();
+
+  if (hasAppUpgradeError) {
+    return false;
+  }
+
+  switch (appUpgradeEventType) {
+    case 'APP_UPGRADE_STATUS_DOWNLOAD_PROGRESS':
+    case 'APP_UPGRADE_STATUS_DOWNLOAD_STARTED':
+    case 'APP_UPGRADE_STATUS_STARTED_INSTALLER':
+    case 'APP_UPGRADE_STATUS_STARTING_INSTALLER':
+    case 'APP_UPGRADE_STATUS_VERIFIED_INSTALLER':
+    case 'APP_UPGRADE_STATUS_VERIFYING_INSTALLER':
+      return true;
+    default:
+      return false;
+  }
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useShouldAppUpgradeInstallManually.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useShouldAppUpgradeInstallManually.ts
@@ -1,0 +1,31 @@
+import { useAppUpgradeError } from '../redux/hooks';
+import { useHasAppUpgradeError } from './useHasAppUpgradeError';
+import { useHasAppUpgradeEvent } from './useHasAppUpgradeEvent';
+import { useHasAppUpgradeVerifiedInstallerPath } from './useHasAppUpgradeVerifiedInstallerPath';
+
+export const useShouldAppUpgradeInstallManually = () => {
+  const { appUpgradeError } = useAppUpgradeError();
+  const hasAppUpgradeError = useHasAppUpgradeError();
+  const hasAppUpgradeVerifiedInstallerPath = useHasAppUpgradeVerifiedInstallerPath();
+  const hasAppUpgradeEvent = useHasAppUpgradeEvent();
+
+  if (!hasAppUpgradeVerifiedInstallerPath) {
+    return false;
+  }
+
+  if (hasAppUpgradeError) {
+    if (appUpgradeError === 'START_INSTALLER_FAILED') {
+      return true;
+    }
+
+    return false;
+  }
+
+  // The absence of the appUpgradeEvent means that the upgrade has been downloaded
+  // and the app has been exited and restarted.
+  if (!hasAppUpgradeEvent) {
+    return true;
+  }
+
+  return false;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useAppUpgradeError';
+export * from './useAppUpgradeEvent';

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/useAppUpgradeError.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/useAppUpgradeError.ts
@@ -1,0 +1,9 @@
+import { useSelector } from '../../store';
+import { setAppUpgradeError } from '../actions';
+
+export const useAppUpgradeError = () => {
+  return {
+    appUpgradeError: useSelector((state) => state.appUpgrade.error),
+    setAppUpgradeError,
+  };
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/useAppUpgradeEvent.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/useAppUpgradeEvent.ts
@@ -1,0 +1,9 @@
+import { useSelector } from '../../store';
+import { setAppUpgradeEvent } from '../actions';
+
+export const useAppUpgradeEvent = () => {
+  return {
+    appUpgradeEvent: useSelector((state) => state.appUpgrade.event),
+    setAppUpgradeEvent,
+  };
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from '../account/hooks';
+export * from '../app-upgrade/hooks';
 export * from '../connection/hooks';
 export * from '../settings/hooks';
 export * from '../userinterface/hooks';

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/hooks/index.ts
@@ -1,5 +1,5 @@
 export * from '../account/hooks';
 export * from '../connection/hooks';
 export * from '../settings/hooks';
-export * from '../version/hooks';
 export * from '../userinterface/hooks';
+export * from '../version/hooks';


### PR DESCRIPTION
- Adds reusable hooks for common AppUpgrade logic.
- Also adds missing selectors to `app-upgrade` Redux namespace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7915)
<!-- Reviewable:end -->
