### PR TITLE
Move padding to within the changelog's implicit scroll view

### DIFF
--- a/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogView.swift
+++ b/ios/MullvadVPN/View controllers/ChangeLog/ChangeLogView.swift
@@ -23,17 +23,18 @@ struct ChangeLogView<ViewModel>: View where ViewModel: ChangeLogViewModelProtoco
                     .fontWeight(.semibold)
                     .foregroundColor(UIColor.primaryTextColor.color)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 24.0)
                 List {
                     ForEach(viewModel.changeLog?.changes ?? [], id: \.self) { item in
                         BulletPointText(text: item)
                             .listRowSeparator(.hidden)
                             .listRowBackground(Color.clear)
                     }
+                    .padding(.horizontal, 24.0)
                 }
                 .listStyle(.plain)
                 .frame(maxHeight: .infinity)
             }
-            .padding(.horizontal, 24.0)
         }
         .onAppear {
             viewModel.getLatestChanges()


### PR DESCRIPTION
This adjusts the structure of the changelog view to move the horizontal padding to list items, and thus within the implicit scroll view that they are created inside.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8593)
<!-- Reviewable:end -->
