### PR TITLE
Correct wording for `Prerequisites` at iOS Readme.md

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -56,7 +56,7 @@ configuration.
    vim ios/Configurations/Screenshots.xcconfig
    ```
 
-### Prerequisitives
+### Prerequisites
 
 1. Make sure you have [rvm](https://rvm.io) installed.
 1. Install Ruby 2.5.1 or later using `rvm install <VERSION>`.


### PR DESCRIPTION
* [x] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [x] The PR description should describe:

Correct the wording at ios/README.md
- Prerequisitives => Prerequisites

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7956)
<!-- Reviewable:end -->
