### PR TITLE
Bump installer downloader to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "installer-downloader"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/installer-downloader/CHANGELOG.md
+++ b/installer-downloader/CHANGELOG.md
@@ -20,12 +20,16 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+
+## [0.3.0] - 2025-05-06
 ### Added
 #### Windows
 - Add window icon.
 
 ### Changed
 - Changed title to "Mullvad VPN loader".
+
 
 ## [0.2.0] - 2025-04-08
 - Initial support for downloading and installing the latest version of the Mullvad VPN app on

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "installer-downloader"
 description = "A secure minimal web installer for the Mullvad app"
-version = "0.2.0"
+version = "0.3.0"
 publish = false
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
This PR bumps installer downloader to 0.3.0 and updates the changelog with the release section.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8127)
<!-- Reviewable:end -->
