### PR TITLE
Ios e2e login timeout fix

### DIFF
--- a/ios/MullvadVPNUITests/Pages/LoginPage.swift
+++ b/ios/MullvadVPNUITests/Pages/LoginPage.swift
@@ -40,22 +40,9 @@ class LoginPage: Page {
     }
 
     @discardableResult public func verifySuccessIconShown() -> Self {
-        // Success icon is only shown very briefly, since another view is presented after success icon is shown.
-        // Therefore we need to poll faster than waitForElement function.
-        let successIconDisplayedExpectation = XCTestExpectation(description: "Success icon shown")
-        let timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [self] _ in
-            let statusImageView = self.app.images[.statusImageView]
+        let isShown = getSuccessIconShown()
 
-            if statusImageView.exists {
-                if statusImageView.value as? String == "success" {
-                    successIconDisplayedExpectation.fulfill()
-                }
-            }
-        }
-
-        let waitResult = XCTWaiter.wait(for: [successIconDisplayedExpectation], timeout: BaseUITestCase.longTimeout)
-        XCTAssertEqual(waitResult, .completed, "Success icon shown")
-        timer.invalidate()
+        XCTAssertTrue(isShown, "Success icon shown")
 
         return self
     }
@@ -70,9 +57,24 @@ class LoginPage: Page {
 
     /// Checks whether success icon is being shown
     func getSuccessIconShown() -> Bool {
-        let predicate = NSPredicate(format: "identifier == 'statusImageView' AND value == 'success'")
-        let elementQuery = app.images.containing(predicate)
-        let elementExists = elementQuery.firstMatch.waitForExistence(timeout: BaseUITestCase.longTimeout)
-        return elementExists
+        // Success icon is only shown very briefly, since another view is presented after success icon is shown.
+        // Therefore we need to poll faster than waitForElement function.
+        let successIconDisplayedExpectation = XCTestExpectation(description: "Success icon shown")
+        var isShown = false
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [self] _ in
+            let statusImageView = self.app.images[.statusImageView]
+
+            if statusImageView.exists {
+                if statusImageView.value as? String == "success" {
+                    isShown = true
+                    successIconDisplayedExpectation.fulfill()
+                }
+            }
+        }
+
+        _ = XCTWaiter.wait(for: [successIconDisplayedExpectation], timeout: BaseUITestCase.longTimeout)
+        timer.invalidate()
+
+        return isShown
     }
 }


### PR DESCRIPTION
The UI tests sometimes have trouble figuring out if a login attempt was successful or not. This PR tries to improves this by pulling the existence of the success icon more frequent (this was already done for some tests, but not all).
Previously the timeout for a successful login was also too short.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8258)
<!-- Reviewable:end -->
