### PR TITLE
Make DAITA/Quantum feature indicators show actual tunnel state

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -146,6 +146,31 @@ enum TunnelState: Equatable, CustomStringConvertible, Sendable {
         }
     }
 
+    // the two accessors below return a Bool?, to differentiate known
+    // truth values from undefined/meaningless values, which the caller
+    // may want to interpret differently
+    var isPostQuantum: Bool? {
+        switch self {
+        case let .connecting(_, isPostQuantum: isPostQuantum, isDaita: _),
+             let .connected(_, isPostQuantum: isPostQuantum, isDaita: _),
+             let .reconnecting(_, isPostQuantum: isPostQuantum, isDaita: _):
+            isPostQuantum
+        default:
+            nil
+        }
+    }
+
+    var isDaita: Bool? {
+        switch self {
+        case let .connecting(_, isPostQuantum: _, isDaita: isDaita),
+             let .connected(_, isPostQuantum: _, isDaita: isDaita),
+             let .reconnecting(_, isPostQuantum: _, isDaita: isDaita):
+            isDaita
+        default:
+            nil
+        }
+    }
+
     var isMultihop: Bool {
         relays?.entry != nil
     }

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
@@ -19,10 +19,10 @@ protocol ChipFeature {
 }
 
 struct DaitaFeature: ChipFeature {
-    let settings: LatestTunnelSettings
+    let state: TunnelState
 
     var isEnabled: Bool {
-        settings.daita.daitaState.isEnabled
+        state.isDaita ?? false
     }
 
     var name: String {
@@ -36,9 +36,10 @@ struct DaitaFeature: ChipFeature {
 }
 
 struct QuantumResistanceFeature: ChipFeature {
-    let settings: LatestTunnelSettings
+    let state: TunnelState
+
     var isEnabled: Bool {
-        settings.tunnelQuantumResistance.isEnabled
+        state.isPostQuantum ?? false
     }
 
     var name: String {

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
@@ -34,8 +34,8 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
         case .connecting, .reconnecting, .negotiatingEphemeralPeer,
              .connected, .pendingReconnect:
             let features: [ChipFeature] = [
-                DaitaFeature(settings: tunnelSettings),
-                QuantumResistanceFeature(settings: tunnelSettings),
+                DaitaFeature(state: tunnelState),
+                QuantumResistanceFeature(state: tunnelState),
                 MultihopFeature(settings: tunnelSettings, state: tunnelState),
                 ObfuscationFeature(settings: tunnelSettings, state: observedState),
                 DNSFeature(settings: tunnelSettings),


### PR DESCRIPTION
This makes the DAITA and Quantum Resistance feature indicators appear iff the current `TunnelState` is connected with the feature active, rather than the settings being configured to enable the feature. This should cover all the feature indicators other than DNS.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8001)
<!-- Reviewable:end -->
