### PR TITLE
Clean up downloads from in-app upgrades

### DIFF
--- a/mullvad-daemon/src/version/downloader.rs
+++ b/mullvad-daemon/src/version/downloader.rs
@@ -17,6 +17,9 @@ pub enum Error {
     #[error("Failed to create download directory")]
     CreateDownloadDir(#[source] std::io::Error),
 
+    #[error("Failed to clean up download directory")]
+    RemoveDownloadDir(#[source] std::io::Error),
+
     #[error("Failed to download app")]
     Download(#[from] DownloadError),
 
@@ -144,6 +147,16 @@ async fn create_download_dir() -> Result<PathBuf> {
     let download_dir = mullvad_paths::cache_dir()?.join("mullvad-update");
     log::trace!("Download directory: {download_dir:?}");
     fs::create_dir_all(&download_dir)
+        .await
+        .map_err(Error::CreateDownloadDir)?;
+    Ok(download_dir)
+}
+
+/// Remove the download directory
+pub async fn clear_download_dir() -> Result<PathBuf> {
+    let download_dir = mullvad_paths::get_cache_dir()?.join("mullvad-update");
+    log::info!("Cleaning up download directory: {}", download_dir.display());
+    fs::remove_dir_all(&download_dir)
         .await
         .map_err(Error::CreateDownloadDir)?;
     Ok(download_dir)


### PR DESCRIPTION
This simply wipes the directory every time the daemon starts.

Fix DES-1981

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8069)
<!-- Reviewable:end -->
