### PR TITLE
Add unsupported WireGuard port notification

### DIFF
--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -325,6 +325,13 @@ msgctxt "accessibility"
 msgid "Forget account number %(accountNumber)s"
 msgstr ""
 
+#. Accessibility label for link to wireguard settings.
+#. Available placeholders:
+#. %(wireGuard)s - Will be replaced with WireGuard
+msgctxt "accessibility"
+msgid "Go to %(wireGuard)s settings."
+msgstr ""
+
 #. Accessibility label for link to blog post about OpenVPN support ending.
 msgctxt "accessibility"
 msgid "Go to blog post to read more, opens externally"
@@ -950,6 +957,13 @@ msgctxt "in-app-notifications"
 msgid "%(openVpn)s support is ending. Switch location or"
 msgstr ""
 
+#. Link in notication to go to WireGuard settings.
+#. Available placeholders:
+#. %(wireGuard)s - Will be replaced with WireGuard
+msgctxt "in-app-notifications"
+msgid "%(wireGuard)s settings."
+msgstr ""
+
 msgctxt "in-app-notifications"
 msgid "ACCOUNT CREDIT EXPIRES SOON"
 msgstr ""
@@ -1029,6 +1043,13 @@ msgstr ""
 #. Button label to send a problem report.
 msgctxt "in-app-notifications"
 msgid "Send problem report"
+msgstr ""
+
+#. Notification subtitle indicating the user is using an unsupported port for WireGuard.
+#. Available placeholders:
+#. %(wireGuard)s - Will be replaced with WireGuard
+msgctxt "in-app-notifications"
+msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr ""
 
 #. The in-app banner displayed to the user when the app beta update is
@@ -2400,9 +2421,6 @@ msgid "%s custom port"
 msgstr ""
 
 msgid "%s more..."
-msgstr ""
-
-msgid "%s settings."
 msgstr ""
 
 msgid "%s was added to \"%s\""

--- a/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
@@ -23,6 +23,7 @@ import {
   NewVersionNotificationProvider,
   NoOpenVpnServerAvailableNotificationProvider,
   OpenVpnSupportEndingNotificationProvider,
+  UnsupportedWireGuardPortNotificationProvider,
 } from '../lib/notifications';
 import { useTunnelProtocol } from '../lib/relay-settings-hooks';
 import { RoutePath } from '../lib/routes';
