### PR TITLE
Remove unused code in settings migration

### DIFF
--- a/mullvad-daemon/src/migrations/v7.rs
+++ b/mullvad-daemon/src/migrations/v7.rs
@@ -1,11 +1,8 @@
-use std::net::SocketAddr;
-
 use super::{Error, Result};
 use mullvad_types::{
     relay_constraints::{BridgeConstraints, BridgeSettings as NewBridgeSettings, BridgeType},
     settings::SettingsVersion,
 };
-use serde::{Deserialize, Serialize};
 use talpid_types::net::{
     Endpoint, TransportProtocol,
     proxy::{CustomProxy, Shadowsocks, Socks5Local, Socks5Remote, SocksAuth},
@@ -14,57 +11,6 @@ use talpid_types::net::{
 // ======================================================
 // Section for vendoring types and values that
 // this settings version depend on. See `mod.rs`.
-
-/// Specifies a specific endpoint or [`BridgeConstraints`] to use when `mullvad-daemon` selects a
-/// bridge server.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(unused)]
-pub enum BridgeSettings {
-    /// Let the relay selection algorithm decide on bridges, based on the relay list.
-    Normal(BridgeConstraints),
-    Custom(ProxySettings),
-}
-
-/// Proxy server options to be used by `OpenVpnMonitor` when starting a tunnel.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ProxySettings {
-    Local(LocalProxySettings),
-    Remote(RemoteProxySettings),
-    Shadowsocks(ShadowsocksProxySettings),
-}
-
-/// Options for a generic proxy running on localhost.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct LocalProxySettings {
-    pub port: u16,
-    pub peer: SocketAddr,
-}
-
-/// Options for a generic proxy running on remote host.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct RemoteProxySettings {
-    pub address: SocketAddr,
-    pub auth: Option<ProxyAuth>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct ProxyAuth {
-    pub username: String,
-    pub password: String,
-}
-
-/// Options for a bundled Shadowsocks proxy.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct ShadowsocksProxySettings {
-    pub peer: SocketAddr,
-    /// Password on peer.
-    pub password: String,
-    pub cipher: String,
-    #[cfg(target_os = "linux")]
-    pub fwmark: Option<u32>,
-}
 
 // ======================================================
 // This is a closed migration.

--- a/mullvad-daemon/src/migrations/v9.rs
+++ b/mullvad-daemon/src/migrations/v9.rs
@@ -31,8 +31,6 @@ const SPLIT_TUNNELING_STATE: &str = "split-tunnelling-enabled.txt";
 
 // ======================================================
 
-/// This is an open migration
-///
 /// This migration onboards the Android app's split tunnel settings into the daemon's settings.
 ///
 /// Until now, split tunneling has been completely handled client side by the Android app. This

--- a/mullvad-daemon/src/migrations/v9.rs
+++ b/mullvad-daemon/src/migrations/v9.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 #[cfg(target_os = "android")]
 use serde_json::json;
 #[cfg(target_os = "android")]
@@ -29,17 +28,6 @@ const SPLIT_TUNNELING_APPS: &str = "split-tunnelling.txt";
 /// The file where the split-tunnelling state (enabled / disabled) is stored.
 #[cfg(target_os = "android")]
 const SPLIT_TUNNELING_STATE: &str = "split-tunnelling-enabled.txt";
-
-/// Tunnel protocol
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename = "tunnel_type")]
-#[allow(unused)]
-pub enum TunnelType {
-    #[serde(rename = "openvpn")]
-    OpenVpn,
-    #[serde(rename = "wireguard")]
-    Wireguard,
-}
 
 // ======================================================
 

--- a/mullvad-daemon/src/migrations/v9.rs
+++ b/mullvad-daemon/src/migrations/v9.rs
@@ -45,7 +45,6 @@ const SPLIT_TUNNELING_STATE: &str = "split-tunnelling-enabled.txt";
 /// This `migrate` function needs to get passed a `settings_dir` to work on Android. This is
 /// because the Android client will pass the settings directory when initializing the daemon,
 /// which means that we can not know ahead of time where the settings are stored.
-#[allow(unused_variables)]
 pub fn migrate(
     settings: &mut serde_json::Value,
     #[cfg(target_os = "android")] directories: Option<Directories<'_>>,


### PR DESCRIPTION
In a sense a follow-up to #8461. I noticed the addition of `#[allow(unused)]` here and was curious as to why this code was unused and why we should ignore it rather than delete it.

Turns out all these structs were unused already when they were introduced. I checked out the commit that first created `v7.rs` and built it with the latest nightly compiler. It complains about these structs being unused already back then. So this must have been a mistake at the creation of this migration, and not caught since the compiler was not as good at finding those back then.

The comment in the commit message from @MarkusPettersson98 is that we should not touch closed migration code. In general I agree. We should ideally not touch this code. But removing code that sits completely unused is different from refactoring code or changing the logic in the code. I don't think this could break anything. If the types were used for anything at all, the compiler should be complaining. We also have  unit tests for the migration, and they pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8492)
<!-- Reviewable:end -->
