### PR TITLE
Support 16kb page size

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -293,6 +293,10 @@ cargo {
 
         if (getBooleanProperty("mullvad.app.build.replaceRustPathPrefix"))
             spec.environment("RUSTFLAGS", generateRemapArguments())
+
+        // Support 16KB page sizes
+        // https://developer.android.com/guide/practices/page-sizes#other-build-systems
+        spec.environment("RUST_ANDROID_GRADLE_CC_LINK_ARG", "-Wl,-z,max-page-size=16384,-soname,lib${libname}.so")
     }
 }
 

--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -493,7 +493,7 @@ fn build_android_dynamic_lib(out_dir: &str) -> anyhow::Result<()> {
         .env("ANDROID_ARCH_NAME", android_arch_name(target))
         .env("GOPATH", &go_path)
         // Note: -w -s results in a stripped binary
-        .env("LDFLAGS", format!("-L{out_dir} -w -s"))
+        .env("LDFLAGS", format!("-L{out_dir} -w -s -Wl -z max-page-size=16384"))
         // Note: the build container overrides CARGO_TARGET_DIR, which will cause problems
         // since we will spawn another cargo process as part of building maybenot (which we
         // link into libwg). A work around is to simply override the overridden value, and we


### PR DESCRIPTION
This should make the app compatible with 16KB memory pages devices.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
