### PR TITLE
Replace @_silgen_name with _cdecl

### DIFF
--- a/ios/MullvadRustRuntime/EphemeralPeerReceiver.swift
+++ b/ios/MullvadRustRuntime/EphemeralPeerReceiver.swift
@@ -25,12 +25,12 @@ import WireGuardKitTypes
 ///   - rawPresharedKey: A raw pointer to the quantum-secure pre shared key
 ///   - rawEphemeralKey: A raw pointer to the ephemeral private key of the device
 ///   - rawDaitaParameters: A raw pointer to negotiated DAITA parameters
-@_silgen_name("swift_ephemeral_peer_ready")
+@_cdecl("swift_ephemeral_peer_ready")
 func receivePostQuantumKey(
     rawEphemeralPeerReceiver: UnsafeMutableRawPointer?,
     rawPresharedKey: UnsafeMutableRawPointer?,
     rawEphemeralKey: UnsafeMutableRawPointer?,
-    rawDaitaParameters: UnsafePointer<DaitaV2Parameters>?
+    rawDaitaParameters: UnsafeRawPointer?
 ) {
     guard let rawEphemeralPeerReceiver else { return }
     let ephemeralPeerReceiver = Unmanaged<EphemeralPeerReceiver>.fromOpaque(rawEphemeralPeerReceiver)

--- a/ios/MullvadRustRuntime/MullvadApiCompletion.swift
+++ b/ios/MullvadRustRuntime/MullvadApiCompletion.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-@_silgen_name("mullvad_api_completion_finish")
+@_cdecl("mullvad_api_completion_finish")
 func mullvadApiCompletionFinish(
     response: SwiftMullvadApiResponse,
     completionCookie: UnsafeMutableRawPointer


### PR DESCRIPTION
Now demangled symbols exported to non-Swift code will use the C calling convention, rather than still using the Swift one. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8090)
<!-- Reviewable:end -->
