### PR TITLE
Add forwarding of command line args in vite

### DIFF
--- a/desktop/packages/mullvad-vpn/vite.config.ts
+++ b/desktop/packages/mullvad-vpn/vite.config.ts
@@ -65,7 +65,7 @@ const viteConfig = defineConfig({
           // had not been enabled again. However, after the default --no-sandbox
           // was omitted we can open the devtools regardless of whether the
           // sandbox is enabled or not.
-          await startup(['.']);
+          await startup(['.', ...process.argv.slice(3)]);
         },
         vite: {
           // We define process.env.NODE_ENV here in order for vite to statically


### PR DESCRIPTION
This PR adds forwarding of command line arguments to the vite config to enable passing command line arguments to the Electron app when running `npm run develop`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8113)
<!-- Reviewable:end -->
