### PR TITLE
Fix shadowsocks not using ip override

### DIFF
--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -77,7 +77,16 @@ extension REST {
                 publicKey: publicKey,
                 includeInCountry: includeInCountry,
                 daita: daita,
-                shadowsocksExtraAddrIn: shadowsocksExtraAddrIn
+                shadowsocksExtraAddrIn: shadowsocksExtraAddrIn?.filter { address in
+                    return switch address {
+                    case let ip where IPv4Address(ip) != nil:
+                        ipv4AddrIn == nil
+                    case let ip where IPv6Address(ip) != nil:
+                        ipv6AddrIn == nil
+                    default:
+                        true
+                    }
+                }
             )
         }
 

--- a/ios/MullvadRESTTests/ServerRelayTests.swift
+++ b/ios/MullvadRESTTests/ServerRelayTests.swift
@@ -1,0 +1,81 @@
+@testable import MullvadREST
+import Network
+import XCTest
+
+class ServerRelayTests: XCTestCase {
+    func testOverrideIPv4AddrIn() throws {
+        let overrideRelay: REST.ServerRelay = self.mockServerRelay.override(
+            ipv4AddrIn: .loopback,
+            ipv6AddrIn: nil
+        )
+
+        XCTAssertEqual(overrideRelay.ipv4AddrIn, .loopback)
+        XCTAssertEqual(overrideRelay.ipv6AddrIn, .any)
+        XCTAssertEqual(overrideRelay.shadowsocksExtraAddrIn, ["\(IPv6Address.any)"])
+    }
+
+    func testOverrideIPv6AddrIn() throws {
+        let overrideRelay: REST.ServerRelay = self.mockServerRelay.override(
+            ipv4AddrIn: nil,
+            ipv6AddrIn: .loopback
+        )
+
+        XCTAssertEqual(overrideRelay.ipv4AddrIn, .any)
+        XCTAssertEqual(overrideRelay.ipv6AddrIn, .loopback)
+        XCTAssertEqual(overrideRelay.shadowsocksExtraAddrIn, ["\(IPv4Address.any)"])
+    }
+
+    func testOverrideBoth() throws {
+        let overrideRelay: REST.ServerRelay = self.mockServerRelay.override(
+            ipv4AddrIn: .loopback,
+            ipv6AddrIn: .loopback
+        )
+
+        XCTAssertEqual(overrideRelay.ipv4AddrIn, .loopback)
+        XCTAssertEqual(overrideRelay.ipv6AddrIn, .loopback)
+        XCTAssertEqual(overrideRelay.shadowsocksExtraAddrIn, [])
+    }
+
+    func testOverrideNone() throws {
+        let overrideRelay: REST.ServerRelay = self.mockServerRelay.override(
+            ipv4AddrIn: nil,
+            ipv6AddrIn: nil
+        )
+
+        XCTAssertEqual(overrideRelay.ipv4AddrIn, .any)
+        XCTAssertEqual(overrideRelay.ipv6AddrIn, .any)
+        XCTAssertEqual(
+            overrideRelay.shadowsocksExtraAddrIn,
+            shadowSocksExtraAddrIn
+        )
+    }
+
+    func testOverrideDaita() throws {
+        let overrideRelay: REST.ServerRelay = self.mockServerRelay.override(
+            daita: true
+        )
+
+        XCTAssertEqual(overrideRelay.daita, true)
+    }
+
+    var shadowSocksExtraAddrIn: [String] {
+        ["\(IPv4Address.any)", "\(IPv6Address.any)"]
+    }
+
+    var mockServerRelay: REST.ServerRelay {
+        REST.ServerRelay(
+            hostname: "Host 1",
+            active: true,
+            owned: true,
+            location: "xx-yyy",
+            provider: "",
+            weight: 0,
+            ipv4AddrIn: .any,
+            ipv6AddrIn: .any,
+            publicKey: Data(),
+            includeInCountry: true,
+            daita: false,
+            shadowsocksExtraAddrIn: shadowSocksExtraAddrIn
+        )
+    }
+}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1101,6 +1101,7 @@
 		F910A4312D4A1B41002FF3BB /* InAppPurchaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A4302D4A1B3B002FF3BB /* InAppPurchaseCoordinator.swift */; };
 		F910A43A2D4A283D002FF3BB /* InAppPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A4392D4A2839002FF3BB /* InAppPurchaseViewController.swift */; };
 		F910A8572D523812002FF3BB /* TunnelSettingsV7.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A8562D523812002FF3BB /* TunnelSettingsV7.swift */; };
+		F924C65F2DAE4554001F4660 /* ServerRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C65E2DAE4554001F4660 /* ServerRelayTests.swift */; };
 		F998EFF82D359C4600D88D01 /* SKProduct+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */; };
 		F998EFFA2D3656BA00D88D01 /* SKProduct+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F998EFF92D3656B100D88D01 /* SKProduct+Sorting.swift */; };
 /* End PBXBuildFile section */
@@ -2498,6 +2499,7 @@
 		F910A4302D4A1B3B002FF3BB /* InAppPurchaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseCoordinator.swift; sourceTree = "<group>"; };
 		F910A4392D4A2839002FF3BB /* InAppPurchaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseViewController.swift; sourceTree = "<group>"; };
 		F910A8562D523812002FF3BB /* TunnelSettingsV7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettingsV7.swift; sourceTree = "<group>"; };
+		F924C65E2DAE4554001F4660 /* ServerRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRelayTests.swift; sourceTree = "<group>"; };
 		F998EFF92D3656B100D88D01 /* SKProduct+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Sorting.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -4140,6 +4142,7 @@
 		58FBFBE7291622580020E046 /* MullvadRESTTests */ = {
 			isa = PBXGroup;
 			children = (
+				F924C65E2DAE4554001F4660 /* ServerRelayTests.swift */,
 				58FBFBE8291622580020E046 /* ExponentialBackoffTests.swift */,
 				A932D9F22B5EB61100999395 /* HeadRequestTests.swift */,
 				58BDEB9E2A98F6B400F578F2 /* Mocks */,
@@ -6717,6 +6720,7 @@
 				A917352129FAAA5200D5DCFD /* TransportStrategyTests.swift in Sources */,
 				58FBFBE9291622580020E046 /* ExponentialBackoffTests.swift in Sources */,
 				F0164EC32B4C49D30020268D /* ShadowsocksLoaderStub.swift in Sources */,
+				F924C65F2DAE4554001F4660 /* ServerRelayTests.swift in Sources */,
 				58BDEB9D2A98F69E00F578F2 /* MemoryCache.swift in Sources */,
 				58BDEB9B2A98F58600F578F2 /* TimeServerProxy.swift in Sources */,
 				A932D9F52B5EBB9D00999395 /* RESTTransportStub.swift in Sources */,


### PR DESCRIPTION
Shadowsocks obfuscation was in some cases not using the ip provided by an ip override. This PR fixes that bug.
To test add an ip override like this
```
{
    "relay_overrides": [
        {
            "hostname": "se-got-wg-001",
            "ipv4_addr_in": "127.0.0.1",
            "ipv6_addr_in": "::"
        }
    ]
}
and try connecting to that relay. It should now use the provided ip for shadowsocks both in automatic and user selected mode with both automatic and user defined port.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8027)
<!-- Reviewable:end -->
