### PR TITLE
Set max UDP payload size in masque client

### DIFF
--- a/mullvad-masque-proxy/examples/masque-client.rs
+++ b/mullvad-masque-proxy/examples/masque-client.rs
@@ -9,6 +9,7 @@ use std::{
 
 #[derive(Parser, Debug)]
 pub struct ClientArgs {
+    /// Destination to forward to
     #[arg(long, short = 't')]
     target_addr: SocketAddr,
 
@@ -20,12 +21,15 @@ pub struct ClientArgs {
     #[arg(long, short = 's')]
     server_addr: SocketAddr,
 
+    /// Server hostname/authority
     #[arg(long, short = 'H')]
     server_hostname: String,
 
+    /// Local bind port
     #[arg(long, short = 'p', default_value = "0")]
     bind_port: u16,
 
+    /// Maximum packet size
     #[arg(long, short = 'S', default_value = "1280")]
     maximum_packet_size: u16,
 }

--- a/mullvad-masque-proxy/examples/masque-server.rs
+++ b/mullvad-masque-proxy/examples/masque-server.rs
@@ -10,6 +10,7 @@ use std::{
 
 #[derive(Parser, Debug)]
 pub struct ServerArgs {
+    /// Bind address
     #[arg(long, short = 'b', default_value = "0.0.0.0:0")]
     bind_addr: SocketAddr,
 
@@ -24,7 +25,8 @@ pub struct ServerArgs {
     /// Allowed IPs
     #[arg(long = "allowed-ip", short = 'a', required = false)]
     allowed_ips: Vec<IpAddr>,
-    /// Maximums packet size
+
+    /// Maximum packet size
     #[arg(long, short = 'm', default_value = "1700")]
     maximum_packet_size: u16,
 }


### PR DESCRIPTION
The offsets are unchanged for now (they're wrong anyway).

Fix DES-1959

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7992)
<!-- Reviewable:end -->
