### PR TITLE
Remove the DispatchQueue use to clear the cached address pointer

### DIFF
--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -77,6 +77,15 @@ typedef struct SwiftRetryStrategy {
   struct RetryStrategy *_0;
 } SwiftRetryStrategy;
 
+/**
+ * A struct used to deallocate a pointer to a C String later than when the pointer's control is relinquished from Swift.
+ * Use the `deallocate_ptr` function on `ptr` to call the custom deallocator provided by Swift.
+ */
+typedef struct LateStringDeallocator {
+  const char *ptr;
+  void (*deallocate_ptr)(const char*);
+} LateStringDeallocator;
+
 typedef struct SwiftMullvadApiResponse {
   uint8_t *body;
   uintptr_t body_size;
@@ -316,7 +325,7 @@ struct SwiftCancelHandle mullvad_ios_delete_account(struct SwiftApiContext api_c
  * `rawAddressCacheProvider` **must** be provided by a call to `init_swift_address_cache_wrapper`
  * It is okay to persist it, and use it accross multiple threads.
  */
-extern const char *swift_get_cached_endpoint(const void *rawAddressCacheProvider);
+extern struct LateStringDeallocator swift_get_cached_endpoint(const void *rawAddressCacheProvider);
 
 /**
  * Called by the Swift side in order to provide an object to rust that provides API addresses in a UTF-8 string form

--- a/mullvad-ios/src/api_client/address_cache_provider.rs
+++ b/mullvad-ios/src/api_client/address_cache_provider.rs
@@ -8,7 +8,9 @@ extern "C" {
     /// # SAFETY
     /// `rawAddressCacheProvider` **must** be provided by a call to `init_swift_address_cache_wrapper`
     /// It is okay to persist it, and use it accross multiple threads.
-    pub fn swift_get_cached_endpoint(rawAddressCacheProvider: *const c_void) -> *const c_char;
+    pub fn swift_get_cached_endpoint(
+        rawAddressCacheProvider: *const c_void,
+    ) -> LateStringDeallocator;
 }
 
 #[derive(Debug)]
@@ -40,16 +42,30 @@ pub struct SwiftAddressCacheProviderContext {
     address_cache: *const c_void,
 }
 
+/// A struct used to deallocate a pointer to a C String later than when the pointer's control is relinquished from Swift.
+/// Use the `deallocate_ptr` function on `ptr` to call the custom deallocator provided by Swift.
+#[repr(C)]
+pub struct LateStringDeallocator {
+    ptr: *const c_char,
+    deallocate_ptr: unsafe extern "C" fn(*const c_char),
+}
+
 impl SwiftAddressCacheProviderContext {
     pub fn get_addrs(&self) -> SocketAddr {
         // SAFETY: See notice for `swift_get_cached_endpoint`
-        let raw_address = unsafe { swift_get_cached_endpoint(self.address_cache) };
+        let deallocator = unsafe { swift_get_cached_endpoint(self.address_cache) };
 
-        // SAFETY: The pointer returned by `swift_get_cached_endpoint` is guaranteed to point to a valid UTF-8 String
+        // SAFETY: The pointer contained in the late deallocator returned by `swift_get_cached_endpoint`
+        // is guaranteed to point to a valid UTF-8 String
         // It is also guaranteed to be a valid representation of either an IPv4 or IPv6 address
-        unsafe { convert_c_string(raw_address) }
+        let cached_address = unsafe { convert_c_string(deallocator.ptr) }
             .parse()
-            .expect("Invalid socket address in cache")
+            .expect("Invalid socket address in cache");
+
+        // SAFETY: The pointer in `deallocator.ptr` must not be used after `deallocate_ptr` has been called.
+        // `deallocate_ptr` must be called only once
+        unsafe { (deallocator.deallocate_ptr)(deallocator.ptr) };
+        cached_address
     }
 }
 


### PR DESCRIPTION
This PR removes a small hack to use something not relying on runloop internals to work, and ultimately gives us more control when a pointer is freed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8245)
<!-- Reviewable:end -->
