### PR TITLE
Disable add time button when app is in blocked state

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelState.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelState.swift
@@ -146,6 +146,15 @@ enum TunnelState: Equatable, CustomStringConvertible, Sendable {
         }
     }
 
+    var isBlockingInternet: Bool {
+        switch self {
+        case .connected, .disconnected:
+            false
+        default:
+            true
+        }
+    }
+
     var relays: SelectedRelays? {
         switch self {
         case let .connected(relays, _, _),

--- a/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Account/AccountInteractor.swift
@@ -19,6 +19,7 @@ final class AccountInteractor: Sendable {
     let apiProxy: APIQuerying
     let deviceProxy: DeviceHandling
 
+    nonisolated(unsafe) var didReceiveTunnelState: (() -> Void)?
     nonisolated(unsafe) var didReceiveDeviceState: (@Sendable (DeviceState) -> Void)?
 
     nonisolated(unsafe) private var tunnelObserver: TunnelObserver?
@@ -35,13 +36,22 @@ final class AccountInteractor: Sendable {
         self.deviceProxy = deviceProxy
 
         let tunnelObserver =
-            TunnelBlockObserver(didUpdateDeviceState: { [weak self] _, deviceState, _ in
-                self?.didReceiveDeviceState?(deviceState)
-            })
+            TunnelBlockObserver(
+                didUpdateTunnelStatus: { [weak self] _, _ in
+                    self?.didReceiveTunnelState?()
+                },
+                didUpdateDeviceState: { [weak self] _, deviceState, _ in
+                    self?.didReceiveDeviceState?(deviceState)
+                }
+            )
 
         tunnelManager.addObserver(tunnelObserver)
 
         self.tunnelObserver = tunnelObserver
+    }
+
+    var tunnelState: TunnelState {
+        tunnelManager.tunnelStatus.state
     }
 
     var deviceState: DeviceState {

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeContentView.swift
@@ -113,6 +113,10 @@ class OutOfTimeContentView: UIView {
         }
     }
 
+    func enablePurchaseButton(_ enabled: Bool) {
+        purchaseButton.isEnabled = enabled
+    }
+
     // MARK: - Private Functions
 
     func setUpSubviews() {

--- a/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
+++ b/ios/MullvadVPN/View controllers/OutOfTime/OutOfTimeViewController.swift
@@ -106,6 +106,7 @@ class OutOfTimeViewController: UIViewController, RootContainment {
     private func applyViewState() {
         let tunnelState = interactor.tunnelStatus.state
         contentView.enableDisconnectButton(tunnelState.isSecured, animated: true)
+        contentView.enablePurchaseButton(!tunnelState.isSecured)
 
         if tunnelState.isSecured {
             contentView.setBodyLabelText(


### PR DESCRIPTION
**Why this needs to be done**

Time cannot be added to account when in blocked state. Since the calls to Apple's servers are handled through the Storekit API we cannot circumvent this by eg. proxying the calls to the packet tunnel process. Instead we need to handle this in the UI.

**What needs to be done**

The add time button on account page needs to be disabled if the app is in blocked state.

**Acceptance criteria**

Add time button cannot be interacted with in blocked state.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8359)
<!-- Reviewable:end -->
