### PR TITLE
Do not filter exit relays when multihop and QUIC is enabled

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/select-location/RelayListContext.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/select-location/RelayListContext.tsx
@@ -80,6 +80,7 @@ export function RelayListContextProvider(props: RelayListContextProviderProps) {
   const fullRelayList = useSelector((state) => state.settings.relayLocations);
   const relaySettings = useNormalRelaySettings();
   const tunnelProtocol = useTunnelProtocol();
+  const multihop = relaySettings?.wireguard.useMultihop ?? false;
 
   // Filters the relays to only keep the ones of the desired endpoint type, e.g. "wireguard",
   // "openvpn" or "bridge"
@@ -96,21 +97,14 @@ export function RelayListContextProvider(props: RelayListContextProviderProps) {
       directOnly,
       locationType,
       tunnelProtocol,
-      relaySettings?.wireguard.useMultihop ?? false,
+      multihop,
     );
-  }, [
-    daita,
-    directOnly,
-    locationType,
-    relayListForEndpointType,
-    tunnelProtocol,
-    relaySettings?.wireguard.useMultihop,
-  ]);
+  }, [daita, directOnly, locationType, relayListForEndpointType, tunnelProtocol, multihop]);
 
   // Only show relays that have QUIC endpoints when QUIC obfuscation is enabled.
   const relayListForQuic = useMemo(() => {
-    return filterLocationsByQuic(relayListForDaita, quic, tunnelProtocol);
-  }, [quic, relayListForDaita, tunnelProtocol]);
+    return filterLocationsByQuic(relayListForDaita, quic, tunnelProtocol, locationType, multihop);
+  }, [quic, relayListForDaita, locationType, tunnelProtocol, multihop]);
 
   // Filters the relays to only keep the relays matching the currently selected filters, e.g.
   // ownership and providers

--- a/desktop/packages/mullvad-vpn/src/renderer/components/select-location/SelectLocation.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/select-location/SelectLocation.tsx
@@ -8,7 +8,11 @@ import { RoutePath } from '../../../shared/routes';
 import { Button, FilterChip, Flex, IconButton, LabelTiny } from '../../lib/components';
 import { FlexColumn } from '../../lib/components/flex-column';
 import { useRelaySettingsUpdater } from '../../lib/constraint-updater';
-import { daitaFilterActive, filterSpecialLocations } from '../../lib/filter-locations';
+import {
+  daitaFilterActive,
+  filterSpecialLocations,
+  quicFilterActive,
+} from '../../lib/filter-locations';
 import { useHistory } from '../../lib/history';
 import { formatHtml } from '../../lib/html-formatter';
 import { useNormalRelaySettings, useTunnelProtocol } from '../../lib/relay-settings-hooks';
@@ -59,18 +63,20 @@ export default function SelectLocation() {
   const tunnelProtocol = useTunnelProtocol();
   const ownership = relaySettings?.ownership ?? Ownership.any;
   const providers = relaySettings?.providers ?? [];
+  const multihop = relaySettings?.wireguard.useMultihop ?? false;
   const filteredProviders = useFilteredProviders(providers, ownership);
   const daita = useSelector((state) => state.settings.wireguard.daita?.enabled ?? false);
   const directOnly = useSelector((state) => state.settings.wireguard.daita?.directOnly ?? false);
-  const showQuicFilter = useSelector(
+  const quic = useSelector(
     (state) => state.settings.obfuscationSettings.selectedObfuscation === ObfuscationType.quic,
   );
+  const showQuicFilter = quicFilterActive(quic, locationType, tunnelProtocol, multihop);
   const showDaitaFilter = daitaFilterActive(
     daita,
     directOnly,
     locationType,
     tunnelProtocol,
-    relaySettings?.wireguard.useMultihop ?? false,
+    multihop,
   );
 
   const [searchValue, setSearchValue] = useState('');

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/filter-locations.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/filter-locations.ts
@@ -36,10 +36,25 @@ export function filterLocationsByQuic(
   locations: IRelayLocationCountryRedux[],
   quic: boolean,
   tunnelProtocol: TunnelProtocol,
+  locationType: LocationType,
+  multihop: boolean,
 ): IRelayLocationCountryRedux[] {
-  const quicFilterActive = quic && tunnelProtocol !== 'openvpn';
   const quickOnRelay = (relay: IRelayLocationRelayRedux) => relay.quic !== undefined;
-  return quicFilterActive ? filterLocationsImpl(locations, quickOnRelay) : locations;
+  return quicFilterActive(quic, locationType, tunnelProtocol, multihop)
+    ? filterLocationsImpl(locations, quickOnRelay)
+    : locations;
+}
+
+export function quicFilterActive(
+  quic: boolean,
+  locationType: LocationType,
+  tunnelProtocol: TunnelProtocol,
+  multihop: boolean,
+) {
+  const isEntry = multihop
+    ? locationType === LocationType.entry
+    : locationType === LocationType.exit;
+  return quic && isEntry && tunnelProtocol !== 'openvpn';
 }
 
 export function filterLocationsByDaita(


### PR DESCRIPTION
This PR fixes a bug of the relay selection screen filtering logic when QUIC and multihop was enabled. The filter was applied to both entry and exit relays, while the filter should've only been applied to the entry relay in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8595)
<!-- Reviewable:end -->
