### PR TITLE
Enable more use of dynamic fonts

### DIFF
--- a/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
+++ b/ios/MullvadVPN/Containers/Root/HeaderBarView.swift
@@ -31,6 +31,7 @@ class HeaderBarView: UIView {
     private lazy var deviceNameLabel: UILabel = {
         let label = UILabel()
         label.font = .mullvadMiniSemiBold
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = UIColor(white: 1.0, alpha: 0.8)
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         label.setAccessibilityIdentifier(.headerDeviceNameLabel)
@@ -40,6 +41,7 @@ class HeaderBarView: UIView {
     private lazy var timeLeftLabel: UILabel = {
         let label = UILabel()
         label.font = .mullvadMiniSemiBold
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = UIColor(white: 1.0, alpha: 0.8)
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return label

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/AboutViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/AboutViewController.swift
@@ -56,7 +56,8 @@ class AboutViewController: UIViewController {
             let label = UILabel()
 
             label.text = header
-            label.font = .systemFont(ofSize: 28, weight: .bold)
+            label.font = .mullvadLarge
+            label.adjustsFontForContentSizeCategory = true
             label.textColor = .primaryTextColor
             label.numberOfLines = 0
             label.textAlignment = .center
@@ -69,7 +70,8 @@ class AboutViewController: UIViewController {
             let label = UILabel()
 
             label.text = preamble
-            label.font = .systemFont(ofSize: 18)
+            label.font = .mullvadSmall
+            label.adjustsFontForContentSizeCategory = true
             label.textColor = .primaryTextColor
             label.numberOfLines = 0
             label.textAlignment = .center
@@ -82,7 +84,8 @@ class AboutViewController: UIViewController {
             let label = UILabel()
 
             label.text = text
-            label.font = .systemFont(ofSize: 15)
+            label.font = .mullvadTiny
+            label.adjustsFontForContentSizeCategory = true
             label.textColor = .secondaryTextColor
             label.numberOfLines = 0
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ListCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ListCellContentConfiguration.swift
@@ -11,17 +11,20 @@ import UIKit
 /// Content configuration presenting a label and switch control.
 struct ListCellContentConfiguration: UIContentConfiguration, Equatable {
     struct TextProperties: Equatable {
-        var font = UIFont.systemFont(ofSize: 17)
+        var font = UIFont.mullvadSmall
+        var adjustsFontForContentSizeCategory = true
         var color = UIColor.Cell.titleTextColor
     }
 
     struct SecondaryTextProperties: Equatable {
-        var font = UIFont.systemFont(ofSize: 17)
+        var font = UIFont.mullvadSmall
+        var adjustsFontForContentSizeCategory = true
         var color = UIColor.Cell.detailTextColor.withAlphaComponent(0.8)
     }
 
     struct TertiaryTextProperties: Equatable {
-        var font = UIFont.systemFont(ofSize: 15)
+        var font = UIFont.mullvadTiny
+        var adjustsFontForContentSizeCategory = true
         var color = UIColor.Cell.titleTextColor.withAlphaComponent(0.6)
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ListCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/ListCellContentView.swift
@@ -59,6 +59,7 @@ class ListCellContentView: UIView, UIContentView, UITextFieldDelegate {
         let textProperties = actualConfiguration.textProperties
 
         textLabel.font = textProperties.font
+        textLabel.adjustsFontForContentSizeCategory = textProperties.adjustsFontForContentSizeCategory
         textLabel.textColor = textProperties.color
 
         textLabel.text = actualConfiguration.text
@@ -68,6 +69,7 @@ class ListCellContentView: UIView, UIContentView, UITextFieldDelegate {
         let textProperties = actualConfiguration.secondaryTextProperties
 
         secondaryTextLabel.font = textProperties.font
+        secondaryTextLabel.adjustsFontForContentSizeCategory = textProperties.adjustsFontForContentSizeCategory
         secondaryTextLabel.textColor = textProperties.color
 
         secondaryTextLabel.text = actualConfiguration.secondaryText
@@ -77,6 +79,7 @@ class ListCellContentView: UIView, UIContentView, UITextFieldDelegate {
         let textProperties = actualConfiguration.tertiaryTextProperties
 
         tertiaryTextLabel.font = textProperties.font
+        tertiaryTextLabel.adjustsFontForContentSizeCategory = textProperties.adjustsFontForContentSizeCategory
         tertiaryTextLabel.textColor = textProperties.color
 
         tertiaryTextLabel.text = actualConfiguration.tertiaryText

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentConfiguration.swift
@@ -11,7 +11,7 @@ import UIKit
 /// Content configuration presenting a label and switch control.
 struct SwitchCellContentConfiguration: UIContentConfiguration, Equatable {
     struct TextProperties: Equatable {
-        var font = UIFont.systemFont(ofSize: 17)
+        var font = UIFont.mullvadSmall
         var color = UIColor.Cell.titleTextColor
     }
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
@@ -68,6 +68,7 @@ class SwitchCellContentView: UIView, UIContentView, UITextFieldDelegate {
         let textProperties = actualConfiguration.textProperties
 
         textLabel.font = textProperties.font
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = textProperties.color
 
         textLabel.text = actualConfiguration.text

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentConfiguration.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentConfiguration.swift
@@ -49,7 +49,8 @@ struct TextCellContentConfiguration: UIContentConfiguration, Equatable {
 extension TextCellContentConfiguration {
     /// The text label properties.
     struct TextProperties: Equatable {
-        var font = UIFont.systemFont(ofSize: 17)
+        var font = UIFont.mullvadSmall
+        var adjustsFontForContentSizeCategory = true
         var color = UIColor.Cell.titleTextColor
     }
 
@@ -77,7 +78,10 @@ extension TextCellContentConfiguration {
     /// Text field configuration.
     struct TextFieldProperties: Equatable {
         /// Text font.
-        var font = UIFont.systemFont(ofSize: 17)
+        var font = UIFont.mullvadSmall
+
+        var adjustsFontForContentSizeCategory = true
+
         /// Text color.
         var textColor = UIColor.Cell.textFieldTextColor
 

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/TextCellContentView.swift
@@ -71,6 +71,7 @@ class TextCellContentView: UIView, UIContentView, UIGestureRecognizerDelegate, S
 
         textLabel.font = textProperties.font
         textLabel.textColor = textProperties.color
+        textLabel.adjustsFontForContentSizeCategory = true
 
         textLabel.text = actualConfiguration.text
     }
@@ -178,6 +179,7 @@ extension TextCellContentConfiguration.TextFieldProperties {
     @MainActor
     func apply(to textField: CustomTextField) {
         textField.font = font
+        textField.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory
         textField.backgroundColor = .clear
         textField.textColor = textColor
         textField.placeholderTextColor = placeholderColor

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/EditAccessMethodViewController.swift
@@ -74,7 +74,8 @@ class EditAccessMethodViewController: UIViewController {
 
     private func createTitle() -> UIView {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .largeTitle, weight: .bold)
+        label.font = .mullvadBig
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.lineBreakStrategy = []

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsViewController.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Edit/MethodSettings/MethodSettingsViewController.swift
@@ -267,7 +267,7 @@ class MethodSettingsViewController: UITableViewController {
         let validationResult = Result { try subject.value.validate() }
         let validationError = validationResult.error as? AccessMethodValidationError
 
-        // Only look for format errors for test(save validation.
+        // Only look for format errors for test (save validation).
         contentValidationErrors = validationError?.fieldErrors.filter { error in
             error.kind != .emptyValue
         } ?? []

--- a/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideStatusView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/IPOverride/IPOverrideStatusView.swift
@@ -11,7 +11,8 @@ import UIKit
 class IPOverrideStatusView: UIView {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 15, weight: .bold)
+        label.font = .mullvadTinySemiBold
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
         return label
     }()
@@ -22,7 +23,8 @@ class IPOverrideStatusView: UIView {
 
     private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 12, weight: .semibold)
+        label.font = .mullvadMiniSemiBold
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .white.withAlphaComponent(0.6)
         label.numberOfLines = 0
         return label

--- a/ios/MullvadVPN/Coordinators/Settings/Views/SwitchRowView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Views/SwitchRowView.swift
@@ -27,7 +27,7 @@ struct SwitchRowView: View {
             infoButtonAction: didTapInfoButton
         ))
         .disabled(disabled)
-        .font(.headline)
+        .font(.mullvadSmall)
         .frame(height: UIMetrics.SettingsRowView.height)
         .padding(UIMetrics.SettingsRowView.layoutMargins)
         .background(Color(.primaryColor))

--- a/ios/MullvadVPN/Extensions/UIListContentConfiguration+Extensions.swift
+++ b/ios/MullvadVPN/Extensions/UIListContentConfiguration+Extensions.swift
@@ -12,8 +12,11 @@ extension UIListContentConfiguration {
     /// Returns cell configured with default text attribute used in Mullvad UI.
     static func mullvadCell(tableStyle: UITableView.Style, isEnabled: Bool = true) -> UIListContentConfiguration {
         var configuration = cell()
-        configuration.textProperties.font = .systemFont(ofSize: 17)
+        configuration.textProperties.font = .mullvadSmall
+        configuration.textProperties.adjustsFontForContentSizeCategory = true
         configuration.textProperties.color = .Cell.titleTextColor.withAlphaComponent(isEnabled ? 1 : 0.8)
+        configuration.secondaryTextProperties.font = .mullvadSmall
+        configuration.secondaryTextProperties.adjustsFontForContentSizeCategory = true
 
         applyMargins(to: &configuration, tableStyle: tableStyle)
 
@@ -23,10 +26,12 @@ extension UIListContentConfiguration {
     /// Returns value cell configured with default text attribute used in Mullvad UI.
     static func mullvadValueCell(tableStyle: UITableView.Style, isEnabled: Bool = true) -> UIListContentConfiguration {
         var configuration = valueCell()
-        configuration.textProperties.font = .systemFont(ofSize: 17)
+        configuration.textProperties.font = .mullvadSmall
+        configuration.textProperties.adjustsFontForContentSizeCategory = true
         configuration.textProperties.color = .Cell.titleTextColor.withAlphaComponent(isEnabled ? 1 : 0.8)
         configuration.secondaryTextProperties.color = .Cell.detailTextColor.withAlphaComponent(0.8)
-        configuration.secondaryTextProperties.font = .systemFont(ofSize: 17)
+        configuration.secondaryTextProperties.font = .mullvadSmall
+        configuration.secondaryTextProperties.adjustsFontForContentSizeCategory = true
 
         applyMargins(to: &configuration, tableStyle: tableStyle)
 
@@ -37,7 +42,8 @@ extension UIListContentConfiguration {
     static func mullvadGroupedHeader(tableStyle: UITableView.Style) -> UIListContentConfiguration {
         var configuration = groupedHeader()
         configuration.textProperties.color = .TableSection.headerTextColor
-        configuration.textProperties.font = .systemFont(ofSize: 13)
+        configuration.textProperties.font = .mullvadTiny
+        configuration.textProperties.adjustsFontForContentSizeCategory = true
 
         applyMargins(to: &configuration, tableStyle: tableStyle)
 
@@ -48,7 +54,8 @@ extension UIListContentConfiguration {
     static func mullvadGroupedFooter(tableStyle: UITableView.Style) -> UIListContentConfiguration {
         var configuration = groupedFooter()
         configuration.textProperties.color = .TableSection.footerTextColor
-        configuration.textProperties.font = .systemFont(ofSize: 13)
+        configuration.textProperties.font = .mullvadMini
+        configuration.textProperties.adjustsFontForContentSizeCategory = true
 
         applyMargins(to: &configuration, tableStyle: tableStyle)
 

--- a/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
+++ b/ios/MullvadVPN/Notifications/UI/NotificationBannerView.swift
@@ -14,6 +14,7 @@ final class NotificationBannerView: UIView {
     private let titleLabel: UILabel = {
         let textLabel = UILabel()
         textLabel.font = .mullvadTinySemiBold
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = UIColor.InAppNotificationBanner.titleColor
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping
@@ -24,6 +25,7 @@ final class NotificationBannerView: UIView {
     private let bodyLabel: UILabel = {
         let textLabel = UILabel()
         textLabel.font = .mullvadTiny
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = UIColor.InAppNotificationBanner.bodyColor
         textLabel.numberOfLines = 0
         textLabel.lineBreakMode = .byWordWrapping

--- a/ios/MullvadVPN/View controllers/Account/AccountDeviceRow.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountDeviceRow.swift
@@ -27,14 +27,16 @@ class AccountDeviceRow: UIView {
             value: "Device name",
             comment: ""
         )
-        label.font = UIFont.systemFont(ofSize: 14)
+        label.font = .mullvadTiny
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = UIColor(white: 1.0, alpha: 0.6)
         return label
     }()
 
     private let deviceLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 17)
+        label.font = .mullvadSmall
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
         return label
     }()
@@ -43,6 +45,7 @@ class AccountDeviceRow: UIView {
         let button = IncreasedHitButton(type: .system)
         button.isExclusiveTouch = true
         button.setAccessibilityIdentifier(.infoButton)
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.tintColor = .white
         button.setBackgroundImage(UIImage.Buttons.info, for: .normal)
         button.heightAnchor.constraint(equalToConstant: UIMetrics.Button.accountInfoSize).isActive = true

--- a/ios/MullvadVPN/View controllers/Account/AccountExpiryRow.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountExpiryRow.swift
@@ -52,7 +52,8 @@ class AccountExpiryRow: UIView {
             value: "Paid until",
             comment: ""
         )
-        textLabel.font = UIFont.systemFont(ofSize: 14)
+        textLabel.font = .mullvadTiny
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = UIColor(white: 1.0, alpha: 0.6)
         return textLabel
     }()
@@ -60,7 +61,8 @@ class AccountExpiryRow: UIView {
     private let valueLabel: UILabel = {
         let valueLabel = UILabel()
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
-        valueLabel.font = UIFont.systemFont(ofSize: 17)
+        valueLabel.font = .mullvadSmall
+        valueLabel.adjustsFontForContentSizeCategory = true
         valueLabel.textColor = .white
         valueLabel.setAccessibilityIdentifier(.accountPagePaidUntilLabel)
         return valueLabel

--- a/ios/MullvadVPN/View controllers/Account/AccountNumberRow.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountNumberRow.swift
@@ -32,14 +32,16 @@ class AccountNumberRow: UIView {
             value: "Account number",
             comment: ""
         )
-        textLabel.font = UIFont.systemFont(ofSize: 14)
+        textLabel.font = .mullvadTiny
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = UIColor(white: 1.0, alpha: 0.6)
         return textLabel
     }()
 
     private let accountNumberLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = UIFont.monospacedSystemFont(ofSize: 17, weight: .regular)
+        textLabel.font = .mullvadMiniSemiBold
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = .white
         return textLabel
     }()
@@ -47,12 +49,14 @@ class AccountNumberRow: UIView {
     private let showHideButton: UIButton = {
         let button = UIButton(type: .system)
         button.tintColor = .white
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return button
     }()
 
     private let copyButton: UIButton = {
         let button = UIButton(type: .system)
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.tintColor = .white
         button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return button

--- a/ios/MullvadVPN/View controllers/Account/RestorePurchasesView.swift
+++ b/ios/MullvadVPN/View controllers/Account/RestorePurchasesView.swift
@@ -26,6 +26,7 @@ class RestorePurchasesView: UIView {
         let label = UILabel()
         label.setAccessibilityIdentifier(.restorePurchasesButton)
         label.attributedText = makeAttributedString()
+        label.adjustsFontForContentSizeCategory = true
         label.isUserInteractionEnabled = true
         label.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapRestoreButton)))
         return label
@@ -69,7 +70,7 @@ class RestorePurchasesView: UIView {
         )
 
         return NSAttributedString(string: text, attributes: [
-            .font: UIFont.systemFont(ofSize: 13, weight: .semibold),
+            .font: UIFont.mullvadMini,
             .foregroundColor: UIColor.white,
             .underlineStyle: NSUnderlineStyle.single.rawValue,
         ])

--- a/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
+++ b/ios/MullvadVPN/View controllers/CreationAccount/Welcome/WelcomeContentView.swift
@@ -24,7 +24,7 @@ final class WelcomeContentView: UIView, Sendable {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .largeTitle, weight: .bold)
+        label.font = .mullvadLarge
         label.textColor = .white
         label.adjustsFontForContentSizeCategory = true
         label.lineBreakMode = .byWordWrapping
@@ -40,7 +40,7 @@ final class WelcomeContentView: UIView, Sendable {
 
     private let subtitleLabel: UILabel = {
         let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .body)
+        label.font = .mullvadSmall
         label.textColor = .white
         label.adjustsFontForContentSizeCategory = true
         label.lineBreakMode = .byWordWrapping
@@ -60,7 +60,7 @@ final class WelcomeContentView: UIView, Sendable {
         label.adjustsFontForContentSizeCategory = true
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = .zero
-        label.font = .preferredFont(forTextStyle: .title2, weight: .bold)
+        label.font = .mullvadMedium
         label.textColor = .white
         return label
     }()
@@ -68,6 +68,7 @@ final class WelcomeContentView: UIView, Sendable {
     private let copyButton: UIButton = {
         let button = UIButton(type: .system)
         button.setAccessibilityIdentifier(.copyButton)
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.tintColor = .white
         button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return button
@@ -77,7 +78,7 @@ final class WelcomeContentView: UIView, Sendable {
         let label = UILabel()
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .preferredFont(forTextStyle: .body)
+        label.font = .mullvadSmall
         label.textColor = .white
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -87,6 +88,7 @@ final class WelcomeContentView: UIView, Sendable {
     private let infoButton: UIButton = {
         let button = IncreasedHitButton(type: .system)
         button.setAccessibilityIdentifier(.infoButton)
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.tintColor = .white
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setImage(UIImage.Buttons.info, for: .normal)
@@ -97,7 +99,7 @@ final class WelcomeContentView: UIView, Sendable {
 
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.font = .preferredFont(forTextStyle: .body)
+        label.font = .mullvadSmall
         label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
         label.numberOfLines = .zero

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementContentView.swift
@@ -30,7 +30,8 @@ class DeviceManagementContentView: UIView {
 
     let titleLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = UIFont.systemFont(ofSize: 32)
+        textLabel.font = .mullvadLarge
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = .white
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         return textLabel
@@ -38,7 +39,8 @@ class DeviceManagementContentView: UIView {
 
     let messageLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = UIFont.systemFont(ofSize: 17)
+        textLabel.font = .mullvadSmall
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = .white
         textLabel.translatesAutoresizingMaskIntoConstraints = false
         textLabel.numberOfLines = 0

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceRowView.swift
@@ -15,7 +15,8 @@ class DeviceRowView: UIView {
     let textLabel: UILabel = {
         let textLabel = UILabel()
         textLabel.translatesAutoresizingMaskIntoConstraints = false
-        textLabel.font = UIFont.systemFont(ofSize: 17)
+        textLabel.font = .mullvadSmallSemiBold
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = .white
         return textLabel
     }()
@@ -29,7 +30,8 @@ class DeviceRowView: UIView {
     let creationDateLabel: UILabel = {
         let creationDateLabel = UILabel()
         creationDateLabel.translatesAutoresizingMaskIntoConstraints = false
-        creationDateLabel.font = UIFont.systemFont(ofSize: 14)
+        creationDateLabel.font = .mullvadMiniSemiBold
+        creationDateLabel.adjustsFontForContentSizeCategory = true
         creationDateLabel.textColor = .white.withAlphaComponent(0.6)
         return creationDateLabel
     }()

--- a/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
@@ -51,8 +51,9 @@ final class AccountInputGroupView: UIView {
 
     private let privateTextField: AccountTextField = {
         let textField = AccountTextField()
-        textField.font = accountNumberFont()
+        textField.font = .mullvadMedium
         textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.adjustsFontForContentSizeCategory = true
         textField.placeholder = "0000 0000 0000 0000"
         textField.placeholderTextColor = .lightGray
         textField.textContentType = .username
@@ -107,7 +108,7 @@ final class AccountInputGroupView: UIView {
         button.configuration?
             .titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { attributeContainer in
                 var updatedAttributeContainer = attributeContainer
-                updatedAttributeContainer.font = AccountInputGroupView.accountNumberFont()
+                updatedAttributeContainer.font = .mullvadMedium
                 updatedAttributeContainer.foregroundColor = .AccountTextField.NormalState.textColor
                 return updatedAttributeContainer
             }
@@ -374,10 +375,6 @@ final class AccountInputGroupView: UIView {
     }
 
     // MARK: - Private
-
-    private static func accountNumberFont() -> UIFont {
-        UIFont.monospacedSystemFont(ofSize: 20, weight: .regular)
-    }
 
     private func addTextFieldNotificationObservers() {
         let notificationCenter = NotificationCenter.default

--- a/ios/MullvadVPN/View controllers/Login/LoginContentView.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginContentView.swift
@@ -13,17 +13,19 @@ class LoginContentView: UIView {
 
     let titleLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = UIFont.systemFont(ofSize: 32)
+        textLabel.font = .mullvadBig
         textLabel.textColor = .white
         textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.adjustsFontForContentSizeCategory = true
         return textLabel
     }()
 
     let messageLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = UIFont.systemFont(ofSize: 17)
+        textLabel.font = .mullvadTinySemiBold
         textLabel.textColor = UIColor.white.withAlphaComponent(0.6)
         textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.numberOfLines = 0
         return textLabel
     }()
@@ -71,9 +73,11 @@ class LoginContentView: UIView {
 
     let footerLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = UIFont.systemFont(ofSize: 17)
+        textLabel.font = .mullvadSmall
         textLabel.textColor = UIColor.white.withAlphaComponent(0.6)
         textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.adjustsFontForContentSizeCategory = true
+        textLabel.numberOfLines = 0
         textLabel.text = NSLocalizedString(
             "CREATE_BUTTON_HEADER_LABEL",
             tableName: "Login",

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
@@ -24,7 +24,8 @@ class OutOfTimeContentView: UIView {
             value: "Out of time",
             comment: ""
         )
-        label.font = UIFont.systemFont(ofSize: 32)
+        label.font = .mullvadLarge
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
         return label
     }()
@@ -33,6 +34,7 @@ class OutOfTimeContentView: UIView {
         let label = UILabel()
         label.textColor = .white
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
@@ -147,7 +149,7 @@ class OutOfTimeContentView: UIView {
     func setBodyLabelText(_ text: String) {
         bodyLabel.attributedText = NSAttributedString(
             markdownString: text,
-            options: MarkdownStylingOptions(font: .preferredFont(forTextStyle: .body))
+            options: MarkdownStylingOptions(font: .mullvadSmall)
         )
     }
 }

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportReviewViewController.swift
@@ -60,10 +60,8 @@ class ProblemReportReviewViewController: UIViewController {
         textView.setAccessibilityIdentifier(.problemReportAppLogsTextView)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.isEditable = false
-        textView.font = UIFont.monospacedSystemFont(
-            ofSize: UIFont.systemFontSize,
-            weight: .regular
-        )
+        textView.font = .mullvadSmall
+        textView.adjustsFontForContentSizeCategory = true
         textView.backgroundColor = .systemBackground
 
         view.addConstrainedSubviews([textView]) {

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportSubmissionOverlayView.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportSubmissionOverlayView.swift
@@ -156,7 +156,8 @@ class ProblemReportSubmissionOverlayView: UIView {
 
     let titleLabel: UILabel = {
         let textLabel = UILabel()
-        textLabel.font = UIFont.systemFont(ofSize: 32)
+        textLabel.font = .mullvadLarge
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.textColor = .white
         textLabel.numberOfLines = 0
         return textLabel
@@ -300,7 +301,8 @@ class ProblemReportSubmissionOverlayView: UIView {
         bodyLabelContainer.subviews.forEach { $0.removeFromSuperview() }
         state.body?.forEach { attributedString in
             let textLabel = UILabel()
-            textLabel.font = UIFont.systemFont(ofSize: 17)
+            textLabel.font = .mullvadSmall
+            textLabel.adjustsFontForContentSizeCategory = true
             textLabel.textColor = .white.withAlphaComponent(0.6)
             textLabel.numberOfLines = 0
             textLabel.attributedText = attributedString

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController+ViewManagement.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController+ViewManagement.swift
@@ -28,6 +28,8 @@ extension ProblemReportViewController {
     func makeSubheaderLabel() -> UILabel {
         let textLabel = UILabel()
         textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.font = .mullvadTinySemiBold
+        textLabel.adjustsFontForContentSizeCategory = true
         textLabel.numberOfLines = 0
         textLabel.textColor = .white
         textLabel.text = ProblemReportViewModel.subheadLabelText
@@ -47,7 +49,8 @@ extension ProblemReportViewController {
         textField.borderStyle = .none
         textField.backgroundColor = .white
         textField.inputAccessoryView = emailAccessoryToolbar
-        textField.font = UIFont.systemFont(ofSize: 17)
+        textField.font = .mullvadSmall
+        textField.adjustsFontForContentSizeCategory = true
         textField.placeholder = ProblemReportViewModel.emailPlaceholderText
         return textField
     }
@@ -57,7 +60,8 @@ extension ProblemReportViewController {
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.backgroundColor = .white
         textView.inputAccessoryView = messageAccessoryToolbar
-        textView.font = UIFont.systemFont(ofSize: 17)
+        textView.font = .mullvadSmall
+        textView.adjustsFontForContentSizeCategory = true
         textView.placeholder = ProblemReportViewModel.messageTextViewPlaceholder
         textView.contentInsetAdjustmentBehavior = .never
 

--- a/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
+++ b/ios/MullvadVPN/View controllers/RevokedDevice/RevokedDeviceViewController.swift
@@ -18,7 +18,8 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        titleLabel.font = .mullvadLarge
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.numberOfLines = 0
         titleLabel.textColor = .white
         titleLabel.text = NSLocalizedString(
@@ -33,7 +34,8 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
     private lazy var bodyLabel: UILabel = {
         let bodyLabel = UILabel()
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
-        bodyLabel.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        bodyLabel.adjustsFontForContentSizeCategory = true
+        bodyLabel.font = .mullvadSmall
         bodyLabel.numberOfLines = 0
         bodyLabel.textColor = .white
         bodyLabel.text = NSLocalizedString(
@@ -48,7 +50,8 @@ class RevokedDeviceViewController: UIViewController, RootContainment {
     private lazy var footerLabel: UILabel = {
         let bodyLabel = UILabel()
         bodyLabel.translatesAutoresizingMaskIntoConstraints = false
-        bodyLabel.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        bodyLabel.font = .mullvadSmall
+        bodyLabel.adjustsFontForContentSizeCategory = true
         bodyLabel.numberOfLines = 0
         bodyLabel.textColor = .white
         bodyLabel.text = NSLocalizedString(

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationCell.swift
@@ -18,7 +18,8 @@ class LocationCell: UITableViewCell {
 
     private let locationLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 16)
+        label.font = .mullvadSmall
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
         label.lineBreakMode = .byTruncatingTail
         label.numberOfLines = 1
@@ -34,6 +35,7 @@ class LocationCell: UITableViewCell {
 
     private let tickImageView: UIImageView = {
         let imageView = UIImageView(image: UIImage.tick)
+        imageView.adjustsImageSizeForAccessibilityContentSizeCategory = true
         imageView.tintColor = .white
         return imageView
     }()
@@ -54,6 +56,7 @@ class LocationCell: UITableViewCell {
     private let collapseButton: UIButton = {
         let button = UIButton(type: .custom)
         button.isAccessibilityElement = false
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.tintColor = .white
         return button
     }()

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderFooterView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationSectionHeaderFooterView.swift
@@ -73,6 +73,7 @@ class LocationSectionHeaderFooterView: UIView, UIContentView {
         nameLabel.textColor = configuration.style.textColor
         nameLabel.text = configuration.name
         nameLabel.font = configuration.style.font
+        nameLabel.adjustsFontForContentSizeCategory = true
         nameLabel.textAlignment = configuration.style.textAlignment
         actionButton.isHidden = isActionHidden
         actionButton.accessibilityIdentifier = nil

--- a/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsCell.swift
@@ -50,6 +50,7 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
 
             if let image {
                 disclosureImageView.image = image
+                disclosureImageView.adjustsImageSizeForAccessibilityContentSizeCategory = true
                 disclosureImageView.sizeToFit()
                 accessoryView = disclosureImageView
             } else {
@@ -60,7 +61,8 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
 
     let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 17)
+        label.font = .mullvadSmallSemiBold
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = UIColor.Cell.titleTextColor
         label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
@@ -69,7 +71,8 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
 
     let detailTitleLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 13)
+        label.font = .mullvadTiny
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = UIColor.Cell.detailTextColor
         label.setContentHuggingPriority(.defaultLow, for: .horizontal)
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -84,6 +87,7 @@ class SettingsCell: UITableViewCell, CustomCellDisclosureHandling {
         button.setAccessibilityIdentifier(.infoButton)
         button.tintColor = .white
         button.setImage(UIImage.Buttons.info, for: .normal)
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.isHidden = true
         return button
     }()

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDNSInfoCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDNSInfoCell.swift
@@ -17,6 +17,7 @@ class SettingsDNSInfoCell: UITableViewCell {
         backgroundColor = .secondaryColor
         contentView.directionalLayoutMargins = UIMetrics.SettingsCell.layoutMargins
 
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.textColor = UIColor.Cell.titleTextColor
         titleLabel.numberOfLines = 0

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDNSTextCell.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDNSTextCell.swift
@@ -24,7 +24,8 @@ class SettingsDNSTextCell: SettingsCell, UITextFieldDelegate {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        textField.font = UIFont.systemFont(ofSize: 17)
+        textField.font = .mullvadSmall
+        textField.adjustsFontForContentSizeCategory = true
         textField.backgroundColor = .clear
         textField.textColor = UIColor.TextField.textColor
         textField.textMargins = UIMetrics.SettingsCell.textFieldContentInsets

--- a/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsHeaderView.swift
@@ -15,7 +15,8 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
     let titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = .systemFont(ofSize: 17)
+        titleLabel.font = .mullvadSmallSemiBold
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textColor = UIColor.Cell.titleTextColor
         titleLabel.numberOfLines = 0
         return titleLabel
@@ -24,6 +25,7 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
     let infoButton: UIButton = {
         let button = UIButton(type: .custom)
         button.setAccessibilityIdentifier(.infoButton)
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.tintColor = .white
         button.setImage(UIImage.Buttons.info, for: .normal)
         return button
@@ -31,6 +33,7 @@ class SettingsHeaderView: UITableViewHeaderFooterView {
 
     let collapseButton: UIButton = {
         let button = UIButton(type: .custom)
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
         button.setAccessibilityIdentifier(.expandButton)
         button.tintColor = .white
         return button

--- a/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/CustomDNSCellFactory.swift
@@ -219,7 +219,7 @@ final class CustomDNSCellFactory: @preconcurrency CellFactoryProtocol {
 
             cell.titleLabel.attributedText = viewModel.customDNSPrecondition.attributedLocalizedDescription(
                 isEditing: isEditing,
-                preferredFont: .systemFont(ofSize: 14)
+                preferredFont: .mullvadSmallSemiBold
             )
         }
     }

--- a/ios/MullvadVPN/Views/AppButton.swift
+++ b/ios/MullvadVPN/Views/AppButton.swift
@@ -115,7 +115,7 @@ class AppButton: CustomButton {
         config.titleTextAttributesTransformer =
             UIConfigurationTextAttributesTransformer { [weak self] attributeContainer in
                 var updatedAttributeContainer = attributeContainer
-                updatedAttributeContainer.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+                updatedAttributeContainer.font = .mullvadSmallSemiBold
                 updatedAttributeContainer.foregroundColor = self?.state.customButtonTitleColor
                 return updatedAttributeContainer
             }

--- a/ios/MullvadVPN/Views/CheckboxView.swift
+++ b/ios/MullvadVPN/Views/CheckboxView.swift
@@ -30,6 +30,8 @@ class CheckboxView: UIView {
             checkboxSelectedView.pinEdgesToSuperview()
             checkboxUnselectedView.pinEdgesToSuperview()
         }
+        checkboxSelectedView.adjustsImageSizeForAccessibilityContentSizeCategory = true
+        checkboxUnselectedView.adjustsImageSizeForAccessibilityContentSizeCategory = true
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/MullvadVPN/Views/CustomTextView.swift
+++ b/ios/MullvadVPN/Views/CustomTextView.swift
@@ -41,7 +41,7 @@ class CustomTextView: UITextView {
 
     override var font: UIFont? {
         didSet {
-            placeholderTextLabel.font = font ?? UIFont.preferredFont(forTextStyle: .body)
+            placeholderTextLabel.font = font ?? .mullvadSmall
         }
     }
 
@@ -94,6 +94,7 @@ class CustomTextView: UITextView {
         placeholderTextLabel.textColor = UIColor.TextField.placeholderTextColor
         placeholderTextLabel.highlightedTextColor = UIColor.TextField.placeholderTextColor
         placeholderTextLabel.translatesAutoresizingMaskIntoConstraints = false
+        placeholderTextLabel.adjustsFontForContentSizeCategory = true
         placeholderTextLabel.numberOfLines = 0
         addSubview(placeholderTextLabel)
 

--- a/ios/MullvadVPN/Views/InfoHeaderView.swift
+++ b/ios/MullvadVPN/Views/InfoHeaderView.swift
@@ -24,6 +24,7 @@ class InfoHeaderView: UIView, UITextViewDelegate {
 
         infoLabel.backgroundColor = .clear
         infoLabel.attributedText = makeAttributedString()
+        infoLabel.adjustsFontForContentSizeCategory = true
         infoLabel.numberOfLines = 0
         infoLabel.accessibilityTraits = .link
 
@@ -38,12 +39,12 @@ class InfoHeaderView: UIView, UITextViewDelegate {
     }
 
     private let defaultTextAttributes: [NSAttributedString.Key: Any] = [
-        .font: UIFont.systemFont(ofSize: 13),
+        .font: UIFont.mullvadTiny,
         .foregroundColor: UIColor.ContentHeading.textColor,
     ]
 
     private let defaultLinkAttributes: [NSAttributedString.Key: Any] = [
-        .font: UIFont.boldSystemFont(ofSize: 13),
+        .font: UIFont.mullvadTiny,
         .foregroundColor: UIColor.ContentHeading.linkColor,
         .attachment: "#",
     ]

--- a/ios/MullvadVPN/Views/StatusImageView.swift
+++ b/ios/MullvadVPN/Views/StatusImageView.swift
@@ -45,10 +45,6 @@ class StatusImageView: UIImageView {
         }
     }
 
-    override var intrinsicContentSize: CGSize {
-        CGSize(width: 60, height: 60)
-    }
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         image = style.image
@@ -58,6 +54,7 @@ class StatusImageView: UIImageView {
         self.style = style
         super.init(image: style.image)
         image = style.image
+        self.adjustsImageSizeForAccessibilityContentSizeCategory = true
         setAccessibilityIdentifier(.statusImageView)
     }
 


### PR DESCRIPTION
This PR Enables dynamic fonts in most of the application.
I tried to also make icons scale wherever, whenever appropriate. I tested most of the things, but I might have missed a couple of things here and there, or could not get them to scale appropriately, and so left them.

Please do a thorough check of the application, it's probably easier to use the simulator for this.
You can use the following shortcuts to increase or decrease the font size in the simulator without having to access the settings.
- ⌥ ⌘ +
- ⌥ ⌘ -