### PR TITLE
Fix ios ui tests after quick access buttons

### DIFF
--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -195,13 +195,13 @@ class TunnelControlPage: Page {
 
     /// Verify that the app attempts to connect over Multihop.
     @discardableResult func verifyConnectingOverMultihop() -> Self {
-        XCTAssertTrue(app.staticTexts["Multihop"].exists)
+        XCTAssertTrue(app.buttons["Multihop"].exists)
         return self
     }
 
     /// Verify that the app attempts to connect using DAITA.
     @discardableResult func verifyConnectingUsingDAITA() -> Self {
-        XCTAssertTrue(app.staticTexts["DAITA"].exists)
+        XCTAssertTrue(app.buttons["DAITA"].exists)
         return self
     }
 


### PR DESCRIPTION
Feature indicators were changed from text to buttons which broke the ui tests. Now they are fixed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8323)
<!-- Reviewable:end -->
