### PR TITLE
macOS: use `/opt/homebrew` for zsh completions if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 #### macOS
 - Use a local DNS resolver on the 127.0.0.0/8 network, regardless of macOS version.
+- Install zsh completions in `/opt/homebrew` if available.
 
 ### Fixed
 #### macOS

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -62,7 +62,11 @@ DAEMON_PLIST=$(cat <<-EOM
 EOM
 )
 
-ZSH_COMPLETIONS_DIR="/usr/local/share/zsh/site-functions/"
+if [[ -d "/opt/homebrew/share/zsh/site-functions/" ]]; then
+    ZSH_COMPLETIONS_DIR="/opt/homebrew/share/zsh/site-functions/"
+else
+    ZSH_COMPLETIONS_DIR="/usr/local/share/zsh/site-functions/"
+fi
 
 if [[ -d "/opt/homebrew/share/fish/vendor_completions.d/" ]]; then
     FISH_COMPLETIONS_DIR="/opt/homebrew/share/fish/vendor_completions.d/"

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -36,10 +36,10 @@ sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup reset-firew
 sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup remove-device || echo "Failed to remove device from account"
 
 echo "Removing zsh shell completion symlink ..."
-sudo rm -f /usr/local/share/zsh/site-functions/_mullvad
+sudo rm -f "/opt/homebrew/share/zsh/site-functions/_mullvad"
+sudo rm -f "/usr/local/share/zsh/site-functions/_mullvad"
 
 echo "Removing fish shell completion symlink ..."
-
 sudo rm -f "/opt/homebrew/share/fish/vendor_completions.d/mullvad.fish"
 sudo rm -f "/usr/local/share/fish/vendor_completions.d/mullvad.fish"
 


### PR DESCRIPTION
Following how `fish` completions are installed in `/opt/homebrew`, this does the same for `zsh` completions by editing the macOS installer's postinstall and uninstall scripts.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8313)
<!-- Reviewable:end -->
