### PR TITLE
Remove dead code and add some more comments

### DIFF
--- a/ios/MullvadVPN/TunnelManager/WgKeyRotation.swift
+++ b/ios/MullvadVPN/TunnelManager/WgKeyRotation.swift
@@ -89,7 +89,7 @@ struct WgKeyRotation: Sendable {
     /**
      Returns the date of next key rotation, as it normally occurs in the app process using the following rules:
 
-     1. Returns the date relative to key creation date + 14 days, if last rotation attempt was successful.
+     1. Returns the date relative to key creation date + 30 days, if last rotation attempt was successful.
      2. Returns the date relative to last rotation attempt date + 24 hours, if last rotation attempt was unsuccessful.
 
      If the date produced is in the past then `Date()` is returned instead.


### PR DESCRIPTION
_Originally Mojgan's PR_

**Why this needs to be done**

The device checker keeps failing with a network error when the packet tunnel starts. Using mullvad api should solve this.

The device checker is responsible to rotate the key when there is a mismatch with the server. Fixing this should solve the login/logout issue.

To reproduce the issue, try the steps in acceptance criteria.

**What needs to be done**

Use the new mullvad api device proxy and account proxy for the device checker. This is being used in Debug.

There is also dead code related to key switching that should be removed:
- switchToCurrentKey()
- switchToCurrentKeyInner()
- private func setCurrentKeyPolicy(_ keyPolicy: inout State.KeyPolicy)

Write a document about this relating it to Login / Logout issue on Confluence. Make sure this talks about how to reproduce login logout Send a message to support advertising the existence of this document just to raise awareness

**Acceptance criteria**

- The device checker can fetch data successfully and rotate the wireguard key if needed. 
- A successful key rotation should result in the tunnel state: connected. It should not get stuck in connecting…

**How to test this**

To test the wg key rotation create a key mismatch like this:
- Change the rotationInterval in WgKeyRotation.swift to something like  .seconds(10)
- Add a break above line 67 in RotateKeyOperation.swift
- Run the app, login, put it into background and wait 10 sec
- Open the app and check the logs for Send request to /accounts/v1/devices/{id}/pubkey
- Kill the app
- Wait 10 minutes (the old key remains valid for a while)
- Revert the changes in RotateKeyOperation.swiftand WgKeyRotation.swiftand run the app again
- Connect to the tunnel
- Expected behavior before mullvad api:
  - Getting stuck in connecting…
  - network errors from the device checker
- Expected behavior with mullvad api:
  - No network errors
  - Connected state

**Tests**

We already have a bunch of tests for key rotation operation then adding tests for DeviceChecker won't add any extra values.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8229)
<!-- Reviewable:end -->
