### PR TITLE
Localise access method names on creation

### DIFF
--- a/ios/MullvadSettings/AccessMethodRepository.swift
+++ b/ios/MullvadSettings/AccessMethodRepository.swift
@@ -18,6 +18,8 @@ public class AccessMethodRepository: AccessMethodRepositoryProtocol, @unchecked 
 
     private let logger = Logger(label: "AccessMethodRepository")
 
+    // The access method names will be localised on creation time. As they are persisted
+    // to on-device storage, they will not be relocalised if the user changes language.
     private let direct = PersistentAccessMethod(
         id: AccessMethodRepository.directId,
         name: NSLocalizedString(

--- a/ios/MullvadSettings/AccessMethodRepository.swift
+++ b/ios/MullvadSettings/AccessMethodRepository.swift
@@ -20,21 +20,36 @@ public class AccessMethodRepository: AccessMethodRepositoryProtocol, @unchecked 
 
     private let direct = PersistentAccessMethod(
         id: AccessMethodRepository.directId,
-        name: "Direct",
+        name: NSLocalizedString(
+            "ACCESS_METHOD_NAME_DIRECT",
+            tableName: "APIAccess",
+            value: "Direct",
+            comment: ""
+        ),
         isEnabled: true,
         proxyConfiguration: .direct
     )
 
     private let bridge = PersistentAccessMethod(
         id: AccessMethodRepository.bridgeId,
-        name: "Mullvad bridges",
+        name: NSLocalizedString(
+            "ACCESS_METHOD_NAME_BRIDGES",
+            tableName: "APIAccess",
+            value: "Mullvad bridges",
+            comment: ""
+        ),
         isEnabled: true,
         proxyConfiguration: .bridges
     )
 
     private let encryptedDNS = PersistentAccessMethod(
         id: AccessMethodRepository.encryptedDNSId,
-        name: "Encrypted DNS proxy",
+        name: NSLocalizedString(
+            "ACCESS_METHOD_NAME_ENCRYPTED_DNS",
+            tableName: "APIAccess",
+            value: "Encrypted DNS proxy",
+            comment: ""
+        ),
         isEnabled: true,
         proxyConfiguration: .encryptedDNS
     )


### PR DESCRIPTION
This localises the one thing (other than changelog) found that was unlocalised: access method names. 
Note that currently these are generated in the code and persisted to device storage, meaning that, when we have multiple languages, they will be fixed in the language the user installed the app whilst using even if they change language. That should perhaps be fixed before we add languages.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
