### PR TITLE
Update custom list for `test_quantum_resistant_multihop_quic_tunnel`

### DIFF
--- a/test/test-manager/docs/config.md
+++ b/test/test-manager/docs/config.md
@@ -60,6 +60,7 @@ run the GitHub workflow for desktop end to end tests. Make sure to keep it updat
     { "test_quantum_resistant_tunnel": ["se-got"] },
     { "test_quantum_resistant_multihop_udp2tcp_tunnel": ["se-got"] },
     { "test_quantum_resistant_multihop_shadowsocks_tunnel": ["se-got"] },
+    { "test_quantum_resistant_multihop_quic_tunnel": ["se-sto", "ca-tor"] },
     { "test_ui_tunnel_settings": ["se-got"] },
     { "*": ["se", "no", "fi", "dk"] }
   ]


### PR DESCRIPTION
This is a follow up to https://github.com/mullvad/mullvadvpn-app/pull/8454

Only 2 relays have QUIC enabled in production: One in Sweden and one in Canada. Canadian relays are not included in the default set of relays used for our e2e tests. This PR updates the test manager config to fix that for the QUIC tests that need 2 relays to work due to multihop constraints. 

First test run where this change was applied: https://github.com/mullvad/mullvadvpn-app/actions/runs/16875507172/job/47799801853. All previous test runs used the default custom list of the nordic countries. :cry: :violin: :iceland: 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8577)
<!-- Reviewable:end -->
