### PR TITLE
Rename system notification action `'open-url'` to `'navigate-external'`

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/notification-controller.ts
+++ b/desktop/packages/mullvad-vpn/src/main/notification-controller.ts
@@ -10,9 +10,9 @@ import {
   DaemonDisconnectedNotificationProvider,
   DisconnectedNotificationProvider,
   ErrorNotificationProvider,
-  NotificationAction,
   ReconnectingNotificationProvider,
   SystemNotification,
+  SystemNotificationAction,
   SystemNotificationCategory,
   SystemNotificationProvider,
   SystemNotificationSeverityType,
@@ -269,7 +269,7 @@ export default class NotificationController {
     });
   }
 
-  private performAction(action?: NotificationAction) {
+  private performAction(action?: SystemNotificationAction) {
     if (action && action.type === 'open-url') {
       void this.notificationControllerDelegate.openLink(action.url, action.withAuth);
     }

--- a/desktop/packages/mullvad-vpn/src/main/notification-controller.ts
+++ b/desktop/packages/mullvad-vpn/src/main/notification-controller.ts
@@ -238,7 +238,7 @@ export default class NotificationController {
     // Action buttons are only available on macOS.
     if (process.platform === 'darwin') {
       if (systemNotification.action) {
-        notification.actions = [{ type: 'button', text: systemNotification.action.text }];
+        notification.actions = [{ type: 'button', text: systemNotification.action.link.text }];
         notification.on('action', () => this.performAction(systemNotification.action));
       }
       notification.on('click', () => this.notificationControllerDelegate.openApp());
@@ -270,8 +270,8 @@ export default class NotificationController {
   }
 
   private performAction(action?: SystemNotificationAction) {
-    if (action && action.type === 'open-url') {
-      void this.notificationControllerDelegate.openLink(action.url, action.withAuth);
+    if (action && action.type === 'navigate-external') {
+      void this.notificationControllerDelegate.openLink(action.link.to, action.link.withAuth);
     }
   }
 

--- a/desktop/packages/mullvad-vpn/src/renderer/components/ExternalLink.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/ExternalLink.tsx
@@ -7,6 +7,7 @@ import { Link, LinkProps } from '../lib/components';
 
 export type ExternalLinkProps = Omit<LinkProps<'a'>, 'href' | 'as'> & {
   to: Url;
+  withAuth?: boolean;
 };
 
 const StyledLink = styled(Link)`
@@ -14,17 +15,21 @@ const StyledLink = styled(Link)`
   width: fit-content;
 `;
 
-function ExternalLink({ to, onClick, ...props }: ExternalLinkProps) {
-  const { openUrl } = useAppContext();
+function ExternalLink({ to, onClick, withAuth, ...props }: ExternalLinkProps) {
+  const { openUrl, openUrlWithAuth } = useAppContext();
   const navigate = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
       e.preventDefault();
       if (onClick) {
         onClick(e);
       }
+
+      if (withAuth) {
+        return openUrlWithAuth(to);
+      }
       return openUrl(to);
     },
-    [onClick, openUrl, to],
+    [onClick, openUrl, openUrlWithAuth, to, withAuth],
   );
   return <StyledLink href="" onClick={navigate} {...props} />;
 }

--- a/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/NotificationArea.tsx
@@ -245,11 +245,11 @@ function NotificationActionWrapper({
   const handleClick = useCallback(() => {
     if (action) {
       switch (action.type) {
-        case 'open-url':
-          if (action.withAuth) {
-            return openUrlWithAuth(action.url);
+        case 'navigate-external':
+          if (action.link.withAuth) {
+            return openUrlWithAuth(action.link.to);
           } else {
-            return openUrl(action.url);
+            return openUrl(action.link.to);
           }
         case 'troubleshoot-dialog':
           setIsModalOpen(true);
@@ -271,7 +271,7 @@ function NotificationActionWrapper({
   let actionComponent: React.ReactElement | undefined;
   if (action) {
     switch (action.type) {
-      case 'open-url':
+      case 'navigate-external':
         actionComponent = <NotificationOpenLinkAction onClick={handleClick} />;
         break;
       case 'troubleshoot-dialog':

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/account-expired.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/account-expired.ts
@@ -32,10 +32,12 @@ export class AccountExpiredNotificationProvider implements SystemNotificationPro
       severity: SystemNotificationSeverityType.high,
       presentOnce: { value: true, name: this.constructor.name },
       action: {
-        type: 'open-url',
-        url: urls.purchase,
-        withAuth: true,
-        text: messages.pgettext('notifications', 'Buy more'),
+        type: 'navigate-external',
+        link: {
+          text: messages.pgettext('notifications', 'Buy more'),
+          to: urls.purchase,
+          withAuth: true,
+        },
       },
     };
   }

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/close-to-account-expiry.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/close-to-account-expiry.ts
@@ -43,10 +43,12 @@ export class CloseToAccountExpiryNotificationProvider
       category: SystemNotificationCategory.expiry,
       severity: SystemNotificationSeverityType.medium,
       action: {
-        type: 'open-url',
-        url: urls.purchase,
-        withAuth: true,
-        text: messages.pgettext('notifications', 'Buy more'),
+        type: 'navigate-external',
+        link: {
+          text: messages.pgettext('notifications', 'Buy more'),
+          to: urls.purchase,
+          withAuth: true,
+        },
       },
     };
   }

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/close-to-account-expiry.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/close-to-account-expiry.ts
@@ -66,7 +66,13 @@ export class CloseToAccountExpiryNotificationProvider
       indicator: 'warning',
       title: messages.pgettext('in-app-notifications', 'ACCOUNT CREDIT EXPIRES SOON'),
       subtitle,
-      action: { type: 'open-url', url: urls.purchase, withAuth: true },
+      action: {
+        type: 'navigate-external',
+        link: {
+          to: urls.purchase,
+          withAuth: true,
+        },
+      },
     };
   }
 }

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
@@ -23,7 +23,6 @@ export interface InAppNotificationTroubleshootButton {
 }
 
 export type InAppNotificationAction =
-  | NotificationAction
   | {
       type: 'troubleshoot-dialog';
       troubleshoot: InAppNotificationTroubleshootInfo;

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
@@ -4,10 +4,12 @@ import { ButtonProps } from '../../renderer/lib/components';
 import { Url } from '../constants';
 
 export type SystemNotificationAction = {
-  type: 'open-url';
-  url: Url;
-  text?: string;
-  withAuth?: boolean;
+  type: 'navigate-external';
+  link: {
+    to: Url;
+    text?: string;
+    withAuth?: boolean;
+  };
 };
 
 export interface InAppNotificationTroubleshootInfo {

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
@@ -38,7 +38,7 @@ export type InAppNotificationAction =
     }
   | {
       type: 'navigate-external';
-      link: Pick<ExternalLinkProps, 'to' | 'onClick' | 'aria-label'>;
+      link: Pick<ExternalLinkProps, 'to' | 'onClick' | 'aria-label' | 'withAuth'>;
     }
   | {
       type: 'run-function';

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/notification.ts
@@ -3,7 +3,7 @@ import { InternalLinkProps } from '../../renderer/components/InternalLink';
 import { ButtonProps } from '../../renderer/lib/components';
 import { Url } from '../constants';
 
-export type NotificationAction = {
+export type SystemNotificationAction = {
   type: 'open-url';
   url: Url;
   text?: string;
@@ -71,7 +71,7 @@ export interface SystemNotification {
   throttle?: boolean;
   presentOnce?: { value: boolean; name: string };
   suppressInDevelopment?: boolean;
-  action?: NotificationAction;
+  action?: SystemNotificationAction;
 }
 
 export interface InAppNotification {

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
@@ -45,8 +45,10 @@ export class UnsupportedVersionNotificationProvider
       title: messages.pgettext('in-app-notifications', 'UNSUPPORTED VERSION'),
       subtitle: this.getMessage(),
       action: {
-        type: 'open-url',
-        url: getDownloadUrl(this.context.suggestedIsBeta ?? false),
+        type: 'navigate-external',
+        link: {
+          to: getDownloadUrl(this.context.suggestedIsBeta ?? false),
+        },
       },
     };
   }

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
@@ -30,9 +30,11 @@ export class UnsupportedVersionNotificationProvider
       category: SystemNotificationCategory.newVersion,
       severity: SystemNotificationSeverityType.high,
       action: {
-        type: 'open-url',
-        url: getDownloadUrl(this.context.suggestedIsBeta ?? false),
-        text: messages.pgettext('notifications', 'Upgrade'),
+        type: 'navigate-external',
+        link: {
+          text: messages.pgettext('notifications', 'Upgrade'),
+          to: getDownloadUrl(this.context.suggestedIsBeta ?? false),
+        },
       },
       presentOnce: { value: true, name: this.constructor.name },
       suppressInDevelopment: true,

--- a/desktop/packages/mullvad-vpn/src/shared/notifications/update-available.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/update-available.ts
@@ -28,9 +28,11 @@ export class UpdateAvailableNotificationProvider implements SystemNotificationPr
       category: SystemNotificationCategory.newVersion,
       severity: SystemNotificationSeverityType.medium,
       action: {
-        type: 'open-url',
-        url: getDownloadUrl(this.context.suggestedIsBeta ?? false),
-        text: messages.pgettext('notifications', 'Upgrade'),
+        type: 'navigate-external',
+        link: {
+          text: messages.pgettext('notifications', 'Upgrade'),
+          to: getDownloadUrl(this.context.suggestedIsBeta ?? false),
+        },
       },
       presentOnce: { value: true, name: this.constructor.name },
       suppressInDevelopment: true,


### PR DESCRIPTION
- Migrates in app banners from using 'open-url' to 'navigate-external'
- Splits up the system and in app notifications to have separate but mostly equal types.
- Renames system notification 'open-url' to 'navigate-external'
- Add support to ExternalLink component to open links with auth.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8217)
<!-- Reviewable:end -->
