### PR TITLE
Add the ability to use QUIC obfuscation in the UI, and update Settings

### DIFF
--- a/ios/MullvadREST/Relay/ObfuscationMethodSelector.swift
+++ b/ios/MullvadREST/Relay/ObfuscationMethodSelector.swift
@@ -15,6 +15,7 @@ public struct ObfuscationMethodSelector {
         connectionAttemptCount: UInt,
         tunnelSettings: LatestTunnelSettings
     ) -> WireGuardObfuscationState {
+        // TODO: Revisit this when QUIC obfuscation is added
         if tunnelSettings.wireGuardObfuscation.state == .automatic {
             if connectionAttemptCount.isOrdered(nth: 3, forEverySetOf: 4) {
                 .shadowsocks

--- a/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
+++ b/ios/MullvadREST/Relay/ObfuscatorPortSelector.swift
@@ -55,6 +55,10 @@ struct ObfuscatorPortSelector {
                 tunnelSettings: tunnelSettings,
                 shadowsocksPortRanges: relays.wireguard.shadowsocksPortRanges
             )
+        #if DEBUG
+        case .quic:
+            port = .only(443)
+        #endif
         default:
             break
         }

--- a/ios/MullvadSettings/WireGuardObfuscationSettings.swift
+++ b/ios/MullvadSettings/WireGuardObfuscationSettings.swift
@@ -18,6 +18,9 @@ public enum WireGuardObfuscationState: Codable, Sendable {
     case automatic
     case udpOverTcp
     case shadowsocks
+    #if DEBUG
+    case quic
+    #endif
     case off
 
     public init(from decoder: Decoder) throws {
@@ -42,14 +45,24 @@ public enum WireGuardObfuscationState: Codable, Sendable {
             self = .udpOverTcp
         case .shadowsocks:
             self = .shadowsocks
+        #if DEBUG
+        case .quic:
+            self = .quic
+        #endif
         case .off:
             self = .off
         }
     }
 
+    #if DEBUG
+    public var isEnabled: Bool {
+        [.udpOverTcp, .shadowsocks, .quic].contains(self)
+    }
+    #else
     public var isEnabled: Bool {
         [.udpOverTcp, .shadowsocks].contains(self)
     }
+    #endif
 }
 
 public enum WireGuardObfuscationUdpOverTcpPort: Codable, Equatable, CustomStringConvertible, Sendable {

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -191,6 +191,9 @@ public enum AccessibilityIdentifier: Equatable {
     case wireGuardObfuscationOff
     case wireGuardObfuscationUdpOverTcp
     case wireGuardObfuscationShadowsocks
+    #if DEBUG
+    case wireGuardObfuscationQuic
+    #endif
     case wireGuardObfuscationUdpOverTcpPort
     case wireGuardObfuscationShadowsocksPort
     case wireGuardPort(UInt16?)

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -876,7 +876,8 @@ final class TunnelManager: StorePaymentObserver, @unchecked Sendable {
     private func startNetworkMonitor() {
         cancelNetworkMonitor()
 
-        networkMonitor = NWPathMonitor(prohibitedInterfaceTypes: [.other])
+//        networkMonitor = NWPathMonitor(prohibitedInterfaceTypes: [.other])
+        networkMonitor = NWPathMonitor()
         networkMonitor?.pathUpdateHandler = { [weak self] path in
             self?.didUpdateNetworkPath(path)
         }

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -224,6 +224,21 @@ final class VPNSettingsCellFactory: @preconcurrency CellFactoryProtocol {
                 self?.delegate?.showDetails(for: .wireguardOverShadowsocks)
             }
 
+        #if DEBUG
+        case .wireGuardObfuscationQuic:
+            guard let cell = cell as? SelectableSettingsCell else { return }
+
+            cell.titleLabel.text = NSLocalizedString(
+                "WIREGUARD_OBFUSCATION_QUIC_LABEL",
+                tableName: "VPNSettings",
+                value: "QUIC",
+                comment: ""
+            )
+
+            cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
+            cell.detailTitleLabel.setAccessibilityIdentifier(.wireGuardObfuscationQuic)
+            cell.applySubCellStyling()
+        #endif
         case .wireGuardObfuscationOff:
             guard let cell = cell as? SelectableSettingsCell else { return }
 

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -83,6 +83,9 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         case wireGuardObfuscationAutomatic
         case wireGuardObfuscationUdpOverTcp
         case wireGuardObfuscationShadowsocks
+        #if DEBUG
+        case wireGuardObfuscationQuic
+        #endif
         case wireGuardObfuscationOff
         case wireGuardObfuscationPort(_ port: WireGuardObfuscationUdpOverTcpPort)
         case quantumResistanceAutomatic
@@ -96,6 +99,17 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
             return [.wireGuardPort(nil)] + defaultPorts + [.wireGuardCustomPort]
         }
 
+        #if DEBUG
+        static var wireGuardObfuscation: [Item] {
+            [
+                .wireGuardObfuscationAutomatic,
+                .wireGuardObfuscationShadowsocks,
+                .wireGuardObfuscationUdpOverTcp,
+                .wireGuardObfuscationQuic,
+                .wireGuardObfuscationOff,
+            ]
+        }
+        #else
         static var wireGuardObfuscation: [Item] {
             [
                 .wireGuardObfuscationAutomatic,
@@ -104,7 +118,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
                 .wireGuardObfuscationOff,
             ]
         }
-
+        #endif
         static var wireGuardObfuscationPort: [Item] {
             [
                 .wireGuardObfuscationPort(.automatic),
@@ -120,58 +134,67 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         var accessibilityIdentifier: AccessibilityIdentifier {
             switch self {
             case .includeAllNetworks:
-                return .includeAllNetworks
+                .includeAllNetworks
             case .localNetworkSharing:
-                return .localNetworkSharing
+                .localNetworkSharing
             case .dnsSettings:
-                return .dnsSettings
+                .dnsSettings
             case .ipOverrides:
-                return .ipOverrides
+                .ipOverrides
             case let .wireGuardPort(port):
-                return .wireGuardPort(port)
+                .wireGuardPort(port)
             case .wireGuardCustomPort:
-                return .wireGuardCustomPort
+                .wireGuardCustomPort
             case .wireGuardObfuscationAutomatic:
-                return .wireGuardObfuscationAutomatic
+                .wireGuardObfuscationAutomatic
             case .wireGuardObfuscationUdpOverTcp:
-                return .wireGuardObfuscationUdpOverTcp
+                .wireGuardObfuscationUdpOverTcp
             case .wireGuardObfuscationShadowsocks:
-                return .wireGuardObfuscationShadowsocks
+                .wireGuardObfuscationShadowsocks
+            #if DEBUG
+            case .wireGuardObfuscationQuic:
+                .wireGuardObfuscationQuic
+            #endif
             case .wireGuardObfuscationOff:
-                return .wireGuardObfuscationOff
+                .wireGuardObfuscationOff
             case .wireGuardObfuscationPort:
-                return .wireGuardObfuscationPort
+                .wireGuardObfuscationPort
             case .quantumResistanceAutomatic:
-                return .quantumResistanceAutomatic
+                .quantumResistanceAutomatic
             case .quantumResistanceOn:
-                return .quantumResistanceOn
+                .quantumResistanceOn
             case .quantumResistanceOff:
-                return .quantumResistanceOff
+                .quantumResistanceOff
             }
         }
 
         var reuseIdentifier: CellReuseIdentifiers {
             switch self {
             case .includeAllNetworks:
-                return .includeAllNetworks
+                .includeAllNetworks
             case .localNetworkSharing:
-                return .localNetworkSharing
+                .localNetworkSharing
             case .dnsSettings:
-                return .dnsSettings
+                .dnsSettings
             case .ipOverrides:
-                return .ipOverrides
+                .ipOverrides
             case .wireGuardPort:
-                return .wireGuardPort
+                .wireGuardPort
             case .wireGuardCustomPort:
-                return .wireGuardCustomPort
+                .wireGuardCustomPort
+            #if DEBUG
+            case .wireGuardObfuscationAutomatic, .wireGuardObfuscationOff, .wireGuardObfuscationQuic:
+                .wireGuardObfuscation
+            #else
             case .wireGuardObfuscationAutomatic, .wireGuardObfuscationOff:
-                return .wireGuardObfuscation
+                .wireGuardObfuscation
+            #endif
             case .wireGuardObfuscationUdpOverTcp, .wireGuardObfuscationShadowsocks:
-                return .wireGuardObfuscationOption
+                .wireGuardObfuscationOption
             case .wireGuardObfuscationPort:
-                return .wireGuardObfuscationPort
+                .wireGuardObfuscationPort
             case .quantumResistanceAutomatic, .quantumResistanceOn, .quantumResistanceOff:
-                return .quantumResistance
+                .quantumResistance
             }
         }
     }
@@ -205,6 +228,9 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         case .off: .wireGuardObfuscationOff
         case .on, .udpOverTcp: .wireGuardObfuscationUdpOverTcp
         case .shadowsocks: .wireGuardObfuscationShadowsocks
+        #if DEBUG
+        case .quic: .wireGuardObfuscationQuic
+        #endif
         }
 
         let quantumResistanceItem: Item = switch viewModel.quantumResistance {
@@ -340,6 +366,11 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         case .wireGuardObfuscationShadowsocks:
             selectObfuscationState(.shadowsocks)
             delegate?.didUpdateTunnelSettings(TunnelSettingsUpdate.obfuscation(obfuscationSettings))
+        #if DEBUG
+        case .wireGuardObfuscationQuic:
+            selectObfuscationState(.quic)
+            delegate?.didUpdateTunnelSettings(TunnelSettingsUpdate.obfuscation(obfuscationSettings))
+        #endif
         case .wireGuardObfuscationOff:
             selectObfuscationState(.off)
             delegate?.didUpdateTunnelSettings(TunnelSettingsUpdate.obfuscation(obfuscationSettings))

--- a/ios/MullvadVPNTests/MullvadSettings/TunnelSettingsUpdateTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/TunnelSettingsUpdateTests.swift
@@ -48,6 +48,38 @@ final class TunnelSettingsUpdateTests: XCTestCase {
         ))
     }
 
+    func testApplyShadowsocksObfuscation() {
+        // Given:
+        var settings = LatestTunnelSettings()
+
+        // When:
+        let update = TunnelSettingsUpdate.obfuscation(WireGuardObfuscationSettings(
+            state: .shadowsocks
+        ))
+        update.apply(to: &settings)
+
+        // Then:
+        XCTAssertEqual(settings.wireGuardObfuscation, WireGuardObfuscationSettings(
+            state: .shadowsocks
+        ))
+    }
+
+    func testApplyQuicObfuscation() {
+        // Given:
+        var settings = LatestTunnelSettings()
+
+        // When:
+        let update = TunnelSettingsUpdate.obfuscation(WireGuardObfuscationSettings(
+            state: .quic
+        ))
+        update.apply(to: &settings)
+
+        // Then:
+        XCTAssertEqual(settings.wireGuardObfuscation, WireGuardObfuscationSettings(
+            state: .quic
+        ))
+    }
+
     func testApplyRelayConstraints() {
         // Given:
         var settings = LatestTunnelSettings()

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -133,6 +133,7 @@ class TunnelControlPage: Page {
     @discardableResult func verifyConnectingOverTCPAfterUDPAttempts() -> Self {
         let connectionAttempts = waitForConnectionAttempts(4, timeout: 30)
 
+        // TODO: Revisit this when QUIC obfuscation is added
         // Should do four connection attempts but due to UI bug sometimes only two are displayed, sometimes all four
         if connectionAttempts.count == 4 { // Expected retries flow
             for (attemptIndex, attempt) in connectionAttempts.enumerated() {

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -128,6 +128,11 @@ class VPNSettingsPage: Page {
         return self
     }
 
+    @discardableResult func tapWireGuardObufscationQuicCell() -> Self {
+        app.cells[AccessibilityIdentifier.wireGuardObfuscationQuic].tap()
+        return self
+    }
+
     @discardableResult func tapWireGuardObfuscationOffCell() -> Self {
         app.cells[AccessibilityIdentifier.wireGuardObfuscationOff].tap()
 

--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -324,6 +324,47 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapDisconnectButton()
     }
 
+    func testWireGuardOverQuicManually() throws {
+        addTeardownBlock {
+            HeaderBar(self.app)
+                .tapSettingsButton()
+
+            SettingsPage(self.app)
+                .tapVPNSettingsCell()
+
+            VPNSettingsPage(self.app)
+                .tapWireGuardObfuscationExpandButton()
+                .tapWireGuardObfuscationOffCell()
+        }
+
+        HeaderBar(app)
+            .tapSettingsButton()
+
+        SettingsPage(app)
+            .tapVPNSettingsCell()
+
+        VPNSettingsPage(app)
+            .tapWireGuardObfuscationExpandButton()
+            .tapWireGuardObufscationQuicCell()
+            .tapBackButton()
+
+        SettingsPage(app)
+            .tapDoneButton()
+
+        TunnelControlPage(app)
+            .tapConnectButton()
+
+        allowAddVPNConfigurationsIfAsked()
+
+        TunnelControlPage(app)
+            .waitForConnectedLabel()
+
+        try Networking.verifyCanAccessInternet()
+
+        TunnelControlPage(app)
+            .tapDisconnectButton()
+    }
+
     /// Test automatic switching to TCP is functioning when UDP traffic to relay is blocked. This test first connects to a realy to get the IP address of it, in order to block UDP traffic to this relay.
     func testWireGuardOverTCPAutomatically() throws {
         FirewallClient().removeRules()

--- a/ios/PacketTunnelCore/Actor/ProtocolObfuscator.swift
+++ b/ios/PacketTunnelCore/Actor/ProtocolObfuscator.swift
@@ -60,12 +60,23 @@ public class ProtocolObfuscator<Obfuscator: TunnelObfuscation>: ProtocolObfuscat
             return .init(endpoint: endpoint, method: .off)
         }
 
+        #if DEBUG
+        // TODO: Revisit this when QUIC obfuscation is available to use, use shadowsocks over 443 for the time being
+        let obfuscator = Obfuscator(
+            remoteAddress: endpoint.ipv4Relay.ip,
+            tcpPort: remotePort,
+            obfuscationProtocol: (obfuscationMethod == .shadowsocks || obfuscationMethod == .quic)
+                ? .shadowsocks
+                : .udpOverTcp
+        )
+        #else
         // At this point, the only possible obfuscation methods should be either `.udpOverTcp` or `.shadowsocks`
         let obfuscator = Obfuscator(
             remoteAddress: endpoint.ipv4Relay.ip,
             tcpPort: remotePort,
             obfuscationProtocol: obfuscationMethod == .shadowsocks ? .shadowsocks : .udpOverTcp
         )
+        #endif
 
         obfuscator.start()
         tunnelObfuscator = obfuscator


### PR DESCRIPTION
This PR adds the ability to select QUIC obfuscation in the UI.
Since there is no QUIC obfuscator available yet, Shadowsocks obfuscation over 443 will be used behind the scenes as a placeholder.

This also takes care of IOS-1129, since it didn't really make sense to just add the option and not use it.
A UITest was added to this effect, it should run green, we can expand on it later using the packet capture functionalities of the E2E framework to actually verify that the traffic being sent is QUIC when we have QUIC obfuscation available.