### PR TITLE
Only log failures to allow notifications in mock api and e2e tests

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -6,12 +6,14 @@ import android.os.Build
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import co.touchlab.kermit.Logger
 import net.mullvad.mullvadvpn.lib.endpoint.ApiEndpointOverride
 import net.mullvad.mullvadvpn.lib.endpoint.putApiEndpointConfigurationExtra
 import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.constant.LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 import net.mullvad.mullvadvpn.test.common.page.LoginPage
+import net.mullvad.mullvadvpn.test.common.page.PrivacyPage
 import net.mullvad.mullvadvpn.test.common.page.on
 
 class AppInteractor(
@@ -39,7 +41,7 @@ class AppInteractor(
 
     fun launchAndEnsureOnLoginPage() {
         launch()
-        clickAgreeOnPrivacyDisclaimer()
+        on<PrivacyPage> { clickAgreeOnPrivacyDisclaimer() }
         clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
         on<LoginPage>()
     }
@@ -50,10 +52,6 @@ class AppInteractor(
             enterAccountNumber(accountNumber)
             clickLoginButton()
         }
-    }
-
-    private fun clickAgreeOnPrivacyDisclaimer() {
-        device.findObjectWithTimeout(By.text("Agree and continue")).click()
     }
 
     private fun clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove(
@@ -70,10 +68,8 @@ class AppInteractor(
 
         try {
             device.findObjectWithTimeout(selector).click()
-        } catch (_: IllegalArgumentException) {
-            throw IllegalArgumentException(
-                "Failed to allow notification permission within timeout ($timeout ms)"
-            )
+        } catch (e: IllegalArgumentException) {
+            Logger.e("Failed to allow notification permission within timeout ($timeout ms)", e)
         }
     }
 }

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/PrivacyPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/PrivacyPage.kt
@@ -1,15 +1,11 @@
 package net.mullvad.mullvadvpn.test.common.page
 
-import android.os.Build
 import androidx.test.uiautomator.By
-import androidx.test.uiautomator.Until
-import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 
 class PrivacyPage internal constructor() : Page() {
     private val privacySelector = By.text("Privacy")
     private val agreeSelector = By.text("Agree and continue")
-    private val allowSelector = By.text("Allow")
 
     override fun assertIsDisplayed() {
         uiDevice.findObjectWithTimeout(privacySelector)
@@ -17,24 +13,5 @@ class PrivacyPage internal constructor() : Page() {
 
     fun clickAgreeOnPrivacyDisclaimer() {
         uiDevice.findObjectWithTimeout(agreeSelector).click()
-    }
-
-    fun clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove(
-        timeout: Long = DEFAULT_TIMEOUT
-    ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            // Skipping as notification permissions are not shown.
-            return
-        }
-
-        uiDevice.wait(Until.hasObject(allowSelector), timeout)
-
-        try {
-            uiDevice.findObjectWithTimeout(allowSelector).click()
-        } catch (e: IllegalArgumentException) {
-            throw IllegalArgumentException(
-                "Failed to allow notification permission within timeout ($timeout)"
-            )
-        }
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.test.e2e
 
 import net.mullvad.mullvadvpn.test.common.page.ConnectPage
 import net.mullvad.mullvadvpn.test.common.page.LoginPage
-import net.mullvad.mullvadvpn.test.common.page.PrivacyPage
 import net.mullvad.mullvadvpn.test.common.page.on
 import net.mullvad.mullvadvpn.test.e2e.misc.AccountTestRule
 import org.junit.jupiter.api.Disabled
@@ -17,12 +16,7 @@ class LoginTest : EndToEndTest() {
     fun testLoginWithValidCredentials() {
         val validTestAccountNumber = accountTestRule.validAccountNumber
 
-        app.launch()
-
-        on<PrivacyPage> {
-            clickAgreeOnPrivacyDisclaimer()
-            clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
-        }
+        app.launchAndEnsureOnLoginPage()
 
         on<LoginPage> {
             enterAccountNumber(validTestAccountNumber)
@@ -37,12 +31,7 @@ class LoginTest : EndToEndTest() {
     fun testLoginWithInvalidCredentials() {
         val invalidDummyAccountNumber = accountTestRule.invalidAccountNumber
 
-        app.launch()
-
-        on<PrivacyPage> {
-            clickAgreeOnPrivacyDisclaimer()
-            clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
-        }
+        app.launchAndEnsureOnLoginPage()
 
         on<LoginPage> {
             enterAccountNumber(invalidDummyAccountNumber)


### PR DESCRIPTION
Sometimes the allow notification dialog will not show. We should still proceed with the test if that is the case.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8524)
<!-- Reviewable:end -->
