### PR TITLE
Pre-populate Problem report form with upgrade error in description

### DIFF
--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -672,6 +672,12 @@ msgctxt "app-upgrade-view"
 msgid "About %(seconds)s seconds remaining..."
 msgstr ""
 
+#. Instruction to the user shown pre-filled in a form where the user
+#. is asked to add more details about a failed upgrade.
+msgctxt "app-upgrade-view"
+msgid "Add more details here:"
+msgstr ""
+
 #. Label displayed when an unknown error occurred
 msgctxt "app-upgrade-view"
 msgid "An unknown error occurred. Please try again. If this problem persists, please contact support."
@@ -768,6 +774,38 @@ msgstr ""
 #. Main title for the update available view
 msgctxt "app-upgrade-view"
 msgid "Update available"
+msgstr ""
+
+#. Description of an error which occurred in the app's upgrade process
+#. when an unknown error occurred.
+#. The description is included in form field of a form
+#. a user can submit to report the error.
+msgctxt "app-upgrade-view"
+msgid "Update downloader: An unknown error occurred."
+msgstr ""
+
+#. Description of an error which occurred in the app's upgrade process.
+#. when the download of the upgrade failed.
+#. The description is included in form field of a form
+#. a user can submit to report the error.
+msgctxt "app-upgrade-view"
+msgid "Update downloader: Download failed."
+msgstr ""
+
+#. Description of an error which occurred in the app's upgrade process
+#. when the downloaded installer failed to start.
+#. The description is included in form field of a form
+#. a user can submit to report the error.
+msgctxt "app-upgrade-view"
+msgid "Update downloader: The installer failed to start due to an unknown error."
+msgstr ""
+
+#. Description of an error which occurred in the app's upgrade process
+#. when the downloaded installer failed to install the upgrade successfully.
+#. The description is included in form field of a form
+#. a user can submit to report the error.
+msgctxt "app-upgrade-view"
+msgid "Update downloader: The installer failed with an unknown error."
 msgstr ""
 
 #. Label displayed when an error occurred due to the installer failed verification

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/ReportProblemButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/ReportProblemButton.tsx
@@ -1,16 +1,12 @@
 import { messages } from '../../../../../../shared/gettext';
-import { usePushProblemReport } from '../../../../../history/hooks';
 import { Button } from '../../../../../lib/components';
