### PR TITLE
Move api access method test call to mullvad api ios 1195

### DIFF
--- a/ios/MullvadMockData/MullvadREST/APIProxy+Stubs.swift
+++ b/ios/MullvadMockData/MullvadREST/APIProxy+Stubs.swift
@@ -64,17 +64,25 @@ struct APIProxyStub: APIQuerying {
 
     func initStorekitPayment(
         accountNumber: String,
-        retryStrategy: MullvadREST.REST.RetryStrategy,
-        completionHandler: @escaping MullvadREST.ProxyCompletionHandler<String>
+        retryStrategy: REST.RetryStrategy,
+        completionHandler: @escaping ProxyCompletionHandler<String>
     ) -> any MullvadTypes.Cancellable {
         AnyCancellable()
     }
 
     func checkStorekitPayment(
         accountNumber: String,
-        transaction: MullvadTypes.StorekitTransaction,
-        retryStrategy: MullvadREST.REST.RetryStrategy,
-        completionHandler: @escaping MullvadREST.ProxyCompletionHandler<Void>
+        transaction: StorekitTransaction,
+        retryStrategy: REST.RetryStrategy,
+        completionHandler: @escaping ProxyCompletionHandler<Void>
+    ) -> any MullvadTypes.Cancellable {
+        AnyCancellable()
+    }
+
+    func checkApiAvailability(
+        retryStrategy: REST.RetryStrategy,
+        accessMethod: PersistentAccessMethod,
+        completion: @escaping ProxyCompletionHandler<Bool>
     ) -> any MullvadTypes.Cancellable {
         AnyCancellable()
     }

--- a/ios/MullvadREST/ApiHandlers/RESTAPIProxy.swift
+++ b/ios/MullvadREST/ApiHandlers/RESTAPIProxy.swift
@@ -279,6 +279,14 @@ extension REST {
         ) -> any MullvadTypes.Cancellable {
             AnyCancellable()
         }
+
+        public func checkApiAvailability(
+            retryStrategy: REST.RetryStrategy,
+            accessMethod: MullvadTypes.PersistentAccessMethod,
+            completion: @escaping ProxyCompletionHandler<Bool>
+        ) -> any MullvadTypes.Cancellable {
+            AnyCancellable()
+        }
     }
 
     // MARK: - Response types

--- a/ios/MullvadREST/ApiHandlers/RESTAPIProxy.swift
+++ b/ios/MullvadREST/ApiHandlers/RESTAPIProxy.swift
@@ -257,7 +257,7 @@ extension REST {
             request: LegacyStorekitRequest,
             retryStrategy: REST.RetryStrategy,
             completionHandler: @escaping ProxyCompletionHandler<REST.CreateApplePaymentResponse>
-        ) -> any MullvadTypes.Cancellable {
+        ) -> any Cancellable {
             AnyCancellable()
         }
 
@@ -266,25 +266,25 @@ extension REST {
             accountNumber: String,
             retryStrategy: REST.RetryStrategy,
             completionHandler: @escaping ProxyCompletionHandler<String>
-        ) -> any MullvadTypes.Cancellable {
+        ) -> any Cancellable {
             AnyCancellable()
         }
 
         /// Not implemented. Use `MullvadAPIProxy` instead.
         public func checkStorekitPayment(
             accountNumber: String,
-            transaction: MullvadTypes.StorekitTransaction,
+            transaction: StorekitTransaction,
             retryStrategy: REST.RetryStrategy,
             completionHandler: @escaping ProxyCompletionHandler<Void>
-        ) -> any MullvadTypes.Cancellable {
+        ) -> any Cancellable {
             AnyCancellable()
         }
 
         public func checkApiAvailability(
             retryStrategy: REST.RetryStrategy,
-            accessMethod: MullvadTypes.PersistentAccessMethod,
+            accessMethod: PersistentAccessMethod,
             completion: @escaping ProxyCompletionHandler<Bool>
-        ) -> any MullvadTypes.Cancellable {
+        ) -> any Cancellable {
             AnyCancellable()
         }
     }

--- a/ios/MullvadREST/MullvadAPI/APIHandlers/MullvadAPIProxy.swift
+++ b/ios/MullvadREST/MullvadAPI/APIHandlers/MullvadAPIProxy.swift
@@ -60,6 +60,12 @@ public protocol APIQuerying: Sendable {
         retryStrategy: REST.RetryStrategy,
         completionHandler: @escaping @Sendable ProxyCompletionHandler<Void>
     ) -> Cancellable
