### PR TITLE
Bump ignore date for node-gettext CVE

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -21,5 +21,5 @@ reason = "This is just a dev dependency, and we don't have untrusted input to mi
 # node-gettext: Prototype Pullution via the addTranslations function
 [[IgnoredVulns]]
 id = "CVE-2024-21528" # GHSA-g974-hxvm-x689
-ignoreUntil = 2025-07-17
+ignoreUntil = 2025-10-17
 reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"


### PR DESCRIPTION
It has not yet been patched according to https://osv.dev/vulnerability/GHSA-g974-hxvm-x689.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8479)
<!-- Reviewable:end -->
