### PR TITLE
Fix compilation errors for 2024 edition on macOS

### DIFF
--- a/mullvad-daemon/src/macos_launch_daemon.rs
+++ b/mullvad-daemon/src/macos_launch_daemon.rs
@@ -15,7 +15,7 @@ type Id = *mut AnyObject;
 
 // Framework that contains `SMAppService`.
 #[link(name = "ServiceManagement", kind = "framework")]
-extern "C" {}
+unsafe extern "C" {}
 
 /// Returned by `[NSProcessInfo operatingSystemVersion]`. Contains the current
 #[repr(C)]

--- a/mullvad-daemon/src/migrations/v10.rs
+++ b/mullvad-daemon/src/migrations/v10.rs
@@ -62,7 +62,7 @@ fn migrate_tunnel_type_inner(normal: &mut serde_json::Value) -> Result<()> {
         }
         // Migrate '"only": { "tunnel_protocol": $tunnel_protocol }'
         // to '"tunnel_protocol": $tunnel_protocol'
-        Some(serde_json::Value::Object(ref mut constraint)) => {
+        Some(serde_json::Value::Object(constraint)) => {
             if let Some(tunnel_type) = constraint.get("only") {
                 let tunnel_type: TunnelType = serde_json::from_value(tunnel_type.clone())
                     .map_err(|_| Error::InvalidSettingsContent)?;

--- a/mullvad-daemon/src/relay_list/mod.rs
+++ b/mullvad-daemon/src/relay_list/mod.rs
@@ -167,14 +167,19 @@ impl RelayListUpdater {
         proxy: RelayListProxy,
         tag: Option<String>,
     ) -> impl Future<Output = Result<Option<RelayList>, mullvad_api::Error>> + use<> {
-        let download_futures = move || {
+        async fn download_future(
+            api_handle: ApiAvailability,
+            proxy: RelayListProxy,
+            tag: Option<String>,
+        ) -> Result<Option<RelayList>, mullvad_api::Error> {
             let available = api_handle.wait_background();
-            let req = proxy.relay_list(tag.clone());
-            async move {
-                available.await?;
-                req.await.map_err(mullvad_api::Error::from)
-            }
-        };
+            let req = proxy.relay_list(tag);
+            available.await?;
+            req.await.map_err(mullvad_api::Error::from)
+        }
+
+        let download_futures =
+            move || download_future(api_handle.clone(), proxy.clone(), tag.clone());
 
         retry_future(
             download_futures,

--- a/talpid-core/src/split_tunnel/macos/tun.rs
+++ b/talpid-core/src/split_tunnel/macos/tun.rs
@@ -818,7 +818,7 @@ fn fix_ipv6_checksums(
 ///   exist, the function will not fail, but the stream will never return anything.
 fn capture_outbound_packets(
     utun_iface: &str,
-) -> Result<impl Stream<Item = Result<PktapPacket, Error>> + Send, Error> {
+) -> Result<impl Stream<Item = Result<PktapPacket, Error>> + Send + use<>, Error> {
     // We want to create a pktap "pseudo-device" and capture data on it using a bpf device.
     // This provides packet data plus a pktap header including process information.
     // libpcap will do the heavy lifting for us if we simply request a "pktap" device.

--- a/talpid-routing/src/unix/mod.rs
+++ b/talpid-routing/src/unix/mod.rs
@@ -265,7 +265,7 @@ impl RouteManagerHandle {
     #[cfg(target_os = "macos")]
     pub async fn default_route_listener(
         &self,
-    ) -> Result<impl Stream<Item = DefaultRouteEvent>, Error> {
+    ) -> Result<impl Stream<Item = DefaultRouteEvent> + use<>, Error> {
         let (response_tx, response_rx) = oneshot::channel();
         self.tx
             .unbounded_send(RouteManagerCommand::NewDefaultRouteListener(response_tx))


### PR DESCRIPTION
This makes `cargo check` succeed on Rust edition 2024. There's probably lints that fail, so this is not intended to be complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7958)
<!-- Reviewable:end -->
