### PR TITLE
Remove QUIC obfuscation from automatic retry order on Android

### DIFF
--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -69,6 +69,7 @@ pub static WIREGUARD_RETRY_ORDER: LazyLock<Vec<RelayQuery>> = LazyLock::new(|| {
         // 3
         RelayQueryBuilder::wireguard().shadowsocks().build(),
         // 4
+        #[cfg(not(target_os = "android"))]
         RelayQueryBuilder::wireguard().quic().build(),
         // 5
         RelayQueryBuilder::wireguard().udp2tcp().build(),

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -341,6 +341,7 @@ fn assert_wireguard_retry_order() {
         // 3
         RelayQueryBuilder::wireguard().shadowsocks().build(),
         // 4
+        #[cfg(not(target_os = "android"))]
         RelayQueryBuilder::wireguard().quic().build(),
         // 5
         RelayQueryBuilder::wireguard().udp2tcp().build(),


### PR DESCRIPTION
They are not ready yet.
(They might be, but have not tested yet. Disabling it for now)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8465)
<!-- Reviewable:end -->
