### PR TITLE
Small cleanups in desktop release scripts

### DIFF
--- a/desktop/scripts/release/4-make-release
+++ b/desktop/scripts/release/4-make-release
@@ -27,10 +27,10 @@ fi
 
 PRODUCT_VERSION=$1
 
-ARTIFACT_DIR="./artifacts"
+# shellcheck source=desktop/scripts/release/release-config.sh
+source "$SCRIPT_DIR/release-config.sh"
 
-rm -rf $ARTIFACT_DIR
-mkdir -p $ARTIFACT_DIR
+rm -rf "$ARTIFACT_DIR" && mkdir -p "$ARTIFACT_DIR" || exit 1
 
 function publish_release {
     echo ">>> Downloading changelog"
@@ -85,5 +85,5 @@ function publish_release {
     echo "The above URL contains the text \"untagged\", but don't worry it is tagged properly and everything will look correct once it's published."
 }
 
-./download-release-artifacts "$PRODUCT_VERSION"
+./download-release-artifacts "$PRODUCT_VERSION" "$ARTIFACT_DIR"
 publish_release

--- a/desktop/scripts/release/5-update-and-publish-metadata
+++ b/desktop/scripts/release/5-update-and-publish-metadata
@@ -19,16 +19,6 @@ if [ $# -ne 3 ]; then
     exit 1
 fi
 
-# Duplicated from /scripts/utils/gh-ready-check
-if ! command -v gh > /dev/null; then
-    echo "gh (GitHub CLI) is required to run this script"
-    exit 1
-fi
-if ! gh auth status > /dev/null; then
-    echo "Authentication through gh (GitHub CLI) is required to run this script"
-    exit 1
-fi
-
 PRODUCT_VERSION=$1
 BUILDSERVER_HOST=$2
 METADATA_SERVER_HOST=$3

--- a/desktop/scripts/release/5-update-and-publish-metadata
+++ b/desktop/scripts/release/5-update-and-publish-metadata
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # This script downloads the build artifacts along with the signatures, verifies the signatures and
-# publishes new version metadata to Mullvads API. This should be run after `4-make-release`.
+# publishes new version metadata to Mullvads API.
+# * This should be run after `4-make-release`.
+# * You need to put the private ed25519 signing key in the clipboard before running this script.
 
 set -eu
 
@@ -49,8 +51,8 @@ function publish_metadata {
     mullvad-release add-release "$PRODUCT_VERSION" --rollout 1 "${platforms[@]}"
     echo ""
 
-    echo ">>> Signing $PRODUCT_VERSION metadata"
-    mullvad-release sign "${platforms[@]}"
+    echo ">>> Signing $PRODUCT_VERSION metadata. Reading signing key from clipboard"
+    xclip -sensitive | mullvad-release sign "${platforms[@]}"
     echo ""
 
     echo ">>> Verifying signed metadata"

--- a/desktop/scripts/release/5-update-and-publish-metadata
+++ b/desktop/scripts/release/5-update-and-publish-metadata
@@ -23,7 +23,8 @@ PRODUCT_VERSION=$1
 BUILDSERVER_HOST=$2
 METADATA_SERVER_HOST=$3
 
-ARTIFACT_DIR="./artifacts"
+# shellcheck source=desktop/scripts/release/release-config.sh
+source "$SCRIPT_DIR/release-config.sh"
 
 function publish_metadata {
     local platforms
@@ -69,6 +70,6 @@ function remove_release_artifacts {
     rm -r "$ARTIFACT_DIR"
 }
 
-./download-release-artifacts "$PRODUCT_VERSION"
+./download-release-artifacts "$PRODUCT_VERSION" "$ARTIFACT_DIR"
 publish_metadata
 remove_release_artifacts

--- a/desktop/scripts/release/5-update-and-publish-metadata
+++ b/desktop/scripts/release/5-update-and-publish-metadata
@@ -46,7 +46,7 @@ function publish_metadata {
     echo ""
 
     echo ">>> Adding new release $PRODUCT_VERSION (rollout = 1)"
-    mullvad-release add-release "$PRODUCT_VERSION" "${platforms[@]}" 1
+    mullvad-release add-release "$PRODUCT_VERSION" --rollout 1 "${platforms[@]}"
     echo ""
 
     echo ">>> Signing $PRODUCT_VERSION metadata"

--- a/desktop/scripts/release/5-update-and-publish-metadata
+++ b/desktop/scripts/release/5-update-and-publish-metadata
@@ -22,7 +22,9 @@ if [ $# -ne 3 ]; then
 fi
 
 PRODUCT_VERSION=$1
+# The hostname (can be the alias in your ~/.ssh/config) of the build server
 BUILDSERVER_HOST=$2
+# The server to upload the metadata to *from* the build server (argument above)
 METADATA_SERVER_HOST=$3
 
 # shellcheck source=desktop/scripts/release/release-config.sh

--- a/desktop/scripts/release/download-release-artifacts
+++ b/desktop/scripts/release/download-release-artifacts
@@ -7,19 +7,22 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
-if [ $# -ne 1 ]; then
+if [ $# -ne 2 ]; then
     echo "Please provide the following arguments:"
     echo "    $(basename "$0") \\"
-    echo "        <product version>"
+    echo "        <product version> \\"
+    echo "        <artifact download directory> "
     exit 1
 fi
 
+# The app version to download
 PRODUCT_VERSION=$1
+# The directory where the artifacts will be downloaded to
+ARTIFACT_DIR=$2
 
-ARTIFACT_DIR="./artifacts"
 URL_BASE="https://releases.mullvad.net/desktop/releases"
 
-mkdir -p $ARTIFACT_DIR
+mkdir -p "$ARTIFACT_DIR"
 
 # The signer key file "mullvad-code-signing-key.asc" is expected to exist in the current working directory.
 SIGNER_KEY_FILE="./mullvad-code-signing-key.asc"

--- a/desktop/scripts/release/release-config.sh
+++ b/desktop/scripts/release/release-config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Configuration variables shared between the release scripts in this directory.
+
+# Where to download app installers locally during the release process.
+# This value is also hardcoded into the `mullvad-release` binary and
+# has to be in sync with that value
+export ARTIFACT_DIR="artifacts"


### PR DESCRIPTION
I think this PR is easiest reviewed one commit at a time.

1. Removes the check for the `gh` command in a script that (no longer?) uses it.
2. The `ARTIFACT_DIR` variable was defined in three scripts and they depended on having the same value, but this was not obvious at all. I moved the definition into a config file that we source, and then use that single definition.
3. Fix bug in `5-update-and-publish-metadata` where the rollout percentage was passed on an invalid format to `mullvad-release`
4. Use `xclip -sensitive` to read the ed25519 signing key from the clipboard, instead of expecting the person running the script from manually pasting it. Removes a manual step and helps avoid accidentally pasting the key in the wrong place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7960)
<!-- Reviewable:end -->
