### PR TITLE
Show ip unavailble error message on desktop

### DIFF
--- a/android/lib/resource/src/main/res/values/strings.xml
+++ b/android/lib/resource/src/main/res/values/strings.xml
@@ -406,8 +406,8 @@
     <string name="uri_market_app_not_found">No Android app store installed, could not open link</string>
     <string name="uri_browser_app_not_found">No browser app installed, could not open link</string>
     <string name="ipv6_info">When this feature is enabled, IPv6 can be used alongside IPv4 in the VPN tunnel to communicate with internet services.</string>
-    <string name="ip_version_v4_unavailable">IPv4 is not available</string>
-    <string name="ip_version_v6_unavailable">IPv6 is not available</string>
+    <string name="ip_version_v4_unavailable">IPv4 is not available, please try changing \"Device IP version\" setting.</string>
+    <string name="ip_version_v6_unavailable">IPv6 is not available, please try changing \"Device IP version\" setting.</string>
     <string name="device_ip_info_first_paragraph">This feature allows you to choose whether to use only IPv4, only IPv6, or allow the app to automatically decide the best option when connecting to a server.</string>
     <string name="device_ip_info_second_paragraph">It can be useful when you are aware of problems caused by a certain IP version.</string>
 </resources>

--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -1249,6 +1249,16 @@ msgctxt "notifications"
 msgid "Failed to enable split tunneling. Please try reconnecting or disable split tunneling."
 msgstr ""
 
+#. Label for notification when IPv4 is not available.
+msgctxt "notifications"
+msgid "IPv4 is not available, please try changing <b>%(ipVersionFeatureName)</b> setting."
+msgstr ""
+
+#. Label for notification when IPv6 is not available.
+msgctxt "notifications"
+msgid "IPv6 is not available, please try changing <b>%(ipVersionFeatureName)</b> setting."
+msgstr ""
+
 msgctxt "notifications"
 msgid "Lockdown mode active, connection blocked"
 msgstr ""
@@ -2599,10 +2609,10 @@ msgstr ""
 msgid "Google Play unavailable"
 msgstr ""
 
-msgid "IPv4 is not available"
+msgid "IPv4 is not available, please try changing \"Device IP version\" setting."
 msgstr ""
 
-msgid "IPv6 is not available"
+msgid "IPv6 is not available, please try changing \"Device IP version\" setting."
 msgstr ""
 
 msgid "If the split tunneling feature is used, then the app queries your system for a list of all installed applications. This list is only retrieved in the split tunneling view. The list of installed applications is never sent from the device."

--- a/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
@@ -320,6 +320,10 @@ function convertFromParameterError(
       return TunnelParameterError.noWireguardKey;
     case grpcTypes.ErrorState.GenerationError.CUSTOM_TUNNEL_HOST_RESOLUTION_ERROR:
       return TunnelParameterError.customTunnelHostResolutionError;
+    case grpcTypes.ErrorState.GenerationError.NETWORK_IPV4_UNAVAILABLE:
+      return TunnelParameterError.ipv4Unavailable;
+    case grpcTypes.ErrorState.GenerationError.NETWORK_IPV6_UNAVAILABLE:
+      return TunnelParameterError.ipv6Unavailable;
   }
 }
 

--- a/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
@@ -63,6 +63,8 @@ export enum TunnelParameterError {
   noMatchingBridgeRelay,
   noWireguardKey,
   customTunnelHostResolutionError,
+  ipv4Unavailable,
+  ipv6Unavailable,
 }
 
 export type ErrorStateDetails =

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/error.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/error.ts
@@ -205,6 +205,7 @@ export class ErrorNotificationProvider
   }
 
   private getTunnelParameterMessage(error: TunnelParameterError): string {
+    const ipVersion = messages.pgettext('wireguard-settings-view', 'IP version');
     switch (error) {
       /// TODO: once bridge constraints can be set, add a more descriptive error message
       case TunnelParameterError.noMatchingBridgeRelay:
@@ -227,6 +228,24 @@ export class ErrorNotificationProvider
         return messages.pgettext(
           'notifications',
           'Unable to resolve host of custom tunnel. Try changing your settings.',
+        );
+      case TunnelParameterError.ipv4Unavailable:
+        return sprintf(
+          // TRANSLATORS: Label for notification when IPv4 is not available.
+          messages.pgettext(
+            'notifications',
+            'IPv4 is not available, please try changing <b>%(ipVersionFeatureName)</b> setting.',
+          ),
+          { ipVersionFeatureName: ipVersion },
+        );
+      case TunnelParameterError.ipv6Unavailable:
+        return sprintf(
+          // TRANSLATORS: Label for notification when IPv6 is not available.
+          messages.pgettext(
+            'notifications',
+            'IPv6 is not available, please try changing <b>%(ipVersionFeatureName)</b> setting.',
+          ),
+          { ipVersionFeatureName: ipVersion },
         );
     }
   }


### PR DESCRIPTION
This adds support for the same error message to the desktop frontend as was introduced on android in the following PR:
https://github.com/mullvad/mullvadvpn-app/pull/7976

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7987)
<!-- Reviewable:end -->
