### PR TITLE
Run cleanup tasks when macOS app is dropped in bin

### DIFF
--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -76,3 +76,7 @@ if [[ $ASSUMEYES == "y" || "$REPLY" =~ [Yy]$ ]]; then
         fi
     done
 fi
+
+# When run from a non-standard directory, like when detecting that the launch daemon is gone,
+# we must also delete the uninstall script itself
+rm -f "$0" || true

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -2,8 +2,21 @@
 
 set -ue
 
-read -r -p "Are you sure you want to stop and uninstall Mullvad VPN? (y/n) "
-if [[ "$REPLY" =~ [Yy]$ ]]; then
+ASSUMEYES="n"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --yes) ASSUMEYES="y";;
+        *)
+            echo "Unknown parameter: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+[[ $ASSUMEYES == "y" ]] || read -r -p "Are you sure you want to stop and uninstall Mullvad VPN? (y/n) "
+if [[ $ASSUMEYES == "y" || "$REPLY" =~ [Yy]$ ]]; then
     echo "Uninstalling Mullvad VPN ..."
 else
     echo "Aborting uninstall"
@@ -40,8 +53,8 @@ sudo pkgutil --forget net.mullvad.vpn || true
 echo "Removing login item ..."
 osascript -e 'tell application "System Events" to delete login item "Mullvad VPN"' 2>/dev/null || true
 
-read -r -p "Do you want to delete the log and cache files the app has created? (y/n) "
-if [[ "$REPLY" =~ [Yy]$ ]]; then
+[[ $ASSUMEYES == "y" ]] || read -r -p "Do you want to delete the log and cache files the app has created? (y/n) "
+if [[ $ASSUMEYES == "y" || "$REPLY" =~ [Yy]$ ]]; then
     sudo rm -rf /var/log/mullvad-vpn /var/root/Library/Caches/mullvad-vpn /Library/Caches/mullvad-vpn
     for user in /Users/*; do
         user_log_dir="$user/Library/Logs/Mullvad VPN"
@@ -52,8 +65,8 @@ if [[ "$REPLY" =~ [Yy]$ ]]; then
     done
 fi
 
-read -r -p "Do you want to delete the Mullvad VPN settings? (y/n) "
-if [[ "$REPLY" =~ [Yy]$ ]]; then
+[[ $ASSUMEYES == "y" ]] || read -r -p "Do you want to delete the Mullvad VPN settings? (y/n) "
+if [[ $ASSUMEYES == "y" || "$REPLY" =~ [Yy]$ ]]; then
     sudo rm -rf /etc/mullvad-vpn
     for user in /Users/*; do
         user_settings_dir="$user/Library/Application Support/Mullvad VPN"

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -962,6 +962,14 @@ impl Daemon {
 
         api_availability.unsuspend();
 
+        let account_manager = daemon.account_manager.clone();
+        #[cfg(target_os = "macos")]
+        tokio::task::spawn(async {
+            if let Err(error) = macos::handle_app_bundle_removal(account_manager).await {
+                log::error!("Failed to handle app removal: {error}");
+            }
+        });
+
         Ok(daemon)
     }
 

--- a/mullvad-daemon/src/macos.rs
+++ b/mullvad-daemon/src/macos.rs
@@ -1,4 +1,10 @@
-use std::io;
+use std::{fmt, io, path::Path, process::Stdio, time::Duration};
+
+use anyhow::Context;
+use std::io::Write;
+use tokio::{fs::File, process::Command};
+
+use crate::device::AccountManagerHandle;
 
 /// Bump filehandle limit
 pub fn bump_filehandle_limit() {
@@ -34,4 +40,90 @@ pub fn bump_filehandle_limit() {
             status
         );
     }
+}
+
+/// Detect when the app bundle is deleted
+pub async fn handle_app_bundle_removal(
+    account_manager_handle: AccountManagerHandle,
+) -> anyhow::Result<()> {
+    const UNINSTALL_SCRIPT: &[u8] = include_bytes!("../../dist-assets/uninstall_macos.sh");
+    const UNINSTALL_SCRIPT_PATH: &str = "/var/root/uninstall_mullvad.sh";
+    const APPLICATION_PATH: &str = "/Applications/Mullvad VPN.app";
+
+    loop {
+        // TODO: monitor files using fnotify?
+        if !Path::new(APPLICATION_PATH).exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(10)).await;
+    }
+
+    // Create file to log output from uninstallation process.
+    // This is useful since the daemon will be killed during uninstallation.
+    let mut log_file = async {
+        let log_path: std::path::PathBuf = mullvad_paths::log_dir()?.join("uninstall.log");
+
+        let file = File::create(log_path).await?;
+        anyhow::Ok(file.into_std().await)
+    }
+    .await
+    .inspect_err(|e| {
+        log::warn!("Failed to create uninstaller log-file: {e:#?}");
+    })
+    .ok();
+
+    // Log to both daemon log and uninstaller log.
+    let mut log = |msg: fmt::Arguments<'_>| {
+        log::info!("{msg}");
+        if let Some(log_file) = &mut log_file {
+            let _ = writeln!(log_file, "{msg}");
+        }
+    };
+
+    log(format_args!(
+        "{APPLICATION_PATH:?} was removed. Running uninstaller."
+    ));
+
+    tokio::fs::write(UNINSTALL_SCRIPT_PATH, UNINSTALL_SCRIPT).await?;
+
+    // If reset_firewall errors, log the error and continue anyway.
+    log(format_args!("Resetting firewall"));
+    if let Err(error) = reset_firewall() {
+        log(format_args!("{error:#?}"));
+    }
+
+    // Remove the current device from the account
+    log(format_args!("Logging out"));
+    if let Err(error) = account_manager_handle.logout().await {
+        log(format_args!("Failed to remove device: {error:#?}"));
+    }
+
+    // This will kill the daemon.
+    log(format_args!("Running {UNINSTALL_SCRIPT_PATH:?}"));
+    let mut cmd = Command::new("/bin/bash");
+    cmd
+        .arg(UNINSTALL_SCRIPT_PATH)
+        // Don't prompt for confirmation.
+        .arg("--yes") 
+        // Spawn as its own process group.
+        // This prevents the command from being killed when the daemon is killed.
+        .process_group(0)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    if let Some(log_file) = log_file {
+        cmd.stdout(log_file.try_clone().context("Failed to clone log fd")?);
+        cmd.stderr(log_file);
+    };
+    cmd.spawn().context("Failed to spawn uninstaller script")?;
+
+    Ok(())
+}
+
+fn reset_firewall() -> anyhow::Result<()> {
+    talpid_core::firewall::Firewall::new()
+        .context("Failed to create firewall instance")?
+        .reset_policy()
+        .context("Failed to reset firewall policy")
 }


### PR DESCRIPTION
Previously, we didn't properly clean up the launch daemon when the app was removed by dragging and dropping it in the bin. This PR adds a task to run the uninstall script and other cleanup tasks when the app is removed this way.

Fix DES-1912.