### PR TITLE
Make IP Override feature indicator check current tunnel endpoint

### DIFF
--- a/ios/MullvadREST/Relay/RelaySelectorProtocol.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorProtocol.swift
@@ -53,6 +53,10 @@ public struct SelectedRelays: Equatable, Codable, Sendable {
     public let exit: SelectedRelay
     public let retryAttempt: UInt
 
+    public var ingress: SelectedRelay {
+        entry ?? exit
+    }
+
     public init(entry: SelectedRelay?, exit: SelectedRelay, retryAttempt: UInt) {
         self.entry = entry
         self.exit = exit

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipFeature.swift
@@ -126,10 +126,17 @@ struct DNSFeature: ChipFeature {
 }
 
 struct IPOverrideFeature: ChipFeature {
+    let state: TunnelState
     let overrides: [IPOverride]
 
     var isEnabled: Bool {
-        !overrides.isEmpty
+        guard
+            let endpoint = state.relays?.ingress.endpoint
+        else { return false }
+        return overrides.contains { override in
+            (override.ipv4Address.map { $0 == endpoint.ipv4Gateway } ?? false) ||
+                (override.ipv6Address.map { $0 == endpoint.ipv6Gateway } ?? false)
+        }
     }
 
     var name: String {

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/FeatureIndicatorsViewModel.swift
@@ -39,7 +39,7 @@ class FeatureIndicatorsViewModel: ChipViewModelProtocol {
                 MultihopFeature(state: tunnelState),
                 ObfuscationFeature(settings: tunnelSettings, state: observedState),
                 DNSFeature(settings: tunnelSettings),
-                IPOverrideFeature(overrides: ipOverrides),
+                IPOverrideFeature(state: tunnelState, overrides: ipOverrides),
             ]
 
             return features


### PR DESCRIPTION
The IP Override feature indicator will now only be shown if the currently connected tunnel ingress endpoint matches one of the IP addresses in the set IP overrides. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
