### PR TITLE
Add QUIC to relay selector

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/WireguardSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/WireguardSettings.tsx
@@ -216,16 +216,10 @@ function ObfuscationSettings() {
           ariaLabel: messages.pgettext('accessibility', 'UDP-over-TCP settings'),
         },
       },
-      // TODO: Remove 'development' condition before releasing QUIC.
-      //       https://linear.app/mullvad/issue/DES-2105
-      ...(window.env?.development
-        ? [
-            {
-              label: messages.pgettext('wireguard-settings-view', 'QUIC'),
-              value: ObfuscationType.quic,
-            },
-          ]
-        : []),
+      {
+        label: messages.pgettext('wireguard-settings-view', 'QUIC'),
+        value: ObfuscationType.quic,
+      },
       {
         label: messages.gettext('Off'),
         value: ObfuscationType.off,

--- a/mullvad-api/src/relay_list.rs
+++ b/mullvad-api/src/relay_list.rs
@@ -167,6 +167,7 @@ fn into_mullvad_relay(
     relay: Relay,
     location: location::Location,
     endpoint_data: relay_list::RelayEndpointData,
+    features: relay_list::Features,
 ) -> relay_list::Relay {
     relay_list::Relay {
         hostname: relay.hostname,
@@ -181,6 +182,7 @@ fn into_mullvad_relay(
         weight: relay.weight,
         endpoint_data,
         location,
+        features,
     }
 }
 
@@ -247,11 +249,21 @@ struct Relay {
 
 impl Relay {
     fn into_openvpn_mullvad_relay(self, location: location::Location) -> relay_list::Relay {
-        into_mullvad_relay(self, location, relay_list::RelayEndpointData::Openvpn)
+        into_mullvad_relay(
+            self,
+            location,
+            relay_list::RelayEndpointData::Openvpn,
+            relay_list::Features::default(), /* TODO: Replace */
+        )
     }
 
     fn into_bridge_mullvad_relay(self, location: location::Location) -> relay_list::Relay {
-        into_mullvad_relay(self, location, relay_list::RelayEndpointData::Bridge)
+        into_mullvad_relay(
+            self,
+            location,
+            relay_list::RelayEndpointData::Bridge,
+            relay_list::Features::default(), /* TODO: Replace */
+        )
     }
 
     fn convert_to_lowercase(&mut self) {
@@ -345,10 +357,18 @@ struct WireGuardRelay {
     daita: bool,
     #[serde(default)]
     shadowsocks_extra_addr_in: Vec<IpAddr>,
+    #[serde(default)]
+    features: relay_list::Features,
 }
 
 impl WireGuardRelay {
     fn into_mullvad_relay(self, location: location::Location) -> relay_list::Relay {
+        let features = relay_list::Features::default();
+        let features = if self.daita {
+            features.configure_daita()
+        } else {
+            features
+        };
         into_mullvad_relay(
             self.relay,
             location,
@@ -357,6 +377,7 @@ impl WireGuardRelay {
                 daita: self.daita,
                 shadowsocks_extra_addr_in: self.shadowsocks_extra_addr_in,
             }),
+            features,
         )
     }
 }

--- a/mullvad-management-interface/src/types/conversions/relay_list.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_list.rs
@@ -285,7 +285,11 @@ impl TryFrom<proto::Relay> for mullvad_types::relay_list::Relay {
             })
             .transpose()?;
 
-        Ok(MullvadRelay {
+        // TODO: Eventually, we will need to decide how to represent extra relay features in the
+        // protobuf message.
+        let features = mullvad_types::relay_list::Features::default();
+
+        let relay = MullvadRelay {
             hostname: relay.hostname,
             ipv4_addr_in: relay.ipv4_addr_in.parse().map_err(|_err| {
                 FromProtobufTypeError::InvalidArgument("invalid relay IPv4 address")
@@ -311,7 +315,10 @@ impl TryFrom<proto::Relay> for mullvad_types::relay_list::Relay {
                 })
                 .ok_or("missing relay location")
                 .map_err(FromProtobufTypeError::InvalidArgument)?,
-        })
+            features,
+        };
+
+        Ok(relay)
     }
 }
 

--- a/mullvad-relay-selector/src/relay_selector/matcher.rs
+++ b/mullvad-relay-selector/src/relay_selector/matcher.rs
@@ -144,9 +144,10 @@ fn filter_on_obfuscation(
                 relay,
             )
         }
-
-        // If Shadowsocks is not a requirement, then there are no relay-specific constraints
-        _ => true,
+        // QUIC is only enabled on some relays
+        ObfuscationQuery::Quic => relay.features.quic().is_some(),
+        // Other relays are compatible with this query
+        ObfuscationQuery::Off | ObfuscationQuery::Auto | ObfuscationQuery::Udp2tcp(_) => true,
     }
 }
 

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -915,15 +915,8 @@ impl RelaySelector {
                 Ok(Some(obfuscation))
             }
             ObfuscationQuery::Quic => {
-                let obfuscator = SelectedObfuscator {
-                    config: ObfuscatorConfig::Quic {
-                        // TODO: do not hardcode port
-                        endpoint: std::net::SocketAddr::from((endpoint.peer.endpoint.ip(), 443)),
-                        // TODO: do not hardcode
-                        hostname: "test.mullvad.net".to_owned(),
-                    },
-                    relay: obfuscator_relay,
-                };
+                let obfuscator = helpers::get_quic_obfuscator(obfuscator_relay)
+                    .map_err(box_obfsucation_error)?;
                 Ok(Some(obfuscator))
             }
         }

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -27,9 +27,9 @@ use mullvad_types::{
         RelayConstraints, RelayOverride, RelaySettings, TransportPort,
     },
     relay_list::{
-        BridgeEndpointData, OpenVpnEndpoint, OpenVpnEndpointData, Relay, RelayEndpointData,
-        RelayList, RelayListCity, RelayListCountry, ShadowsocksEndpointData, WireguardEndpointData,
-        WireguardRelayEndpointData,
+        BridgeEndpointData, Features, OpenVpnEndpoint, OpenVpnEndpointData, Relay,
+        RelayEndpointData, RelayList, RelayListCity, RelayListCountry, ShadowsocksEndpointData,
+        WireguardEndpointData, WireguardRelayEndpointData,
     },
 };
 
