### PR TITLE
Bump `tokio` to `1.44.2`

### DIFF
--- a/ci/ios/test-router/raas/Cargo.lock
+++ b/ci/ios/test-router/raas/Cargo.lock
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
This PR is a follow-up to https://github.com/mullvad/mullvadvpn-app/pull/7971 - it addresses the same CVE in the `raas` workspace!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7980)
<!-- Reviewable:end -->
