### PR TITLE
Add e2e test for clearing upgrade firewall rules on reboot

### DIFF
--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod test_metadata;
 mod tunnel;
 mod tunnel_state;
 mod ui;
+mod windows;
 
 use itertools::Itertools;
 use mullvad_types::relay_constraints::{GeographicLocationConstraint, LocationConstraint};

--- a/test/test-manager/src/tests/mod.rs
+++ b/test/test-manager/src/tests/mod.rs
@@ -214,19 +214,35 @@ async fn ensure_daemon_version(
 ) -> anyhow::Result<MullvadProxyClient> {
     let app_package_filename = &TEST_CONFIG.app_package_filename;
 
-    let mullvad_client = if correct_daemon_version_is_running(rpc_provider.new_client().await).await
-    {
-        ensure_daemon_environment(rpc)
-            .await
-            .context("Failed to reset daemon environment")?;
-        rpc_provider.new_client().await
-    } else {
+    let must_reinstall_app =
+        match correct_daemon_version_is_running(rpc_provider.new_client().await).await {
+            Ok(correct_version) => !correct_version,
+            // Failing to reach the daemon is a sign that it is not installed
+            Err(mullvad_management_interface::Error::Rpc(..)) => {
+                log::debug!("Daemon is not running, attempting to start it");
+
+                let failed_starting_daemon = rpc.enable_mullvad_daemon().await.is_err()
+                    || rpc.start_mullvad_daemon().await.is_err();
+                if failed_starting_daemon {
+                    log::warn!("Failed to start the daemon service");
+                }
+                failed_starting_daemon
+            }
+            Err(e) => panic!("Failed to get app version: {e}"),
+        };
+
+    if must_reinstall_app {
         // NOTE: Reinstalling the app resets the daemon environment
         install_app(rpc, app_package_filename, rpc_provider)
             .await
-            .with_context(|| format!("Failed to install app '{app_package_filename}'"))?
-    };
-    Ok(mullvad_client)
+            .with_context(|| format!("Failed to install app '{app_package_filename}'"))
+    } else {
+        ensure_daemon_environment(rpc)
+            .await
+            .context("Failed to reset daemon environment")?;
+
+        Ok(rpc_provider.new_client().await)
+    }
 }
 
 /// Conditionally restart the running daemon
@@ -254,23 +270,12 @@ pub async fn ensure_daemon_environment(rpc: &ServiceClient) -> Result<(), anyhow
 }
 
 /// Checks if daemon is installed with the version specified by `TEST_CONFIG.app_package_filename`
