### PR TITLE
Change too many devices view to sheet

### DIFF
--- a/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
@@ -109,7 +109,7 @@ final class LoginCoordinator: Coordinator, Presenting, @preconcurrency DeviceMan
     private func returnToLogin(repeatLogin: Bool) {
         guard let loginController else { return }
 
-        navigationController.popToViewController(loginController, animated: true) {
+        navigationController.dismiss(animated: true) {
             if let lastLoginAction = self.lastLoginAction, repeatLogin {
                 self.loginController?.start(action: lastLoginAction)
             }
@@ -125,6 +125,7 @@ final class LoginCoordinator: Coordinator, Presenting, @preconcurrency DeviceMan
             interactor: interactor,
             alertPresenter: AlertPresenter(context: self)
         )
+        controller.isModalInPresentation = true
         controller.delegate = self
 
         controller.fetchDevices(animateUpdates: false) { [weak self] result in
@@ -133,7 +134,7 @@ final class LoginCoordinator: Coordinator, Presenting, @preconcurrency DeviceMan
             switch result {
             case .success:
                 Task { @MainActor in
-                    navigationController.pushViewController(controller, animated: true) {
+                    navigationController.present(controller, animated: true) {
                         completion(nil)
                     }
                 }

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
@@ -73,14 +73,14 @@ class DeviceManagementContentView: UIView {
         return button
     }()
 
-    let backButton: AppButton = {
+    let cancelButton: AppButton = {
         let button = AppButton(style: .default)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(
             NSLocalizedString(
-                "BACK_BUTTON",
+                "CANCEL_BUTTON",
                 tableName: "DeviceManagement",
-                value: "Back",
+                value: "Cancel",
                 comment: ""
             ),
             for: .normal
@@ -89,7 +89,7 @@ class DeviceManagementContentView: UIView {
     }()
 
     private lazy var buttonStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [continueButton, backButton])
+        let stackView = UIStackView(arrangedSubviews: [continueButton, cancelButton])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.distribution = .fillEqually
@@ -128,7 +128,7 @@ class DeviceManagementContentView: UIView {
 
     private func constraintViews() {
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
 
@@ -156,7 +156,7 @@ class DeviceManagementContentView: UIView {
             scrollContentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
 
             statusImageView.topAnchor
-                .constraint(equalTo: scrollContentView.layoutMarginsGuide.topAnchor),
+                .constraint(equalTo: scrollContentView.topAnchor),
             statusImageView.centerXAnchor.constraint(equalTo: scrollContentView.centerXAnchor),
 
             titleLabel.topAnchor.constraint(equalTo: statusImageView.bottomAnchor, constant: 22),

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementViewController.swift
@@ -60,7 +60,7 @@ class DeviceManagementViewController: UIViewController, RootContainment {
 
         view.addSubview(contentView)
 
-        contentView.backButton.addTarget(
+        contentView.cancelButton.addTarget(
             self,
             action: #selector(didTapBackButton(_:)),
             for: .touchUpInside


### PR DESCRIPTION
The too-many–devices view now gets presented instead of pushed. Swipe down to dismiss is disabled since the view contains a scroll view and therefore might dismiss unexpectedly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8209)
<!-- Reviewable:end -->
