### PR TITLE
Remove custom license allowance for ring

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -51,18 +51,9 @@ allow = [
     "BSD-3-Clause",
     "BSD-2-Clause",
     "CC0-1.0",
-    # https://github.com/briansmith/ring/issues/902
-    "LicenseRef-ring",
     "Unicode-DFS-2016",
     "Zlib",
     "Unicode-3.0"
-]
-
-[[licenses.clarify]]
-name = "ring"
-expression = "LicenseRef-ring"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
 ]
 
 [licenses.private]


### PR DESCRIPTION
I noticed that `cargo deny check license` returned a warning that `LicenseRef-ring` was unused. Ring switched over to Apache-2.0 AND ISC, so they are now compatible with our regular list of allowed licenses.

https://github.com/briansmith/ring/blob/3496a3be28fb83daf4f86a824bf6b0a656a535c6/Cargo.toml#L7