### PR TITLE
Fix obfuscation not handling .off in release mode

### DIFF
--- a/ios/PacketTunnelCore/Actor/ProtocolObfuscator.swift
+++ b/ios/PacketTunnelCore/Actor/ProtocolObfuscator.swift
@@ -57,18 +57,19 @@ public class ProtocolObfuscator<Obfuscator: TunnelObfuscation>: ProtocolObfuscat
 
         remotePort = endpoint.ipv4Relay.port
 
-        #if DEBUG
         let obfuscationProtocol: TunnelObfuscationProtocol? = switch obfuscationMethod {
         case .udpOverTcp:
             .udpOverTcp
         case .shadowsocks:
             .shadowsocks
+        #if DEBUG
         case .quic:
             if let relayFeatures = relayFeatures?.quic {
                 .quic(hostname: relayFeatures.domain, token: relayFeatures.token)
             } else {
                 nil
             }
+        #endif
         default:
             // This is fine, since ObfuscationMethodSelector.obfuscationMethodBy` above should never
             // return .automatic.
@@ -85,14 +86,6 @@ public class ProtocolObfuscator<Obfuscator: TunnelObfuscation>: ProtocolObfuscat
             tcpPort: remotePort,
             obfuscationProtocol: obfuscationProtocol
         )
-        #else
-        // At this point, the only possible obfuscation methods should be either `.udpOverTcp` or `.shadowsocks`
-        let obfuscator = Obfuscator(
-            remoteAddress: endpoint.ipv4Relay.ip,
-            tcpPort: remotePort,
-            obfuscationProtocol: obfuscationMethod == .shadowsocks ? .shadowsocks : .udpOverTcp
-        )
-        #endif
 
         obfuscator.start()
         tunnelObfuscator = obfuscator


### PR DESCRIPTION
When adding .quic to obfuscation the debug mode was changed and obfuscation = .off was missed. This fixes that.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8557)
<!-- Reviewable:end -->
