### PR TITLE
Improvements to app upgrade implementation

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -178,6 +178,10 @@ export default class AppRenderer {
     IpcRendererEventChannel.app.listenUpgradeEvent((appUpgradeEvent) => {
       this.reduxActions.appUpgrade.setAppUpgradeEvent(appUpgradeEvent);
 
+      if (appUpgradeEvent.type === 'APP_UPGRADE_STATUS_DOWNLOAD_PROGRESS') {
+        this.reduxActions.appUpgrade.setLastProgress(appUpgradeEvent.progress);
+      }
+
       // Check if the installer should be started automatically
       this.maybeStartAppUpgradeInstaller();
     });

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/UpdateAvailableListItem.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-info/components/update-available-list-item/UpdateAvailableListItem.tsx
@@ -5,7 +5,7 @@ import { useIsPlatformLinux } from '../../../../../hooks';
 import { Flex, Icon } from '../../../../../lib/components';
 import { Dot } from '../../../../../lib/components/dot';
 import { ListItem } from '../../../../../lib/components/list-item';
-import { useConnectionIsBlocked, useVersionSuggestedUpgrade } from '../../../../../redux/hooks';
+import { useVersionSuggestedUpgrade } from '../../../../../redux/hooks';
 import { useHandleClick } from './hooks';
 
 const StyledText = styled(ListItem.Text)`
@@ -14,13 +14,12 @@ const StyledText = styled(ListItem.Text)`
 
 export function UpdateAvailableListItem() {
   const { suggestedUpgrade } = useVersionSuggestedUpgrade();
-  const { isBlocked } = useConnectionIsBlocked();
 
   const isLinux = useIsPlatformLinux();
   const handleClick = useHandleClick();
 
   return (
-    <ListItem disabled={isBlocked}>
+    <ListItem>
       <ListItem.Item>
         <ListItem.Trigger onClick={handleClick}>
           <ListItem.Content>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/AppUpgradeView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/AppUpgradeView.tsx
@@ -19,13 +19,11 @@ import {
 import {
   usePresent,
   useShowCancelButton,
-  useShowDownloadProgress,
   useShowInstallButton,
   useShowManualDownloadButton,
   useShowReportProblemButton,
   useShowRetryUpgradeButton,
   useShowUpgradeButton,
-  useShowUpgradeLabel,
 } from './hooks';
 
 const StyledFooter = styled.div`
@@ -40,13 +38,11 @@ export const AppUpgradeView = () => {
   const { pop } = useHistory();
   const present = usePresent();
   const showCancelButton = useShowCancelButton();
-  const showDownloadProgress = useShowDownloadProgress();
   const showInstallButton = useShowInstallButton();
   const showManualDownloadButton = useShowManualDownloadButton();
   const showReportProblemButton = useShowReportProblemButton();
   const showRetryUpgradeButton = useShowRetryUpgradeButton();
   const showUpgradeButton = useShowUpgradeButton();
-  const showUpgradeLabel = useShowUpgradeLabel();
 
   return (
     <BackAction action={pop}>
@@ -54,12 +50,10 @@ export const AppUpgradeView = () => {
         <UpgradeDetails />
         <StyledFooter>
           <Flex $padding="large" $flexDirection="column">
-            <Animate
-              animations={[{ type: 'fade' }, { type: 'wipe', direction: 'vertical' }]}
-              present={present}>
+            <Animate animations={[{ type: 'wipe', direction: 'vertical' }]} present={present}>
               <Flex $gap="medium" $flexDirection="column" $margin={{ bottom: 'medium' }}>
-                {showUpgradeLabel && <UpgradeLabel />}
-                {showDownloadProgress && <DownloadProgress />}
+                <UpgradeLabel />
+                <DownloadProgress />
               </Flex>
             </Animate>
             <Flex $gap="medium" $flexDirection="column">

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/DownloadProgress.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/DownloadProgress.tsx
@@ -1,13 +1,14 @@
 import { useAppUpgradeDownloadProgressValue } from '../../../../../hooks';
 import { Progress } from '../../../../../lib/components/progress';
-import { useMessage } from './hooks';
+import { useDisabled, useMessage } from './hooks';
 
 export function DownloadProgress() {
   const message = useMessage();
   const value = useAppUpgradeDownloadProgressValue();
+  const disabled = useDisabled();
 
   return (
-    <Progress value={value}>
+    <Progress value={value} disabled={disabled}>
       <Progress.Track>
         <Progress.Range />
       </Progress.Track>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useMessage';
+export * from './useDisabled';

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/hooks/useDisabled.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/hooks/useDisabled.ts
@@ -1,0 +1,13 @@
+import { useAppUpgradeEventType, useHasAppUpgradeError } from '../../../../../../hooks';
+import { useConnectionIsBlocked } from '../../../../../../redux/hooks';
+
+export const useDisabled = () => {
+  const appUpgradeEventType = useAppUpgradeEventType();
+  const hasAppUpgradeError = useHasAppUpgradeError();
+  const { isBlocked } = useConnectionIsBlocked();
+  if (hasAppUpgradeError || isBlocked || appUpgradeEventType === 'APP_UPGRADE_STATUS_ABORTED') {
+    return true;
+  }
+
+  return false;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/hooks/useMessage/useMessage.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/download-progress/hooks/useMessage/useMessage.ts
@@ -10,7 +10,7 @@ export const useMessage = () => {
   const getMessageTimeLeft = useGetMessageTimeLeft();
   const hasAppUpgradeError = useHasAppUpgradeError();
 
-  if (isBlocked) {
+  if (isBlocked || appUpgradeEventType === 'APP_UPGRADE_STATUS_ABORTED') {
     // TRANSLATORS: Status text displayed below a progress bar when the download of an update has been paused
     return messages.pgettext('app-upgrade-view', 'Download paused');
   }

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/installer-ready/InstallerReady.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/installer-ready/InstallerReady.tsx
@@ -4,7 +4,7 @@ import { Colors } from '../../../../../../../lib/foundations';
 
 export function InstallerReady() {
   return (
-    <Flex $gap="small">
+    <Flex $gap="tiny" $alignItems="center">
       <Icon icon="checkmark" color={Colors.green} size="small" />
       <LabelTiny>
         {

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/starting-installer/StartingInstaller.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/starting-installer/StartingInstaller.tsx
@@ -4,7 +4,7 @@ import { Colors } from '../../../../../../../lib/foundations';
 
 export function StartingInstaller() {
   return (
-    <Flex $gap="small">
+    <Flex $gap="tiny" $alignItems="center">
       <Icon icon="checkmark" color={Colors.green} size="small" />
       <LabelTiny>
         {

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/upgrade-error/UpgradeError.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/upgrade-error/UpgradeError.tsx
@@ -6,7 +6,7 @@ export function UpgradeError() {
   const message = useMessage();
 
   return (
-    <Flex $gap="small" $flexDirection="row">
+    <Flex $gap="tiny" $flexDirection="row">
       <div>
         <Icon size="small" icon="alert-circle" color={Colors.red} />
       </div>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/verifying-installer/VerifyingInstaller.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/upgrade-label/components/verifying-installer/VerifyingInstaller.tsx
@@ -3,7 +3,7 @@ import { Flex, LabelTiny, Spinner } from '../../../../../../../lib/components';
 
 export function VerifyingInstaller() {
   return (
-    <Flex $gap="small">
+    <Flex $gap="tiny" $alignItems="center">
       <Spinner size="small" />
       <LabelTiny>
         {

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/hooks/useShowDownloadProgress.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/hooks/useShowDownloadProgress.ts
@@ -1,22 +1,17 @@
 import {
   useHasAppUpgradeError,
   useHasAppUpgradeInitiated,
-  useHasAppUpgradeVerifiedInstallerPath,
-  useIsAppUpgradePending,
+  useShouldAppUpgradeInstallManually,
 } from '../../../../hooks';
-import { useAppUpgradeError, useConnectionIsBlocked } from '../../../../redux/hooks';
+import { useAppUpgradeError } from '../../../../redux/hooks';
 
 export const useShowDownloadProgress = () => {
-  const { isBlocked } = useConnectionIsBlocked();
   const { error } = useAppUpgradeError();
   const hasAppUpgradeInitiated = useHasAppUpgradeInitiated();
   const hasAppUpgradeError = useHasAppUpgradeError();
-  const isAppUpgradePending = useIsAppUpgradePending();
-  const hasAppUpgradeVerifiedInstallerPath = useHasAppUpgradeVerifiedInstallerPath();
+  const shouldUpgradeInstallManually = useShouldAppUpgradeInstallManually();
 
-  if (isBlocked && hasAppUpgradeInitiated) {
-    return true;
-  }
+  if (shouldUpgradeInstallManually) return true;
 
   if (hasAppUpgradeError) {
     if (
@@ -30,7 +25,7 @@ export const useShowDownloadProgress = () => {
     return false;
   }
 
-  const showDownloadProgress = isAppUpgradePending || hasAppUpgradeVerifiedInstallerPath;
+  const showDownloadProgress = hasAppUpgradeInitiated;
 
   return showDownloadProgress;
 };

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/useAppUpgradeDownloadProgressValue.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useAppUpgradeDownloadProgressValue/useAppUpgradeDownloadProgressValue.ts
@@ -1,3 +1,4 @@
+import { useAppUpgradeLastProgress } from '../../redux/hooks';
 import { useAppUpgradeEventType } from '../useAppUpgradeEventType';
 import { useHasAppUpgradeError } from '../useHasAppUpgradeError';
 import { useHasAppUpgradeVerifiedInstallerPath } from '../useHasAppUpgradeVerifiedInstallerPath';
@@ -10,6 +11,7 @@ export const useAppUpgradeDownloadProgressValue = () => {
   const getValueError = useGetValueError();
   const hasAppUpgradeError = useHasAppUpgradeError();
   const hasAppUpgradeVerifiedInstallerPath = useHasAppUpgradeVerifiedInstallerPath();
+  const lastProgress = useAppUpgradeLastProgress();
 
   if (hasAppUpgradeError) {
     return getValueError();
@@ -29,6 +31,8 @@ export const useAppUpgradeDownloadProgressValue = () => {
     case 'APP_UPGRADE_STATUS_VERIFYING_INSTALLER':
       return DOWNLOAD_COMPLETE_VALUE;
     default:
-      return FALLBACK_VALUE;
+      break;
   }
+
+  return lastProgress ?? FALLBACK_VALUE;
 };

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/progress/Progress.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/progress/Progress.tsx
@@ -23,7 +23,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
     const percent = ((normalizedValue - min) / (max - min)) * 100;
     return (
       <ProgressProvider value={value} min={min} max={max} percent={percent} disabled={disabled}>
-        <Flex $flexDirection="column" $gap="small" ref={ref} {...props}>
+        <Flex $flexDirection="column" $gap="small" ref={ref} $flex={1} {...props}>
           {children}
         </Flex>
       </ProgressProvider>

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/actions.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/actions.ts
@@ -21,6 +21,11 @@ export type AppUpgradeActionSetError = {
   error: AppUpgradeError;
 };
 
+export type AppUpgradeActionSetLastProgress = {
+  type: 'APP_UPGRADE_SET_LAST_PROGRESS';
+  lastProgress: number;
+};
+
 export const setAppUpgradeError = (error: AppUpgradeError): AppUpgradeActionSetError => ({
   type: 'APP_UPGRADE_SET_ERROR',
   error,
@@ -36,15 +41,22 @@ export const setAppUpgradeEvent = (event: AppUpgradeEvent): AppUpgradeActionSetE
   event,
 });
 
+export const setLastProgress = (lastProgress: number): AppUpgradeActionSetLastProgress => ({
+  type: 'APP_UPGRADE_SET_LAST_PROGRESS',
+  lastProgress,
+});
+
 export const appUpgradeActions = {
   resetAppUpgrade,
   resetAppUpgradeError,
   setAppUpgradeError,
   setAppUpgradeEvent,
+  setLastProgress,
 };
 
 export type AppUpgradeAction =
   | AppUpgradeActionReset
   | AppUpgradeActionResetError
   | AppUpgradeActionSetError
-  | AppUpgradeActionSetEvent;
+  | AppUpgradeActionSetEvent
+  | AppUpgradeActionSetLastProgress;

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useAppUpgradeError';
 export * from './useAppUpgradeErrorCount';
 export * from './useAppUpgradeEvent';
+export * from './useAppUpgradeLastProgress';

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/useAppUpgradeLastProgress.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/hooks/useAppUpgradeLastProgress.ts
@@ -1,0 +1,5 @@
+import { useSelector } from '../../store';
+
+export const useAppUpgradeLastProgress = () => {
+  return useSelector((state) => state.appUpgrade.lastProgress);
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/reducers.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/app-upgrade/reducers.ts
@@ -5,12 +5,14 @@ export interface AppUpgradeReduxState {
   error?: AppUpgradeError;
   errorCount: number;
   event?: AppUpgradeEvent;
+  lastProgress?: number;
 }
 
 const initialState: AppUpgradeReduxState = {
   error: undefined,
   errorCount: 0,
   event: undefined,
+  lastProgress: undefined,
 };
 
 export function appUpgradeReducer(
@@ -22,6 +24,11 @@ export function appUpgradeReducer(
       return {
         ...state,
         event: action.event,
+      };
+    case 'APP_UPGRADE_SET_LAST_PROGRESS':
+      return {
+        ...state,
+        lastProgress: action.lastProgress,
       };
     case 'APP_UPGRADE_SET_ERROR':
       if (action.error === 'START_INSTALLER_AUTOMATIC_FAILED') {


### PR DESCRIPTION
- Makes progress bar visible most steps of app upgrade flow after initialization
- Animates label and progress bar separately to make animations stutter less
- Removes disable from app upgrade list item when connection is blocked

This also adds a state in app upgrades redux state which currently keeps track of the latest progress percentage number. This is used to prevent some cases where the progress could be set to 0 when toggling the connection on and off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8037)
<!-- Reviewable:end -->