+import { useHandleClick } from './hooks';
 
 export function ReportProblemButton() {
-  const pushProblemReport = usePushProblemReport({
-    state: {
-      options: [{ type: 'suppress-outdated-version-warning' }],
-    },
-  });
+  const handleClick = useHandleClick();
 
   return (
-    <Button onClick={pushProblemReport}>
+    <Button onClick={handleClick}>
       <Button.Text>
         {
           // TRANSLATORS: Button text to report a problem

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/index.ts
@@ -1,0 +1,4 @@
+export * from './useErrorMessage';
+export * from './useHandleClick';
+export * from './useMessage';
+export * from './usePrePopulateProblemReportForm';

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/useErrorMessage.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/useErrorMessage.ts
@@ -1,0 +1,47 @@
+import { messages } from '../../../../../../../shared/gettext';
+import { useAppUpgradeError } from '../../../../../../redux/hooks';
+
+export const useErrorMessage = () => {
+  const { error } = useAppUpgradeError();
+
+  switch (error) {
+    case 'DOWNLOAD_FAILED':
+      // TRANSLATORS: Description of an error which occurred in the app's upgrade process.
+      // TRANSLATORS: when the download of the upgrade failed.
+      // TRANSLATORS: The description is included in form field of a form
+      // TRANSLATORS: a user can submit to report the error.
+      return messages.pgettext('app-upgrade-view', 'Update downloader: Download failed.');
+    case 'GENERAL_ERROR':
+      // TRANSLATORS: Description of an error which occurred in the app's upgrade process
+      // TRANSLATORS: when an unknown error occurred.
+      // TRANSLATORS: The description is included in form field of a form
+      // TRANSLATORS: a user can submit to report the error.
+      return messages.pgettext('app-upgrade-view', 'Update downloader: An unknown error occurred.');
+    case 'INSTALLER_FAILED':
+      // TRANSLATORS: Description of an error which occurred in the app's upgrade process
+      // TRANSLATORS: when the downloaded installer failed to install the upgrade successfully.
+      // TRANSLATORS: The description is included in form field of a form
+      // TRANSLATORS: a user can submit to report the error.
+      return messages.pgettext(
+        'app-upgrade-view',
+        'Update downloader: The installer failed with an unknown error.',
+      );
+    case 'START_INSTALLER_FAILED':
+      // TRANSLATORS: Description of an error which occurred in the app's upgrade process
+      // TRANSLATORS: when the downloaded installer failed to start.
+      // TRANSLATORS: The description is included in form field of a form
+      // TRANSLATORS: a user can submit to report the error.
+      return messages.pgettext(
+        'app-upgrade-view',
+        'Update downloader: The installer failed to start due to an unknown error.',
+      );
+    case 'VERIFICATION_FAILED':
+      // TRANSLATORS: Description of an error which occurred in the app's upgrade process
+      // TRANSLATORS: when the downloaded installer failed to verify its signature.
+      // TRANSLATORS: The description is included in form field of a form
+      // TRANSLATORS: a user can submit to report the error.
+      return 'Update downloader: The installer failed verification.';
+    default:
+      return null;
+  }
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/useHandleClick.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/useHandleClick.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+import { usePushProblemReport } from '../../../../../../history/hooks';
+import { usePrePopulateProblemReportForm } from './usePrePopulateProblemReportForm';
+
+export const useHandleClick = () => {
+  const prePopulateProblemReportForm = usePrePopulateProblemReportForm();
+  const pushProblemReport = usePushProblemReport({
+    state: {
+      options: [{ type: 'suppress-outdated-version-warning' }],
+    },
+  });
+
+  const handleClick = useCallback(() => {
+    prePopulateProblemReportForm();
+    pushProblemReport();
+  }, [prePopulateProblemReportForm, pushProblemReport]);
+
+  return handleClick;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/useMessage.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/useMessage.ts
@@ -1,0 +1,21 @@
+import { messages } from '../../../../../../../shared/gettext';
+import { useErrorMessage } from './useErrorMessage';
+
+// TRANSLATORS: Instruction to the user shown pre-filled in a form where the user
+// TRANSLATORS: is asked to add more details about a failed upgrade.
+const POST_ERROR_MESSAGE_USER_INSTRUCTIONS = messages.pgettext(
+  'app-upgrade-view',
+  'Add more details here:',
+);
+
+export const useMessage = () => {
+  const errorMessage = useErrorMessage();
+
+  if (errorMessage) {
+    const message = `${errorMessage}\n\n${POST_ERROR_MESSAGE_USER_INSTRUCTIONS}\n\n`;
+
+    return message;
+  }
+
+  return null;
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/usePrePopulateProblemReportForm.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/report-problem-button/hooks/usePrePopulateProblemReportForm.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+
+import useActions from '../../../../../../lib/actionsHook';
+import supportActions from '../../../../../../redux/support/actions';
+import { useMessage } from './useMessage';
+
+export const usePrePopulateProblemReportForm = () => {
+  const { saveReportForm } = useActions(supportActions);
+  const message = useMessage();
+
+  const prePopulateProblemReportForm = useCallback(() => {
+    if (message) {
+      saveReportForm({
+        email: '',
+        message,
+      });
+    }
+  }, [message, saveReportForm]);
+
+  return prePopulateProblemReportForm;
+};


### PR DESCRIPTION
Pre-populate the Report problem form with a message related to the kind of error encountered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8063)
<!-- Reviewable:end -->
