### PR TITLE
Update ProblemReport view to integrate better with in app upgrade feature

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/ProblemReport.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/ProblemReport.tsx
@@ -324,7 +324,16 @@ function OutdatedVersionWarningDialog() {
   const outdatedVersion = useSelector((state) => !!state.version.suggestedUpgrade);
   const pushAppUpgrade = usePushAppUpgrade();
 
-  const [showOutdatedVersionWarning, setShowOutdatedVersionWarning] = useState(outdatedVersion);
+  const { location } = useHistory();
+  const { state } = location;
+  const hasSuppressOutdatedVersionWarning = state?.options?.includes(
+    'suppress-outdated-version-warning',
+  );
+  const showOutdatedVersionWarningInitial = outdatedVersion && !hasSuppressOutdatedVersionWarning;
+
+  const [showOutdatedVersionWarning, setShowOutdatedVersionWarning] = useState(
+    showOutdatedVersionWarningInitial,
+  );
 
   const acknowledgeOutdatedVersion = useCallback(() => {
     setShowOutdatedVersionWarning(false);

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/UpdateAvailableListItem.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/UpdateAvailableListItem.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 
 import { messages } from '../../../../../../shared/gettext';
+import { useIsPlatformLinux } from '../../../../../hooks';
 import { Flex, Icon } from '../../../../../lib/components';
 import { Dot } from '../../../../../lib/components/dot';
 import { ListItem } from '../../../../../lib/components/list-item';
 import { useConnectionIsBlocked, useVersionSuggestedUpgrade } from '../../../../../redux/hooks';
-import { useHandleClick, useIsLinux } from './hooks';
+import { useHandleClick } from './hooks';
 
 const StyledText = styled(ListItem.Text)`
   margin-top: -4px;
@@ -15,7 +16,7 @@ export function UpdateAvailableListItem() {
   const { suggestedUpgrade } = useVersionSuggestedUpgrade();
   const { isBlocked } = useConnectionIsBlocked();
 
-  const isLinux = useIsLinux();
+  const isLinux = useIsPlatformLinux();
   const handleClick = useHandleClick();
 
   return (

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/hooks/index.ts
@@ -1,3 +1,2 @@
 export * from './useOpenDownloadUrl';
-export * from './useIsLinux';
 export * from './useHandleClick';

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/hooks/useHandleClick.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/hooks/useHandleClick.tsx
@@ -1,10 +1,10 @@
 import { usePushAppUpgrade } from '../../../../../../history/hooks';
-import { useIsLinux } from './useIsLinux';
+import { useIsPlatformLinux } from '../../../../../../hooks';
 import { useOpenDownloadUrl } from './useOpenDownloadUrl';
 
 export const useHandleClick = () => {
   const openDownloadUrl = useOpenDownloadUrl();
   const pushAppUpgrade = usePushAppUpgrade();
-  const isLinux = useIsLinux();
+  const isLinux = useIsPlatformLinux();
   return isLinux ? openDownloadUrl : pushAppUpgrade;
 };

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/hooks/useIsLinux.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/hooks/useIsLinux.tsx
@@ -1,3 +1,0 @@
-export const useIsLinux = () => {
-  return window.env.platform === 'linux';
-};

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/ReportProblemButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/ReportProblemButton.tsx
@@ -4,7 +4,9 @@ import { Button } from '../../../../../lib/components';
 
 export function ReportProblemButton() {
   const pushProblemReport = usePushProblemReport({
-    search: '?suppress-outdated-version-warning=true',
+    state: {
+      options: ['suppress-outdated-version-warning'],
+    },
   });
 
   return (

--- a/desktop/packages/mullvad-vpn/src/renderer/history/hooks/usePushProblemReport.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/history/hooks/usePushProblemReport.ts
@@ -1,21 +1,24 @@
 import { useCallback } from 'react';
 import { useHistory } from 'react-router';
 
+import { LocationState } from '../../../shared/ipc-types';
 import { RoutePath } from '../../lib/routes';
 
 export type PushProblemReportProps = {
-  search?: string;
+  state?: Partial<LocationState>;
 };
 
-export const usePushProblemReport = ({ search }: PushProblemReportProps = {}) => {
+export const usePushProblemReport = ({ state }: PushProblemReportProps = {}) => {
   const history = useHistory();
 
   const pushProblemReport = useCallback(() => {
-    history.push({
-      pathname: RoutePath.problemReport,
-      search,
-    });
-  }, [history, search]);
+    history.push(
+      {
+        pathname: RoutePath.problemReport,
+      },
+      state,
+    );
+  }, [history, state]);
 
   return pushProblemReport;
 };

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
@@ -6,4 +6,5 @@ export * from './useHasAppUpgradeInitiated';
 export * from './useHasAppUpgradeVerifiedInstallerPath';
 export * from './useIsAppUpgradeInProgress';
 export * from './useIsAppUpgradePending';
+export * from './useIsPlatformLinux';
 export * from './useShouldAppUpgradeInstallManually';

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useIsPlatformLinux.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useIsPlatformLinux.ts
@@ -1,0 +1,5 @@
+export const useIsPlatformLinux = () => {
+  const isPlatformLinux = window.env.platform === 'linux';
+
+  return isPlatformLinux;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/history.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/history.tsx
@@ -243,6 +243,7 @@ export default class History {
       scrollPosition: state?.scrollPosition ?? [0, 0],
       expandedSections: state?.expandedSections ?? {},
       transition: state?.transition ?? transitions.none,
+      options: state?.options,
     };
   }
 

--- a/desktop/packages/mullvad-vpn/src/shared/ipc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/ipc-types.ts
@@ -19,6 +19,7 @@ export interface LocationState {
   scrollPosition: [number, number];
   expandedSections: Record<string, boolean>;
   transition: ITransitionSpecification;
+  options?: Array<string>;
 }
 
 export interface IHistoryObject {


### PR DESCRIPTION
- Makes the modal optional so it can be disabled when navigating to it from the AppUpgrade view.
- Conditionally sets the "Upgrade app" button to navigate to an external URL or the AppUpgrade route, depending on platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7963)
<!-- Reviewable:end -->
