### PR TITLE
Display actual obfuscation method in feature chips

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 import MullvadSettings
+import PacketTunnelCore
 import SwiftUI
 
 // Opting to use NSLocalizedString instead of LocalizedStringKey here in order
@@ -69,12 +70,26 @@ struct MultihopFeature: ChipFeature {
 
 struct ObfuscationFeature: ChipFeature {
     let settings: LatestTunnelSettings
+    let state: ObservedState
+
+    var actualObfuscationMethod: WireGuardObfuscationState {
+        state.connectionState.map { $0.obfuscationMethod } ?? .off
+    }
 
     var isEnabled: Bool {
-        settings.wireGuardObfuscation.state.isEnabled
+        actualObfuscationMethod != .off
+    }
+
+    var isAutomatic: Bool {
+        settings.wireGuardObfuscation.state == .automatic
     }
 
     var name: String {
+        // This just currently says "Obfuscation".
+        // To add an automaticity indicator (a trailing " (automatic)"
+        // or a colour/border style or whatever), use the `isAutomatic` field.
+        // To say what type of obfuscation it is,
+        // we can look at `actualObfuscationMethod`
         NSLocalizedString(
             "FEATURE_INDICATORS_CHIP_OBFUSCATION",
             tableName: "FeatureIndicatorsChip",

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
@@ -70,8 +70,7 @@ struct ConnectionViewComponentPreview<Content: View>: View {
             FeatureIndicatorsViewModel(
                 tunnelSettings: tunnelSettings,
                 ipOverrides: [],
-                tunnelState: connectedTunnelStatus.state,
-                observedState: connectedTunnelStatus.observedState
+                tunnelStatus: connectedTunnelStatus
             ),
             viewModel,
             $isExpanded

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
@@ -70,7 +70,8 @@ struct ConnectionViewComponentPreview<Content: View>: View {
             FeatureIndicatorsViewModel(
                 tunnelSettings: tunnelSettings,
                 ipOverrides: [],
-                tunnelState: connectedTunnelStatus.state
+                tunnelState: connectedTunnelStatus.state,
+                observedState: connectedTunnelStatus.observedState
             ),
             viewModel,
             $isExpanded

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
@@ -7,17 +7,25 @@
 //
 
 import MullvadSettings
+import PacketTunnelCore
 import SwiftUI
 
 class FeatureIndicatorsViewModel: ChipViewModelProtocol {
     @Published var tunnelSettings: LatestTunnelSettings
     @Published var ipOverrides: [IPOverride]
     @Published var tunnelState: TunnelState
+    @Published var observedState: ObservedState
 
-    init(tunnelSettings: LatestTunnelSettings, ipOverrides: [IPOverride], tunnelState: TunnelState) {
+    init(
+        tunnelSettings: LatestTunnelSettings,
+        ipOverrides: [IPOverride],
+        tunnelState: TunnelState,
+        observedState: ObservedState
+    ) {
         self.tunnelSettings = tunnelSettings
         self.ipOverrides = ipOverrides
         self.tunnelState = tunnelState
+        self.observedState = observedState
     }
 
     var chips: [ChipModel] {
@@ -30,7 +38,7 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
                 DaitaFeature(settings: tunnelSettings),
                 QuantumResistanceFeature(settings: tunnelSettings),
                 MultihopFeature(settings: tunnelSettings, state: tunnelState),
-                ObfuscationFeature(settings: tunnelSettings),
+                ObfuscationFeature(settings: tunnelSettings, state: observedState),
                 DNSFeature(settings: tunnelSettings),
                 IPOverrideFeature(overrides: ipOverrides),
             ]

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
@@ -19,13 +19,12 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
     init(
         tunnelSettings: LatestTunnelSettings,
         ipOverrides: [IPOverride],
-        tunnelState: TunnelState,
-        observedState: ObservedState
+        tunnelStatus: TunnelStatus
     ) {
         self.tunnelSettings = tunnelSettings
         self.ipOverrides = ipOverrides
-        self.tunnelState = tunnelState
-        self.observedState = observedState
+        self.tunnelState = tunnelStatus.state
+        self.observedState = tunnelStatus.observedState
     }
 
     var chips: [ChipModel] {

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -74,8 +74,7 @@ class TunnelViewController: UIViewController, RootContainment {
         indicatorsViewViewModel = FeatureIndicatorsViewModel(
             tunnelSettings: interactor.tunnelSettings,
             ipOverrides: interactor.ipOverrides,
-            tunnelState: tunnelState,
-            observedState: interactor.tunnelStatus.observedState
+            tunnelStatus: interactor.tunnelStatus
         )
 
         connectionView = ConnectionView(

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -74,7 +74,8 @@ class TunnelViewController: UIViewController, RootContainment {
         indicatorsViewViewModel = FeatureIndicatorsViewModel(
             tunnelSettings: interactor.tunnelSettings,
             ipOverrides: interactor.ipOverrides,
-            tunnelState: tunnelState
+            tunnelState: tunnelState,
+            observedState: interactor.tunnelStatus.observedState
         )
 
         connectionView = ConnectionView(
@@ -100,6 +101,7 @@ class TunnelViewController: UIViewController, RootContainment {
             self?.connectionViewViewModel.update(tunnelStatus: tunnelStatus)
             self?.setTunnelState(tunnelStatus.state, animated: true)
             self?.indicatorsViewViewModel.tunnelState = tunnelStatus.state
+            self?.indicatorsViewViewModel.observedState = tunnelStatus.observedState
             self?.view.setNeedsLayout()
         }
 

--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnelCore/PacketTunnelActorReducerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnelCore/PacketTunnelActorReducerTests.swift
@@ -36,7 +36,8 @@ final class PacketTunnelActorReducerTests: XCTestCase {
             transportLayer: .udp,
             remotePort: 12345,
             isPostQuantum: false,
-            isDaitaEnabled: false
+            isDaitaEnabled: false,
+            obfuscationMethod: .off
         )
     }
 

--- a/ios/PacketTunnelCore/Actor/ObservedState.swift
+++ b/ios/PacketTunnelCore/Actor/ObservedState.swift
@@ -9,6 +9,7 @@
 import Combine
 import Foundation
 import MullvadREST
+import MullvadSettings
 import MullvadTypes
 import Network
 @preconcurrency import WireGuardKitTypes
@@ -36,6 +37,7 @@ public struct ObservedConnectionState: Equatable, Codable, Sendable {
     public var lastKeyRotation: Date?
     public let isPostQuantum: Bool
     public let isDaitaEnabled: Bool
+    public let obfuscationMethod: WireGuardObfuscationState
 
     public var isNetworkReachable: Bool {
         networkReachability != .unreachable
@@ -50,7 +52,8 @@ public struct ObservedConnectionState: Equatable, Codable, Sendable {
         remotePort: UInt16,
         lastKeyRotation: Date? = nil,
         isPostQuantum: Bool,
-        isDaitaEnabled: Bool
+        isDaitaEnabled: Bool,
+        obfuscationMethod: WireGuardObfuscationState = .off
     ) {
         self.selectedRelays = selectedRelays
         self.relayConstraints = relayConstraints
@@ -61,6 +64,7 @@ public struct ObservedConnectionState: Equatable, Codable, Sendable {
         self.lastKeyRotation = lastKeyRotation
         self.isPostQuantum = isPostQuantum
         self.isDaitaEnabled = isDaitaEnabled
+        self.obfuscationMethod = obfuscationMethod
     }
 }
 
@@ -111,7 +115,8 @@ extension State.ConnectionData {
             remotePort: remotePort,
             lastKeyRotation: lastKeyRotation,
             isPostQuantum: isPostQuantum,
-            isDaitaEnabled: isDaitaEnabled
+            isDaitaEnabled: isDaitaEnabled,
+            obfuscationMethod: obfuscationMethod
         )
     }
 }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -402,7 +402,8 @@ extension PacketTunnelActor {
                 transportLayer: .udp,
                 remotePort: connectedRelay.endpoint.ipv4Relay.port,
                 isPostQuantum: settings.quantumResistance.isEnabled,
-                isDaitaEnabled: settings.daita.daitaState.isEnabled
+                isDaitaEnabled: settings.daita.daitaState.isEnabled,
+                obfuscationMethod: .off
             )
         case .disconnecting, .disconnected:
             return nil
@@ -426,7 +427,7 @@ extension PacketTunnelActor {
         guard let connectionState = try makeConnectionState(nextRelays: nextRelays, settings: settings, reason: reason)
         else { return nil }
 
-        let obfuscatedEndpoint = protocolObfuscator.obfuscate(
+        let obfuscated = protocolObfuscator.obfuscate(
             connectionState.connectedEndpoint,
             settings: settings.tunnelSettings,
             retryAttempts: connectionState.selectedRelays.retryAttempt
@@ -441,11 +442,12 @@ extension PacketTunnelActor {
             networkReachability: connectionState.networkReachability,
             connectionAttemptCount: connectionState.connectionAttemptCount,
             lastKeyRotation: connectionState.lastKeyRotation,
-            connectedEndpoint: obfuscatedEndpoint,
+            connectedEndpoint: obfuscated.endpoint,
             transportLayer: transportLayer,
             remotePort: protocolObfuscator.remotePort,
             isPostQuantum: settings.quantumResistance.isEnabled,
-            isDaitaEnabled: settings.daita.daitaState.isEnabled
+            isDaitaEnabled: settings.daita.daitaState.isEnabled,
+            obfuscationMethod: obfuscated.method
         )
     }
 

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -9,6 +9,7 @@
 import Foundation
 import MullvadREST
 import MullvadRustRuntime
+import MullvadSettings
 import MullvadTypes
 @preconcurrency import WireGuardKitTypes
 
@@ -153,6 +154,9 @@ extension State {
 
         /// True if Daita is enabled
         public let isDaitaEnabled: Bool
+
+        /// The obfuscation method in force on the connection
+        public let obfuscationMethod: WireGuardObfuscationState
     }
 
     /// Data associated with error state.

--- a/ios/PacketTunnelCoreTests/Mocks/ProtocolObfuscationStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/ProtocolObfuscationStub.swift
@@ -18,8 +18,8 @@ struct ProtocolObfuscationStub: ProtocolObfuscation {
         _ endpoint: MullvadEndpoint,
         settings: LatestTunnelSettings,
         retryAttempts: UInt
-    ) -> MullvadEndpoint {
-        endpoint
+    ) -> ProtocolObfuscationResult {
+        .init(endpoint: endpoint, method: .off)
     }
 
     var transportLayer: TransportLayer? { .udp }

--- a/ios/PacketTunnelCoreTests/ProtocolObfuscatorTests.swift
+++ b/ios/PacketTunnelCoreTests/ProtocolObfuscatorTests.swift
@@ -33,39 +33,39 @@ final class ProtocolObfuscatorTests: XCTestCase {
 
     func testObfuscateOffDoesNotChangeEndpoint() {
         let settings = settings(.off, obfuscationPort: .automatic)
-        let nonObfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings)
+        let nonObfuscated = obfuscator.obfuscate(endpoint, settings: settings)
 
-        XCTAssertEqual(endpoint, nonObfuscatedEndpoint)
+        XCTAssertEqual(endpoint, nonObfuscated.endpoint)
     }
 
     func testObfuscateUdpOverTcp() throws {
         let settings = settings(.udpOverTcp, obfuscationPort: .automatic)
-        let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings)
+        let obfuscated = obfuscator.obfuscate(endpoint, settings: settings)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
-        validate(obfuscatedEndpoint, against: obfuscationProtocol)
+        validate(obfuscated.endpoint, against: obfuscationProtocol)
     }
 
     func testObfuscateShadowsocks() throws {
         let settings = settings(.shadowsocks, obfuscationPort: .automatic)
-        let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings)
+        let obfuscated = obfuscator.obfuscate(endpoint, settings: settings)
         let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
 
-        validate(obfuscatedEndpoint, against: obfuscationProtocol)
+        validate(obfuscated.endpoint, against: obfuscationProtocol)
     }
 
     func testObfuscateAutomatic() throws {
         let settings = settings(.automatic, obfuscationPort: .automatic)
 
         try (UInt(0) ... 3).forEach { attempt in
-            let obfuscatedEndpoint = obfuscator.obfuscate(endpoint, settings: settings, retryAttempts: attempt)
+            let obfuscated = obfuscator.obfuscate(endpoint, settings: settings, retryAttempts: attempt)
 
             switch attempt {
             case 0, 1:
-                XCTAssertEqual(endpoint, obfuscatedEndpoint)
+                XCTAssertEqual(endpoint, obfuscated.endpoint)
             case 2, 3:
                 let obfuscationProtocol = try XCTUnwrap(obfuscator.tunnelObfuscator as? TunnelObfuscationStub)
-                validate(obfuscatedEndpoint, against: obfuscationProtocol)
+                validate(obfuscated.endpoint, against: obfuscationProtocol)
             default:
                 XCTExpectFailure("Should not end up here, test setup is wrong")
             }


### PR DESCRIPTION
This captures the chosen obfuscation method and stores it in `ObservedState`, and uses this for displaying the feature chip. Currently it just reads "Obfuscation" if it is enabled, though the logic exists to display the method used and whether it was automatically chosen.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7984)
<!-- Reviewable:end -->
