### PR TITLE
Fix incorrect error log in installer-downloader

### DIFF
--- a/installer-downloader/src/controller.rs
+++ b/installer-downloader/src/controller.rs
@@ -264,8 +264,8 @@ impl<D: AppDelegate + 'static, A: From<UiAppDownloaderParameters<D>> + AppDownlo
     }
 
     fn handle_try_beta(&mut self) {
-        log::error!("Attempted 'try beta' without beta version");
         let Some(beta_info) = self.version_info.beta.as_ref() else {
+            log::error!("Attempted 'try beta' without beta version");
             return;
         };
 


### PR DESCRIPTION
This was logged unconditionally instead of only in the error case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8148)
<!-- Reviewable:end -->
