### PR TITLE
Invalidate CDN cache after uploading release artifacts

### DIFF
--- a/ci/buildserver-config.sh
+++ b/ci/buildserver-config.sh
@@ -20,3 +20,7 @@ export CARGO_REGISTRY_VOLUME_NAME="cargo-registry"
 # Where buildserver-build.sh should move artifacts (on Linux) and where
 # buildserver-upload.sh should pick artifacts to upload
 export UPLOAD_DIR="PLEASE CONFIGURE ME"
+
+# Used by buildserver-upload.sh to invalidate the CDN cache
+export BUNNYCDN_PULL_ZONE_ID="PLEASE CONFIGURE ME"
+export BUNNYCDN_API_KEY="PLEASE CONFIGURE ME"

--- a/ci/buildserver-upload.sh
+++ b/ci/buildserver-upload.sh
@@ -12,6 +12,14 @@ source "$SCRIPT_DIR/buildserver-config.sh"
 
 cd "$UPLOAD_DIR"
 
+function invalidate_bunny_cdn_cache {
+    curl --request POST \
+        --url "https://api.bunny.net/pullzone/${BUNNYCDN_PULL_ZONE_ID}/purgeCache" \
+        --header "AccessKey: ${BUNNYCDN_API_KEY}" \
+        --header 'content-type: application/json' \
+        --fail-with-body
+}
+
 function rsync_upload {
     local file=$1
     local upload_dir=$2
@@ -23,6 +31,9 @@ function rsync_upload {
 
 while true; do
     sleep 10
+
+    should_invalidate_bunny_cdn_cache="false"
+
     for checksums_path in **/*.sha256; do
         sleep 1
 
@@ -43,6 +54,7 @@ while true; do
             upload_path="$platform/builds"
         else
             upload_path="$platform/releases"
+            should_invalidate_bunny_cdn_cache="true"
         fi
 
         # Read all files listed in the checksum file at $checksums_path into an array.
@@ -74,4 +86,9 @@ while true; do
         # shellcheck disable=SC2216
         yes | rm "$checksums_path"
     done
+
+    if [[ "$should_invalidate_bunny_cdn_cache" == "true" ]]; then
+        echo "Invalidating Bunny CDN cache"
+        invalidate_bunny_cdn_cache || continue
+    fi
 done


### PR DESCRIPTION
Fixes artifacts not being updated when release tags are replaced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8591)
<!-- Reviewable:end -->
