### PR TITLE
In app upgrades fix connection blocked button

### DIFF
--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -679,7 +679,7 @@ msgstr ""
 
 #. Label displayed when an error occurred due to the connection being blocked
 msgctxt "app-upgrade-view"
-msgid "Connection blocked. Try changing server or other settings"
+msgid "Connection blocked. Try changing server or other settings."
 msgstr ""
 
 #. Label displayed when an error occurred due to the installer failing to start

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/connection-blocked-label/ConnectionBlockedLabel.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/connection-blocked-label/ConnectionBlockedLabel.tsx
@@ -11,7 +11,7 @@ export function ConnectionBlockedLabel() {
           // TRANSLATORS: Label displayed when an error occurred due to the connection being blocked
           messages.pgettext(
             'app-upgrade-view',
-            'Connection blocked. Try changing server or other settings',
+            'Connection blocked. Try changing server or other settings.',
           )
         }
       </LabelTiny>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/footer/components/initial-footer/components/connection-blocked/ConnectionBlocked.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/footer/components/initial-footer/components/connection-blocked/ConnectionBlocked.tsx
@@ -1,23 +1,21 @@
 import { messages } from '../../../../../../../../../../shared/gettext';
 import { Flex } from '../../../../../../../../../lib/components';
 import { ConnectionBlockedLabel } from '../../../../../connection-blocked-label';
-import { DownloadProgress } from '../../../../../download-progress';
-import { LaunchInstallerButton } from '../../../../../launch-installer-button';
+import { UpgradeButton } from '../../../../../upgrade-button';
 
 export function ConnectionBlocked() {
   return (
     <Flex $padding="large" $flexDirection="column">
       <Flex $gap="medium" $flexDirection="column" $margin={{ bottom: 'medium' }}>
         <ConnectionBlockedLabel />
-        <DownloadProgress />
       </Flex>
       <Flex $flexDirection="column">
-        <LaunchInstallerButton disabled>
+        <UpgradeButton disabled>
           {
-            // TRANSLATORS: Button text to install an update
-            messages.pgettext('app-upgrade-view', 'Install update')
+            // TRANSLATORS: Button text to download and install an update
+            messages.pgettext('app-upgrade-view', 'Download & install')
           }
-        </LaunchInstallerButton>
+        </UpgradeButton>
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
- Fix wrong button used in the initial footer when the connection is blocked.
- Add a period at the end of a sentence, for conformity as other sentences are marked with a period at the end.
