### PR TITLE
Fix build target for `mullvad-daemon` build script

### DIFF
--- a/mullvad-daemon/build.rs
+++ b/mullvad-daemon/build.rs
@@ -36,7 +36,7 @@ fn main() {
 
     // Enable in-app upgrades on macOS and Windows
     println!("cargo::rustc-check-cfg=cfg(update)");
-    if cfg!(any(target_os = "macos", target_os = "windows")) {
+    if matches!(target_os(), Os::Windows | Os::Macos) {
         println!(r#"cargo::rustc-cfg=update"#);
     }
 }
@@ -50,4 +50,23 @@ fn commit_date() -> String {
         .unwrap()
         .trim()
         .to_owned()
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum Os {
+    Windows,
+    Macos,
+    Linux,
+    Android,
+}
+
+fn target_os() -> Os {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    match target_os.as_str() {
+        "windows" => Os::Windows,
+        "macos" => Os::Macos,
+        "linux" => Os::Linux,
+        "android" => Os::Android,
+        _ => panic!("Unsupported target os: {target_os}"),
+    }
 }


### PR DESCRIPTION
This PR fixes an issue in the build script for `mullvad-daemon` - check for the actual target OS instead of the target for the build script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7944)
<!-- Reviewable:end -->
