### PR TITLE
Bump the version of installer downloader to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "installer-downloader"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/installer-downloader/CHANGELOG.md
+++ b/installer-downloader/CHANGELOG.md
@@ -20,5 +20,7 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+## [0.2.0] - 2025-04-04
 - Initial support for downloading and installing the latest version of the Mullvad VPN app on
   Windows and macOS.

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "installer-downloader"
 description = "A secure minimal web installer for the Mullvad app"
-version = "0.1.0"
+version = "0.2.0"
 publish = false
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
This is for internal testing and dogfooding. First version pointing to and using production keys and infrastructure. The intention is to bump the version to `1.0.0` before we release to actual users. But we'll evaluate that after seeing how well this version works.

Is everything ready for building a "release" or other stuff we need to merge first?
