### PR TITLE
Revert "use /opt/homebrew for zsh completions if available"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 #### macOS
 - Use a local DNS resolver on the 127.0.0.0/8 network, regardless of macOS version.
-- Install zsh completions in `/opt/homebrew` if available.
 
 ### Fixed
 #### macOS

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -62,11 +62,7 @@ DAEMON_PLIST=$(cat <<-EOM
 EOM
 )
 
-if [[ -d "/opt/homebrew/share/zsh/site-functions/" ]]; then
-    ZSH_COMPLETIONS_DIR="/opt/homebrew/share/zsh/site-functions/"
-else
-    ZSH_COMPLETIONS_DIR="/usr/local/share/zsh/site-functions/"
-fi
+ZSH_COMPLETIONS_DIR="/usr/local/share/zsh/site-functions/"
 
 if [[ -d "/opt/homebrew/share/fish/vendor_completions.d/" ]]; then
     FISH_COMPLETIONS_DIR="/opt/homebrew/share/fish/vendor_completions.d/"

--- a/dist-assets/uninstall_macos.sh
+++ b/dist-assets/uninstall_macos.sh
@@ -36,10 +36,10 @@ sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup reset-firew
 sudo /Applications/Mullvad\ VPN.app/Contents/Resources/mullvad-setup remove-device || echo "Failed to remove device from account"
 
 echo "Removing zsh shell completion symlink ..."
-sudo rm -f "/opt/homebrew/share/zsh/site-functions/_mullvad"
-sudo rm -f "/usr/local/share/zsh/site-functions/_mullvad"
+sudo rm -f /usr/local/share/zsh/site-functions/_mullvad
 
 echo "Removing fish shell completion symlink ..."
+
 sudo rm -f "/opt/homebrew/share/fish/vendor_completions.d/mullvad.fish"
 sudo rm -f "/usr/local/share/fish/vendor_completions.d/mullvad.fish"
 


### PR DESCRIPTION
This PR reverts https://github.com/mullvad/mullvadvpn-app/pull/8313, since the motivation for adding it was too vague in hindsight. Sorry to the original author.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8429)
<!-- Reviewable:end -->
