### PR TITLE
Disable `SSHKEYLOGFILE` by default in masque client

### DIFF
--- a/mullvad-masque-proxy/examples/masque-client.rs
+++ b/mullvad-masque-proxy/examples/masque-client.rs
@@ -6,6 +6,7 @@ use tokio::net::UdpSocket;
 use std::{
     net::{Ipv4Addr, SocketAddr},
     path::PathBuf,
+    sync::Arc,
     time::Duration,
 };
 
@@ -76,11 +77,12 @@ async fn main() {
         auth,
     } = ClientArgs::parse();
 
-    let tls_config = match root_cert_path {
+    let mut tls_config = match root_cert_path {
         Some(path) => mullvad_masque_proxy::client::client_tls_config_from_cert_path(path.as_ref())
             .expect("Failed to get TLS config"),
         None => mullvad_masque_proxy::client::default_tls_config(),
     };
+    Arc::get_mut(&mut tls_config).unwrap().key_log = Arc::new(rustls::KeyLogFile::new());
 
     let _keylog = rustls::KeyLogFile::new();
 

--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -597,7 +597,6 @@ fn new_connect_request(
     Ok(request)
 }
 
-// TODO: resuse the same TLS code from `mullvad-api` maybe
 pub fn default_tls_config() -> Arc<rustls::ClientConfig> {
     static TLS_CONFIG: LazyLock<Arc<rustls::ClientConfig>> =
         LazyLock::new(|| client_tls_config_with_certs(read_cert_store()));
@@ -616,7 +615,6 @@ fn client_tls_config_with_certs(certs: rustls::RootCertStore) -> Arc<rustls::Cli
     config.alpn_protocols = vec![b"h3".to_vec()];
 
     let approver = Approver {};
-    config.key_log = Arc::new(rustls::KeyLogFile::new());
     config
         .dangerous()
         .set_certificate_verifier(Arc::new(approver));


### PR DESCRIPTION
This prevents `SSLKEYLOGFILE` from being used to dump keys to a file. I've kept it enabled in the example client.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8228)
<!-- Reviewable:end -->
