### PR TITLE
Add Fedora 42 beta VM to end-to-end tests

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -16,10 +16,10 @@ on:
         description: "Space-delimited list of targets to run tests on, e.g. `debian12 ubuntu2004`. \
           Available images:\n
           `debian11 debian12 ubuntu2004 ubuntu2204 ubuntu2404 ubuntu2410 fedora39 \
-          fedora40 fedora41 windows10 windows11 macos12 macos13 macos14 macos15`.\n
+          fedora40 fedora41 fedora42 windows10 windows11 macos12 macos13 macos14 macos15`.\n
           Default images:\n
           `debian12 ubuntu2004 ubuntu2204 ubuntu2404 ubuntu2410 fedora39 \
-          fedora40 fedora41 windows10 windows11 macos13 macos14 macos15`."
+          fedora40 fedora41 fedora42 windows10 windows11 macos13 macos14 macos15`."
         default: ''
         required: false
         type: string
@@ -41,8 +41,8 @@ jobs:
         run: |
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
-          all='["debian11","debian12","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","fedora39","fedora40","fedora41"]'
-          default='["debian12","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","fedora39","fedora40","fedora41"]'
+          all='["debian11","debian12","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","fedora39","fedora40","fedora41","fedora42"]'
+          default='["debian12","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","fedora40","fedora41","fedora42"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then


### PR DESCRIPTION
This PR adds a Fedora 42 beta VM to the desktop end-to-end test CI workflow. This means that it will be automatically tested every night and that we can manually trigger tests with a Fedora 42 VM.

Here is a run with the new VM: https://github.com/mullvad/mullvadvpn-app/actions/runs/14400552518

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8010)
<!-- Reviewable:end -->
