### PR TITLE
Set opt-level=3 globally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,12 +132,6 @@ proptest = "1.4"
 insta = { version = "1.42", features = ["yaml"] }
 
 [profile.release]
-opt-level = "s"
+opt-level = 3
 lto = true
 strip = true
-
-# Key generation may take over one minute without optimizations enabled.
-[profile.dev.package."classic-mceliece-rust"]
-opt-level = 3
-[profile.release.package."classic-mceliece-rust"]
-opt-level = 3

--- a/desktop/scripts/pack-universal-win.sh
+++ b/desktop/scripts/pack-universal-win.sh
@@ -57,6 +57,7 @@ if [[ -z ${WIN_X64_INSTALLER-} ]] || [[ -z ${WIN_ARM64_INSTALLER-} ]]; then
     exit 1
 fi
 
+export RUSTFLAGS="-C opt-level=s"
 cargo build "${CARGO_ARGS[@]}" -p windows-installer --target x86_64-pc-windows-msvc
 
 dest="dist/MullvadVPN-${PRODUCT_VERSION}.exe"


### PR DESCRIPTION
I've seen a noticeable performance increase on mullvad-masque-proxy by setting opt-level=3 on it. I suspect that we'd see an improvement for shadowsocks, maybe udp2tcp, and maybe macos split tunneling.

Given the number of dependencies that these crates have, it would be a hassle to set opt-level=3 individually on each dependency that might benefit from it.

Here are size comparisons for some binaries that would be affected:

| bin             | opt-level=s | opt-level=3 | tested on |
| --------------- | ----------- | ----------- | --- |
| mullvad-daemon  | 15.9 MiB    | 22.7 MiB    | linux |
| mullvad-cli     | 5.4 MiB     | 7.3 MiB     | linux |
| mullvad-exclude | 362.3 KiB   | 367.5 KiB   | linux |

With opt-level=3: https://releases.mullvad.net/desktop/builds/2025.5-dev-66a2c9%2Btest-opt-level-3/?C=M&O=D

With opt-level=s: https://releases.mullvad.net/desktop/builds/2025.5-dev-b2b32e/?C=M&O=D

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8024)
<!-- Reviewable:end -->
