### PR TITLE
Add static deb repo codenames "stable" and "beta"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+#### Linux
+- The deb package repositores now have static codenames on top of the existing distro version
+  specific codenames. The stable repository always have the "stable" codename,
+  and the beta repository has the "beta" codename.
+
 ### Changed
 - Replace Classic McEliece with HQC as one of the post-quantum safe key exchange
   mechanisms used for the quantum-resistant tunnels. The main benefits here are that HQC

--- a/ci/linux-repository-builder/build-linux-repositories-config.sh
+++ b/ci/linux-repository-builder/build-linux-repositories-config.sh
@@ -7,6 +7,9 @@
 export CODE_SIGNING_KEY_FINGERPRINT="A1198702FC3E0A09A9AE5B75D5A1D4F266DE8DDF"
 
 # Debian codenames we support.
+# On top of these we also add the name of the repository as a codename as
+# well. Meaning the `stable` repository will also have a `stable` codename,
+# and `beta` will have `beta` as a codename.
 SUPPORTED_DEB_CODENAMES=("sid" "testing" "trixie" "bookworm" "bullseye")
 # Ubuntu codenames we support. Latest two LTS. But when adding a new
 # don't immediately remove the oldest one. Allow for some transition period

--- a/ci/linux-repository-builder/build-linux-repositories.sh
+++ b/ci/linux-repository-builder/build-linux-repositories.sh
@@ -159,6 +159,8 @@ repositories_were_updated="false"
 for repository in "${REPOSITORIES[@]}"; do
     deb_remote_repo_dir="deb/$repository"
     rpm_remote_repo_dir="rpm/$repository"
+    # Stable or beta
+    release_channel="$repository"
 
     repository_inbox_dir="$inbox_dir/$repository"
     if ! process_inbox "$repository_inbox_dir"; then
@@ -179,7 +181,7 @@ for repository in "${REPOSITORIES[@]}"; do
 
     deb_repo_dir="$repository_inbox_dir/repos/deb"
     rm -rf "$deb_repo_dir" && mkdir -p "$deb_repo_dir" || exit 1
-    "$SCRIPT_DIR/prepare-apt-repository.sh" "$deb_repo_dir" "${artifact_dirs[@]}"
+    "$SCRIPT_DIR/prepare-apt-repository.sh" "$release_channel" "$deb_repo_dir" "${artifact_dirs[@]}"
 
     # Generate rpm repository from all the .latest artifacts
 

--- a/desktop/scripts/release/print-package-versions
+++ b/desktop/scripts/release/print-package-versions
@@ -76,7 +76,7 @@ if [[ $deb == "true" ]]; then
         \"apt update $silent_stderr $silent_stdout; \
         apt install -y curl $silent_stderr $silent_stdout; \
         curl -fsSLo /usr/share/keyrings/mullvad-keyring.asc $repository_server_public_url/deb/mullvad-keyring.asc; \
-        echo \\\"deb [signed-by=/usr/share/keyrings/mullvad-keyring.asc arch=amd64] $repository_server_public_url/deb/$release_channel bookworm main\\\" > /etc/apt/sources.list.d/mullvad.list; \
+        echo \\\"deb [signed-by=/usr/share/keyrings/mullvad-keyring.asc arch=amd64] $repository_server_public_url/deb/$release_channel $release_channel main\\\" > /etc/apt/sources.list.d/mullvad.list; \
         apt update $silent_stderr $silent_stdout; \
         apt list mullvad-* $silent_stderr | grep 'amd64'\" $silent_stderr"
 fi


### PR DESCRIPTION
As discussed previously, it can be a hassle for users on Linux distribution other than Ubuntu or Debian to install our repository. Because our instructions include the use of `lsb_release -cs` to compute what "codename" to fetch the repository for. And we don't publish the repository for codenames of distributions we don't support. It is also a maintenance burden to have to update supported codenames as new Debian and Ubuntu releases come out.

We publish the exact same `.deb` file regardless of distro and codename anyway. We only have one deb file. So we decided that it would be much more pragmatic, easier for us to maintain and easier for the users to use if the codenames were just "stable" and "beta".

We have to keep the old codenames for now, since all existing repo users use them. We can figure out later if/how we migrate away from that. But this PR simply adds the static codename "stable" to the stable repos and "beta" to the beta repos.

When this change has been deployed, the installation instructions can be updated from:
```
https://repository.mullvad.net/deb/stable $(lsb_release -cs) main
```
to:
```
https://repository.mullvad.net/deb/stable stable main
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8199)
<!-- Reviewable:end -->
