### PR TITLE
Add property flag to enable keep native symbols

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,7 +88,15 @@ android {
                 "proguard-rules.pro",
             )
         }
-        getByName(BuildTypes.DEBUG) { packaging { jniLibs.keepDebugSymbols.add("**/*.so") } }
+        getByName(BuildTypes.DEBUG) {
+            if (
+                gradleLocalProperties(rootProject.projectDir, providers)
+                    .getProperty("KEEP_DEBUG_SYMBOLS")
+                    .toBoolean()
+            ) {
+                packaging { jniLibs.keepDebugSymbols.add("**/*.so") }
+            }
+        }
         create(BuildTypes.FDROID) {
             initWith(buildTypes.getByName(BuildTypes.RELEASE))
             signingConfig = null


### PR DESCRIPTION
The native symbols blows up the size of the APK by a lot, so we add a flag `KEEP_DEBUG_SYMBOLS` that must be set to `true` or else we strip the native lib symbols.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