+
+    func checkApiAvailability(
+        retryStrategy: REST.RetryStrategy,
+        accessMethod: PersistentAccessMethod,
+        completion: @escaping @Sendable ProxyCompletionHandler<Bool>
+    ) -> Cancellable
 }
 
 extension REST {
@@ -157,6 +163,24 @@ extension REST {
             RESTRequestExecutorStub<REST.CreateApplePaymentResponse>(success: {
                 .timeAdded(0, .now)
             })
+        }
+
+        public func checkApiAvailability(
+            retryStrategy: REST.RetryStrategy,
+            accessMethod: PersistentAccessMethod,
+            completion: @escaping @Sendable ProxyCompletionHandler<Bool>
+        ) -> Cancellable {
+            let responseHandler = rustEmptyResponseHandler()
+            return createNetworkOperation(
+                request: .checkApiAvailability(retryStrategy, accessMethod: accessMethod),
+                responseHandler: responseHandler
+            ) { result in
+                if case let .failure(err) = result {
+                    completion(.failure(err))
+                } else {
+                    completion(.success(true))
+                }
+            }
         }
 
         public func legacyStorekitPayment(

--- a/ios/MullvadREST/MullvadAPI/APIRequest/APIRequest.swift
+++ b/ios/MullvadREST/MullvadAPI/APIRequest/APIRequest.swift
@@ -13,6 +13,7 @@ public enum APIRequest: Codable, Sendable {
     case getAddressList(_ retryStrategy: REST.RetryStrategy)
     case getRelayList(_ retryStrategy: REST.RetryStrategy, etag: String?)
     case sendProblemReport(_ retryStrategy: REST.RetryStrategy, problemReportRequest: ProblemReportRequest)
+    case checkApiAvailability(_ retryStrategy: REST.RetryStrategy, accessMethod: PersistentAccessMethod)
 
     // Account Proxy
     case createAccount(_ retryStrategy: REST.RetryStrategy)
@@ -72,6 +73,8 @@ public enum APIRequest: Codable, Sendable {
             "init-storekit-payment"
         case .checkStorekitPayment:
             "check-storekit-payment"
+        case .checkApiAvailability:
+            "check-api-availability"
         }
     }
 
@@ -90,7 +93,8 @@ public enum APIRequest: Codable, Sendable {
              let .rotateDeviceKey(strategy, _, _, _),
              let .legacyStorekitPayment(strategy, _, _),
              let .initStorekitPayment(strategy, _),
-             let .checkStorekitPayment(strategy, _, _):
+             let .checkStorekitPayment(strategy, _, _),
+             let .checkApiAvailability(strategy, _):
             strategy
         }
     }

--- a/ios/MullvadREST/MullvadAPI/MullvadApiRequestFactory.swift
+++ b/ios/MullvadREST/MullvadAPI/MullvadApiRequestFactory.swift
@@ -114,6 +114,13 @@ public struct MullvadApiRequestFactory: Sendable {
                     accountNumber,
                     request.publicKey.rawValue.map { $0 }
                 ))
