### PR TITLE
Fix `test_openvpn_ip_override`

### DIFF
--- a/test/test-manager/src/tests/relay_ip_overrides.rs
+++ b/test/test-manager/src/tests/relay_ip_overrides.rs
@@ -98,6 +98,8 @@ pub async fn test_wireguard_ip_override(
         .await?;
 
     log::info!("checking that the connection works again with the added overrides");
+    // Setting an IP override will cause the client to reconnect, so we have to wait for that
+    helpers::connect_and_wait(&mut mullvad_client).await?;
     let _ = helpers::geoip_lookup_with_retries(&rpc)
         .await
         .with_context(|| "Can't access internet through relay ip override")?;
@@ -158,6 +160,8 @@ pub async fn test_openvpn_ip_override(
         .await?;
 
     log::info!("checking that the connection works again with the added overrides");
+    // Setting an IP override will cause the client to reconnect, so we have to wait for that
+    helpers::connect_and_wait(&mut mullvad_client).await?;
     let _ = helpers::geoip_lookup_with_retries(&rpc)
         .await
         .with_context(|| "Can't access internet through relay ip override")?;


### PR DESCRIPTION
There were two versions of `constrain_to_relay`, and then one used by the test was outdated after the addition of relay white-listing for e2e tests.

The function did not consider the mullvad clients current relay settings, i.e. the custom list that the test is initiated with. It could choose any OpenVPN relay in Sweden, even if it wasn't pickable.

Test run:
~https://github.com/mullvad/mullvadvpn-app/actions/runs/14910156898/job/41883686408~
~https://github.com/mullvad/mullvadvpn-app/actions/runs/14924636786/job/41927213348~
https://github.com/mullvad/mullvadvpn-app/actions/runs/14929831581
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8143)
<!-- Reviewable:end -->
