### PR TITLE
Update FFI to handle new QUIC params

### DIFF
--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -54,9 +54,9 @@ constraints the following default ones will take effect
 #### Tunnel protocol is Wireguard
 
 - The first attempt will connect to a Wireguard relay on a random port
-- The second attempt will connect to a Wireguard relay on port 443
-- The third attempt will connect to a Wireguard relay over IPv6 (if IPv6 is configured on the host) on a random port
-- The fourth attempt will connect to a Wireguard relay on a random port using Shadowsocks for obfuscation
+- The second attempt will connect to a Wireguard relay over IPv6 (if IPv6 is configured on the host) on a random port
+- The third attempt will connect to a Wireguard relay on a random port using Shadowsocks for obfuscation
+- The fourth attempt will connect to a Wireguard relay using QUIC for obfuscation (if QUIC is implemented)
 - The fifth attempt will connect to a Wireguard relay on a random port using [UDP2TCP obfuscation](https://github.com/mullvad/udp-over-tcp)
 - The sixth attempt will connect to a Wireguard relay over IPv6 on a random port using UDP2TCP obfuscation (if IPv6 is configured on the host)
 
@@ -73,8 +73,8 @@ Note: This is not applicable to Android nor iOS.
 The iOS platform does not support OpenVPN, or connecting to a relay over IPv6.
 As such, the above algorithm is simplified to the following version:
   - The first attempt will connect to a Wireguard relay on a random port
-  - The second attempt will connect to a Wireguard relay on port 443
-  - The third attempt will connect to a Wireguard relay on a random port using Shadowsocks for obfuscation
+  - The second attempt will connect to a Wireguard relay on a random port using Shadowsocks for obfuscation
+  - The third attempt will connect to a Wireguard relay using QUIC for obfuscation
   - The fourth attempt will connect to a Wireguard relay on a random port using [UDP2TCP obfuscation](https://github.com/mullvad/udp-over-tcp)
 
 ### Random Ports for UDP2TCP and Shadowsocks

--- a/ios/MullvadMockData/MullvadREST/RelaySelectorStub.swift
+++ b/ios/MullvadMockData/MullvadREST/RelaySelectorStub.swift
@@ -63,7 +63,8 @@ extension RelaySelectorStub {
                     cityCode: "got",
                     latitude: 0,
                     longitude: 0
-                )
+                ),
+                features: nil
             )
 
             return SelectedRelays(

--- a/ios/MullvadMockData/MullvadREST/SelectedRelaysStub+Stubs.swift
+++ b/ios/MullvadMockData/MullvadREST/SelectedRelaysStub+Stubs.swift
@@ -29,7 +29,8 @@ public struct SelectedRelaysStub {
                 cityCode: "got",
                 latitude: 42,
                 longitude: 42
-            )
+            ),
+            features: nil
         ),
         retryAttempt: 0
     )

