### PR TITLE
Validate product version in mullvad-version

### DIFF
--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -191,6 +191,11 @@ mod tests {
     }
 
     #[test]
+    fn test_product_version() {
+        parse(VERSION);
+    }
+
+    #[test]
     fn test_version_ordering() {
         // Test year comparison
         assert!(parse("2022.1") > parse("2021.1"),);


### PR DESCRIPTION
This verifies that `dist-assets/desktop-product-version.txt` contains a valid version by adding a little unit test.

Side-note: Maybe we ought to parse the string instead.

Fix DES-1503

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7918)
<!-- Reviewable:end -->
