### PR TITLE
Implement new `ManagementService`

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -391,6 +391,13 @@ pub enum DaemonCommand {
     ExportJsonSettings(ResponseTx<String, settings::patch::Error>),
     /// Request the current feature indicators.
     GetFeatureIndicators(oneshot::Sender<FeatureIndicators>),
+    // App upgrade
+    /// Prompt the daemon to start an app version upgrade.
+    ///
+    /// If an upgrade had previously been started but not completed the daemon should continue the upgrade process at the appropriate step. The client need not be notified about this detail.
+    AppUpgrade(ResponseTx<(), Error>),
+    /// Prompt the daemon to abort the current upgrade.
+    AppUpgradeAbort(ResponseTx<(), Error>),
 }
 
 /// All events that can happen in the daemon. Sent from various threads and exposed interfaces.
@@ -1452,6 +1459,8 @@ impl Daemon {
             ApplyJsonSettings(tx, blob) => self.on_apply_json_settings(tx, blob).await,
             ExportJsonSettings(tx) => self.on_export_json_settings(tx),
             GetFeatureIndicators(tx) => self.on_get_feature_indicators(tx),
+            AppUpgrade(sender) => todo!("Implement `on_app_upgrade`"),
+            AppUpgradeAbort(sender) => todo!("Implement `on_app_upgrade_abort`"),
         }
     }
 

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -41,11 +41,17 @@ pub enum Error {
 struct ManagementServiceImpl {
     daemon_tx: DaemonCommandSender,
     subscriptions: Arc<Mutex<Vec<EventsListenerSender>>>,
+    app_upgrade_event_subscribers: Arc<Mutex<Vec<AppUpgradeEventListenerSender>>>,
 }
 
 pub type ServiceResult<T> = std::result::Result<Response<T>, Status>;
 type EventsListenerReceiver = UnboundedReceiverStream<Result<types::DaemonEvent, Status>>;
 type EventsListenerSender = tokio::sync::mpsc::UnboundedSender<Result<types::DaemonEvent, Status>>;
+
+type AppUpgradeEventListenerReceiver =
+    UnboundedReceiverStream<Result<types::AppUpgradeEvent, Status>>;
+type AppUpgradeEventListenerSender =
+    tokio::sync::mpsc::UnboundedSender<Result<types::AppUpgradeEvent, Status>>;
 
 const INVALID_VOUCHER_MESSAGE: &str = "This voucher code is invalid";
 const USED_VOUCHER_MESSAGE: &str = "This voucher code has already been used";
@@ -54,8 +60,7 @@ const USED_VOUCHER_MESSAGE: &str = "This voucher code has already been used";
 impl ManagementService for ManagementServiceImpl {
     type GetSplitTunnelProcessesStream = UnboundedReceiverStream<Result<i32, Status>>;
     type EventsListenStream = EventsListenerReceiver;
-    type AppUpgradeEventsListenStream =
-        UnboundedReceiverStream<Result<types::AppUpgradeEvent, Status>>;
+    type AppUpgradeEventsListenStream = AppUpgradeEventListenerReceiver;
 
     // Control and get the tunnel state
     //
@@ -1101,18 +1106,38 @@ impl ManagementService for ManagementServiceImpl {
     // App upgrade
 
     async fn app_upgrade(&self, _: Request<()>) -> ServiceResult<()> {
-        todo!()
+        log::debug!("app_upgrade");
+
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::AppUpgrade(tx))?;
+
+        self.wait_for_result(rx).await?.map_err(map_daemon_error)?;
+
+        Ok(Response::new(()))
     }
 
     async fn app_upgrade_abort(&self, _: Request<()>) -> ServiceResult<()> {
-        todo!()
+        log::debug!("app_upgrade_abort");
+
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::AppUpgradeAbort(tx))?;
+
+        self.wait_for_result(rx).await?.map_err(map_daemon_error)?;
+
+        Ok(Response::new(()))
     }
 
     async fn app_upgrade_events_listen(
         &self,
         _: Request<()>,
     ) -> ServiceResult<Self::AppUpgradeEventsListenStream> {
-        todo!()
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let mut subscriptions = self.app_upgrade_event_subscribers.lock().unwrap();
+        subscriptions.push(tx);
+
+        let upgrade_event_stream = UnboundedReceiverStream::new(rx);
+        Ok(Response::new(upgrade_event_stream))
     }
 }
 
@@ -1148,6 +1173,8 @@ impl ManagementInterfaceServer {
         rpc_socket_path: impl AsRef<Path>,
     ) -> Result<ManagementInterfaceServer, Error> {
         let subscriptions = Arc::<Mutex<Vec<EventsListenerSender>>>::default();
+        let app_upgrade_event_subscriptions =
+            Arc::<Mutex<Vec<AppUpgradeEventListenerSender>>>::default();
         // NOTE: It is important that the channel buffer size is kept at 0. When sending a signal
         // to abort the gRPC server, the sender can be awaited to know when the gRPC server has
         // received and started processing the shutdown signal.
@@ -1155,6 +1182,7 @@ impl ManagementInterfaceServer {
         let server = ManagementServiceImpl {
             daemon_tx,
             subscriptions: subscriptions.clone(),
+            app_upgrade_event_subscribers: app_upgrade_event_subscriptions.clone(),
         };
         let rpc_server_join_handle = mullvad_management_interface::spawn_rpc_server(
             server,
@@ -1170,7 +1198,10 @@ impl ManagementInterfaceServer {
             rpc_socket_path.as_ref().display()
         );
 
-        let broadcast = ManagementInterfaceEventBroadcaster { subscriptions };
+        let broadcast = ManagementInterfaceEventBroadcaster {
+            subscriptions,
+            app_upgrade_event_subscriptions,
+        };
 
         Ok(ManagementInterfaceServer {
             rpc_server_join_handle,
@@ -1210,12 +1241,18 @@ impl ManagementInterfaceServer {
 #[derive(Clone)]
 pub struct ManagementInterfaceEventBroadcaster {
     subscriptions: Arc<Mutex<Vec<EventsListenerSender>>>,
+    app_upgrade_event_subscriptions: Arc<Mutex<Vec<AppUpgradeEventListenerSender>>>,
 }
 
 impl ManagementInterfaceEventBroadcaster {
     fn notify(&self, value: types::DaemonEvent) {
         let mut subscriptions = self.subscriptions.lock().unwrap();
         subscriptions.retain(|tx| tx.send(Ok(value.clone())).is_ok());
+    }
+
+    pub(crate) fn notify_upgrade_event(&self, value: version::AppUpgradeEvent) {
+        let mut subscriptions = self.app_upgrade_event_subscriptions.lock().unwrap();
+        subscriptions.retain(|tx| tx.send(Ok(value.clone().into())).is_ok());
     }
 
     /// Notify that the tunnel state changed.

--- a/mullvad-management-interface/src/types/conversions/version.rs
+++ b/mullvad-management-interface/src/types/conversions/version.rs
@@ -1,11 +1,12 @@
 use std::path::PathBuf;
 
 use crate::types::proto;
+use mullvad_types::version::*;
 
 use super::FromProtobufTypeError;
 
-impl From<mullvad_types::version::AppVersionInfo> for proto::AppVersionInfo {
-    fn from(version_info: mullvad_types::version::AppVersionInfo) -> Self {
+impl From<AppVersionInfo> for proto::AppVersionInfo {
+    fn from(version_info: AppVersionInfo) -> Self {
         Self {
             supported: version_info.current_version_supported,
             suggested_upgrade: version_info
@@ -15,7 +16,7 @@ impl From<mullvad_types::version::AppVersionInfo> for proto::AppVersionInfo {
     }
 }
 
-impl TryFrom<proto::AppVersionInfo> for mullvad_types::version::AppVersionInfo {
+impl TryFrom<proto::AppVersionInfo> for AppVersionInfo {
     type Error = FromProtobufTypeError;
 
     fn try_from(version_info: proto::AppVersionInfo) -> Result<Self, Self::Error> {
@@ -23,14 +24,14 @@ impl TryFrom<proto::AppVersionInfo> for mullvad_types::version::AppVersionInfo {
             current_version_supported: version_info.supported,
             suggested_upgrade: version_info
                 .suggested_upgrade
-                .map(mullvad_types::version::SuggestedUpgrade::try_from)
+                .map(SuggestedUpgrade::try_from)
                 .transpose()?,
         })
     }
 }
 
-impl From<mullvad_types::version::SuggestedUpgrade> for proto::SuggestedUpgrade {
-    fn from(suggested_upgrade: mullvad_types::version::SuggestedUpgrade) -> Self {
+impl From<SuggestedUpgrade> for proto::SuggestedUpgrade {
+    fn from(suggested_upgrade: SuggestedUpgrade) -> Self {
         Self {
             version: suggested_upgrade.version.to_string(),
             changelog: suggested_upgrade.changelog,
@@ -41,7 +42,7 @@ impl From<mullvad_types::version::SuggestedUpgrade> for proto::SuggestedUpgrade 
     }
 }
 
-impl TryFrom<proto::SuggestedUpgrade> for mullvad_types::version::SuggestedUpgrade {
+impl TryFrom<proto::SuggestedUpgrade> for SuggestedUpgrade {
     type Error = FromProtobufTypeError;
 
     fn try_from(suggested_upgrade: proto::SuggestedUpgrade) -> Result<Self, Self::Error> {
@@ -58,5 +59,131 @@ impl TryFrom<proto::SuggestedUpgrade> for mullvad_types::version::SuggestedUpgra
             changelog: suggested_upgrade.changelog,
             verified_installer_path,
         })
+    }
+}
+
+impl From<AppUpgradeEvent> for proto::AppUpgradeEvent {
+    fn from(upgrade_event: AppUpgradeEvent) -> Self {
+        type ProtoEvent = proto::app_upgrade_event::Event;
+
+        let event = match upgrade_event {
+            AppUpgradeEvent::DownloadStarting => {
+                ProtoEvent::DownloadStarting(proto::AppUpgradeDownloadStarting {})
+            }
+            AppUpgradeEvent::DownloadProgress(progress) => {
+                ProtoEvent::DownloadProgress(progress.into())
+            }
+            AppUpgradeEvent::VerifyingInstaller => {
+                ProtoEvent::VerifyingInstaller(proto::AppUpgradeVerifyingInstaller {})
+            }
+            AppUpgradeEvent::VerifiedInstaller => {
+                ProtoEvent::VerifiedInstaller(proto::AppUpgradeVerifiedInstaller {})
+            }
+            AppUpgradeEvent::Aborted => ProtoEvent::UpgradeAborted(proto::AppUpgradeAborted {}),
+            AppUpgradeEvent::Error(app_upgrade_error) => {
+                ProtoEvent::Error(app_upgrade_error.into())
+            }
+        };
+        Self { event: Some(event) }
+    }
+}
+
+impl TryFrom<proto::AppUpgradeEvent> for AppUpgradeEvent {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(upgrade_event: proto::AppUpgradeEvent) -> Result<Self, FromProtobufTypeError> {
+        type ProtoEvent = proto::app_upgrade_event::Event;
+
+        let event = upgrade_event
+            .event
+            .ok_or(FromProtobufTypeError::InvalidArgument(
+                "Non-existent AppUpgradeEvent",
+            ))?;
+
+        let event = match event {
+            ProtoEvent::DownloadStarting(_starting) => AppUpgradeEvent::DownloadStarting,
+            ProtoEvent::DownloadProgress(progress) => {
+                let progress = AppUpgradeDownloadProgress::try_from(progress)?;
+                AppUpgradeEvent::DownloadProgress(progress)
+            }
+            ProtoEvent::VerifyingInstaller(_verifying) => AppUpgradeEvent::VerifyingInstaller,
+            ProtoEvent::VerifiedInstaller(_verified) => AppUpgradeEvent::VerifiedInstaller,
+            ProtoEvent::UpgradeAborted(_aborted) => AppUpgradeEvent::Aborted,
+            ProtoEvent::Error(error) => {
+                let error = AppUpgradeError::try_from(error)?;
+                AppUpgradeEvent::Error(error)
+            }
+        };
+        Ok(event)
+    }
+}
+
+impl From<AppUpgradeDownloadProgress> for proto::AppUpgradeDownloadProgress {
+    fn from(value: AppUpgradeDownloadProgress) -> Self {
+        // TODO: Is it acceptable to unwrap in this case?
+        // From the docs: Converts a std::time::Duration to a Duration, failing if the duration is too large.
+        let time_left = prost_types::Duration::try_from(value.time_left).unwrap();
+        proto::AppUpgradeDownloadProgress {
+            server: value.server,
+            progress: value.progress,
+            time_left: Some(time_left),
+        }
+    }
+}
+
+impl TryFrom<proto::AppUpgradeDownloadProgress> for AppUpgradeDownloadProgress {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(value: proto::AppUpgradeDownloadProgress) -> Result<Self, Self::Error> {
+        let Some(time_left) = value.time_left else {
+            return Err(FromProtobufTypeError::InvalidArgument(
+                "Non-existent AppUpgradeDownloadProgress::time_left",
+            ));
+        };
+        // TODO: Is it acceptable to unwrap in this case?
+        // From the docs: Converts a Duration to a std::time::Duration, failing if the duration is negative.
+        let time_left = std::time::Duration::try_from(time_left).unwrap();
+        let progress = AppUpgradeDownloadProgress {
+            server: value.server,
+            progress: value.progress,
+            time_left,
+        };
+        Ok(progress)
+    }
+}
+
+impl From<AppUpgradeError> for proto::AppUpgradeError {
+    fn from(value: AppUpgradeError) -> Self {
+        type ProtoError = proto::app_upgrade_error::Error;
+        match value {
+            AppUpgradeError::GeneralError => proto::AppUpgradeError {
+                error: ProtoError::GeneralError as i32,
+            },
+            AppUpgradeError::DownloadFailed => proto::AppUpgradeError {
+                error: ProtoError::DownloadFailed as i32,
+            },
+            AppUpgradeError::VerificationFailed => proto::AppUpgradeError {
+                // TODO: Spelling mistake! Should be VerificationFailed xd
+                error: ProtoError::VerficationFailed as i32,
+            },
+        }
+    }
+}
+
+impl TryFrom<proto::AppUpgradeError> for AppUpgradeError {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(value: proto::AppUpgradeError) -> Result<Self, Self::Error> {
+        type ProtoError = proto::app_upgrade_error::Error;
+        let Ok(error) = ProtoError::try_from(value.error) else {
+            return Err(FromProtobufTypeError::InvalidArgument(
+                "invalid AppUpgradeError",
+            ));
+        };
+        match error {
+            ProtoError::GeneralError => Ok(AppUpgradeError::GeneralError),
+            ProtoError::DownloadFailed => Ok(AppUpgradeError::DownloadFailed),
+            ProtoError::VerficationFailed => Ok(AppUpgradeError::VerificationFailed),
+        }
     }
 }


### PR DESCRIPTION
This PR implements 3 new functions on the `ManagementService` trait: `app_upgrade`, `app_upgrade_abort` and `app_upgrade_events_listen`. This allow any Mullvad client to start a new version upgrade, abort an ongoing upgrade and subscribe to upgrade events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7916)
<!-- Reviewable:end -->
