### PR TITLE
Hide in-app upgrade errors on Linux and Android

### DIFF
--- a/mullvad-daemon/src/version/downloader.rs
+++ b/mullvad-daemon/src/version/downloader.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use std::{future::Future, path::PathBuf};
 use tokio::fs;
 
-use super::Error;
 type Result<T> = std::result::Result<T, Error>;
 
 pub struct Downloader(());
@@ -33,6 +32,17 @@ pub enum UpdateEvent {
     VerificationFailed,
     /// There is a downloaded and verified installer available
     Verified { verified_installer_path: PathBuf },
+}
+
+pub enum Error {
+    #[error("Failed to get download directory")]
+    GetDownloadDir(#[from] mullvad_paths::Error),
+
+    #[error("Failed to create download directory")]
+    CreateDownloadDir(#[source] io::Error),
+
+    #[error("Could not select URL for app update")]
+    NoUrlFound,
 }
 
 impl Downloader {

--- a/mullvad-daemon/src/version/mod.rs
+++ b/mullvad-daemon/src/version/mod.rs
@@ -39,14 +39,8 @@ pub enum Error {
     #[error("Version cache update was aborted")]
     UpdateAborted,
 
-    #[error("Failed to get download directory")]
-    GetDownloadDir(#[from] mullvad_paths::Error),
-
-    #[error("Failed to create download directory")]
-    CreateDownloadDir(#[source] io::Error),
-
-    #[error("Could not select URL for app update")]
-    NoUrlFound,
+    #[cfg(update)]
+    Update(#[transparent] downloader::Error),
 }
 
 /// Contains the date of the git commit this was built from


### PR DESCRIPTION
Linux and Android does not have the in-app upgrade feature, thus exposing the errors related to that feature does not make any sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7939)
<!-- Reviewable:end -->