@@ -73,6 +73,7 @@ static RELAYS: LazyLock<RelayList> = LazyLock::new(|| RelayList {
                         shadowsocks_extra_addr_in: vec![],
                     }),
                     location: DUMMY_LOCATION.clone(),
+                    features: Features::default().configure_daita(),
                 },
                 Relay {
                     hostname: "se10-wireguard".to_string(),
@@ -94,6 +95,7 @@ static RELAYS: LazyLock<RelayList> = LazyLock::new(|| RelayList {
                         shadowsocks_extra_addr_in: vec![],
                     }),
                     location: DUMMY_LOCATION.clone(),
+                    features: Features::default(),
                 },
                 Relay {
                     hostname: "se11-wireguard".to_string(),
@@ -115,6 +117,7 @@ static RELAYS: LazyLock<RelayList> = LazyLock::new(|| RelayList {
                         shadowsocks_extra_addr_in: vec![],
                     }),
                     location: DUMMY_LOCATION.clone(),
+                    features: Features::default().configure_daita(),
                 },
                 Relay {
                     hostname: "se-got-001".to_string(),
@@ -129,6 +132,7 @@ static RELAYS: LazyLock<RelayList> = LazyLock::new(|| RelayList {
                     weight: 1,
                     endpoint_data: RelayEndpointData::Openvpn,
                     location: DUMMY_LOCATION.clone(),
+                    features: Features::default(),
                 },
                 Relay {
                     hostname: "se-got-002".to_string(),
@@ -143,6 +147,7 @@ static RELAYS: LazyLock<RelayList> = LazyLock::new(|| RelayList {
                     weight: 1,
                     endpoint_data: RelayEndpointData::Openvpn,
                     location: DUMMY_LOCATION.clone(),
+                    features: Features::default(),
                 },
                 Relay {
                     hostname: "se-got-br-001".to_string(),
@@ -157,6 +162,7 @@ static RELAYS: LazyLock<RelayList> = LazyLock::new(|| RelayList {
                     weight: 1,
                     endpoint_data: RelayEndpointData::Bridge,
                     location: DUMMY_LOCATION.clone(),
+                    features: Features::default(),
                 },
                 SHADOWSOCKS_RELAY.clone(),
             ],
@@ -241,6 +247,7 @@ static SHADOWSOCKS_RELAY: LazyLock<Relay> = LazyLock::new(|| Relay {
         shadowsocks_extra_addr_in: SHADOWSOCKS_RELAY_EXTRA_ADDRS.to_vec(),
     }),
     location: DUMMY_LOCATION.clone(),
+    features: Features::default(),
 });
 const SHADOWSOCKS_RELAY_IPV4: Ipv4Addr = Ipv4Addr::new(123, 123, 123, 1);
 const SHADOWSOCKS_RELAY_IPV6: Ipv6Addr = Ipv6Addr::new(0x123, 0, 0, 0, 0, 0, 0, 2);
@@ -574,6 +581,7 @@ fn test_wireguard_entry() {
                             shadowsocks_extra_addr_in: vec![],
                         }),
                         location: DUMMY_LOCATION.clone(),
+                        features: Features::default(),
                     },
                     Relay {
                         hostname: "se10-wireguard".to_string(),
@@ -595,6 +603,7 @@ fn test_wireguard_entry() {
                             shadowsocks_extra_addr_in: vec![],
                         }),
                         location: DUMMY_LOCATION.clone(),
+                        features: Features::default(),
                     },
                 ],
             }],