--- a/ios/MullvadREST/Relay/ObfuscationMethodSelector.swift
+++ b/ios/MullvadREST/Relay/ObfuscationMethodSelector.swift
@@ -11,15 +11,18 @@ import MullvadSettings
 public struct ObfuscationMethodSelector {
     /// This retry logic used is explained at the following link:
     /// https://github.com/mullvad/mullvadvpn-app/blob/main/docs/relay-selector.md#default-constraints-for-tunnel-endpoints
+    ///
+    /// - Note: This method should never return `.automatic`.
     public static func obfuscationMethodBy(
         connectionAttemptCount: UInt,
         tunnelSettings: LatestTunnelSettings
     ) -> WireGuardObfuscationState {
-        // TODO: Revisit this when QUIC obfuscation is added
         if tunnelSettings.wireGuardObfuscation.state == .automatic {
-            if connectionAttemptCount.isOrdered(nth: 2, forEverySetOf: 3) {
+            if connectionAttemptCount.isOrdered(nth: 2, forEverySetOf: 4) {
                 .shadowsocks
-            } else if connectionAttemptCount.isOrdered(nth: 3, forEverySetOf: 3) {
+            } else if connectionAttemptCount.isOrdered(nth: 3, forEverySetOf: 4) {
+                .quic
+            } else if connectionAttemptCount.isOrdered(nth: 4, forEverySetOf: 4) {
                 .udpOverTcp
             } else {
                 .off

--- a/ios/MullvadREST/Relay/RelayPicking/RelayPicking.swift
+++ b/ios/MullvadREST/Relay/RelayPicking/RelayPicking.swift
@@ -39,7 +39,8 @@ extension RelayPicking {
         return SelectedRelay(
             endpoint: match.endpoint,
             hostname: match.relay.hostname,
-            location: match.location
+            location: match.location,
+            features: match.relay.features
         )
     }
 

--- a/ios/MullvadREST/Relay/RelaySelectorProtocol.swift
+++ b/ios/MullvadREST/Relay/RelaySelectorProtocol.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-import Foundation
 import MullvadSettings
 import MullvadTypes
 
@@ -34,11 +33,15 @@ public struct SelectedRelay: Equatable, Codable, Sendable {
     /// Relay geo location.
     public let location: Location
 
+    /// Relay features, such as `DAITA` or `QUIC`.
+    public let features: REST.ServerRelay.Features?
+
     /// Designated initializer.
-    public init(endpoint: MullvadEndpoint, hostname: String, location: Location) {
+    public init(endpoint: MullvadEndpoint, hostname: String, location: Location, features: REST.ServerRelay.Features?) {
         self.endpoint = endpoint
         self.hostname = hostname
         self.location = location
+        self.features = features
     }
 }
 

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -17,16 +17,6 @@ enum SwiftAccessMethodKind {
 };
 typedef uint8_t SwiftAccessMethodKind;
 
-/**
- * SAFETY: `TunnelObfuscatorProtocol` values must either be `0` or `1`
- */
-enum TunnelObfuscatorProtocol {
-  UdpOverTcp = 0,
-  Shadowsocks,
-  Quic,
-};
-typedef uint8_t TunnelObfuscatorProtocol;
-
 typedef struct ApiContext ApiContext;
 
 /**
@@ -930,10 +920,21 @@ int32_t start_shadowsocks_proxy(const uint8_t *forward_address,
  */
 int32_t stop_shadowsocks_proxy(struct ProxyHandle *proxy_config);
 
-int32_t start_tunnel_obfuscator_proxy(const uint8_t *peer_address,
-                                      uintptr_t peer_address_len,
-                                      uint16_t peer_port,
-                                      TunnelObfuscatorProtocol obfuscation_protocol,
-                                      struct ProxyHandle *proxy_handle);
+int32_t start_udp2tcp_obfuscator_proxy(const uint8_t *peer_address,
+                                       uintptr_t peer_address_len,
+                                       uint16_t peer_port,
+                                       struct ProxyHandle *proxy_handle);
+
+int32_t start_shadowsocks_obfuscator_proxy(const uint8_t *peer_address,
+                                           uintptr_t peer_address_len,
+                                           uint16_t peer_port,
+                                           struct ProxyHandle *proxy_handle);
+
+int32_t start_quic_obfuscator_proxy(const uint8_t *peer_address,
+                                    uintptr_t peer_address_len,
+                                    uint16_t peer_port,
+                                    const char *hostname,
+                                    const char *token,
+                                    struct ProxyHandle *proxy_handle);
 
 int32_t stop_tunnel_obfuscator_proxy(struct ProxyHandle *proxy_handle);

--- a/ios/MullvadSettings/WireGuardObfuscationSettings.swift
+++ b/ios/MullvadSettings/WireGuardObfuscationSettings.swift
@@ -18,9 +18,7 @@ public enum WireGuardObfuscationState: Codable, Sendable {
     case automatic
     case udpOverTcp
     case shadowsocks
-    #if DEBUG
     case quic
-    #endif
     case off
 
     public init(from decoder: Decoder) throws {
@@ -45,10 +43,8 @@ public enum WireGuardObfuscationState: Codable, Sendable {
             self = .udpOverTcp
         case .shadowsocks:
             self = .shadowsocks
-        #if DEBUG
         case .quic:
             self = .quic
-        #endif
         case .off:
             self = .off
         }

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipContainerView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ChipView/ChipContainerView.swift
@@ -115,7 +115,8 @@ struct ChipContainerView<ViewModel>: View where ViewModel: ChipViewModelProtocol
                             cityCode: "gbg",
                             latitude: 1234,
                             longitude: 1234
-                        )
+                        ),
+                        features: nil
                     ),
                     retryAttempt: 0
                 ),

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsCellFactory.swift
@@ -224,7 +224,6 @@ final class VPNSettingsCellFactory: @preconcurrency CellFactoryProtocol {
                 self?.delegate?.showDetails(for: .wireguardOverShadowsocks)
             }
 
-        #if DEBUG
         case .wireGuardObfuscationQuic:
             guard let cell = cell as? SelectableSettingsCell else { return }
 
@@ -238,7 +237,7 @@ final class VPNSettingsCellFactory: @preconcurrency CellFactoryProtocol {
             cell.setAccessibilityIdentifier(item.accessibilityIdentifier)
             cell.detailTitleLabel.setAccessibilityIdentifier(.wireGuardObfuscationQuic)
             cell.applySubCellStyling()
-        #endif
+
         case .wireGuardObfuscationOff:
             guard let cell = cell as? SelectableSettingsCell else { return }
 

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -83,9 +83,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         case wireGuardObfuscationAutomatic
         case wireGuardObfuscationUdpOverTcp
         case wireGuardObfuscationShadowsocks
-        #if DEBUG
         case wireGuardObfuscationQuic
-        #endif
         case wireGuardObfuscationOff
         case wireGuardObfuscationPort(_ port: WireGuardObfuscationUdpOverTcpPort)
         case quantumResistanceAutomatic
@@ -151,10 +149,8 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
                 .wireGuardObfuscationUdpOverTcp
             case .wireGuardObfuscationShadowsocks:
                 .wireGuardObfuscationShadowsocks
-            #if DEBUG
             case .wireGuardObfuscationQuic:
                 .wireGuardObfuscationQuic
-            #endif
             case .wireGuardObfuscationOff:
                 .wireGuardObfuscationOff
             case .wireGuardObfuscationPort:
@@ -182,13 +178,8 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
                 .wireGuardPort
             case .wireGuardCustomPort:
                 .wireGuardCustomPort
-            #if DEBUG
             case .wireGuardObfuscationAutomatic, .wireGuardObfuscationOff, .wireGuardObfuscationQuic:
                 .wireGuardObfuscation
-            #else
-            case .wireGuardObfuscationAutomatic, .wireGuardObfuscationOff:
-                .wireGuardObfuscation
-            #endif
             case .wireGuardObfuscationUdpOverTcp, .wireGuardObfuscationShadowsocks:
                 .wireGuardObfuscationOption
             case .wireGuardObfuscationPort:
@@ -228,9 +219,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
         case .off: .wireGuardObfuscationOff
         case .on, .udpOverTcp: .wireGuardObfuscationUdpOverTcp
         case .shadowsocks: .wireGuardObfuscationShadowsocks
-        #if DEBUG
         case .quic: .wireGuardObfuscationQuic
-        #endif
         }
 
         let quantumResistanceItem: Item = switch viewModel.quantumResistance {

--- a/ios/MullvadVPNTests/MullvadREST/Relay/ObfuscationMethodSelectorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/ObfuscationMethodSelectorTests.swift
@@ -29,7 +29,7 @@ class ObfuscationMethodSelectorTests: XCTestCase {
                 connectionAttemptCount: attempt,
                 tunnelSettings: tunnelSettings
             )
-            if attempt.isOrdered(nth: 1, forEverySetOf: 3) {
+            if attempt.isOrdered(nth: 1, forEverySetOf: 4) {
                 XCTAssertEqual(method, .off)
             } else {
                 XCTAssertNotEqual(method, .off)
@@ -53,10 +53,34 @@ class ObfuscationMethodSelectorTests: XCTestCase {
                 connectionAttemptCount: attempt,
                 tunnelSettings: tunnelSettings
             )
-            if attempt.isOrdered(nth: 2, forEverySetOf: 3) {
+            if attempt.isOrdered(nth: 2, forEverySetOf: 4) {
                 XCTAssertEqual(method, .shadowsocks)
             } else {
                 XCTAssertNotEqual(method, .shadowsocks)
+            }
+        }
+    }
+
+    func testMethodSelectionQuic() throws {
+        (UInt(0) ... 10).forEach { attempt in
+            tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(state: .quic)
+
+            var method = ObfuscationMethodSelector.obfuscationMethodBy(
+                connectionAttemptCount: attempt,
+                tunnelSettings: tunnelSettings
+            )
+            XCTAssertEqual(method, .quic)
+
+            tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(state: .automatic)
+
+            method = ObfuscationMethodSelector.obfuscationMethodBy(
+                connectionAttemptCount: attempt,
+                tunnelSettings: tunnelSettings
+            )
+            if attempt.isOrdered(nth: 3, forEverySetOf: 4) {
+                XCTAssertEqual(method, .quic)
+            } else {
+                XCTAssertNotEqual(method, .quic)
             }
         }
     }
@@ -77,7 +101,7 @@ class ObfuscationMethodSelectorTests: XCTestCase {
                 connectionAttemptCount: attempt,
                 tunnelSettings: tunnelSettings
             )
-            if attempt.isOrdered(nth: 3, forEverySetOf: 3) {
+            if attempt.isOrdered(nth: 4, forEverySetOf: 4) {
                 XCTAssertEqual(method, .udpOverTcp)
             } else {
                 XCTAssertNotEqual(method, .udpOverTcp)

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -32,9 +32,9 @@ class BaseUITestCase: XCTestCase {
     /// Default relay to use in tests
     static let testsDefaultRelayName = "se-got-wg-001"
 
-    static let testsDefaultQuicCountryName = "Relay Software Country"
-    static let testsDefaultQuicCityName = "Relay Software city"
-    static let testsDefaultQuicRelayName = "se-got-wg-881"
+    static let testsDefaultQuicCountryName = "Ireland"
+    static let testsDefaultQuicCityName = "Dublin"
+    static let testsDefaultQuicRelayName = "ie-dub-wg-001"
 
     /// True when the current test case is capturing packets
     private var currentTestCaseShouldCapturePackets = false

--- a/ios/PacketTunnelCore/Actor/ProtocolObfuscator.swift
+++ b/ios/PacketTunnelCore/Actor/ProtocolObfuscator.swift
@@ -21,7 +21,8 @@ public protocol ProtocolObfuscation {
     func obfuscate(
         _ endpoint: MullvadEndpoint,
         settings: LatestTunnelSettings,
-        retryAttempts: UInt
+        retryAttempts: UInt,
+        relayFeatures: REST.ServerRelay.Features?
     ) -> ProtocolObfuscationResult
     var transportLayer: TransportLayer? { get }
     var remotePort: UInt16 { get }
@@ -46,7 +47,8 @@ public class ProtocolObfuscator<Obfuscator: TunnelObfuscation>: ProtocolObfuscat
     public func obfuscate(
         _ endpoint: MullvadEndpoint,
         settings: LatestTunnelSettings,
-        retryAttempts: UInt = 0
+        retryAttempts: UInt = 0,
+        relayFeatures: REST.ServerRelay.Features?
     ) -> ProtocolObfuscationResult {
         let obfuscationMethod = ObfuscationMethodSelector.obfuscationMethodBy(
             connectionAttemptCount: retryAttempts,
@@ -55,17 +57,29 @@ public class ProtocolObfuscator<Obfuscator: TunnelObfuscation>: ProtocolObfuscat
 
         remotePort = endpoint.ipv4Relay.port
 
-        guard obfuscationMethod != .off else {
+        #if DEBUG
+        let obfuscationProtocol: TunnelObfuscationProtocol? = switch obfuscationMethod {
+        case .udpOverTcp:
+            .udpOverTcp
+        case .shadowsocks:
+            .shadowsocks
+        case .quic:
+            if let relayFeatures = relayFeatures?.quic {
+                .quic(hostname: relayFeatures.domain, token: relayFeatures.token)
+            } else {
+                nil
+            }
+        default:
+            // This is fine, since ObfuscationMethodSelector.obfuscationMethodBy` above should never
+            // return .automatic.
+            nil
+        }
+
+        guard let obfuscationProtocol else {
             tunnelObfuscator = nil
             return .init(endpoint: endpoint, method: .off)
         }
 
-        #if DEBUG
-        let obfuscationProtocol: TunnelObfuscationProtocol = switch obfuscationMethod {
-        case .shadowsocks: .shadowsocks
-        case .quic: .quic
-        default: .udpOverTcp
-        }
         let obfuscator = Obfuscator(
             remoteAddress: endpoint.ipv4Relay.ip,
             tcpPort: remotePort,

--- a/ios/PacketTunnelCoreTests/AppMessageHandlerTests.swift
+++ b/ios/PacketTunnelCoreTests/AppMessageHandlerTests.swift
@@ -138,7 +138,8 @@ final class AppMessageHandlerTests: XCTestCase {
             exit: SelectedRelay(
                 endpoint: match.endpoint,
                 hostname: match.relay.hostname,
-                location: match.location
+                location: match.location,
+                features: nil
             ),
             retryAttempt: 0
         )

--- a/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
+++ b/ios/PacketTunnelCoreTests/EphemeralPeerExchangingPipelineTests.swift
@@ -51,12 +51,14 @@ final class EphemeralPeerExchangingPipelineTests: XCTestCase {
         entryRelay = SelectedRelay(
             endpoint: entryMatch.endpoint,
             hostname: entryMatch.relay.hostname,
-            location: entryMatch.location
+            location: entryMatch.location,
+            features: nil
         )
         exitRelay = SelectedRelay(
             endpoint: exitMatch.endpoint,
             hostname: exitMatch.relay.hostname,
-            location: exitMatch.location
+            location: exitMatch.location,
+            features: nil
         )
     }
 

--- a/ios/PacketTunnelCoreTests/Mocks/ProtocolObfuscationStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/ProtocolObfuscationStub.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-import Foundation
+@testable import MullvadREST
 @testable import MullvadSettings
 @testable import MullvadTypes
 @testable import PacketTunnelCore
@@ -17,7 +17,8 @@ struct ProtocolObfuscationStub: ProtocolObfuscation {
     func obfuscate(
         _ endpoint: MullvadEndpoint,
         settings: LatestTunnelSettings,
-        retryAttempts: UInt
+        retryAttempts: UInt,
+        relayFeatures: REST.ServerRelay.Features?
     ) -> ProtocolObfuscationResult {
         .init(endpoint: endpoint, method: .off)
     }

--- a/ios/PacketTunnelCoreTests/MultiHopEphemeralPeerExchangerTests.swift
+++ b/ios/PacketTunnelCoreTests/MultiHopEphemeralPeerExchangerTests.swift
@@ -50,12 +50,14 @@ final class MultiHopEphemeralPeerExchangerTests: XCTestCase {
         entryRelay = SelectedRelay(
             endpoint: entryMatch.endpoint,
             hostname: entryMatch.relay.hostname,
-            location: entryMatch.location
+            location: entryMatch.location,
+            features: nil
         )
         exitRelay = SelectedRelay(
             endpoint: exitMatch.endpoint,
             hostname: exitMatch.relay.hostname,
-            location: exitMatch.location
+            location: exitMatch.location,
+            features: nil
         )
     }
 

--- a/ios/PacketTunnelCoreTests/SingleHopEphemeralPeerExchangerTests.swift
+++ b/ios/PacketTunnelCoreTests/SingleHopEphemeralPeerExchangerTests.swift
@@ -35,7 +35,12 @@ final class SingleHopEphemeralPeerExchangerTests: XCTestCase {
             numberOfFailedAttempts: 0
         )
 
-        exitRelay = SelectedRelay(endpoint: match.endpoint, hostname: match.relay.hostname, location: match.location)
+        exitRelay = SelectedRelay(
+            endpoint: match.endpoint,
+            hostname: match.relay.hostname,
+            location: match.location,
+            features: nil
+        )
     }
 
     func testEphemeralPeerExchangeFailsWhenNegotiationCannotStart() async {

--- a/mullvad-ios/src/api_client/access_method_settings.rs
+++ b/mullvad-ios/src/api_client/access_method_settings.rs
@@ -11,7 +11,7 @@ use mullvad_types::access_method::{
 };
 use talpid_types::net::proxy::{self, Shadowsocks, Socks5Remote};
 
-use super::helpers::convert_c_string;
+use crate::get_string;
 
 /// Converts parameters into a `Box<AccessMethodSetting>` raw representation that
 /// can be passed across the FFI boundary
@@ -54,9 +54,9 @@ fn convert_builtin_access_method_setting_inner(
     proxy_configuration: *const c_void,
 ) -> Option<AccessMethodSetting> {
     // SAFETY: See `convert_builtin_access_method_setting`
-    let id = Id::from_string(unsafe { convert_c_string(unique_identifier) })?;
+    let id = unsafe { Id::from_string(get_string(unique_identifier))? };
     // SAFETY: See `convert_builtin_access_method_setting`
-    let name = unsafe { convert_c_string(name) };
+    let name = unsafe { get_string(name) };
     match method_kind {
         SwiftAccessMethodKind::KindDirect => Some(AccessMethodSetting::with_id(
             id,

--- a/mullvad-ios/src/api_client/address_cache_provider.rs
+++ b/mullvad-ios/src/api_client/address_cache_provider.rs
@@ -1,6 +1,7 @@
-use super::helpers::convert_c_string;
 use libc::c_char;
 use std::{ffi::c_void, net::SocketAddr};
+
+use super::get_string;
 
 extern "C" {
     /// Return the latest available endpoint, or a default one if none are cached
@@ -58,7 +59,7 @@ impl SwiftAddressCacheProviderContext {
         // SAFETY: The pointer contained in the late deallocator returned by `swift_get_cached_endpoint`
         // is guaranteed to point to a valid UTF-8 String
         // It is also guaranteed to be a valid representation of either an IPv4 or IPv6 address
-        let cached_address = unsafe { convert_c_string(deallocator.ptr) }
+        let cached_address = unsafe { get_string(deallocator.ptr) }
             .parse()
             .expect("Invalid socket address in cache");
 

--- a/mullvad-ios/src/api_client/storekit.rs
+++ b/mullvad-ios/src/api_client/storekit.rs
@@ -9,8 +9,7 @@ use mullvad_types::account::AccountNumber;
 use super::{
     cancellation::{RequestCancelHandle, SwiftCancelHandle},
     completion::{CompletionCookie, SwiftCompletionHandler},
-    do_request,
-    helpers::convert_c_string,
+    do_request, get_string,
     response::SwiftMullvadApiResponse,
     retry_strategy::{RetryStrategy, SwiftRetryStrategy},
     SwiftApiContext,
@@ -58,7 +57,7 @@ pub unsafe extern "C" fn mullvad_ios_legacy_storekit_payment(
     let completion = completion_handler.clone();
 
     // SAFETY: See param documentation for `account_number`.
-    let account_number = unsafe { AccountNumber::from(convert_c_string(account_number)) };
+    let account_number = AccountNumber::from(get_string(account_number));
 
     // SAFETY: See param documentation for `body`.
     let body = unsafe { std::slice::from_raw_parts(body, body_size) }.to_vec();
@@ -133,7 +132,7 @@ pub unsafe extern "C" fn mullvad_ios_init_storekit_payment(
     let completion = completion_handler.clone();
 
     // SAFETY: See param documentation for `account_number`.
-    let account_number = unsafe { AccountNumber::from(convert_c_string(account_number)) };
+    let account_number = AccountNumber::from(get_string(account_number));
 
     let task = tokio_handle.spawn(async move {
         match mullvad_ios_init_storekit_payment_inner(
@@ -208,7 +207,7 @@ pub unsafe extern "C" fn mullvad_ios_check_storekit_payment(
     let completion = completion_handler.clone();
 
     // SAFETY: See param documentation for `account_number`.
-    let account_number = unsafe { AccountNumber::from(convert_c_string(account_number)) };
+    let account_number = AccountNumber::from(get_string(account_number));
 
     // SAFETY: See param documentation for `body`.
     let body = unsafe { std::slice::from_raw_parts(body, body_size) }.to_vec();

--- a/mullvad-ios/src/lib.rs
+++ b/mullvad-ios/src/lib.rs
@@ -1,4 +1,9 @@
 #![cfg(target_os = "ios")]
+use libc::c_char;
+use std::ffi::CStr;
+use std::sync::OnceLock;
+use tokio::runtime::{Builder, Handle, Runtime};
+
 mod api_client;
 mod encrypted_dns_proxy;
 mod ephemeral_peer_proxy;
@@ -14,23 +19,30 @@ pub struct ProxyHandle {
 #[unsafe(no_mangle)]
 pub static CONFIG_SERVICE_PORT: u16 = talpid_tunnel_config_client::CONFIG_SERVICE_PORT;
 
-mod ios {
-    use std::sync::OnceLock;
-    use tokio::runtime::{Builder, Handle, Runtime};
+static RUNTIME: OnceLock<Result<Runtime, String>> = OnceLock::new();
 
-    static RUNTIME: OnceLock<Result<Runtime, String>> = OnceLock::new();
-
-    pub fn mullvad_ios_runtime() -> Result<Handle, String> {
-        match RUNTIME.get_or_init(|| {
-            Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .map_err(|error| ToString::to_string(&error))
-        }) {
-            Ok(runtime) => Ok(runtime.handle().clone()),
-            Err(error) => Err(error.clone()),
-        }
+fn mullvad_ios_runtime() -> Result<Handle, String> {
+    match RUNTIME.get_or_init(|| {
+        Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| ToString::to_string(&error))
+    }) {
+        Ok(runtime) => Ok(runtime.handle().clone()),
+        Err(error) => Err(error.clone()),
     }
 }
 
-use ios::*;
+/// Try to convert a C string to an owned [String]. if `ptr` is null, an empty [String] is
+/// returned.
+///
+/// # Safety
+/// - `ptr` must uphold all safety invariants as required by [CStr::from_ptr].
+unsafe fn get_string(ptr: *const c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    // Safety: See function doc comment.
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    cstr.to_str().map(ToOwned::to_owned).unwrap_or_default()
+}

--- a/mullvad-ios/src/tunnel_obfuscator_proxy/ffi.rs
+++ b/mullvad-ios/src/tunnel_obfuscator_proxy/ffi.rs
@@ -1,52 +1,131 @@
+use libc::c_char;
+
 use super::{TunnelObfuscatorHandle, TunnelObfuscatorRuntime};
 use crate::ProxyHandle;
 use std::{net::SocketAddr, sync::Once};
 
-use crate::api_client::helpers::parse_ip_addr;
+use crate::{api_client::helpers::parse_ip_addr, get_string};
 
 static INIT_LOGGING: Once = Once::new();
 
-/// SAFETY: `TunnelObfuscatorProtocol` values must either be `0` or `1`
-#[repr(u8)]
-pub enum TunnelObfuscatorProtocol {
-    UdpOverTcp = 0,
-    Shadowsocks,
-    Quic,
+macro_rules! throw_int_error {
+    ($result:expr) => {
+        match $result {
+            Ok(value) => value,
+            Err(value) => return value,
+        }
+    };
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn start_tunnel_obfuscator_proxy(
+pub unsafe extern "C" fn start_udp2tcp_obfuscator_proxy(
     peer_address: *const u8,
     peer_address_len: usize,
     peer_port: u16,
-    obfuscation_protocol: TunnelObfuscatorProtocol,
     proxy_handle: *mut ProxyHandle,
 ) -> i32 {
+    init_logging();
+
+    let peer_sock_addr = throw_int_error!(get_socket_address(
+        peer_address,
+        peer_address_len,
+        peer_port
+    ));
+    let result = TunnelObfuscatorRuntime::new_udp2tcp(peer_sock_addr).run();
+
+    start(proxy_handle, result)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn start_shadowsocks_obfuscator_proxy(
+    peer_address: *const u8,
+    peer_address_len: usize,
+    peer_port: u16,
+    proxy_handle: *mut ProxyHandle,
+) -> i32 {
+    init_logging();
+
+    let peer_sock_addr = throw_int_error!(get_socket_address(
+        peer_address,
+        peer_address_len,
+        peer_port
+    ));
+    let result = TunnelObfuscatorRuntime::new_shadowsocks(peer_sock_addr).run();
+
+    start(proxy_handle, result)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn start_quic_obfuscator_proxy(
+    peer_address: *const u8,
+    peer_address_len: usize,
+    peer_port: u16,
+    hostname: *const c_char,
+    token: *const c_char,
+    proxy_handle: *mut ProxyHandle,
+) -> i32 {
+    init_logging();
+
+    let peer_sock_addr = throw_int_error!(get_socket_address(
+        peer_address,
+        peer_address_len,
+        peer_port
+    ));
+    let hostname = get_string(hostname);
+    let token = get_string(token);
+    let result = TunnelObfuscatorRuntime::new_quic(peer_sock_addr, hostname, token).run();
+
+    start(proxy_handle, result)
+}
+
+fn init_logging() {
     INIT_LOGGING.call_once(|| {
         let _ = oslog::OsLogger::new("net.mullvad.MullvadVPN.TunnelObfuscatorProxy")
             .level_filter(log::LevelFilter::Info)
             .init();
     });
+}
 
-    let peer_sock_addr: SocketAddr =
-        if let Some(ip_address) = parse_ip_addr(peer_address, peer_address_len) {
+/// Constructs a new IP address from a pointer containing bytes representing an IP address.
+///
+/// SAFETY: `addr` pointer must be non-null, aligned, and point to at least addr_len bytes
+unsafe fn get_socket_address(
+    peer_address: *const u8,
+    peer_address_len: usize,
+    peer_port: u16,
+) -> Result<SocketAddr, i32> {
+    let peer_sock_addr =
+        // SAFETY: See notes for `parse_ip_addr`.
+        if let Some(ip_address) = unsafe { parse_ip_addr(peer_address, peer_address_len) } {
             SocketAddr::new(ip_address, peer_port)
         } else {
-            return -1;
+            return Err(-1);
         };
+    Ok(peer_sock_addr)
+}
 
-    let result = TunnelObfuscatorRuntime::new(peer_sock_addr, obfuscation_protocol).run();
-
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `proxy_handle` must be [valid] for writes.
+/// * `proxy_handle` must be properly aligned. Use [`write_unaligned`] if this is not the
+///   case.
+unsafe fn start(
+    proxy_handle: *mut ProxyHandle,
+    result: Result<(SocketAddr, TunnelObfuscatorHandle), std::io::Error>,
+) -> i32 {
     match result {
         Ok((local_endpoint, obfuscator_handle)) => {
             let boxed_handle = Box::new(obfuscator_handle);
-            std::ptr::write(
-                proxy_handle,
-                ProxyHandle {
-                    context: Box::into_raw(boxed_handle) as *mut _,
-                    port: local_endpoint.port(),
-                },
-            );
+            let source_handle = ProxyHandle {
+                context: Box::into_raw(boxed_handle) as *mut _,
+                port: local_endpoint.port(),
+            };
+
+            // SAFETY: Caller guarantees that this pointer is valid.
+            unsafe { std::ptr::write(proxy_handle, source_handle) };
+
             0
         }
         Err(err) => {

--- a/mullvad-ios/src/tunnel_obfuscator_proxy/mod.rs
+++ b/mullvad-ios/src/tunnel_obfuscator_proxy/mod.rs
@@ -1,4 +1,3 @@
-use ffi::TunnelObfuscatorProtocol;
 use std::{
     io,
     net::{Ipv4Addr, SocketAddr},
@@ -17,27 +16,26 @@ pub struct TunnelObfuscatorRuntime {
 }
 
 impl TunnelObfuscatorRuntime {
-    pub fn new(peer: SocketAddr, obfuscation_protocol: TunnelObfuscatorProtocol) -> Self {
-        let settings: ObfuscationSettings = match obfuscation_protocol {
-            TunnelObfuscatorProtocol::UdpOverTcp => {
-                ObfuscationSettings::Udp2Tcp(udp2tcp::Settings { peer })
-            }
-            TunnelObfuscatorProtocol::Shadowsocks => {
-                ObfuscationSettings::Shadowsocks(shadowsocks::Settings {
-                    shadowsocks_endpoint: peer,
-                    wireguard_endpoint: SocketAddr::from((Ipv4Addr::LOCALHOST, 51820)),
-                })
-            }
-            TunnelObfuscatorProtocol::Quic => {
-                ObfuscationSettings::Quic(quic::Settings {
-                    quic_endpoint: peer,
-                    wireguard_endpoint: SocketAddr::from((Ipv4Addr::LOCALHOST, 51820)),
-                    // TODO: fetch the real hostname from the relay list
-                    hostname: "www.mullvad.net".to_string(),
-                })
-            }
-        };
+    pub fn new_udp2tcp(peer: SocketAddr) -> Self {
+        let settings = ObfuscationSettings::Udp2Tcp(udp2tcp::Settings { peer });
+        Self { settings }
+    }
 
+    pub fn new_shadowsocks(peer: SocketAddr) -> Self {
+        let settings = ObfuscationSettings::Shadowsocks(shadowsocks::Settings {
+            shadowsocks_endpoint: peer,
+            wireguard_endpoint: SocketAddr::from((Ipv4Addr::LOCALHOST, 51820)),
+        });
+        Self { settings }
+    }
+
+    pub fn new_quic(peer: SocketAddr, hostname: String, token: String) -> Self {
+        let settings = ObfuscationSettings::Quic(quic::Settings {
+            quic_endpoint: peer,
+            wireguard_endpoint: SocketAddr::from((Ipv4Addr::LOCALHOST, 51820)),
+            hostname,
+            token,
+        });
         Self { settings }
     }
 

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -16,6 +16,9 @@ use tunnel_obfuscation::{
     create_obfuscator, quic, shadowsocks, udp2tcp, Settings as ObfuscationSettings,
 };
 
+/// Test authentication header to set for the CONNECT request.
+const AUTH_HEADER: &str = "test";
+
 /// Begin running obfuscation machine, if configured. This function will patch `config`'s endpoint
 /// to point to an endpoint on localhost
 pub async fn apply_obfuscation_config(
@@ -101,6 +104,7 @@ fn settings_from_config(
                 quic_endpoint: *endpoint,
                 wireguard_endpoint: SocketAddr::from((Ipv4Addr::LOCALHOST, 51820)),
                 hostname: hostname.to_owned(),
+                token: AUTH_HEADER.to_owned(),
                 #[cfg(target_os = "linux")]
                 fwmark,
             })

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -12,9 +12,6 @@ use crate::Obfuscator;
 
 type Result<T> = std::result::Result<T, Error>;
 
-/// Authentication header to set for the CONNECT request
-const AUTH_HEADER: &str = "Bearer test";
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Failed to bind UDP socket")]
@@ -36,6 +33,8 @@ pub struct Settings {
     pub wireguard_endpoint: SocketAddr,
     /// Hostname to use for QUIC
     pub hostname: String,
+    /// Auth token to use for QUIC. Must NOT be prefixed with "Bearer".
+    pub token: String,
     /// fwmark to apply to use for the QUIC connection
     #[cfg(target_os = "linux")]
     pub fwmark: Option<u32>,
@@ -48,6 +47,7 @@ impl Quic {
             .map_err(Error::BindError)?;
 
         let local_endpoint = local_socket.local_addr().unwrap();
+        let token = settings.token.clone();
 
         let config_builder = ClientConfig::builder()
             .client_socket(local_socket)
@@ -55,7 +55,7 @@ impl Quic {
             .server_addr(settings.quic_endpoint)
             .server_host(settings.hostname.clone())
             .target_addr(settings.wireguard_endpoint)
-            .auth_header(Some(AUTH_HEADER.to_owned()));
+            .auth_header(Some(format!("Bearer {token}").to_owned()));
 
         #[cfg(target_os = "linux")]
         let config_builder = config_builder.fwmark(settings.fwmark);


### PR DESCRIPTION
**Why this needs to be done**

The server relay structure has been update with domain and token fields. They need to be passed to the Rust layer and used by the Rust obfuscator.

QUIC is currently only supported on staging.

```
"domain": "se-got-wg-881.blockerad.eu"
"token": "test"
```

**What needs to be done**

Update the FFI layers and pass the domain and token fields to the Rust QUIC obfuscator.

**Acceptance criteria**

QUIC obfuscator works with the new params.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8381)
<!-- Reviewable:end -->
