### PR TITLE
Remove default implementation from settings

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -443,13 +443,13 @@ mod windows {
 mod test {
     use mullvad_types::settings::{CURRENT_SETTINGS_VERSION, Settings};
 
-    use crate::migrations::migrate_settings;
+    use crate::{migrations::migrate_settings, settings::default_settings};
 
     /// Ensure that no migration logic runs for the default settings by checking whether anything
     /// has changed after running the migration code
     #[tokio::test]
     async fn test_settings_format_version() {
-        let default_settings = serde_json::to_value(Settings::default()).unwrap();
+        let default_settings = serde_json::to_value(default_settings()).unwrap();
         let mut migrated_settings = default_settings.clone();
 
         migrate_settings(None, &mut migrated_settings)

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -68,6 +68,60 @@ impl From<Error> for mullvad_management_interface::Status {
     }
 }
 
+/// Returns the default settings for the application. The value is constant except for the
+/// `show_beta_releases` field, which is set to true if the current version is a beta version.
+pub(crate) fn default_settings() -> Settings {
+    use mullvad_types::{
+        access_method,
+        constraints::Constraint,
+        custom_list::CustomListsSettings,
+        relay_constraints::{
+            BridgeSettings, BridgeState, GeographicLocationConstraint, LocationConstraint,
+            ObfuscationSettings, SelectedObfuscation,
+        },
+        settings::{CURRENT_SETTINGS_VERSION, TunnelOptions},
+    };
+    let mut settings = Settings {
+        relay_settings: RelaySettings::Normal(RelayConstraints {
+            location: Constraint::Only(LocationConstraint::Location(
+                GeographicLocationConstraint::Country("se".to_owned()),
+            )),
+            wireguard_constraints: WireguardConstraints {
+                entry_location: Constraint::Only(LocationConstraint::Location(
+                    GeographicLocationConstraint::Country("se".to_owned()),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        bridge_settings: BridgeSettings::default(),
+        obfuscation_settings: ObfuscationSettings {
+            selected_obfuscation: SelectedObfuscation::Auto,
+            ..Default::default()
+        },
+        bridge_state: BridgeState::Auto,
+        custom_lists: CustomListsSettings::default(),
+        api_access_methods: access_method::Settings::default(),
+        allow_lan: false,
+        #[cfg(not(target_os = "android"))]
+        block_when_disconnected: false,
+        auto_connect: false,
+        tunnel_options: TunnelOptions::default(),
+        relay_overrides: vec![],
+        show_beta_releases: false,
+        #[cfg(any(windows, target_os = "android", target_os = "macos"))]
+        split_tunnel: SplitTunnelSettings::default(),
+        settings_version: CURRENT_SETTINGS_VERSION,
+        recents: Some(vec![]),
+        update_default_location: false,
+    };
+
+    if crate::version::is_beta_version() {
+        settings.show_beta_releases = true;
+    }
+    settings
+}
+
 fn handle_custom_list_error(
     custom_list_err: CustomListError,
 ) -> mullvad_management_interface::Status {
@@ -158,7 +212,7 @@ impl SettingsPersister {
             Err(Error::ReadError(_, err)) if err.kind() == io::ErrorKind::NotFound => {
                 log::info!("No settings were found. Using defaults.");
                 LoadSettingsResult {
-                    settings: Self::default_settings(),
+                    settings: default_settings(),
                     should_save: true,
                 }
             }
@@ -175,7 +229,7 @@ impl SettingsPersister {
                     // has no effect.
                     #[cfg(not(target_os = "android"))]
                     block_when_disconnected: true,
-                    ..Self::default_settings()
+                    ..default_settings()
                 };
 
                 LoadSettingsResult {
@@ -238,7 +292,7 @@ impl SettingsPersister {
 
     /// Resets default settings
     pub async fn reset(&mut self) -> Result<(), Error> {
-        self.settings = Self::default_settings();
+        self.settings = default_settings();
         let path = self.path.clone();
         self.save()
             .or_else(|e| async move {
@@ -264,24 +318,6 @@ impl SettingsPersister {
 
     pub fn to_settings(&self) -> Settings {
         self.settings.clone()
-    }
-
-    /// Modifies `Settings::default()` somewhat, e.g. depending on whether a beta version
-    /// is being run or not.
-    fn default_settings() -> Settings {
-        let mut settings = Settings::default();
-
-        if crate::version::is_beta_version() {
-            settings.show_beta_releases = true;
-        }
-        // We only want to set this flag to true if the settings file hasn't been
-        // created yet so that we don't affect existing users' relay settings.
-        #[cfg(target_os = "android")]
-        {
-            settings.update_default_location = true;
-        }
-
-        settings
     }
 
     /// Edit the settings in a closure and write the changes to disk.

--- a/mullvad-daemon/src/settings/patch.rs
+++ b/mullvad-daemon/src/settings/patch.rs
@@ -452,7 +452,7 @@ fn test_valid_patch_files() {
     const OVERRIDE_PATCH: &str =
         include_str!("../../../docs/patch-examples/override-relay-ips.json");
 
-    let prev_settings = Settings::default();
+    let prev_settings = crate::settings::default_settings();
     let _ = merge_validate_patch_inner(&prev_settings, OVERRIDE_PATCH)
         .expect("failed to apply relay overrides");
 }
@@ -461,7 +461,7 @@ fn test_valid_patch_files() {
 fn test_patch_export() {
     use mullvad_types::relay_constraints::RelayOverride;
 
-    let mut settings = Settings::default();
+    let mut settings = crate::settings::default_settings();
 
     let mut relay_override = RelayOverride::empty("test".to_owned());
     relay_override.ipv4_addr_in = Some("1.2.3.4".parse().unwrap());

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -273,21 +273,6 @@ pub struct SelectedObfuscator {
     pub relay: Relay,
 }
 
-impl Default for SelectorConfig {
-    fn default() -> Self {
-        let default_settings = Settings::default();
-        SelectorConfig {
-            relay_settings: default_settings.relay_settings,
-            additional_constraints: AdditionalRelayConstraints::default(),
-            bridge_settings: default_settings.bridge_settings,
-            obfuscation_settings: default_settings.obfuscation_settings,
-            bridge_state: default_settings.bridge_state,
-            custom_lists: default_settings.custom_lists,
-            relay_overrides: default_settings.relay_overrides,
-        }
-    }
-}
-
 impl TryFrom<Settings> for RelayQuery {
     type Error = crate::Error;
 

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -301,7 +301,42 @@ fn tunnel_type(relay: &Relay) -> TunnelType {
 }
 
 fn default_relay_selector() -> RelaySelector {
-    RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone())
+    RelaySelector::from_list(default_selector_config(), RELAYS.clone())
+}
+
+fn default_selector_config() -> SelectorConfig {
+    use mullvad_relay_selector::AdditionalRelayConstraints;
+    use mullvad_types::{
+        constraints::Constraint,
+        custom_list::CustomListsSettings,
+        relay_constraints::{
+            BridgeSettings, BridgeState, GeographicLocationConstraint, LocationConstraint,
+            ObfuscationSettings, RelayConstraints, SelectedObfuscation, WireguardConstraints,
+        },
+    };
+    SelectorConfig {
+        relay_settings: RelaySettings::Normal(RelayConstraints {
+            location: Constraint::Only(LocationConstraint::Location(
+                GeographicLocationConstraint::Country("se".to_owned()),
+            )),
+            wireguard_constraints: WireguardConstraints {
+                entry_location: Constraint::Only(LocationConstraint::Location(
+                    GeographicLocationConstraint::Country("se".to_owned()),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        additional_constraints: AdditionalRelayConstraints::default(),
+        bridge_settings: BridgeSettings::default(),
+        obfuscation_settings: ObfuscationSettings {
+            selected_obfuscation: SelectedObfuscation::Auto,
+            ..Default::default()
+        },
+        bridge_state: BridgeState::Auto,
+        custom_lists: CustomListsSettings::default(),
+        relay_overrides: vec![],
+    }
 }
 
 fn supports_daita(relay: &Relay) -> bool {
@@ -456,7 +491,7 @@ fn test_openvpn_retry_order() {
             tunnel_protocol: TunnelType::OpenVpn,
             ..Default::default()
         }),
-        ..Default::default()
+        ..default_selector_config()
     });
 
     for (retry_attempt, query) in OPENVPN_RETRY_ORDER.iter().enumerate() {
@@ -618,7 +653,7 @@ fn test_wireguard_entry() {
         },
     };
 
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relays);
+    let relay_selector = RelaySelector::from_list(default_selector_config(), relays);
     let specific_hostname = "se10-wireguard";
     let specific_location = GeographicLocationConstraint::hostname("se", "got", specific_hostname);
     let general_location = GeographicLocationConstraint::city("se", "got");
@@ -827,7 +862,7 @@ fn test_selecting_wireguard_location_will_consider_multihop() {
 /// selected.
 #[test]
 fn test_selecting_wireguard_over_shadowsocks() {
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
+    let relay_selector = RelaySelector::from_list(default_selector_config(), RELAYS.clone());
 
     let query = RelayQueryBuilder::wireguard().shadowsocks().build();
     assert!(!query.wireguard_constraints().multihop());
@@ -853,7 +888,7 @@ fn test_selecting_wireguard_over_shadowsocks() {
 /// Test whether extra Shadowsocks IPs are selected when available
 #[test]
 fn test_selecting_wireguard_over_shadowsocks_extra_ips() {
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
+    let relay_selector = RelaySelector::from_list(default_selector_config(), RELAYS.clone());
 
     let query = RelayQueryBuilder::wireguard()
         .location(SHADOWSOCKS_RELAY_LOCATION.clone())
@@ -888,7 +923,7 @@ fn test_selecting_wireguard_over_shadowsocks_extra_ips() {
 /// Test whether Quic is always selected as the obfuscation protocol when Quic is selected.
 #[test]
 fn test_selecting_wireguard_over_quic() {
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
+    let relay_selector = RelaySelector::from_list(default_selector_config(), RELAYS.clone());
 
     let query = RelayQueryBuilder::wireguard().quic().build();
     assert!(!query.wireguard_constraints().multihop());
@@ -914,7 +949,7 @@ fn test_selecting_wireguard_over_quic() {
 /// Selecting QUIC should not affect OpenVPN
 #[test]
 fn test_selecting_openvpn_and_quic() {
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
+    let relay_selector = RelaySelector::from_list(default_selector_config(), RELAYS.clone());
 
     let mut query = RelayQueryBuilder::wireguard().quic().build();
     query.set_tunnel_protocol(TunnelType::OpenVpn).unwrap();
@@ -929,7 +964,7 @@ fn test_selecting_openvpn_and_quic() {
 fn test_selecting_wireguard_ignore_extra_ips_override_v4() {
     const OVERRIDE_IPV4: Ipv4Addr = Ipv4Addr::new(1, 3, 3, 7);
 
-    let config = mullvad_relay_selector::SelectorConfig {
+    let config = SelectorConfig {
         relay_overrides: vec![RelayOverride {
             hostname: SHADOWSOCKS_RELAY_LOCATION
                 .get_hostname()
@@ -938,7 +973,7 @@ fn test_selecting_wireguard_ignore_extra_ips_override_v4() {
             ipv4_addr_in: Some(OVERRIDE_IPV4),
             ipv6_addr_in: None,
         }],
-        ..Default::default()
+        ..default_selector_config()
     };
 
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
@@ -985,7 +1020,7 @@ fn test_selecting_wireguard_ignore_extra_ips_override_v6() {
             ipv4_addr_in: None,
             ipv6_addr_in: Some(OVERRIDE_IPV6),
         }],
-        ..Default::default()
+        ..default_selector_config()
     };
 
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
@@ -1206,7 +1241,7 @@ fn test_openvpn_auto_bridge() {
             tunnel_protocol: TunnelType::OpenVpn,
             ..Default::default()
         }),
-        ..Default::default()
+        ..default_selector_config()
     });
     let retry_order = [
         // This attempt should not use bridge
@@ -1323,7 +1358,7 @@ fn test_include_in_country() {
     };
 
     // If include_in_country is false for all relays, a relay must be selected anyway.
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relay_list.clone());
+    let relay_selector = RelaySelector::from_list(default_selector_config(), relay_list.clone());
     assert!(
         relay_selector
             .get_relay(0, talpid_types::net::IpAvailability::Ipv4)
@@ -1333,7 +1368,7 @@ fn test_include_in_country() {
     // If include_in_country is true for some relay, it must always be selected.
     relay_list.countries[0].cities[0].relays[0].include_in_country = true;
     let expected_hostname = relay_list.countries[0].cities[0].relays[0].hostname.clone();
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relay_list);
+    let relay_selector = RelaySelector::from_list(default_selector_config(), relay_list);
     let relay = unwrap_relay(
         relay_selector
             .get_relay(0, talpid_types::net::IpAvailability::Ipv4)
@@ -1353,7 +1388,7 @@ fn ignore_bridge_state_when_wireguard_is_used() {
     let query = RelayQueryBuilder::wireguard().build();
     let config = SelectorConfig {
         bridge_state: BridgeState::On,
-        ..SelectorConfig::default()
+        ..default_selector_config()
     };
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
     for _ in 0..100 {
@@ -1371,7 +1406,7 @@ fn openvpn_handle_bridge_settings() {
 
     let config = SelectorConfig {
         bridge_state: BridgeState::On,
-        ..SelectorConfig::default()
+        ..default_selector_config()
     };
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
     let relay = relay_selector.get_relay_by_query(query.clone()).unwrap();
@@ -1428,7 +1463,7 @@ fn openvpn_bridge_with_automatic_transport_protocol() {
     // Enable bridge mode.
     let config = SelectorConfig {
         bridge_state: BridgeState::On,
-        ..SelectorConfig::default()
+        ..default_selector_config()
     };
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
 
@@ -1473,7 +1508,7 @@ fn openvpn_bridge_with_automatic_transport_protocol() {
 /// DAITA is a core privacy feature
 #[test]
 fn test_daita_smart_routing_overrides_multihop() {
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
+    let relay_selector = RelaySelector::from_list(default_selector_config(), RELAYS.clone());
     let query = RelayQueryBuilder::
         wireguard()
         .daita()
@@ -1525,7 +1560,7 @@ fn test_daita_smart_routing_overrides_multihop() {
 /// to be filtered out.
 #[test]
 fn test_daita() {
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), RELAYS.clone());
+    let relay_selector = RelaySelector::from_list(default_selector_config(), RELAYS.clone());
 
     // Only pick relays that support DAITA
     let query = RelayQueryBuilder::wireguard()
@@ -1667,7 +1702,7 @@ fn valid_user_setting_should_yield_relay() {
 
     let config = SelectorConfig {
         relay_settings: user_constraints.into(),
-        ..SelectorConfig::default()
+        ..default_selector_config()
     };
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
     let user_result = relay_selector.get_relay_by_query(user_query.clone());
@@ -1696,7 +1731,7 @@ fn test_shadowsocks_runtime_ipv4_unavailable() {
     let config = SelectorConfig {
         relay_settings: relay_constraints.into(),
         obfuscation_settings: obfs_settings,
-        ..SelectorConfig::default()
+        ..default_selector_config()
     };
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
     let runtime_parameters = talpid_types::net::IpAvailability::Ipv6;
@@ -1724,7 +1759,7 @@ fn test_runtime_ipv4_unavailable() {
 
     let config = SelectorConfig {
         relay_settings: relay_constraints.into(),
-        ..SelectorConfig::default()
+        ..default_selector_config()
     };
     let relay_selector = RelaySelector::from_list(config, RELAYS.clone());
     let runtime_parameters = talpid_types::net::IpAvailability::Ipv6;
@@ -1830,7 +1865,7 @@ fn include_in_country_with_few_relays() -> Result<(), Error> {
             ..Default::default()
         }
     };
-    let relay_selector = RelaySelector::from_list(SelectorConfig::default(), relays);
+    let relay_selector = RelaySelector::from_list(default_selector_config(), relays);
 
     relay_selector.get_relay_by_query(query)?;
     Ok(())

--- a/mullvad-types/src/features.rs
+++ b/mullvad-types/src/features.rs
@@ -240,9 +240,56 @@ mod tests {
 
     use super::*;
 
+    pub fn get_settings() -> Settings {
+        use crate::{
+            access_method,
+            constraints::Constraint,
+            custom_list::CustomListsSettings,
+            relay_constraints::{
+                BridgeSettings, BridgeState, GeographicLocationConstraint, LocationConstraint,
+                ObfuscationSettings, RelayConstraints, SelectedObfuscation, WireguardConstraints,
+            },
+            settings::{CURRENT_SETTINGS_VERSION, Settings, TunnelOptions},
+        };
+        Settings {
+            relay_settings: RelaySettings::Normal(RelayConstraints {
+                location: Constraint::Only(LocationConstraint::Location(
+                    GeographicLocationConstraint::Country("se".to_owned()),
+                )),
+                wireguard_constraints: WireguardConstraints {
+                    entry_location: Constraint::Only(LocationConstraint::Location(
+                        GeographicLocationConstraint::Country("se".to_owned()),
+                    )),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            bridge_settings: BridgeSettings::default(),
+            obfuscation_settings: ObfuscationSettings {
+                selected_obfuscation: SelectedObfuscation::Auto,
+                ..Default::default()
+            },
+            bridge_state: BridgeState::Auto,
+            custom_lists: CustomListsSettings::default(),
+            api_access_methods: access_method::Settings::default(),
+            allow_lan: false,
+            #[cfg(not(target_os = "android"))]
+            block_when_disconnected: false,
+            auto_connect: false,
+            tunnel_options: TunnelOptions::default(),
+            relay_overrides: vec![],
+            show_beta_releases: false,
+            #[cfg(any(windows, target_os = "android", target_os = "macos"))]
+            split_tunnel: SplitTunnelSettings::default(),
+            settings_version: CURRENT_SETTINGS_VERSION,
+            recents: Some(vec![]),
+            update_default_location: false,
+        }
+    }
+
     #[test]
     fn test_one_indicator_at_a_time() {
-        let mut settings = Settings::default();
+        let mut settings = get_settings();
         let mut endpoint = TunnelEndpoint {
             endpoint: Endpoint {
                 address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -1,11 +1,9 @@
 use crate::{
     access_method,
-    constraints::Constraint,
     custom_list::CustomListsSettings,
     relay_constraints::{
         BridgeSettings, BridgeState, GeographicLocationConstraint, LocationConstraint,
-        ObfuscationSettings, RelayConstraints, RelayOverride, RelaySettings,
-        RelaySettingsFormatter, SelectedObfuscation, WireguardConstraints,
+        ObfuscationSettings, RelayOverride, RelaySettings, RelaySettingsFormatter,
     },
     wireguard,
 };
@@ -71,7 +69,6 @@ impl Serialize for SettingsVersion {
 
 /// Mullvad daemon settings.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-#[serde(default)]
 pub struct Settings {
     pub relay_settings: RelaySettings,
     pub bridge_settings: BridgeSettings,
@@ -241,45 +238,6 @@ impl From<std::path::PathBuf> for SplitApp {
 impl From<String> for SplitApp {
     fn from(value: String) -> Self {
         SplitApp(value)
-    }
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Settings {
-            relay_settings: RelaySettings::Normal(RelayConstraints {
-                location: Constraint::Only(LocationConstraint::Location(
-                    GeographicLocationConstraint::Country("se".to_owned()),
-                )),
-                wireguard_constraints: WireguardConstraints {
-                    entry_location: Constraint::Only(LocationConstraint::Location(
-                        GeographicLocationConstraint::Country("se".to_owned()),
-                    )),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }),
-            update_default_location: false,
-            bridge_settings: BridgeSettings::default(),
-            obfuscation_settings: ObfuscationSettings {
-                selected_obfuscation: SelectedObfuscation::Auto,
-                ..Default::default()
-            },
-            bridge_state: BridgeState::Auto,
-            custom_lists: CustomListsSettings::default(),
-            api_access_methods: access_method::Settings::default(),
-            allow_lan: false,
-            #[cfg(not(target_os = "android"))]
-            block_when_disconnected: false,
-            auto_connect: false,
-            tunnel_options: TunnelOptions::default(),
-            relay_overrides: vec![],
-            show_beta_releases: false,
-            #[cfg(any(windows, target_os = "android", target_os = "macos"))]
-            split_tunnel: SplitTunnelSettings::default(),
-            settings_version: CURRENT_SETTINGS_VERSION,
-            recents: Some(vec![]),
-        }
     }
 }
 


### PR DESCRIPTION
Moves the definition of the default settings into the `mullvad_daemon` crate, to reduce the scope of the API, see linear issue.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8546)
<!-- Reviewable:end -->
