### PR TITLE
Silence `GO-2025-3503` in `libwg/wireguard-go`

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -52,3 +52,9 @@ reason = "wireguard-go does not use the affected code"
 id = "CVE-2025-22866" # GO-2025-3447
 ignoreUntil = 2025-06-12
 reason = "wireguard-go does not use the affected code"
+
+# HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net
+[[IgnoredVulns]]
+id = "CVE-2025-22870" # GO-2025-3503
+ignoreUntil = 2025-07-01
+reason = "wireguard-go does not use x/net/proxy nor x/net/http/httpproxy"


### PR DESCRIPTION
This PR silences a CVE filed against `golang.org/x/net/http/httpproxy` and `golang.org/x/net/proxy`  that was detected by `osv-scanner`: https://osv.dev/vulnerability/GO-2025-3503.

Wireguard-go does not use any of these libraries, so it is safe to simply ignore these CVE warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7931)
<!-- Reviewable:end -->
