### PR TITLE
Fix incorrect fragmentation/reassembly logic in masque proxy

### DIFF
--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -246,25 +246,12 @@ impl Client {
                                 // log::trace!("Received datagram with an unexpected stream ID");
                                 continue;
                             }
-                            let mut payload = response.into_payload();
-                            let context = VarInt::decode(&mut payload);
-                            match  context {
-                                Ok(crate::HTTP_MASQUE_DATAGRAM_CONTEXT_ID) => {
-                                    self.client_socket
-                                        .send_to(payload.as_ref(), return_addr)
-                                        .await
-                                        .map_err(Error::ClientWrite)?;
-                                }
-                                Ok(crate::HTTP_MASQUE_FRAGMENTED_DATAGRAM_CONTEXT_ID) => {
-                                    if let Ok(Some(payload)) = self.fragments.handle_incoming_packet(payload) {
-                                        self.client_socket
-                                            .send_to(payload.chunk(), return_addr)
-                                            .await
-                                            .map_err(Error::ClientWrite)?;
-                                    }
-                                },
-                                _ => (),
-
+                            let payload = response.into_payload();
+                            if let Ok(Some(payload)) = self.fragments.handle_incoming_packet(payload) {
+                                self.client_socket
+                                    .send_to(payload.chunk(), return_addr)
+                                    .await
+                                    .map_err(Error::ClientWrite)?;
                             }
                         }
                         Ok(None) => {

--- a/mullvad-masque-proxy/src/server/mod.rs
+++ b/mullvad-masque-proxy/src/server/mod.rs
@@ -184,7 +184,7 @@ impl Server {
 
                             let mut received_packet = proxy_recv_buf.split().freeze();
 
-                            if proxy_recv_buf.len() < maximum_packet_size.into() {
+                            if received_packet.len() < maximum_packet_size.into() {
                                 if connection.send_datagram(stream_id, received_packet).is_err() {
                                     return;
                                 }

--- a/mullvad-masque-proxy/src/server/mod.rs
+++ b/mullvad-masque-proxy/src/server/mod.rs
@@ -33,7 +33,7 @@ const MASQUE_WELL_KNOWN_PATH: &str = "/.well-known/masque/udp/";
 pub struct Server {
     endpoint: Endpoint,
     allowed_hosts: AllowedIps,
-    max_packet_size: u16,
+    maximum_packet_size: u16,
 }
 
 #[derive(Clone)]
@@ -52,7 +52,7 @@ impl Server {
         bind_addr: SocketAddr,
         allowed_hosts: HashSet<IpAddr>,
         tls_config: Arc<rustls::ServerConfig>,
-        max_packet_size: u16,
+        maximum_packet_size: u16,
     ) -> Result<Self> {
         let server_config = quinn::ServerConfig::with_crypto(Arc::new(
             QuicServerConfig::try_from(tls_config).map_err(Error::BadTlsConfig)?,
@@ -65,7 +65,7 @@ impl Server {
             allowed_hosts: AllowedIps {
                 hosts: Arc::new(allowed_hosts),
             },
-            max_packet_size,
+            maximum_packet_size,
         })
     }
 
@@ -74,7 +74,7 @@ impl Server {
             tokio::spawn(Self::handle_incoming_connection(
                 new_connection,
                 self.allowed_hosts.clone(),
-                self.max_packet_size,
+                self.maximum_packet_size,
             ));
         }
         Ok(())


### PR DESCRIPTION
This fixes the following issues:
* The server never fragments due to not checking packet length correctly.
* The client reads the context ID twice (and so skips the first bytes when receiving fragments).

Fix DES-1986

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7970)
<!-- Reviewable:end -->
