### PR TITLE
Check named pipe/UDS ownership when connecting to gRPC server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ Line wrap the file at 100 chars.                                              Th
 - Add grace period when best default route goes away to reduce frequency of random reconnects.
 
 ### Security
+- Prevent unprivileged users from impersonating the gRPC server. This was relatively harmless
+  previously but is required due to in-app updates.
+
 #### Windows
 - Enable control flow integrity checks (CFG) for some C++ code. This excludes `wintun`,
   `wireguard-nt`, and OpenVPN. This addresses `MLLVD-CR-24-101` to the extent that we found

--- a/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
@@ -1,4 +1,5 @@
 import * as grpc from '@grpc/grpc-js';
+import fs from 'fs';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb.js';
 import {
   BoolValue,
@@ -12,6 +13,8 @@ import log from '../shared/logging';
 
 const NETWORK_CALL_TIMEOUT = 10000;
 const CHANNEL_STATE_TIMEOUT = 1000 * 60 * 60;
+
+const RPC_PATH_PREFIX = 'unix://';
 
 type CallFunctionArgument<T, R> =
   | ((arg: T, callback: (error: Error | null, result: R) => void) => void)
@@ -49,7 +52,7 @@ export class GrpcClient {
     private connectionObserver?: ConnectionObserver,
   ) {
     this.client = new ManagementServiceClient(
-      rpcPath,
+      this.prefixedRpcPath(),
       grpc.credentials.createInsecure(),
       this.channelOptions(),
     );
@@ -63,7 +66,7 @@ export class GrpcClient {
     if (this.isClosed) {
       this.isClosed = false;
       this.client = new ManagementServiceClient(
-        this.rpcPath,
+        this.prefixedRpcPath(),
         grpc.credentials.createInsecure(),
         this.channelOptions(),
       );
@@ -86,11 +89,19 @@ export class GrpcClient {
           this.ensureConnectivity();
           reject(error);
         } else {
-          this.reconnectionTimeout = undefined;
-          this.isConnectedValue = true;
-          this.connectionObserver?.onOpen();
-          this.setChannelCallback();
-          resolve();
+          this.verifyOwnership()
+            .then(() => {
+              this.reconnectionTimeout = undefined;
+              this.isConnectedValue = true;
+              this.connectionObserver?.onOpen();
+              this.setChannelCallback();
+              resolve();
+            })
+            .catch((error) => {
+              this.onClose(error);
+              this.ensureConnectivity();
+              reject(error);
+            });
         }
       });
     });
@@ -150,6 +161,10 @@ export class GrpcClient {
     } else {
       throw noConnectionError;
     }
+  }
+
+  private prefixedRpcPath(): string {
+    return `${RPC_PATH_PREFIX}${this.rpcPath}`;
   }
 
   private deadlineFromNow() {
@@ -242,5 +257,28 @@ export class GrpcClient {
         });
       }
     }, 3000);
+  }
+
+  // Assert that the gRPC connection is owned by an administrator
+  private async verifyOwnership() {
+    if (process.platform === 'win32') {
+      try {
+        const { pipeIsAdminOwned } = await import('windows-utils');
+        pipeIsAdminOwned(this.rpcPath);
+      } catch (e) {
+        if (e && typeof e === 'object' && 'message' in e) {
+          throw new Error(`Failed to verify admin ownership of named pipe. ${e.message}`);
+        } else {
+          throw new Error('Failed to verify admin ownership of named pipe');
+        }
+      }
+      log.info('Verified pipe ownership');
+    } else {
+      const stat = fs.statSync(this.rpcPath);
+      if (stat.uid !== 0) {
+        throw new Error('Failed to verify root ownership of socket');
+      }
+      log.info('Verified socket ownership');
+    }
   }
 }

--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -523,17 +523,6 @@ class ApplicationMain
 
     log.info('Connected to the daemon');
 
-    // verify daemon ownership
-    try {
-      await this.daemonRpc.verifyDaemonOwnership();
-      log.info('Verified daemon ownership');
-    } catch (e) {
-      const error = e as Error;
-      log.error(`Failed to verify daemon ownership: ${error.message}`);
-
-      return;
-    }
-
     this.notificationController.closeNotificationsInCategory(
       SystemNotificationCategory.tunnelState,
     );


### PR DESCRIPTION
This fixes some races, e.g. when the file is opened as the gRPC server is shutting down, by retrying.

Fix DES-2314

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8466)
<!-- Reviewable:end -->
