### PR TITLE
Verify ownership of socket/named pipe before communicating with daemon

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
+++ b/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
@@ -49,7 +49,9 @@ import {
 } from './grpc-type-convertions';
 
 const DAEMON_RPC_PATH =
-  process.platform === 'win32' ? 'unix:////./pipe/Mullvad VPN' : 'unix:///var/run/mullvad-vpn';
+  process.platform === 'win32' ? '//./pipe/Mullvad VPN' : '/var/run/mullvad-vpn';
+const DAEMON_RPC_PATH_PREFIX = 'unix://';
+const DAEMON_RPC_PATH_PREFIXED = `${DAEMON_RPC_PATH_PREFIX}${DAEMON_RPC_PATH}`;
 
 export class SubscriptionListener<T> {
   // Only meant to be used by DaemonRpc
@@ -82,7 +84,7 @@ export class DaemonRpc extends GrpcClient {
   > = new Map();
 
   public constructor(connectionObserver?: ConnectionObserver) {
-    super(DAEMON_RPC_PATH, connectionObserver);
+    super(DAEMON_RPC_PATH_PREFIXED, connectionObserver);
   }
 
   public disconnect() {

--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -523,6 +523,10 @@ class ApplicationMain
 
     log.info('Connected to the daemon');
 
+    await this.daemonRpc.verifyDaemonOwnership();
+
+    log.info('Verified daemon ownership');
+
     this.notificationController.closeNotificationsInCategory(
       SystemNotificationCategory.tunnelState,
     );


### PR DESCRIPTION
The Electron app should verify that the socket/named pipe which is used to communicate with the daemon is owned by the correct user before it starts communicating with the daemon. This PR verifies that ownership or throws an error. See issue on Linear for details about ownership check failing.

Fixes: DES-1881

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7930)
<!-- Reviewable:end -->
