### PR TITLE
Add another forgotten conditional compilation check

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationViewControllerWrapper.swift
@@ -320,12 +320,12 @@ extension LocationViewControllerWrapper: @preconcurrency LocationViewControllerD
 }
 
 private extension WireGuardObfuscationState {
+    /// This flag affects whether the "Setting: Obfuscation" pill is shown when selecting a location
     var affectsRelaySelection: Bool {
         switch self {
         case .shadowsocks:
             true
-        case .on, .off, .automatic, .udpOverTcp, .quic:
-            false
+        default: false
         }
     }
 }


### PR DESCRIPTION
This PR adds another conditional compilation check that was forgotten and killed release builds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8082)
<!-- Reviewable:end -->
