### PR TITLE
Attempt to fix potential ANR

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/receiver/NotificationAlarmReceiver.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/receiver/NotificationAlarmReceiver.kt
@@ -6,9 +6,9 @@ import android.content.Intent
 import co.touchlab.kermit.Logger
 import java.time.Duration
 import java.time.ZonedDateTime
-import kotlinx.coroutines.runBlocking
 import net.mullvad.mullvadvpn.service.notifications.accountexpiry.AccountExpiryNotificationProvider
 import net.mullvad.mullvadvpn.usecase.ScheduleNotificationAlarmUseCase
+import net.mullvad.mullvadvpn.util.goAsync
 import net.mullvad.mullvadvpn.util.serializable
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -28,8 +28,9 @@ class NotificationAlarmReceiver : BroadcastReceiver(), KoinComponent {
         Logger.d("Account expiry alarm triggered")
         val untilExpiry = Duration.between(ZonedDateTime.now(), expiry)
 
-        runBlocking {
-            notificationProvider.showNotification(untilExpiry)
+        notificationProvider.showNotification(untilExpiry)
+
+        goAsync {
             // Only schedule the next alarm if we still have time left on the account.
             if (context != null && expiry > ZonedDateTime.now()) {
                 scheduleNotificationAlarmUseCase(context = context, accountExpiry = expiry)

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/BroadcastReceiverExtensions.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/BroadcastReceiverExtensions.kt
@@ -1,0 +1,23 @@
+package net.mullvad.mullvadvpn.util
+
+import android.content.BroadcastReceiver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+@OptIn(DelicateCoroutinesApi::class)
+fun BroadcastReceiver.goAsync(
+    coroutineScope: CoroutineScope = GlobalScope,
+    block: suspend () -> Unit,
+) {
+    val result = goAsync()
+    coroutineScope.launch {
+        try {
+            block()
+        } finally {
+            // Always call finish(), even if the coroutineScope was cancelled
+            result.finish()
+        }
+    }
+}

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/accountexpiry/AccountExpiryNotificationProvider.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/notifications/accountexpiry/AccountExpiryNotificationProvider.kt
@@ -20,7 +20,7 @@ class AccountExpiryNotificationProvider(private val channelId: NotificationChann
     override val notifications: Flow<NotificationUpdate<Notification.AccountExpiry>>
         get() = notificationChannel.receiveAsFlow()
 
-    suspend fun showNotification(durationUntilExpiry: Duration) {
+    fun showNotification(durationUntilExpiry: Duration) {
         val notification =
             Notification.AccountExpiry(
                 channelId = channelId,
@@ -29,7 +29,8 @@ class AccountExpiryNotificationProvider(private val channelId: NotificationChann
             )
 
         val notificationUpdate = NotificationUpdate.Notify(NOTIFICATION_ID, notification)
-        notificationChannel.send(notificationUpdate)
+        // Always succeeds because the channel is conflated.
+        notificationChannel.trySend(notificationUpdate)
     }
 
     suspend fun cancelNotification() {


### PR DESCRIPTION
In onReceive in NotificationAlarmReceiver onBlocking() was used which could potentially take too much time and cause an ANR. This PR changes the onBlocking() call to instead use the goAsync() API so that the onReceive method can return immediately.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8542)
<!-- Reviewable:end -->
