### PR TITLE
Bump `ignoreUntil` in libwg

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -71,7 +71,7 @@
 # The `paste` crate is no longer maintained
 [[IgnoredVulns]]
 id = "RUSTSEC-2024-0436"
-ignoreUntil = 2025-06-11
+ignoreUntil = 2025-09-12
 reason = """
 The `paste` crate is no longer maintained. `htmlize` depend on it, and there is currently no "fix" for this.
 We have no reason to suspect that `paste` is vulnerable in any way.

--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -2,71 +2,71 @@
 # Stack exhaustion in Decoder.Decode in encoding/gob
 [[IgnoredVulns]]
 id = "CVE-2024-34156" # GO-2024-3106
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Stack exhaustion in Parse in go/build/constraint
 [[IgnoredVulns]]
 id = "CVE-2024-34158" # GO-2024-3107
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Stack exhaustion in all Parse functions in go/parser
 [[IgnoredVulns]]
 id = "CVE-2024-34155" # GO-2024-3105
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Denial of service in HTML Parse function in go/net/html
 [[IgnoredVulns]]
 id = "CVE-2024-45338" # GO-2024-3333
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Denial of service in HTML Parse function in go/net/html
 [[IgnoredVulns]]
 id = "GHSA-w32m-9786-jp63" # GO-2024-3333
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Sensitive headers incorrectly sent after cross-domain redirect in net/http
 [[IgnoredVulns]]
 id = "CVE-2024-45336" # GO-2025-3420
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
 [[IgnoredVulns]]
 id = "CVE-2024-45341" # GO-2025-3373
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Denial of service in golang.org/x/crypto (for SSH server implementations)
 [[IgnoredVulns]]
 id = "CVE-2025-22869" # GO-2025-3487
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # Timing sidechannel for P-256 on ppc64le in crypto/internal/nistec. We don't deploy to PowerPC.
 [[IgnoredVulns]]
 id = "CVE-2025-22866" # GO-2025-3447
-ignoreUntil = 2025-06-12
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use the affected code"
 
 # HTTP Proxy bypass using IPv6 Zone IDs in golang.org/x/net
 [[IgnoredVulns]]
 id = "CVE-2025-22870" # GO-2025-3503
-ignoreUntil = 2025-07-01
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use x/net/proxy nor x/net/http/httpproxy"
 
 # Request smuggling due to acceptance of invalid chunked data in net/http
 [[IgnoredVulns]]
 id = "CVE-2025-22871" # GO-2025-3563
-ignoreUntil = 2025-07-08
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use net/http"
 
 # Incorrect Neutralization of Input During Web Page Generation in x/net
 [[IgnoredVulns]]
 id = "CVE-2025-22872" # GO-2025-3595
-ignoreUntil = 2025-07-17
+ignoreUntil = 2025-09-12
 reason = "wireguard-go does not use x/net/html"


### PR DESCRIPTION
Note: We cannot get rid of `paste` yet since `rtnetlink` transitively depends on it: https://github.com/rust-netlink/rtnetlink/pull/102

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8325)
<!-- Reviewable:end -->
