### PR TITLE
Modify Filters view to start in expanded state; also, some refactoring

### DIFF
--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterDataSourceItem.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterDataSourceItem.swift
@@ -55,3 +55,9 @@ struct RelayFilterDataSourceItem: Hashable, Comparable {
         return nameComparison == .orderedAscending
     }
 }
+
+extension RelayFilterDataSourceItem.ItemType {
+    var isSpecificOwnership: Bool {
+        return self == .ownershipOwned || self == .ownershipRented
+    }
+}

--- a/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterDataSourceItem.swift
+++ b/ios/MullvadVPN/View controllers/RelayFilter/RelayFilterDataSourceItem.swift
@@ -55,9 +55,3 @@ struct RelayFilterDataSourceItem: Hashable, Comparable {
         return nameComparison == .orderedAscending
     }
 }
-
-extension RelayFilterDataSourceItem.ItemType {
-    var isSpecificOwnership: Bool {
-        return self == .ownershipOwned || self == .ownershipRented
-    }
-}

--- a/ios/MullvadVPNUITests/Screenshots/ScreenshotTests.swift
+++ b/ios/MullvadVPNUITests/Screenshots/ScreenshotTests.swift
@@ -104,10 +104,6 @@ class ScreenshotTests: LoggedInWithTimeUITestCase {
         SelectLocationPage(app)
             .tapFilterButton()
 
-        SelectLocationFilterPage(app)
-            .tapOwnershipCellExpandButton()
-            .tapProvidersCellExpandButton()
-
         snapshot("RelayFilter")
     }
 


### PR DESCRIPTION
This makes the Filters view start in expanded state, though it remains collapsible. Some changes were made to where in the lifecycle the current selection is set due to the previous method not working correctly with a view that is visible at start. Additionally, some duplication was factored out.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8172)
<!-- Reviewable:end -->
