### PR TITLE
Add release-debuginfo config and Cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,3 +152,8 @@ quinn-udp.opt-level = 3
 quinn.opt-level = 3
 mullvad-masque-proxy.opt-level = 3
 ring.opt-level = 3
+
+[profile.release-debuginfo]
+inherits = "release"
+debug = true
+strip = false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -29,9 +29,13 @@ mullvad.app.build.cargo.targets=arm,arm64,x86,x86_64
 # Perform a clean the cargo before each build
 mullvad.app.build.cargo.cleanBuild=true
 
-# Keep debug symbols in debug builds, this will cause the debug artifacts
+# If true, debug symbols are generated for release builds and not just debug builds.
+mullvad.app.build.cargo.generateDebugSymbolsForReleaseBuilds=true
+
+# Keep debug symbols if they exist. This will cause the debug artifacts
 # to be substantially larger.
 mullvad.app.build.keepDebugSymbols=false
+
 # Replace source file path prefixes in the Rust build artifacts with fixed values.
 # This must be set to true for the app build to be reprodcible, but should be set to false
 # when debugging to the Rust native libs from Android Studio.


### PR DESCRIPTION
When doing performance profiling we want to used the optimized Rust artifacts but we also want to keep the debug symbols.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