@@ -55,6 +56,8 @@ export default function NotificationArea(props: IProps) {
   const version = useSelector((state: IReduxState) => state.version);
   const tunnelProtocol = useTunnelProtocol();
   const fullRelayList = useSelector((state) => state.settings.relayLocations);
+  const allowedPortRanges = useSelector((state) => state.settings.wireguardEndpointData.portRanges);
+  const relaySettings = useSelector((state) => state.settings.relaySettings);
 
   const blockWhenDisconnected = useSelector(
     (state: IReduxState) => state.settings.blockWhenDisconnected,
@@ -98,6 +101,12 @@ export default function NotificationArea(props: IProps) {
       connection,
       tunnelProtocol,
       relayLocations: fullRelayList,
+    }),
+    new UnsupportedWireGuardPortNotificationProvider({
+      connection,
+      relaySettings,
+      tunnelProtocol,
+      allowedPortRanges,
     }),
     new ErrorNotificationProvider({
       tunnelState,

--- a/desktop/packages/mullvad-vpn/src/renderer/components/WireguardSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/WireguardSettings.tsx
@@ -12,6 +12,7 @@ import {
 import { messages } from '../../shared/gettext';
 import log from '../../shared/logging';
 import { removeNonNumericCharacters } from '../../shared/string-helpers';
+import { isInRanges } from '../../shared/utils';
 import { useAppContext } from '../context';
 import { useRelaySettingsUpdater } from '../lib/constraint-updater';
 import { useHistory } from '../lib/history';
@@ -133,7 +134,7 @@ function PortSelector() {
   const parseValue = useCallback((port: string) => parseInt(port), []);
 
   const validateValue = useCallback(
-    (value: number) => allowedPortRanges.some(([start, end]) => value >= start && value <= end),
+    (value: number) => isInRanges(value, allowedPortRanges),
     [allowedPortRanges],
   );
 

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/notifications/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/notifications/index.ts
@@ -2,3 +2,4 @@ export * from './new-device';
 export * from './new-version';
 export * from './open-vpn-support-ending';
 export * from './no-open-vpn-server-available';
+export * from './unsupported-wireguard-port';

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/notifications/unsupported-wireguard-port.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/notifications/unsupported-wireguard-port.ts
@@ -1,0 +1,75 @@
+import { sprintf } from 'sprintf-js';
+
+import { strings } from '../../../shared/constants';
+import { TunnelProtocol } from '../../../shared/daemon-rpc-types';
+import { messages } from '../../../shared/gettext';
+import { InAppNotification, InAppNotificationProvider } from '../../../shared/notifications';
+import { isInRanges } from '../../../shared/utils';
+import { IConnectionReduxState } from '../../redux/connection/reducers';
+import { RelaySettingsRedux } from '../../redux/settings/reducers';
+import { RoutePath } from '../routes';
+
+interface UnsupportedWireGuardPortNotificationContext {
+  connection: IConnectionReduxState;
+  tunnelProtocol: TunnelProtocol;
+  relaySettings: RelaySettingsRedux;
+  allowedPortRanges: [number, number][];
+}
+
+export class UnsupportedWireGuardPortNotificationProvider implements InAppNotificationProvider {
+  public constructor(private context: UnsupportedWireGuardPortNotificationContext) {}
+
+  public mayDisplay = () => {
+    const { connection, tunnelProtocol, relaySettings, allowedPortRanges } = this.context;
+    if (tunnelProtocol === 'wireguard' && connection.status.state === 'error') {
+      if ('normal' in relaySettings) {
+        const { port } = relaySettings.normal.wireguard;
+        if (port !== 'any' && !isInRanges(port, allowedPortRanges)) return true;
+      }
+    }
+    return false;
+  };
+
+  public getInAppNotification(): InAppNotification {
+    return {
+      indicator: 'error',
+      title: messages.pgettext('in-app-notifications', 'BLOCKING INTERNET'),
+      subtitle: [
+        {
+          content: sprintf(
+            // TRANSLATORS: Notification subtitle indicating the user is using an unsupported port for WireGuard.
+            // TRANSLATORS: Available placeholders:
+            // TRANSLATORS: %(wireGuard)s - Will be replaced with WireGuard
+            messages.pgettext(
+              'in-app-notifications',
+              'The selected %(wireGuard)s port is not supported, please change it under ',
+            ),
+            { wireGuard: strings.wireguard },
+          ),
+        },
+        {
+          content: sprintf(
+            // TRANSLATORS: Link in notication to go to WireGuard settings.
+            // TRANSLATORS: Available placeholders:
+            // TRANSLATORS: %(wireGuard)s - Will be replaced with WireGuard
+            messages.pgettext('in-app-notifications', '%(wireGuard)s settings.'),
+            { wireGuard: strings.wireguard },
+          ),
+          action: {
+            type: 'navigate-internal',
+            link: {
+              to: RoutePath.wireguardSettings,
+              'aria-label': sprintf(
+                // TRANSLATORS: Accessibility label for link to wireguard settings.
+                // TRANSLATORS: Available placeholders:
+                // TRANSLATORS: %(wireGuard)s - Will be replaced with WireGuard
+                messages.pgettext('accessibility', 'Go to %(wireGuard)s settings.'),
+                { wireGuard: strings.wireguard },
+              ),
+            },
+          },
+        },
+      ],
+    };
+  }
+}

--- a/desktop/packages/mullvad-vpn/src/shared/utils.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/utils.ts
@@ -3,3 +3,7 @@ export type NonEmptyArray<T> = [T, ...T[]];
 export function hasValue<T>(value: T): value is NonNullable<T> {
   return value !== undefined && value !== null;
 }
+
+export function isInRanges(value: number, ranges: [number, number][]): boolean {
+  return ranges.some(([min, max]) => value >= min && value <= max);
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/notifications.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/notifications.spec.ts
@@ -1,9 +1,17 @@
 import { expect, test } from '@playwright/test';
 import { Page } from 'playwright';
 
+import { getDefaultSettings } from '../../../src/main/default-settings';
 import { colors } from '../../../src/renderer/lib/foundations';
 import { RoutePath } from '../../../src/renderer/lib/routes';
-import { IAccountData } from '../../../src/shared/daemon-rpc-types';
+import {
+  Constraint,
+  ErrorStateCause,
+  IAccountData,
+  IRelayListWithEndpointData,
+  ISettings,
+  TunnelState,
+} from '../../../src/shared/daemon-rpc-types';
 import { getBackgroundColor } from '../utils';
 import { MockedTestUtils, startMockedApp } from './mocked-utils';
 
@@ -51,4 +59,113 @@ test('App should notify user about account expiring soon', async () => {
   });
   subTitle = page.getByTestId('notificationSubTitle');
   await expect(subTitle).toContainText(/less than a day left\. buy more credit\./i);
+});
+
+test.describe('Unsupported wireguard port', () => {
+  const portRanges: [number, number][] = [
+    [1, 50],
+    [51, 100],
+  ];
+  const portInRange = portRanges[0][0];
+  const portOutOfRange = portRanges[1][1] + 1;
+
+  const updatePort = async (port: Constraint<number>) => {
+    const settings = getDefaultSettings();
+    if ('normal' in settings.relaySettings) {
+      settings.relaySettings.normal.wireguardConstraints.port = port;
+    }
+    await util.sendMockIpcResponse<ISettings>({
+      channel: 'settings-',
+      response: settings,
+    });
+  };
+
+  const updatePortRanges = async (portRanges: [number, number][]) => {
+    await util.sendMockIpcResponse<IRelayListWithEndpointData>({
+      channel: 'relays-',
+      response: {
+        relayList: {
+          countries: [],
+        },
+        wireguardEndpointData: {
+          portRanges,
+          udp2tcpPorts: [],
+        },
+      },
+    });
+  };
+
+  const updateTunnelState = async (tunnelState: TunnelState) => {
+    await util.sendMockIpcResponse<TunnelState>({
+      channel: 'tunnel-',
+      response: tunnelState,
+    });
+  };
+
+  test.beforeAll(async () => {
+    await updatePortRanges(portRanges);
+  });
+
+  const cases: {
+    name: string;
+    port: Constraint<number>;
+    tunnelState: TunnelState;
+  }[] = [
+    {
+      name: 'Should not show notification when any port is allowed',
+      port: 'any',
+      tunnelState: {
+        state: 'error',
+        details: { cause: ErrorStateCause.startTunnelError },
+      },
+    },
+    {
+      name: 'Should not show notification when port is in range',
+      port: { only: portInRange },
+      tunnelState: {
+        state: 'error',
+        details: { cause: ErrorStateCause.startTunnelError },
+      },
+    },
+    {
+      name: 'Should not show notification when tunnel is not in error state',
+      port: { only: portOutOfRange },
+      tunnelState: {
+        state: 'connected',
+        details: {
+          endpoint: {
+            address: '',
+            daita: false,
+            protocol: 'tcp',
+            quantumResistant: false,
+            tunnelType: 'wireguard',
+          },
+        },
+      },
+    },
+  ];
+
+  cases.forEach(({ name, port, tunnelState }) => {
+    test(name, async () => {
+      await updatePort(port);
+      await updateTunnelState(tunnelState);
+
+      const subTitle = page.getByTestId('notificationSubTitle');
+
+      await expect(subTitle).not.toContainText(/The selected WireGuard port is not supported/i);
+    });
+  });
+
+  test('Should show notification when port is out of range', async () => {
+    await updatePort({ only: portOutOfRange });
+    await updateTunnelState({
+      state: 'error',
+      details: { cause: ErrorStateCause.startTunnelError },
+    });
+
+    const title = page.getByTestId('notificationTitle');
+    const subTitle = page.getByTestId('notificationSubTitle');
+    await expect(title).toHaveText('BLOCKING INTERNET');
+    await expect(subTitle).toContainText(/The selected WireGuard port is not supported/i);
+  });
 });


### PR DESCRIPTION
Adds notification that shows when the user is connected to WireGuard with a port that is not supported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8187)
<!-- Reviewable:end -->
