### PR TITLE
Enable opt-in to MTE async mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
     <application android:name=".MullvadApplication"
                  android:banner="@mipmap/ic_banner"
                  android:allowBackup="false"
+                 tools:targetApi="31"
+                 android:memtagMode="async"
                  android:fullBackupContent="@xml/full_backup_content"
                  android:dataExtractionRules="@xml/data_extraction_rules"
                  android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
android:memtagMode="async"
to the <application> element in the AndroidManifest.xml.

Why this is wanted

Catch memory safety issues early. Asynchronous MTE allows the system to tag heap allocations and check pointer usage at runtime, helping detect buffer overflows and use-after-free bugs in native code without significant performance overhead.

Improve security. Mullvad relies on native libraries (e.g. for crypto). MTE hardens these components against memory-corruption exploits on supported devices.

Align with platform defaults. Newer Android versions (Android 13+) ship with MTE support; opting into async mode ensures we’re taking advantage of platform improvements.

How it’s implemented

Open app/src/main/AndroidManifest.xml.

In the <application> tag, add the attribute:

<application
    android:name=".MullvadApp"
+   android:memtagMode="async"
    …>
    …
</application>
No additional code changes are required—MTE is managed by the platform once enabled in the manifest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8338)
<!-- Reviewable:end -->
