### PR TITLE
Mark trusted-metadata-signing-pubkeys as needing signatures to be edited

### DIFF
--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -32,6 +32,7 @@ on:
       - building/linux-container-image.txt
       - building/android-container-image.txt
       - building/sigstore/**
+      - mullvad-update/trusted-metadata-signing-pubkeys
 
 permissions: {}
 


### PR DESCRIPTION
This file is extremely important to the installer downloader (and soon in app upgrades). When adding these keys we put strict codeowners permissions on it. But we should also make sure the file is always signed when changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7942)
<!-- Reviewable:end -->
