### PR TITLE
Fix issue with "No OpenVPN servers" warning being displayed erroneously

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
@@ -51,9 +51,9 @@ export default function NotificationArea(props: IProps) {
   const account = useSelector((state: IReduxState) => state.account);
   const locale = useSelector((state: IReduxState) => state.userInterface.locale);
   const tunnelState = useSelector((state: IReduxState) => state.connection.status);
+  const connection = useSelector((state: IReduxState) => state.connection);
   const version = useSelector((state: IReduxState) => state.version);
   const tunnelProtocol = useTunnelProtocol();
-  const reduxConnection = useSelector((state) => state.connection);
   const fullRelayList = useSelector((state) => state.settings.relayLocations);
 
   const blockWhenDisconnected = useSelector(
@@ -95,8 +95,8 @@ export default function NotificationArea(props: IProps) {
       hasExcludedApps,
     }),
     new NoOpenVpnServerAvailableNotificationProvider({
+      connection,
       tunnelProtocol,
-      tunnelState: reduxConnection.status,
       relayLocations: fullRelayList,
     }),
     new ErrorNotificationProvider({

--- a/desktop/packages/mullvad-vpn/src/shared/constants/urls.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/constants/urls.ts
@@ -5,7 +5,7 @@ export const urls = {
   faq: 'https://mullvad.net/help/tag/mullvad-app/',
   privacyGuide: 'https://mullvad.net/help/first-steps-towards-online-privacy/',
   download: 'https://mullvad.net/download/vpn/',
-  removingOpenVpnBlog: 'https://mullvad.net/en/blog/removing-openvpn-15th-january-2026',
+  removingOpenVpnBlog: 'https://mullvad.net/blog/removing-openvpn-15th-january-2026',
 } as const;
 
 type BaseUrl = (typeof urls)[keyof typeof urls];


### PR DESCRIPTION
Ensure OpenVPN ending notification only displays for associated relays. The notification should only be displayed if the user has selected a bridge or openvpn relay.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8052)
<!-- Reviewable:end -->
