### PR TITLE
Add confirmation dialogs when removing saved account number

### DIFF
--- a/ios/Assets/Localizable.xcstrings
+++ b/ios/Assets/Localizable.xcstrings
@@ -1541,6 +1541,9 @@
         }
       }
     },
+    "Create new account" : {
+
+    },
     "Creating new account" : {
       "localizations" : {
         "de" : {
@@ -5185,6 +5188,9 @@
         }
       }
     },
+    "Remove" : {
+
+    },
     "Remove last used account" : {
       "localizations" : {
         "de" : {
@@ -5206,6 +5212,9 @@
           }
         }
       }
+    },
+    "Removing the saved account number from this device cannot be undone.\nDo you want to remove the saved account number?" : {
+
     },
     "Rented" : {
       "localizations" : {
@@ -7372,6 +7381,9 @@
           }
         }
       }
+    },
+    "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone.\nDo you want to create a new account?" : {
+
     },
     "You are about to send the problem report without a way for us to get back to you. If you want an answer to your report you will have to enter an email address." : {
       "localizations" : {

--- a/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
+++ b/ios/MullvadVPN/Classes/AccessbilityIdentifier.swift
@@ -27,6 +27,10 @@ public enum AccessibilityIdentifier: Equatable {
     case collapseButton
     case expandButton
     case createAccountButton
+    case createAccountConfirmationButton
+    case createAccountCancelButton
+    case removeLastUsedAccountButton
+    case cancelRemoveLastUsedAccountButton
     case deleteButton
     case deviceCellRemoveButton
     case disconnectButton

--- a/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
@@ -44,7 +44,10 @@ final class LoginCoordinator: Coordinator, Presenting {
 
     func start(animated: Bool) {
         let interactor = LoginInteractor(tunnelManager: tunnelManager)
-        let loginController = LoginViewController(interactor: interactor)
+        let loginController = LoginViewController(
+            interactor: interactor,
+            alertPresenter: AlertPresenter(context: self)
+        )
 
         loginController.didFinishLogin = { [weak self] action, error in
             self?.didFinishLogin(action: action, error: error) ?? .nothing

--- a/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
+++ b/ios/MullvadVPN/View controllers/Login/AccountInputGroupView.swift
@@ -356,7 +356,6 @@ final class AccountInputGroupView: UIView {
 
     @objc private func didTapRemoveLastUsedAccount() {
         didRemoveLastUsedAccount?()
-        setLastUsedAccount(nil, animated: true)
     }
 
     // MARK: - Private

--- a/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
@@ -16,6 +16,9 @@ final class LoginInteractor: @unchecked Sendable {
     private var tunnelObserver: TunnelObserver?
     var didCreateAccount: (@MainActor @Sendable () -> Void)?
     var suggestPreferredAccountNumber: (@Sendable (String) -> Void)?
+    var hasLastAccountNumber: Bool {
+        getLastUsedAccount() != nil
+    }
 
     init(tunnelManager: TunnelManager) {
         self.tunnelManager = tunnelManager

--- a/ios/MullvadVPNUITests/AccountTests.swift
+++ b/ios/MullvadVPNUITests/AccountTests.swift
@@ -25,6 +25,38 @@ class AccountTests: LoggedOutUITestCase {
         mullvadAPIWrapper.deleteAccount(accountNumber)
     }
 
+    func testCreateAccountWithLastUsedAccount() throws {
+        // Setup
+        let temporaryAccountNumber = createTemporaryAccountWithoutTime()
+
+        // Teardown
+        addTeardownBlock {
+            self.mullvadAPIWrapper.deleteAccount(temporaryAccountNumber)
+        }
+
+        LoginPage(app)
+            .tapAccountNumberTextField()
+            .enterText(temporaryAccountNumber)
+            .tapAccountNumberSubmitButton()
+
+        OutOfTimePage(app)
+
+        HeaderBar(app)
+            .tapAccountButton()
+
+        AccountPage(app)
+            .tapLogOutButton()
+
+        LoginPage(app)
+            .tapCreateAccountButton()
+            .confirmAccountCreation()
+
+        // Verify welcome page is shown and get account number from it
+        let accountNumber = WelcomePage(app).getAccountNumber()
+
+        self.mullvadAPIWrapper.deleteAccount(accountNumber)
+    }
+
     func testDeleteAccount() throws {
         let accountNumber = createTemporaryAccountWithoutTime()
 

--- a/ios/MullvadVPNUITests/Pages/LoginPage.swift
+++ b/ios/MullvadVPNUITests/Pages/LoginPage.swift
@@ -47,6 +47,11 @@ class LoginPage: Page {
         return self
     }
 
+    @discardableResult public func confirmAccountCreation() -> Self {
+        app.buttons[AccessibilityIdentifier.createAccountConfirmationButton].tap()
+        return self
+    }
+
     @discardableResult public func verifyFailIconShown() -> Self {
         let predicate = NSPredicate(format: "identifier == 'statusImageView' AND value == 'fail'")
         let elementQuery = app.images.containing(predicate)


### PR DESCRIPTION
Adds a confirmation dialog before the saved last used account number gets removed from the device. This happens when creating a new account and when the user actively removes the number.

This is a draft for now since the copy is not decided on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8588)
<!-- Reviewable:end -->
