### PR TITLE
Enable Swift 6 mode for the PacketTunnel and test Target

### DIFF
--- a/ios/MullvadRustRuntimeTests/EphemeralPeerExchangeActorTests.swift
+++ b/ios/MullvadRustRuntimeTests/EphemeralPeerExchangeActorTests.swift
@@ -15,12 +15,10 @@ import NetworkExtension
 import XCTest
 
 class EphemeralPeerExchangeActorTests: XCTestCase {
-    var tcpConnection: NWTCPConnectionStub!
     var tunnelProvider: TunnelProviderStub!
 
     override func setUpWithError() throws {
-        tcpConnection = NWTCPConnectionStub()
-        tunnelProvider = TunnelProviderStub(tcpConnection: tcpConnection)
+        tunnelProvider = TunnelProviderStub()
     }
 
     func testKeyExchangeFailsWhenNegotiationCannotStart() {
@@ -37,7 +35,6 @@ class EphemeralPeerExchangeActorTests: XCTestCase {
 
         let privateKey = PrivateKey()
         keyExchangeActor.startNegotiation(with: privateKey, enablePostQuantum: true, enableDaita: false)
-        tcpConnection.becomeViable()
 
         wait(for: [negotiationFailure])
     }

--- a/ios/MullvadRustRuntimeTests/MullvadPostQuantum+Stubs.swift
+++ b/ios/MullvadRustRuntimeTests/MullvadPostQuantum+Stubs.swift
@@ -12,19 +12,6 @@ import NetworkExtension
 @testable import PacketTunnelCore
 @testable import WireGuardKitTypes
 
-class NWTCPConnectionStub: NWTCPConnection {
-    var _isViable = false
-    override var isViable: Bool {
-        _isViable
-    }
-
-    func becomeViable() {
-        willChangeValue(for: \.isViable)
-        _isViable = true
-        didChangeValue(for: \.isViable)
-    }
-}
-
 class TunnelProviderStub: TunnelProvider {
     func tunnelHandle() throws -> Int32 {
         0
@@ -37,21 +24,6 @@ class TunnelProviderStub: TunnelProvider {
             receive: { _, _, _, _ in return 0 },
             send: { _, _, _, _ in return 0 }
         )
-    }
-
-    let tcpConnection: NWTCPConnectionStub
-
-    init(tcpConnection: NWTCPConnectionStub) {
-        self.tcpConnection = tcpConnection
-    }
-
-    func createTCPConnectionThroughTunnel(
-        to remoteEndpoint: NWEndpoint,
-        enableTLS: Bool,
-        tlsParameters TLSParameters: NWTLSParameters?,
-        delegate: Any?
-    ) -> NWTCPConnection {
-        tcpConnection
     }
 }
 

--- a/ios/MullvadRustRuntimeTests/TCPConnection.swift
+++ b/ios/MullvadRustRuntimeTests/TCPConnection.swift
@@ -11,7 +11,7 @@ import Network
 
 /// Minimal implementation of TCP connection capable of receiving data.
 /// > Warning: Do not use this implementation in production code. See the warning in `start()`.
-class TCPConnection: Connection {
+class TCPConnection: Connection, @unchecked Sendable {
     private let dispatchQueue = DispatchQueue(label: "TCPConnection")
     private let nwConnection: NWConnection
 

--- a/ios/MullvadRustRuntimeTests/UDPConnection.swift
+++ b/ios/MullvadRustRuntimeTests/UDPConnection.swift
@@ -16,7 +16,7 @@ protocol Connection {
 
 /// Minimal implementation of UDP connection capable of sending data.
 /// > Warning: Do not use this implementation in production code. See the warning in `start()`.
-class UDPConnection: Connection {
+class UDPConnection: Connection, @unchecked Sendable {
     private let dispatchQueue = DispatchQueue(label: "UDPConnection")
     private let nwConnection: NWConnection
 

--- a/ios/MullvadTypes/Promise.swift
+++ b/ios/MullvadTypes/Promise.swift
@@ -52,7 +52,7 @@ public final class Promise<Success, Failure: Error>: @unchecked Sendable {
 // allows the waiter to wait to `receive()` from another operation
 // asynchronously. It is important not to forget to call `send`, otherwise this
 // operation will block indefinitely.
-public struct OneshotChannel {
+public struct OneshotChannel: Sendable {
     private var continuation: AsyncStream<Void>.Continuation?
     private var stream: AsyncStream<Void>
 

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1108,9 +1108,8 @@
 		F910A4312D4A1B41002FF3BB /* InAppPurchaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A4302D4A1B3B002FF3BB /* InAppPurchaseCoordinator.swift */; };
 		F910A43A2D4A283D002FF3BB /* InAppPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A4392D4A2839002FF3BB /* InAppPurchaseViewController.swift */; };
 		F910A8572D523812002FF3BB /* TunnelSettingsV7.swift in Sources */ = {isa = PBXBuildFile; fileRef = F910A8562D523812002FF3BB /* TunnelSettingsV7.swift */; };
-		F924C5A42DA65F28001F4660 /* Storekit2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C5A32DA65F28001F4660 /* Storekit2.swift */; };
-		F924C65F2DAE4554001F4660 /* ServerRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C65E2DAE4554001F4660 /* ServerRelayTests.swift */; };
 		F924C4532D70692E001F4660 /* MullvadApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C4522D706929001F4660 /* MullvadApiTests.swift */; };
+		F924C5A42DA65F28001F4660 /* Storekit2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C5A32DA65F28001F4660 /* Storekit2.swift */; };
 		F924C65F2DAE4554001F4660 /* ServerRelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C65E2DAE4554001F4660 /* ServerRelayTests.swift */; };
 		F998EFF82D359C4600D88D01 /* SKProduct+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FD5BEF24238EB300112C88 /* SKProduct+Formatting.swift */; };
 		F998EFFA2D3656BA00D88D01 /* SKProduct+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F998EFF92D3656B100D88D01 /* SKProduct+Sorting.swift */; };
@@ -2523,9 +2522,8 @@
 		F910A4302D4A1B3B002FF3BB /* InAppPurchaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseCoordinator.swift; sourceTree = "<group>"; };
 		F910A4392D4A2839002FF3BB /* InAppPurchaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseViewController.swift; sourceTree = "<group>"; };
 		F910A8562D523812002FF3BB /* TunnelSettingsV7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettingsV7.swift; sourceTree = "<group>"; };
-		F924C65E2DAE4554001F4660 /* ServerRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRelayTests.swift; sourceTree = "<group>"; };
-		F924C5A32DA65F28001F4660 /* Storekit2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storekit2.swift; sourceTree = "<group>"; };
 		F924C4522D706929001F4660 /* MullvadApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadApiTests.swift; sourceTree = "<group>"; };
+		F924C5A32DA65F28001F4660 /* Storekit2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storekit2.swift; sourceTree = "<group>"; };
 		F924C65E2DAE4554001F4660 /* ServerRelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerRelayTests.swift; sourceTree = "<group>"; };
 		F998EFF92D3656B100D88D01 /* SKProduct+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Sorting.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -7299,7 +7297,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -7319,7 +7317,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -7430,7 +7428,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -7470,7 +7468,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -7493,7 +7491,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -7514,7 +7512,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -7716,7 +7714,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = minimal;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -7736,7 +7734,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APPLICATION_IDENTIFIER).PacketTunnel";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_STRICT_CONCURRENCY = minimal;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -8191,7 +8189,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG MULLVAD_ENVIRONMENT_PRODUCTION $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/MullvadVPNUITests/BridgingHeader.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = MullvadVPN;
 			};
@@ -8223,7 +8221,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/MullvadVPNUITests/BridgingHeader.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = MullvadVPN;
 			};
@@ -8357,7 +8355,7 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Packet Tunnel Development";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = minimal;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Staging;
 		};
@@ -8376,7 +8374,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Staging;
@@ -8595,7 +8593,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -8618,7 +8616,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Staging;
@@ -8750,7 +8748,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG MULLVAD_ENVIRONMENT_STAGING";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/MullvadVPNUITests/BridgingHeader.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = MullvadVPN;
 			};
@@ -8774,7 +8772,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = MULLVAD_ENVIRONMENT_PRODUCTION;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/MullvadVPNUITests/BridgingHeader.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = MullvadVPN;
 			};
@@ -8825,7 +8823,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -8876,7 +8874,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -8927,7 +8925,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -8977,7 +8975,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -9005,7 +9003,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -9030,7 +9028,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Staging;
@@ -9055,7 +9053,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -9080,7 +9078,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = MockRelease;
@@ -9203,7 +9201,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Packet Tunnel Development";
 				SWIFT_STRICT_CONCURRENCY = minimal;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = MockRelease;
 		};
@@ -9222,7 +9220,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = MockRelease;
@@ -9441,7 +9439,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -9464,7 +9462,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = MockRelease;

--- a/ios/MullvadVPNTests/MullvadLogging/LogFileOutputStreamTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LogFileOutputStreamTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-import Foundation
+@preconcurrency import Foundation
 @testable import MullvadLogging
 import Testing
 

--- a/ios/MullvadVPNTests/MullvadSettings/IPOverrideRepositoryStub.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/IPOverrideRepositoryStub.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-import Combine
+@preconcurrency import Combine
 import MullvadSettings
 
 struct IPOverrideRepositoryStub: IPOverrideRepositoryProtocol {

--- a/ios/MullvadVPNTests/MullvadSettings/MigrationManagerMultiProcessUpgradeTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/MigrationManagerMultiProcessUpgradeTests.swift
@@ -26,8 +26,8 @@ extension MigrationManagerTests {
 
         let backgroundMigrationExpectation = expectation(description: "Migration from packet tunnel")
         let foregroundMigrationExpectation = expectation(description: "Migration from host")
-        var migrationHappenedInPacketTunnel = false
-        var migrationHappenedInHost = false
+        nonisolated(unsafe) var migrationHappenedInPacketTunnel = false
+        nonisolated(unsafe) var migrationHappenedInHost = false
 
         packetTunnelProcess.async { [unowned self] in
             manager.migrateSettings(store: MigrationManagerTests.store) { backgroundMigrationResult in

--- a/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
@@ -12,7 +12,7 @@
 @testable import MullvadTypes
 import XCTest
 
-final class MigrationManagerTests: XCTestCase {
+final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
     static let store = InMemorySettingsStore<SettingNotFound>()
 
     var manager: MigrationManager!

--- a/ios/MullvadVPNTests/MullvadVPN/Classes/InputTextFormatterTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Classes/InputTextFormatterTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 
+@MainActor
 class InputTextFormatterTests: XCTestCase {
     private let accountNumber = "12345678"
     private var inputTextFormatter: InputTextFormatter!
@@ -19,14 +20,14 @@ class InputTextFormatterTests: XCTestCase {
         maxGroups: 4
     )
 
-    override func setUp() {
+    override func setUp() async throws {
         inputTextFormatter = InputTextFormatter(
             string: accountNumber,
             configuration: configuration
         )
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         inputTextFormatter = nil
     }
 

--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
@@ -12,14 +12,14 @@ import MullvadSettings
 import MullvadTypes
 import Operations
 import PacketTunnelCore
-import WireGuardKitTypes
+@preconcurrency import WireGuardKitTypes
 import XCTest
 
 class DeviceCheckOperationTests: XCTestCase {
     private let operationQueue = AsyncOperationQueue()
     private let dispatchQueue = DispatchQueue(label: "TestQueue")
 
-    func testShouldReportExpiredAccount() {
+    func testShouldReportExpiredAccount() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -45,10 +45,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldNotRotateKeyForInvalidAccount() {
+    func testShouldNotRotateKeyForInvalidAccount() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -76,10 +76,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldNotRotateKeyForRevokedDevice() {
+    func testShouldNotRotateKeyForRevokedDevice() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -107,10 +107,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldRotateKeyOnMismatchImmediately() {
+    func testShouldRotateKeyOnMismatchImmediately() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -136,10 +136,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldRespectCooldownWhenAttemptingToRotateImmediately() {
+    func testShouldRespectCooldownWhenAttemptingToRotateImmediately() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -165,10 +165,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldNotRotateDeviceKeyWhenServerKeyIsIdentical() {
+    func testShouldNotRotateDeviceKeyWhenServerKeyIsIdentical() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -188,10 +188,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldNotRotateKeyBeforeRetryIntervalPassed() {
+    func testShouldNotRotateKeyBeforeRetryIntervalPassed() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -213,10 +213,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldRotateKeyOnceInTwentyFourHours() {
+    func testShouldRotateKeyOnceInTwentyFourHours() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -238,10 +238,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldReportFailedKeyRotationAttempt() {
+    func testShouldReportFailedKeyRotationAttempt() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -268,10 +268,10 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
-    func testShouldFailOnKeyRotationRace() {
+    func testShouldFailOnKeyRotationRace() async {
         let expect = expectation(description: "Wait for operation to complete")
 
         let currentKey = PrivateKey()
@@ -305,7 +305,7 @@ class DeviceCheckOperationTests: XCTestCase {
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: .UnitTest.timeout)
+        await fulfillment(of: [expect], timeout: .UnitTest.timeout)
     }
 
     private func startDeviceCheck(
@@ -327,7 +327,7 @@ class DeviceCheckOperationTests: XCTestCase {
 }
 
 /// Mock implementation of a remote service used by `DeviceCheckOperation` to reach the API.
-private class MockRemoteService: DeviceCheckRemoteServiceProtocol {
+private class MockRemoteService: DeviceCheckRemoteServiceProtocol, @unchecked Sendable {
     typealias AccountDataHandler = (_ accountNumber: String) throws -> Account
     typealias DeviceDataHandler = (_ accountNumber: String, _ deviceIdentifier: String) throws -> Device
     typealias RotateDeviceKeyHandler = (
@@ -356,7 +356,7 @@ private class MockRemoteService: DeviceCheckRemoteServiceProtocol {
 
     func getAccountData(
         accountNumber: String,
-        completion: @escaping (Result<Account, Error>) -> Void
+        completion: @escaping @Sendable (Result<Account, Error>) -> Void
     ) -> Cancellable {
         DispatchQueue.main.async { [self] in
             let result: Result<Account, Error> = Result {
@@ -374,7 +374,7 @@ private class MockRemoteService: DeviceCheckRemoteServiceProtocol {
     func getDevice(
         accountNumber: String,
         identifier: String,
-        completion: @escaping (Result<Device, Error>) -> Void
+        completion: @escaping @Sendable (Result<Device, Error>) -> Void
     ) -> Cancellable {
         DispatchQueue.main.async { [self] in
             let result: Result<Device, Error> = Result {
@@ -395,7 +395,7 @@ private class MockRemoteService: DeviceCheckRemoteServiceProtocol {
         accountNumber: String,
         identifier: String,
         publicKey: PublicKey,
-        completion: @escaping (Result<Device, Error>) -> Void
+        completion: @escaping @Sendable (Result<Device, Error>) -> Void
     ) -> Cancellable {
         DispatchQueue.main.async { [self] in
             let result: Result<Device, Error> = Result {

--- a/ios/PacketTunnel/DeviceCheck/DeviceCheckOperation.swift
+++ b/ios/PacketTunnel/DeviceCheck/DeviceCheckOperation.swift
@@ -66,7 +66,7 @@ final class DeviceCheckOperation: ResultOperation<DeviceCheck>, @unchecked Senda
      Begins the flow by fetching device state and then fetching account and device data. Calls `didReceiveData()` with
      the received data when done.
      */
-    private func startFlow(completion: @escaping (Result<DeviceCheck, Error>) -> Void) {
+    private func startFlow(completion: @escaping @Sendable (Result<DeviceCheck, Error>) -> Void) {
         do {
             guard case let .loggedIn(accountData, deviceData) = try deviceStateAccessor.read() else {
                 throw DeviceCheckError.invalidDeviceState
@@ -90,7 +90,7 @@ final class DeviceCheckOperation: ResultOperation<DeviceCheck>, @unchecked Senda
     private func didReceiveData(
         accountResult: Result<Account, Error>,
         deviceResult: Result<Device, Error>,
-        completion: @escaping (Result<DeviceCheck, Error>) -> Void
+        completion: @escaping @Sendable (Result<DeviceCheck, Error>) -> Void
     ) {
         do {
             let accountVerdict = try accountVerdict(from: accountResult)
@@ -158,7 +158,7 @@ final class DeviceCheckOperation: ResultOperation<DeviceCheck>, @unchecked Senda
      then it rotate device key by marking the beginning of key rotation, updating device state and persisting before
      proceeding to rotate the key.
      */
-    private func rotateKeyIfNeeded(completion: @escaping (Result<KeyRotationStatus, Error>) -> Void) {
+    private func rotateKeyIfNeeded(completion: @escaping @Sendable (Result<KeyRotationStatus, Error>) -> Void) {
         let deviceState: DeviceState
         do {
             deviceState = try deviceStateAccessor.read()

--- a/ios/PacketTunnel/PacketTunnelProvider/NEProviderStopReason+Debug.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/NEProviderStopReason+Debug.swift
@@ -46,6 +46,8 @@ extension NEProviderStopReason: CustomStringConvertible {
             return "sleep"
         case .appUpdate:
             return "app update"
+        case .internalError:
+            return "internal error"
         @unknown default:
             return "unknown value (\(rawValue))"
         }

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+Extensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-import Combine
+@preconcurrency import Combine
 import Foundation
 
 extension PacketTunnelActor {

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActorCommand.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActorCommand.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import MullvadTypes
+@preconcurrency import MullvadTypes
 import Network
 import WireGuardKitTypes
 

--- a/ios/PacketTunnelCore/Pinger/PingerProtocol.swift
+++ b/ios/PacketTunnelCore/Pinger/PingerProtocol.swift
@@ -29,7 +29,7 @@ public struct PingerSendResult {
 }
 
 /// A type capable of sending and receving ICMP traffic.
-public protocol PingerProtocol {
+public protocol PingerProtocol: Sendable {
     var onReply: ((PingerReply) -> Void)? { get set }
 
     func startPinging(destAddress: IPv4Address) throws

--- a/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
+++ b/ios/PacketTunnelCore/Pinger/TunnelPinger.swift
@@ -12,7 +12,7 @@ import Network
 import PacketTunnelCore
 import WireGuardKit
 
-public final class TunnelPinger: PingerProtocol {
+public final class TunnelPinger: PingerProtocol, @unchecked Sendable {
     private var sequenceNumber: UInt16 = 0
     private let stateLock = NSLock()
     private let pingReceiveQueue: DispatchQueue

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelDeviceInfoProtocol.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelDeviceInfoProtocol.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A type that can provide statistics and basic information about tunnel device.
-public protocol TunnelDeviceInfoProtocol {
+public protocol TunnelDeviceInfoProtocol: Sendable {
     /// Returns tunnel interface name (i.e utun0) if available.
     var interfaceName: String? { get }
 

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitor.swift
@@ -13,7 +13,7 @@ import Network
 import NetworkExtension
 
 /// Tunnel monitor.
-public final class TunnelMonitor: TunnelMonitorProtocol {
+public final class TunnelMonitor: TunnelMonitorProtocol, @unchecked Sendable {
     private let tunnelDeviceInfo: TunnelDeviceInfoProtocol
 
     private let nslock = NSLock()
@@ -22,7 +22,6 @@ public final class TunnelMonitor: TunnelMonitorProtocol {
     private let timings: TunnelMonitorTimings
 
     private var pinger: PingerProtocol
-    private var isObservingDefaultPath = false
     private var timer: DispatchSourceTimer?
 
     private var state: TunnelMonitorState

--- a/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorTimings.swift
+++ b/ios/PacketTunnelCore/TunnelMonitor/TunnelMonitorTimings.swift
@@ -8,7 +8,7 @@
 
 import MullvadTypes
 
-public struct TunnelMonitorTimings {
+public struct TunnelMonitorTimings: Sendable {
     /// Interval for periodic heartbeat ping issued when traffic is flowing.
     /// Should help to detect connectivity issues on networks that drop traffic in one of directions,
     /// regardless if tx/rx counters are being updated.

--- a/ios/PacketTunnelCore/URLRequestProxy/ProxyURLRequest.swift
+++ b/ios/PacketTunnelCore/URLRequestProxy/ProxyURLRequest.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Struct describing serializable URLRequest data.
-public struct ProxyURLRequest: Codable {
+public struct ProxyURLRequest: Codable, Sendable {
     public let id: UUID
     public let url: URL
     public let method: String?

--- a/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
+++ b/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
@@ -89,10 +89,7 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
         let connectionState = stubConnectionState(enableMultiHop: false, enablePostQuantum: true, enableDaita: false)
         await postQuantumKeyExchangingPipeline.startNegotiation(connectionState, privateKey: PrivateKey())
 
-        wait(
-            for: [reconfigurationExpectation, negotiationSuccessful],
-            timeout: .UnitTest.invertedTimeout
-        )
+        await fulfillment(of: [reconfigurationExpectation, negotiationSuccessful], timeout: .UnitTest.invertedTimeout)
     }
 
     func testSingleHopDaitaPeerExchange() async throws {
@@ -123,10 +120,7 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
         let connectionState = stubConnectionState(enableMultiHop: false, enablePostQuantum: false, enableDaita: true)
         await postQuantumKeyExchangingPipeline.startNegotiation(connectionState, privateKey: PrivateKey())
 
-        wait(
-            for: [reconfigurationExpectation, negotiationSuccessful],
-            timeout: .UnitTest.invertedTimeout
-        )
+        await fulfillment(of: [reconfigurationExpectation, negotiationSuccessful], timeout: .UnitTest.invertedTimeout)
     }
 
     func testMultiHopPostQuantumKeyExchange() async throws {
@@ -158,10 +152,7 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
         let connectionState = stubConnectionState(enableMultiHop: true, enablePostQuantum: true, enableDaita: false)
         await postQuantumKeyExchangingPipeline.startNegotiation(connectionState, privateKey: PrivateKey())
 
-        wait(
-            for: [reconfigurationExpectation, negotiationSuccessful],
-            timeout: .UnitTest.invertedTimeout
-        )
+        await fulfillment(of: [reconfigurationExpectation, negotiationSuccessful], timeout: .UnitTest.invertedTimeout)
     }
 
     func testMultiHopDaitaExchange() async throws {
@@ -188,10 +179,7 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
         let connectionState = stubConnectionState(enableMultiHop: true, enablePostQuantum: false, enableDaita: true)
         await postQuantumKeyExchangingPipeline.startNegotiation(connectionState, privateKey: PrivateKey())
 
-        wait(
-            for: [reconfigurationExpectation, negotiationSuccessful],
-            timeout: .UnitTest.invertedTimeout
-        )
+        await fulfillment(of: [reconfigurationExpectation, negotiationSuccessful], timeout: .UnitTest.invertedTimeout)
     }
 
     func stubConnectionState(

--- a/ios/PacketTunnelCoreTests/Mocks/EphemeralPeerExchangeActorStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/EphemeralPeerExchangeActorStub.swift
@@ -12,7 +12,7 @@ import NetworkExtension
 @testable import PacketTunnelCore
 @testable import WireGuardKitTypes
 
-final class EphemeralPeerExchangeActorStub: EphemeralPeerExchangeActorProtocol {
+final class EphemeralPeerExchangeActorStub: EphemeralPeerExchangeActorProtocol, @unchecked Sendable {
     typealias KeyNegotiationResult = Result<(PreSharedKey, PrivateKey), EphemeralPeerExchangeErrorStub>
     var result: KeyNegotiationResult = .failure(.unknown)
 

--- a/ios/PacketTunnelCoreTests/Mocks/PacketTunnelActor+Mocks.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/PacketTunnelActor+Mocks.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 import MullvadMockData
-import MullvadREST
-import PacketTunnelCore
+@preconcurrency import MullvadREST
+@preconcurrency import PacketTunnelCore
 
 extension PacketTunnelActorTimings {
     static var timingsForTests: PacketTunnelActorTimings {

--- a/ios/PacketTunnelCoreTests/Mocks/PingerMock.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/PingerMock.swift
@@ -12,7 +12,7 @@ import Network
 @testable import PacketTunnelCore
 
 /// Ping client mock that can be used to simulate network transmission errors and delays.
-class PingerMock: PingerProtocol {
+class PingerMock: PingerProtocol, @unchecked Sendable {
     typealias OutcomeDecider = (IPv4Address, UInt16) -> Outcome
 
     private let decideOutcome: OutcomeDecider

--- a/ios/PacketTunnelCoreTests/Mocks/TunnelDeviceInfoStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/TunnelDeviceInfoStub.swift
@@ -10,7 +10,7 @@ import Foundation
 import PacketTunnelCore
 
 /// Tunnel device stub that returns fixed interface name and feeds network stats from the type implementing `NetworkStatsProviding`
-struct TunnelDeviceInfoStub: TunnelDeviceInfoProtocol {
+struct TunnelDeviceInfoStub: TunnelDeviceInfoProtocol, @unchecked Sendable {
     let networkStatsProviding: NetworkStatsProviding
 
     var interfaceName: String? {

--- a/ios/PacketTunnelCoreTests/MultiHopEphemeralPeerExchangerTests.swift
+++ b/ios/PacketTunnelCoreTests/MultiHopEphemeralPeerExchangerTests.swift
@@ -90,8 +90,8 @@ final class MultiHopEphemeralPeerExchangerTests: XCTestCase {
 
         await multiHopExchanger.start()
 
-        wait(
-            for: [expectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
+        await fulfillment(
+            of: [expectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
             timeout: .UnitTest.invertedTimeout
         )
     }
@@ -133,8 +133,8 @@ final class MultiHopEphemeralPeerExchangerTests: XCTestCase {
             })
         await multiHopPeerExchanger.start()
 
-        wait(
-            for: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
+        await fulfillment(
+            of: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
             timeout: .UnitTest.invertedTimeout
         )
     }
@@ -171,8 +171,8 @@ final class MultiHopEphemeralPeerExchangerTests: XCTestCase {
         })
         await multiHopPeerExchanger.start()
 
-        wait(
-            for: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
+        await fulfillment(
+            of: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
             timeout: .UnitTest.invertedTimeout
         )
     }
@@ -213,8 +213,8 @@ final class MultiHopEphemeralPeerExchangerTests: XCTestCase {
         })
         await multiHopPeerExchanger.start()
 
-        wait(
-            for: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
+        await fulfillment(
+            of: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
             timeout: .UnitTest.invertedTimeout
         )
     }

--- a/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
+++ b/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-import Combine
+@preconcurrency import Combine
 @testable import MullvadMockData
 @testable import MullvadREST
 @testable import MullvadSettings

--- a/ios/PacketTunnelCoreTests/SingleHopEphemeralPeerExchangerTests.swift
+++ b/ios/PacketTunnelCoreTests/SingleHopEphemeralPeerExchangerTests.swift
@@ -68,8 +68,8 @@ final class SingleHopEphemeralPeerExchangerTests: XCTestCase {
 
         await singleHopPostQuantumKeyExchanging.start()
 
-        wait(
-            for: [expectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
+        await fulfillment(
+            of: [expectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
             timeout: .UnitTest.invertedTimeout
         )
     }
@@ -110,8 +110,8 @@ final class SingleHopEphemeralPeerExchangerTests: XCTestCase {
             })
         await singleHopPostQuantumKeyExchanging.start()
 
-        wait(
-            for: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
+        await fulfillment(
+            of: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
             timeout: .UnitTest.invertedTimeout
         )
     }
@@ -147,8 +147,8 @@ final class SingleHopEphemeralPeerExchangerTests: XCTestCase {
         })
         await multiHopPeerExchanger.start()
 
-        wait(
-            for: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
+        await fulfillment(
+            of: [unexpectedNegotiationFailure, reconfigurationExpectation, negotiationSuccessful],
             timeout: .UnitTest.invertedTimeout
         )
     }

--- a/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
+++ b/ios/PacketTunnelCoreTests/TunnelMonitorTests.swift
@@ -15,7 +15,7 @@ import XCTest
 final class TunnelMonitorTests: XCTestCase {
     let networkCounters = NetworkCounters()
 
-    func testShouldDetermineConnectionEstablished() throws {
+    func testShouldDetermineConnectionEstablished() async throws {
         let connectedExpectation = expectation(description: "Should report connected.")
         let connectionLostExpectation = expectation(description: "Should not report connection loss")
         connectionLostExpectation.isInverted = true
@@ -38,10 +38,10 @@ final class TunnelMonitorTests: XCTestCase {
 
         tunnelMonitor.start(probeAddress: .loopback)
 
-        waitForExpectations(timeout: .UnitTest.invertedTimeout)
+        await fulfillment(of: [connectedExpectation, connectionLostExpectation], timeout: .UnitTest.invertedTimeout)
     }
 
-    func testInitialConnectionTimings() {
+    func testInitialConnectionTimings() async throws {
         // Setup pinger so that it never receives any replies.
         let pinger = PingerMock(networkStatsReporting: networkCounters) { _, _ in .ignore }
 
@@ -108,7 +108,7 @@ final class TunnelMonitorTests: XCTestCase {
         // Start monitoring.
         tunnelMonitor.start(probeAddress: .loopback)
 
-        waitForExpectations(timeout: TimeInterval(timeout) / 1000)
+        await fulfillment(of: [expectation], timeout: TimeInterval(timeout) / 1000)
     }
 }
 


### PR DESCRIPTION
This PR enables the Swift 6 compilation mode for the `PacketTunnel` target and all associated tests.