### PR TITLE
Add e2e tests for language selection

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/user-interface-settings/user-interface-settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/user-interface-settings/user-interface-settings.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import { Page } from 'playwright';
+
+import { RoutesObjectModel } from '../../route-object-models';
+import { MockedTestUtils, startMockedApp } from '../mocked-utils';
+
+let page: Page;
+let util: MockedTestUtils;
+let routes: RoutesObjectModel;
+
+test.describe('User interface settings', () => {
+  const startup = async () => {
+    ({ page, util } = await startMockedApp());
+    routes = new RoutesObjectModel(page, util);
+
+    await routes.main.waitForRoute();
+
+    await routes.main.gotoSettings();
+    await routes.settings.gotoUserInterfaceSettings();
+  };
+
+  test.beforeAll(async () => {
+    await startup();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test.describe('Select language', () => {
+    ['Svenska', 'Deutsch', 'English', 'System default'].forEach((language) => {
+      test(`Should change language to ${language}`, async () => {
+        await routes.userInterfaceSettings.gotoSelectLanguage();
+        await routes.selectLanguage.selectLanguage(language);
+
+        await routes.userInterfaceSettings.waitForRoute();
+
+        await expect(
+          routes.userInterfaceSettings.getLocalizedLanguageButton(language),
+        ).toBeVisible();
+      });
+    });
+  });
+});

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/index.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/index.ts
@@ -1,0 +1,1 @@
+export * from './routes-object-model';

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/index.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/index.ts
@@ -1,0 +1,2 @@
+export * from './main-route-object-model';
+export * from './selectors';

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/main-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/main-route-object-model.ts
@@ -1,0 +1,26 @@
+import { Page } from 'playwright';
+
+import { RoutePath } from '../../../../src/renderer/lib/routes';
+import { MockedTestUtils } from '../../mocked/mocked-utils';
+import { createSelectors } from './selectors';
+
+export class MainRouteObjectModel {
+  readonly page: Page;
+  readonly utils: MockedTestUtils;
+  readonly selectors: ReturnType<typeof createSelectors>;
+
+  constructor(page: Page, util: MockedTestUtils) {
+    this.page = page;
+    this.utils = util;
+    this.selectors = createSelectors(page);
+  }
+
+  async waitForRoute() {
+    await this.utils.waitForRoute(RoutePath.main);
+  }
+
+  async gotoSettings() {
+    await this.selectors.settingsButton().click();
+    await this.utils.waitForRoute(RoutePath.settings);
+  }
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/selectors.ts
@@ -1,0 +1,5 @@
+import { Page } from 'playwright';
+
+export const createSelectors = (page: Page) => ({
+  settingsButton: () => page.locator('button[aria-label="Settings"]'),
+});

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/routes-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/routes-object-model.ts
@@ -1,0 +1,21 @@
+import { Page } from 'playwright';
+
+import { MockedTestUtils } from '../mocked/mocked-utils';
+import { MainRouteObjectModel } from './main';
+import { SelectLanguageRouteObjectModel } from './select-language';
+import { SettingsRouteObjectModel } from './settings/settings-route-object-model';
+import { UserInterfaceSettingsRouteObjectModel } from './user-interface-settings';
+
+export class RoutesObjectModel {
+  readonly main: MainRouteObjectModel;
+  readonly settings: SettingsRouteObjectModel;
+  readonly userInterfaceSettings: UserInterfaceSettingsRouteObjectModel;
+  readonly selectLanguage: SelectLanguageRouteObjectModel;
+
+  constructor(page: Page, utils: MockedTestUtils) {
+    this.selectLanguage = new SelectLanguageRouteObjectModel(page, utils);
+    this.main = new MainRouteObjectModel(page, utils);
+    this.settings = new SettingsRouteObjectModel(page, utils);
+    this.userInterfaceSettings = new UserInterfaceSettingsRouteObjectModel(page, utils);
+  }
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-language/index.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-language/index.ts
@@ -1,0 +1,2 @@
+export * from './select-language-route-object-model';
+export * from './selectors';

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-language/select-language-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-language/select-language-route-object-model.ts
@@ -1,0 +1,20 @@
+import { Page } from 'playwright';
+
+import { MockedTestUtils } from '../../mocked/mocked-utils';
+import { createSelectors } from './selectors';
+
+export class SelectLanguageRouteObjectModel {
+  readonly page: Page;
+  readonly utils: MockedTestUtils;
+  readonly selectors: ReturnType<typeof createSelectors>;
+
+  constructor(page: Page, util: MockedTestUtils) {
+    this.page = page;
+    this.utils = util;
+    this.selectors = createSelectors(page);
+  }
+
+  async selectLanguage(language: string) {
+    await this.selectors.languageOption(language).click();
+  }
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-language/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-language/selectors.ts
@@ -1,0 +1,8 @@
+import { Page } from 'playwright';
+
+export const createSelectors = (page: Page) => ({
+  languageOption: (language: string) =>
+    page.locator('button', {
+      has: page.locator('div', { hasText: language }),
+    }),
+});

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/index.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/index.ts
@@ -1,0 +1,2 @@
+export * from './settings-route-object-model';
+export * from './selectors';

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/selectors.ts
@@ -1,0 +1,5 @@
+import { Page } from 'playwright';
+
+export const createSelectors = (page: Page) => ({
+  userInterfaceButton: () => page.getByRole('button', { name: 'User interface settings' }),
+});

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/settings-route-object-model.ts
@@ -1,0 +1,22 @@
+import { Page } from 'playwright';
+
+import { RoutePath } from '../../../../src/renderer/lib/routes';
+import { MockedTestUtils } from '../../mocked/mocked-utils';
+import { createSelectors } from './selectors';
+
+export class SettingsRouteObjectModel {
+  readonly page: Page;
+  readonly utils: MockedTestUtils;
+  readonly selectors: ReturnType<typeof createSelectors>;
+
+  constructor(page: Page, utils: MockedTestUtils) {
+    this.page = page;
+    this.utils = utils;
+    this.selectors = createSelectors(page);
+  }
+
+  async gotoUserInterfaceSettings() {
+    await this.selectors.userInterfaceButton().click();
+    await this.utils.waitForRoute(RoutePath.userInterfaceSettings);
+  }
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/index.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/index.ts
@@ -1,0 +1,2 @@
+export * from './user-interface-settings-route-object-model';
+export * from './selectors';

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/selectors.ts
@@ -1,0 +1,12 @@
+import { Page } from 'playwright';
+
+export const createSelectors = (page: Page) => ({
+  languageButton: () =>
+    page.locator('button', {
+      has: page.locator('img'),
+    }),
+  languageButtonLabel: (label: string) =>
+    page.locator('button', {
+      hasText: label,
+    }),
+});

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/user-interface-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/user-interface-settings-route-object-model.ts
@@ -1,0 +1,30 @@
+import { Page } from 'playwright';
+
+import { RoutePath } from '../../../../src/renderer/lib/routes';
+import { MockedTestUtils } from '../../mocked/mocked-utils';
+import { createSelectors } from './selectors';
+
+export class UserInterfaceSettingsRouteObjectModel {
+  readonly page: Page;
+  readonly utils: MockedTestUtils;
+  readonly selectors: ReturnType<typeof createSelectors>;
+
+  constructor(page: Page, utils: MockedTestUtils) {
+    this.page = page;
+    this.utils = utils;
+    this.selectors = createSelectors(page);
+  }
+
+  async gotoSelectLanguage() {
+    await this.selectors.languageButton().click();
+    await this.utils.waitForRoute(RoutePath.selectLanguage);
+  }
+
+  async waitForRoute() {
+    await this.utils.waitForRoute(RoutePath.userInterfaceSettings);
+  }
+
+  getLocalizedLanguageButton(language: string) {
+    return this.selectors.languageButtonLabel(language);
+  }
+}


### PR DESCRIPTION
Adds e2e test for testing language selection in the user interface view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8138)
<!-- Reviewable:end -->
