### PR TITLE
Improve error handling in buildserver code checkout

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -156,8 +156,15 @@ function checkout_ref {
 
     # Clean our working dir and check out the code we want to build
     rm -r dist/ 2&>/dev/null || true
-    git reset --hard
+
+    # Reset to main in case there is some issue on the current branch that prevents resetting to it.
+    git reset --hard origin/main
+
     git checkout "$ref"
+
+    # Return an error if it's not possible to reset to the current branch. Some errors will result in exit code 0 from `checkout` but >0 from `reset`.
+    git reset --hard || return 1
+
     git submodule update
     git submodule update --init wireguard-go-rs/libwg/wireguard-go || true
     git clean -df


### PR DESCRIPTION
This PR improves the error handling in `buildserver-build.sh` for checking out commits/tags. Me and Tobias ran into a situation where `reset` failed due to the branch containing a file with a path length greater than the maximum path length for Git on Windows. The result was that when building a tag, the repo remained on the broken branch. This PR addresses that by resetting to `origin/main` to get a clean slate which will allow the `checkout` command to work in such scenarios.

The path length issue has been resolved separately by enabling the longpaths option in git.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8178)
<!-- Reviewable:end -->
