### PR TITLE
Set opt-level=3 for libs that improve quic performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,3 +150,6 @@ opt-level = 3
 
 [profile.release.package."quinn"]
 opt-level = 3
+
+[profile.release.package."mullvad-masque-proxy"]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ strip = true
 [profile.release.package]
 pqcrypto-hqc.opt-level = 3
 quinn-proto.opt-level = 3
+quinn-udp.opt-level = 3
 quinn.opt-level = 3
 mullvad-masque-proxy.opt-level = 3
 ring.opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,3 +147,6 @@ opt-level = 3
 
 [profile.release.package."quinn-proto"]
 opt-level = 3
+
+[profile.release.package."quinn"]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,3 +141,6 @@ strip = true
 # Selectively optimize packages where we know it makes a difference
 [profile.release.package."pqcrypto-hqc"]
 opt-level = 3
+
+[profile.release.package."ring"]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,3 +144,6 @@ opt-level = 3
 
 [profile.release.package."ring"]
 opt-level = 3
+
+[profile.release.package."quinn-proto"]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,17 +139,10 @@ lto = true
 strip = true
 
 # Selectively optimize packages where we know it makes a difference
-[profile.release.package."pqcrypto-hqc"]
-opt-level = 3
+[profile.release.package]
+pqcrypto-hqc.opt-level = 3
+quinn-proto.opt-level = 3
+quinn.opt-level = 3
+mullvad-masque-proxy.opt-level = 3
+ring.opt-level = 3
 
-[profile.release.package."ring"]
-opt-level = 3
-
-[profile.release.package."quinn-proto"]
-opt-level = 3
-
-[profile.release.package."quinn"]
-opt-level = 3
-
-[profile.release.package."mullvad-masque-proxy"]
-opt-level = 3


### PR DESCRIPTION
Saw a ~7% improvement in wireguard+masque benchmarks with this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8201)
<!-- Reviewable:end -->
