### PR TITLE
Fix Rust CI failing due to expired metadata

### DIFF
--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -131,9 +131,10 @@ impl HttpVersionInfoProvider {
         verifying_keys: &Vec1<format::key::VerifyingKey>,
     ) -> anyhow::Result<format::SignedResponse> {
         self.get_versions_inner(|raw_json| {
-            format::SignedResponse::deserialize_and_verify_with_keys(
+            format::SignedResponse::deserialize_and_verify_at_time(
                 verifying_keys,
                 raw_json,
+                chrono::DateTime::UNIX_EPOCH,
                 lowest_metadata_version,
             )
         })
@@ -272,9 +273,13 @@ mod test {
 
         // Expect: Dumped data should exist and look the same
         let cached_data = fs::read(temp_dump).await.expect("expected dumped info");
-        let cached_info =
-            SignedResponse::deserialize_and_verify_with_keys(&verifying_keys, &cached_data, 0)
-                .unwrap();
+        let cached_info = SignedResponse::deserialize_and_verify_at_time(
+            &verifying_keys,
+            &cached_data,
+            chrono::DateTime::UNIX_EPOCH,
+            0,
+        )
+        .unwrap();
         assert_eq!(cached_info, info);
 
         Ok(())

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -52,7 +52,7 @@ impl SignedResponse {
     /// If successful, the deserialized data is returned.
     ///
     /// This is typically only used for testing. Prefer [deserialize_and_verify].
-    fn deserialize_and_verify_at_time(
+    pub(crate) fn deserialize_and_verify_at_time(
         keys: &Vec1<VerifyingKey>,
         bytes: &[u8],
         current_time: chrono::DateTime<chrono::Utc>,


### PR DESCRIPTION
This PR fixes some failing Rust tests by making tests, for verifying `mullvad-update` metadata, run with mocked time.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8416)
<!-- Reviewable:end -->
