### PR TITLE
Fix boringtun device not being closed when disconnecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/mullvad/boringtun?rev=a7e11fb46d4a#a7e11fb46d4ae65d4c7bf4efb9617548c072afa0"
+source = "git+https://github.com/mullvad/boringtun?rev=c29681df54e1c10ba06d9ca7ff98722c9dcb5a81#c29681df54e1c10ba06d9ca7ff98722c9dcb5a81"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -46,7 +46,7 @@ tokio-stream = { version = "0.1", features = ["io-util"] }
 optional = true
 features = ["device"]
 git = "https://github.com/mullvad/boringtun"
-rev = "a7e11fb46d4a"
+rev = "c29681df54e1c10ba06d9ca7ff98722c9dcb5a81"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.23"


### PR DESCRIPTION
This fixes the issue where reconnecting fails every time, because not all spawned tasks were aborted.

Close DES-2161

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8278)
<!-- Reviewable:end -->
