### PR TITLE
Add public signing keys for metadata to `mullvad-update`

### DIFF
--- a/installer-downloader/src/controller.rs
+++ b/installer-downloader/src/controller.rs
@@ -20,9 +20,6 @@ use tokio::{
     task::JoinHandle,
 };
 
-/// Pinned root certificate used when fetching version metadata
-const PINNED_CERTIFICATE: &[u8] = include_bytes!("../../mullvad-api/le_root_cert.pem");
-
 /// Base URL for pulling metadata. Actual JSON files should be stored at `<base
 /// url>/<platform>.json`
 const META_REPOSITORY_URL: &str = "https://api.mullvad.net/app/releases/";
@@ -49,12 +46,7 @@ pub fn initialize_controller<T: AppDelegate + 'static>(delegate: &mut T, environ
     // Directory provider to use
     type DirProvider = crate::temp::TempDirProvider;
 
-    let cert = reqwest::Certificate::from_pem(PINNED_CERTIFICATE).expect("invalid cert");
-    let version_provider = HttpVersionInfoProvider {
-        url: get_metadata_url(),
-        pinned_certificate: Some(cert),
-        verifying_keys: mullvad_update::keys::TRUSTED_METADATA_SIGNING_PUBKEYS.clone(),
-    };
+    let version_provider = HttpVersionInfoProvider::new(get_metadata_url());
 
     AppController::initialize::<_, Downloader<T>, _, DirProvider>(
         delegate,

--- a/mullvad-api/src/version.rs
+++ b/mullvad-api/src/version.rs
@@ -66,7 +66,7 @@ impl AppVersionProxy {
             let response = service.request(request).await?;
             let bytes = response.body_with_max_size(Self::SIZE_LIMIT).await?;
 
-            let response = mullvad_update::format::SignedResponse::deserialize_and_verify(
+            let response = mullvad_update::format::SignedResponse::deserialize_and_verify_with_keys(
                 &mullvad_update::keys::TRUSTED_METADATA_SIGNING_PUBKEYS,
                 &bytes,
                 lowest_metadata_version,

--- a/mullvad-api/src/version.rs
+++ b/mullvad-api/src/version.rs
@@ -66,8 +66,7 @@ impl AppVersionProxy {
             let response = service.request(request).await?;
             let bytes = response.body_with_max_size(Self::SIZE_LIMIT).await?;
 
-            let response = mullvad_update::format::SignedResponse::deserialize_and_verify_with_keys(
-                &mullvad_update::keys::TRUSTED_METADATA_SIGNING_PUBKEYS,
+            let response = mullvad_update::format::SignedResponse::deserialize_and_verify(
                 &bytes,
                 lowest_metadata_version,
             )

--- a/mullvad-update/meta/src/platform.rs
+++ b/mullvad-update/meta/src/platform.rs
@@ -231,7 +231,7 @@ impl Platform {
         println!("Verifying signature of {}...", signed_path.display());
         let bytes = fs::read(signed_path).await.context("Failed to read file")?;
 
-        format::SignedResponse::deserialize_and_verify(
+        format::SignedResponse::deserialize_and_verify_with_keys(
             &mullvad_update::keys::TRUSTED_METADATA_SIGNING_PUBKEYS,
             &bytes,
             crate::MIN_VERIFY_METADATA_VERSION,

--- a/mullvad-update/meta/src/platform.rs
+++ b/mullvad-update/meta/src/platform.rs
@@ -10,7 +10,6 @@ use std::{
     fmt,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::LazyLock,
 };
 use tokio::{fs, io};
 
@@ -22,12 +21,6 @@ use crate::{
 /// Base URL for metadata found with `meta pull`.
 /// Actual JSON files should be stored at `<base url>/<platform>.json`.
 const META_REPOSITORY_URL: &str = "https://releases.mullvad.net/desktop/metadata/";
-
-/// TLS certificate to pin to for `meta pull`.
-static PINNED_CERTIFICATE: LazyLock<reqwest::Certificate> = LazyLock::new(|| {
-    const CERT_BYTES: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pem");
-    reqwest::Certificate::from_pem(CERT_BYTES).expect("invalid cert")
-});
 
 #[derive(Clone, Copy)]
 pub enum Platform {
@@ -127,11 +120,7 @@ impl Platform {
 
         println!("Pulling {self} metadata from {url}...");
 
-        let version_provider = HttpVersionInfoProvider {
-            pinned_certificate: Some(PINNED_CERTIFICATE.clone()),
-            url,
-            verifying_keys: mullvad_update::keys::TRUSTED_METADATA_SIGNING_PUBKEYS.clone(),
-        };
+        let version_provider = HttpVersionInfoProvider::new(url);
         let response = version_provider
             .get_versions(crate::MIN_VERIFY_METADATA_VERSION)
             .await
@@ -231,12 +220,8 @@ impl Platform {
         println!("Verifying signature of {}...", signed_path.display());
         let bytes = fs::read(signed_path).await.context("Failed to read file")?;
 
-        format::SignedResponse::deserialize_and_verify_with_keys(
-            &mullvad_update::keys::TRUSTED_METADATA_SIGNING_PUBKEYS,
-            &bytes,
-            crate::MIN_VERIFY_METADATA_VERSION,
-        )
-        .context("Failed to verify metadata for {platform}: {error}")?;
+        format::SignedResponse::deserialize_and_verify(&bytes, crate::MIN_VERIFY_METADATA_VERSION)
+            .context("Failed to verify metadata for {platform}: {error}")?;
 
         Ok(())
     }

--- a/mullvad-update/meta/src/platform.rs
+++ b/mullvad-update/meta/src/platform.rs
@@ -103,10 +103,12 @@ impl Platform {
 
         println!("Pulling {self} metadata from {}...", platform.url());
 
-        let response = HttpVersionInfoProvider::from(platform)
-            .get_versions(crate::MIN_VERIFY_METADATA_VERSION)
-            .await
-            .context("Failed to retrieve versions")?;
+        let response = HttpVersionInfoProvider::get_versions_for_platform(
+            platform,
+            crate::MIN_VERIFY_METADATA_VERSION,
+        )
+        .await
+        .context("Failed to retrieve versions")?;
 
         let json = serde_json::to_string_pretty(&response)
             .context("Failed to serialize updated metadata")?;

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -41,7 +41,7 @@ impl HttpVersionInfoProvider {
         lowest_metadata_version: usize,
     ) -> anyhow::Result<format::SignedResponse> {
         let raw_json = Self::get(&self.url, self.pinned_certificate.clone()).await?;
-        let response = format::SignedResponse::deserialize_and_verify(
+        let response = format::SignedResponse::deserialize_and_verify_with_keys(
             &self.verifying_keys,
             &raw_json,
             lowest_metadata_version,

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -56,11 +56,11 @@ pub trait VersionInfoProvider {
 /// Obtain version data using a GET request
 pub struct HttpVersionInfoProvider {
     /// Endpoint for GET request
-    pub url: String,
+    url: String,
     /// Accepted root certificate. Defaults are used unless specified
-    pub pinned_certificate: Option<reqwest::Certificate>,
+    pinned_certificate: Option<reqwest::Certificate>,
     /// Key to use for verifying the response
-    pub verifying_keys: Vec1<format::key::VerifyingKey>,
+    verifying_keys: Vec1<format::key::VerifyingKey>,
 }
 
 #[async_trait::async_trait]

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -42,8 +42,8 @@ impl HttpVersionInfoProvider {
     pub fn new(url: String) -> Self {
         HttpVersionInfoProvider {
             url,
-            pinned_certificate: Some(crate::keys::PINNED_CERTIFICATE.clone()),
-            verifying_keys: crate::keys::TRUSTED_METADATA_SIGNING_PUBKEYS.clone(),
+            pinned_certificate: Some(crate::defaults::PINNED_CERTIFICATE.clone()),
+            verifying_keys: crate::defaults::TRUSTED_METADATA_SIGNING_PUBKEYS.clone(),
         }
     }
 

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -35,6 +35,18 @@ impl HttpVersionInfoProvider {
     /// Maximum size of the GET response, in bytes
     const SIZE_LIMIT: usize = 1024 * 1024;
 
+    /// Construct an [HttpVersionInfoProvider] for `url` using reasonable defaults.
+    ///
+    /// By default, `pinned_certificate` will be set to the LE root certificate, and
+    /// `verifying_keys` will be set to the keys in `trusted-metadata-signing-keys`.
+    pub fn new(url: String) -> Self {
+        HttpVersionInfoProvider {
+            url,
+            pinned_certificate: Some(crate::keys::PINNED_CERTIFICATE.clone()),
+            verifying_keys: crate::keys::TRUSTED_METADATA_SIGNING_PUBKEYS.clone(),
+        }
+    }
+
     /// Download and verify signed data
     pub async fn get_versions(
         &self,

--- a/mullvad-update/src/client/snapshots/mullvad_update__client__api__test__http_version_provider.snap
+++ b/mullvad-update/src/client/snapshots/mullvad_update__client__api__test__http_version_provider.snap
@@ -1,83 +1,66 @@
 ---
-source: mullvad-update/src/api.rs
+source: mullvad-update/src/client/api.rs
 expression: info
 snapshot_kind: text
 ---
-stable:
-  version: "2025.2"
-  urls:
-    - "https://releases.mullvad.net/desktop/releases/2025.2/MullvadVPN-2025.2.exe"
-  size: 101384672
-  changelog: "[macos] Adding support for quicfuscator\n[windows] Less bugs"
-  sha256:
-    - 244
-    - 178
-    - 87
-    - 19
-    - 209
-    - 63
-    - 40
-    - 25
-    - 163
-    - 0
-    - 242
-    - 255
-    - 169
-    - 77
-    - 150
-    - 116
-    - 99
-    - 170
-    - 238
-    - 160
-    - 211
-    - 87
-    - 251
-    - 215
-    - 71
-    - 154
-    - 40
-    - 17
-    - 84
-    - 186
-    - 4
-    - 96
-beta:
-  version: 2025.3-beta1
-  urls:
-    - "https://releases.mullvad.net/desktop/releases/2025.3-beta1/MullvadVPN-2025.3-beta1_x64.exe"
-  size: 106297504
-  changelog: "[macos] Adding support for quicfuscator\n[windows] Less bugs"
-  sha256:
-    - 12
-    - 86
-    - 154
-    - 160
-    - 145
-    - 46
-    - 185
-    - 54
-    - 5
-    - 168
-    - 80
-    - 115
-    - 68
-    - 125
-    - 66
-    - 186
-    - 12
-    - 166
-    - 18
-    - 54
-    - 27
-    - 239
-    - 120
-    - 239
-    - 4
-    - 239
-    - 3
-    - 142
-    - 128
-    - 177
-    - 84
-    - 3
+signatures:
+  - keytype: ed25519
+    keyid: bb4ef63ffdcc6bd5a19c30cd23b9de03099407a04463418f17ae338b98aa09d4
+    sig: 253ec37846dcd909bfc5119c0e0d06535767e179eb8b4465015eaa95f4bed362c8c9186311192c987871722bf7d319d44e4f04eaf79c269820bc13ff1a901f0b
+signed:
+  metadata_version: 0
+  metadata_expiry: "2025-07-02T15:33:00Z"
+  releases:
+    - version: "2025.2"
+      changelog: "[macos] Adding support for quicfuscator\n[windows] Less bugs"
+      installers:
+        - architecture: x86
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.2/MullvadVPN-2025.2.exe"
+          size: 101384672
+          sha256: F4B25713D13F2819A300F2FFA94D967463AAEEA0D357FBD7479A281154BA0460
+        - architecture: arm64
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.2/MullvadVPN-2025.2_arm64.exe"
+          size: 104146312
+          sha256: AFD8098A1FF89D69A243EC4E2E946CF5FBF8D1C10998230D6C8FC0A5C9C39541
+    - version: "2025.3"
+      changelog: "[macos] Adding support for quicfuscator\n[windows] Less bugs"
+      installers:
+        - architecture: x86
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.2/MullvadVPN-2025.2.exe"
+          size: 101384672
+          sha256: F4B25713D13F2819A300F2FFA94D967463AAEEA0D357FBD7479A281154BA0460
+        - architecture: arm64
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.2/MullvadVPN-2025.2_arm64.exe"
+          size: 104146312
+          sha256: AFD8098A1FF89D69A243EC4E2E946CF5FBF8D1C10998230D6C8FC0A5C9C39541
+      rollout: 0.5
+    - version: 2025.1-beta1
+      changelog: "[macos] Adding support for quicfuscator\n[windows] Less bugs"
+      installers:
+        - architecture: x86
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.3-beta1/MullvadVPN-2025.3-beta1_x64.exe"
+          size: 106297504
+          sha256: 0c569aa0912eb93605a85073447d42ba0ca612361bef78ef04ef038e80b15403
+        - architecture: arm64
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.3-beta1/MullvadVPN-2025.3-beta1_arm64.exe"
+          size: 111488248
+          sha256: 82948D3DB5B869EE5F0D246DB557A81B72B68DFDDD2267872B7B8A5B19A05444
+    - version: 2025.3-beta1
+      changelog: "[macos] Adding support for quicfuscator\n[windows] Less bugs"
+      installers:
+        - architecture: x86
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.3-beta1/MullvadVPN-2025.3-beta1_x64.exe"
+          size: 106297504
+          sha256: 0c569aa0912eb93605a85073447d42ba0ca612361bef78ef04ef038e80b15403
+        - architecture: arm64
+          urls:
+            - "https://releases.mullvad.net/desktop/releases/2025.3-beta1/MullvadVPN-2025.3-beta1_arm64.exe"
+          size: 111488248
+          sha256: 82948D3DB5B869EE5F0D246DB557A81B72B68DFDDD2267872B7B8A5B19A05444

--- a/mullvad-update/src/defaults.rs
+++ b/mullvad-update/src/defaults.rs
@@ -1,10 +1,11 @@
-//! Keys that may be used for verifying data
+//! Default keys and certificates that may be used for verifying data
 
 use crate::format::key::VerifyingKey;
 use std::sync::LazyLock;
 use vec1::Vec1;
 
 /// Default TLS certificate to pin to
+#[cfg(feature = "client")]
 pub static PINNED_CERTIFICATE: LazyLock<reqwest::Certificate> = LazyLock::new(|| {
     const CERT_BYTES: &[u8] = include_bytes!("../../mullvad-api/le_root_cert.pem");
     reqwest::Certificate::from_pem(CERT_BYTES).expect("invalid cert")

--- a/mullvad-update/src/defaults.rs
+++ b/mullvad-update/src/defaults.rs
@@ -4,6 +4,10 @@ use crate::format::key::VerifyingKey;
 use std::sync::LazyLock;
 use vec1::Vec1;
 
+/// Default repository URL for version metadata
+#[cfg(feature = "client")]
+pub const META_REPOSITORY_URL: &str = "https://api.mullvad.net/app/releases/";
+
 /// Default TLS certificate to pin to
 #[cfg(feature = "client")]
 pub static PINNED_CERTIFICATE: LazyLock<reqwest::Certificate> = LazyLock::new(|| {

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -10,7 +10,7 @@ use super::{PartialSignedResponse, ResponseSignature, SignedResponse};
 impl SignedResponse {
     /// Deserialize some bytes to JSON, and verify them, including signature and expiry.
     /// If successful, the deserialized data is returned.
-    pub fn deserialize_and_verify(
+    pub fn deserialize_and_verify_with_keys(
         keys: &Vec1<VerifyingKey>,
         bytes: &[u8],
         min_metadata_version: usize,

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -25,6 +25,8 @@ impl SignedResponse {
 
     /// Deserialize some bytes to JSON, and verify them, including signature and expiry.
     /// If successful, the deserialized data is returned.
+    ///
+    /// This is typically only used for testing. Prefer [deserialize_and_verify].
     pub(crate) fn deserialize_and_verify_with_keys(
         keys: &Vec1<VerifyingKey>,
         bytes: &[u8],
@@ -48,6 +50,8 @@ impl SignedResponse {
 
     /// Deserialize some bytes to JSON, and verify them, including signature and expiry.
     /// If successful, the deserialized data is returned.
+    ///
+    /// This is typically only used for testing. Prefer [deserialize_and_verify].
     fn deserialize_and_verify_at_time(
         keys: &Vec1<VerifyingKey>,
         bytes: &[u8],

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -17,7 +17,7 @@ impl SignedResponse {
         min_metadata_version: usize,
     ) -> Result<Self, anyhow::Error> {
         Self::deserialize_and_verify_with_keys(
-            &crate::keys::TRUSTED_METADATA_SIGNING_PUBKEYS,
+            &crate::defaults::TRUSTED_METADATA_SIGNING_PUBKEYS,
             bytes,
             min_metadata_version,
         )

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -25,7 +25,7 @@ impl SignedResponse {
 
     /// Deserialize some bytes to JSON, and verify them, including signature and expiry.
     /// If successful, the deserialized data is returned.
-    pub fn deserialize_and_verify_with_keys(
+    pub(crate) fn deserialize_and_verify_with_keys(
         keys: &Vec1<VerifyingKey>,
         bytes: &[u8],
         min_metadata_version: usize,

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -10,6 +10,21 @@ use super::{PartialSignedResponse, ResponseSignature, SignedResponse};
 impl SignedResponse {
     /// Deserialize some bytes to JSON, and verify them, including signature and expiry.
     /// If successful, the deserialized data is returned.
+    ///
+    /// This uses the keys in `trusted-metadata-signing-pubkeys`
+    pub fn deserialize_and_verify(
+        bytes: &[u8],
+        min_metadata_version: usize,
+    ) -> Result<Self, anyhow::Error> {
+        Self::deserialize_and_verify_with_keys(
+            &crate::keys::TRUSTED_METADATA_SIGNING_PUBKEYS,
+            bytes,
+            min_metadata_version,
+        )
+    }
+
+    /// Deserialize some bytes to JSON, and verify them, including signature and expiry.
+    /// If successful, the deserialized data is returned.
     pub fn deserialize_and_verify_with_keys(
         keys: &Vec1<VerifyingKey>,
         bytes: &[u8],

--- a/mullvad-update/src/keys.rs
+++ b/mullvad-update/src/keys.rs
@@ -4,6 +4,12 @@ use crate::format::key::VerifyingKey;
 use std::sync::LazyLock;
 use vec1::Vec1;
 
+/// Default TLS certificate to pin to
+pub static PINNED_CERTIFICATE: LazyLock<reqwest::Certificate> = LazyLock::new(|| {
+    const CERT_BYTES: &[u8] = include_bytes!("../../mullvad-api/le_root_cert.pem");
+    reqwest::Certificate::from_pem(CERT_BYTES).expect("invalid cert")
+});
+
 /// Pubkeys used to verify metadata from the Mullvad API (production)
 pub static TRUSTED_METADATA_SIGNING_PUBKEYS: LazyLock<Vec1<VerifyingKey>> =
     LazyLock::new(|| parse_keys(include_str!("../trusted-metadata-signing-pubkeys")));

--- a/mullvad-update/src/lib.rs
+++ b/mullvad-update/src/lib.rs
@@ -6,8 +6,7 @@ mod client;
 #[cfg(feature = "client")]
 pub use client::*;
 
-#[cfg(feature = "client")]
-mod keys;
+mod defaults;
 
 pub mod version;
 

--- a/mullvad-update/src/lib.rs
+++ b/mullvad-update/src/lib.rs
@@ -6,7 +6,8 @@ mod client;
 #[cfg(feature = "client")]
 pub use client::*;
 
-pub mod keys;
+#[cfg(feature = "client")]
+mod keys;
 
 pub mod version;
 


### PR DESCRIPTION
This hides certificate pinning and pubkeys (mostly) in `mullvad-update`. Details are still somewhat duplicated in `mullvad-api`, since it has its own HTTP client.

Fix DES-1944.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7940)
<!-- Reviewable:end -->
