### PR TITLE
Fix clippy warnings

### DIFF
--- a/installer-downloader/src/cacao_impl/ui.rs
+++ b/installer-downloader/src/cacao_impl/ui.rs
@@ -41,6 +41,11 @@ static BANNER_COLOR: LazyLock<Color> = LazyLock::new(|| {
     //       calibrated uses the current color profile.
     //       Maybe using calibrated colors is more correct? Rendering different colors *definitely*
     //       is not.
+    // ---
+    // The unexpected cfg warning stems from https://github.com/SSheldon/rust-objc/issues/125
+    // We need to ignore this until cacao migrates to another objc implementation,
+    // or we use another `msg_send!` macro ourselves.
+    #[allow(unexpected_cfgs)]
     let id =
         // SAFETY: This function returns a pointer to a refcounted NSColor instance, and panics if
         //         a null pointer is passed.

--- a/mullvad-cli/src/cmds/account.rs
+++ b/mullvad-cli/src/cmds/account.rs
@@ -131,7 +131,7 @@ impl Account {
             DeviceState::Revoked => {
                 println!("{REVOKED_MESSAGE}");
                 if let Some(account_number) = rpc.get_account_history().await? {
-                    println!("Mullvad account: {}", account_number);
+                    println!("Mullvad account: {account_number}");
                 }
             }
         }

--- a/mullvad-cli/src/cmds/api_access.rs
+++ b/mullvad-cli/src/cmds/api_access.rs
@@ -234,7 +234,7 @@ impl ApiAccess {
         let current = rpc.get_current_api_access_method().await?;
         let mut access_method_formatter = pp::ApiAccessMethodFormatter::new(&current);
         access_method_formatter.settings.write_enabled = false;
-        println!("{}", access_method_formatter);
+        println!("{access_method_formatter}");
         Ok(())
     }
 
@@ -466,7 +466,7 @@ mod pp {
                     let formatter = CustomProxyFormatter {
                         custom_proxy: method,
                     };
-                    write!(f, "{}", formatter)?;
+                    write!(f, "{formatter}")?;
                     Ok(())
                 }
             }

--- a/mullvad-cli/src/cmds/tunnel.rs
+++ b/mullvad-cli/src/cmds/tunnel.rs
@@ -245,7 +245,7 @@ impl Tunnel {
             match interval {
                 Constraint::Only(interval) => {
                     rpc.set_wireguard_rotation_interval(interval).await?;
-                    println!("Set key rotation interval to {}", interval);
+                    println!("Set key rotation interval to {interval}");
                 }
                 Constraint::Any => {
                     rpc.reset_wireguard_rotation_interval().await?;

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -213,13 +213,13 @@ fn print_connection_info(
 pub fn format_location(location: &GeoIpLocation) -> String {
     let mut formatted_location = location.country.to_string();
     if let Some(city) = &location.city {
-        formatted_location.push_str(&format!(", {}", city));
+        formatted_location.push_str(&format!(", {city}"));
     }
     if let Some(ipv4) = location.ipv4 {
-        formatted_location.push_str(&format!(". IPv4: {}", ipv4));
+        formatted_location.push_str(&format!(". IPv4: {ipv4}"));
     }
     if let Some(ipv6) = location.ipv6 {
-        formatted_location.push_str(&format!(", IPv6: {}", ipv6));
+        formatted_location.push_str(&format!(", IPv6: {ipv6}"));
     }
     formatted_location
 }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -654,7 +654,7 @@ impl ManagementService for ManagementServiceImpl {
         let allowed_ips = AllowedIps::parse(&allowed_ips_str)
             .map_err(|e| {
                 log::error!("{e}");
-                Status::invalid_argument(format!("Invalid allowed IPs: {}", e))
+                Status::invalid_argument(format!("Invalid allowed IPs: {e}"))
             })?
             .to_constraint();
 

--- a/mullvad-ios/src/ephemeral_peer_proxy/ios_tcp_connection.rs
+++ b/mullvad-ios/src/ephemeral_peer_proxy/ios_tcp_connection.rs
@@ -18,13 +18,17 @@ fn connection_closed_err() -> io::Error {
 #[repr(C)]
 pub struct WgTcpConnectionFunctions {
     pub open_fn:
-        unsafe extern "C" fn(tunnelHandle: i32, address: *const libc::c_char, timeout: u64) -> i32,
-    pub close_fn: unsafe extern "C" fn(tunnelHandle: i32, socketHandle: i32) -> i32,
-    pub recv_fn:
-        unsafe extern "C" fn(tunnelHandle: i32, socketHandle: i32, data: *mut u8, len: i32) -> i32,
+        unsafe extern "C" fn(tunnel_handle: i32, address: *const libc::c_char, timeout: u64) -> i32,
+    pub close_fn: unsafe extern "C" fn(tunnel_handle: i32, socket_handle: i32) -> i32,
+    pub recv_fn: unsafe extern "C" fn(
+        tunnel_handle: i32,
+        socket_handle: i32,
+        data: *mut u8,
+        len: i32,
+    ) -> i32,
     pub send_fn: unsafe extern "C" fn(
-        tunnelHandle: i32,
-        socketHandle: i32,
+        tunnel_handle: i32,
+        socket_handle: i32,
         data: *const u8,
         len: i32,
     ) -> i32,

--- a/mullvad-update/src/client/app.rs
+++ b/mullvad-update/src/client/app.rs
@@ -196,10 +196,10 @@ impl VerifiedInstaller for InstallerFile<true> {
 
 pub fn bin_path(app_version: &mullvad_version::Version, cache_dir: &Path) -> PathBuf {
     #[cfg(windows)]
-    let bin_filename = format!("mullvad-{}.exe", app_version);
+    let bin_filename = format!("mullvad-{app_version}.exe");
 
     #[cfg(target_os = "macos")]
-    let bin_filename = format!("mullvad-{}.pkg", app_version);
+    let bin_filename = format!("mullvad-{app_version}.pkg");
 
     cache_dir.join(bin_filename)
 }


### PR DESCRIPTION
When trying to upgrade to Rust 1.88, I hit some issues. New clippy lints etc. This is a standalone PR to try to fix these things before we get on with the actual Rust upgrade.

We also need parts of #8237 merged before we can upgrade Rust, since that PR also contains fixes for new warnings. Please create a separate PR for just the fixes that allows us to use the latest Rust without warnings :pray: 