### PR TITLE
Upgrade vite to 6.2.5 to fix CVE

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -14975,9 +14975,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15744,7 +15744,7 @@
         "tsc-watch": "^5.0.3",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
-        "vite": "6.2.4",
+        "vite": "6.2.5",
         "vite-plugin-electron": "^0.29.0",
         "xvfb-maybe": "^0.2.1"
       },
@@ -23987,7 +23987,7 @@
         "tsc-watch": "^5.0.3",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
-        "vite": "6.2.4",
+        "vite": "6.2.5",
         "vite-plugin-electron": "^0.29.0",
         "windows-utils": "0.0.0",
         "xvfb-maybe": "^0.2.1"
@@ -27222,9 +27222,9 @@
       }
     },
     "vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -33,7 +33,7 @@
     "typescript-eslint": "^8.15.0"
   },
   "overrides": {
-    "vite": "6.2.4"
+    "vite": "6.2.5"
   },
   "engines": {
     "node": ">=16",

--- a/desktop/packages/mullvad-vpn/package.json
+++ b/desktop/packages/mullvad-vpn/package.json
@@ -71,7 +71,7 @@
     "tsc-watch": "^5.0.3",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
-    "vite": "6.2.4",
+    "vite": "6.2.5",
     "vite-plugin-electron": "^0.29.0",
     "xvfb-maybe": "^0.2.1"
   },


### PR DESCRIPTION
Addresses this CVE: https://osv.dev/GHSA-xcj6-pq6g-qj4x

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7974)
<!-- Reviewable:end -->
