### PR TITLE
Update RelaySelector to handle extra addresses

### DIFF
--- a/ios/MullvadMockData/MullvadREST/ServerRelaysResponse+Stubs.swift
+++ b/ios/MullvadMockData/MullvadREST/ServerRelaysResponse+Stubs.swift
@@ -89,8 +89,6 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: true,
                     shadowsocksExtraAddrIn: ["0.0.0.0"],
-                    quicHostname: nil,
-                    masqueExtraAddrIn: nil,
                     features: .init(daita: .init(), quic: nil)
                 ),
                 REST.ServerRelay(
@@ -106,9 +104,10 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: false,
                     shadowsocksExtraAddrIn: ["0.0.0.0"],
-                    quicHostname: nil,
-                    masqueExtraAddrIn: nil,
-                    features: nil
+                    features: .init(
+                        daita: nil,
+                        quic: .init(addrIn: ["0.0.0.0"], domain: "quic.domain", token: "")
+                    )
                 ),
                 REST.ServerRelay(
                     hostname: "se2-wireguard",
@@ -123,8 +122,6 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: false,
                     shadowsocksExtraAddrIn: ["0.0.0.0"],
-                    quicHostname: nil,
-                    masqueExtraAddrIn: nil,
                     features: nil
                 ),
                 REST.ServerRelay(
@@ -140,8 +137,6 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: false,
                     shadowsocksExtraAddrIn: ["0.0.0.0"],
-                    quicHostname: nil,
-                    masqueExtraAddrIn: nil,
                     features: nil
                 ),
                 REST.ServerRelay(
@@ -157,8 +152,6 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: false,
                     shadowsocksExtraAddrIn: ["0.0.0.0"],
-                    quicHostname: nil,
-                    masqueExtraAddrIn: nil,
                     features: nil
                 ),
                 REST.ServerRelay(
@@ -174,8 +167,6 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: true,
                     shadowsocksExtraAddrIn: nil,
-                    quicHostname: nil,
-                    masqueExtraAddrIn: nil,
                     features: .init(daita: .init(), quic: nil)
                 ),
                 REST.ServerRelay(
@@ -191,8 +182,6 @@ public enum ServerRelaysResponseStubs {
                     includeInCountry: true,
                     daita: true,
                     shadowsocksExtraAddrIn: nil,
-                    quicHostname: nil,
-                    masqueExtraAddrIn: nil,
                     features: .init(daita: .init(), quic: nil)
                 ),
             ],

--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -79,8 +79,6 @@ extension REST {
         public let includeInCountry: Bool
         public let daita: Bool?
         public let shadowsocksExtraAddrIn: [String]?
-        public let quicHostname: String?
-        public let masqueExtraAddrIn: [String]?
         public let features: Features?
 
         public func override(ipv4AddrIn: IPv4Address?, ipv6AddrIn: IPv6Address?) -> Self {
@@ -106,8 +104,6 @@ extension REST {
                         true
                     }
                 },
-                quicHostname: quicHostname,
-                masqueExtraAddrIn: masqueExtraAddrIn,
                 features: features
             )
         }
@@ -127,8 +123,6 @@ extension REST {
                 includeInCountry: includeInCountry,
                 daita: daita,
                 shadowsocksExtraAddrIn: shadowsocksExtraAddrIn,
-                quicHostname: quicHostname,
-                masqueExtraAddrIn: masqueExtraAddrIn,
                 features: features
             )
         }
@@ -147,8 +141,6 @@ extension REST {
                 includeInCountry: includeInCountry,
                 daita: daita,
                 shadowsocksExtraAddrIn: shadowsocksExtraAddrIn,
-                quicHostname: quicHostname,
-                masqueExtraAddrIn: masqueExtraAddrIn,
                 features: features
             )
         }

--- a/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorWrapper.swift
@@ -108,12 +108,8 @@ public final class RelaySelectorWrapper: RelaySelectorProtocol, Sendable {
                     throw NoRelaysSatisfyingConstraintsError(.invalidPort)
                 }
             }
-        case .on, .udpOverTcp, .shadowsocks:
+        case .on, .udpOverTcp, .shadowsocks, .quic:
             break
-        #if DEBUG
-        case .quic:
-            break
-        #endif
         }
     }
 }

--- a/ios/MullvadRESTTests/ServerRelayTests.swift
+++ b/ios/MullvadRESTTests/ServerRelayTests.swift
@@ -58,8 +58,6 @@ class ServerRelayTests: XCTestCase {
             shadowsocksExtraAddrIn: [
                 "185.213.193.139",
             ],
-            quicHostname: "cat.pictures.com",
-            masqueExtraAddrIn: ["1.2.3.4", "::1"],
             features: .init(
                 daita: .init(),
                 quic: .init(
@@ -151,8 +149,6 @@ class ServerRelayTests: XCTestCase {
             includeInCountry: true,
             daita: false,
             shadowsocksExtraAddrIn: shadowSocksExtraAddrIn,
-            quicHostname: nil,
-            masqueExtraAddrIn: nil,
             features: nil
         )
     }

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelaySelectorTests.swift
@@ -325,8 +325,6 @@ extension RelaySelectorTests {
                         includeInCountry: true,
                         daita: true,
                         shadowsocksExtraAddrIn: nil,
-                        quicHostname: nil,
-                        masqueExtraAddrIn: nil,
                         features: nil
                     ),
                 ],

--- a/ios/MullvadVPNTests/MullvadSettings/IPOverrideWrapperTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/IPOverrideWrapperTests.swift
@@ -86,8 +86,6 @@ extension IPOverrideWrapperTests {
             includeInCountry: true,
             daita: false,
             shadowsocksExtraAddrIn: nil,
-            quicHostname: nil,
-            masqueExtraAddrIn: nil,
             features: nil
         )
     }


### PR DESCRIPTION
**Why this needs to be done**

The RelaySelectorneeds to correctly filter out relays without QUIC support when QUIC is enabled. The new field addr_in will contain extra addresses for QUIC to use. The behavior should be very similar to what we do with Shadowsocks.

**What needs to be done**

The RelaySelector needs to be updated to filter out relays without QUIC support when QUIC is enabled. Look at ObfuscatorPortSelector.obfuscateShadowsocksRelays() for how this is done for Shadowsocks.

**Acceptance criteria**

RelaySelector correctly filters out relays without QUIC support when QUIC is enabled.

**Tests**

Update existing tests.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8368)
<!-- Reviewable:end -->
