### PR TITLE
Update vite to 6.2.7

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -10142,9 +10142,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.7.tgz",
+      "integrity": "sha512-qg3LkeuinTrZoJHHF94coSaTfIPyBYoywp+ys4qu20oSJFbKMYoIJo0FWJT9q6Vp49l6z9IsJRbHdcGtiKbGoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10863,7 +10863,7 @@
         "playwright": "^1.41.1",
         "postject": "^1.0.0-alpha.6",
         "sinon": "^14.0.1",
-        "vite": "6.2.6",
+        "vite": "6.2.7",
         "vite-plugin-electron": "^0.29.0",
         "xvfb-maybe": "^0.2.1"
       },
@@ -16535,7 +16535,7 @@
         "sinon": "^14.0.1",
         "sprintf-js": "^1.1.2",
         "styled-components": "^6.1.13",
-        "vite": "6.2.6",
+        "vite": "6.2.7",
         "vite-plugin-electron": "^0.29.0",
         "windows-utils": "0.0.0",
         "xvfb-maybe": "^0.2.1"
@@ -18249,9 +18249,9 @@
       }
     },
     "vite": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.7.tgz",
+      "integrity": "sha512-qg3LkeuinTrZoJHHF94coSaTfIPyBYoywp+ys4qu20oSJFbKMYoIJo0FWJT9q6Vp49l6z9IsJRbHdcGtiKbGoQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -33,7 +33,7 @@
     "typescript-eslint": "^8.15.0"
   },
   "overrides": {
-    "vite": "6.2.6"
+    "vite": "6.2.7"
   },
   "engines": {
     "node": ">=16",

--- a/desktop/packages/mullvad-vpn/package.json
+++ b/desktop/packages/mullvad-vpn/package.json
@@ -63,7 +63,7 @@
     "playwright": "^1.41.1",
     "postject": "^1.0.0-alpha.6",
     "sinon": "^14.0.1",
-    "vite": "6.2.6",
+    "vite": "6.2.7",
     "vite-plugin-electron": "^0.29.0",
     "xvfb-maybe": "^0.2.1"
   },


### PR DESCRIPTION
This fixes `CVE-2025-46565`: https://osv.dev/vulnerability/GHSA-859w-5945-r5v3

Note: This only seems to potentially affect the development server only, so it doesn't have any implications for end users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8105)
<!-- Reviewable:end -->
