### PR TITLE
Revert merge of `disable-enablenodecliinspectarguments-fuse-des-1969`

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -612,47 +612,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/@electron/fuses": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
-      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.1",
-        "fs-extra": "^9.0.1",
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "electron-fuses": "dist/bin.js"
-      }
-    },
-    "node_modules/@electron/fuses/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@electron/fuses/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/get": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
@@ -10872,7 +10831,6 @@
         "windows-utils": "0.0.0"
       },
       "devDependencies": {
-        "@electron/fuses": "^1.8.0",
         "@playwright/test": "^1.41.1",
         "@types/chai": "^4.3.3",
         "@types/chai-as-promised": "^7.1.5",
@@ -11355,37 +11313,6 @@
         "commander": "^5.0.0",
         "glob": "^7.1.6",
         "minimatch": "^3.0.4"
-      }
-    },
-    "@electron/fuses": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
-      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.1",
-        "fs-extra": "^9.0.1",
-        "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
-        }
       }
     },
     "@electron/get": {
@@ -16554,7 +16481,6 @@
     "mullvad-vpn": {
       "version": "file:packages/mullvad-vpn",
       "requires": {
-        "@electron/fuses": "^1.8.0",
         "@grpc/grpc-js": "^1.12.2",
         "@playwright/test": "^1.41.1",
         "@rollup/rollup-darwin-arm64": "4.34.6",

--- a/desktop/packages/mullvad-vpn/package.json
+++ b/desktop/packages/mullvad-vpn/package.json
@@ -31,7 +31,6 @@
     "windows-utils": "0.0.0"
   },
   "devDependencies": {
-    "@electron/fuses": "^1.8.0",
     "@playwright/test": "^1.41.1",
     "@types/chai": "^4.3.3",
     "@types/chai-as-promised": "^7.1.5",

--- a/desktop/packages/mullvad-vpn/tasks/distribution.js
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const builder = require('electron-builder');
 const { Arch } = require('electron-builder');
 const { execFileSync } = require('child_process');
-const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
 
 const noCompression = process.argv.includes('--no-compression');
 const shouldNotarize = process.argv.includes('--notarize');
@@ -19,28 +18,6 @@ function getOptionValue(option) {
   if (optionIndex !== -1) {
     return process.argv[optionIndex + 1];
   }
-}
-
-// Adapted from example usages in this Github issue:
-// https://github.com/electron-userland/electron-builder/issues/6365
-async function flipElectronFuses(context) {
-  const { arch, appOutDir, electronPlatformName } = context;
-
-  const fileName = {
-    darwin: 'Mullvad VPN.app',
-    linux: 'mullvad-vpn',
-    win32: 'Mullvad VPN.exe',
-  }[electronPlatformName];
-
-  const electronBinaryPath = path.join(appOutDir, fileName);
-  const resetAdHocDarwinSignature =
-    electronPlatformName === 'darwin' && arch === builder.Arch.arm64; // necessary for building on Apple Silicon
-
-  await flipFuses(electronBinaryPath, {
-    version: FuseVersion.V1,
-    resetAdHocDarwinSignature,
-    [FuseV1Options.EnableNodeCliInspectArguments]: false,
-  });
 }
 
 function newConfig() {
@@ -84,23 +61,7 @@ function newConfig() {
     ],
 
     // Make sure that all files declared in "extraResources" exists and abort if they don't.
-    afterPack: async (context) => {
-      const isMac = context.electronPlatformName === 'darwin';
-      const isMacUniversal = isMac && context.arch === builder.Arch.universal;
-
-      if (
-        // Flip fuses for non-MacOS platforms
-        !isMac ||
-        // Flip fuses for all MacOS platforms if universal flag
-        // is not set
-        !universal ||
-        // Only flip fuses for universal MacOS package,
-        // when the universal flag is set
-        isMacUniversal
-      ) {
-        await flipElectronFuses(context);
-      }
-
+    afterPack: (context) => {
       if (context.arch !== Arch.universal) {
         const resources = context.packager.platformSpecificBuildOptions.extraResources;
         for (const resource of resources) {
@@ -415,8 +376,8 @@ function packMac() {
         await removeNseventforwarderNativeModules();
         config.beforePack?.(context);
       },
-      afterPack: async (context) => {
-        await config.afterPack?.(context);
+      afterPack: (context) => {
+        config.afterPack?.(context);
 
         if (context.arch !== Arch.universal) {
           delete process.env.TARGET_TRIPLE;
@@ -475,7 +436,7 @@ function packLinux() {
         return true;
       },
       afterPack: async (context) => {
-        await config.afterPack?.(context);
+        config.afterPack?.(context);
 
         const sourceExecutable = path.join(context.appOutDir, 'mullvad-vpn');
         const targetExecutable = path.join(context.appOutDir, 'mullvad-gui');


### PR DESCRIPTION
This reverts commit 2ea8801957c79ad81ec3d7d0048f1ae632654f84, reversing changes made to 84f7346714930ed7306253315b93f59a60a23b3b.

This change is done because Playwright cannot use the installed app
when the fuse is disabled. Quote from Playwright's documentation:

> Known issues:
> If you are not able to launch Electron and it will end up in timeouts during launch, try the following:
> Ensure that nodeCliInspect (FuseV1Options.EnableNodeCliInspectArguments) fuse is not set to false.

Link: https://playwright.dev/docs/api/class-electron


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8259)
<!-- Reviewable:end -->
