### PR TITLE
Refactor location state options to use objects

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/ProblemReport.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/ProblemReport.tsx
@@ -326,8 +326,8 @@ function OutdatedVersionWarningDialog() {
 
   const { location } = useHistory();
   const { state } = location;
-  const hasSuppressOutdatedVersionWarning = state?.options?.includes(
-    'suppress-outdated-version-warning',
+  const hasSuppressOutdatedVersionWarning = state?.options?.some(
+    (option) => option.type === 'suppress-outdated-version-warning',
   );
   const showOutdatedVersionWarningInitial = outdatedVersion && !hasSuppressOutdatedVersionWarning;
 

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/ReportProblemButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/ReportProblemButton.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../../../../lib/components';
 export function ReportProblemButton() {
   const pushProblemReport = usePushProblemReport({
     state: {
-      options: ['suppress-outdated-version-warning'],
+      options: [{ type: 'suppress-outdated-version-warning' }],
     },
   });
 

--- a/desktop/packages/mullvad-vpn/src/shared/ipc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/ipc-types.ts
@@ -13,13 +13,19 @@ export interface IWindowShapeParameters {
   arrowPosition?: number;
 }
 
+export type SuppressOutdatedVersionOption = {
+  type: 'suppress-outdated-version-warning';
+};
+
+export type LocationStateOptions = SuppressOutdatedVersionOption;
+
 export type IChangelog = Array<string>;
 
 export interface LocationState {
   scrollPosition: [number, number];
   expandedSections: Record<string, boolean>;
   transition: ITransitionSpecification;
-  options?: Array<string>;
+  options?: LocationStateOptions[];
 }
 
 export interface IHistoryObject {


### PR DESCRIPTION
Refactor location state to use objects instead of a string array.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8058)
<!-- Reviewable:end -->
