### PR TITLE
Add --wait flag to desktop release scripts

### DIFF
--- a/desktop/scripts/release/2-create-and-push-tag
+++ b/desktop/scripts/release/2-create-and-push-tag
@@ -10,9 +10,24 @@ cd "$SCRIPT_DIR"
 REPO_ROOT=../../../
 PRODUCT_VERSION_PATH=$REPO_ROOT/dist-assets/desktop-product-version.txt
 PRODUCT_VERSION=$(cat $PRODUCT_VERSION_PATH)
+BASE_URL="https://releases.mullvad.net/desktop/releases/$PRODUCT_VERSION"
 
 source $REPO_ROOT/scripts/utils/print-and-run
 source $REPO_ROOT/scripts/utils/log
+
+WAIT="false"
+
+for argument in "$@"; do
+    case "$argument" in
+        --wait)
+          WAIT="true"
+          ;;
+        *)
+            log_error "Unknown option \"$argument\""
+            exit 1
+            ;;
+    esac
+done
 
 function push_tag {
     product_version=$(echo -n "$PRODUCT_VERSION")
@@ -23,7 +38,26 @@ function push_tag {
     log_success "\nTag pushed!"
 }
 
+function wait_for_build {
+  log_header "Checking availability of release artifacts"
+  for ext in .exe _arm64.exe _x64.exe _amd64.deb _arm64.deb _x86_64.rpm _aarch64.rpm .pkg; do
+    pkg_filename="MullvadVPN-${PRODUCT_VERSION}${ext}"
+    url="$BASE_URL/$pkg_filename"
+
+    log_info "Waiting for $ext"
+    while ! curl --head --fail --silent "$url" > /dev/null; do
+      sleep 30s
+    done
+  done
+
+  log_success "\nAll artifacts are now available"
+}
+
 git verify-commit HEAD
 push_tag
 
-log_success "Follow build progress here: https://releases.mullvad.net/desktop/releases/$PRODUCT_VERSION"
+log_success "Follow build progress here: $BASE_URL"
+
+if [[ "$WAIT" == "true" ]]; then
+  wait_for_build
+fi

--- a/desktop/scripts/release/3-verify-build
+++ b/desktop/scripts/release/3-verify-build
@@ -16,6 +16,20 @@ PRODUCT_VERSION=$(cat $PRODUCT_VERSION_PATH)
 $REPO_ROOT/scripts/utils/gh-ready-check
 source $REPO_ROOT/scripts/utils/log
 
+WAIT="false"
+
+for argument in "$@"; do
+    case "$argument" in
+        --wait)
+          WAIT="true"
+          ;;
+        *)
+            log_error "Unknown option \"$argument\""
+            exit 1
+            ;;
+    esac
+done
+
 function verify_repository_versions {
   print_versions_args=( --staging )
 
@@ -42,7 +56,34 @@ function verify_repository_versions {
   fi
 }
 
+function wait_for_workflow_result {
+  log_header "Waiting workflow result..."
+  sleep 30 # Sleep to allow the workflow run to start
+
+  while true; do
+    run=$(gh run list --workflow desktop-e2e.yml --branch "$PRODUCT_VERSION" --limit 1 --json conclusion,status,updatedAt,url | jq --exit-status '.[0]')
+
+    status=$(echo "$run" | jq --exit-status --raw-output '.status')
+    echo "Status: $status"
+    if [[ "$status" != "in_progress" ]] && [[ "$status" != "queued" ]]; then
+      if echo "$run" | jq --exit-status '.conclusion == "success"' > /dev/null; then
+        log_success "Workflow run successfull"
+        break
+      else
+        log_error "Workflow failed"
+        exit 1
+      fi
+    fi
+
+    sleep 60
+  done
+}
+
 verify_repository_versions
 gh workflow run desktop-e2e.yml --ref "$PRODUCT_VERSION" \
     -f oses="fedora41 ubuntu2404 windows11 macos15" \
     -f tests="test_quantum_resistant_tunnel test_ui_tunnel_settings"
+
+if [[ "$WAIT" == "true" ]]; then
+  wait_for_workflow_result
+fi


### PR DESCRIPTION
This PR adds a `--wait` flag to  release script 2 and 3, that waits until the process has completed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8070)
<!-- Reviewable:end -->
