### PR TITLE
Create button for StoreKit 2 refunds

### DIFF
--- a/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountContentView.swift
@@ -21,12 +21,23 @@ class AccountContentView: UIView {
         return button
     }()
 
-    let storeKit2Button: AppButton = {
+    let storeKit2PurchaseButton: AppButton = {
         let button = AppButton(style: .success)
         button.setTitle(NSLocalizedString(
             "BUY_SUBSCRIPTION_STOREKIT_2",
             tableName: "Account",
             value: "Make a purchase with StoreKit2",
+            comment: ""
+        ), for: .normal)
+        return button
+    }()
+
+    let storeKit2RefundButton: AppButton = {
+        let button = AppButton(style: .success)
+        button.setTitle(NSLocalizedString(
+            "BUY_SUBSCRIPTION_STOREKIT_2",
+            tableName: "Account",
+            value: "Refund last purchase with StoreKit2",
             comment: ""
         ), for: .normal)
         return button
@@ -102,7 +113,8 @@ class AccountContentView: UIView {
         var arrangedSubviews = [UIView]()
         #if DEBUG
         arrangedSubviews.append(redeemVoucherButton)
-        arrangedSubviews.append(storeKit2Button)
+        arrangedSubviews.append(storeKit2PurchaseButton)
+        arrangedSubviews.append(storeKit2RefundButton)
         #endif
         arrangedSubviews.append(contentsOf: [
             purchaseButton,

--- a/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
@@ -50,7 +50,7 @@ final class AccountInteractor: Sendable {
     }
 
     func sendStoreKitReceipt(_ transaction: VerificationResult<Transaction>, for accountNumber: String) async throws {
-        try await apiProxy.createApplePayment(
+        _ = try await apiProxy.createApplePayment(
             accountNumber: accountNumber,
             receiptString: transaction.jwsRepresentation.data(using: .utf8)!
         ).execute()

--- a/ios/MullvadVPN/View controllers/Account/PaymentAlertPresenter.swift
+++ b/ios/MullvadVPN/View controllers/Account/PaymentAlertPresenter.swift
@@ -13,6 +13,36 @@ import Routing
 struct PaymentAlertPresenter {
     let alertContext: any Presenting
 
+    func showAlertForRefund(completion: (@MainActor @Sendable () -> Void)? = nil) {
+        let presentation = AlertPresentation(
+            id: "payment-refund-alert",
+            title: NSLocalizedString(
+                "PAYMENT_REFUND_ALERT_TITLE",
+                tableName: "Payment",
+                value: "Refund successful",
+                comment: ""
+            ),
+            message: NSLocalizedString(
+                "PAYMENT_REFUND_ALERT_MESSAGE",
+                tableName: "Payment",
+                value: "Your purchase was successfully refunded.",
+                comment: ""
+            ),
+            buttons: [
+                AlertAction(
+                    title: okButtonTextForKey("PAYMENT_REFUND_ALERT_OK_ACTION"),
+                    style: .default,
+                    handler: {
+                        completion?()
+                    }
+                ),
+            ]
+        )
+
+        let presenter = AlertPresenter(context: alertContext)
+        presenter.showAlert(presentation: presentation, animated: true)
+    }
+
     func showAlertForError(
         _ error: StorePaymentManagerError,
         context: REST.CreateApplePaymentResponse.Context,

--- a/ios/MullvadVPN/View controllers/Account/PaymentState.swift
+++ b/ios/MullvadVPN/View controllers/Account/PaymentState.swift
@@ -13,13 +13,14 @@ enum PaymentState: Equatable {
     case none
     case makingPayment(SKPayment)
     case makingStoreKit2Purchase
+    case makingStoreKit2Refund
     case restoringPurchases
 
     var allowsViewInteraction: Bool {
         switch self {
         case .none:
             return true
-        case .restoringPurchases, .makingPayment, .makingStoreKit2Purchase:
+        case .restoringPurchases, .makingPayment, .makingStoreKit2Purchase, .makingStoreKit2Refund:
             return false
         }
     }


### PR DESCRIPTION
Services needs a button to test refunds in StoreKit 2. This is a debug only button that refunds the last made purchase.

**Note: This PR introduces code that is only for testing.**

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7978)
<!-- Reviewable:end -->
