### PR TITLE
Add CI permission check

### DIFF
--- a/.github/workflows/android-reproducible-builds.yml
+++ b/.github/workflows/android-reproducible-builds.yml
@@ -142,3 +142,31 @@ jobs:
 
       - name: Compare files
         run: diff container/app-oss-prod-fdroid-unsigned.apk fdroidserver/app-oss-prod-fdroid-unsigned.apk
+
+  # Included in this workflow since it's the only place
+  # release artifacts are built. Should eventually be moved.
+  check-permissions:
+    name: Check APK permissions
+    runs-on: ubuntu-latest
+    needs: [set-up-env, build-fdroid-app]
+    steps:
+      - name: Install apktool
+        run: sudo apt-get install -y apktool
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.set-up-env.outputs.COMMIT_HASH }}
+
+      - name: Download container apk
+        uses: actions/download-artifact@v4
+        with:
+          name: container-app
+
+      - name: Extract resources
+        run: |
+          apktool d app-oss-prod-fdroid-unsigned.apk -s -o output
+
+      - name: Compare manifest permissions with checked in snapshot
+        run: |
+          diff android/snapshot/manifest-permissions-oss.txt <(cat output/AndroidManifest.xml | grep uses-permission)

--- a/android/snapshot/manifest-permissions-oss.txt
+++ b/android/snapshot/manifest-permissions-oss.txt
@@ -1,0 +1,8 @@
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="net.mullvad.mullvadvpn.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"/>


### PR DESCRIPTION
This PR aims to add a CI job to catch unwanted manifest permissions changes introduced by dependencies. It does this by extracting built release artifacts.
    
It was added to the reproducible/F-Droid workflow since that's the only place where we build release artifacts at the time of adding this job. However, it should be moved to a more suitable place once we expand and refactor our CI setup.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8111)
<!-- Reviewable:end -->
