### PR TITLE
Fix metadata version not being bumped

### DIFF
--- a/mullvad-update/mullvad-release/src/platform.rs
+++ b/mullvad-update/mullvad-release/src/platform.rs
@@ -181,8 +181,8 @@ impl Platform {
 
         // Increment metadata version
         let new_version = response.signed.metadata_version + 1;
-
         println!("Incrementing metadata version to {new_version}");
+        response.signed.metadata_version = new_version;
 
         // Sign it
         let signed_response = format::SignedResponse::sign(secret, response.signed)?;


### PR DESCRIPTION
This PR addresses an issue in the the `mullvad-release` tool where the bumped metadata version never was comitted to the new metadata.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8374)
<!-- Reviewable:end -->
