### PR TITLE
Upgrade vite to 6.2.4

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -14975,9 +14975,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15744,7 +15744,7 @@
         "tsc-watch": "^5.0.3",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
-        "vite": "6.2.3",
+        "vite": "6.2.4",
         "vite-plugin-electron": "^0.29.0",
         "xvfb-maybe": "^0.2.1"
       },
@@ -23987,7 +23987,7 @@
         "tsc-watch": "^5.0.3",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
-        "vite": "6.2.3",
+        "vite": "6.2.4",
         "vite-plugin-electron": "^0.29.0",
         "windows-utils": "0.0.0",
         "xvfb-maybe": "^0.2.1"
@@ -27222,9 +27222,9 @@
       }
     },
     "vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -33,7 +33,7 @@
     "typescript-eslint": "^8.15.0"
   },
   "overrides": {
-    "vite": "6.2.3"
+    "vite": "6.2.4"
   },
   "engines": {
     "node": ">=16",

--- a/desktop/packages/mullvad-vpn/package.json
+++ b/desktop/packages/mullvad-vpn/package.json
@@ -71,7 +71,7 @@
     "tsc-watch": "^5.0.3",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
-    "vite": "6.2.3",
+    "vite": "6.2.4",
     "vite-plugin-electron": "^0.29.0",
     "xvfb-maybe": "^0.2.1"
   },


### PR DESCRIPTION
Patches the following vulnerability: https://osv.dev/GHSA-4r4m-qw57-chr8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7932)
<!-- Reviewable:end -->
