### PR TITLE
Fix tun file descriptor ownership.

### DIFF
--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -604,7 +604,7 @@ impl SharedTunnelStateValues {
 
     #[cfg(target_os = "android")]
     pub fn bypass_socket(&mut self, fd: RawFd, tx: oneshot::Sender<()>) {
-        if let Err(err) = self.tun_provider.lock().unwrap().bypass(fd) {
+        if let Err(err) = self.tun_provider.lock().unwrap().bypass(&fd) {
             log::error!("Failed to bypass socket {}", err);
         }
         let _ = tx.send(());

--- a/talpid-tunnel/src/tun_provider/android/mod.rs
+++ b/talpid-tunnel/src/tun_provider/android/mod.rs
@@ -197,7 +197,7 @@ impl AndroidTunProvider {
     }
 
     /// Allow a socket to bypass the tunnel.
-    pub fn bypass(&mut self, socket: RawFd) -> Result<(), Error> {
+    pub fn bypass(&mut self, socket: &impl AsRawFd) -> Result<(), Error> {
         let env = JnixEnv::from(
             self.jvm
                 .attach_current_thread_as_daemon()
@@ -212,7 +212,7 @@ impl AndroidTunProvider {
                 self.object.as_obj(),
                 create_tun_method,
                 JavaType::Primitive(Primitive::Boolean),
-                &[JValue::Int(socket)],
+                &[JValue::Int(socket.as_raw_fd())],
             )
             .map_err(|cause| Error::CallMethod("bypass", cause))?;
 
@@ -404,7 +404,7 @@ impl VpnServiceTun {
     }
 
     /// Allow a socket to bypass the tunnel.
-    pub fn bypass(&mut self, socket: RawFd) -> Result<(), Error> {
+    pub fn bypass(&mut self, socket: &impl AsFd) -> Result<(), Error> {
         let env = JnixEnv::from(
             self.jvm
                 .attach_current_thread_as_daemon()
@@ -419,7 +419,7 @@ impl VpnServiceTun {
                 self.object.as_obj(),
                 create_tun_method,
                 JavaType::Primitive(Primitive::Boolean),
-                &[JValue::Int(socket)],
+                &[JValue::Int(socket.as_fd().as_raw_fd())],
             )
             .map_err(|cause| Error::CallMethod("bypass", cause))?;
 

--- a/talpid-tunnel/src/tun_provider/android/mod.rs
+++ b/talpid-tunnel/src/tun_provider/android/mod.rs
@@ -203,14 +203,14 @@ impl AndroidTunProvider {
                 .attach_current_thread_as_daemon()
                 .map_err(Error::AttachJvmToThread)?,
         );
-        let create_tun_method = env
+        let bypass_method = env
             .get_method_id(&self.class, "bypass", "(I)Z")
             .map_err(|cause| Error::FindMethod("bypass", cause))?;
 
         let result = env
             .call_method_unchecked(
                 self.object.as_obj(),
-                create_tun_method,
+                bypass_method,
                 JavaType::Primitive(Primitive::Boolean),
                 &[JValue::Int(socket.as_raw_fd())],
             )
@@ -410,14 +410,14 @@ impl VpnServiceTun {
                 .attach_current_thread_as_daemon()
                 .map_err(Error::AttachJvmToThread)?,
         );
-        let create_tun_method = env
+        let bypass_method = env
             .get_method_id(&self.class, "bypass", "(I)Z")
             .map_err(|cause| Error::FindMethod("bypass", cause))?;
 
         let result = env
             .call_method_unchecked(
                 self.object.as_obj(),
-                create_tun_method,
+                bypass_method,
                 JavaType::Primitive(Primitive::Boolean),
                 &[JValue::Int(socket.as_fd().as_raw_fd())],
             )

--- a/talpid-wireguard/src/boringtun/mod.rs
+++ b/talpid-wireguard/src/boringtun/mod.rs
@@ -90,9 +90,7 @@ pub async fn open_boringtun_tunnel(
         let mut config = tun07::Configuration::default();
         config.raw_fd(fd);
 
-        boringtun_config.on_bind = Some(Box::new(move |socket| {
-            tun.bypass(socket.as_raw_fd()).unwrap()
-        }));
+        boringtun_config.on_bind = Some(Box::new(move |socket| tun.bypass(socket).unwrap()));
 
         let device = tun07::Device::new(&config).unwrap();
         tun07::AsyncDevice::new(device).unwrap()

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -117,7 +117,7 @@ async fn bypass_vpn(
     // Exclude remote obfuscation socket or bridge
     log::debug!("Excluding remote socket fd from the tunnel");
     let _ = tokio::task::spawn_blocking(move || {
-        if let Err(error) = tun_provider.lock().unwrap().bypass(remote_socket_fd) {
+        if let Err(error) = tun_provider.lock().unwrap().bypass(&remote_socket_fd) {
             log::error!("Failed to exclude remote socket fd: {error}");
         }
     })

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -18,8 +18,6 @@ use std::borrow::Cow;
 #[cfg(daita)]
 use std::ffi::CString;
 #[cfg(unix)]
-use std::os::unix::io::AsRawFd;
-#[cfg(unix)]
 use std::sync::{Arc, Mutex};
 use std::{
     future::Future,
@@ -300,10 +298,10 @@ impl WgGoTunnelState {
             let socket_v6 = self.tunnel_handle.get_socket_v6();
             let mut provider = tun_provider.lock().unwrap();
             provider
-                .bypass(socket_v4)
+                .bypass(&socket_v4)
                 .map_err(super::TunnelError::BypassError)?;
             provider
-                .bypass(socket_v6)
+                .bypass(&socket_v6)
                 .map_err(super::TunnelError::BypassError)?;
         }
 
@@ -334,7 +332,7 @@ impl WgGoTunnel {
         let handle = wireguard_go_rs::Tunnel::turn_on(
             mtu,
             &wg_config_str,
-            tunnel_fd.as_raw_fd(),
+            tunnel_fd,
             Some(logging::wg_go_logging_callback),
             logging_context.ordinal,
         )
@@ -529,7 +527,7 @@ impl WgGoTunnel {
 
         let handle = wireguard_go_rs::Tunnel::turn_on(
             &wg_config_str,
-            tunnel_fd.as_raw_fd(),
+            tunnel_fd,
             Some(logging::wg_go_logging_callback),
             logging_context.ordinal,
         )
@@ -611,7 +609,7 @@ impl WgGoTunnel {
             &exit_config_str,
             &entry_config_str,
             &private_ip,
-            tunnel_fd.as_raw_fd(),
+            tunnel_fd,
             Some(logging::wg_go_logging_callback),
             logging_context.ordinal,
         )
@@ -658,8 +656,8 @@ impl WgGoTunnel {
         let socket_v4 = handle.get_socket_v4();
         let socket_v6 = handle.get_socket_v6();
 
-        tunnel_device.bypass(socket_v4)?;
-        tunnel_device.bypass(socket_v6)?;
+        tunnel_device.bypass(&socket_v4)?;
+        tunnel_device.bypass(&socket_v6)?;
 
         Ok(())
     }


### PR DESCRIPTION
We accidentally borrowed the file descriptor when we should have moved it. This commit adds more `OwnedFd` and friends to help handle ownership correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8326)
<!-- Reviewable:end -->
