### PR TITLE
Fix access method disable logic

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentConfiguration.swift
@@ -32,6 +32,9 @@ struct SwitchCellContentConfiguration: UIContentConfiguration, Equatable {
     /// Content view layout margins.
     var directionalLayoutMargins: NSDirectionalEdgeInsets = UIMetrics.SettingsCell.apiAccessInsetLayoutMargins
 
+    /// Whether the toggle is enabled or disabled
+    var isEnabled = true
+
     func makeContentView() -> UIView & UIContentView {
         return SwitchCellContentView(configuration: self)
     }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
@@ -77,6 +77,7 @@ class SwitchCellContentView: UIView, UIContentView, UITextFieldDelegate {
         switchContainer.control.isOn = actualConfiguration.isOn
         switchContainer.transform = CGAffineTransform(scaleX: 0.85, y: 0.85)
         switchContainer.setAccessibilityIdentifier(actualConfiguration.accessibilityIdentifier)
+        switchContainer.isEnabled = actualConfiguration.isEnabled
     }
 
     private func addSubviews() {

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodInteractor.swift
@@ -15,14 +15,40 @@ struct EditAccessMethodInteractor: EditAccessMethodInteractorProtocol {
     let repository: AccessMethodRepositoryProtocol
     let proxyConfigurationTester: ProxyConfigurationTesterProtocol
 
+    init(
+        subject: CurrentValueSubject<AccessMethodViewModel, Never>,
+        repository: AccessMethodRepositoryProtocol,
+        proxyConfigurationTester: ProxyConfigurationTesterProtocol
+    ) {
+        self.subject = subject
+        self.repository = repository
+        self.proxyConfigurationTester = proxyConfigurationTester
+        checkIfSwitchCanBeToggled()
+    }
+
+    // The access method can only be disabled if at least one other method is enabled
+    private func checkIfSwitchCanBeToggled() {
+        let enabledMethodsCount = repository.fetchAll().count { $0.isEnabled }
+        if enabledMethodsCount < 2 {
+            subject.value.canBeToggled = !subject.value.isEnabled
+        } else {
+            subject.value.canBeToggled = true
+        }
+    }
+
     func saveAccessMethod() {
         guard let persistentMethod = try? subject.value.intoPersistentAccessMethod() else { return }
 
         repository.save(persistentMethod)
+        checkIfSwitchCanBeToggled()
     }
 
     func deleteAccessMethod() {
         repository.delete(id: subject.value.id)
+        // Enable direct access if all methods are disabled
+        if repository.fetchAll().count(where: { $0.isEnabled }) == 0 {
+            repository.save(repository.directAccess)
+        }
     }
 
     func startProxyConfigurationTest(_ completion: (@Sendable (Bool) -> Void)?) {

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodSectionIdentifier.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodSectionIdentifier.swift
@@ -26,8 +26,14 @@ enum EditAccessMethodSectionIdentifier: Hashable {
                 value: "Performs a connection test to a Mullvad API server via this access method.",
                 comment: ""
             )
-
-        case .enableMethod, .methodSettings, .cancelTest, .testingStatus, .deleteMethod:
+        case .enableMethod:
+            NSLocalizedString(
+                "METHOD_FOOTER",
+                tableName: "APIAccess",
+                value: "At least one method needs to be enabled.",
+                comment: ""
+            )
+        case .methodSettings, .cancelTest, .testingStatus, .deleteMethod:
             nil
         }
     }

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
@@ -140,6 +140,9 @@ extension EditAccessMethodViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard let sectionIdentifier = dataSource?.snapshot().sectionIdentifiers[section] else { return nil }
+        if sectionIdentifier == .enableMethod && subject.value.canBeToggled {
+            return nil
+        }
         guard let sectionFooterText = sectionIdentifier.sectionFooter else { return nil }
 
         guard let headerView = tableView
@@ -250,6 +253,8 @@ extension EditAccessMethodViewController: UITableViewDelegate {
                 self?.onSave()
             }
         }
+
+        contentConfiguration.isEnabled = subject.value.canBeToggled
         cell.contentConfiguration = contentConfiguration
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodViewModel.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodViewModel.swift
@@ -63,6 +63,9 @@ struct AccessMethodViewModel: Identifiable {
     /// The flag indicating whether configuration is enabled.
     var isEnabled = true
 
+    /// The flag indicating whether configuration is enabled.
+    var canBeToggled = true
+
     /// The status of testing the entered proxy configuration.
     var testingStatus: TestingStatus = .initial
 

--- a/ios/MullvadVPNUITests/AccessMethodsTests.swift
+++ b/ios/MullvadVPNUITests/AccessMethodsTests.swift
@@ -56,4 +56,41 @@ class AccessMethodsTests: LoggedOutUITestCase {
             .tapTestMethodButton()
             .verifyTestStatus(.reachable)
     }
+
+    func testCanNotDisableLast() throws {
+        HeaderBar(app)
+            .tapSettingsButton()
+
+        SettingsPage(app)
+            .tapAPIAccessCell()
+
+        APIAccessPage(app)
+            .getAccessMethodCell(
+                accessibilityId: AccessibilityIdentifier.accessMethodDirectCell
+            )
+            .tap()
+
+        EditAccessMethodPage(app)
+            .tapEnableMethodSwitch()
+            .tapBackButton()
+
+        APIAccessPage(app)
+            .getAccessMethodCell(
+                accessibilityId: AccessibilityIdentifier.accessMethodBridgesCell
+            )
+            .tap()
+
+        EditAccessMethodPage(app)
+            .tapEnableMethodSwitch()
+            .tapBackButton()
+
+        APIAccessPage(app)
+            .getAccessMethodCell(
+                accessibilityId: AccessibilityIdentifier.accessMethodEncryptedDNSCell
+            )
+            .tap()
+
+        EditAccessMethodPage(app)
+            .verifySwitchDisabled()
+    }
 }

--- a/ios/MullvadVPNUITests/Pages/EditAccessMethodPage.swift
+++ b/ios/MullvadVPNUITests/Pages/EditAccessMethodPage.swift
@@ -59,4 +59,9 @@ class EditAccessMethodPage: Page {
         backButton.tap()
         return self
     }
+
+    @discardableResult func verifySwitchDisabled() -> Self {
+        XCTAssertFalse(app.switches[AccessibilityIdentifier.accessMethodEnableSwitch].isEnabled)
+        return self
+    }
 }


### PR DESCRIPTION
Earlier all access methods could be disabled in the UI. 
Now, the last enabled access method can not be disabled.
When the last enabled access method is a custom method and it gets deleted, `direct` will be enabled again.
This is the same behavior as on android.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8239)
<!-- Reviewable:end -->
