### PR TITLE
Add filter pill to location view when obfuscation is used

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -647,6 +647,7 @@
 		7AB3BEB52BD7A6CB00E34384 /* LocationViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */; };
 		7AB401852DA53D5300522E17 /* NewAccountData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB401842DA53D4E00522E17 /* NewAccountData.swift */; };
 		7AB401872DA53DA300522E17 /* NewAccountDataMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB401862DA53D9B00522E17 /* NewAccountDataMock.swift */; };
+		7AB4018D2DA790DA00522E17 /* SelectLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4018C2DA790CE00522E17 /* SelectLocationTests.swift */; };
 		7AB4CCB92B69097E006037F5 /* IPOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4CCB82B69097E006037F5 /* IPOverrideTests.swift */; };
 		7AB4CCBB2B691BBB006037F5 /* IPOverrideInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB4CCBA2B691BBB006037F5 /* IPOverrideInteractor.swift */; };
 		7AB73F6E2D9AAD0A00DA5E1D /* MullvadAccountProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AB73F6D2D9AAD0400DA5E1D /* MullvadAccountProxy.swift */; };
@@ -2171,6 +2172,7 @@
 		7AB3BEB42BD7A6CB00E34384 /* LocationViewControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationViewControllerWrapper.swift; sourceTree = "<group>"; };
 		7AB401842DA53D4E00522E17 /* NewAccountData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAccountData.swift; sourceTree = "<group>"; };
 		7AB401862DA53D9B00522E17 /* NewAccountDataMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAccountDataMock.swift; sourceTree = "<group>"; };
+		7AB4018C2DA790CE00522E17 /* SelectLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationTests.swift; sourceTree = "<group>"; };
 		7AB4CCB82B69097E006037F5 /* IPOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideTests.swift; sourceTree = "<group>"; };
 		7AB4CCBA2B691BBB006037F5 /* IPOverrideInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideInteractor.swift; sourceTree = "<group>"; };
 		7AB73F6D2D9AAD0400DA5E1D /* MullvadAccountProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadAccountProxy.swift; sourceTree = "<group>"; };
@@ -4403,6 +4405,7 @@
 				A9BFAFFE2BD004ED00F2BCA1 /* CustomListsTests.swift */,
 				85F1E17D2C0A256200DB8F55 /* LeakTests.swift */,
 				850201DA2B503D7700EF8C96 /* RelayTests.swift */,
+				7AB4018C2DA790CE00522E17 /* SelectLocationTests.swift */,
 				85D039972BA4711800940E7F /* SettingsMigrationTests.swift */,
 				85C7A2E82B89024B00035D5A /* SettingsTests.swift */,
 				856952E12BD6B04C008C1F84 /* XCUIElement+Extensions.swift */,
@@ -6756,6 +6759,7 @@
 				85139B2D2B84B4A700734217 /* OutOfTimePage.swift in Sources */,
 				852969362B4E9724007EAD4C /* AccessbilityIdentifier.swift in Sources */,
 				4495ECD52D131A4800A7358B /* ShadowsocksObfuscationSettingsPage.swift in Sources */,
+				7AB4018D2DA790DA00522E17 /* SelectLocationTests.swift in Sources */,
 				85E3BDE52B70E18C00FA71FD /* Networking.swift in Sources */,
 				856952E22BD6B04C008C1F84 /* XCUIElement+Extensions.swift in Sources */,
 				85C7A2E92B89024B00035D5A /* SettingsTests.swift in Sources */,

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterView.swift
@@ -71,6 +71,21 @@ class RelayFilterView: UIView {
         hideIfNeeded()
     }
 
