### PR TITLE
Check for location cells matching name and tag in e2e tests

### DIFF
--- a/android/lib/ui/component/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/component/relaylist/SelectableRelayListItem.kt
+++ b/android/lib/ui/component/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/component/relaylist/SelectableRelayListItem.kt
@@ -43,7 +43,10 @@ import net.mullvad.mullvadvpn.lib.ui.component.ExpandChevron
 import net.mullvad.mullvadvpn.lib.ui.designsystem.RelayListItem
 import net.mullvad.mullvadvpn.lib.ui.designsystem.RelayListItemDefaults
 import net.mullvad.mullvadvpn.lib.ui.designsystem.RelayListTokens
+import net.mullvad.mullvadvpn.lib.ui.tag.CUSTOM_LIST_ENTRY_NAME_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.EXPAND_BUTTON_TEST_TAG
+import net.mullvad.mullvadvpn.lib.ui.tag.GEOLOCATION_NAME_TAG
+import net.mullvad.mullvadvpn.lib.ui.tag.RECENT_NAME_TAG
 
 @Composable
 @Preview
@@ -100,6 +103,15 @@ fun SelectableRelayListItem(
                 }
 
                 Name(
+                    modifier =
+                        Modifier.testTag(
+                            when (relayListItem) {
+                                is RelayListItem.CustomListEntryItem -> CUSTOM_LIST_ENTRY_NAME_TAG
+                                is RelayListItem.CustomListItem -> CUSTOM_LIST_ENTRY_NAME_TAG
+                                is RelayListItem.GeoLocationItem -> GEOLOCATION_NAME_TAG
+                                is RelayListItem.RecentListItem -> RECENT_NAME_TAG
+                            }
+                        ),
                     name = relayListItem.hop.displayName(LocalContext.current),
                     state = relayListItem.state,
                     active = relayListItem.hop.isActive,

--- a/android/lib/ui/tag/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/tag/TestTagConstants.kt
+++ b/android/lib/ui/tag/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/tag/TestTagConstants.kt
@@ -41,6 +41,10 @@ const val CIRCULAR_PROGRESS_INDICATOR_TEST_TAG = "circular_progress_indicator_te
 const val EXPAND_BUTTON_TEST_TAG = "expand_button_test_tag"
 const val LOCATION_CELL_TEST_TAG = "location_cell_test_tag"
 
+const val GEOLOCATION_NAME_TAG = "geolocation_name_test_tag"
+const val CUSTOM_LIST_NAME_TAG = "custom_list_name_test_tag"
+const val CUSTOM_LIST_ENTRY_NAME_TAG = "custom_list_entry_name_test_tag"
+const val RECENT_NAME_TAG = "recent_name_test_tag"
 // ConnectScreen
 const val SELECT_LOCATION_BUTTON_TEST_TAG = "select_location_button_test_tag"
 const val CONNECT_BUTTON_TEST_TAG = "connect_button_test_tag"

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/SelectLocationPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/SelectLocationPage.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.test.common.page
 
 import androidx.test.uiautomator.By
 import net.mullvad.mullvadvpn.lib.ui.tag.EXPAND_BUTTON_TEST_TAG
+import net.mullvad.mullvadvpn.lib.ui.tag.GEOLOCATION_NAME_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.SELECT_LOCATION_SCREEN_TEST_TAG
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 
@@ -11,7 +12,11 @@ class SelectLocationPage internal constructor() : Page() {
     }
 
     fun clickLocationExpandButton(locationName: String) {
-        val locationCell = uiDevice.findObjectWithTimeout(By.text(locationName)).parent.parent
+        val locationCell =
+            uiDevice
+                .findObjectWithTimeout(By.textContains(locationName).res(GEOLOCATION_NAME_TAG))
+                .parent
+                .parent
         val expandButton = locationCell.findObjectWithTimeout(By.res(EXPAND_BUTTON_TEST_TAG))
         expandButton.click()
     }


### PR DESCRIPTION
Previously it would look for the first location cell and try to expand that one. Since this can in some cases be a recents cell the test would fail as it is not possible to expand a recents cell.

~This PR instead changes this behaviour to instead look for all matching location cells and then try to expand all of them. It will not throw an error if it can find any which is expandable.~

Instead we will add a type of cell tag to all names so that we can check for both name and tag and avoid trying to click on the expand cell of recent location items.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8511)
<!-- Reviewable:end -->
