### PR TITLE
Allow long filenames in git for the windows GitHub runners

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -125,6 +125,11 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.config.os }}
     steps:
+      # By default, the longest path a filename can have in git on Windows is 260 character.
+      - name: Set git config for long paths
+        run: |
+          git config --system core.longpaths true
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
By default, the longest path a filename can have in git on Windows is 260 character. We recently made a change on the Windows build server to allow for filenames up to 4096 characters (which is git's limit). We need to introduce the same change on our Windows Github runners.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8198)
<!-- Reviewable:end -->
