### PR TITLE
Make the git signature verification CI stricter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 
 # Security related github action workflow changes must be approved by leads
 /.github/workflows/verify-locked-down-signatures.yml @faern @raksooo @pinkisemils @albin-mullvad
+/ci/verify-locked-down-signatures.sh @faern @raksooo @pinkisemils @albin-mullvad
 /.github/workflows/unicop.yml @faern @raksooo @pinkisemils @albin-mullvad
 
 # The CODEOWNERS itself must be protected from unauthorized changes,

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -1,5 +1,5 @@
 ---
-name: Verify lockfile signatures
+name: Verify git signatures on important files
 on:
   pull_request:
     paths:
@@ -39,6 +39,7 @@ permissions: {}
 
 jobs:
   verify-signatures:
+    name: Verify git signatures
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
1. `/ci/verify-locked-down-signatures.sh` was not defined in `CODEOWNERS`. Meaning any non-teamlead could modify it. This sort of nullifies the security guarantees we tried to uphold by protecting `verify-locked-down-signatures.yml`, since it relies on the bash script for its check.
2. Add names to the CI jobs. This seems required to be able to refer to them in github rulesets regarding what CI jobs *must* pass for a PR to be mergable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8504)
<!-- Reviewable:end -->
