### PR TITLE
Update copy after QA testing

### DIFF
--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -675,11 +675,6 @@ msgctxt "app-upgrade-view"
 msgid "About %(seconds)s seconds remaining..."
 msgstr ""
 
-#. Label displayed when an unknown error occurred
-msgctxt "app-upgrade-view"
-msgid "An unknown error occurred. Please try again. If this problem persists, please contact support."
-msgstr ""
-
 #. Label displayed when an error occurred due to the connection being blocked
 msgctxt "app-upgrade-view"
 msgid "Connection blocked. Try changing server or other settings."
@@ -688,7 +683,7 @@ msgstr ""
 #. Label displayed when an error occurred due to the installer failing to start
 #. and the suggested resolution is to download the update again.
 msgctxt "app-upgrade-view"
-msgid "Could not start the update installer. Try again. If this problem persists, please contact support."
+msgid "Could not open installer, please try again or send a problem report."
 msgstr ""
 
 #. Button text to download and install an update
@@ -699,6 +694,11 @@ msgstr ""
 #. Status text displayed below a progress bar when the download of an update is complete
 msgctxt "app-upgrade-view"
 msgid "Download complete!"
+msgstr ""
+
+#. Label displayed when an error occurred due to the download failing
+msgctxt "app-upgrade-view"
+msgid "Download failed, please check your connection/firewall and try again, or send a problem report."
 msgstr ""
 
 #. Status text displayed below a progress bar when the download of an update has been paused
@@ -730,7 +730,7 @@ msgstr ""
 
 #. Label displayed when an error occurred within the installer
 msgctxt "app-upgrade-view"
-msgid "Installer encountered an error. Try again. If this problem persists, please contact support."
+msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr ""
 
 #. Button text to manually download the update
@@ -778,9 +778,9 @@ msgctxt "app-upgrade-view"
 msgid "Starting installer..."
 msgstr ""
 
-#. Label displayed when an error occurred due to the download failing
+#. Label displayed when an unknown error occurred
 msgctxt "app-upgrade-view"
-msgid "Unable to download update. Check your connection and/or firewall then try again. If this problem persists, please contact support."
+msgid "Unknown error occurred. Please try again or send a problem report."
 msgstr ""
 
 #. Title in navigation bar
@@ -791,7 +791,7 @@ msgstr ""
 
 #. Label displayed when an error occurred due to the installer failed verification
 msgctxt "app-upgrade-view"
-msgid "Verification failed. Try again. If this problem persists, please contact support."
+msgid "Verification failed, please try again or send a problem report."
 msgstr ""
 
 #. Label displayed above a progress bar when the update is verified successfully
@@ -1237,11 +1237,6 @@ msgctxt "in-app-notifications"
 msgid "Install the latest app version to stay up to date."
 msgstr ""
 
-#. Notification subtitle when the installer verification failed.
-msgctxt "in-app-notifications"
-msgid "Installer could not be verified."
-msgstr ""
-
 #. Notification title when the installer failed.
 msgctxt "in-app-notifications"
 msgid "INSTALLER FAILED"
@@ -1308,6 +1303,11 @@ msgstr ""
 #. Button label to send a problem report.
 msgctxt "in-app-notifications"
 msgid "Send problem report"
+msgstr ""
+
+#. Notification subtitle when the installer verification failed.
+msgctxt "in-app-notifications"
+msgid "The installer could not be verified."
 msgstr ""
 
 #. Notification subtitle when the installer failed.

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/footer/components/error-footer/hooks/useMessage.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/app-upgrade/components/footer/components/error-footer/hooks/useMessage.ts
@@ -19,32 +19,32 @@ export const useMessage = () => {
       // TRANSLATORS: Label displayed when an error occurred due to the download failing
       return messages.pgettext(
         'app-upgrade-view',
-        'Unable to download update. Check your connection and/or firewall then try again. If this problem persists, please contact support.',
+        'Download failed, please check your connection/firewall and try again, or send a problem report.',
       );
     case 'INSTALLER_FAILED':
       // TRANSLATORS: Label displayed when an error occurred within the installer
       return messages.pgettext(
         'app-upgrade-view',
-        'Installer encountered an error. Try again. If this problem persists, please contact support.',
+        'Installer quit unexpectedly, please try again or send a problem report.',
       );
     case 'START_INSTALLER_FAILED':
       // TRANSLATORS: Label displayed when an error occurred due to the installer failing to start
       // TRANSLATORS: and the suggested resolution is to download the update again.
       return messages.pgettext(
         'app-upgrade-view',
-        'Could not start the update installer. Try again. If this problem persists, please contact support.',
+        'Could not open installer, please try again or send a problem report.',
       );
     case 'VERIFICATION_FAILED':
       // TRANSLATORS: Label displayed when an error occurred due to the installer failed verification
       return messages.pgettext(
         'app-upgrade-view',
-        'Verification failed. Try again. If this problem persists, please contact support.',
+        'Verification failed, please try again or send a problem report.',
       );
     default:
       // TRANSLATORS: Label displayed when an unknown error occurred
       return messages.pgettext(
         'app-upgrade-view',
-        'An unknown error occurred. Please try again. If this problem persists, please contact support.',
+        'Unknown error occurred. Please try again or send a problem report.',
       );
   }
 };

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/notifications/app-upgrade-error.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/notifications/app-upgrade-error.ts
@@ -49,7 +49,7 @@ export class AppUpgradeErrorNotificationProvider implements InAppNotificationPro
             {
               content:
                 // TRANSLATORS: Notification subtitle when the installer verification failed.
-                messages.pgettext('in-app-notifications', 'Installer could not be verified.'),
+                messages.pgettext('in-app-notifications', 'The installer could not be verified.'),
             },
             retrySubtitle,
           ],

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/app-upgrade/app-upgrade.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/app-upgrade/app-upgrade.spec.ts
@@ -135,7 +135,7 @@ test.describe('App upgrade', () => {
 
       await expect(
         page.getByText(
-          'Unable to download update. Check your connection and/or firewall then try again. If this problem persists, please contact support.',
+          'Download failed, please check your connection/firewall and try again, or send a problem report.',
         ),
       ).toBeVisible();
 
@@ -196,9 +196,7 @@ test.describe('App upgrade', () => {
       await expect(installUpdateButton).not.toBeVisible();
 
       await expect(
-        page.getByText(
-          'Could not start the update installer. Try again. If this problem persists, please contact support.',
-        ),
+        page.getByText('Could not open installer, please try again or send a problem report.'),
       ).toBeVisible();
       const retryButton = selectors.retryButton();
       await expect(retryButton).toBeVisible();


### PR DESCRIPTION
The UX designers wanted to tweak the error messages after a QA session.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8182)
<!-- Reviewable:end -->
