### PR TITLE
Fix cleanup of metadata on build server

### DIFF
--- a/desktop/scripts/release/publish-metadata-to-api
+++ b/desktop/scripts/release/publish-metadata-to-api
@@ -44,7 +44,7 @@ function buildserver_rsync {
 }
 
 function remove_buildserver_tmp_dir {
-  run_on_build_server rm -rf $BUILDSERVER_METADATA_DIR
+  run_on_build_server rm -rf $BUILDSERVER_TMP_DIR
 }
 
 # Clean up previous metadata dir on build server in case this failed the last time this script ran


### PR DESCRIPTION
This PR fixes a bug that prevented upload of release metadata to build server if someone else did the previous release. The problem was that a directory owned by the previous person remained and prevented the current release from being uploaded due to missing permission. Removing the top level release directory solves this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8384)
<!-- Reviewable:end -->
