### PR TITLE
Fix spelling errors in some comments.

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -37,7 +37,7 @@ mullvad.app.build.cargo.generateDebugSymbolsForReleaseBuilds=false
 mullvad.app.build.keepDebugSymbols=false
 
 # Replace source file path prefixes in the Rust build artifacts with fixed values.
-# This must be set to true for the app build to be reprodcible, but should be set to false
+# This must be set to true for the app build to be reproducible, but should be set to false
 # when debugging to the Rust native libs from Android Studio.
 mullvad.app.build.replaceRustPathPrefix=true
 
@@ -46,9 +46,9 @@ mullvad.app.build.boringtun.enable=false
 
 ## E2E tests ##
 
-# To run e2e tests you need to provide credentails for the enviroment you
+# To run e2e tests you need to provide credentials for the environment you
 # are targeting. Either provide a partnerAuth that will automatically create
-# accounts as needed or provide already valid credentaisl
+# accounts as needed or provide already valid credentials
 
 #mullvad.test.e2e.prod.partnerAuth=
 # OR

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -313,7 +313,7 @@ struct SwiftCancelHandle mullvad_ios_delete_account(struct SwiftApiContext api_c
  *
  * # SAFETY
  * `rawAddressCacheProvider` **must** be provided by a call to `init_swift_address_cache_wrapper`
- * It is okay to persist it, and use it accross multiple threads.
+ * It is okay to persist it, and use it across multiple threads.
  */
 extern struct LateStringDeallocator swift_get_cached_endpoint(const void *rawAddressCacheProvider);
 

--- a/mullvad-ios/src/api_client/address_cache_provider.rs
+++ b/mullvad-ios/src/api_client/address_cache_provider.rs
@@ -8,7 +8,7 @@ unsafe extern "C" {
     ///
     /// # SAFETY
     /// `rawAddressCacheProvider` **must** be provided by a call to `init_swift_address_cache_wrapper`
-    /// It is okay to persist it, and use it accross multiple threads.
+    /// It is okay to persist it, and use it across multiple threads.
     pub fn swift_get_cached_endpoint(
         rawAddressCacheProvider: *const c_void,
     ) -> LateStringDeallocator;

--- a/test/test-manager/README.md
+++ b/test/test-manager/README.md
@@ -20,7 +20,7 @@ pub async fn test(
 ```
 
 The `test_function` macro allows you to write tests for the MullvadVPN App in a
-format which is very similiar to [standard Rust unit
+format which is very similar to [standard Rust unit
 tests](https://doc.rust-lang.org/book/ch11-01-writing-tests.html). A more
 detailed writeup on how the `#[test_function]` macro works is given as a
 doc-comment in [test_macro::test_function](./test_macro/src/lib.rs).


### PR DESCRIPTION

* [x] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [x] The PR description should describe:
  * **What:** this PR correct some words that is incorrect in typo.
  * **Why:** correct some words.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8576)
<!-- Reviewable:end -->
