### PR TITLE
Add link to installer downloader audit on Assured's website

### DIFF
--- a/audits/2025-03-20-assured-installer-downloader.md
+++ b/audits/2025-03-20-assured-installer-downloader.md
@@ -19,10 +19,11 @@ Quoting the key conclusions and recommendations chapter of the report:
 > * Consider if the TOCTOU is really mitigated by the randomly generated directory name
 > * Increase the number of characters in the randomly generated directory name
 
-The [full audit report] can be found next to this file.
+The [full audit report] can be found next to this file, or [on Assured's website].
 
 [Assured Security Consultants]: https://www.assured.se/
 [full audit report]: ./2025-03-20-assured-MUL020_Installer_Downloader_Audit.pdf
+[on Assured's website]: https://www.assured.se/publications/Assured_Mullvad_Installer_Downloader_Audit_2025.pdf
 
 ## Overview of findings
 


### PR DESCRIPTION
Just adding a link to the same report, but hosted on Assured's website as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8194)
<!-- Reviewable:end -->
