### PR TITLE
Use GitHub hosted Windows ARM runner

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -139,8 +139,6 @@ jobs:
           git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
       - name: Install Protoc
-        # NOTE: ARM runner already has protoc
-        if: ${{ matrix.config.arch != 'arm64' }}
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -121,7 +121,7 @@ jobs:
         config:
           - os: windows-latest
             arch: x64
-          - os: [self-hosted, ARM64, Windows]
+          - os: windows-11-arm
             arch: arm64
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -169,11 +169,15 @@ jobs:
       # The x64 toolchain is needed to build talpid-openvpn-plugin
       # TODO: Remove once fixed
       - name: Install Rust x64 target
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         if: ${{ matrix.config.arch == 'arm64' }}
-        run: rustup target add x86_64-pc-windows-msvc
+        with:
+          target: x86_64-pc-windows-msvc
 
       - name: Install Rust
-        run: rustup target add i686-pc-windows-msvc
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: i686-pc-windows-msvc
 
       - name: Install msbuild
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -183,8 +183,6 @@ jobs:
           vs-version: 16
 
       - name: Install latest zig
-        # NOTE: This action doesn't support ARM64 for the time being (2025-01-27)
-        if: ${{ matrix.config.arch == 'x64' }}
         uses: mlugg/setup-zig@v1
 
       - name: Install Go


### PR DESCRIPTION
This PR switches over to using GitHub hosted Windows ARM runner(s) instead of our self-hosted ditto (which we've had a flaky experience with). Currently we only make use of Windows ARM runner(s) in the `daemon.yml` workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8212)
<!-- Reviewable:end -->
