### PR TITLE
Listen for all network events to fix missing default network events

### DIFF
--- a/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/talpid/util/ConnectivityManagerUtilKtTest.kt
+++ b/android/app/src/androidTest/kotlin/net/mullvad/mullvadvpn/talpid/util/ConnectivityManagerUtilKtTest.kt
@@ -18,11 +18,13 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import net.mullvad.talpid.model.Connectivity
 import net.mullvad.talpid.model.IpAvailability
 import net.mullvad.talpid.util.NetworkEvent
 import net.mullvad.talpid.util.UnderlyingConnectivityStatusResolver
+import net.mullvad.talpid.util.allNetworkEvents
 import net.mullvad.talpid.util.defaultNetworkEvents
 import net.mullvad.talpid.util.hasInternetConnectivity
 import org.junit.jupiter.api.BeforeEach
@@ -34,6 +36,7 @@ class ConnectivityManagerUtilKtTest {
     @BeforeEach
     fun setup() {
         mockkStatic(CONNECTIVITY_MANAGER_UTIL_CLASS)
+        every { connectivityManager.allNetworkEvents() } returns flowOf(NetworkEvent.Unavailable)
     }
 
     /** User being online, the listener should emit once with `true` */

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/ConnectivityManagerUtil.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/util/ConnectivityManagerUtil.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager.NetworkCallback
 import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import co.touchlab.kermit.Logger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.FlowPreview
@@ -12,59 +13,127 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
 import net.mullvad.talpid.model.Connectivity
 
 private val CONNECTIVITY_DEBOUNCE = 300.milliseconds
 
-fun ConnectivityManager.defaultNetworkEvents(): Flow<NetworkEvent> = callbackFlow {
-    val callback =
-        object : NetworkCallback() {
-            override fun onLinkPropertiesChanged(network: Network, linkProperties: LinkProperties) {
-                super.onLinkPropertiesChanged(network, linkProperties)
-                trySendBlocking(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
-            }
+fun ConnectivityManager.defaultNetworkEvents(): Flow<NetworkEvent> =
+    callbackFlow {
+            val callback =
+                object : NetworkCallback() {
+                    override fun onLinkPropertiesChanged(
+                        network: Network,
+                        linkProperties: LinkProperties,
+                    ) {
+                        super.onLinkPropertiesChanged(network, linkProperties)
+                        trySendBlocking(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
+                    }
 
-            override fun onAvailable(network: Network) {
-                super.onAvailable(network)
-                trySendBlocking(NetworkEvent.Available(network))
-            }
+                    override fun onAvailable(network: Network) {
+                        super.onAvailable(network)
+                        trySendBlocking(NetworkEvent.Available(network))
+                    }
 
-            override fun onCapabilitiesChanged(
-                network: Network,
-                networkCapabilities: NetworkCapabilities,
-            ) {
-                super.onCapabilitiesChanged(network, networkCapabilities)
-                trySendBlocking(NetworkEvent.CapabilitiesChanged(network, networkCapabilities))
-            }
+                    override fun onCapabilitiesChanged(
+                        network: Network,
+                        networkCapabilities: NetworkCapabilities,
+                    ) {
+                        super.onCapabilitiesChanged(network, networkCapabilities)
+                        trySendBlocking(
+                            NetworkEvent.CapabilitiesChanged(network, networkCapabilities)
+                        )
+                    }
 
-            override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
-                super.onBlockedStatusChanged(network, blocked)
-                trySendBlocking(NetworkEvent.BlockedStatusChanged(network, blocked))
-            }
+                    override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
+                        super.onBlockedStatusChanged(network, blocked)
+                        trySendBlocking(NetworkEvent.BlockedStatusChanged(network, blocked))
+                    }
 
-            override fun onLosing(network: Network, maxMsToLive: Int) {
-                super.onLosing(network, maxMsToLive)
-                trySendBlocking(NetworkEvent.Losing(network, maxMsToLive))
-            }
+                    override fun onLosing(network: Network, maxMsToLive: Int) {
+                        super.onLosing(network, maxMsToLive)
+                        trySendBlocking(NetworkEvent.Losing(network, maxMsToLive))
+                    }
 
-            override fun onLost(network: Network) {
-                super.onLost(network)
-                trySendBlocking(NetworkEvent.Lost(network))
-            }
+                    override fun onLost(network: Network) {
+                        super.onLost(network)
+                        trySendBlocking(NetworkEvent.Lost(network))
+                    }
 
-            override fun onUnavailable() {
-                super.onUnavailable()
-                trySendBlocking(NetworkEvent.Unavailable)
-            }
+                    override fun onUnavailable() {
+                        super.onUnavailable()
+                        trySendBlocking(NetworkEvent.Unavailable)
+                    }
+                }
+            registerDefaultNetworkCallback(callback)
+
+            awaitClose { unregisterNetworkCallback(callback) }
         }
-    registerDefaultNetworkCallback(callback)
+        .onEach { Logger.d("Got a default network event type: ${it::class.simpleName}") }
 
-    awaitClose { unregisterNetworkCallback(callback) }
-}
+fun ConnectivityManager.nonVpnInternetNetworksEvents(): Flow<NetworkEvent> =
+    callbackFlow {
+            val callback =
+                object : NetworkCallback() {
+                    override fun onLinkPropertiesChanged(
+                        network: Network,
+                        linkProperties: LinkProperties,
+                    ) {
+                        super.onLinkPropertiesChanged(network, linkProperties)
+                        trySendBlocking(NetworkEvent.LinkPropertiesChanged(network, linkProperties))
+                    }
+
+                    override fun onAvailable(network: Network) {
+                        super.onAvailable(network)
+                        trySendBlocking(NetworkEvent.Available(network))
+                    }
+
+                    override fun onCapabilitiesChanged(
+                        network: Network,
+                        networkCapabilities: NetworkCapabilities,
+                    ) {
+                        super.onCapabilitiesChanged(network, networkCapabilities)
+                        trySendBlocking(
+                            NetworkEvent.CapabilitiesChanged(network, networkCapabilities)
+                        )
+                    }
+
+                    override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
+                        super.onBlockedStatusChanged(network, blocked)
+                        trySendBlocking(NetworkEvent.BlockedStatusChanged(network, blocked))
+                    }
+
+                    override fun onLosing(network: Network, maxMsToLive: Int) {
+                        super.onLosing(network, maxMsToLive)
+                        trySendBlocking(NetworkEvent.Losing(network, maxMsToLive))
+                    }
+
+                    override fun onLost(network: Network) {
+                        super.onLost(network)
+                        trySendBlocking(NetworkEvent.Lost(network))
+                    }
+
+                    override fun onUnavailable() {
+                        super.onUnavailable()
+                        trySendBlocking(NetworkEvent.Unavailable)
+                    }
+                }
+            registerNetworkCallback(
+                NetworkRequest.Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build(),
+                callback,
+            )
+
+            awaitClose { unregisterNetworkCallback(callback) }
+        }
+        .onEach { Logger.d("Got an other network event type: ${it::class.simpleName}") }
 
 internal fun ConnectivityManager.defaultRawNetworkStateFlow(): Flow<RawNetworkState?> =
     defaultNetworkEvents().scan(null as RawNetworkState?) { state, event -> state.reduce(event) }
@@ -130,13 +199,18 @@ internal fun ConnectivityManager.activeRawNetworkState(): RawNetworkState? =
  * default network and depending on if it is a VPN. If it is not a VPN we check the network
  * properties directly and if it is a VPN we use a socket to check the underlying network. A
  * debounce is applied to avoid emitting too many events and to avoid setting the app in an offline
- * state when switching networks.
+ * state when switching networks. The flow is combined with the all network events to fix issues
+ * with the default network not being updated correctly on Android 9 and below when the VPN is
+ * turned on. The all network event is not used it is just there to trigger a new connectivity
+ * check.
  */
 @OptIn(FlowPreview::class)
 fun ConnectivityManager.hasInternetConnectivity(
     resolver: UnderlyingConnectivityStatusResolver
 ): Flow<Connectivity> =
-    this.defaultRawNetworkStateFlow()
+    combine(nonVpnInternetNetworksEvents(), defaultRawNetworkStateFlow()) { _, defaultEvent ->
+            defaultEvent
+        }
         .debounce(CONNECTIVITY_DEBOUNCE)
         .map { resolveConnectivityStatus(it, resolver) }
         .distinctUntilChanged()


### PR DESCRIPTION
Default network is not updated on Android 9 (and presumably Android 8 as well) if the VPN is connected and the internetet connection goes from offline to online. This fixes the issue by checking the online status on all network events.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8286)
<!-- Reviewable:end -->
