### PR TITLE
Bump `crossbeam-channel` to `0.5.15` to mitigate RUSTSEC-2025-0024

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
This PR bumps `crossbeam-channel` from `0.5.12` to `0.5.15` in the test workspace to fix a memory corruption error present in `crossbeam-channel [0.5.12, 0.5.15)` : https://osv.dev/vulnerability/RUSTSEC-2025-0024

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8007)
<!-- Reviewable:end -->
