### PR TITLE
Fix debug keystore usage in fork jobs

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -232,9 +232,10 @@ jobs:
           submodules: true
 
       - name: Prepare dummy debug keystore
+        env:
+          KEYSTORE: ${{ vars.ANDROID_DUMMY_DEBUG_KEYSTORE }}
         run: |
-          echo "${{ secrets.ANDROID_DUMMY_DEBUG_KEYSTORE }}" | \
-            base64 -d > /root/.android/debug.keystore
+          echo "$KEYSTORE" | tr -d '\n\r' | base64 -d > /root/.android/debug.keystore
 
       - name: Compile app
         uses: burrunan/gradle-cache-action@v1
@@ -339,9 +340,10 @@ jobs:
           submodules: true
 
       - name: Prepare dummy debug keystore
+        env:
+          KEYSTORE: ${{ vars.ANDROID_DUMMY_DEBUG_KEYSTORE }}
         run: |
-          echo "${{ secrets.ANDROID_DUMMY_DEBUG_KEYSTORE }}" | \
-            base64 -d > /root/.android/debug.keystore
+          echo "$KEYSTORE" | tr -d '\n\r' | base64 -d > /root/.android/debug.keystore
 
       - name: Assemble instrumented test apk
         uses: burrunan/gradle-cache-action@v1


### PR DESCRIPTION
Moving the dummy debug keystore to an enviornment variable to make it accessible for forks. The dummy `debug.keystore` is not considered a secret and is only used for test and verification.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8451)
<!-- Reviewable:end -->
