### PR TITLE
Fix too many devices view showing success in the beginning

### DIFF
--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceListView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceListView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct DeviceListView: View {
-    @Binding var devices: [Device]
+    @Binding var devices: [Device]?
     @Binding var loading: Bool
     var onRemoveDevice: ((Device) -> Void)?
 
@@ -27,7 +27,7 @@ struct DeviceListView: View {
             Text("Fetching devices...")
                 .padding(.top, 16)
                 .foregroundColor(.mullvadTextPrimary.opacity(0.6))
-        } else {
+        } else if let devices {
             MullvadList(devices) { device in
                 MullvadListActionItemView(
                     item: .init(

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementView.swift
@@ -49,11 +49,14 @@ struct DeviceManagementView: View {
     let style: Style
     let onError: (String, Error) -> Void
 
-    @State private var loggedInDevices: [DeviceListView.Device] = []
+    @State private var loggedInDevices: [DeviceListView.Device]? = nil
     @State private var loading = true
 
     var canLoginNewDevice: Bool {
-        loggedInDevices.count < ApplicationConfiguration.maxAllowedDevices
+        guard let loggedInDevices else {
+            return false
+        }
+        return loggedInDevices.count < ApplicationConfiguration.maxAllowedDevices
     }
 
     var bodyText: LocalizedStringKey {
@@ -157,7 +160,10 @@ struct DeviceManagementView: View {
                             identifier: AccessibilityIdentifier.logOutDeviceConfirmButton,
                             handler: {
                                 await withCheckedContinuation { continuation in
-                                    loggedInDevices = loggedInDevices.map {
+                                    guard let loggedInDevices else {
+                                        return
+                                    }
+                                    self.loggedInDevices = loggedInDevices.map {
                                         $0.id == device.id ? $0.setIsBeingRemoved(true) : $0
                                     }
                                     deviceManagementAlert = nil
@@ -167,9 +173,9 @@ struct DeviceManagementView: View {
                                             Task { @MainActor in
                                                 switch result {
                                                 case .success:
-                                                    loggedInDevices.removeAll(where: { $0.id == device.id })
+                                                    self.loggedInDevices?.removeAll(where: { $0.id == device.id })
                                                 case let .failure(error):
-                                                    loggedInDevices = loggedInDevices.map {
+                                                    self.loggedInDevices = loggedInDevices.map {
                                                         $0.id == device
                                                             .id ? $0.setIsBeingRemoved(false) : $0
                                                     }


### PR DESCRIPTION
The too many devices view showed "success" while fetching devices. It now shows the correct message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8402)
<!-- Reviewable:end -->