+            case let .checkApiAvailability(retryStrategy, accessMethod):
+                return MullvadApiCancellable(handle: mullvad_ios_api_addrs_available(
+                    apiContext.context,
+                    rawCompletionPointer,
+                    retryStrategy.toRustStrategy(),
+                    convertAccessMethod(accessMethod: accessMethod)
+                ))
             case let .legacyStorekitPayment(
                 retryStrategy: retryStrategy,
                 accountNumber: accountNumber,

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -89,10 +89,10 @@ typedef struct LateStringDeallocator {
 typedef struct SwiftMullvadApiResponse {
   uint8_t *body;
   uintptr_t body_size;
-  uint8_t *etag;
+  char *etag;
   uint16_t status_code;
-  uint8_t *error_description;
-  uint8_t *server_response_code;
+  char *error_description;
+  char *server_response_code;
   bool success;
 } SwiftMullvadApiResponse;
 

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -373,7 +373,8 @@ struct SwiftCancelHandle mullvad_ios_get_addresses(struct SwiftApiContext api_co
  */
 struct SwiftCancelHandle mullvad_ios_api_addrs_available(struct SwiftApiContext api_context,
                                                          void *completion_cookie,
-                                                         struct SwiftRetryStrategy retry_strategy);
+                                                         struct SwiftRetryStrategy retry_strategy,
+                                                         const void *access_method_setting);
 
 /**
  * # Safety

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -366,6 +366,25 @@ struct SwiftCancelHandle mullvad_ios_get_addresses(struct SwiftApiContext api_co
  * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
  * when completion finishes (in completion.finish).
  *
+ * `retry_strategy` must have been created by a call to either of the following functions
+ * `mullvad_api_retry_strategy_never`, `mullvad_api_retry_strategy_constant` or `mullvad_api_retry_strategy_exponential`
+ *
+ * This function is not safe to call multiple times with the same `CompletionCookie`.
+ */
+struct SwiftCancelHandle mullvad_ios_api_addrs_available(struct SwiftApiContext api_context,
+                                                         void *completion_cookie,
+                                                         struct SwiftRetryStrategy retry_strategy);
+
+/**
+ * # Safety
+ *
+ * `api_context` must be pointing to a valid instance of `SwiftApiContext`. A `SwiftApiContext` is created
+ * by calling `mullvad_api_init_new`.
+ *
+ * This function takes ownership of `completion_cookie`, which must be pointing to a valid instance of Swift
+ * object `MullvadApiCompletion`. The pointer will be freed by calling `mullvad_api_completion_finish`
+ * when completion finishes (in completion.finish).
+ *
  * `etag` must be a pointer to a null terminated string.
  *
  * `retry_strategy` must have been created by a call to either of the following functions

--- a/ios/MullvadTypes/PersistentAccessMethod.swift
+++ b/ios/MullvadTypes/PersistentAccessMethod.swift
@@ -24,7 +24,7 @@ public struct PersistentAccessMethodStore: Codable {
 }
 
 /// Persistent access method model.
-public struct PersistentAccessMethod: Identifiable, Codable, Equatable {
+public struct PersistentAccessMethod: Identifiable, Codable, Equatable, Sendable {
     /// The unique identifier used for referencing the access method entry in a persistent store.
     public var id: UUID
 
@@ -63,7 +63,7 @@ public struct PersistentAccessMethod: Identifiable, Codable, Equatable {
 }
 
 /// Persistent proxy configuration.
-public enum PersistentProxyConfiguration: Codable, Equatable {
+public enum PersistentProxyConfiguration: Codable, Equatable, Sendable {
     /// Direct communication without proxy.
     case direct
 
@@ -98,7 +98,7 @@ extension PersistentProxyConfiguration {
     }
 
     /// Socks v5 proxy configuration.
-    public struct SocksConfiguration: Codable, Equatable {
+    public struct SocksConfiguration: Codable, Equatable, Sendable {
         /// Proxy server address.
         public var server: AnyIPAddress
 
@@ -132,7 +132,7 @@ extension PersistentProxyConfiguration {
     }
 
     /// Shadowsocks configuration.
-    public struct ShadowsocksConfiguration: Codable, Equatable {
+    public struct ShadowsocksConfiguration: Codable, Equatable, Sendable {
         /// Server address.
         public var server: AnyIPAddress
 

--- a/ios/MullvadVPN/AccessMethodRepository/ProxyConfigurationTesterProtocol.swift
+++ b/ios/MullvadVPN/AccessMethodRepository/ProxyConfigurationTesterProtocol.swift
@@ -15,7 +15,7 @@ protocol ProxyConfigurationTesterProtocol {
     /// - Parameters:
     ///   - configuration: a proxy configuration.
     ///   - completion: a completion handler that receives `nil` upon success, otherwise the underlying error.
-    func start(configuration: PersistentProxyConfiguration, completion: @escaping @Sendable (Error?) -> Void)
+    func start(configuration: PersistentAccessMethod, completion: @escaping @Sendable (Error?) -> Void)
 
     /// Cancel testing proxy configuration.
     func cancel()

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -570,7 +570,10 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
         let navigationController = CustomNavigationController()
         navigationController.view.setAccessibilityIdentifier(.settingsContainerView)
 
-        let configurationTester = ProxyConfigurationTester(transportProvider: configuredTransportProvider)
+        let configurationTester = ProxyConfigurationTester(
+            transportProvider: configuredTransportProvider,
+            apiProxy: apiProxy
+        )
 
         let coordinator = SettingsCoordinator(
             navigationController: navigationController,

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodInteractor.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodInteractor.swift
@@ -52,7 +52,7 @@ struct EditAccessMethodInteractor: EditAccessMethodInteractorProtocol {
     }
 
     func startProxyConfigurationTest(_ completion: (@Sendable (Bool) -> Void)?) {
-        guard let config = try? subject.value.intoPersistentProxyConfiguration() else { return }
+        guard let config = try? subject.value.intoPersistentAccessMethod() else { return }
 
         let subject = subject
         subject.value.testingStatus = .inProgress

--- a/mullvad-ios/src/api_client/response.rs
+++ b/mullvad-ios/src/api_client/response.rs
@@ -61,6 +61,25 @@ impl SwiftMullvadApiResponse {
         }
     }
 
+    pub fn access_method_error(err: mullvad_api::access_mode::Error) -> Self {
+        let to_cstr_pointer = |str| {
+            CString::new(str)
+                .map(|cstr| cstr.into_raw().cast())
+                .unwrap_or(null_mut())
+        };
+        let error_description = to_cstr_pointer(err.to_string());
+
+        Self {
+            body: null_mut(),
+            body_size: 0,
+            etag: null_mut(),
+            status_code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+            error_description,
+            server_response_code: null_mut(),
+            success: false,
+        }
+    }
+
     pub fn rest_error(err: mullvad_api::rest::Error) -> Self {
         if err.is_aborted() {
             return Self::cancelled();

--- a/mullvad-ios/src/api_client/response.rs
+++ b/mullvad-ios/src/api_client/response.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::CString,
+    ffi::{c_char, CString},
     ptr::{self, null_mut},
 };
 
@@ -12,10 +12,10 @@ use mullvad_api::{
 pub struct SwiftMullvadApiResponse {
     body: *mut u8,
     body_size: usize,
-    etag: *mut u8,
+    etag: *mut c_char,
     status_code: u16,
-    error_description: *mut u8,
-    server_response_code: *mut u8,
+    error_description: *mut c_char,
+    server_response_code: *mut c_char,
     success: bool,
 }
 
@@ -33,7 +33,7 @@ impl SwiftMullvadApiResponse {
             Some(etag) => {
                 let header_value =
                     CString::new(etag).map_err(|_| rest::Error::InvalidHeaderError)?;
-                header_value.into_raw().cast()
+                header_value.into_raw()
             }
             None => ptr::null_mut(),
         };
@@ -64,7 +64,7 @@ impl SwiftMullvadApiResponse {
     pub fn access_method_error(err: mullvad_api::access_mode::Error) -> Self {
         let to_cstr_pointer = |str| {
             CString::new(str)
-                .map(|cstr| cstr.into_raw().cast())
+                .map(|cstr| cstr.into_raw())
                 .unwrap_or(null_mut())
         };
         let error_description = to_cstr_pointer(err.to_string());
@@ -87,7 +87,7 @@ impl SwiftMullvadApiResponse {
 
         let to_cstr_pointer = |str| {
             CString::new(str)
-                .map(|cstr| cstr.into_raw().cast())
+                .map(|cstr| cstr.into_raw())
                 .unwrap_or(null_mut())
         };
 
@@ -113,7 +113,7 @@ impl SwiftMullvadApiResponse {
     pub fn cancelled() -> Self {
         Self {
             success: false,
-            error_description: c"Request was cancelled".to_owned().into_raw().cast(),
+            error_description: c"Request was cancelled".to_owned().into_raw(),
             body: null_mut(),
             body_size: 0,
             etag: null_mut(),
@@ -125,7 +125,7 @@ impl SwiftMullvadApiResponse {
     pub fn no_tokio_runtime() -> Self {
         Self {
             success: false,
-            error_description: c"Failed to get Tokio runtime".to_owned().into_raw().cast(),
+            error_description: c"Failed to get Tokio runtime".to_owned().into_raw(),
             body: null_mut(),
             body_size: 0,
             etag: null_mut(),
@@ -149,14 +149,14 @@ pub unsafe extern "C" fn mullvad_response_drop(response: SwiftMullvadApiResponse
     }
 
     if !response.etag.is_null() {
-        let _ = CString::from_raw(response.etag.cast());
+        let _ = CString::from_raw(response.etag);
     }
 
     if !response.error_description.is_null() {
-        let _ = CString::from_raw(response.error_description.cast());
+        let _ = CString::from_raw(response.error_description);
     }
 
     if !response.server_response_code.is_null() {
-        let _ = CString::from_raw(response.server_response_code.cast());
+        let _ = CString::from_raw(response.server_response_code);
     }
 }


### PR DESCRIPTION
This PR adds the ability to `Test` the API in AccessMethods using the Rust API client.
The client will only be used in Debug builds, we still rely on `URLSession` for release builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8282)
<!-- Reviewable:end -->