+    func setObfuscation(_ enabled: Bool) {
+        let text = NSLocalizedString(
+            "RELAY_FILTER_APPLIED_OBFUSCATION",
+            tableName: "RelayFilter",
+            value: "Setting: Obfuscation",
+            comment: ""
+        )
+        chips.removeAll(where: { $0.title.contains(text) })
+        if enabled {
+            chips.insert(ChipConfiguration(group: .settings, title: text, didTapButton: nil), at: 0)
+        }
+        chipsView.setChips(chips)
+        hideIfNeeded()
+    }
+
     // MARK: - Private
 
     private func setUpViews() {
@@ -79,10 +94,9 @@ class RelayFilterView: UIView {
 
         let contentContainer = UIStackView(arrangedSubviews: [dummyView, chipsView])
         contentContainer.distribution = .fill
-        contentContainer.alignment = .firstBaseline
 
         collectionViewHeightConstraint = chipsView.collectionView.heightAnchor
-            .constraint(equalToConstant: 8.0)
+            .constraint(equalToConstant: 8)
         collectionViewHeightConstraint.isActive = true
 
         dummyView.addConstrainedSubviews([titleLabel]) {
@@ -90,7 +104,7 @@ class RelayFilterView: UIView {
         }
 
         addConstrainedSubviews([contentContainer]) {
-            contentContainer.pinEdgesToSuperview(PinnableEdges([.top(8.0), .bottom(8.0), .leading(4), .trailing(4)]))
+            contentContainer.pinEdgesToSuperview(PinnableEdges([.top(8), .bottom(8), .leading(4), .trailing(4)]))
         }
 
         // Add KVO for observing collectionView's contentSize changes

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewController.swift
@@ -29,6 +29,7 @@ final class LocationViewController: UIViewController {
     private var filter = RelayFilter()
     private var selectedRelays: RelaySelection
     private var shouldFilterDaita: Bool
+    private var shouldFilterObfuscation: Bool
     weak var delegate: LocationViewControllerDelegate?
     var customListRepository: CustomListRepositoryProtocol
 
@@ -39,11 +40,13 @@ final class LocationViewController: UIViewController {
     init(
         customListRepository: CustomListRepositoryProtocol,
         selectedRelays: RelaySelection,
-        shouldFilterDaita: Bool
+        shouldFilterDaita: Bool,
+        shouldFilterObfuscation: Bool
     ) {
         self.customListRepository = customListRepository
         self.selectedRelays = selectedRelays
         self.shouldFilterDaita = shouldFilterDaita
+        self.shouldFilterObfuscation = shouldFilterObfuscation
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -89,6 +92,11 @@ final class LocationViewController: UIViewController {
     func setDaitaChip(_ isEnabled: Bool) {
         self.shouldFilterDaita = isEnabled
         filterView.setDaita(isEnabled)
+    }
+
+    func setObfuscationChip(_ isEnabled: Bool) {
+        self.shouldFilterObfuscation = isEnabled
+        filterView.setObfuscation(isEnabled)
     }
 
     func refreshCustomLists() {
@@ -175,6 +183,7 @@ final class LocationViewController: UIViewController {
         topContentView.addArrangedSubview(filterView)
         topContentView.addArrangedSubview(searchBar)
         filterView.setDaita(shouldFilterDaita)
+        filterView.setObfuscation(shouldFilterObfuscation)
 
         filterView.didUpdateFilter = { [weak self] in
             self?.delegate?.didUpdateFilter(filter: $0)

--- a/ios/MullvadVPNUITests/SelectLocationTests.swift
+++ b/ios/MullvadVPNUITests/SelectLocationTests.swift
@@ -1,0 +1,53 @@
+//
+//  SelectLocationTests.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2025-04-10.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+import XCTest
+
+class SelectLocationTests: LoggedInWithTimeUITestCase {
+    func testEnableDAITA() {
+        HeaderBar(app)
+            .tapSettingsButton()
+
+        SettingsPage(app)
+            .tapDAITACell()
+
+        DAITAPage(app)
+            .tapEnableSwitch()
+            .tapDirectOnlySwitch()
+            .tapBackButton()
+
+        SettingsPage(app)
+            .tapDoneButton()
+
+        TunnelControlPage(app)
+            .tapSelectLocationButton()
+
+        XCTAssertTrue(app.staticTexts["Setting: DAITA"].exists)
+    }
+
+    func testEnableShadowsocksObfuscation() {
+        HeaderBar(app)
+            .tapSettingsButton()
+
+        SettingsPage(app)
+            .tapVPNSettingsCell()
+
+        VPNSettingsPage(app)
+            .tapWireGuardObfuscationExpandButton()
+            .tapWireGuardObfuscationShadowsocksCell()
+            .tapBackButton()
+
+        SettingsPage(app)
+            .tapDoneButton()
+
+        TunnelControlPage(app)
+            .tapSelectLocationButton()
+
+        XCTAssertTrue(app.staticTexts["Setting: Obfuscation"].exists)
+    }
+}


### PR DESCRIPTION
**Why this needs to be done**

Obfuscation might filter out some relays in the location view due to incompatible settings. This currently only happens when a user sets a custom port for Shadowsocks. We should have a new filter pill telling the user that obfuscation is active, much like we do for DAITA.

**What needs to be done**

Add filter pill to location view when shadowsocks obfuscation is active

Make sure that future obfuscators will not be forgotten, perhaps by using an enum with an @unknown default: case.

**Acceptance criteria**

When obfuscation is active, there should be a filter pill in the location view indicating as much.

The pill should say Setting: Obfuscation

**Tests**

Add UI tests for this.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
