### PR TITLE
Do not overwrite settings in `mullvad-early-boot-blocking.service`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ supported.
 
 #### Linux
 - Fix syntax error in Apparmor profile.
+- Fix issue where settings were lost after an upgrade if `mullvad-daemon` was not restarted
+  before `mullvad-early-boot-blocking.service`. That is, before a reboot.
 
 #### Windows
 - Fix issue where daemon got stuck trying to connect only over IPv4 (or only IPv6).

--- a/mullvad-daemon/src/early_boot_firewall.rs
+++ b/mullvad-daemon/src/early_boot_firewall.rs
@@ -33,6 +33,9 @@ pub async fn initialize_firewall() -> Result<(), Error> {
 
 async fn get_allow_lan() -> Result<bool, Error> {
     let path = mullvad_paths::settings_dir()?;
-    let settings = SettingsPersister::load(&path).await;
+    // NOTE: This may fail if the daemon has not been restarted after an upgrade.
+    //       This will cause `allow_lan` to be disabled during early boot. This
+    //       is probably acceptable.
+    let settings = SettingsPersister::read_only(&path).await;
     Ok(settings.allow_lan)
 }


### PR DESCRIPTION
We currently do not run any migration logic in this service. Instead, we just fetch the current settings, and overwrite them it this fails. This PR updates the early blocking code path to never overwrite existing settings.

Fix DES-2178

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8233)
<!-- Reviewable:end -->
