### PR TITLE
Fix maximum packet size calculations

### DIFF
--- a/mullvad-masque-proxy/examples/masque-client.rs
+++ b/mullvad-masque-proxy/examples/masque-client.rs
@@ -31,7 +31,7 @@ pub struct ClientArgs {
 
     /// Maximum packet size
     #[arg(long, short = 'S', default_value = "1280")]
-    maximum_packet_size: u16,
+    mtu: u16,
 }
 
 #[tokio::main]
@@ -42,7 +42,7 @@ async fn main() {
         root_cert_path,
         server_hostname,
         bind_port,
-        maximum_packet_size,
+        mtu,
     } = ClientArgs::parse();
 
     let tls_config = match root_cert_path {
@@ -67,7 +67,7 @@ async fn main() {
         target_addr,
         &server_hostname,
         tls_config,
-        maximum_packet_size,
+        mtu,
     )
     .await;
     if let Err(err) = &client {

--- a/mullvad-masque-proxy/examples/masque-server.rs
+++ b/mullvad-masque-proxy/examples/masque-server.rs
@@ -28,7 +28,7 @@ pub struct ServerArgs {
 
     /// Maximum packet size
     #[arg(long, short = 'm', default_value = "1700")]
-    maximum_packet_size: u16,
+    mtu: u16,
 }
 
 #[tokio::main]
@@ -42,7 +42,7 @@ async fn main() {
         args.bind_addr,
         args.allowed_ips.iter().cloned().collect(),
         tls_config.into(),
-        args.maximum_packet_size,
+        args.mtu,
     )
     .expect("Failed to initialize server");
     println!("Listening on {}", args.bind_addr);

--- a/mullvad-masque-proxy/src/fragment.rs
+++ b/mullvad-masque-proxy/src/fragment.rs
@@ -6,6 +6,8 @@ use std::{
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use h3::proto::varint::VarInt;
 
+use crate::FRAGMENT_HEADER_SIZE_FRAGMENTED;
+
 #[derive(Default)]
 pub struct Fragments {
     fragment_map: BTreeMap<u16, Vec<Fragment>>,
@@ -102,19 +104,29 @@ struct Fragment {
     time_received: Instant,
 }
 
+/// Fragment packet using the given maximum fragment size (including headers).
+///
+/// `payload` must not contain any fragmentation headers.
+/// `maximum_packet_size` is the maximum fragment size including headers.
 pub fn fragment_packet(
     maximum_packet_size: u16,
     payload: &'_ mut Bytes,
     packet_id: u16,
 ) -> Result<impl Iterator<Item = Bytes> + '_, PacketTooLarge> {
-    let num_fragments: usize = payload.chunks(maximum_packet_size.into()).count();
+    let fragment_payload_size = maximum_packet_size - FRAGMENT_HEADER_SIZE_FRAGMENTED;
+
+    let num_fragments: usize = payload.chunks(fragment_payload_size.into()).count();
     let Ok(fragment_count): std::result::Result<u8, _> = num_fragments.try_into() else {
         return Err(PacketTooLarge(payload.len()));
     };
 
-    let iterator = payload.chunks(maximum_packet_size.into()).enumerate().map(
-        move |(fragment_index, fragment_payload)| {
-            let mut fragment = BytesMut::with_capacity((maximum_packet_size + 1).into());
+    let iterator = payload
+        .chunks(fragment_payload_size.into())
+        .enumerate()
+        .map(move |(fragment_index, fragment_payload)| {
+            let mut fragment = BytesMut::with_capacity(
+                usize::from(fragment_payload_size) + usize::from(FRAGMENT_HEADER_SIZE_FRAGMENTED),
+            );
             crate::HTTP_MASQUE_FRAGMENTED_DATAGRAM_CONTEXT_ID.encode(&mut fragment);
             fragment.put_u16(packet_id);
             fragment.put_u8(
@@ -123,36 +135,44 @@ pub fn fragment_packet(
                     .expect("fragment index must fit in an u8, since num_fragments fits is an u8"),
             );
             fragment.put_u8(fragment_count);
+
+            debug_assert!(fragment.len() == usize::from(FRAGMENT_HEADER_SIZE_FRAGMENTED));
+
             fragment.extend_from_slice(fragment_payload);
             fragment.freeze()
-        },
-    );
+        });
     Ok(iterator)
 }
 
-#[test]
-fn test_fragment_reconstruction() {
-    use rand::{seq::SliceRandom, thread_rng};
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    let payload = (0..255).collect::<Vec<u8>>();
-    let max_payload_size = 50;
-    let packet_id = 76;
+    #[test]
+    fn test_fragment_reconstruction() {
+        use rand::{seq::SliceRandom, thread_rng};
 
-    let mut fragments = Fragments::default();
+        let payload = (0..255).collect::<Vec<u8>>();
+        let max_payload_size = 50;
+        let packet_id = 76;
 
-    let mut payload_clone = Bytes::from(payload.clone());
-    let mut fragment_buf = fragment_packet(max_payload_size, &mut payload_clone, packet_id)
-        .unwrap()
-        .collect::<Vec<_>>();
+        let mut fragments = Fragments::default();
 
-    fragment_buf.shuffle(&mut thread_rng());
+        let mut payload_clone = Bytes::from(payload.clone());
+        let mut fragment_buf = fragment_packet(max_payload_size, &mut payload_clone, packet_id)
+            .unwrap()
+            .collect::<Vec<_>>();
 
-    for fragment in fragment_buf {
-        if let Some(reconstructed_packet) = fragments.handle_incoming_packet(fragment).unwrap() {
-            assert_eq!(payload.as_slice(), reconstructed_packet.as_ref());
-            return;
+        fragment_buf.shuffle(&mut thread_rng());
+
+        for fragment in fragment_buf {
+            if let Some(reconstructed_packet) = fragments.handle_incoming_packet(fragment).unwrap()
+            {
+                assert_eq!(payload.as_slice(), reconstructed_packet.as_ref());
+                return;
+            }
         }
-    }
 
-    panic!("Failed to reconstruct packet");
+        panic!("Failed to reconstruct packet");
+    }
 }

--- a/mullvad-masque-proxy/src/fragment.rs
+++ b/mullvad-masque-proxy/src/fragment.rs
@@ -124,9 +124,9 @@ pub fn fragment_packet(
         .chunks(fragment_payload_size.into())
         .enumerate()
         .map(move |(fragment_index, fragment_payload)| {
-            let mut fragment = BytesMut::with_capacity(
-                usize::from(fragment_payload_size) + usize::from(FRAGMENT_HEADER_SIZE_FRAGMENTED),
-            );
+            let mut fragment = BytesMut::with_capacity(usize::from(
+                fragment_payload_size + FRAGMENT_HEADER_SIZE_FRAGMENTED,
+            ));
             crate::HTTP_MASQUE_FRAGMENTED_DATAGRAM_CONTEXT_ID.encode(&mut fragment);
             fragment.put_u16(packet_id);
             fragment.put_u8(

--- a/mullvad-masque-proxy/src/lib.rs
+++ b/mullvad-masque-proxy/src/lib.rs
@@ -27,11 +27,13 @@ const fn compute_udp_payload_size(mtu: u16, target_addr: SocketAddr) -> u16 {
 }
 
 /// Minimum allowed MTU (IPv6) is the overhead of all headers, plus 1 byte for actual data.
+/// QUIC defines that clients must support UDP payloads of at least 1200 bytes.
+/// <https://datatracker.ietf.org/doc/html/rfc9000#section-8.1>
 // 20 = IPv4 header (without optional fields)
-const MIN_IPV4_MTU: u16 =
-    20 + UDP_HEADER_SIZE + QUIC_HEADER_SIZE + FRAGMENT_HEADER_SIZE_FRAGMENTED + 1;
+pub const MIN_IPV4_MTU: u16 = 20 + UDP_HEADER_SIZE + 1200;
 
 /// Minimum allowed MTU (IPv6) is the overhead of all headers, plus 1 byte for actual data.
+/// QUIC defines that clients must support UDP payloads of at least 1200 bytes.
+/// <https://datatracker.ietf.org/doc/html/rfc9000#section-8.1>
 // 40 = IPv6 header (without optional fields)
-const MIN_IPV6_MTU: u16 =
-    40 + UDP_HEADER_SIZE + QUIC_HEADER_SIZE + FRAGMENT_HEADER_SIZE_FRAGMENTED + 1;
+pub const MIN_IPV6_MTU: u16 = 40 + UDP_HEADER_SIZE + 1200;

--- a/mullvad-masque-proxy/src/lib.rs
+++ b/mullvad-masque-proxy/src/lib.rs
@@ -1,10 +1,37 @@
 use h3::proto::varint::VarInt;
+use std::net::SocketAddr;
 
 pub mod client;
 mod fragment;
 pub mod server;
 mod stats;
 
-const PACKET_BUFFER_SIZE: usize = 1700;
+const PACKET_BUFFER_SIZE: usize = 64 * 1024;
 pub const HTTP_MASQUE_DATAGRAM_CONTEXT_ID: VarInt = VarInt::from_u32(0);
 pub const HTTP_MASQUE_FRAGMENTED_DATAGRAM_CONTEXT_ID: VarInt = VarInt::from_u32(1);
+
+/// Fragment headers size for fragmented packets
+const FRAGMENT_HEADER_SIZE_FRAGMENTED: u16 = 5;
+
+/// UDP header overhead
+const UDP_HEADER_SIZE: u16 = 8;
+
+/// QUIC header size. This is conservative, real overhead varies
+const QUIC_HEADER_SIZE: u16 = 41;
+
+/// This is the size of the payload that stores QUIC packets
+/// MTU - IP header - UDP header
+const fn compute_udp_payload_size(mtu: u16, target_addr: SocketAddr) -> u16 {
+    let ip_overhead = if target_addr.is_ipv4() { 20 } else { 40 };
+    mtu - ip_overhead - UDP_HEADER_SIZE
+}
+
+/// Minimum allowed MTU (IPv6) is the overhead of all headers, plus 1 byte for actual data.
+// 20 = IPv4 header (without optional fields)
+const MIN_IPV4_MTU: u16 =
+    20 + UDP_HEADER_SIZE + QUIC_HEADER_SIZE + FRAGMENT_HEADER_SIZE_FRAGMENTED + 1;
+
+/// Minimum allowed MTU (IPv6) is the overhead of all headers, plus 1 byte for actual data.
+// 40 = IPv6 header (without optional fields)
+const MIN_IPV6_MTU: u16 =
+    40 + UDP_HEADER_SIZE + QUIC_HEADER_SIZE + FRAGMENT_HEADER_SIZE_FRAGMENTED + 1;

--- a/mullvad-masque-proxy/src/server/mod.rs
+++ b/mullvad-masque-proxy/src/server/mod.rs
@@ -20,7 +20,7 @@ use tokio::{net::UdpSocket, time::interval};
 use crate::{
     compute_udp_payload_size,
     fragment::{self, Fragments},
-    FRAGMENT_HEADER_SIZE_FRAGMENTED, MIN_IPV4_MTU, MIN_IPV6_MTU, QUIC_HEADER_SIZE,
+    MIN_IPV4_MTU, MIN_IPV6_MTU, QUIC_HEADER_SIZE,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -181,6 +181,7 @@ impl Server {
         let max_udp_payload_size = compute_udp_payload_size(mtu, target_addr);
 
         let stream_id = stream.id();
+        let stream_id_size = VarInt::from(stream_id).size() as u16;
         let mut proxy_recv_buf = BytesMut::with_capacity(100 * crate::PACKET_BUFFER_SIZE);
 
         let mut fragments = Fragments::default();
@@ -216,9 +217,9 @@ impl Server {
 
                             // Maximum QUIC payload (including fragmentation headers)
                             let maximum_packet_size = if let Some(max_datagram_size) = quinn_conn.max_datagram_size() {
-                                max_datagram_size as u16 - 1
+                               max_datagram_size as u16 - stream_id_size
                             } else {
-                                max_udp_payload_size - QUIC_HEADER_SIZE
+                                max_udp_payload_size - QUIC_HEADER_SIZE - stream_id_size
                             };
 
                             if received_packet.len() <= usize::from(maximum_packet_size) {
@@ -227,9 +228,8 @@ impl Server {
                                 }
                             } else {
                                 let _ = VarInt::decode(&mut received_packet);
-                                let fragment_payload_size = maximum_packet_size - FRAGMENT_HEADER_SIZE_FRAGMENTED;
 
-                                let Ok(fragments) = fragment::fragment_packet(fragment_payload_size, &mut received_packet, fragment_id) else { continue; };
+                                let Ok(fragments) = fragment::fragment_packet(maximum_packet_size, &mut received_packet, fragment_id) else { continue; };
                                 fragment_id += 1;
                                 for payload in fragments {
                                     if connection.send_datagram(stream_id, payload).is_err() {

--- a/mullvad-masque-proxy/src/server/mod.rs
+++ b/mullvad-masque-proxy/src/server/mod.rs
@@ -17,7 +17,11 @@ use http::{Request, StatusCode};
 use quinn::{crypto::rustls::QuicServerConfig, Endpoint, Incoming};
 use tokio::{net::UdpSocket, time::interval};
 
-use crate::fragment::{self, Fragments};
+use crate::{
+    compute_udp_payload_size,
+    fragment::{self, Fragments},
+    FRAGMENT_HEADER_SIZE_FRAGMENTED, MIN_IPV4_MTU, MIN_IPV6_MTU, QUIC_HEADER_SIZE,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -27,6 +31,8 @@ pub enum Error {
     BindSocket(#[source] io::Error),
     #[error("Failed to send negotiation response")]
     SendNegotiationResponse(#[source] h3::Error),
+    #[error("Invalid MTU: must be at least {min_mtu}")]
+    InvalidMtu { min_mtu: u16 },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -36,7 +42,7 @@ const MASQUE_WELL_KNOWN_PATH: &str = "/.well-known/masque/udp/";
 pub struct Server {
     endpoint: Endpoint,
     allowed_hosts: AllowedIps,
-    maximum_packet_size: u16,
+    mtu: u16,
 }
 
 #[derive(Clone)]
@@ -55,8 +61,10 @@ impl Server {
         bind_addr: SocketAddr,
         allowed_hosts: HashSet<IpAddr>,
         tls_config: Arc<rustls::ServerConfig>,
-        maximum_packet_size: u16,
+        mtu: u16,
     ) -> Result<Self> {
+        Self::validate_mtu(mtu, bind_addr)?;
+
         let server_config = quinn::ServerConfig::with_crypto(Arc::new(
             QuicServerConfig::try_from(tls_config).map_err(Error::BadTlsConfig)?,
         ));
@@ -68,8 +76,21 @@ impl Server {
             allowed_hosts: AllowedIps {
                 hosts: Arc::new(allowed_hosts),
             },
-            maximum_packet_size,
+            mtu,
         })
+    }
+
+    const fn validate_mtu(mtu: u16, bind_addr: SocketAddr) -> Result<()> {
+        let min_mtu = if bind_addr.is_ipv4() {
+            MIN_IPV4_MTU
+        } else {
+            MIN_IPV6_MTU
+        };
+        if mtu >= min_mtu {
+            Ok(())
+        } else {
+            Err(Error::InvalidMtu { min_mtu })
+        }
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -81,20 +102,18 @@ impl Server {
             tokio::spawn(Self::handle_incoming_connection(
                 new_connection,
                 self.allowed_hosts.clone(),
-                self.maximum_packet_size,
+                self.mtu,
             ));
         }
         Ok(())
     }
 
-    async fn handle_incoming_connection(
-        connection: Incoming,
-        allowed_hosts: AllowedIps,
-        maximum_packet_size: u16,
-    ) {
+    async fn handle_incoming_connection(connection: Incoming, allowed_hosts: AllowedIps, mtu: u16) {
         match connection.await {
             Ok(conn) => {
                 println!("new connection established");
+
+                let quinn_conn = conn.clone();
 
                 let Ok(mut connection) = server::builder()
                     .enable_datagram(true)
@@ -109,10 +128,11 @@ impl Server {
                     Ok(Some((req, stream))) => {
                         tokio::spawn(Self::handle_proxy_request(
                             connection,
+                            quinn_conn,
                             req,
                             stream,
                             allowed_hosts.clone(),
-                            maximum_packet_size,
+                            mtu,
                         ));
                     }
 
@@ -132,10 +152,11 @@ impl Server {
 
     async fn handle_proxy_request<T: BidiStream<Bytes>>(
         mut connection: Connection<h3_quinn::Connection, Bytes>,
+        quinn_conn: quinn::Connection,
         request: Request<()>,
         mut stream: RequestStream<T, Bytes>,
         allowed_hosts: AllowedIps,
-        maximum_packet_size: u16,
+        mtu: u16,
     ) {
         let Some(target_addr) = get_target_socketaddr(request.uri().path()) else {
             return;
@@ -157,8 +178,10 @@ impl Server {
             return;
         }
 
+        let max_udp_payload_size = compute_udp_payload_size(mtu, target_addr);
+
         let stream_id = stream.id();
-        let mut proxy_recv_buf = BytesMut::with_capacity(crate::PACKET_BUFFER_SIZE);
+        let mut proxy_recv_buf = BytesMut::with_capacity(100 * crate::PACKET_BUFFER_SIZE);
 
         let mut fragments = Fragments::default();
         let mut fragment_id = 0u16;
@@ -191,13 +214,22 @@ impl Server {
 
                             let mut received_packet = proxy_recv_buf.split().freeze();
 
-                            if received_packet.len() < maximum_packet_size.into() {
+                            // Maximum QUIC payload (including fragmentation headers)
+                            let maximum_packet_size = if let Some(max_datagram_size) = quinn_conn.max_datagram_size() {
+                                max_datagram_size as u16 - 1
+                            } else {
+                                max_udp_payload_size - QUIC_HEADER_SIZE
+                            };
+
+                            if received_packet.len() <= usize::from(maximum_packet_size) {
                                 if connection.send_datagram(stream_id, received_packet).is_err() {
                                     return;
                                 }
                             } else {
                                 let _ = VarInt::decode(&mut received_packet);
-                                let Ok(fragments) = fragment::fragment_packet(maximum_packet_size, &mut received_packet, fragment_id) else { continue; };
+                                let fragment_payload_size = maximum_packet_size - FRAGMENT_HEADER_SIZE_FRAGMENTED;
+
+                                let Ok(fragments) = fragment::fragment_packet(fragment_payload_size, &mut received_packet, fragment_id) else { continue; };
                                 fragment_id += 1;
                                 for payload in fragments {
                                     if connection.send_datagram(stream_id, payload).is_err() {
@@ -296,21 +328,26 @@ fn unspecified_addr(addr: IpAddr) -> IpAddr {
     }
 }
 
-#[test]
-fn test_get_good_slashy_ocketaddr() {
-    let addr: IpAddr = "192.168.1.1".parse().unwrap();
-    let port: u16 = 7979;
-    let expected_addr = SocketAddr::new(addr, port);
-    let good_path = format!("{MASQUE_WELL_KNOWN_PATH}///{addr}/{port}////");
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    assert_eq!(get_target_socketaddr(&good_path).unwrap(), expected_addr)
-}
+    #[test]
+    fn test_get_good_slashy_ocketaddr() {
+        let addr: IpAddr = "192.168.1.1".parse().unwrap();
+        let port: u16 = 7979;
+        let expected_addr = SocketAddr::new(addr, port);
+        let good_path = format!("{MASQUE_WELL_KNOWN_PATH}///{addr}/{port}////");
 
-#[test]
-fn test_get_bad_socketaddr() {
-    let addr: IpAddr = "192.168.1.1".parse().unwrap();
-    let port: u16 = 7979;
-    let good_path = format!("{MASQUE_WELL_KNOWN_PATH}{addr}adsfasd/asdfasdf/{port}");
+        assert_eq!(get_target_socketaddr(&good_path).unwrap(), expected_addr)
+    }
 
-    assert_eq!(get_target_socketaddr(&good_path), None)
+    #[test]
+    fn test_get_bad_socketaddr() {
+        let addr: IpAddr = "192.168.1.1".parse().unwrap();
+        let port: u16 = 7979;
+        let good_path = format!("{MASQUE_WELL_KNOWN_PATH}{addr}adsfasd/asdfasdf/{port}");
+
+        assert_eq!(get_target_socketaddr(&good_path), None)
+    }
 }

--- a/mullvad-masque-proxy/tests/proxy.rs
+++ b/mullvad-masque-proxy/tests/proxy.rs
@@ -12,7 +12,7 @@ use tokio::net::UdpSocket;
 /// Set up a MASQUE proxy and test that it can be used to communicate with some UDP destination
 #[tokio::test]
 async fn test_server_and_client_forwarding() -> anyhow::Result<()> {
-    const MAXIMUM_PACKET_SIZE: u16 = 1700;
+    const MTU: u16 = 1500;
     const HOST: &str = "test.test";
 
     let any_localhost_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
@@ -29,7 +29,7 @@ async fn test_server_and_client_forwarding() -> anyhow::Result<()> {
         any_localhost_addr,
         Default::default(),
         Arc::new(server_tls_config),
-        MAXIMUM_PACKET_SIZE,
+        MTU,
     )
     .context("Failed to start MASQUE server")?;
 
@@ -51,7 +51,7 @@ async fn test_server_and_client_forwarding() -> anyhow::Result<()> {
         target_udp_addr,
         HOST,
         client::default_tls_config(),
-        MAXIMUM_PACKET_SIZE,
+        MTU,
     )
     .await
     .context("Failed to start MASQUE client")?;

--- a/mullvad-masque-proxy/tests/proxy.rs
+++ b/mullvad-masque-proxy/tests/proxy.rs
@@ -1,9 +1,12 @@
+use std::iter;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::anyhow;
 use anyhow::Context;
 use bytes::BytesMut;
+use mullvad_masque_proxy::MIN_IPV4_MTU;
 use rand::RngCore;
 use tokio::fs;
 
@@ -47,20 +50,33 @@ async fn test_server_and_client_forwarding() -> anyhow::Result<()> {
 /// reach their destinations when fragmentation *should* be present.
 #[tokio::test]
 async fn test_server_and_client_fragmentation() -> anyhow::Result<()> {
-    timeout(Duration::from_secs(1), async {
-        const MTU: u16 = 1500;
-        const SEND_PACKET_SIZE: usize = 2500;
+    #[allow(unused_mut)]
+    let mut valid_send_packet_sizes = vec![0u16, 1, 10, 100, 1280, 5000];
 
-        let (client, server) = setup_masque(MTU).await?;
+    // Maximum packet size sans UDP and QUIC headers, sans 1 byte context ID.
+    //
+    // NOTE: On macOS, the maximum UDP packet size is equal to the value set by
+    // `sysctl net.inet.udp.maxdgram`
+    #[cfg(not(target_os = "macos"))]
+    valid_send_packet_sizes.push(u16::MAX - 8 - 41 - 1);
+
+    let valid_mtus = [MIN_IPV4_MTU, 1280, 1500, 1700, 5000, 20000, u16::MAX];
+
+    let params = valid_mtus
+        .into_iter()
+        .flat_map(|mtu| iter::repeat(mtu).zip(&valid_send_packet_sizes));
+
+    async fn run_test(mtu: u16, send_packet_size: usize) -> anyhow::Result<()> {
+        let (client, server) = setup_masque(mtu).await?;
 
         // Proxy client -> destination
         // Send a random packet, large enough to be fragmented
-        let mut fragment_me = vec![0u8; SEND_PACKET_SIZE];
+        let mut fragment_me = vec![0u8; send_packet_size];
         rand::thread_rng().fill_bytes(&mut fragment_me);
 
         client.send(&fragment_me).await?;
 
-        let mut rx_buf = BytesMut::with_capacity(SEND_PACKET_SIZE + 100);
+        let mut rx_buf = BytesMut::with_capacity(send_packet_size + 100);
         let (_, proxy_addr) = server
             .recv_buf_from(&mut rx_buf)
             .await
@@ -73,12 +89,12 @@ async fn test_server_and_client_fragmentation() -> anyhow::Result<()> {
 
         // Destination -> proxy client
         // Send a random packet, large enough to be fragmented
-        let mut fragment_me = vec![0u8; SEND_PACKET_SIZE];
+        let mut fragment_me = vec![0u8; send_packet_size];
         rand::thread_rng().fill_bytes(&mut fragment_me);
 
         server.send_to(&fragment_me, proxy_addr).await?;
 
-        let mut rx_buf = BytesMut::with_capacity(SEND_PACKET_SIZE + 100);
+        let mut rx_buf = BytesMut::with_capacity(send_packet_size + 100);
         let blen = client
             .recv_buf(&mut rx_buf)
             .await
@@ -97,8 +113,18 @@ async fn test_server_and_client_fragmentation() -> anyhow::Result<()> {
         );
 
         Ok(())
-    })
-    .await?
+    }
+
+    for (mtu, &send_packet_size) in params {
+        timeout(
+            Duration::from_secs(1),
+            run_test(mtu, send_packet_size.into()),
+        )
+        .await?
+        .context(anyhow!("mtu={mtu}, send_packet_size={send_packet_size}"))?;
+    }
+
+    Ok(())
 }
 
 /// Set up a client and server connected by a MASQUE proxy.


### PR DESCRIPTION
Fix all relative size calculations, including taking into account IPv4 vs. IPv6. This currently bases the fragment size on the maximum datagram size for the QUIC endpoint, and uses a constant QUIC header overhead of 41 bytes if that's not available.

Fix DES-1967

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/7993)
<!-- Reviewable:end -->
