### PR TITLE
Remove default implementation from settings - V2

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -449,7 +449,7 @@ mod test {
     /// has changed after running the migration code
     #[tokio::test]
     async fn test_settings_format_version() {
-        let default_settings = serde_json::to_value(Settings::default()).unwrap();
+        let default_settings = serde_json::to_value(Settings::default_settings()).unwrap();
         let mut migrated_settings = default_settings.clone();
 
         migrate_settings(None, &mut migrated_settings)

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -269,7 +269,7 @@ impl SettingsPersister {
     /// Modifies `Settings::default()` somewhat, e.g. depending on whether a beta version
     /// is being run or not.
     fn default_settings() -> Settings {
-        let mut settings = Settings::default();
+        let mut settings = Settings::default_settings();
 
         if crate::version::is_beta_version() {
             settings.show_beta_releases = true;

--- a/mullvad-daemon/src/settings/patch.rs
+++ b/mullvad-daemon/src/settings/patch.rs
@@ -452,7 +452,7 @@ fn test_valid_patch_files() {
     const OVERRIDE_PATCH: &str =
         include_str!("../../../docs/patch-examples/override-relay-ips.json");
 
-    let prev_settings = Settings::default();
+    let prev_settings = Settings::default_settings();
     let _ = merge_validate_patch_inner(&prev_settings, OVERRIDE_PATCH)
         .expect("failed to apply relay overrides");
 }
@@ -461,7 +461,7 @@ fn test_valid_patch_files() {
 fn test_patch_export() {
     use mullvad_types::relay_constraints::RelayOverride;
 
-    let mut settings = Settings::default();
+    let mut settings = Settings::default_settings();
 
     let mut relay_override = RelayOverride::empty("test".to_owned());
     relay_override.ipv4_addr_in = Some("1.2.3.4".parse().unwrap());

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -273,16 +273,7 @@ pub struct SelectedObfuscator {
 
 impl Default for SelectorConfig {
     fn default() -> Self {
-        let default_settings = Settings::default();
-        SelectorConfig {
-            relay_settings: default_settings.relay_settings,
-            additional_constraints: AdditionalRelayConstraints::default(),
-            bridge_settings: default_settings.bridge_settings,
-            obfuscation_settings: default_settings.obfuscation_settings,
-            bridge_state: default_settings.bridge_state,
-            custom_lists: default_settings.custom_lists,
-            relay_overrides: default_settings.relay_overrides,
-        }
+        Self::from_settings(&Settings::default_settings())
     }
 }
 

--- a/mullvad-types/src/features.rs
+++ b/mullvad-types/src/features.rs
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_one_indicator_at_a_time() {
-        let mut settings = Settings::default();
+        let mut settings = Settings::default_settings();
         let mut endpoint = TunnelEndpoint {
             endpoint: Endpoint {
                 address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),

--- a/mullvad-version/src/lib.rs
+++ b/mullvad-version/src/lib.rs
@@ -9,6 +9,10 @@ use regex_lite::Regex;
 #[cfg(has_version)]
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/product-version.txt"));
 
+pub fn is_beta_version() -> bool {
+    crate::VERSION.contains("beta")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Version {
     pub year: u32,


### PR DESCRIPTION
Version two of previous attempt [8546](https://github.com/mullvad/mullvadvpn-app/pull/8546). This time we only remove the trait implementation, but keep it in `mullvad-types`. Honestly not even really sure what this accomplishes. 
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8572)
<!-- Reviewable:end -->
