### PR TITLE
Prevent hickory-resolver from reading the /etc/hosts file

### DIFF
--- a/mullvad-daemon/src/android_dns.rs
+++ b/mullvad-daemon/src/android_dns.rs
@@ -39,6 +39,7 @@ impl DnsResolver for AndroidDnsResolver {
         let config = ResolverConfig::from_parts(None, vec![], group);
         let mut opts = ResolverOpts::default();
         opts.attempts = 0;
+        opts.use_hosts_file = false;
         let resolver = TokioAsyncResolver::tokio(config, opts);
 
         let lookup = resolver


### PR DESCRIPTION
Reading /etc/hosts causes OOM issues if the hosts files on the device is large (e.g. > 10 MB). We should not need to read the hosts files because the only lookups we do with hickory are to our own servies which should not be resolved from /etc/hosts.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8457)
<!-- Reviewable:end -->
