### PR TITLE
Add QUIC end-to-end tests

### DIFF
--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -804,7 +804,7 @@ pub mod builder {
             }
         }
 
-        /// Enable QUIC obufscation.
+        /// Enable QUIC obfuscation.
         pub fn quic(
             mut self,
         ) -> RelayQueryBuilder<Wireguard<Multihop, Quic, Daita, QuantumResistant>> {


### PR DESCRIPTION
Nothing fancy, just to ensure QUIC doesn't unexpectedly break over time.

This PR is currently blocked on QUIC being deployed to production relays.