### PR TITLE
Do not flush mDNS states on macOS

### DIFF
--- a/talpid-core/src/firewall/macos.rs
+++ b/talpid-core/src/firewall/macos.rs
@@ -1,7 +1,5 @@
 use std::env;
 use std::io;
-use std::net::Ipv6Addr;
-use std::net::SocketAddr;
 use std::net::{IpAddr, Ipv4Addr};
 use std::ptr;
 use std::sync::LazyLock;
@@ -146,14 +144,10 @@ impl Firewall {
         }
 
         // Socket addresses for Multicast DNS.
-        let mdns_port = 5353;
-        let mdns_addrs = [
-            SocketAddr::from((Ipv4Addr::new(224, 0, 0, 251), mdns_port)),
-            SocketAddr::from((Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb), mdns_port)),
-        ];
-
-        if mdns_addrs.contains(&remote_address) {
-            // Ignore MDNS states. PQ *seems* to timeout if these states are flushed.
+        const MDNS_PORT: u16 = 5353;
+        if remote_address.port() == MDNS_PORT {
+            // Blocking mDNS sometimes causes the tunnel to fail. Seemingly by interferring with
+            // configd, mDNSResponder, or another macOS service.
             return Ok(false);
         }
 


### PR DESCRIPTION
For reasons we don't understand, blocking mDNS queries can result in the tunnel breaking

Fix DES-2311

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8460)
<!-- Reviewable:end -->
