### PR TITLE
Fix arg order lost when adding to messages.pot

### DIFF
--- a/android/translations-converter/src/android/plurals.rs
+++ b/android/translations-converter/src/android/plurals.rs
@@ -1,5 +1,8 @@
 use super::string_value::StringValue;
 use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
 use std::{
     fmt::{self, Display, Formatter},
     ops::{Deref, DerefMut},
@@ -49,6 +52,18 @@ pub enum PluralQuantity {
     Few,
     Many,
     Other,
+}
+
+impl TryFrom<&Path> for PluralResources {
+    type Error = String;
+
+    fn try_from(value: &Path) -> Result<Self, Self::Error> {
+        let strings_file = File::open(value)
+            .map_err(|e| format!("Failed to open plural resources file: {}", e))?;
+
+        quick_xml::de::from_reader(BufReader::new(strings_file))
+            .map_err(|e| format!("Failed to parse plural resources file: {}", e))
+    }
 }
 
 impl Deref for PluralResources {

--- a/android/translations-converter/src/android/strings.rs
+++ b/android/translations-converter/src/android/strings.rs
@@ -1,5 +1,8 @@
 use super::string_value::StringValue;
 use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
 use std::{
     fmt::{self, Display, Formatter},
     ops::{Deref, DerefMut},
@@ -43,6 +46,18 @@ impl StringResources {
     pub fn sort(&mut self) {
         self.entries
             .sort_by(|left, right| left.name.cmp(&right.name));
+    }
+}
+
+impl TryFrom<&Path> for StringResources {
+    type Error = String;
+
+    fn try_from(value: &Path) -> Result<Self, Self::Error> {
+        let strings_file = File::open(value)
+            .map_err(|e| format!("Failed to open string resources file: {}", e))?;
+
+        quick_xml::de::from_reader(BufReader::new(strings_file))
+            .map_err(|e| format!("Failed to parse string resources file: {}", e))
     }
 }
 

--- a/android/translations-converter/src/normalize.rs
+++ b/android/translations-converter/src/normalize.rs
@@ -29,6 +29,18 @@ mod android {
             htmlize::unescape(value).into()
         }
     }
+
+    impl StringValue {
+        pub fn normalize_keep_parameter_indices(&self) -> String {
+            // Unescape apostrophes
+            let value = APOSTROPHES.replace_all(self, "'");
+            // Unescape double quotes
+            let value = DOUBLE_QUOTES.replace_all(&value, r#"""#);
+
+            // Unescape XML characters
+            htmlize::unescape(value).into()
+        }
+    }
 }
 
 mod gettext {


### PR DESCRIPTION
Currently when we add new strings from strings.xml in the android app and these gets added to message.pot by the translation script the arguments get added only as "%s" and "%d" and any ordering is lost. This means that if you would add a string to the android app that is something like "%1$s %2$s %1$s" this would be added to messages.pot as msgid "%s %s %s" and it would treat it as the string has 3 different arguments instead of 2.

This PR changes the code so that when the Android strings.xml strings are added to messages.pot the argument index (if it exists) is not removed as it was previously.

So the Android string "%1$s %2$s %1$s" will now result in the exact same string being added to messages.pot.

However, the current normalizaion behavior is kept when it comes to checking if an Android string already exists in messages.pot, so e.g. the string `"Not all our servers are %1$s-enabled. Therefore, we use multihop automatically to enable %1$s with any server."` will still match the current value in the pot file which is: `"Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."` and no new string is added to messages.pot.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
