### PR TITLE
Remove mold from build container

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -31,9 +31,6 @@ ENV CARGO_TARGET_DIR=/cargo-target/target
 ARG GOLANG_VERSION=1.21.3 \
     GOLANG_HASH=1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8
 
-# The pinned commit has this solved: https://github.com/rui314/mold/issues/1003.
-ARG MOLD_COMMIT_REF=c4722fe5aed96295837d9150b20ef8698c7a28db
-
 # Pinned to commit hash for tag v4.24.3
 ARG PROTOBUF_COMMIT_REF=ee1355459c9ce7ffe264bc40cfdc7b7623d37e99
 
@@ -83,21 +80,6 @@ RUN apt-get update -y && \
     cmake --build . -j $(nproc) && \
     cmake --install . && \
     cd .. && rm -rf protobuf && \
-    apt-get autoremove -y
-
-# === mold (fast linker) ===
-# Allows linking Rust binaries significantly faster.
-
-RUN apt-get update -y && \
-    apt-get install -y --mark-auto cmake libssl-dev zlib1g-dev gcc g++ && \
-    rm -rf /var/lib/apt/lists/* && \
-    git clone https://github.com/rui314/mold.git && \
-    mkdir mold/build && cd mold/build && \
-    git reset --hard "$MOLD_COMMIT_REF" && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ .. && \
-    cmake --build . -j $(nproc) && \
-    cmake --install . && \
-    cd ../.. && rm -rf mold && \
     apt-get autoremove -y
 
 # === Volta for npm + node ===

--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -16,10 +16,6 @@ CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
 GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
 ANDROID_CREDENTIALS_DIR=${ANDROID_CREDENTIALS_DIR:-""}
 CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
-# Temporarily do not use mold for linking by default due to it causing build errors.
-# There's a separate issue (DES-1177) to address this problem.
-# Build servers also opt out of this and instead use GNU ld.
-USE_MOLD=${USE_MOLD:-"false"}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -47,11 +43,6 @@ case ${1-:""} in
         exit 1
 esac
 
-optional_mold=""
-if [[ "$USE_MOLD" == "true" ]]; then
-    optional_mold="mold -run"
-fi
-
 set -x
 exec "$CONTAINER_RUNNER" run --rm -it \
     -v "/$REPO_DIR:$REPO_MOUNT_TARGET:Z" \
@@ -59,4 +50,4 @@ exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \
     "${optional_android_credentials_volume[@]}" \
-    "$container_image_name" bash -c "$optional_mold $*"
+    "$container_image_name" bash -c "$*"

--- a/ci/buildserver-build-android.sh
+++ b/ci/buildserver-build-android.sh
@@ -29,7 +29,7 @@ function upload {
 }
 
 function run_in_linux_container {
-    USE_MOLD=false ./building/container-run.sh linux "$@"
+    ./building/container-run.sh linux "$@"
 }
 
 # Builds the app artifacts and move them to the passed in `artifact_dir`.
@@ -38,7 +38,6 @@ function build {
     ANDROID_CREDENTIALS_DIR=$ANDROID_CREDENTIALS_DIR \
         CARGO_TARGET_VOLUME_NAME="cargo-target-android" \
         CARGO_REGISTRY_VOLUME_NAME="cargo-registry-android" \
-        USE_MOLD=false \
         ./building/containerized-build.sh android --app-bundle --enable-play-publishing || return 1
 
     mv dist/*.{aab,apk} "$artifact_dir" || return 1

--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -103,7 +103,7 @@ function upload {
 # means in a container on Linux, and straight up in the local shell elsewhere.
 function run_in_build_env {
     if [[ "$(uname -s)" == "Linux" ]]; then
-        USE_MOLD=false ./building/container-run.sh linux "$@"
+        ./building/container-run.sh linux "$@"
     else
         bash -c "$*"
     fi


### PR DESCRIPTION
Since the mold version in the container is very old, we should either upgrade it or remove it. I benchmarked mold version 2.40.2 (much newer than what we currently have in the container). The result was that it was just a few percent faster than the default linker. So there is no strong argument for keeping mold. Developers can still use mold outside of the containers if they want to.

Since mold was disabled by default, and no one I have spoken to seems to enable mold, this change should not really have any impact at all, except making building the containers faster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8563)
<!-- Reviewable:end -->
