### PR TITLE
Fix failure to connect when IP version does not match offline monitor state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ supported.
 - Use a local DNS resolver on the 127.0.0.0/8 network, regardless of macOS version.
 
 ### Fixed
+- Automatically connect when IP version becomes available.
+
 #### Linux
 - Fix syntax error in Apparmor profile.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ supported.
 #### Linux
 - Fix syntax error in Apparmor profile.
 
+#### Windows
+- Fix issue where daemon got stuck trying to connect only over IPv4 (or only IPv6).
+
 #### macOS
 - Fully uninstall the app when it is removed by being dropped in the bin.
 - Add grace period when best default route goes away to reduce frequency of random reconnects.

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -613,6 +613,14 @@ impl Connectivity {
             .unwrap_or(false)
     }
 
+    /// Whether connectivity for `ip_version` seems to be available on the host.
+    pub fn has_family(&self, ip_version: IpVersion) -> bool {
+        match ip_version {
+            IpVersion::V4 => self.has_ipv4(),
+            IpVersion::V6 => self.has_ipv6(),
+        }
+    }
+
     pub fn new(ipv4: bool, ipv6: bool) -> Connectivity {
         match (ipv4, ipv6) {
             (true, true) => Connectivity::Online(IpAvailability::Ipv4AndIpv6),

--- a/talpid-types/src/net/mod.rs
+++ b/talpid-types/src/net/mod.rs
@@ -570,16 +570,6 @@ pub enum Connectivity {
     Online(IpAvailability),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(target_os = "android", derive(FromJava))]
-#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.talpid.model"))]
-/// Available IP versions
-pub enum IpAvailability {
-    Ipv4,
-    Ipv6,
-    Ipv4AndIpv6,
-}
-
 impl Connectivity {
     /// Inverse of [`Connectivity::is_offline`].
     pub fn is_online(&self) -> bool {
@@ -592,27 +582,35 @@ impl Connectivity {
         *self == Connectivity::Offline
     }
 
+    /// Convert `self` to `IpAvailability`. Return `None` when `self` is `Connectivity::Offline`.
+    ///
+    /// If connectivity is unknown, return the default value of `IpAvailability` (IPv4).
+    pub fn availability(&self) -> Option<IpAvailability> {
+        match *self {
+            Connectivity::Online(availability) => Some(availability),
+            Connectivity::PresumeOnline => Some(IpAvailability::default()),
+            Connectivity::Offline => None,
+        }
+    }
+
     /// Whether IPv4 connectivity seems to be available on the host.
     ///
     /// If IPv4 status is unknown, `true` is returned.
     pub fn has_ipv4(&self) -> bool {
-        matches!(
-            self,
-            Connectivity::PresumeOnline
-                | Connectivity::Online(IpAvailability::Ipv4)
-                | Connectivity::Online(IpAvailability::Ipv4AndIpv6)
-        )
+        self.availability()
+            .as_ref()
+            .map(IpAvailability::has_ipv4)
+            .unwrap_or(false)
     }
 
     /// Whether IPv6 connectivity seems to be available on the host.
     ///
     /// If IPv6 status is unknown, `false` is returned.
     pub fn has_ipv6(&self) -> bool {
-        matches!(
-            self,
-            Connectivity::Online(IpAvailability::Ipv6)
-                | Connectivity::Online(IpAvailability::Ipv4AndIpv6)
-        )
+        self.availability()
+            .as_ref()
+            .map(IpAvailability::has_ipv6)
+            .unwrap_or(false)
     }
 
     pub fn new(ipv4: bool, ipv6: bool) -> Connectivity {
@@ -622,5 +620,40 @@ impl Connectivity {
             (false, true) => Connectivity::Online(IpAvailability::Ipv6),
             (false, false) => Connectivity::Offline,
         }
+    }
+}
+
+impl fmt::Display for Connectivity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Connectivity::Online(IpAvailability::Ipv4AndIpv6) => "Connected (IPv4 and IPv6)",
+            Connectivity::Online(IpAvailability::Ipv4) => "Connected (IPv4)",
+            Connectivity::Online(IpAvailability::Ipv6) => "Connected (IPv6)",
+            Connectivity::PresumeOnline => "Online (assume IPv4)",
+            Connectivity::Offline => "Offline",
+        })
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(target_os = "android", derive(FromJava))]
+#[cfg_attr(target_os = "android", jnix(package = "net.mullvad.talpid.model"))]
+/// Available IP versions
+pub enum IpAvailability {
+    #[default]
+    Ipv4,
+    Ipv6,
+    Ipv4AndIpv6,
+}
+
+impl IpAvailability {
+    /// Whether IPv4 connectivity is available.
+    pub fn has_ipv4(&self) -> bool {
+        matches!(self, Self::Ipv4 | Self::Ipv4AndIpv6)
+    }
+
+    /// Whether IPv6 connectivity is available.
+    pub fn has_ipv6(&self) -> bool {
+        matches!(self, Self::Ipv6 | Self::Ipv4AndIpv6)
     }
 }


### PR DESCRIPTION
Currently, if an IP version is set, the tunnel state machine fails to connect and gets stuck until users manually reconnect. The daemon now reconnects automatically in that case.

Also, this fixes an issue where the daemon got stuck connecting using a particular IP family on Windows.

Fix DES-2198
Fix DES-2201

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8231)
<!-- Reviewable:end -->
