### PR TITLE
Mention "Add unsupported WireGuard port notification" in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
+- Add notification that shows when the user is connected to WireGuard with a port that is not
+supported.
+
 #### Linux
 - The deb package repositores now have static codenames on top of the existing distro version
   specific codenames. The stable repository always have the "stable" codename,


### PR DESCRIPTION
This PR adds https://github.com/mullvad/mullvadvpn-app/pull/8187 to the changelog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8200)
<!-- Reviewable:end -->
