### PR TITLE
Support windows, linux and macos in setup-rust

### DIFF
--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -9,9 +9,9 @@ on your platform please submit an issue or a pull request.
 ## All platforms
 
 - Get the latest **stable** Rust toolchain via [rustup.rs](https://rustup.rs/).
-  - Install default targets and components needed for desktop
+  - Install default targets and components needed for your platform:
     ```bash
-    ./scripts/setup-rust desktop
+    ./scripts/setup-rust android|ios|windows|linux|macos
      ```
   - (Optional) Run the following to install a git `post-checkout` hook that will automatically
     run the `setup-rust` script when the Rust version specified in the `rust-toolchain.toml` file changes:

--- a/scripts/setup-rust
+++ b/scripts/setup-rust
@@ -13,11 +13,17 @@ source scripts/utils/log
 ANDROID_TARGETS="x86_64-linux-android i686-linux-android aarch64-linux-android armv7-linux-androideabi"
 ANDROID_COMPONENTS="rust-analyzer"
 
-DESKTOP_TARGETS="x86_64-pc-windows-msvc x86_64-pc-windows-gnu i686-pc-windows-msvc"
-DESKTOP_COMPONENTS="rust-analyzer"
-
 IOS_TARGETS="aarch64-apple-ios-sim aarch64-apple-ios x86_64-apple-ios"
 IOS_COMPONENTS="rust-analyzer"
+
+WINDOWS_TARGETS="x86_64-pc-windows-msvc x86_64-pc-windows-gnu i686-pc-windows-msvc"
+WINDOWS_COMPONENTS="rust-analyzer"
+
+LINUX_TARGETS="aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu"
+LINUX_COMPONENTS="rust-analyzer"
+
+MACOS_TARGETS="aarch64-apple-darwin x86_64-apple-darwin"
+MACOS_COMPONENTS="rust-analyzer"
 
 function main {
     if [[ $# -eq 0 ]]; then
@@ -26,14 +32,23 @@ function main {
     fi
 
     case "$1" in
+    # A previous version of this script didn't have individual options for the desktop platforms but
+    # had only a single `desktop` option which we keep here for backwards compatibility.
+    # Should be removed at a later point.
+    "windows" | "desktop")
+        setup "Windows" "$WINDOWS_TARGETS" "$WINDOWS_COMPONENTS"
+        ;;
+    "linux")
+        setup "Linux" "$LINUX_TARGETS" "$LINUX_COMPONENTS"
+        ;;
+    "macos")
+        setup "macOS" "$MACOS_TARGETS" "$MACOS_COMPONENTS"
+        ;;
     "android")
         setup "Android" "$ANDROID_TARGETS" "$ANDROID_COMPONENTS"
         ;;
-    "desktop")
-        setup "Desktop" "$DESKTOP_TARGETS" "$DESKTOP_COMPONENTS"
-        ;;
     "ios")
-        setup "Android" "$IOS_TARGETS" "$IOS_COMPONENTS"
+        setup "iOS" "$IOS_TARGETS" "$IOS_COMPONENTS"
         ;;
     "install-hook")
         install_hook
@@ -53,10 +68,12 @@ function main {
 function print_usage {
     log "Setup default Rust targets and components for different platforms"
     log ""
-    log "Usage: setup-rust android|desktop|ios|install-hook"
+    log "Usage: setup-rust android|ios|windows|linux|macos|install-hook"
     log "  android                    Run Android-specific setup"
-    log "  desktop                    Run Desktop-specific setup"
     log "  ios                        Run iOS-specific setup"
+    log "  windows                    Run Windows-specific setup"
+    log "  linux                      Run Linux-specific setup"
+    log "  macos                      Run macOS-specific setup"
     log "  install-hook               Copies the setup-rust-post-checkout file to .git/hooks/post-checkout"
 }
 
@@ -83,8 +100,8 @@ function install_hook {
     else
         cp "$SCRIPT_DIR/setup-rust-post-checkout" "$hook"
         chmod +x "$hook"
-        log "Hook installed. You must now set the environment variable MULLVAD_SETUP_PLATFORM to "
-        log "\`android\`, \`desktop\` or \`ios\` in your shell environment."
+        log "Hook installed. You must now set the environment variable MULLVAD_SETUP_PLATFORM to one of the following:"
+        log "\`android\`, \`ios\`, \`windows\`, \`linux\`, \`macos\`"
     fi
 }
 

--- a/scripts/setup-rust-post-checkout
+++ b/scripts/setup-rust-post-checkout
@@ -5,7 +5,6 @@
 
 set -u
 
-# Set to "android", "desktop", or "ios".
 MULLVAD_SETUP_PLATFORM="${MULLVAD_SETUP_PLATFORM:-}"
 
 SETUP_RUST_SCRIPT="scripts/setup-rust"
@@ -15,8 +14,8 @@ if [[ ! -f "$SETUP_RUST_SCRIPT" ]]; then
 fi
 
 if [[ -z ${MULLVAD_SETUP_PLATFORM+x} ]]; then
-    echo "MULLVAD_SETUP_PLATFORM is not set, must be set to " >&2
-    echo "\`android\`, \`desktop\` or \`ios\`" >&2
+    echo "MULLVAD_SETUP_PLATFORM is not set, must be set to one of the following: " >&2
+    echo "\`android\`, \`ios\`, \`windows\`, \`linux\`, \`macos\`" >&2
     exit 1
 fi
 


### PR DESCRIPTION
This PR aims to properly support all desktop platforms in the `setup-rust` helper script and hook.

Targets to try installing before we merge:
* [x] Linux
* [x] macOS
* [x] Windows

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8088)
<!-- Reviewable:end -->
