### PR TITLE
Fix flaky Rust workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -71,6 +71,10 @@ jobs:
         with:
           go-version: 1.21.3
 
+      - name: Install Rust components
+        shell: bash
+        run: rustup component add clippy
+
       - name: Clippy check
         shell: bash
         env:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout wireguard-go submodule
         run: git submodule update --init --depth=1 wireguard-go-rs
 
+      - name: Install Rust components
+        shell: bash
+        run: rustup component add rustfmt
+
       - name: Check formatting
         run: |-
           rustfmt --version

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -34,6 +34,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install libdbus-1-dev
 
+      - name: Install Rust components
+        shell: bash
+        run: rustup component add clippy
+
       - name: Clippy check
         working-directory: test
         shell: bash
@@ -54,6 +58,10 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust components
+        shell: bash
+        run: rustup component add clippy
 
       - name: Clippy check
         working-directory: test

--- a/.github/workflows/testframework-rustfmt.yml
+++ b/.github/workflows/testframework-rustfmt.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Rust components
+        shell: bash
+        run: rustup component add rustfmt
+
       - name: Check formatting
         working-directory: test
         run: |-


### PR DESCRIPTION
It seems like clippy, etc., aren't installed by default when the Rust toolchain of the runner doesn't match that of `rust-toolchain.yml`.

See
* https://github.com/mullvad/mullvadvpn-app/actions/runs/15015897235/job/42193633200?pr=8036
* https://github.com/mullvad/mullvadvpn-app/actions/runs/15015689619/job/42192968675?pr=8175

Fix DES-2158

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8183)
<!-- Reviewable:end -->
