### PR TITLE
Switch to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
 edition = "2024"
 # Must be less than or equal to `channel` in `rust-toolchain.toml`
-rust-version = "1.83.0"
+rust-version = "1.87.0"
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
-edition = "2021"
+edition = "2024"
 # Must be less than or equal to `channel` in `rust-toolchain.toml`
 rust-version = "1.83.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Must be greater than or equal to `rust-version` in `Cargo.toml`
-channel = "1.83.0"
+channel = "1.87.0"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.83.0"
 
 [workspace]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.83.0"
+rust-version = "1.87.0"
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
This PR switches the Rust version to 2024. updates the Rust version to 1.87.0, and fixes new lints resulting from this.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
