### PR TITLE
Make the API cancellation handle safe, and properly clear out pointers

### DIFF
--- a/ios/MullvadRustRuntime/MullvadApiCancellable.swift
+++ b/ios/MullvadRustRuntime/MullvadApiCancellable.swift
@@ -9,17 +9,17 @@
 import MullvadTypes
 
 public class MullvadApiCancellable: Cancellable {
-    private let handle: SwiftCancelHandle
+    private var handle: SwiftCancelHandle
 
     public init(handle: consuming SwiftCancelHandle) {
         self.handle = handle
     }
 
     deinit {
-        mullvad_api_cancel_task_drop(handle)
+        mullvad_api_cancel_task_drop(&handle)
     }
 
     public func cancel() {
-        mullvad_api_cancel_task(handle)
+        mullvad_api_cancel_task(&handle)
     }
 }

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -345,10 +345,9 @@ struct SwiftCancelHandle mullvad_ios_get_relays(struct SwiftApiContext api_conte
  *
  * # Safety
  *
- * `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`. This function
- * is not safe to call multiple times with the same `SwiftCancelHandle`.
+ * `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`.
  */
-void mullvad_api_cancel_task(struct SwiftCancelHandle handle_ptr);
+void mullvad_api_cancel_task(struct SwiftCancelHandle *handle_ptr);
 
 /**
  * Called by the Swift side to signal that the Rust `SwiftCancelHandle` can be safely
@@ -356,10 +355,9 @@ void mullvad_api_cancel_task(struct SwiftCancelHandle handle_ptr);
  *
  * # Safety
  *
- * `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`. This function
- * is not safe to call multiple times with the same `SwiftCancelHandle`.
+ * `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`.
  */
-void mullvad_api_cancel_task_drop(struct SwiftCancelHandle handle_ptr);
+void mullvad_api_cancel_task_drop(struct SwiftCancelHandle *handle_ptr);
 
 /**
  * Maps to `mullvadApiCompletionFinish` on Swift side to facilitate callback based completion flow when doing

--- a/mullvad-ios/src/api_client/cancellation.rs
+++ b/mullvad-ios/src/api_client/cancellation.rs
@@ -21,7 +21,7 @@ impl SwiftCancelHandle {
     /// This call is safe as long as the pointer is only ever used from a single thread and the
     /// instance of `SwiftCancelHandle` was created with a valid pointer to
     /// `RequestCancelHandle`.
-    unsafe fn into_handle(mut self) -> RequestCancelHandle {
+    unsafe fn as_handle(&mut self) -> RequestCancelHandle {
         // SAFETY: See safety notes above
         let handle = unsafe { *Box::from_raw(self.ptr) };
         self.ptr = null_mut();
@@ -61,16 +61,15 @@ impl RequestCancelHandle {
 ///
 /// # Safety
 ///
-/// `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`. This function
-/// is not safe to call multiple times with the same `SwiftCancelHandle`.
+/// `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`.
 #[no_mangle]
-extern "C" fn mullvad_api_cancel_task(handle_ptr: SwiftCancelHandle) {
+extern "C" fn mullvad_api_cancel_task(handle_ptr: &mut SwiftCancelHandle) {
     if handle_ptr.ptr.is_null() {
         return;
     }
 
-    // SAFETY: See notes for `into_handle`
-    let handle = unsafe { handle_ptr.into_handle() };
+    // SAFETY: See notes for `as_handle`
+    let handle = unsafe { handle_ptr.as_handle() };
     handle.cancel()
 }
 
@@ -79,14 +78,13 @@ extern "C" fn mullvad_api_cancel_task(handle_ptr: SwiftCancelHandle) {
 ///
 /// # Safety
 ///
-/// `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`. This function
-/// is not safe to call multiple times with the same `SwiftCancelHandle`.
+/// `handle_ptr` must be pointing to a valid instance of `SwiftCancelHandle`.
 #[no_mangle]
-extern "C" fn mullvad_api_cancel_task_drop(handle_ptr: SwiftCancelHandle) {
+extern "C" fn mullvad_api_cancel_task_drop(handle_ptr: &mut SwiftCancelHandle) {
     if handle_ptr.ptr.is_null() {
         return;
     }
 
-    // SAFETY: See notes for `into_handle`
-    let _handle = unsafe { handle_ptr.into_handle() };
+    // SAFETY: See notes for `as_handle`
+    let _handle = unsafe { handle_ptr.as_handle() };
 }


### PR DESCRIPTION
This PR modifies the signature of `mullvad_api_cancel_task` and `mullvad_api_cancel_task_drop`
to make them take a reference to a `SwiftCancelHandle`

We need to do this in order to avoid passing a copy of the struct to the FFI which would not clear out correctly the pointer contained in it, hence creating double free issues when cancelling and dropping immediately after a `SwiftCancelHandle`.

Big thanks to @hulthe for helping out on this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8179)
<!-- Reviewable:end -->
