### PR TITLE
Add QUIC obfuscation to feature table in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ the current state of the latest code in git, not necessarily any existing releas
 | WireGuard multihop            |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
 | WireGuard over TCP            |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
 | WireGuard over Shadowsocks    |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| WireGuard over QUIC           |    ✓    |   ✓   |   ✓   |         |  ✓  |
 | OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |
 | Split tunneling               |    ✓    |   ✓   |   ✓   |    ✓    |     |
 | Custom DNS server             |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |


### PR DESCRIPTION
This PR adds the new QUIC obfuscation method to the feature table in our README :tada: 