-async fn correct_daemon_version_is_running(mut mullvad_client: MullvadProxyClient) -> bool {
+async fn correct_daemon_version_is_running(
+    mut mullvad_client: MullvadProxyClient,
+) -> Result<bool, mullvad_management_interface::Error> {
     let app_package_filename = &TEST_CONFIG.app_package_filename;
     let expected_version = get_version_from_path(std::path::Path::new(app_package_filename))
         .unwrap_or_else(|_| panic!("Invalid app version: {app_package_filename}"));
-
-    use mullvad_management_interface::Error::*;
-    match mullvad_client.get_current_version().await {
-        // Failing to reach the daemon is a sign that it is not installed
-        Err(Rpc(..)) => {
-            log::debug!("Could not reach active daemon before test, it is not running");
-            false
-        }
-        Err(e) => panic!("Failed to get app version: {e}"),
-        Ok(version) if version == expected_version => true,
-        _ => {
-            log::debug!("Daemon version mismatch");
-            false
-        }
-    }
+    let version = mullvad_client.get_current_version().await?;
+    Ok(version == expected_version)
 }

--- a/test/test-manager/src/tests/windows.rs
+++ b/test/test-manager/src/tests/windows.rs
@@ -10,19 +10,23 @@ use crate::tests::helpers::{geoip_lookup_with_retries, wait_for_tunnel_state};
 
 use super::TestContext;
 
-/// TODO: Explain me
+/// Test that, on a failed upgrade, blocking firewall rules are cleared on a reboot.
 #[test_function(target_os = "windows")]
 async fn test_clearing_blocked_state_on_failed_upgrade(
     _: TestContext,
     mut rpc: ServiceClient,
     mut mullvad_client: MullvadProxyClient,
 ) -> anyhow::Result<()> {
-    let settings = mullvad_client.get_settings().await?;
-    assert!(
-        !settings.block_when_disconnected,
-        "Block when dissconnected should be disabled"
-    );
-    assert!(!settings.auto_connect, "Auto connect should be disabled");
+    // Assert that the below settings are disabled. If they are not,
+    // then blocking firewall rules *will* persist after a reboot.
+    {
+        let settings = mullvad_client.get_settings().await?;
+        ensure!(
+            !settings.block_when_disconnected,
+            "Block when disconnected should be disabled"
+        );
+        ensure!(!settings.auto_connect, "Auto connect should be disabled");
+    }
 
     log::info!("Connecting to tunnel to enter secured state");
     // This is necessary to ensure that the firewall rules are applied
@@ -35,21 +39,20 @@ async fn test_clearing_blocked_state_on_failed_upgrade(
     wait_for_tunnel_state(mullvad_client.clone(), |state| {
         matches!(
             state,
-            TunnelState::Connecting { .. } | TunnelState::Error(..)
+            TunnelState::Connected { .. } | TunnelState::Error(..)
         )
     })
     .await?;
-    // Simulate a failed upgrade
     log::info!("Preparing daemon for restart (simulate failed upgrade)");
-    // Prepare the daemon for restarting
     mullvad_client
         .prepare_restart_v2(false)
         .await
         .context("Failed to prepare restart")?;
-    // Simulate that the daemon has been removed
+
+    // Simulate that the daemon has been uninstalled, by disabling the system service.
+    // We cannot actually uninstall the daemon here, because it would remove the blocking firewall rules,
+    // regardless of having called `prepare_restart_v2`.
     log::info!("Disabling Mullvad daemon system service");
-    // Do this by disabling the system service (the important part is that it does not restart
-    // automatically on reboot)
     rpc.disable_mullvad_daemon().await?;
     rpc.stop_mullvad_daemon().await?;
 
@@ -71,7 +74,74 @@ async fn test_clearing_blocked_state_on_failed_upgrade(
         .context("Device is offline after reboot")?
         .mullvad_exit_ip;
     ensure!(!mullvad_exit_ip, "Should *not* be a Mullvad Exit IP");
-    // Make sure system service is enabled in the test runner.
+
+    // Do the same thing again, but with lockdown mode enabled?
+    // assert that the firewall rules are still applied
+
+    // TODO: Move this to clean up routine
+    log::info!("Re-enabling Mullvad daemon system service");
+    rpc.enable_mullvad_daemon().await?;
+    Ok(())
+}
+
+/// Test that, on a failed upgrade when `Auto-connect` is enabled, blocking firewall rules are *not* cleared on a reboot.
+#[test_function(target_os = "windows")]
+async fn test_not_clearing_blocked_state_on_failed_upgrade_with_lockdown_mode(
+    _: TestContext,
+    mut rpc: ServiceClient,
+    mut mullvad_client: MullvadProxyClient,
+) -> anyhow::Result<()> {
+    // Make sure that lockdown mode is enabled.
+    // If it is not, then blocking firewall rules *will not* persist after a reboot.
+    {
+        mullvad_client.set_block_when_disconnected(true).await?;
+        let settings = mullvad_client.get_settings().await?;
+        ensure!(
+            settings.block_when_disconnected,
+            "Block when disconnected should be enabled"
+        );
+        ensure!(!settings.auto_connect, "Auto connect should be disabled");
+    }
+
+    log::info!("Waiting for tunnel state to be Disconnected with lockdown enabled");
+    wait_for_tunnel_state(mullvad_client.clone(), |state| {
+        matches!(
+            state,
+            TunnelState::Disconnected { locked_down, .. }  if *locked_down
+        )
+    })
+    .await?;
+    log::info!("Preparing daemon for restart (simulate failed upgrade)");
+    mullvad_client
+        .prepare_restart_v2(false)
+        .await
+        .context("Failed to prepare restart")?;
+
+    // Simulate that the daemon has been uninstalled, by disabling the system service.
+    // We cannot actually uninstall the daemon here, because it would remove the blocking firewall rules,
+    // regardless of having called `prepare_restart_v2`.
+    log::info!("Disabling Mullvad daemon system service");
+    rpc.disable_mullvad_daemon().await?;
+    rpc.stop_mullvad_daemon().await?;
+
+    // Make sure that blocking firewall rules are active - there should be no leaks 💦❌
+    log::info!("Checking that blocking firewall rules are active...");
+    let blocked = geoip_lookup_with_retries(&rpc).await.is_err();
+    ensure!(
+        blocked,
+        "Device is leaking - blocking rules have not applied properly"
+    );
+    // Reboot - we expect desperate users to take this measure
+    log::info!("Rebooting device...");
+    rpc.reboot().await?;
+
+    // The conn check should now fail - the firewall filters should *not* have been removed at this point 💦❌
+    log::info!("Checking connectivity after reboot (should be blocked)");
+    let blocked = geoip_lookup_with_retries(&rpc).await.is_err();
+    ensure!(
+        blocked,
+        "Device is leaking - blocking rules have not applied properly"
+    );
 
     // Do the same thing again, but with lockdown mode enabled?
     // assert that the firewall rules are still applied

--- a/test/test-manager/src/tests/windows.rs
+++ b/test/test-manager/src/tests/windows.rs
@@ -1,0 +1,83 @@
+//! Windows-specific tests.
+
+use anyhow::{Context, ensure};
+use mullvad_management_interface::MullvadProxyClient;
+use mullvad_types::states::TunnelState;
+use test_macro::test_function;
+use test_rpc::ServiceClient;
+
+use crate::tests::helpers::{geoip_lookup_with_retries, wait_for_tunnel_state};
+
+use super::TestContext;
+
+/// TODO: Explain me
+#[test_function(target_os = "windows")]
+async fn test_clearing_blocked_state_on_failed_upgrade(
+    _: TestContext,
+    mut rpc: ServiceClient,
+    mut mullvad_client: MullvadProxyClient,
+) -> anyhow::Result<()> {
+    let settings = mullvad_client.get_settings().await?;
+    assert!(
+        !settings.block_when_disconnected,
+        "Block when dissconnected should be disabled"
+    );
+    assert!(!settings.auto_connect, "Auto connect should be disabled");
+
+    log::info!("Connecting to tunnel to enter secured state");
+    // This is necessary to ensure that the firewall rules are applied
+    // Note that we do not need to wait for the tunnel to be fully connected
+    mullvad_client
+        .connect_tunnel()
+        .await
+        .context("failed to begin connecting")?;
+    log::info!("Waiting for tunnel state to be Connected or Error");
+    wait_for_tunnel_state(mullvad_client.clone(), |state| {
+        matches!(
+            state,
+            TunnelState::Connecting { .. } | TunnelState::Error(..)
+        )
+    })
+    .await?;
+    // Simulate a failed upgrade
+    log::info!("Preparing daemon for restart (simulate failed upgrade)");
+    // Prepare the daemon for restarting
+    mullvad_client
+        .prepare_restart_v2(false)
+        .await
+        .context("Failed to prepare restart")?;
+    // Simulate that the daemon has been removed
+    log::info!("Disabling Mullvad daemon system service");
+    // Do this by disabling the system service (the important part is that it does not restart
+    // automatically on reboot)
+    rpc.disable_mullvad_daemon().await?;
+    rpc.stop_mullvad_daemon().await?;
+
+    // Make sure that blocking firewall rules are active - there should be no leaks (yet) 💦❌
+    log::info!("Checking that blocking firewall rules are active...");
+    let geoip = geoip_lookup_with_retries(&rpc).await;
+    ensure!(
+        geoip.is_err(),
+        "Device is leaking with geo IP '{:?}'- blocking rules have not applied properly",
+        geoip.unwrap()
+    );
+    // Reboot - we expect desperate users to take this measure
+    log::info!("Rebooting device...");
+    rpc.reboot().await?;
+    // The conn check should now fail - the firewall filters should have been removed at this point 💦💦💦
+    log::info!("Checking connectivity after reboot (should be online, but not secured)");
+    let mullvad_exit_ip = geoip_lookup_with_retries(&rpc)
+        .await
+        .context("Device is offline after reboot")?
+        .mullvad_exit_ip;
+    ensure!(!mullvad_exit_ip, "Should *not* be a Mullvad Exit IP");
+    // Make sure system service is enabled in the test runner.
+
+    // Do the same thing again, but with lockdown mode enabled?
+    // assert that the firewall rules are still applied
+
+    // TODO: Move this to clean up routine
+    log::info!("Re-enabling Mullvad daemon system service");
+    rpc.enable_mullvad_daemon().await?;
+    Ok(())
+}

--- a/test/test-manager/src/tests/windows.rs
+++ b/test/test-manager/src/tests/windows.rs
@@ -75,12 +75,6 @@ async fn test_clearing_blocked_state_on_failed_upgrade(
         .mullvad_exit_ip;
     ensure!(!mullvad_exit_ip, "Should *not* be a Mullvad Exit IP");
 
-    // Do the same thing again, but with lockdown mode enabled?
-    // assert that the firewall rules are still applied
-
-    // TODO: Move this to clean up routine
-    log::info!("Re-enabling Mullvad daemon system service");
-    rpc.enable_mullvad_daemon().await?;
     Ok(())
 }
 
@@ -143,11 +137,5 @@ async fn test_not_clearing_blocked_state_on_failed_upgrade_with_lockdown_mode(
         "Device is leaking - blocking rules have not applied properly"
     );
 
-    // Do the same thing again, but with lockdown mode enabled?
-    // assert that the firewall rules are still applied
-
-    // TODO: Move this to clean up routine
-    log::info!("Re-enabling Mullvad daemon system service");
-    rpc.enable_mullvad_daemon().await?;
     Ok(())
 }

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -298,6 +298,18 @@ impl ServiceClient {
         Ok(())
     }
 
+    /// Enable the daemon system service.
+    ///
+    /// Does *not* start a stopped app. See [start_mullvad_daemon].
+    pub async fn enable_mullvad_daemon_service(&self) -> Result<(), Error> {
+        let mut ctx = tarpc::context::current();
+        ctx.deadline = SystemTime::now()
+            .checked_add(DAEMON_RESTART_TIMEOUT)
+            .unwrap();
+        let _ = todo!("self.client.enable_mullvad_daemon(ctx).await?;");
+        Ok(())
+    }
+
     pub async fn set_daemon_log_level(
         &self,
         verbosity_level: mullvad_daemon::Verbosity,
@@ -372,6 +384,8 @@ impl ServiceClient {
             .await?
     }
 
+    /// Reboot the testing VM. The VM should be completely rebooted and responsive when this
+    /// future completes.
     pub async fn reboot(&mut self) -> Result<(), Error> {
         log::debug!("Rebooting server");
 

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -301,12 +301,35 @@ impl ServiceClient {
     /// Enable the daemon system service.
     ///
     /// Does *not* start a stopped app. See [start_mullvad_daemon].
-    pub async fn enable_mullvad_daemon_service(&self) -> Result<(), Error> {
+    pub async fn enable_mullvad_daemon(&self) -> Result<(), Error> {
         let mut ctx = tarpc::context::current();
         ctx.deadline = SystemTime::now()
             .checked_add(DAEMON_RESTART_TIMEOUT)
             .unwrap();
-        let _ = todo!("self.client.enable_mullvad_daemon(ctx).await?;");
+        self.client
+            .enable_mullvad_daemon(ctx)
+            .await
+            .map_err(Error::Tarpc)??;
+        Ok(())
+    }
+
+    /// Disable the daemon system service. *Current only works on Windows*.
+    ///
+    /// This will not stop the daemon system service, but it will prevent it from starting
+    /// automatically on system boot.
+    ///
+    /// Note that if the daemon is also stopped, using [stop_mullvad_daemon], it will
+    /// not be possible to start it again until it is enabled again using
+    /// [enable_mullvad_daemon].
+    pub async fn disable_mullvad_daemon(&self) -> Result<(), Error> {
+        let mut ctx = tarpc::context::current();
+        ctx.deadline = SystemTime::now()
+            .checked_add(DAEMON_RESTART_TIMEOUT)
+            .unwrap();
+        self.client
+            .disable_mullvad_daemon(ctx)
+            .await
+            .map_err(Error::Tarpc)??;
         Ok(())
     }
 

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -230,6 +230,9 @@ mod service {
         /// Start the Mullvad VPN application.
         async fn start_mullvad_daemon() -> Result<(), Error>;
 
+        /// Disable the Mullvad VPN system service.
+        async fn disable_mullvad_daemon() -> Result<(), Error>;
+
         /// Sets the log level of the daemon service, the verbosity level represents the number of
         /// `-v`s passed on the command line. This will restart the daemon system service.
         async fn set_daemon_log_level(

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -89,7 +89,8 @@ impl Error {
 pub struct AmIMullvad {
     pub ip: IpAddr,
     pub mullvad_exit_ip: bool,
-    pub mullvad_exit_ip_hostname: String,
+    /// Will be `None` when not connected via mullvad relay
+    pub mullvad_exit_ip_hostname: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -233,6 +233,9 @@ mod service {
         /// Disable the Mullvad VPN system service.
         async fn disable_mullvad_daemon() -> Result<(), Error>;
 
+        /// Enable the Mullvad VPN system service.
+        async fn enable_mullvad_daemon() -> Result<(), Error>;
+
         /// Sets the log level of the daemon service, the verbosity level represents the number of
         /// `-v`s passed on the command line. This will restart the daemon system service.
         async fn set_daemon_log_level(

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -319,19 +319,22 @@ impl Service for TestServer {
     }
 
     /// Disable the Mullvad VPN system service.
-    async fn disable_mullvad_daemon_service(
-        self,
-        _: context::Context,
-    ) -> Result<(), test_rpc::Error> {
-        sys::disable_system_service_startup().await
+    async fn disable_mullvad_daemon(self, _: context::Context) -> Result<(), test_rpc::Error> {
+        #[cfg(not(target_os = "windows"))]
+        unimplemented!("disable_mullvad_daemon is only implemented on Windows");
+        #[cfg(target_os = "windows")]
+        {
+            sys::disable_system_service_startup().await
+        }
     }
 
-    /// Enable the Mullvad VPN system service.
-    async fn enable_mullvad_daemon_service(
-        self,
-        _: context::Context,
-    ) -> Result<(), test_rpc::Error> {
-        sys::enable_system_service_startup().await
+    async fn enable_mullvad_daemon(self, _: context::Context) -> Result<(), test_rpc::Error> {
+        #[cfg(not(target_os = "windows"))]
+        unimplemented!("enable_mullvad_daemon is only implemented on Windows");
+        #[cfg(target_os = "windows")]
+        {
+            sys::enable_system_service_startup().await
+        }
     }
 
     async fn set_daemon_log_level(

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -318,6 +318,22 @@ impl Service for TestServer {
         sys::start_app().await
     }
 
+    /// Disable the Mullvad VPN system service.
+    async fn disable_mullvad_daemon_service(
+        self,
+        _: context::Context,
+    ) -> Result<(), test_rpc::Error> {
+        sys::disable_system_service_startup().await
+    }
+
+    /// Enable the Mullvad VPN system service.
+    async fn enable_mullvad_daemon_service(
+        self,
+        _: context::Context,
+    ) -> Result<(), test_rpc::Error> {
+        sys::enable_system_service_startup().await
+    }
+
     async fn set_daemon_log_level(
         self,
         _: context::Context,

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -321,7 +321,10 @@ impl Service for TestServer {
     /// Disable the Mullvad VPN system service.
     async fn disable_mullvad_daemon(self, _: context::Context) -> Result<(), test_rpc::Error> {
         #[cfg(not(target_os = "windows"))]
-        unimplemented!("disable_mullvad_daemon is only implemented on Windows");
+        {
+            log::warn!("disable_mullvad_daemon is only implemented on Windows");
+            return Err(test_rpc::Error::Syscall);
+        }
         #[cfg(target_os = "windows")]
         {
             sys::disable_system_service_startup().await
@@ -330,7 +333,10 @@ impl Service for TestServer {
 
     async fn enable_mullvad_daemon(self, _: context::Context) -> Result<(), test_rpc::Error> {
         #[cfg(not(target_os = "windows"))]
-        unimplemented!("enable_mullvad_daemon is only implemented on Windows");
+        {
+            log::warn!("enable_mullvad_daemon is only implemented on Windows");
+            return Err(test_rpc::Error::Syscall);
+        }
         #[cfg(target_os = "windows")]
         {
             sys::enable_system_service_startup().await

--- a/test/test-runner/src/sys.rs
+++ b/test/test-runner/src/sys.rs
@@ -284,6 +284,12 @@ pub async fn start_app() -> Result<(), test_rpc::Error> {
     Ok(())
 }
 
+/// Disable the Mullvad VPN system service.
+#[cfg(target_os = "windows")]
+pub async fn disable_system_service() -> Result<(), test_rpc::Error> {
+    todo!("sc.exe disable?")
+}
+
 /// Restart the Mullvad VPN application.
 ///
 /// This function waits for the app to successfully start again.


### PR DESCRIPTION
Test run: ~https://github.com/mullvad/mullvadvpn-app/actions/runs/16170030641/job/45642313111~
~https://github.com/mullvad/mullvadvpn-app/actions/runs/16196025240~
https://github.com/mullvad/mullvadvpn-app/actions/workflows/desktop-e2e.yml
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8438)
<!-- Reviewable:end -->
