### PR TITLE
Add UITests for QUIC, add ability to block Wireguard traffic

### DIFF
--- a/ios/MullvadVPNTests/MullvadREST/Relay/ObfuscatorPortSelectorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/ObfuscatorPortSelectorTests.swift
@@ -14,6 +14,7 @@ import XCTest
 
 final class ObfuscatorPortSelectorTests: XCTestCase {
     let defaultWireguardPort: RelayConstraint<UInt16> = .only(56)
+    let defaultQuicPort: RelayConstraint<UInt16> = .only(443)
 
     let sampleRelays = ServerRelaysResponseStubs.sampleRelays
     var tunnelSettings = LatestTunnelSettings()
@@ -174,5 +175,22 @@ final class ObfuscatorPortSelectorTests: XCTestCase {
         )
 
         XCTAssertEqual(obfuscationResult.wireguard.relays.count, sampleRelays.wireguard.relays.count)
+    }
+
+    // MARK: QUIC
+
+    func testObfuscateQuicOverPort443() throws {
+        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(
+            state: .quic
+        )
+
+        let obfuscationResult = try ObfuscatorPortSelector(
+            relays: sampleRelays
+        ).obfuscate(
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: 0
+        )
+
+        XCTAssertEqual(obfuscationResult.port, defaultQuicPort)
     }
 }

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -31,6 +31,10 @@ class BaseUITestCase: XCTestCase {
     /// Default relay to use in tests
     static let testsDefaultRelayName = "se-got-wg-001"
 
+    static let testsDefaultQuicCountryName = "Relay Software Country"
+    static let testsDefaultQuicCityName = "Relay Software city"
+    static let testsDefaultQuicRelayName = "se-got-wg-881"
+
     /// True when the current test case is capturing packets
     private var currentTestCaseShouldCapturePackets = false
 

--- a/ios/MullvadVPNUITests/Networking/FirewallRule.swift
+++ b/ios/MullvadVPNUITests/Networking/FirewallRule.swift
@@ -12,13 +12,13 @@ import XCTest
 struct FirewallRule {
     let fromIPAddress: String
     let toIPAddress: String
-    let protocols: [NetworkTransportProtocol]
+    let protocols: [TransportProtocol]
 
     /// - Parameters:
     ///     - fromIPAddress: Block traffic originating from this source IP address.
     ///     - toIPAddress: Block traffic to this destination IP address.
     ///     - protocols: Protocols which should be blocked. If none is specified all will be blocked.
-    private init(fromIPAddress: String, toIPAddress: String, protocols: [NetworkTransportProtocol]) {
+    private init(fromIPAddress: String, toIPAddress: String, protocols: [TransportProtocol]) {
         self.fromIPAddress = fromIPAddress
         self.toIPAddress = toIPAddress
         self.protocols = protocols
@@ -35,7 +35,7 @@ struct FirewallRule {
         return FirewallRule(
             fromIPAddress: deviceIPAddress,
             toIPAddress: apiIPAddress,
-            protocols: [.TCP]
+            protocols: [.transport(.TCP)]
         )
     }
 
@@ -45,7 +45,18 @@ struct FirewallRule {
         return FirewallRule(
             fromIPAddress: deviceIPAddress,
             toIPAddress: toIPAddress,
-            protocols: [.ICMP, .TCP, .UDP]
+            protocols: [.transport(.ICMP), .transport(.TCP), .transport(.UDP)]
+        )
+    }
+
+    public static func makeBlockWireGuardTrafficRule(
+        fromIPAddress: String,
+        toIPAddress: String
+    ) throws -> FirewallRule {
+        FirewallRule(
+            fromIPAddress: fromIPAddress,
+            toIPAddress: toIPAddress,
+            protocols: [.application(.wireguard)]
         )
     }
 
@@ -55,7 +66,7 @@ struct FirewallRule {
         return FirewallRule(
             fromIPAddress: deviceIPAddress,
             toIPAddress: toIPAddress,
-            protocols: [.UDP]
+            protocols: [.transport(.UDP)]
         )
     }
 }

--- a/ios/MullvadVPNUITests/Networking/Networking.swift
+++ b/ios/MullvadVPNUITests/Networking/Networking.swift
@@ -10,10 +10,27 @@ import Foundation
 import Network
 import XCTest
 
+enum TransportProtocol: Codable {
+    case transport(NetworkTransportProtocol)
+    case application(ApplicationProtocol)
+
+    var rawValue: String {
+        switch self {
+        case let .transport(transport): transport.rawValue
+        case let .application(application): application.rawValue
+        }
+    }
+}
+
+enum ApplicationProtocol: String, Codable {
+    case wireguard
+}
+
 enum NetworkTransportProtocol: String, Codable {
     case TCP = "tcp"
     case UDP = "udp"
     case ICMP = "icmp"
+    case ICMP6 = "icmp_v6"
 }
 
 enum NetworkingError: Error {

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -71,10 +71,6 @@ class TunnelControlPage: Page {
         return connectionAttempts
     }
 
-    func getInIPv4AddressLabel() -> String {
-        app.staticTexts[AccessibilityIdentifier.connectionPanelInAddressRow].label.components(separatedBy: ":")[0]
-    }
-
     @discardableResult override init(_ app: XCUIApplication) {
         super.init(app)
 


### PR DESCRIPTION
This PR adds tests for QUIC settings and UI Tests that guarantee that QUIC is working properly by blocking all Wireguard traffic when the test is running.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8215)
<!-- Reviewable:end -->
