### PR TITLE
Improve security docs around TLS connection to API server

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -130,10 +130,15 @@ forwarded. All other forward traffic is rejected.
 #### Mullvad API
 
 The firewall allows traffic to the API regardless of tunnel state, so the daemon is able to update
-keys, fetch account data, etc. In the [Connected] state, API traffic is only allowed inside the tunnel.
+keys, fetch account data and more. In the [Connected] state, API traffic is only allowed inside the tunnel.
 For the other states, API traffic will bypass the firewall. On Windows, only the Mullvad service and
 problem report tool are able to communicate with the API in any of the blocking states. On macOS and
 Linux all applications running as root are able to reach the API in blocking states.
+
+All API connections use TLS 1.3 with certificate pinning. The app comes bundled with the
+[Let's encrypt root certificate](../mullvad-api/le_root_cert.pem) and only accepts connections
+with servers having a valid certificate issued to `api.mullvad.net` and signed with this
+bundled certificate.
 
 ### Disconnected
 


### PR DESCRIPTION
We got questions about the security of the connection to `api.mullvad.net` during some audits. This PR adds some more information about that connection to our existing security document. Should help security researchers and users understand the security properties of the app in the future.

Please suggest more things we can add that could be helpful, but without going into too much details that risk becoming outdated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8494)
<!-- Reviewable:end -->
