### PR TITLE
Add documentation for instances of SwiftRetryStrategy

### DIFF
--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -247,6 +247,9 @@ struct SwiftAccessMethodSettingsWrapper init_access_method_settings_wrapper(cons
  *
  * `account_number` must be a pointer to a null terminated string.
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
 struct SwiftCancelHandle mullvad_ios_get_account(struct SwiftApiContext api_context,
@@ -263,6 +266,9 @@ struct SwiftCancelHandle mullvad_ios_get_account(struct SwiftApiContext api_cont
  * This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
+ *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
  *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
@@ -282,6 +288,9 @@ struct SwiftCancelHandle mullvad_ios_create_account(struct SwiftApiContext api_c
  *
  * `account_number` must be a pointer to a null terminated string.
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
 struct SwiftCancelHandle mullvad_ios_delete_account(struct SwiftApiContext api_context,
@@ -298,6 +307,9 @@ struct SwiftCancelHandle mullvad_ios_delete_account(struct SwiftApiContext api_c
  * This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
+ *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
  *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
@@ -316,6 +328,9 @@ struct SwiftCancelHandle mullvad_ios_get_addresses(struct SwiftApiContext api_co
  * when completion finishes (in completion.finish).
  *
  * `etag` must be a pointer to a null terminated string.
+ *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
  *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
@@ -376,6 +391,9 @@ extern void mullvad_api_completion_finish(struct SwiftMullvadApiResponse respons
  * the `account_number` must be a pointer to a null terminated string.
  * the `identifier` must be a pointer to a null terminated string.
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
 struct SwiftCancelHandle mullvad_ios_get_device(struct SwiftApiContext api_context,
@@ -398,6 +416,9 @@ struct SwiftCancelHandle mullvad_ios_get_device(struct SwiftApiContext api_conte
  *
  * the `account_number` must be a pointer to a null terminated string.
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
 struct SwiftCancelHandle mullvad_ios_get_devices(struct SwiftApiContext api_context,
@@ -416,6 +437,9 @@ struct SwiftCancelHandle mullvad_ios_get_devices(struct SwiftApiContext api_cont
  * This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
+ *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
  *
  * the `account_number` must be a pointer to a null terminated string.
  * the `identifier` must be a pointer to a null terminated string.
@@ -440,6 +464,9 @@ struct SwiftCancelHandle mullvad_ios_create_device(struct SwiftApiContext api_co
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
  * the `account_number` must be a pointer to a null terminated string.
  * the `identifier` must be a pointer to a null terminated string.
  * This function is not safe to call multiple times with the same `CompletionCookie`.
@@ -461,6 +488,9 @@ struct SwiftCancelHandle mullvad_ios_delete_device(struct SwiftApiContext api_co
  * This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
+ *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
  *
  * the `account_number` must be a pointer to a null terminated string.
  * the `identifier` must be a pointer to a null terminated string.
@@ -558,6 +588,9 @@ void mullvad_api_mock_drop(struct SwiftServerMock mock_ptr);
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
  * the string properties of `SwiftProblemReportRequest` must be pointers to a null terminated strings.
  *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
@@ -650,6 +683,9 @@ struct SwiftShadowsocksLoaderWrapper init_swift_shadowsocks_loader_wrapper(const
  *
  * `account_number` must be a pointer to a null terminated string.
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
  * This function is not safe to call multiple times with the same `CompletionCookie`.
  */
 struct SwiftCancelHandle mullvad_ios_init_storekit_payment(struct SwiftApiContext api_context,
@@ -666,6 +702,9 @@ struct SwiftCancelHandle mullvad_ios_init_storekit_payment(struct SwiftApiContex
  * This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
+ *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
  *
  * `account_number` must be a pointer to a null terminated string.
  *

--- a/mullvad-ios/src/api_client/account.rs
+++ b/mullvad-ios/src/api_client/account.rs
@@ -26,6 +26,9 @@ use super::{
 ///
 /// `account_number` must be a pointer to a null terminated string.
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[no_mangle]
 pub unsafe extern "C" fn mullvad_ios_get_account(
@@ -79,6 +82,9 @@ pub unsafe extern "C" fn mullvad_ios_get_account(
 /// object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
 /// when completion finishes (in completion.finish).
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[no_mangle]
 pub unsafe extern "C" fn mullvad_ios_create_account(
@@ -121,6 +127,9 @@ pub unsafe extern "C" fn mullvad_ios_create_account(
 /// when completion finishes (in completion.finish).
 ///
 /// `account_number` must be a pointer to a null terminated string.
+///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
 ///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[no_mangle]

--- a/mullvad-ios/src/api_client/api.rs
+++ b/mullvad-ios/src/api_client/api.rs
@@ -24,6 +24,9 @@ use super::{
 /// object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
 /// when completion finishes (in completion.finish).
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[no_mangle]
 pub unsafe extern "C" fn mullvad_ios_get_addresses(
@@ -66,6 +69,9 @@ pub unsafe extern "C" fn mullvad_ios_get_addresses(
 /// when completion finishes (in completion.finish).
 ///
 /// `etag` must be a pointer to a null terminated string.
+///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
 ///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[no_mangle]

--- a/mullvad-ios/src/api_client/device.rs
+++ b/mullvad-ios/src/api_client/device.rs
@@ -30,6 +30,9 @@ use talpid_types::net::wireguard::PublicKey;
 /// the `account_number` must be a pointer to a null terminated string.
 /// the `identifier` must be a pointer to a null terminated string.
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mullvad_ios_get_device(
@@ -86,6 +89,9 @@ pub unsafe extern "C" fn mullvad_ios_get_device(
 ///
 /// the `account_number` must be a pointer to a null terminated string.
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mullvad_ios_get_devices(
@@ -136,6 +142,9 @@ pub unsafe extern "C" fn mullvad_ios_get_devices(
 /// This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
 /// object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
 /// when completion finishes (in completion.finish).
+///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
 ///
 /// the `account_number` must be a pointer to a null terminated string.
 /// the `identifier` must be a pointer to a null terminated string.
@@ -195,6 +204,9 @@ pub unsafe extern "C" fn mullvad_ios_create_device(
 /// object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
 /// when completion finishes (in completion.finish).
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// the `account_number` must be a pointer to a null terminated string.
 /// the `identifier` must be a pointer to a null terminated string.
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
@@ -250,6 +262,9 @@ pub unsafe extern "C" fn mullvad_ios_delete_device(
 /// This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
 /// object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
 /// when completion finishes (in completion.finish).
+///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
 ///
 /// the `account_number` must be a pointer to a null terminated string.
 /// the `identifier` must be a pointer to a null terminated string.

--- a/mullvad-ios/src/api_client/problem_report.rs
+++ b/mullvad-ios/src/api_client/problem_report.rs
@@ -29,6 +29,9 @@ use tokio::task::JoinHandle;
 /// object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
 /// when completion finishes (in completion.finish).
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// the string properties of `SwiftProblemReportRequest` must be pointers to a null terminated strings.
 ///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.

--- a/mullvad-ios/src/api_client/storekit.rs
+++ b/mullvad-ios/src/api_client/storekit.rs
@@ -27,6 +27,9 @@ use super::{
 ///
 /// `account_number` must be a pointer to a null terminated string.
 ///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+///
 /// This function is not safe to call multiple times with the same `CompletionCookie`.
 #[no_mangle]
 pub unsafe extern "C" fn mullvad_ios_init_storekit_payment(
@@ -91,6 +94,9 @@ async fn mullvad_ios_init_storekit_payment_inner(
 /// This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
 /// object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
 /// when completion finishes (in completion.finish).
+///
+/// `retry_strategy` must have been created by a call to either of the following functions
+/// `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
 ///
 /// `account_number` must be a pointer to a null terminated string.
 ///


### PR DESCRIPTION
Following the pinky promise we made, this PR updates all the documentation mentioning `SwiftRetryStrategy`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8140)
<!-- Reviewable:end -->
