### PR TITLE
Silence CVE `GO-2025-3563` in `libwg`

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -58,3 +58,9 @@ reason = "wireguard-go does not use the affected code"
 id = "CVE-2025-22870" # GO-2025-3503
 ignoreUntil = 2025-07-01
 reason = "wireguard-go does not use x/net/proxy nor x/net/http/httpproxy"
+
+# Request smuggling due to acceptance of invalid chunked data in net/http
+[[IgnoredVulns]]
+id = "CVE-2025-22871" # GO-2025-3563
+ignoreUntil = 2025-07-08
+reason = "wireguard-go does not use net/http"


### PR DESCRIPTION
This PR silences [GO-2025-3563](https://osv.dev/vulnerability/GO-2025-3563) which `osv-scanner` flagged this morning. Neither `libwg` nor `wireguard-go` uses the affected library, so we may safely ignore this CVE for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7985)
<!-- Reviewable:end -->
