### PR TITLE
Silence `GO-2025-3595` in libwg

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -64,3 +64,9 @@ reason = "wireguard-go does not use x/net/proxy nor x/net/http/httpproxy"
 id = "CVE-2025-22871" # GO-2025-3563
 ignoreUntil = 2025-07-08
 reason = "wireguard-go does not use net/http"
+
+# Incorrect Neutralization of Input During Web Page Generation in x/net
+[[IgnoredVulns]]
+id = "CVE-2025-22872" # GO-2025-3595
+ignoreUntil = 2025-07-17
+reason = "wireguard-go does not use x/net/html"


### PR DESCRIPTION
This PR silences [GO-2025-3595](https://osv.dev/vulnerability/GO-2025-3595) in `libwg/osv-scanner.toml`. Neither `libwg` nor `wireguard-go` uses the affected parse/tokenize functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8049)
<!-- Reviewable:end -->