@@ -1220,6 +1229,7 @@ fn test_include_in_country() {
                             daita: false,
                         }),
                         location: DUMMY_LOCATION.clone(),
+                        features: Features::default(),
                     },
                     Relay {
                         hostname: "se10-wireguard".to_string(),
@@ -1241,6 +1251,7 @@ fn test_include_in_country() {
                             daita: false,
                         }),
                         location: DUMMY_LOCATION.clone(),
+                        features: Features::default(),
                     },
                 ],
             }],

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -639,9 +639,6 @@ pub enum SelectedObfuscation {
     #[cfg_attr(feature = "clap", clap(name = "udp2tcp"))]
     Udp2Tcp,
     Shadowsocks,
-    // TODO: Remove 'debug_assertions' condition
-    //       See https://linear.app/mullvad/issue/DES-2105
-    #[cfg_attr(all(feature = "clap", not(debug_assertions)), value(skip))]
     Quic,
 }
 

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -88,6 +88,49 @@ pub struct Relay {
     pub weight: u64,
     pub endpoint_data: RelayEndpointData,
     pub location: Location,
+    #[serde(default)] // TODO: Either use Default impl, or change `features` to Option.
+    pub features: Features,
+}
+
+/// Wireguard (?) specific extra features enabled on some relay.
+/// TODO: Document mee
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct Features {
+    daita: Option<Daita>,
+    quic: Option<Quic>,
+}
+
+impl Features {
+    /// Enable Daita for this relay
+    pub fn daita(self) -> Self {
+        let daita = Some(Daita);
+        Self { daita, ..self }
+    }
+
+    /// Configure QUIC for this relay
+    pub fn quic(self, options: Quic) -> Self {
+        let quic = Some(options);
+        Self { quic, ..self }
+    }
+}
+
+/// TODO: Document mee
+/// Empty struct, DAITA doesn't have any configuration options (exposed by the API).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Daita;
+
+/// TODO: Document mee
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Quic {
+    /// TODO: Document what this is used for
+    /// TODO: Is this always a tuple of an IPv4 & IPv6-inaddr?
+    /// If that's the case, I think this should be reflected in the type.
+    addr_in: Vec<IpAddr>,
+    /// TODO: Document what this is used for
+    token: String,
+    /// TODO: Document what this is used for
+    /// TODO: Is the type suitable?
+    domain: String,
 }
 
 impl Relay {
@@ -229,6 +272,7 @@ pub struct WireguardRelayEndpointData {
     /// Public key used by the relay peer
     pub public_key: wireguard::PublicKey,
     /// Whether the server supports DAITA
+    /// FIXME: This has been superceded by [Features] + [Daita].
     #[serde(default)]
     pub daita: bool,
     /// Optional IP addresses used by Shadowsocks

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -101,14 +101,24 @@ pub struct Features {
 }
 
 impl Features {
+    /// Whether Daita is enabled
+    pub fn daita(&self) -> bool {
+        self.daita.is_some()
+    }
+
+    /// Whether Quic is enabled and its config
+    pub fn quic(&self) -> Option<&Quic> {
+        self.quic.as_ref()
+    }
+
     /// Enable Daita for this relay
-    pub fn daita(self) -> Self {
+    pub fn configure_daita(self) -> Self {
         let daita = Some(Daita);
         Self { daita, ..self }
     }
 
     /// Configure QUIC for this relay
-    pub fn quic(self, options: Quic) -> Self {
+    pub fn configure_quic(self, options: Quic) -> Self {
         let quic = Some(options);
         Self { quic, ..self }
     }
@@ -131,6 +141,31 @@ pub struct Quic {
     /// TODO: Document what this is used for
     /// TODO: Is the type suitable?
     domain: String,
+}
+
+impl Quic {
+    /// TODO: Document mee
+    /// Pinky promise, IPv4 address 🤞
+    /// Is there only ever one in-IPv4 address?
+    pub fn in_ipv4(&self) -> IpAddr {
+        // TODO: Is this sound ??
+        debug_assert!(self.addr_in.len() == 2);
+        // TODO: Is this sound ??
+        //
+        let in_addr = self.addr_in.first().unwrap();
+        *in_addr
+    }
+
+    /// TODO: Document mee
+    pub const fn port(&self) -> u16 {
+        // TODO: Should this even be hardcoded?
+        // TODO: Is this even correct??
+        443
+    }
+
+    pub fn hostname(&self) -> &str {
+        &self.domain
+    }
 }
 
 impl Relay {


### PR DESCRIPTION
This PR adds (de)serialization for the new relay list format, adding the new `features` and `features.quic` keys. With this new relay list information, the relay selector can know which relays have QUIC obfuscation, and as such we are able to properly select & configure QUIC obfuscation :tada: