### PR TITLE
Fix printing product version in release script

### DIFF
--- a/desktop/scripts/release/5-update-and-publish-metadata
+++ b/desktop/scripts/release/5-update-and-publish-metadata
@@ -61,7 +61,7 @@ function publish_metadata {
     mullvad-release verify "${platforms[@]}"
     echo ""
 
-    echo ">>> New metadata including $$PRODUCT_VERSION"
+    echo ">>> New metadata including $PRODUCT_VERSION"
     git --no-pager diff --no-index -- currently_published/ $signed_dir || true
     echo ""
 


### PR DESCRIPTION
This PR fixes a typo that prevents the product version from being printed properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8045)
<!-- Reviewable:end -->
