### PR TITLE
Make flakey unit test less flakey

### DIFF
--- a/talpid-core/src/resolver.rs
+++ b/talpid-core/src/resolver.rs
@@ -691,7 +691,7 @@ mod test {
         config::{NameServerConfigGroup, ResolverConfig, ResolverOpts},
         TokioAsyncResolver,
     };
-    use std::{net::UdpSocket, sync::Mutex};
+    use std::{net::UdpSocket, sync::Mutex, thread};
     use typed_builder::TypedBuilder;
 
     /// Can't have multiple local resolvers running at the same time, as they will try to bind to
@@ -747,6 +747,7 @@ mod test {
                 .expect("lookup should succeed");
             drop(_sock);
             handle.stop().await;
+            thread::sleep(Duration::from_millis(300));
 
             // bind() succeeds if wildcard address is bound with REUSEADDR and REUSEPORT
             let _sock = bind_sock(
@@ -826,6 +827,7 @@ mod test {
         let addr = handle.listening_addr();
         assert_eq!(addr, SocketAddr::from((Ipv4Addr::LOCALHOST, DNS_PORT)));
         rt.block_on(handle.stop());
+        thread::sleep(Duration::from_millis(300));
         UdpSocket::bind(addr).expect("Failed to bind to a port that should have been removed");
     }
 


### PR DESCRIPTION
For some reason, the UDP socket is not unbound right away when stopping the handler, so the test would sometimes fail with "Address in use"

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8320)
<!-- Reviewable:end -->
