### PR TITLE
Fix e2e logs not being saved properly

### DIFF
--- a/android/scripts/run-instrumented-tests.sh
+++ b/android/scripts/run-instrumented-tests.sh
@@ -162,7 +162,6 @@ DEVICE_TEST_ATTACHMENTS_PATH="/sdcard/Download/test-attachments"
 echo ""
 echo "### Ensure clean report structure ###"
 rm -rf "${REPORT_DIR:?}/*"
-adb logcat --clear
 adb shell rm -rf "$DEVICE_SCREENSHOT_PATH"
 adb shell rm -rf "$DEVICE_TEST_ATTACHMENTS_PATH"
 echo ""
@@ -209,6 +208,11 @@ if [[ "$USE_ORCHESTRATOR" == "true" ]]; then
 fi
 echo ""
 
+echo "### Start logging ###"
+adb logcat --clear
+adb logcat > "$LOGCAT_FILE_PATH" &
+running_pid=$!
+
 echo "### Run instrumented test command ###"
 if [[ "$USE_ORCHESTRATOR" == "true" ]]; then
     INSTRUMENTATION_COMMAND="\
@@ -228,6 +232,9 @@ fi
 adb shell "$GRADLE_ENVIRONMENT_VARIABLES $INSTRUMENTATION_COMMAND" | tee "$INSTRUMENTATION_LOG_FILE_PATH"
 echo ""
 
+echo "### Stop logging ###"
+kill $running_pid
+
 echo "### Ensure that packages are uninstalled ###"
 adb uninstall "$PACKAGE_NAME" || echo "App package not installed"
 adb uninstall "$TEST_PACKAGE_NAME" || echo "Test package not installed"
@@ -243,7 +250,6 @@ else
     echo "Collecting report..."
     adb pull "$DEVICE_SCREENSHOT_PATH" "$LOCAL_SCREENSHOT_PATH" || echo "No screenshots"
     adb pull "$DEVICE_TEST_ATTACHMENTS_PATH" "$LOCAL_TEST_ATTACHMENTS_PATH" || echo "No test attachments"
-    adb logcat -d > "$LOGCAT_FILE_PATH"
     exit 1
 fi
 


### PR DESCRIPTION
Currently we use `logcat -d` this will dump the current logs however this relies on the buffer of app logs being long enough which didn't end up being the case. Now we starting logging in the begging of the test and stop once all tests are complete.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7927)
<!-- Reviewable:end -->
