### PR TITLE
Add OpenVPN warnings to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Add a notification for notifying users about the sunsetting of OpenVPN.
+
 ### Changed
 #### Windows
 - Rename `win-shortcuts` native module to `windows-utils`.


### PR DESCRIPTION
This PR simply notes the added warnings for the upcoming sunsetting of OpenVPN in the changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7935)
<!-- Reviewable:end -->
