### PR TITLE
Fix disabled button text color

### DIFF
--- a/ios/MullvadVPN/UI appearance/Color+Mullvad.swift
+++ b/ios/MullvadVPN/UI appearance/Color+Mullvad.swift
@@ -9,7 +9,7 @@ extension Color {
 
     static let mullvadBackground: Color = .mullvadSecondaryColor
     static let mullvadTextPrimary: Color = UIColor.primaryTextColor.color
-    static let mullvadTextPrimaryDisabled: Color = .mullvadPrimaryColor.opacity(
+    static let mullvadTextPrimaryDisabled: Color = .mullvadTextPrimary.opacity(
         0.2
     )
 


### PR DESCRIPTION
Uses correct base color for disabled button text color

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8298)
<!-- Reviewable:end -->
