### PR TITLE
Disable pre-generation of PQ keys on Android

### DIFF
--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -25,6 +25,7 @@ use talpid_routing::RouteManagerHandle;
 #[cfg(target_os = "macos")]
 use talpid_tunnel::TunnelMetadata;
 use talpid_tunnel::{tun_provider::TunProvider, TunnelEvent};
+#[cfg(not(target_os = "android"))]
 use talpid_tunnel_config_client::classic_mceliece::spawn_keypair_generator;
 #[cfg(target_os = "macos")]
 use talpid_types::ErrorExt;
@@ -181,6 +182,10 @@ pub async fn spawn(
     });
 
     // Spawn a worker that pre-computes McEliece key pairs for PQ tunnels
+    //
+    // On Android we have a different lifecycle of the daemon and creating new keys on start up
+    // comes at a high cost, thus we let the generator be created lazily.
+    #[cfg(not(target_os = "android"))]
     spawn_keypair_generator();
 
     Ok(TunnelStateMachineHandle {


### PR DESCRIPTION
By generating 2 PQ keys on start we slow the start up of the android app with out about 20%. On android we don't have the daemon running continously and by default PQ nor Multihop is enabled, thus all our users doing a cold start of the app will be 20% slower. 

Ideally the solution would be to conditionally & dynamically change the buffer size depending on what features are active, e.g PQ gives buffer of 1, PQ and Multihop gives a buffer of 2.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7929)
<!-- Reviewable:end -->
