### PR TITLE
Backport translations to 2025.8 release branch

### DIFF
--- a/android/lib/resource/src/main/res/values-da/strings.xml
+++ b/android/lib/resource/src/main/res/values-da/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Hvis du logger ud, fjernes enheden og enhedsnavnet. Når du logger på igen, får enheden et nyt navn.</string>
     <string name="direct_only">Kun direkte</string>
     <string name="direct_only_description">Ikke alle vores servere er %1$s-kompatible. For at kunne bruge internettet skal du muligvis vælge en ny placering efter aktivering.</string>
+    <string name="disable_recents">Deaktiver nylige</string>
     <string name="discard">Kassér</string>
     <string name="discard_changes">Vil du kassere ændringer?</string>
     <string name="disconnect">Afbryd forbindelse</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Aktivér %1$s</string>
     <string name="enable_ipv6">IPv6 i tunnel</string>
     <string name="enable_method">Aktiver metode</string>
+    <string name="enable_recents">Aktivér nylige</string>
     <string name="encrypted_dns_proxy_info_message_part1">Med metoden \"krypteret DNS-proxy\" vil appen kommunikere med vores Mullvad API via en proxy-adresse. Det gør den ved at hente en adresse fra en DNS over HTTPS-server (DoH) og derefter bruge den til at få adgang til en vores API-servere.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Hvis du ikke er tilsluttet vores VPN, vil den krypterede DNS-proxy bruge din egen ikke-VPN IP,-adresse når du opretter forbindelse. DoH-serverne hostes af en af følgende udbydere: Quad9 eller CloudFlare.</string>
     <string name="enter_value_placeholder">Indtast MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Log ud af mindst én ved at fjerne den fra listen nedenfor. Du kan finde det tilsvarende enhedsnavn under enhedens kontoindstillinger.</string>
     <string name="max_devices_warning_title">For mange enheder</string>
+    <string name="more_actions">Flere handlinger</string>
     <string name="more_information">Mere information</string>
     <string name="mullvad_owned_only">Kun ejet af Mullvad</string>
     <string name="multihop">Multihop</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Navnet blev ændret til %1$s</string>
     <string name="new_changelog_notification_message">Klik her for at se nyhederne.</string>
     <string name="new_changelog_notification_title">NY VERSION INSTALLERET</string>
+    <string name="new_device_notification_message">Velkommen, denne enhed har nu fået navnet &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NY ENHED OPRETTET</string>
     <string name="new_list">Ny liste</string>
     <string name="no_custom_lists_available">Ingen brugerdefinerede lister tilgængelige</string>
     <string name="no_internet_connection">Ingen internetforbindelse</string>
     <string name="no_locations_found">Ingen placeringer fundet</string>
     <string name="no_matching_relay">Ingen servere matcher dine indstillinger. Prøv at ændre server eller andre indstillinger.</string>
+    <string name="no_recent_selection">Ingen nylig valghistorik</string>
     <string name="no_wireguard_key">Gyldig WireGuard-nøgle mangler. Administrer nøgler under Avancerede indstillinger.</string>
     <string name="not_found">Ikke fundet</string>
     <string name="number_of_providers">Udbydere: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Denne funktion gør WireGuard-tunnelen modstandsdygtig over for potentielle angreb fra kvantecomputere.</string>
     <string name="quantum_resistant_info_second_paragaph">Det gør den ved at udføre en ekstra nøgleudveksling ved hjælp af en kvantesikker algoritme og blande resultatet med WireGuards almindelige kryptering. Dette ekstra trin bruger cirka 500 kB trafik, hver gang en ny tunnel etableres.</string>
     <string name="quantum_resistant_title">Kvante-modstandsdygtig tunnel</string>
+    <string name="recents">Nylige</string>
+    <string name="recents_disabled">Nylige er deaktiveret og historikken ryddet</string>
     <string name="reconnect">Genopret forbindelse</string>
     <string name="redeem">Indløs</string>
     <string name="redeem_voucher">Indløs kupon</string>
+    <string name="relayitem_is_inactive">%1$s er ikke tilgængelig</string>
     <string name="remove_button">Fjern</string>
     <string name="remove_location_from_list">Fjern %1$s fra %2$s</string>
     <string name="removed_provider">%1$s (er fjernet)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Dette felt er påkrævet</string>
     <string name="this_is_already_set_as_current">Den er allerede indstillet som aktuel</string>
     <string name="time_added">Tid tilføjet</string>
+    <string name="to_add_locations_to_a_list">For at føje placeringer til en liste kan du trykke på pennen eller foretage et langt tryk på et land, en by eller en server.</string>
+    <string name="to_create_a_custom_list">For at oprette en brugerdefineret liste kan du trykke på \"+\"</string>
     <string name="toggle_vpn">Slå VPN til/fra</string>
     <string name="top_bar_device_name">Enhedsnavn: %1$s</string>
     <string name="top_bar_time_left">Resterende tid: %1$s</string>

--- a/android/lib/resource/src/main/res/values-de/strings.xml
+++ b/android/lib/resource/src/main/res/values-de/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Wenn Sie sich abmelden, werden das Gerät und der Gerätename entfernt. Wenn Sie sich wieder anmelden, erhält das Gerät einen neuen Namen.</string>
     <string name="direct_only">Nur direkt</string>
     <string name="direct_only_description">Nicht alle unsere Server sind %1$s-fähig. Um das Internet nutzen zu können, müssen Sie nach der Aktivierung möglicherweise einen neuen Standort auswählen.</string>
+    <string name="disable_recents">Letzte deaktivieren</string>
     <string name="discard">Verwerfen</string>
     <string name="discard_changes">Änderungen verwerfen?</string>
     <string name="disconnect">Verbindung trennen</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">%1$s aktivieren</string>
     <string name="enable_ipv6">In-Tunnel-IPv6</string>
     <string name="enable_method">Methode aktivieren</string>
+    <string name="enable_recents">Letzte aktivieren</string>
     <string name="encrypted_dns_proxy_info_message_part1">Mit der Methode „Verschlüsseltes-DNS-Proxy“ kommuniziert die App mit unserer Mullvad-API über eine Proxy-Adresse. Sie tut dies, indem sie eine Adresse von einem DNS-over-HTTPS-Server (DoH) abruft und dann diese verwendet, um unsere API-Server zu erreichen.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Wenn Sie nicht mit unserem VPN verbunden sind, verwendet der Verschlüsseltes-DNS-Proxy bei der Verbindung Ihre eigene Nicht-VPN-IP. Die DoH-Server werden von einem der folgenden Anbieter gehostet: Quad9 oder CloudFlare.</string>
     <string name="enter_value_placeholder">MTU eingeben</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Bitte melden Sie sich von mindestens einem Gerät ab, indem Sie es aus der Liste unten entfernen. Sie finden den entsprechenden Gerätenamen unter den Kontoeinstellungen des Geräts.</string>
     <string name="max_devices_warning_title">Zu viele Geräte</string>
+    <string name="more_actions">Weitere Aktionen</string>
     <string name="more_information">Weitere Informationen</string>
     <string name="mullvad_owned_only">Nur im Besitz von Mullvad</string>
     <string name="multihop">Multihop</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Name wurde geändert in %1$s</string>
     <string name="new_changelog_notification_message">Klicken Sie hier, um die Änderungen zu sehen.</string>
     <string name="new_changelog_notification_title">NEUE VERSION INSTALLIERT</string>
+    <string name="new_device_notification_message">Willkommen, dieses Gerät heißt jetzt &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NEUES GERÄT ERSTELLT</string>
     <string name="new_list">Neue Liste</string>
     <string name="no_custom_lists_available">Keine eigenen Listen verfügbar</string>
     <string name="no_internet_connection">Keine Internetverbindung</string>
     <string name="no_locations_found">Keine Standorte gefunden</string>
     <string name="no_matching_relay">Kein Server entspricht Ihren Einstellungen. Versuchen Sie, den Server oder andere Einstellungen zu ändern.</string>
+    <string name="no_recent_selection">Kein aktueller Auswahlverlauf</string>
     <string name="no_wireguard_key">Gültiger WireGuard-Schlüssel fehlt. Sie können Ihre Schlüssel in den erweiterten Einstellungen verwalten.</string>
     <string name="not_found">Nicht gefunden</string>
     <string name="number_of_providers">Provider: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Diese Funktion macht den WireGuard-Tunnel resistent gegen mögliche Angriffe von Quantencomputern.</string>
     <string name="quantum_resistant_info_second_paragaph">Dazu wird ein zusätzlicher Schlüsselaustausch mit einem quantensicheren Algorithmus durchgeführt und das Ergebnis mit der regulären Verschlüsselung von WireGuard vermischt. Dieser zusätzliche Schritt verbraucht jedes Mal, wenn ein neuer Tunnel aufgebaut wird, etwa 500 KiB an Datenverkehr.</string>
     <string name="quantum_resistant_title">Quantenresistenter Tunnel</string>
+    <string name="recents">Letzte</string>
+    <string name="recents_disabled">Letzte deaktiviert und Verlauf gelöscht</string>
     <string name="reconnect">Erneut verbinden</string>
     <string name="redeem">Einlösen</string>
     <string name="redeem_voucher">Gutschein einlösen</string>
+    <string name="relayitem_is_inactive">%1$s ist nicht verfügbar</string>
     <string name="remove_button">Entfernen</string>
     <string name="remove_location_from_list">%1$s von %2$s entfernen</string>
     <string name="removed_provider">%1$s (entfernt)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Dieses Feld ist erforderlich</string>
     <string name="this_is_already_set_as_current">Diese ist bereits die aktuelle</string>
     <string name="time_added">Zeit hinzugefügt</string>
+    <string name="to_add_locations_to_a_list">Um Standorte zu einer Liste hinzuzufügen, drücken Sie auf den Stift oder drücken Sie lange auf ein Land, eine Stadt oder einen Server.</string>
+    <string name="to_create_a_custom_list">Um eine eigene Liste zu erstellen, drücken Sie auf „+“</string>
     <string name="toggle_vpn">VPN umschalten</string>
     <string name="top_bar_device_name">Gerätename: %1$s</string>
     <string name="top_bar_time_left">Verbleibende Zeit: %1$s</string>

--- a/android/lib/resource/src/main/res/values-es/strings.xml
+++ b/android/lib/resource/src/main/res/values-es/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Si cierra sesión, se quita el dispositivo y el nombre del dispositivo. Cuando vuelve a iniciar sesión, el dispositivo recibirá un nombre nuevo.</string>
     <string name="direct_only">Conexión directa</string>
     <string name="direct_only_description">No todos nuestros servidores están habilitados para %1$s. Para usar Internet, quizá deba seleccionar una nueva ubicación tras habilitar esta característica.</string>
+    <string name="disable_recents">Deshabilitar recientes</string>
     <string name="discard">Descartar</string>
     <string name="discard_changes">¿Descartar los cambios?</string>
     <string name="disconnect">Desconectar</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Habilitar %1$s</string>
     <string name="enable_ipv6">Tunelización IPv6</string>
     <string name="enable_method">Habilitar método</string>
+    <string name="enable_recents">Habilitar recientes</string>
     <string name="encrypted_dns_proxy_info_message_part1">Con el método «Proxy DNS cifrado», la aplicación se comunicará con nuestra API de Mullvad a través de una dirección proxy. Para ello, recupera una dirección de un servidor DNS sobre HTTPS (DoH) y luego la utiliza para contactar con nuestros servidores API.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Si no está conectado a nuestra VPN, el proxy DNS cifrado utilizará su propia IP no VPN al conectarse. Los servidores de DoH están alojados en uno de los siguientes proveedores: Quad9 o CloudFlare.</string>
     <string name="enter_value_placeholder">Introducir MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">¡Genial!</string>
     <string name="max_devices_warning_description">Cierre la sesión como mínimo en un dispositivo (para hacerlo, quítelo de la lista siguiente). Consulte el nombre del dispositivo en la configuración de la cuenta del dispositivo.</string>
     <string name="max_devices_warning_title">Demasiados dispositivos</string>
+    <string name="more_actions">Más acciones</string>
     <string name="more_information">Más información</string>
     <string name="mullvad_owned_only">Solo propiedad de Mullvad</string>
     <string name="multihop">Salto múltiple</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Se ha cambiado el nombre a %1$s</string>
     <string name="new_changelog_notification_message">Haga clic aquí para ver las novedades.</string>
     <string name="new_changelog_notification_title">NUEVA VERSIÓN INSTALADA</string>
+    <string name="new_device_notification_message">¡Le damos la bienvenida! Este dispositivo ahora se llama &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NUEVO DISPOSITIVO CREADO</string>
     <string name="new_list">Nueva lista</string>
     <string name="no_custom_lists_available">No hay listas personalizadas disponibles</string>
     <string name="no_internet_connection">No hay conexión a Internet</string>
     <string name="no_locations_found">No se ha encontrado ninguna ubicación</string>
     <string name="no_matching_relay">Ningún servidor coincide con su configuración, pruebe con otro servidor u otra configuración.</string>
+    <string name="no_recent_selection">No hay historial de selecciones recientes</string>
     <string name="no_wireguard_key">Falta una clave de WireGuard válida. Para administrar las claves, vaya a Configuración avanzada.</string>
     <string name="not_found">No encontrado</string>
     <string name="number_of_providers">Proveedores: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Esta característica permite que el túnel de WireGuard resista posibles ataques de ordenadores cuánticos.</string>
     <string name="quantum_resistant_info_second_paragaph">Lo hace al realizar un intercambio de claves adicional usando un algoritmo cuántico seguro y combinando el resultado en el cifrado normal de WireGuard. Este paso extra utiliza aproximadamente 500 kiB de tráfico cada vez que se establece un nuevo túnel.</string>
     <string name="quantum_resistant_title">Túnel con resistencia cuántica</string>
+    <string name="recents">Recientes</string>
+    <string name="recents_disabled">Recientes deshabilitados e historial borrado</string>
     <string name="reconnect">Reconectar</string>
     <string name="redeem">Canjear</string>
     <string name="redeem_voucher">Canjear cupón</string>
+    <string name="relayitem_is_inactive">%1$s no está disponible</string>
     <string name="remove_button">Quitar</string>
     <string name="remove_location_from_list">Quitar %1$s de %2$s</string>
     <string name="removed_provider">%1$s (eliminado)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Este campo es obligatorio</string>
     <string name="this_is_already_set_as_current">Este ya está configurado como actual</string>
     <string name="time_added">Tiempo añadido</string>
+    <string name="to_add_locations_to_a_list">Para añadir ubicaciones a una lista, pulse el icono de lápiz o mantenga pulsado un país, una ciudad o un servidor.</string>
+    <string name="to_create_a_custom_list">Para crear una lista personalizada, pulse «+»</string>
     <string name="toggle_vpn">Alternar VPN</string>
     <string name="top_bar_device_name">Nombre del dispositivo: %1$s</string>
     <string name="top_bar_time_left">Tiempo restante: %1$s</string>

--- a/android/lib/resource/src/main/res/values-fi/strings.xml
+++ b/android/lib/resource/src/main/res/values-fi/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Jos kirjaudut ulos, laite ja laitteen nimi poistetaan. Kun kirjaudut sisään uudelleen, laitteelle annetaan uusi nimi.</string>
     <string name="direct_only">Vain suora</string>
     <string name="direct_only_description">Kaikissa palvelimissamme ei ole %1$s-tukea. Käyttääksesi internetiä sinun on ehkä valittava uusi sijainti käyttöönoton jälkeen.</string>
+    <string name="disable_recents">Poista viimeisimmät käytöstä</string>
     <string name="discard">Hylkää</string>
     <string name="discard_changes">Hylätäänkö muokkaukset?</string>
     <string name="disconnect">Katkaise yhteys</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Ota %1$s käyttöön</string>
     <string name="enable_ipv6">Tunnelin IPv6</string>
     <string name="enable_method">Ota menetelmä käyttöön</string>
+    <string name="enable_recents">Ota viimeisimmät käyttöön</string>
     <string name="encrypted_dns_proxy_info_message_part1">Sovellus kommunikoi Mullvad API:n kanssa välityspalvelinosoitteen kautta \"Salattu DNS-välityspalvelin\" -menetelmällä, joka toimii niin, että sovellus hakee osoitteen DNS over HTTPS (DoH) -palvelimelta ja käyttää sitä API-palvelimillemme pääsemiseen.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Jos et ole yhteydessä VPN-verkkoomme, salattu DNS-välityspalvelin käyttää yhdistämiseen omaa, ei-VPN-pohjaista IP-osoitettasi. DoH-palvelimia isännöi joko Quad9 tai CloudFlare.</string>
     <string name="enter_value_placeholder">Syötä MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Mahtavaa!</string>
     <string name="max_devices_warning_description">Kirjaudu ulos vähintään yhdestä luettelon laitteesta poistamalla se. Löydät vastaavan laitteen nimen laitteen tiliasetuksista.</string>
     <string name="max_devices_warning_title">Liikaa laitteita</string>
+    <string name="more_actions">Lisää toimintoja</string>
     <string name="more_information">Lisätietoja</string>
     <string name="mullvad_owned_only">Vain Mullvadin omistamat</string>
     <string name="multihop">Multihop</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Nimeksi vaihdettiin \"%1$s\"</string>
     <string name="new_changelog_notification_message">Katso uudet ominaisuudet napsauttamalla tästä.</string>
     <string name="new_changelog_notification_title">UUSI VERSIO ASENNETTIIN</string>
+    <string name="new_device_notification_message">Tervetuloa! Tämän laitteen nimi on nyt &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">UUSI LAITE LUOTIIN</string>
     <string name="new_list">Uusi luettelo</string>
     <string name="no_custom_lists_available">Mukautettuja luetteloita ei löytynyt</string>
     <string name="no_internet_connection">Ei verkkoyhteyttä</string>
     <string name="no_locations_found">Sijainteja ei löytynyt</string>
     <string name="no_matching_relay">Mikään palvelin ei vastaa asetuksiasi. Kokeile vaihtaa palvelinta tai muuttaa muita asetuksia.</string>
+    <string name="no_recent_selection">Ei viimeisimpien valintojen historiaa</string>
     <string name="no_wireguard_key">Käypä WireGuard-avain puuttuu. Voit hallinnoida avaimia lisäasetuksissa.</string>
     <string name="not_found">Ei löydy</string>
     <string name="number_of_providers">Palveluntarjoajat: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Tämä ominaisuus tekee WireGuard-tunnelista kestävän kvanttitietokoneiden mahdollisia hyökkäyksiä vastaan.</string>
     <string name="quantum_resistant_info_second_paragaph">Tunneli torjuu hyökkäykset suorittamalla ylimääräisen avaimenvaihdon käyttämällä ensin kvanttiturvallista algoritmia, jonka tuloksen se sekoittaa WireGuardin tavalliseen salaukseen. Tämä ylimääräinen vaihe käyttää noin 500 kiB liikennettä joka kerta, kun uusi tunneli luodaan.</string>
     <string name="quantum_resistant_title">Kvanttihyökkäyksiä kestävä tunneli</string>
+    <string name="recents">Viimeisimmät</string>
+    <string name="recents_disabled">Viimeisimmät on poistettu käytöstä ja historia on tyhjennetty</string>
     <string name="reconnect">Yhdistä uudelleen</string>
     <string name="redeem">Lunasta</string>
     <string name="redeem_voucher">Lunasta kuponki</string>
+    <string name="relayitem_is_inactive">%1$s ei ole käytettävissä</string>
     <string name="remove_button">Poista</string>
     <string name="remove_location_from_list">Poista %1$s luettelosta %2$s</string>
     <string name="removed_provider">%1$s (poistettu)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Tämä kenttä on pakollinen</string>
     <string name="this_is_already_set_as_current">Tämä on jo asetettu nykyiseksi</string>
     <string name="time_added">Käyttöaikaa lisätty</string>
+    <string name="to_add_locations_to_a_list">Jos haluat lisätä luetteloon sijainteja, paina kynää tai paina pitkään maata, kaupunkia tai palvelinta.</string>
+    <string name="to_create_a_custom_list">Voit luoda mukautetun luettelon painamalla \"+\"</string>
     <string name="toggle_vpn">Vaihda VPN:ää</string>
     <string name="top_bar_device_name">Laitteen nimi: %1$s</string>
     <string name="top_bar_time_left">Aikaa jäljellä: %1$s</string>

--- a/android/lib/resource/src/main/res/values-fr/strings.xml
+++ b/android/lib/resource/src/main/res/values-fr/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Si vous vous déconnectez, l\'appareil et son nom sont supprimés. Lorsque vous vous reconnectez, l\'appareil reçoit un nouveau nom.</string>
     <string name="direct_only">Directe uniquement</string>
     <string name="direct_only_description">Tous nos serveurs ne sont pas compatibles %1$s. Pour utiliser l\'internet, vous devrez peut-être sélectionner une nouvelle localisation après activation.</string>
+    <string name="disable_recents">Désactiver les récents</string>
     <string name="discard">Annuler</string>
     <string name="discard_changes">Annuler les modifications ?</string>
     <string name="disconnect">Déconnexion</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Activer %1$s</string>
     <string name="enable_ipv6">IPv6 en tunnel</string>
     <string name="enable_method">Activer la méthode</string>
+    <string name="enable_recents">Activer les récents</string>
     <string name="encrypted_dns_proxy_info_message_part1">Avec la méthode « proxy DNS chiffré », l\'application communiquera avec notre API Mullvad par le biais d\'une adresse proxy. Pour ce faire, elle récupère une adresse auprès d\'un serveur DNS over HTTPS (DoH) et l\'utilise pour atteindre nos serveurs API.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Si vous n\'êtes pas connecté à notre VPN, le proxy DNS chiffré utilisera votre propre IP non VPN lors de la connexion. Les serveurs DoH sont hébergés par l\'un des fournisseurs suivants : Quad 9 ou CloudFlare.</string>
     <string name="enter_value_placeholder">Saisir le MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Super !</string>
     <string name="max_devices_warning_description">Merci de vous déconnecter d\'au moins un appareil en le supprimant de la liste ci-dessous. Vous trouverez le nom de l\'appareil correspondant dans les paramètres du compte de l\'appareil.</string>
     <string name="max_devices_warning_title">Trop d\'appareils</string>
+    <string name="more_actions">Plus d\'actions</string>
     <string name="more_information">Plus d\'informations</string>
     <string name="mullvad_owned_only">Propriété de Mullvad uniquement</string>
     <string name="multihop">Multihop</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Le nom a été changé en %1$s</string>
     <string name="new_changelog_notification_message">Cliquez ici pour voir les nouveautés.</string>
     <string name="new_changelog_notification_title">NOUVELLE VERSION INSTALLÉE</string>
+    <string name="new_device_notification_message">Bienvenue, cet appareil est maintenant appelé &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NOUVEL APPAREIL CRÉÉ</string>
     <string name="new_list">Nouvelle liste</string>
     <string name="no_custom_lists_available">Aucune liste personnalisée disponible</string>
     <string name="no_internet_connection">Aucune connexion à Internet</string>
     <string name="no_locations_found">Aucune localisation trouvée</string>
     <string name="no_matching_relay">Aucun serveur ne correspond à vos paramètres, essayez de modifier les paramètres du serveur ou d\'autres paramètres.</string>
+    <string name="no_recent_selection">Aucun historique des sélections récentes</string>
     <string name="no_wireguard_key">Une clé WireGuard valide manque. Gérez les clés dans les paramètres avancés.</string>
     <string name="not_found">Introuvable</string>
     <string name="number_of_providers">Fournisseurs : %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Cette fonctionnalité rend le tunnel WireGuard résistant aux attaques potentielles des ordinateurs quantiques.</string>
     <string name="quantum_resistant_info_second_paragaph">Pour ce faire, il effectue un échange de clés supplémentaire à l\'aide d\'un algorithme à sécurité quantique et mélange le résultat au chiffrement habituel de WireGuard. Cette étape supplémentaire utilise environ 500 kiB de trafic chaque fois qu\'un nouveau tunnel est établi.</string>
     <string name="quantum_resistant_title">Tunnel résistant aux attaques quantiques</string>
+    <string name="recents">Récents</string>
+    <string name="recents_disabled">Récents désactivés et historique effacé</string>
     <string name="reconnect">Reconnexion</string>
     <string name="redeem">Échanger</string>
     <string name="redeem_voucher">Échanger un bon</string>
+    <string name="relayitem_is_inactive">%1$s est indisponible</string>
     <string name="remove_button">Supprimer</string>
     <string name="remove_location_from_list">Supprimer %1$s de %2$s</string>
     <string name="removed_provider">%1$s (supprimé)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Ce champ est requis</string>
     <string name="this_is_already_set_as_current">Déjà définie comme méthode actuelle</string>
     <string name="time_added">Temps ajouté</string>
+    <string name="to_add_locations_to_a_list">Pour ajouter des localisations à une liste, appuyez sur le stylo ou appuyez longuement sur un pays, une ville ou un serveur.</string>
+    <string name="to_create_a_custom_list">Appuyez sur « + » pour créer une liste personnalisée</string>
     <string name="toggle_vpn">Activer/désactiver le VPN</string>
     <string name="top_bar_device_name">Nom de l\'appareil : %1$s</string>
     <string name="top_bar_time_left">Temps restant : %1$s</string>

--- a/android/lib/resource/src/main/res/values-it/strings.xml
+++ b/android/lib/resource/src/main/res/values-it/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Se ti disconnetti, il dispositivo e il relativo nome verranno rimossi. Quando accedi nuovamente, il dispositivo assumerà un nuovo nome.</string>
     <string name="direct_only">Solo diretta</string>
     <string name="direct_only_description">Non tutti i nostri server sono abilitati per %1$s. Per usare Internet, potresti dover selezionare una nuova posizione dopo l\'abilitazione.</string>
+    <string name="disable_recents">Disabilita recenti</string>
     <string name="discard">Ignora modifiche</string>
     <string name="discard_changes">Ignorare le modifiche?</string>
     <string name="disconnect">Disconnetti</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Abilita %1$s</string>
     <string name="enable_ipv6">In-tunnel IPv6</string>
     <string name="enable_method">Abilita metodo</string>
+    <string name="enable_recents">Abilita recenti</string>
     <string name="encrypted_dns_proxy_info_message_part1">Con il metodo \"Proxy DNS crittografato\", l\'app comunicherà con la nostra API Mullvad tramite un indirizzo proxy. Lo fa recuperando un indirizzo da un server DNS over HTTPS (DoH) e quindi utilizzandolo per raggiungere i nostri server API.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Se non sei connesso alla nostra VPN, il proxy DNS crittografato utilizzerà il tuo IP non VPN durante la connessione. I server DoH sono ospitati da uno dei seguenti provider: Quad9 o CloudFlare.</string>
     <string name="enter_value_placeholder">Inserisci MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Fantastico!</string>
     <string name="max_devices_warning_description">Disconnettiti da almeno un dispositivo rimuovendolo dall\'elenco seguente. Puoi trovare il nome del dispositivo corrispondente nelle impostazioni dell\'account del dispositivo.</string>
     <string name="max_devices_warning_title">Troppi dispositivi</string>
+    <string name="more_actions">Più azioni</string>
     <string name="more_information">Maggiori informazioni</string>
     <string name="mullvad_owned_only">Solo di proprietà di Mullvad</string>
     <string name="multihop">Multihop</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Il nome è stato modificato in %1$s</string>
     <string name="new_changelog_notification_message">Clicca qui per vedere le novità.</string>
     <string name="new_changelog_notification_title">NUOVA VERSIONE INSTALLATA</string>
+    <string name="new_device_notification_message">Ti diamo il benvenuto, questo dispositivo ora si chiama &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NUOVO DISPOSITIVO CREATO</string>
     <string name="new_list">Nuovo elenco</string>
     <string name="no_custom_lists_available">Nessun elenco personalizzato disponibile</string>
     <string name="no_internet_connection">Nessuna connessione Internet</string>
     <string name="no_locations_found">Nessuna posizione trovata</string>
     <string name="no_matching_relay">Nessun server corrispondente alle tue impostazioni, prova a cambiare server o impostazioni.</string>
+    <string name="no_recent_selection">Nessuna cronologia di selezioni recente</string>
     <string name="no_wireguard_key">Manca una chiave WireGuard valida. Gestisci le chiavi da Impostazioni avanzate.</string>
     <string name="not_found">Non trovato</string>
     <string name="number_of_providers">Fornitori: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Questa funzionalità rende il tunnel WireGuard resistente ai potenziali attacchi dei computer quantistici.</string>
     <string name="quantum_resistant_info_second_paragaph">L\'operazione viene effettuata eseguendo uno scambio di chiavi aggiuntivo con un algoritmo di sicurezza quantistica e mescolando il risultato nella normale crittografia di WireGuard. Questo passaggio aggiuntivo utilizza circa 500 kiB di traffico ogni volta che viene stabilito un nuovo tunnel.</string>
     <string name="quantum_resistant_title">Tunnel resistente agli attacchi quantistici</string>
+    <string name="recents">Recenti</string>
+    <string name="recents_disabled">Recenti disabilitati e cronologia cancellata</string>
     <string name="reconnect">Riconnetti</string>
     <string name="redeem">Riscatta</string>
     <string name="redeem_voucher">Riscatta voucher</string>
+    <string name="relayitem_is_inactive">%1$s non disponibile</string>
     <string name="remove_button">Rimuovi</string>
     <string name="remove_location_from_list">Rimuovi %1$s da %2$s</string>
     <string name="removed_provider">%1$s (rimosso)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Questo campo è obbligatorio</string>
     <string name="this_is_already_set_as_current">È già impostato come attuale</string>
     <string name="time_added">Tempo aggiunto</string>
+    <string name="to_add_locations_to_a_list">Per aggiungere posizioni a un elenco, premi il simbolo della penna o tieni premuto su un Paese, una città o un server.</string>
+    <string name="to_create_a_custom_list">Per creare un elenco personalizzato, premi \"+\"</string>
     <string name="toggle_vpn">Attiva/disattiva VPN</string>
     <string name="top_bar_device_name">Nome del dispositivo: %1$s</string>
     <string name="top_bar_time_left">Tempo rimasto: %1$s</string>

--- a/android/lib/resource/src/main/res/values-ja/strings.xml
+++ b/android/lib/resource/src/main/res/values-ja/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">ログアウトすると、デバイスとデバイス名が削除されます。もう一度ログインすると、デバイスに新しい名前が付けられます。</string>
     <string name="direct_only">ダイレクトのみ</string>
     <string name="direct_only_description">すべてのサーバーが%1$sに対応しているわけではありません。インターネットを使用するには、有効化した後に新しい場所を選択する必要がある場合もあります。</string>
+    <string name="disable_recents">最近の項目を無効化</string>
     <string name="discard">破棄</string>
     <string name="discard_changes">変更内容を破棄しますか？</string>
     <string name="disconnect">接続解除</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">%1$sを有効にする</string>
     <string name="enable_ipv6">トンネル内のIPv6</string>
     <string name="enable_method">方法を有効化する</string>
+    <string name="enable_recents">最近の項目を有効化</string>
     <string name="encrypted_dns_proxy_info_message_part1">[暗号化DNSプロキシ] 方式を使用すると、アプリはプロキシアドレスを通じてMullvad APIと通信します。これはDNS over HTTPS (DoH) サーバーからアドレスを取得し、APIサーバーへのアクセスに利用することで行われます。</string>
     <string name="encrypted_dns_proxy_info_message_part2">当社のVPNに接続していない場合、暗号化DNSプロキシは接続時に独自の非VPN IPを使用します。DoHサーバーは、Quad9またはCloudFlareのいずれかによってホストされます。</string>
     <string name="enter_value_placeholder">MTU を入力</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">素晴らしい！</string>
     <string name="max_devices_warning_description">以下のリストから少なくとも1つを削除してログアウトしてください。対応するデバイス名はデバイスのアカウント設定で確認できます。</string>
     <string name="max_devices_warning_title">デバイスが多すぎます</string>
+    <string name="more_actions">その他の操作</string>
     <string name="more_information">詳細情報</string>
     <string name="mullvad_owned_only">Mullvad 所有サーバーのみ</string>
     <string name="multihop">マルチホップ</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">名前が %1$s に変更されました</string>
     <string name="new_changelog_notification_message">新機能を確認するにはここをクリックしてください。</string>
     <string name="new_changelog_notification_title">新バージョンがインストールされました</string>
+    <string name="new_device_notification_message">ようこそ。このデバイス名は&lt;b&gt;%1$s&lt;/b&gt;です。</string>
     <string name="new_device_notification_title">新しいデバイスが作成されました</string>
     <string name="new_list">新規リスト</string>
     <string name="no_custom_lists_available">利用可能なカスタムリストはありません</string>
     <string name="no_internet_connection">インターネット接続がありません</string>
     <string name="no_locations_found">場所が見つかりませんでした</string>
     <string name="no_matching_relay">設定に一致するサーバーはありません。サーバーまたは他の設定を変更してみてください。</string>
+    <string name="no_recent_selection">最近の選択履歴はありません</string>
     <string name="no_wireguard_key">有効なWireGuard鍵が見つかりません。詳細設定で鍵を管理してください。</string>
     <string name="not_found">見つかりませんでした</string>
     <string name="number_of_providers">プロバイダ数: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">この機能は、WireGuardトンネルに量子コンピューターからの潜在的な攻撃に対する耐性を与えます。</string>
     <string name="quantum_resistant_info_second_paragaph">耐量子アルゴリズムで追加の鍵の交換を実行し、結果をWireGuardの通常の暗号化に混合させることで行われます。この追加ステップでは、新しいトンネルが確立されるたびに約500kiBのトラフィックが使用されます。</string>
     <string name="quantum_resistant_title">耐量子トンネル</string>
+    <string name="recents">最近の項目</string>
+    <string name="recents_disabled">最近の項目を無効化し、履歴を消去しました</string>
     <string name="reconnect">再接続</string>
     <string name="redeem">使用する</string>
     <string name="redeem_voucher">バウチャーを使用する</string>
+    <string name="relayitem_is_inactive">%1$sは使用できません</string>
     <string name="remove_button">削除</string>
     <string name="remove_location_from_list">%1$sを%2$sから削除する</string>
     <string name="removed_provider">%1$s (削除済み)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">このフィールドは必須です</string>
     <string name="this_is_already_set_as_current">これはすでに現在の設定として設定されています</string>
     <string name="time_added">時間が追加されました</string>
+    <string name="to_add_locations_to_a_list">リストに場所を追加するには鉛筆アイコンをタップするか、国、都市、サーバーを長押ししてください。</string>
+    <string name="to_create_a_custom_list">カスタムリストを作成するには [+] を押してください</string>
     <string name="toggle_vpn">VPNの切り替え</string>
     <string name="top_bar_device_name">デバイス名: %1$s</string>
     <string name="top_bar_time_left">残り時間: %1$s</string>

--- a/android/lib/resource/src/main/res/values-ko/strings.xml
+++ b/android/lib/resource/src/main/res/values-ko/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">로그아웃하면 해당 장치와 장치 이름이 제거됩니다. 다시 로그인하면 장치에 새 이름이 부여됩니다.</string>
     <string name="direct_only">직접 전용</string>
     <string name="direct_only_description">일부 서버에는 %1$s가 활성화되어 있지 않습니다. 인터넷 사용을 위해 활성화 후 새 위치를 선택해야 할 수 있습니다.</string>
+    <string name="disable_recents">최근 항목 비활성화</string>
     <string name="discard">취소</string>
     <string name="discard_changes">변경 사항을 취소하시겠습니까?</string>
     <string name="disconnect">연결 끊기</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">%1$s 활성화</string>
     <string name="enable_ipv6">터널 내 IPv6</string>
     <string name="enable_method">방법 활성화</string>
+    <string name="enable_recents">최근 항목 활성화</string>
     <string name="encrypted_dns_proxy_info_message_part1">앱은 \"암호화된 DNS 프록시\" 방식을 사용하여 프록시 주소를 통해 Mullvad API와 통신합니다. 이는 DoH(DNS over HTTPS) 서버에서 주소를 검색한 다음, 그 주소를 사용해 당사 API 서버에 도달하는 방식으로 이루어집니다.</string>
     <string name="encrypted_dns_proxy_info_message_part2">당사 VPN에 연결되지 않은 경우, 연결 시 암호화된 DNS 프록시는 사용자의 비 VPN IP를 사용합니다. DoH 서버는 Quad 9, CloudFlare 등의 제공업체에서 호스팅합니다.</string>
     <string name="enter_value_placeholder">MTU 입력</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">좋습니다!</string>
     <string name="max_devices_warning_description">하나 이상의 항목을 아래 목록에서 제거하여 로그아웃하세요. 장치의 계정 설정에서 해당 장치 이름을 찾을 수 있습니다.</string>
     <string name="max_devices_warning_title">장치가 너무 많음</string>
+    <string name="more_actions">추가 작업</string>
     <string name="more_information">추가 정보</string>
     <string name="mullvad_owned_only">Mullvad 소유만</string>
     <string name="multihop">멀티홉</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">이름이 %1$s(으)로 변경되었습니다</string>
     <string name="new_changelog_notification_message">업데이트 내역을 확인하려면 여기를 클릭하세요.</string>
     <string name="new_changelog_notification_title">새 버전 설치 완료</string>
+    <string name="new_device_notification_message">환영합니다. 이 장치의 호칭은 이제 &lt;b&gt;%1$s&lt;/b&gt;입니다.</string>
     <string name="new_device_notification_title">새 장치가 생성됨</string>
     <string name="new_list">새 목록</string>
     <string name="no_custom_lists_available">이용 가능한 사용자 지정 목록 없음</string>
     <string name="no_internet_connection">인터넷에 연결되지 않음</string>
     <string name="no_locations_found">위치를 찾을 수 없음</string>
     <string name="no_matching_relay">설정과 일치하는 서버가 없습니다. 서버 또는 기타 설정을 변경해 보세요.</string>
+    <string name="no_recent_selection">최근 선택 내역이 없습니다</string>
     <string name="no_wireguard_key">유효한 WireGuard 키가 없습니다. 고급 설정에서 키를 관리하세요.</string>
     <string name="not_found">찾을 수 없음</string>
     <string name="number_of_providers">제공업체: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">이 기능은 WireGuard 터널이 양자 컴퓨터의 잠재적인 공격에 맞서도록 합니다.</string>
     <string name="quantum_resistant_info_second_paragaph">이를 위해 양자 안전 알고리즘을 사용하여 추가 키 교환을 수행하고 결과를 WireGuard의 일반 암호화에 혼합하는 방법이 이용됩니다. 이 추가 단계는 새 터널이 설정될 때마다 약 500kiB의 트래픽을 사용합니다.</string>
     <string name="quantum_resistant_title">양자 저항 터널</string>
+    <string name="recents">최근 항목</string>
+    <string name="recents_disabled">최근 항목이 비활성화되고 내역이 삭제되었습니다</string>
     <string name="reconnect">다시 연결</string>
     <string name="redeem">사용</string>
     <string name="redeem_voucher">바우처 사용</string>
+    <string name="relayitem_is_inactive">%1$s 사용 불가</string>
     <string name="remove_button">제거</string>
     <string name="remove_location_from_list">%1$s에서 %2$s 제거</string>
     <string name="removed_provider">%1$s(제거됨)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">이 필드는 필수입니다</string>
     <string name="this_is_already_set_as_current">이미 현재로 설정되어 있습니다</string>
     <string name="time_added">시간 추가됨</string>
+    <string name="to_add_locations_to_a_list">목록에 위치를 추가하려면 펜을 누르거나 국가, 도시 또는 서버를 길게 누릅니다.</string>
+    <string name="to_create_a_custom_list">사용자 지정 목록을 생성하려면 \"+\"를 누릅니다</string>
     <string name="toggle_vpn">VPN 전환</string>
     <string name="top_bar_device_name">장치 이름: %1$s</string>
     <string name="top_bar_time_left">남은 시간: %1$s</string>

--- a/android/lib/resource/src/main/res/values-my/strings.xml
+++ b/android/lib/resource/src/main/res/values-my/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">ထွက်လိုက်ပါက စက်နှင့် စက်အမည်ကို ဖယ်ရှားပါသည်။ နောက်တစ်ကြိမ် ပြန်ဝင်ရောက်သည့်အခါ စက်သည် အမည်သစ်တစ်ခု ရရှိပါမည်။</string>
     <string name="direct_only">တိုက်ရိုက်သာ</string>
     <string name="direct_only_description">ကျွန်ုပ်တို့၏ဆာဗာအားလုံးတွင် %1$s ကိုဖွင့်ထားခြင်းမရှိပါ။ အင်တာနက်အသုံးပြုရန်အတွက် သင်သည် ၎င်းကို ဖွင့်ပြီးနောက် တည်နေရာအသစ်တစ်ခုကို ရွေးချယ်ရပေမည်။</string>
+    <string name="disable_recents">လတ်တလောအရာများကို ပိတ်ပါ</string>
     <string name="discard">ပယ်ဖျက်မည်</string>
     <string name="discard_changes">အပြောင်းအလဲများကို ပယ်ဖျက်မည်လား။</string>
     <string name="disconnect">ချိတ်ဆက်မှုဖြုတ်ရန်</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">%1$s ကို ဖွင့်ရန်</string>
     <string name="enable_ipv6">Tunnel-အဝင် IPv6</string>
     <string name="enable_method">နည်းလမ်းကို ဖွင့်ရန်</string>
+    <string name="enable_recents">လတ်တလောအရာများကို ဖွင့်ရန်</string>
     <string name="encrypted_dns_proxy_info_message_part1">ထိုအက်ပ်သည် “ကုဒ်ဝှက်ထားသော DNS ပရောက်စီ” နည်းလမ်းအားဖြင့် ကျွန်ုပ်တို့၏ Mullvad API ထံသို့ ပရောက်စီလိပ်စာမှတစ်ဆင့် ဆက်သွယ်ပေးမည်ဖြစ်သည်။ HTTPS (DoH) ဆာဗာရှိ DNS မှ လိပ်စာတစ်ခုကို ပြန်လည်ရယူခြင်းအားဖြင့် ထိုသို့လုပ်ဆောင်ပြီးနောက် ကျွန်ုပ်တို့၏ API ဆာဗာများသို့ရောက်ရှိရန် ၎င်းကို အသုံးပြုသည်။</string>
     <string name="encrypted_dns_proxy_info_message_part2">အကယ်၍ သင်သည် ကျွန်ုပ်တို့၏ VPN သို့ ချိတ်ဆက်ထားခြင်းမရှိပါက ကုဒ်ဝှက်ထားသော DNS ပရောက်စီသည် ချိတ်ဆက်ရာတွင် သင်၏ကိုယ်ပိုင် VPN မဟုတ်သော IP ကို ​​အသုံးပြုပါမည်။ DoH ဆာဗာများကို အောက်ပါဝန်ဆောင်မှုပေးသူများထဲမှ တစ်ခုမှ လက်ခံဆောင်ရွက်ပေးသည်- Quad 9 သို့မဟုတ် CloudFlare ။</string>
     <string name="enter_value_placeholder">MTU ကို ရိုက်ထည့်ရန်</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">အလွန်ကောင်း။</string>
     <string name="max_devices_warning_description">အောက်ပါစာရင်းမှ အနည်းဆုံး တစ်ခုကို ဖယ်ရှားခြင်းဖြင့် ၎င်းမှ ထွက်ပါ။ စက်၏ အကောင့်ဆက်တင်အောက်တွင် သက်ဆိုင်သော စက်အမည်ကို သင် ရှာနိုင်သည်။</string>
     <string name="max_devices_warning_title">စက်များလွန်းနေသည်</string>
+    <string name="more_actions">နောက်ထပ်လုပ်ဆောင်ချက်များ</string>
     <string name="more_information">နောက်ထပ်အချက်အလက်</string>
     <string name="mullvad_owned_only">Mullvad ပိုင်ဆိုင်သည်များသာ</string>
     <string name="multihop">မာလ်တီဟော့ပ်</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">အမည်ကို %1$s သို့ ပြောင်းလိုက်ပါသည်</string>
     <string name="new_changelog_notification_message">အသစ်ထူးသော အကြောင်းအရာကို ကြည့်ရန် ဤနေရာကို နှိပ်ပါ</string>
     <string name="new_changelog_notification_title">ဗားရှင်းအသစ်ကို ထည့်သွင်းထားသည်</string>
+    <string name="new_device_notification_message">ကြိုဆိုပါတယ်၊ ဤစက်ကို ယခု &lt;b&gt;%1$s&lt;/b&gt; ဟု ခေါ်ပါသည်။</string>
     <string name="new_device_notification_title">စက်အသစ် ဖန်တီးထားသည်</string>
     <string name="new_list">စာရင်းသစ်</string>
     <string name="no_custom_lists_available">စိတ်ကြိုက် စာရင်းများကို မရရှိနိုင်ပါ</string>
     <string name="no_internet_connection">အင်တာနက် ချိတ်ဆက်မှု မရှိပါ</string>
     <string name="no_locations_found">တည်နေရာများကို ရှာမတွေ့ပါ</string>
     <string name="no_matching_relay">သင့်ဆက်တင်နှင့် ကိုက်ညီသော ဆာဗာများ မရှိပါ၊ ဆာဗာ သို့မဟုတ် အခြားဆက်တင်တို့ကို ပြောင်းလဲရန် ကြိုးစားကြည့်ပါ။</string>
+    <string name="no_recent_selection">လတ်တလောရွေးချယ်မှု မှတ်တမ်း မရှိပါ</string>
     <string name="no_wireguard_key">အကျုံးဝင်သည့် WireGuard ကီး မရှိပါ။ အဆင့်မြင့်ဆက်တင် အောက်တွင် ကီးများကို စီမံခန့်ခွဲပါ။</string>
     <string name="not_found">ရှာမတွေ့ပါ</string>
     <string name="number_of_providers">ပံ့ပိုးသူများ- %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">ဤလုပ်ဆောင်ချက်သည် Quantum ကွန်ပျူတာများမှ ဖြစ်လာနိုင်ခြေရှိသော တိုက်ခိုက်မှုများကို ခုခံနိုင်သည့် WireGuard Tunnel ကို ပြုလုပ်သည်။</string>
     <string name="quantum_resistant_info_second_paragaph">Quantum Safe အယ်လဂိုရီသမ်တစ်ခုကို သုံး၍ ထပ်ဆောင်း ကီးဖလှယ်မှုတစ်ခုကို ဆောင်ရွက်ပြီး WireGuard ၏ ပုံမှန် ကုဒ်ပြောင်းဝှက်မှုအတွင်း ရလဒ်ကို ရောနှောခြင်းအားဖြင့် ဤသည်ကို လုပ်ဆောင်ပါသည်။ ဤထပ်ဆောင်းအဆင့်သည် Tunnel အသစ်တစ်ခု တည်ဆောက်တိုင်း ဒေတာ 500 kiB ခန့်ကို သုံးပါသည်။</string>
     <string name="quantum_resistant_title">Quantum-resistant Tunnel</string>
+    <string name="recents">လတ်တလောအရာများ</string>
+    <string name="recents_disabled">လတ်တလောအရာများကို ပိတ်ထားပြီး မှတ်တမ်းကို ရှင်းထားသည်</string>
     <string name="reconnect">ပြန်ချိတ်ဆက်ရန်</string>
     <string name="redeem">လဲယူရန်</string>
     <string name="redeem_voucher">ဘောက်ချာဖြင့် လဲယူရန်</string>
+    <string name="relayitem_is_inactive">%1$s ကို မရရှိနိုင်ပါ</string>
     <string name="remove_button">ဖယ်ရှားရန်</string>
     <string name="remove_location_from_list">%1$s မှ %2$s ကို ဖယ်ရှားရန်</string>
     <string name="removed_provider">%1$s (ဖယ်ရှားထား)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">ဤအကွက်ကို မဖြစ်မနေဖြည့်ရမည်</string>
     <string name="this_is_already_set_as_current">၎င်းကို လက်ရှိအဖြစ် သတ်မှတ်ထားပြီးပါပြီ</string>
     <string name="time_added">အချိန်တိုးထားသည်</string>
+    <string name="to_add_locations_to_a_list">တည်နေရာများကို စာရင်းတစ်ခုတွင် ထည့်ရန် ဘောပင်ပုံကို နှိပ်ပါ သို့မဟုတ် နိုင်ငံ၊ မြို့ သို့မဟုတ် ဆာဗာပေါ်တွင် ကြာကြာနှိပ်ပါ။</string>
+    <string name="to_create_a_custom_list">စိတ်ကြိုက်စာရင်းတစ်ခု ဖန်တီးရန် \"+\" ကိုနှိပ်ပါ</string>
     <string name="toggle_vpn">VPN ရွေးသုံးရန်</string>
     <string name="top_bar_device_name">စက်အမည်- %1$s</string>
     <string name="top_bar_time_left">ကျန်သည့် အချိန်- %1$s</string>

--- a/android/lib/resource/src/main/res/values-nb/strings.xml
+++ b/android/lib/resource/src/main/res/values-nb/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Hvis du logger ut, vil enheten og enhetsnavnet bli fjernet. Når du logger inn igjen, vil enheten få et nytt navn.</string>
     <string name="direct_only">Kun direkte</string>
     <string name="direct_only_description">Ikke alle serverne våre er %1$s-aktiverte. For å kunne bruke internettet må du kanskje velge en ny plassering etter aktivering.</string>
+    <string name="disable_recents">Deaktiver nylige</string>
     <string name="discard">Forkast</string>
     <string name="discard_changes">Forkaste endringer?</string>
     <string name="disconnect">Koble fra</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Aktiver %1$s</string>
     <string name="enable_ipv6">IPv6 i tunnel</string>
     <string name="enable_method">Aktiver metoden</string>
+    <string name="enable_recents">Aktiver nylige</string>
     <string name="encrypted_dns_proxy_info_message_part1">Med metoden «Kryptert DNS-proxy» vil appen kommunisere med Mullvad API gjennom en proxy-adresse. Dette gjøres ved å hente en adresse fra en DNS over HTTPS-server (DoH) og deretter bruke den til å nå API-serverne våre.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Hvis du ikke er koblet til VPN-tjenesten vår, vil den krypterte DNS-proxyen bruke din egen ikke-VPN-IP når du kobler til. En av følgende leverandører er vert for DoH-serverne: Quad9 eller CloudFlare.</string>
     <string name="enter_value_placeholder">Angi MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Supert!</string>
     <string name="max_devices_warning_description">Logg ut av minst én ved å fjerne den fra listen nedenfor. Du finner det tilsvarende enhetsnavnet under enhetens kontoinnstillinger.</string>
     <string name="max_devices_warning_title">For mange enheter</string>
+    <string name="more_actions">Flere handlinger</string>
     <string name="more_information">Mer informasjon</string>
     <string name="mullvad_owned_only">Kun eid av Mullvad</string>
     <string name="multihop">Multihopp</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Navn ble endret til %1$s</string>
     <string name="new_changelog_notification_message">Klikk her for å se hva som er nytt.</string>
     <string name="new_changelog_notification_title">NY VERSJON INSTALLERT</string>
+    <string name="new_device_notification_message">Velkommen. Denne enheten har fått navnet &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NY ENHET OPPRETTET</string>
     <string name="new_list">Ny liste</string>
     <string name="no_custom_lists_available">Ingen tilgjengelige egendefinerte lister</string>
     <string name="no_internet_connection">Ingen internettforbindelse</string>
     <string name="no_locations_found">Ingen plasseringer funnet</string>
     <string name="no_matching_relay">Ingen servere passer til innstillingene dine. Prøv å endre server eller andre innstillinger.</string>
+    <string name="no_recent_selection">Ingen nylig valghistorikk</string>
     <string name="no_wireguard_key">Det mangler en gyldig WireGuard-nøkkel. Du kan behandle nøklene under avanserte innstillinger.</string>
     <string name="not_found">Ikke funnet</string>
     <string name="number_of_providers">Leverandører: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Denne funksjonen gjør WireGuard-tunnelen motstandsdyktig mot potensielle angrep fra kvantemaskiner.</string>
     <string name="quantum_resistant_info_second_paragaph">Det gjøres ved at å utføre en ekstra nøkkelutveksling med en kvantesikker algoritme og kombinere resultatet med WireGuard sin vanlige kryptering. Dette ekstratrinnet bruker omtrent 500 kiB trafikk hver gang det opprettes en ny tunnel.</string>
     <string name="quantum_resistant_title">Kvantebestandig tunnel</string>
+    <string name="recents">Nylige</string>
+    <string name="recents_disabled">Nylige er deaktivert og historikken er slettet</string>
     <string name="reconnect">Koble til på nytt</string>
     <string name="redeem">Løs inn</string>
     <string name="redeem_voucher">Løs inn kupong</string>
+    <string name="relayitem_is_inactive">%1$s er utilgjengelig</string>
     <string name="remove_button">Fjern</string>
     <string name="remove_location_from_list">Fjern %1$s fra %2$s</string>
     <string name="removed_provider">%1$s (fjernet)</string>
@@ -370,10 +378,12 @@
     <string name="this_field_is_required">Feltet er påkrevd</string>
     <string name="this_is_already_set_as_current">Denne er allerede angitt som gjeldende</string>
     <string name="time_added">Tid lagt til</string>
+    <string name="to_add_locations_to_a_list">Hvis du vil legge til plasseringer i en liste, kan du trykke på pennen eller hold inne på et land, en by eller en server.</string>
+    <string name="to_create_a_custom_list">For å opprette en egendefinert liste, kan du trykke på «+»</string>
     <string name="toggle_vpn">Velg VPN</string>
     <string name="top_bar_device_name">Enhetsnavn: %1$s</string>
     <string name="top_bar_time_left">Tid igjen: %1$s</string>
-    <string name="try_again">Prøv på nytt</string>
+    <string name="try_again">Prøv igjen</string>
     <string name="type">Type</string>
     <string name="udp">UDP</string>
     <string name="udp_over_tcp_port_info">TCP-porten som UDP-over-TCP-tilsløringen skal koble til på VPN-serveren.</string>

--- a/android/lib/resource/src/main/res/values-nl/strings.xml
+++ b/android/lib/resource/src/main/res/values-nl/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Als u zich afmeldt, worden het apparaat en de apparaatnaam verwijderd. Wanneer u zich weer aanmeldt, krijgt het apparaat een nieuwe naam.</string>
     <string name="direct_only">Alleen rechtstreeks</string>
     <string name="direct_only_description">Niet al onze servers zijn geschikt voor %1$s. Om het internet te kunnen gebruiken, moet u na het inschakelen mogelijk een nieuwe locatie selecteren.</string>
+    <string name="disable_recents">Recente uitschakelen</string>
     <string name="discard">Verwerpen</string>
     <string name="discard_changes">Wijzigingen verwerpen?</string>
     <string name="disconnect">Verbinding verbreken</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">%1$s inschakelen</string>
     <string name="enable_ipv6">IPv6 in tunnel</string>
     <string name="enable_method">Methode inschakelen</string>
+    <string name="enable_recents">Recente inschakelen</string>
     <string name="encrypted_dns_proxy_info_message_part1">Met de methode \"Versleutelde DNS-proxy\" communiceert de app met onze Mullvad-API via een proxyadres. De app doet dit door een adres op te halen van een DoH-server (DNS over HTTPS) en dat te gebruiken om onze API-servers te bereiken.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Als u niet verbonden bent met onze VPN, gebruikt de versleutelde DNS-proxy uw eigen niet-VPN IP-adres bij het verbinden. De DoH-servers worden gehost door een van de volgende aanbieders: Quad9 of CloudFlare.</string>
     <string name="enter_value_placeholder">Voer MTU in</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Meld u bij minstens één apparaat af door het te verwijderen uit de onderstaande lijst. U kunt de bijbehorende apparaatnaam vinden in de accountinstellingen van het apparaat.</string>
     <string name="max_devices_warning_title">Te veel apparaten</string>
+    <string name="more_actions">Andere acties</string>
     <string name="more_information">Meer informatie</string>
     <string name="mullvad_owned_only">Alleen in eigendom van Multivad</string>
     <string name="multihop">Multihop</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Naam is gewijzigd in %1$s</string>
     <string name="new_changelog_notification_message">Klik hier om te zien wat er nieuw is.</string>
     <string name="new_changelog_notification_title">NIEUWE VERSIE GEÏNSTALLEERD</string>
+    <string name="new_device_notification_message">Welkom. De naam van dit apparaat is nu &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NIEUW APPARAAT GEMAAKT</string>
     <string name="new_list">Nieuwe lijst</string>
     <string name="no_custom_lists_available">Geen aangepaste lijsten beschikbaar</string>
     <string name="no_internet_connection">Geen internetverbinding</string>
     <string name="no_locations_found">Geen locaties gevonden</string>
     <string name="no_matching_relay">Er zijn geen servers die overeenkomen met uw instellingen. Probeer een andere server of andere instellingen.</string>
+    <string name="no_recent_selection">Geen recente selectiegeschiedenis</string>
     <string name="no_wireguard_key">Geldige WireGuard-sleutel ontbreekt. Beheer sleutels onder Geavanceerde instellingen.</string>
     <string name="not_found">Niet gevonden</string>
     <string name="number_of_providers">Providers: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Deze eigenschap maakt de WireGuard-tunnel bestand tegen mogelijke aanvallen met kwantumcomputers.</string>
     <string name="quantum_resistant_info_second_paragaph">Het doet dit door een extra sleuteluitwisseling uit te voeren met een kwantumveilig algoritme en het resultaat te mengen met de reguliere versleuteling van WireGuard. Deze extra stap gebruikt ongeveer 500 kiB aan verkeer elke keer dat een nieuwe tunnel wordt opgezet.</string>
     <string name="quantum_resistant_title">Kwantumbestendige tunnel</string>
+    <string name="recents">Recente</string>
+    <string name="recents_disabled">Recente uitgeschakeld en geschiedenis gewist</string>
     <string name="reconnect">Opnieuw verbinden</string>
     <string name="redeem">Inwisselen</string>
     <string name="redeem_voucher">Voucher inwisselen</string>
+    <string name="relayitem_is_inactive">%1$s is niet beschikbaar</string>
     <string name="remove_button">Verwijderen</string>
     <string name="remove_location_from_list">%1$s verwijderen uit %2$s</string>
     <string name="removed_provider">%1$s (verwijderd)</string>
@@ -370,10 +378,12 @@
     <string name="this_field_is_required">Dit veld is verplicht</string>
     <string name="this_is_already_set_as_current">Deze is al ingesteld als huidige</string>
     <string name="time_added">Tijd van toevoegen</string>
+    <string name="to_add_locations_to_a_list">Druk op het potlood of houd een land, plaats of server ingedrukt om locaties toe te voegen aan de lijst.</string>
+    <string name="to_create_a_custom_list">Druk op \"+\" om een aangepaste lijst te maken</string>
     <string name="toggle_vpn">VPN in-/uitschakelen</string>
     <string name="top_bar_device_name">Apparaatnaam: %1$s</string>
     <string name="top_bar_time_left">Resterende tijd: %1$s</string>
-    <string name="try_again">Probeer het opnieuw</string>
+    <string name="try_again">Opnieuw proberen</string>
     <string name="type">Type</string>
     <string name="udp">UDP</string>
     <string name="udp_over_tcp_port_info">Met welke TCP-poort moet het UDP-over-TCP-obfuscatieprotocol verbinding maken op de VPN-server.</string>

--- a/android/lib/resource/src/main/res/values-pl/strings.xml
+++ b/android/lib/resource/src/main/res/values-pl/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Przy wylogowaniu urządzenie i jego nazwa zostają usunięte. Po ponownym zalogowaniu urządzenie otrzymuje nową nazwę.</string>
     <string name="direct_only">Tylko Direct</string>
     <string name="direct_only_description">Nie wszystkie nasze serwery obsługują %1$s. Aby korzystać z Internetu, być może trzeba będzie wybrać nową lokalizację po włączeniu tej funkcji.</string>
+    <string name="disable_recents">Wyłącz ostatnie</string>
     <string name="discard">Odrzuć</string>
     <string name="discard_changes">Odrzucić zmiany?</string>
     <string name="disconnect">Rozłącz</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Włącz %1$s</string>
     <string name="enable_ipv6">Protokół IPv6 w tunelu</string>
     <string name="enable_method">Włącz metodę</string>
+    <string name="enable_recents">Włącz ostatnie</string>
     <string name="encrypted_dns_proxy_info_message_part1">Dzięki metodzie „szyfrowany serwer proxy DNS” aplikacja będzie komunikować się z naszym interfejsem API Mullvad za pośrednictwem adresu serwera proxy. Odbywa się to poprzez pobranie adresu z serwera DNS over HTTPS (DoH), a następnie użycie go do połączenia z naszymi serwerami interfejsu API.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Jeśli nie masz połączenia z naszą siecią VPN, szyfrowany serwer proxy DNS użyje Twojego własnego adresu IP bez VPN podczas łączenia. Serwery DoH są hostowane przez jednego z następujących dostawców: Quad 9 lub CloudFlare.</string>
     <string name="enter_value_placeholder">Wprowadź MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Wyloguj się z co najmniej jednego urządzenia, usuwając je z poniższej listy. Odpowiednią nazwę urządzenia można znaleźć w ustawieniach konta urządzenia.</string>
     <string name="max_devices_warning_title">Zbyt wiele urządzeń</string>
+    <string name="more_actions">Więcej działań</string>
     <string name="more_information">Więcej informacji</string>
     <string name="mullvad_owned_only">Wyłącznie firmy Mullvad</string>
     <string name="multihop">Wielokrotny przeskok</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Nazwę zmieniono na %1$s</string>
     <string name="new_changelog_notification_message">Kliknij tutaj, aby zobaczyć, co nowego.</string>
     <string name="new_changelog_notification_title">ZAINSTALOWANO NOWĄ WERSJĘ</string>
+    <string name="new_device_notification_message">To urządzenie ma teraz nazwę &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">UTWORZONO NOWE URZĄDZENIE</string>
     <string name="new_list">Nowa lista</string>
     <string name="no_custom_lists_available">Brak dostępnych list niestandardowych</string>
     <string name="no_internet_connection">Brak połączenia z Internetem</string>
     <string name="no_locations_found">Nie znaleziono lokalizacji</string>
     <string name="no_matching_relay">Żaden serwer nie odpowiada ustawieniom. Spróbuj zmienić serwer lub inne ustawienia.</string>
+    <string name="no_recent_selection">Brak historii ostatnich wyborów</string>
     <string name="no_wireguard_key">Brak prawidłowego klucza WireGuard. Zarządzaj kluczami w Ustawieniach zaawansowanych.</string>
     <string name="not_found">Nie znaleziono</string>
     <string name="number_of_providers">Dostawcy: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Ta funkcja sprawia, że tunel WireGuard jest odporny na potencjalne ataki ze strony komputerów kwantowych.</string>
     <string name="quantum_resistant_info_second_paragaph">Jest to wykonywane poprzez dodatkową wymianę kluczy przy użyciu algorytmu odpornego na ataki z użyciem komputerów kwantowych i zmieszanie wyniku ze zwykłym szyfrowaniem WireGuard. Ten dodatkowy krok zużywa około 500 kB ruchu za każdym razem, gdy ustanawiany jest nowy tunel.</string>
     <string name="quantum_resistant_title">Tunel odporny na ataki z użyciem komputerów kwantowych</string>
+    <string name="recents">Ostatnie</string>
+    <string name="recents_disabled">Ostatnie: wyłączono i wyczyszczono historię</string>
     <string name="reconnect">Połącz ponownie</string>
     <string name="redeem">Zrealizuj</string>
     <string name="redeem_voucher">Zrealizuj kupon</string>
+    <string name="relayitem_is_inactive">%1$s: niedostępne</string>
     <string name="remove_button">Usuń</string>
     <string name="remove_location_from_list">Usuń %1$s z %2$s</string>
     <string name="removed_provider">%1$s (usunięto)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">To pole jest wymagane</string>
     <string name="this_is_already_set_as_current">Już ustawiona jako bieżąca</string>
     <string name="time_added">Dodano czas</string>
+    <string name="to_add_locations_to_a_list">Aby dodać lokalizacje do listy, naciśnij przycisk ołówka lub naciśnij i przytrzymaj kraj, miasto albo serwer.</string>
+    <string name="to_create_a_custom_list">Aby utworzyć listę niestandardową, naciśnij przycisk „+”</string>
     <string name="toggle_vpn">Przełącz VPN</string>
     <string name="top_bar_device_name">Nazwa urządzenia: %1$s</string>
     <string name="top_bar_time_left">Pozostało: %1$s</string>

--- a/android/lib/resource/src/main/res/values-pt/strings.xml
+++ b/android/lib/resource/src/main/res/values-pt/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Se terminar a sessão, o dispositivo e o nome do dispositivo são removidos. Quando voltar a iniciar sessão, o dispositivo recebe um novo nome.</string>
     <string name="direct_only">Apenas direta</string>
     <string name="direct_only_description">Nem todos os servidores suportam %1$s. Para utilizar a Internet, pode ter de selecionar uma nova localização após ativar esta funcionalidade.</string>
+    <string name="disable_recents">Desativar recentes</string>
     <string name="discard">Descartar</string>
     <string name="discard_changes">Descartar alterações?</string>
     <string name="disconnect">Desligar</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Ativar %1$s</string>
     <string name="enable_ipv6">IPv6 em túnel</string>
     <string name="enable_method">Ativar método</string>
+    <string name="enable_recents">Ativar recentes</string>
     <string name="encrypted_dns_proxy_info_message_part1">Com o método \"Proxy DNS encriptado\", a aplicação irá comunicar com a nossa API Mullvad através de um endereço proxy. Para tal, obtém um endereço de um servidor DNS sobre HTTPS (DoH) e utiliza-o para aceder aos nossos servidores de API.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Se não estiver ligado à nossa VPN, o proxy DNS encriptado utiliza o seu próprio IP e não a VPN ao estabelecer a ligação. Os servidores DoH são alojados por um dos seguintes fornecedores: Quad9 ou CloudFlare.</string>
     <string name="enter_value_placeholder">Introduzir MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Excelente!</string>
     <string name="max_devices_warning_description">Desligue-se de pelo menos um dos dispositivos removendo-o da lista abaixo. Pode encontrar o nome do dispositivo correspondente nas definições de Conta do dispositivo.</string>
     <string name="max_devices_warning_title">Demasiados dispositivos</string>
+    <string name="more_actions">Mais ações</string>
     <string name="more_information">Mais informações</string>
     <string name="mullvad_owned_only">Apenas propriedade de Mullvad</string>
     <string name="multihop">Multihop</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">O nome foi alterado para %1$s</string>
     <string name="new_changelog_notification_message">Clique aqui para ver as novidades.</string>
     <string name="new_changelog_notification_title">NOVA VERSÃO INSTALADA</string>
+    <string name="new_device_notification_message">As boas-vindas, este dispositivo tem agora o nome &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NOVO DISPOSITIVO CRIADO</string>
     <string name="new_list">Nova lista</string>
     <string name="no_custom_lists_available">Nenhuma lista personalizada disponível</string>
     <string name="no_internet_connection">Sem ligação à internet</string>
     <string name="no_locations_found">Nenhuma localização encontrada</string>
     <string name="no_matching_relay">Nenhum servidor corresponde às suas definições. Tente alterar o servidor ou outras definições.</string>
+    <string name="no_recent_selection">Sem histórico de seleção recente</string>
     <string name="no_wireguard_key">Chave WireGuard válida em falta. Faça a gestão das chaves em Definições Avançadas.</string>
     <string name="not_found">Não encontrada</string>
     <string name="number_of_providers">Fornecedores: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Esta funcionalidade torna o túnel do WireGuard resistente a potenciais ataques de computadores quânticos.</string>
     <string name="quantum_resistant_info_second_paragaph">Fá-lo ao realizar uma troca de chaves adicional utilizando um algoritmo de segurança quântica e misturando o resultado na encriptação regular do WireGuard. Este passo adicional utiliza aproximadamente 500 kiB de tráfego sempre que um novo túnel é estabelecido.</string>
     <string name="quantum_resistant_title">Túnel com resistência quântica</string>
+    <string name="recents">Recentes</string>
+    <string name="recents_disabled">Recentes desativados e histórico eliminado</string>
     <string name="reconnect">Religar</string>
     <string name="redeem">Reclamar</string>
     <string name="redeem_voucher">Reclamar voucher</string>
+    <string name="relayitem_is_inactive">%1$s não está disponível</string>
     <string name="remove_button">Remover</string>
     <string name="remove_location_from_list">Remover %1$s de %2$s</string>
     <string name="removed_provider">%1$s (removido)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Este campo é obrigatório</string>
     <string name="this_is_already_set_as_current">Este já está definido como o atual</string>
     <string name="time_added">Tempo adicionado</string>
+    <string name="to_add_locations_to_a_list">Para adicionar localizações a uma lista, prima a caneta ou mantenha premido um país, uma cidade ou um servidor.</string>
+    <string name="to_create_a_custom_list">Para criar uma lista personalizada prima o botão \"+\"</string>
     <string name="toggle_vpn">Alternar VPN</string>
     <string name="top_bar_device_name">Nome do dispositivo: %1$s</string>
     <string name="top_bar_time_left">Tempo restante: %1$s</string>

--- a/android/lib/resource/src/main/res/values-ru/strings.xml
+++ b/android/lib/resource/src/main/res/values-ru/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Если вы выйдете, устройство и его имя удалятся. При повторном входе устройство получит новое имя.</string>
     <string name="direct_only">Только напрямую</string>
     <string name="direct_only_description">%1$s поддерживается не на всех серверах. Поэтому, чтобы выйти онлайн после включения этой функции, вам, возможно, придется выбрать новое местоположение.</string>
+    <string name="disable_recents">Отключить недавние</string>
     <string name="discard">Сбросить</string>
     <string name="discard_changes">Сбросить изменения?</string>
     <string name="disconnect">Отключить</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Включить режим %1$s</string>
     <string name="enable_ipv6">IPv6 внутри туннеля</string>
     <string name="enable_method">Включить метод</string>
+    <string name="enable_recents">Включить недавние</string>
     <string name="encrypted_dns_proxy_info_message_part1">При использовании метода «Прокси через зашифрованный DNS» приложение будет взаимодействовать с API Mullvad через прокси-адрес. Полученный от сервера «DNS по HTTPS» (DoH) адрес будет использоваться для доступа к нашим серверам API.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Если вы не подключены к нашему VPN, функция «Зашифрованный DNS-прокси» при подключении будет использовать ваш IP-адрес, не относящийся к VPN. Серверы DoH размещаются у одного из следующих провайдеров: Quad9 или CloudFlare.</string>
     <string name="enter_value_placeholder">Введите MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Отлично!</string>
     <string name="max_devices_warning_description">Выйдите из учетной записи хотя бы на одном из устройств, удалив его из списка ниже. Имя устройства указано в настройках учетной записи.</string>
     <string name="max_devices_warning_title">Слишком много устройств</string>
+    <string name="more_actions">Дополнительные действия</string>
     <string name="more_information">Подробнее</string>
     <string name="mullvad_owned_only">Только принадлежащие Mullvad</string>
     <string name="multihop">Многократный переход</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Имя изменено на «%1$s»</string>
     <string name="new_changelog_notification_message">Нажмите здесь и узнайте, что нового.</string>
     <string name="new_changelog_notification_title">УСТАНОВЛЕНА НОВАЯ ВЕРСИЯ</string>
+    <string name="new_device_notification_message">Добро пожаловать! Это устройство теперь называется &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">СОЗДАНО НОВОЕ УСТРОЙСТВО</string>
     <string name="new_list">Новый список</string>
     <string name="no_custom_lists_available">Нет своих списков</string>
     <string name="no_internet_connection">Нет подключения к Интернету</string>
     <string name="no_locations_found">Местоположения не найдены</string>
     <string name="no_matching_relay">Нет серверов, соответствующих вашим настройкам. Попробуйте изменить сервер или задайте другие настройки.</string>
+    <string name="no_recent_selection">Нет истории недавнего выбора</string>
     <string name="no_wireguard_key">Не найден действительный ключ WireGuard. Управлять ключами можно в дополнительных настройках.</string>
     <string name="not_found">Не найдено</string>
     <string name="number_of_providers">провайдеры: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Эта функция делает туннель WireGuard устойчивым к потенциальным атакам с использованием квантовых компьютеров.</string>
     <string name="quantum_resistant_info_second_paragaph">Для этого функция выполняет дополнительный обмен ключами с использованием квантово-устойчивого алгоритма и добавляет результат к обычному шифрованию WireGuard. Эта дополнительная мера использует примерно 500 КиБ трафика при каждом создании нового туннеля.</string>
     <string name="quantum_resistant_title">Квантово-устойчивый туннель</string>
+    <string name="recents">Недавние</string>
+    <string name="recents_disabled">Недавние отключены, история очищена</string>
     <string name="reconnect">Переподключить</string>
     <string name="redeem">Погасить</string>
     <string name="redeem_voucher">Погасить ваучер</string>
+    <string name="relayitem_is_inactive">%1$s недоступно</string>
     <string name="remove_button">Удалить</string>
     <string name="remove_location_from_list">Удалить местоположение %1$s из списка «%2$s»</string>
     <string name="removed_provider">%1$s (удалено)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Это обязательное поле</string>
     <string name="this_is_already_set_as_current">Этот метод уже установлен как текущий</string>
     <string name="time_added">Время добавлено</string>
+    <string name="to_add_locations_to_a_list">Чтобы добавить местоположения в список, нажмите значок карандаша или нажмите и удерживайте страну, город или сервер.</string>
+    <string name="to_create_a_custom_list">Чтобы создать свой список, нажмите «+»</string>
     <string name="toggle_vpn">Включение VPN</string>
     <string name="top_bar_device_name">Имя устройства: %1$s</string>
     <string name="top_bar_time_left">Осталось времени: %1$s</string>

--- a/android/lib/resource/src/main/res/values-sv/strings.xml
+++ b/android/lib/resource/src/main/res/values-sv/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Om du loggar ut tas enheten och enhetsnamnet bort. När du loggar in igen får enheten ett nytt namn.</string>
     <string name="direct_only">Endast direkt</string>
     <string name="direct_only_description">Det är inte alla våra servrar som är %1$s-aktiverade. Om du vill använda internet kanske du måste välja en ny plats efter aktivering.</string>
+    <string name="disable_recents">Inaktivera senaste</string>
     <string name="discard">Ignorera</string>
     <string name="discard_changes">Ignorera ändringarna?</string>
     <string name="disconnect">Koppla från</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">Aktivera %1$s</string>
     <string name="enable_ipv6">IPv6 i tunnel</string>
     <string name="enable_method">Aktivera metod</string>
+    <string name="enable_recents">Aktivera senaste</string>
     <string name="encrypted_dns_proxy_info_message_part1">Med metoden \"Krypterad DNS-proxy\" kommunicerar appen med vår Mullvad API via en proxyadress. Den gör det genom att hämta en adress från en DNS over HTTPS-server (DoH) och sedan använda den för att nå våra API-servrar.</string>
     <string name="encrypted_dns_proxy_info_message_part2">Om du inte är ansluten till vår VPN använder den krypterade DNS-proxyn din egen IP-adress utan VPN när du ansluter. En av följande leverantörer är värd för DoH-servrarna: Quad 9 eller CloudFlare.</string>
     <string name="enter_value_placeholder">Ange MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Logga ut på minst en enhet genom att ta bort den från listan nedan. Du hittar motsvarande enhetsnamn i enhetens kontoinställningar.</string>
     <string name="max_devices_warning_title">För många enheter</string>
+    <string name="more_actions">Fler åtgärder</string>
     <string name="more_information">Mer information</string>
     <string name="mullvad_owned_only">Endast Mullvad-ägd</string>
     <string name="multihop">Multihopp</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Namnet har ändrats till %1$s</string>
     <string name="new_changelog_notification_message">Klicka här för att se nyheterna.</string>
     <string name="new_changelog_notification_title">NY VERSION INSTALLERAD</string>
+    <string name="new_device_notification_message">Välkommen. Den här enheten har fått namnet &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">NY ENHET HAR SKAPATS</string>
     <string name="new_list">Ny lista</string>
     <string name="no_custom_lists_available">Inga anpassade listor är tillgängliga</string>
     <string name="no_internet_connection">Ingen internetanslutning</string>
     <string name="no_locations_found">Inga platser hittades</string>
     <string name="no_matching_relay">Inga servrar matchar dina inställningar. Försök att byta server eller ändra inställningarna.</string>
+    <string name="no_recent_selection">Ingen historik av senaste val</string>
     <string name="no_wireguard_key">Giltig WireGuard-nyckel saknas. Hantera nycklar i Avancerade inställningar.</string>
     <string name="not_found">Hittades inte</string>
     <string name="number_of_providers">Leverantörer: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Den här funktionen gör WireGuard-tunneln resistent mot potentiella attacker från kvantdatorer.</string>
     <string name="quantum_resistant_info_second_paragaph">Den gör det genom att göra ett extra nyckelutbyte med en kvantsäker algoritm och kombinera resultatet med WireGuards vanliga kryptering. Det här extra steget använder ungefär 500 KiB i trafik varje gång en ny tunnel upprättas.</string>
     <string name="quantum_resistant_title">Kvantresistent tunnel</string>
+    <string name="recents">Senaste</string>
+    <string name="recents_disabled">Senaste har inaktiverats och historiken har rensats</string>
     <string name="reconnect">Återanslut</string>
     <string name="redeem">Lös in</string>
     <string name="redeem_voucher">Lös in kupong</string>
+    <string name="relayitem_is_inactive">%1$s är inte tillgänglig</string>
     <string name="remove_button">Ta bort</string>
     <string name="remove_location_from_list">Ta bort %1$s från %2$s</string>
     <string name="removed_provider">%1$s (har tagits bort)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">Fältet är obligatoriskt</string>
     <string name="this_is_already_set_as_current">Den har redan ställts in som aktuell</string>
     <string name="time_added">Tid har lagts till</string>
+    <string name="to_add_locations_to_a_list">Om du vill lägga till platser i en lista kan du trycka på pennan eller trycka länge på ett land, en stad eller en server.</string>
+    <string name="to_create_a_custom_list">Om du vill skapa en anpassad lista trycker du på \"+\"</string>
     <string name="toggle_vpn">Växla VPN</string>
     <string name="top_bar_device_name">Enhetsnamn: %1$s</string>
     <string name="top_bar_time_left">Tid kvar: %1$s</string>

--- a/android/lib/resource/src/main/res/values-th/strings.xml
+++ b/android/lib/resource/src/main/res/values-th/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">หากคุณออกจากระบบ อุปกรณ์และชื่ออุปกรณ์จะถูกลบออก และเมื่อคุณลงชื่อเข้าใช้อีกครั้ง อุปกรณ์จะได้รับชื่อใหม่</string>
     <string name="direct_only">โดยตรงเท่านั้น</string>
     <string name="direct_only_description">ไม่ใช่ทุกเซิร์ฟเวอร์ของเราที่เปิดใช้งาน %1$s คุณอาจต้องเลือกตำแหน่งที่ตั้งใหม่หลังจากเปิดใช้งาน เพื่อใช้งานอินเทอร์เน็ต</string>
+    <string name="disable_recents">ปิดใช้งานล่าสุด</string>
     <string name="discard">ละทิ้ง</string>
     <string name="discard_changes">ละทิ้งการเปลี่ยนแปลงหรือไม่</string>
     <string name="disconnect">ตัดการเชื่อมต่อ</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">เปิดใช้งาน %1$s</string>
     <string name="enable_ipv6">IPv6 แบบภายในอุโมงค์</string>
     <string name="enable_method">เปิดใช้งานวิธีการ</string>
+    <string name="enable_recents">เปิดใช้งานล่าสุด</string>
     <string name="encrypted_dns_proxy_info_message_part1">การใช้วิธี \"พร็อกซี DNS ที่เข้ารหัส\" จะช่วยให้แอปสื่อสารกับ Mullvad API ของเราผ่านที่อยู่พร็อกซี ซึ่งทำได้โดยดึงที่อยู่จากเซิร์ฟเวอร์ DNS ผ่าน HTTPS (DoH) แล้วจึงใช้ที่อยู่ดังกล่าวเพื่อเข้าถึงเซิร์ฟเวอร์ API ของเรา</string>
     <string name="encrypted_dns_proxy_info_message_part2">หากคุณไม่ได้เชื่อมต่อกับ VPN ของเรา พร็อกซี DNS ที่เข้ารหัสจะใช้ IP ที่ไม่ใช่ VPN ของคุณในขณะที่เชื่อมต่อ เซิร์ฟเวอร์ DoH ได้รับการโฮสต์โดยผู้ให้บริการรายใดรายหนึ่งต่อไปนี้: Quad9 หรือ CloudFlare</string>
     <string name="enter_value_placeholder">ป้อน MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">เยี่ยมยอด!</string>
     <string name="max_devices_warning_description">โปรดลงชื่อออกจากระบบบนอุปกรณ์อย่างน้อยหนึ่งเครื่อง เพื่อนำอุปกรณ์ออกจากรายการด้านล่าง คุณสามารถดูชื่ออุปกรณ์ที่เกี่ยวข้องได้ ภายใต้การตั้งค่าบัญชีของอุปกรณ์</string>
     <string name="max_devices_warning_title">มีอุปกรณ์มากเกินไป</string>
+    <string name="more_actions">การดำเนินการเพิ่มเติม</string>
     <string name="more_information">ข้อมูลเพิ่มเติม</string>
     <string name="mullvad_owned_only">ของ Mullvad เท่านั้น</string>
     <string name="multihop">มัลติฮอป</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">ชื่อถูกเปลี่ยนเป็น %1$s</string>
     <string name="new_changelog_notification_message">คลิกที่นี่ เพื่อดูว่ามีอะไรใหม่</string>
     <string name="new_changelog_notification_title">ติดตั้งเวอร์ชันใหม่แล้ว</string>
+    <string name="new_device_notification_message">ยินดีต้อนรับ อุปกรณ์นี้มีชื่อว่า &lt;b&gt;%1$s&lt;/b&gt; แล้ว</string>
     <string name="new_device_notification_title">สร้างอุปกรณ์ใหม่แล้ว</string>
     <string name="new_list">รายการใหม่</string>
     <string name="no_custom_lists_available">ไม่มีรายการแบบกำหนดเองที่พร้อมใช้งาน</string>
     <string name="no_internet_connection">ไม่มีการเชื่อมต่ออินเทอร์เน็ต</string>
     <string name="no_locations_found">ไม่พบตำแหน่งที่ตั้ง</string>
     <string name="no_matching_relay">ไม่มีเซิร์ฟเวอร์ที่ตรงกับการตั้งค่าของคุณ โปรดลองเปลี่ยนเซิร์ฟเวอร์ หรือการตั้งค่าอื่นๆ</string>
+    <string name="no_recent_selection">ไม่มีประวัติการเลือกล่าสุด</string>
     <string name="no_wireguard_key">คีย์ WireGuard ที่ใช้ได้ขาดหายไป จัดการคีย์ภายใต้การตั้งค่าขั้นสูง</string>
     <string name="not_found">ไม่พบ</string>
     <string name="number_of_providers">ผู้ให้บริการ: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">คุณลักษณะนี้จะช่วยให้ช่องทาง WireGuard สามารถสกัดกั้นการโจมตีที่อาจมาจากคอมพิวเตอร์ควอนตัมได้</string>
     <string name="quantum_resistant_info_second_paragaph">ระบบจะดำเนินการสิ่งนี้ผ่านการแลกเปลี่ยนคีย์เพิ่มเติม โดยการใช้อัลกอริทึมแบบควอนตัมที่ปลอดภัย และผสมผลลัพธ์เข้ากับการเข้ารหัสตามปกติของ WireGuard และขั้นตอนพิเศษนี้ใช้การรับส่งข้อมูลประมาณ 500 kiB ในทุกครั้งที่สร้างช่องทางใหม่</string>
     <string name="quantum_resistant_title">ช่องทางการสกัดกั้นควอนตัม</string>
+    <string name="recents">ล่าสุด</string>
+    <string name="recents_disabled">ปิดใช้งานล่าสุดและล้างประวัติแล้ว</string>
     <string name="reconnect">เชื่อมต่อใหม่</string>
     <string name="redeem">แลกรับ</string>
     <string name="redeem_voucher">แลกบัตรกำนัล</string>
+    <string name="relayitem_is_inactive">%1$s ไม่พร้อมใช้งาน</string>
     <string name="remove_button">ลบ</string>
     <string name="remove_location_from_list">ลบ %1$s จาก %2$s</string>
     <string name="removed_provider">%1$s (ลบแล้ว)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">จำเป็นต้องกรอกช่องนี้</string>
     <string name="this_is_already_set_as_current">นี่ได้รับการตั้งค่าเป็นปัจจุบันแล้ว</string>
     <string name="time_added">เพิ่มเวลาแล้ว</string>
+    <string name="to_add_locations_to_a_list">หากต้องการเพิ่มตำแหน่งลงในรายการ ให้กดปากกาหรือกดค้างที่ประเทศ เมือง หรือเซิร์ฟเวอร์</string>
+    <string name="to_create_a_custom_list">หากต้องการสร้างรายการที่กำหนดเอง ให้กด \"+\"</string>
     <string name="toggle_vpn">เปิด/ปิด VPN</string>
     <string name="top_bar_device_name">ชื่ออุปกรณ์: %1$s</string>
     <string name="top_bar_time_left">เหลือเวลา: %1$s</string>

--- a/android/lib/resource/src/main/res/values-tr/strings.xml
+++ b/android/lib/resource/src/main/res/values-tr/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">Oturumu kapatırsanız cihaz ve cihaz adı kaldırılır. Tekrar oturum açtığınızda cihaza yeni bir ad verilir.</string>
     <string name="direct_only">Yalnızca doğrudan</string>
     <string name="direct_only_description">%1$s, tüm sunucularımızda etkin değildir. İnterneti kullanmak için özelliği etkinleştirdikten sonra yeni bir konum seçmeniz gerekir.</string>
+    <string name="disable_recents">Son filtreleri devre dışı bırak</string>
     <string name="discard">İptal et</string>
     <string name="discard_changes">Değişiklikler iptal edilsin mi?</string>
     <string name="disconnect">Bağlantıyı Kes</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">%1$s ayarını etkinleştir</string>
     <string name="enable_ipv6">Tünel içi IPv6</string>
     <string name="enable_method">Yöntemi etkinleştir</string>
+    <string name="enable_recents">Son filtreleri etkinleştir</string>
     <string name="encrypted_dns_proxy_info_message_part1">\"Şifreli DNS proxy\'si\" yönteminde, uygulama bir proxy adresi üzerinden Mullvad API ile iletişim kurar. Bunun için bir DNS over HTTPS (DoH) sunucusundan bir adres alır ve bu adresi kullanarak API sunucularımıza bağlanır.</string>
     <string name="encrypted_dns_proxy_info_message_part2">VPN\'imize bağlı değilseniz Şifreli DNS proxy\'si bağlanırken VPN dışı IP\'nizi kullanır. DoH sunucuları şu sağlayıcılardan birinde barındırılır: Quad9 veya CloudFlare.</string>
     <string name="enter_value_placeholder">MTU\'yu girin</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">Süper!</string>
     <string name="max_devices_warning_description">Lütfen aşağıdaki listeden en az bir cihazı kaldırarak çıkış yapın. İlgili cihaz adını cihazın Hesap ayarları altında bulabilirsiniz.</string>
     <string name="max_devices_warning_title">Cihaz sayısı çok fazla</string>
+    <string name="more_actions">Diğer işlemler</string>
     <string name="more_information">Daha fazla bilgi</string>
     <string name="mullvad_owned_only">Sadece Mullvad\'a ait olanlar</string>
     <string name="multihop">Çoklu geçiş</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">Ad, %1$s olarak değiştirildi</string>
     <string name="new_changelog_notification_message">Yenilikleri incelemek için buraya tıklayın.</string>
     <string name="new_changelog_notification_title">YENİ SÜRÜM YÜKLENDİ</string>
+    <string name="new_device_notification_message">Hoş geldiniz, bu cihazın yeni adı artık &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="new_device_notification_title">YENİ CİHAZ OLUŞTURULDU</string>
     <string name="new_list">Yeni liste</string>
     <string name="no_custom_lists_available">Özel listeler mevcut değil</string>
     <string name="no_internet_connection">İnternet bağlantısı yok</string>
     <string name="no_locations_found">Konum bulunamadı</string>
     <string name="no_matching_relay">Ayarlarınızla eşleşen sunucu yok. Sunucuyu veya diğer ayarları değiştirmeyi deneyin.</string>
+    <string name="no_recent_selection">Son seçim geçmişi yok</string>
     <string name="no_wireguard_key">Geçerli WireGuard anahtarı eksik. Gelişmiş ayarlardan anahtarları yönetin.</string>
     <string name="not_found">Bulunamadı</string>
     <string name="number_of_providers">Hizmet sağlayıcılar: %1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">Bu özellik, WireGuard tünelini kuantum bilgisayarlardan gelebilecek potansiyel saldırılara karşı dayanıklı hale getirir.</string>
     <string name="quantum_resistant_info_second_paragaph">Bu işlemi, bir kuantum güvenlik algoritmasıyla ekstra bir anahtar değişimi gerçekleştirdikten sonra sonucu WireGuard\'ın normal şifrelemesiyle karıştırarak yapar. Bu ekstra adım, her yeni tünel kurulduğunda yaklaşık 500 kiB trafik kullanır.</string>
     <string name="quantum_resistant_title">Kuantuma dayanıklı tünel</string>
+    <string name="recents">Son kullanılanlar</string>
+    <string name="recents_disabled">Son kullanılanlar devre dışı bırakıldı ve geçmiş temizlendi</string>
     <string name="reconnect">Yeniden Bağlan</string>
     <string name="redeem">Kullan</string>
     <string name="redeem_voucher">Kuponu kullan</string>
+    <string name="relayitem_is_inactive">%1$s kullanılamıyor</string>
     <string name="remove_button">Kaldır</string>
     <string name="remove_location_from_list">%1$s, %2$s listesinden kaldırılsın</string>
     <string name="removed_provider">%1$s (kaldırıldı)</string>
@@ -370,10 +378,12 @@
     <string name="this_field_is_required">Bu alan gereklidir</string>
     <string name="this_is_already_set_as_current">Bu, zaten geçerli olarak ayarlı yöntemdir</string>
     <string name="time_added">Süre eklendi</string>
+    <string name="to_add_locations_to_a_list">Konumları bir listeye eklemek için kalem simgesine dokunun veya bir ülkeye, şehre ya da sunucuya uzun basın.</string>
+    <string name="to_create_a_custom_list">Özel bir liste oluşturmak için “+” simgesine dokunun</string>
     <string name="toggle_vpn">VPN\'i aç/kapat</string>
     <string name="top_bar_device_name">Cihaz adı: %1$s</string>
     <string name="top_bar_time_left">Kalan süre: %1$s</string>
-    <string name="try_again">Tekrar dene</string>
+    <string name="try_again">Tekrar deneyin</string>
     <string name="type">Tür</string>
     <string name="udp">UDP</string>
     <string name="udp_over_tcp_port_info">TCP üzerinden UDP gizleme protokolünün VPN sunucusunda hangi TCP portuna bağlanması gerekiyor.</string>

--- a/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">如果您退出登录，设备和设备名称将被移除。当您再次登录时，设备将获得新名称。</string>
     <string name="direct_only">仅直连</string>
     <string name="direct_only_description">我们的部分服务器未启用 %1$s。要使用互联网，您可能需要在启用后选择新位置。</string>
+    <string name="disable_recents">禁用最近使用</string>
     <string name="discard">舍弃</string>
     <string name="discard_changes">舍弃更改？</string>
     <string name="disconnect">断开连接</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">启用“%1$s”</string>
     <string name="enable_ipv6">隧道内 IPv6</string>
     <string name="enable_method">启用方法</string>
+    <string name="enable_recents">启用最近使用</string>
     <string name="encrypted_dns_proxy_info_message_part1">利用“加密 DNS 代理”方法，应用将通过代理地址与我们的 Mullvad API 进行通信。通信时，应用从 DNS over HTTPS (DoH) 服务器获取地址，然后使用该地址连接我们的 API 服务器。</string>
     <string name="encrypted_dns_proxy_info_message_part2">如果您未连接到我们的 VPN，加密 DNS 代理将在连接时使用您自己的非 VPN IP。DoH 服务器由下列提供商之一托管：Quad9 或 CloudFlare。</string>
     <string name="enter_value_placeholder">输入 MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">太棒了！</string>
     <string name="max_devices_warning_description">请通过从以下列表中移除的方式退出至少一个帐户。您可以在设备的帐户设置下找到相应设备名称。</string>
     <string name="max_devices_warning_title">设备过多</string>
+    <string name="more_actions">更多操作</string>
     <string name="more_information">更多信息</string>
     <string name="mullvad_owned_only">仅 Mullvad 自有</string>
     <string name="multihop">多跳</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">名称已更改为“%1$s”</string>
     <string name="new_changelog_notification_message">点击此处查看最新变化。</string>
     <string name="new_changelog_notification_title">已安装新版本</string>
+    <string name="new_device_notification_message">欢迎，此设备现已命名为 &lt;b&gt;%1$s&lt;/b&gt;。</string>
     <string name="new_device_notification_title">已创建新设备</string>
     <string name="new_list">新建列表</string>
     <string name="no_custom_lists_available">有可用的自定义列表</string>
     <string name="no_internet_connection">没有互联网连接</string>
     <string name="no_locations_found">找不到位置</string>
     <string name="no_matching_relay">没有与您的设置匹配的服务器，请尝试更改服务器或其他设置。</string>
+    <string name="no_recent_selection">无最近选择历史记录</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 密钥。在“高级”设置下管理密钥。</string>
     <string name="not_found">找不到</string>
     <string name="number_of_providers">提供商：%1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">借助此功能，WireGuard 隧道能够抵抗可能通过量子计算机发起的攻击。</string>
     <string name="quantum_resistant_info_second_paragaph">实现方法是使用量子安全算法执行额外的密钥交换，并将结果混合到 WireGuard 的常规加密中。每次建立新隧道时，这一额外步骤都会使用约 500 kiB 的流量。</string>
     <string name="quantum_resistant_title">抗量子隧道</string>
+    <string name="recents">最近使用</string>
+    <string name="recents_disabled">最近使用已禁用，历史记录已清除</string>
     <string name="reconnect">重新连接</string>
     <string name="redeem">兑换</string>
     <string name="redeem_voucher">兑换优惠券</string>
+    <string name="relayitem_is_inactive">%1$s 不可用</string>
     <string name="remove_button">移除</string>
     <string name="remove_location_from_list">将%1$s从“%2$s”中移除</string>
     <string name="removed_provider">%1$s（已移除）</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">此字段为必填项</string>
     <string name="this_is_already_set_as_current">它已被设置为当前方法</string>
     <string name="time_added">时间已添加</string>
+    <string name="to_add_locations_to_a_list">要将位置添加到列表中，请按笔形图标或长按国家/地区、城市或服务器。</string>
+    <string name="to_create_a_custom_list">要创建自定义列表，请按“+”</string>
     <string name="toggle_vpn">切换 VPN</string>
     <string name="top_bar_device_name">设备名称：%1$s</string>
     <string name="top_bar_time_left">剩余时间：%1$s</string>

--- a/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
@@ -140,6 +140,7 @@
     <string name="device_name_info_third_paragraph">如果您登出，則系統會移除裝置和裝置名稱。當您再次登入時，裝置則會獲得新名稱。</string>
     <string name="direct_only">僅直接連線</string>
     <string name="direct_only_description">我們有些伺服器並未啟用 %1$s。若要使用網際網路，您可能必須在啟用後選取新的位置。</string>
+    <string name="disable_recents">停用最近使用</string>
     <string name="discard">捨棄</string>
     <string name="discard_changes">要捨棄變更嗎？</string>
     <string name="disconnect">中斷連線</string>
@@ -167,6 +168,7 @@
     <string name="enable_direct_only">啟用 %1$s</string>
     <string name="enable_ipv6">通道內 IPv6</string>
     <string name="enable_method">啟用方式</string>
+    <string name="enable_recents">啟用最近使用</string>
     <string name="encrypted_dns_proxy_info_message_part1">使用「加密 DNS 代理伺服器」方法時，應用程式會透過代理伺服器位址和我們的 Mullvad API 通訊。應用程式會先從 DNS over HTTPS (DoH) 伺服器取得一個位址，再利用該位址連線至我們的 API 伺服器。</string>
     <string name="encrypted_dns_proxy_info_message_part2">如果您未連線至我們的 VPN 服務，則加密 DNS 代理伺服器將在連線時使用您本人的非 VPN IP。DoH 伺服器由下列供應商之一負責託管：Quad9 或 CloudFlare。</string>
     <string name="enter_value_placeholder">輸入 MTU</string>
@@ -251,6 +253,7 @@
     <string name="max_devices_resolved_title">太好了！</string>
     <string name="max_devices_warning_description">請從底下清單至少移除一個裝置來將其登出。您可以在裝置的「帳戶」設定下找到相應裝置名稱。</string>
     <string name="max_devices_warning_title">裝置過多</string>
+    <string name="more_actions">更多操作</string>
     <string name="more_information">更多資訊</string>
     <string name="mullvad_owned_only">僅 Mullvad 自有</string>
     <string name="multihop">多點跳躍</string>
@@ -260,12 +263,14 @@
     <string name="name_was_changed_to">名稱已變更為「%1$s」</string>
     <string name="new_changelog_notification_message">按一下此處查看最新動態。</string>
     <string name="new_changelog_notification_title">已安裝新版本</string>
+    <string name="new_device_notification_message">歡迎，此裝置現在名為 &lt;b&gt;%1$s&lt;/b&gt;。</string>
     <string name="new_device_notification_title">已建立新裝置</string>
     <string name="new_list">新清單</string>
     <string name="no_custom_lists_available">有可用的自訂清單</string>
     <string name="no_internet_connection">沒有網際網路連線</string>
     <string name="no_locations_found">找不到位置</string>
     <string name="no_matching_relay">沒有與您的設定相符的伺服器，請嘗試變更伺服器或其他設定。</string>
+    <string name="no_recent_selection">無最近選擇歷史</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 金鑰。在「進階」設定下管理金鑰。</string>
     <string name="not_found">找不到</string>
     <string name="number_of_providers">供應商：%1$d</string>
@@ -305,9 +310,12 @@
     <string name="quantum_resistant_info_first_paragaph">借助此功能，WireGuard 通道便能夠抵抗可能從量子電腦發起的攻擊。</string>
     <string name="quantum_resistant_info_second_paragaph">實現方法是使用量子安全演算法執行額外的金鑰交換，並將結果混合至 WireGuard 的常規加密。每次建立新通道時，這一額外步驟都會使用約 500 kiB 流量。</string>
     <string name="quantum_resistant_title">抗量子通道</string>
+    <string name="recents">最近使用</string>
+    <string name="recents_disabled">已停用最近使用，並已清除歷史</string>
     <string name="reconnect">重新連線</string>
     <string name="redeem">兌換</string>
     <string name="redeem_voucher">兌換憑證</string>
+    <string name="relayitem_is_inactive">%1$s 無法使用</string>
     <string name="remove_button">移除</string>
     <string name="remove_location_from_list">將 %1$s 從 %2$s 中移除</string>
     <string name="removed_provider">%1$s (已移除)</string>
@@ -370,6 +378,8 @@
     <string name="this_field_is_required">此欄位為必填項</string>
     <string name="this_is_already_set_as_current">已將其設定為目前方式</string>
     <string name="time_added">已增加時間</string>
+    <string name="to_add_locations_to_a_list">若要在清單中新增位置，請按筆的圖示，或是長按國家/地區、城市或伺服器。</string>
+    <string name="to_create_a_custom_list">若要建立自訂清單，請按「+」</string>
     <string name="toggle_vpn">切換 VPN</string>
     <string name="top_bar_device_name">裝置名稱：%1$s</string>
     <string name="top_bar_time_left">剩餘時間：%1$s</string>

--- a/desktop/packages/mullvad-vpn/locales/da/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/da/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Danish\n"
 "Language: da_DK\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d mere..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Installationsprogrammet afsluttede uventet, prøv igen eller send en fejlrapport."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Installationsprogrammet bliver downloadet til <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,42 +1399,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Velkommen! Denne enhed hedder nu <b>%(deviceName)s</b>. Se info-knappen i Konto for at flere oplysninger."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Opretter forbindelse til Mullvad-systemtjeneste..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Deaktiver antivirussoftware fra tredjepart."
+msgid "Details"
+msgstr "Oplysninger"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Deaktiver antivirussoftware fra tredjepart"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Kunne ikke starte appen. Prøv igen, eller klik på \"Oplysninger\" for yderligere oplysninger"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Hvis disse trin ikke virker, bedes du indsende en problemrapport."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Tilladelsen til Mullvad VPN-tjenesten er blevet tilbagekaldt. Gå til Systemindstillinger og tillad Mullvad VPN under indstillingen \"Tillad i baggrunden\"."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Geninstallerer appen."
+msgid "Reinstalling the app"
+msgstr "Geninstaller appen"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Genstarter din computer."
+msgid "Restarting the Mullvad background process"
+msgstr "Genstart Mullvad-baggrundsprocessen"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Genstart Mullvad-baggrundsprocessen ved at klikke på \"Tilbage\" og derefter på \"Prøv igen\""
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Genstart din computer"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Send problemrapport"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Systemservicekomponenten i appen er ikke startet eller kan ikke kontaktes. Systemtjenesten er ansvarlig for sikkerheden, kill-switchen og VPN-tunnelen. Prøv følgende for at fejlfinde:"
+msgid "Starting up...."
+msgstr "Starter …"
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Kan ikke kontakte Mullvad-systemtjenesten. Din forbindelse kan være usikker. Fejlfind eller send en problemrapport ved at klikke på knappen Lær mere."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvad-baggrundsprocessen kunne ikke starte. Baggrundsprocessen er ansvarlig for sikkerheden, kill-switchen og VPN-tunnellen. Prøv følgende:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Prøv igen"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Kan ikke kontakte Mullvad-systemtjenesten. Din forbindelse kan være usikker. Fejlfind eller send en problemrapport ved at klikke på knappen \"Find ud af mere\"."
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1911,6 +1953,13 @@ msgstr "Listenavne skal være unikke."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Navnet er allerede taget."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Obfuskering: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (er fjernet)"
 msgid "%s custom port"
 msgstr "%s brugerdefineret port"
 
+msgid "%s is unavailable"
+msgstr "%s er ikke tilgængelig"
+
 msgid "%s was added to your account."
 msgstr "%s blev føjet til din konto."
 
@@ -2923,6 +2975,9 @@ msgstr "Deaktiver \"%s\" nedenfor for at aktivere disse indstillinger."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deaktiver alle \"%s\" ovenfor for at aktivere denne indstilling."
 
+msgid "Disable recents"
+msgstr "Deaktiver nylige"
+
 msgid "Discard"
 msgstr "Kassér"
 
@@ -2961,6 +3016,9 @@ msgstr "Aktivér %1$s"
 
 msgid "Enable method"
 msgstr "Aktiver metode"
+
+msgid "Enable recents"
+msgstr "Aktivér nylige"
 
 msgid "Enter MTU"
 msgstr "Indtast MTU"
@@ -3061,6 +3119,9 @@ msgstr "Sørger for, at enheden altid er på VPN-tunnelen."
 msgid "Manage devices"
 msgstr "Administrer enheder"
 
+msgid "More actions"
+msgstr "Flere handlinger"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad-tjenester er ikke tilgængelige"
 
@@ -3087,6 +3148,9 @@ msgstr "Ingen internetforbindelse"
 
 msgid "No locations found"
 msgstr "Ingen placeringer fundet"
+
+msgid "No recent selection history"
+msgstr "Ingen nylig valghistorik"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Intet resultat for \"%s\". Prøv en anden søgning"
@@ -3126,6 +3190,12 @@ msgstr "Privatliv"
 
 msgid "Privacy policy"
 msgstr "Fortrolighedspolitik"
+
+msgid "Recents"
+msgstr "Nylige"
+
+msgid "Recents disabled and history cleared"
+msgstr "Nylige er deaktiveret og historikken ryddet"
 
 msgid "Recursion limit"
 msgstr "Rekursionsgrænse"
@@ -3229,11 +3299,11 @@ msgstr "Den er allerede indstillet som aktuel"
 msgid "Time added"
 msgstr "Tid tilføjet"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Tryk på \" ︙ \" eller tryk langvarigt på et land, en by eller en server for at tilføje placeringer til en liste."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "For at føje placeringer til en liste kan du trykke på pennen eller foretage et langt tryk på et land, en by eller en server."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Tryk på \" ︙ \" for at oprette en brugerdefineret liste"
+msgid "To create a custom list press the \"+\""
+msgstr "For at oprette en brugerdefineret liste kan du trykke på \"+\""
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "For at sørge for, at du har den mest sikre version og for at informere dig om eventuelle problemer med den aktuelle version, der kører, udfører appen automatisk versionstjek. Dette sender app-versionen og Android-systemversionen til Mullvad-servere. Mullvad holder tal på antallet af brugte app-versioner og Android-versioner. Dataene bliver aldrig opbevaret eller brugt på nogen måde, der kan identificere dig."
@@ -3312,6 +3382,9 @@ msgstr "Vi kunne ikke starte betalingsprocessen. Sørg for, at du har den nyeste
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Vi kunne ikke starte betalingsprocessen. Prøv igen senere."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Velkommen, denne enhed har nu fået navnet <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/da/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/da/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Danish\n"
 "Language: da_DK\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/de/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/de/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d mehr …"
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Das Installationsprogramm wurde unerwartet beendet, bitte versuchen Sie es erneut oder senden Sie einen Problembericht."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Das Installationsprogramm wird nach <b>%(cacheDir)s</b> heruntergeladen."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,41 +1399,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Dieses Gerät heißt jetzt <b>%(deviceName)s</b>. Weitere Details finden Sie über die Info-Schaltfläche in Ihrem Konto."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Verbindung zum Mullvad-Systemdienst wird hergestellt..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Aktivieren Sie Antiviren-Software von Drittanbietern."
+msgid "Details"
+msgstr "Details"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Deaktivieren der Antiviren-Software von Drittanbietern"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Die App konnte nicht gestartet werden, bitte versuchen Sie es erneut oder klicken Sie auf „Details“ für weitere Informationen"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Falls diese Schritte nicht helfen, senden Sie bitte einen Problembericht."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Die Berechtigung für den Mullvad-VPN Dienst wurde widerrufen. Bitte gehen Sie zu den Systemeinstellungen und erlauben Sie Mullvad VPN, im Hintergrund zu laufen."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Installieren Sie die App neu."
+msgid "Reinstalling the app"
+msgstr "Installieren Sie die App neu"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Starten Sie Ihren Computer neu."
+msgid "Restarting the Mullvad background process"
+msgstr "Starten Sie den Mullvad-Hintergrundprozess neu"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Starten Sie den Mullvad-Hintergrundprozess neu, indem Sie auf „Zurück“ klicken und dann auf „Erneut versuchen“"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Starten Sie Ihren Computer neu"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Problembericht senden"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Die Systemdienstkomponente der App ist nicht gestartet oder kann nicht kontaktiert werden. Der Systemdienst ist für die Sicherheit, den Killswitch und den VPN-Tunnel zuständig. Zur Fehlerbehebung probieren Sie Folgendes:"
+msgid "Starting up...."
+msgstr "Wird gestartet …"
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Der Mullvad-Hintergrundprozess konnte nicht gestartet werden. Der Hintergrundprozess ist für die Sicherheit, den Killswitch und den VPN-Tunnel zuständig. Bitte versuchen Sie Folgendes:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Erneut versuchen"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "Es ist nicht möglich, den Mullvad-Systemdienst zu kontaktieren, Ihre Verbindung ist möglicherweise unsicher. Bitte beheben Sie das Problem oder senden Sie einen Problembericht, indem Sie auf „Mehr erfahren“ klicken."
 
 #. This is a warning message shown when the app is blocking the users
@@ -1911,6 +1953,13 @@ msgstr "Die Namen der Listen müssen eindeutig sein."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Der Name ist bereits vergeben."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Verschleierung: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2756,6 +2805,9 @@ msgstr "%s (entfernt)"
 msgid "%s custom port"
 msgstr "%s – eigener Port"
 
+msgid "%s is unavailable"
+msgstr "%s ist nicht verfügbar"
+
 msgid "%s was added to your account."
 msgstr "%s wurde zu Ihrem Konto hinzugefügt."
 
@@ -2924,6 +2976,9 @@ msgstr "Deaktivieren Sie unten „%s“, um diese Einstellungen zu aktivieren."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deaktivieren Sie oben alle „%s“, um diese Einstellung zu aktivieren."
 
+msgid "Disable recents"
+msgstr "Letzte deaktivieren"
+
 msgid "Discard"
 msgstr "Verwerfen"
 
@@ -2962,6 +3017,9 @@ msgstr "%1$s aktivieren"
 
 msgid "Enable method"
 msgstr "Methode aktivieren"
+
+msgid "Enable recents"
+msgstr "Letzte aktivieren"
 
 msgid "Enter MTU"
 msgstr "MTU eingeben"
@@ -3062,6 +3120,9 @@ msgstr "Gewährleistet, dass sich das Gerät immer im VPN-Tunnel befindet."
 msgid "Manage devices"
 msgstr "Geräte verwalten"
 
+msgid "More actions"
+msgstr "Weitere Aktionen"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad-Dienste nicht verfügbar"
 
@@ -3088,6 +3149,9 @@ msgstr "Keine Internetverbindung"
 
 msgid "No locations found"
 msgstr "Keine Standorte gefunden"
+
+msgid "No recent selection history"
+msgstr "Kein aktueller Auswahlverlauf"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Kein Ergebnis für „%s“, bitte versuchen Sie einen anderen Suchbegriff"
@@ -3127,6 +3191,12 @@ msgstr "Datenschutz"
 
 msgid "Privacy policy"
 msgstr "Datenschutzrichtlinie"
+
+msgid "Recents"
+msgstr "Letzte"
+
+msgid "Recents disabled and history cleared"
+msgstr "Letzte deaktiviert und Verlauf gelöscht"
 
 msgid "Recursion limit"
 msgstr "Rekursionslimit"
@@ -3230,11 +3300,11 @@ msgstr "Diese ist bereits die aktuelle"
 msgid "Time added"
 msgstr "Zeit hinzugefügt"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Um Standorte zu einer Liste hinzuzufügen, drücken Sie auf „︙“ oder drücken Sie lange auf ein Land, eine Stadt oder einen Server."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Um Standorte zu einer Liste hinzuzufügen, drücken Sie auf den Stift oder drücken Sie lange auf ein Land, eine Stadt oder einen Server."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Um eine eigene Liste zu erstellen, drücken Sie auf „︙“"
+msgid "To create a custom list press the \"+\""
+msgstr "Um eine eigene Liste zu erstellen, drücken Sie auf „+“"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Um zu gewährleisten, dass Sie die sicherste Version haben und um Sie über eventuelle Probleme mit der aktuellen Version zu informieren, führt die App automatisch Versionsprüfungen durch. Dabei werden die App-Version und die Android-Systemversion an die Mullvad-Server gesendet. Mullvad führt Zähler für die Anzahl der verwendeten App-Versionen und Android-Versionen. Die Daten werden niemals gespeichert oder in einer Weise verwendet, die Sie identifizieren könnte."
@@ -3313,6 +3383,9 @@ msgstr "Wir konnten den Zahlungsvorgang nicht starten. Bitte vergewissern Sie si
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Wir konnten den Zahlungsvorgang nicht starten, bitte versuchen Sie es später noch einmal."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Willkommen, dieses Gerät heißt jetzt <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard-MTU"

--- a/desktop/packages/mullvad-vpn/locales/de/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/de/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/es/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/es/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 13:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d más..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "El instalador se ha cancelado inesperadamente. Inténtelo de nuevo o envíe un informe de problemas."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "El instalador se descargará en <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,41 +1399,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Hola, este dispositivo se llama ahora <b>%(deviceName)s</b>. Para más información, consulte el botón de información en la Cuenta."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Conectando al servicio del sistema Mullvad…"
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Desactive el software antivirus de terceros."
+msgid "Details"
+msgstr "Detalles"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Desactivar software antivirus de terceros"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "No se pudo iniciar la aplicación. Inténtelo de nuevo o haga clic en «Detalles» para obtener más información"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Si estos pasos no funcionan, envíe un informe de problemas."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Se ha revocado el permiso para el servicio de Mullvad VPN. Vaya a la configuración del sistema y permita a Mullvad VPN bajo el ajuste «Permitir en Segundo Plano»."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Reinstalar la aplicación."
+msgid "Reinstalling the app"
+msgstr "Reinstalar la aplicación"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Reiniciar su equipo."
+msgid "Restarting the Mullvad background process"
+msgstr "Reiniciar el proceso en segundo plano de Mullvad"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Reiniciar el proceso en segundo plano de Mullvad haciendo clic en «Atrás» y luego en «Volver a intentarlo»"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Reiniciar el equipo"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Enviar informe de problemas"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "El componente de servicio del sistema de la aplicación no se ha iniciado o no se puede contactar. El servicio del sistema es responsable de la seguridad, desconexión de seguridad y del túnel de la VPN. Para solucionar el problema, intente lo siguiente:"
+msgid "Starting up...."
+msgstr "Iniciando…"
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "No se puede iniciar el proceso en segundo plano de Mullvad. Este proceso es responsable de la seguridad, la desconexión de seguridad y el túnel VPN. Intente lo siguiente:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Volver a intentarlo"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "No se puede contactar con el servicio del sistema Mullvad. Su conexión podría ser insegura. Solucione el problema o envíe un informe de problemas haciendo clic en el botón «Más información»."
 
 #. This is a warning message shown when the app is blocking the users
@@ -1911,6 +1953,13 @@ msgstr "Los nombres de las listas deben ser únicos."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Este nombre ya se está utilizando."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Ofuscación: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (eliminado)"
 msgid "%s custom port"
 msgstr "Puerto personalizado de %s"
 
+msgid "%s is unavailable"
+msgstr "%s no está disponible"
+
 msgid "%s was added to your account."
 msgstr "%s se ha añadido a su cuenta."
 
@@ -2923,6 +2975,9 @@ msgstr "Deshabilite «%s» abajo para activar estos ajustes."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deshabilite todos los «%s» de arriba para activar este ajuste."
 
+msgid "Disable recents"
+msgstr "Deshabilitar recientes"
+
 msgid "Discard"
 msgstr "Descartar"
 
@@ -2961,6 +3016,9 @@ msgstr "Habilitar %1$s"
 
 msgid "Enable method"
 msgstr "Habilitar método"
+
+msgid "Enable recents"
+msgstr "Habilitar recientes"
 
 msgid "Enter MTU"
 msgstr "Introducir MTU"
@@ -3061,6 +3119,9 @@ msgstr "Asegura que el dispositivo esté siempre activado en el túnel de la VPN
 msgid "Manage devices"
 msgstr "Gestionar dispositivos"
 
+msgid "More actions"
+msgstr "Más acciones"
+
 msgid "Mullvad services unavailable"
 msgstr "Servicios de Mullvad no disponibles"
 
@@ -3087,6 +3148,9 @@ msgstr "No hay conexión a Internet"
 
 msgid "No locations found"
 msgstr "No se ha encontrado ninguna ubicación"
+
+msgid "No recent selection history"
+msgstr "No hay historial de selecciones recientes"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "No hay resultados para «%s», intente una búsqueda diferente"
@@ -3126,6 +3190,12 @@ msgstr "Privacidad"
 
 msgid "Privacy policy"
 msgstr "Política de privacidad"
+
+msgid "Recents"
+msgstr "Recientes"
+
+msgid "Recents disabled and history cleared"
+msgstr "Recientes deshabilitados e historial borrado"
 
 msgid "Recursion limit"
 msgstr "Límite de recursión"
@@ -3229,11 +3299,11 @@ msgstr "Este ya está configurado como actual"
 msgid "Time added"
 msgstr "Tiempo añadido"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Para añadir ubicaciones a una lista, pulse «︙» o mantenga pulsado unos segundos un país, ciudad o servidor."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Para añadir ubicaciones a una lista, pulse el icono de lápiz o mantenga pulsado un país, una ciudad o un servidor."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Para crear una lista personalizada, pulse «︙»"
+msgid "To create a custom list press the \"+\""
+msgstr "Para crear una lista personalizada, pulse «+»"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Para garantizar que tiene la versión más segura e informarle de cualquier problema con la versión actual que está ejecutando, la aplicación realiza verificaciones de versiones automáticamente. Esto envía la versión de la aplicación y la versión del sistema Android a los servidores de Mullvad. Mullvad mantiene contadores del número de versiones de la aplicación y versiones de Android usadas. Los datos nunca se almacenan ni utilizan de forma que puedan identificarle."
@@ -3312,6 +3382,9 @@ msgstr "No hemos podido iniciar el proceso de pago. Asegúrese de tener la últi
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "No hemos podido iniciar el proceso de pago. Inténtelo de nuevo más tarde."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "¡Le damos la bienvenida! Este dispositivo ahora se llama <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "MTU de WireGuard"

--- a/desktop/packages/mullvad-vpn/locales/es/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/es/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 13:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/fi/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/fi/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Finnish\n"
 "Language: fi_FI\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 13:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d lisää..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Asennusohjelma sulkeutui odottamattomasti. Yritä uudelleen tai lähetä ongelmaraportti."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Asennusohjelma ladataan kansioon <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,41 +1399,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Tervetuloa! Tämän laitteen nimi on nyt <b>%(deviceName)s</b>. Katso lisätietoja tilin infopainikkeesta."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Yhdistetään Mullvad-järjestelmäpalveluun..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Poista kolmannen osapuolen virustorjuntaohjelmisto käytöstä."
+msgid "Details"
+msgstr "Tiedot"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Poistaa kolmannen osapuolen virustorjuntaohjelmiston käytöstä"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Sovelluksen käynnistäminen epäonnistui. Yritä uudelleen tai katso lisätietoja napsauttamalla Tiedot-painiketta."
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Jos ongelma ei ratkea näillä ohjeilla, lähetä siitä raportti."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Mullvad VPN -palvelun käyttöoikeus on peruutettu. Siirry järjestelmäasetuksiin sallimaan Mullvad VPN \"Salli taustalla\" -asetuksen kautta."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Asentamalla sovellus uudelleen."
+msgid "Reinstalling the app"
+msgstr "Asentaa sovellus uudelleen"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Käynnistämällä tietokoneesi uudelleen."
+msgid "Restarting the Mullvad background process"
+msgstr "Käynnistää Mullvadin taustaprosessi uudelleen"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Käynnistää Mullvadin taustaprosessi uudelleen napsauttamalla Takaisin ja sen jälkeen Yritä uudelleen"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Käynnistää tietokoneesi uudelleen"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Lähetä ongelmaraportti"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Sovelluksen järjestelmän palvelukomponentti ei ole käynnistynyt tai siihen ei saada yhteyttä. Järjestelmän palvelu vastaa turvallisuudesta, tappokytkimestä ja VPN-tunnelista. Yritä paikantaa vika:"
+msgid "Starting up...."
+msgstr "Käynnistetään...."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvadin taustaprosessin käynnistäminen epäonnistui. Taustaprosessi vastaa turvallisuudesta, tappokytkimestä ja VPN-tunnelista. Kokeile:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Yritä uudelleen"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "Mullvad-järjestelmäpalveluun ei saada yhteyttä, eikä yhteytesi välttämättä ole turvallinen. Suorita vianetsintä tai lähetä ongelmaraportti napsauttamalla lisätietojen painiketta."
 
 #. This is a warning message shown when the app is blocking the users
@@ -1911,6 +1953,13 @@ msgstr "Luettelon nimen tulee olla ainutlaatuinen."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Nimi on jo olemassa."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Hämäys: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (poistettu)"
 msgid "%s custom port"
 msgstr "Mukautettu %s-portti"
 
+msgid "%s is unavailable"
+msgstr "%s ei ole käytettävissä"
+
 msgid "%s was added to your account."
 msgstr "%s lisättiin tilillesi."
 
@@ -2923,6 +2975,9 @@ msgstr "Ota nämä asetukset käyttöön poistamalla \"%s\" käytöstä alta."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Ota tämä asetus käyttöön poistamalla kaikki %s käytöstä yllä."
 
+msgid "Disable recents"
+msgstr "Poista viimeisimmät käytöstä"
+
 msgid "Discard"
 msgstr "Hylkää"
 
@@ -2961,6 +3016,9 @@ msgstr "Ota %1$s käyttöön"
 
 msgid "Enable method"
 msgstr "Ota menetelmä käyttöön"
+
+msgid "Enable recents"
+msgstr "Ota viimeisimmät käyttöön"
 
 msgid "Enter MTU"
 msgstr "Syötä MTU"
@@ -3061,6 +3119,9 @@ msgstr "Varmistaa, että laite on aina yhteydessä VPN-tunnelin kautta."
 msgid "Manage devices"
 msgstr "Hallitse laitteita"
 
+msgid "More actions"
+msgstr "Lisää toimintoja"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad-palvelut eivät ole käytettävissä"
 
@@ -3087,6 +3148,9 @@ msgstr "Ei verkkoyhteyttä"
 
 msgid "No locations found"
 msgstr "Sijainteja ei löytynyt"
+
+msgid "No recent selection history"
+msgstr "Ei viimeisimpien valintojen historiaa"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Haulle \"%s\" ei löytynyt tuloksia. Kokeile toista hakua."
@@ -3126,6 +3190,12 @@ msgstr "Tietosuoja"
 
 msgid "Privacy policy"
 msgstr "Tietosuojakäytäntö"
+
+msgid "Recents"
+msgstr "Viimeisimmät"
+
+msgid "Recents disabled and history cleared"
+msgstr "Viimeisimmät on poistettu käytöstä ja historia on tyhjennetty"
 
 msgid "Recursion limit"
 msgstr "Toistorajoitus"
@@ -3229,11 +3299,11 @@ msgstr "Tämä on jo asetettu nykyiseksi"
 msgid "Time added"
 msgstr "Käyttöaikaa lisätty"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Jos haluat lisätä luetteloon sijainteja, paina \"︙\" tai paina pitkään maata, kaupunkia tai palvelinta."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Jos haluat lisätä luetteloon sijainteja, paina kynää tai paina pitkään maata, kaupunkia tai palvelinta."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Voit luoda mukautetun luettelon painamalla \"︙\""
+msgid "To create a custom list press the \"+\""
+msgstr "Voit luoda mukautetun luettelon painamalla \"+\""
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Sovellus suorittaa versiotarkistuksia automaattisesti varmistaakseen, että käytät kaikkein turvallisinta versiota, ja ilmoittaakseen sinulle kaikista parhaillaan käynnissä olevan version ongelmista. Se lähettää Mullvadin palvelimille tiedot sovellusversiosta ja Android-järjestelmäversiosta. Mullvad pitää lukua käytettyjen sovellusversioiden ja Android-versioiden määristä. Tietoja ei koskaan tallenneta tai käytetä tavalla, joka voisi mahdollistaa tunnistamisesi."
@@ -3312,6 +3382,9 @@ msgstr "Emme pystyneet aloittamaan maksun käsittelyä. Varmista, että käytät
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Emme pystyneet aloittamaan maksun käsittelyä. Yritä myöhemmin uudelleen."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Tervetuloa! Tämän laitteen nimi on nyt <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/fi/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/fi/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Finnish\n"
 "Language: fi_FI\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 13:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/fr/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/fr/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d de plus..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "L'installateur s'est arrêté de manière inattendue. Veuillez réessayer ou envoyer un rapport de problème."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "L'installateur sera téléchargé dans <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,42 +1399,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Bienvenue, cet appareil s'appelle désormais <b>%(deviceName)s</b>. Pour plus d'informations, consultez le bouton d'information sous Compte."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Connexion au service système Mullvad..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Désactiver les logiciels antivirus tiers."
+msgid "Details"
+msgstr "Détails"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Désactivation des logiciels antivirus tiers"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Échec du démarrage de l'application. Veuillez réessayer ou cliquer sur « Détails » pour obtenir plus d'informations"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Si ces étapes ne fonctionnent pas, veuillez envoyer un rapport de problème."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "L'autorisation du service Mullvad VPN a été révoquée. Merci de vous rendre dans les paramètres système et d'autoriser le service Mullvad VPN sous le paramètre « Autoriser en arrière-plan »."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Réinstaller l'application."
+msgid "Reinstalling the app"
+msgstr "Réinstaller l'application"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Redémarrer votre ordinateur."
+msgid "Restarting the Mullvad background process"
+msgstr "Redémarrage du processus Mullvad en arrière-plan"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Redémarrez le processus Mullvad en arrière-plan en cliquant sur « Retour », puis sur « Réessayer »"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Redémarrer votre ordinateur"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Envoyer un rapport de problème"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Le service système de l'application n'a pas démarré ou ne peut pas être contacté. Le service système est responsable de la sécurité, du coupe-circuit et du tunnel VPN. Pour résoudre le problème, veuillez essayer de :"
+msgid "Starting up...."
+msgstr "Démarrage…"
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Impossible de contacter le service système Mullvad, votre connexion n'est peut-être pas sécurisée. Merci de résoudre le problème ou d'envoyer un rapport de problème en cliquant sur le bouton En savoir plus."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Le démarrage du processus Mullvad en arrière-plan a échoué. Le processus en arrière-plan est responsable de la sécurité, du coupe-circuit et du tunnel VPN. Veuillez essayer :"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Réessayer"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Impossible de contacter le service système Mullvad, votre connexion n'est peut-être pas sécurisée. Merci de résoudre le problème ou d'envoyer un rapport de problème en cliquant sur le bouton « En savoir plus »."
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1911,6 +1953,13 @@ msgstr "Les noms de listes doivent être uniques."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Le nom est déjà pris."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Dissimulation : %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (supprimé)"
 msgid "%s custom port"
 msgstr "Port %s personnalisé"
 
+msgid "%s is unavailable"
+msgstr "%s est indisponible"
+
 msgid "%s was added to your account."
 msgstr "%s a été ajouté à votre compte."
 
@@ -2923,6 +2975,9 @@ msgstr "Désactivez « %s » ci-dessous pour activer ces paramètres."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Désactivez tous les « %s » ci-dessus pour activer ce paramètre."
 
+msgid "Disable recents"
+msgstr "Désactiver les récents"
+
 msgid "Discard"
 msgstr "Annuler"
 
@@ -2961,6 +3016,9 @@ msgstr "Activer %1$s"
 
 msgid "Enable method"
 msgstr "Activer la méthode"
+
+msgid "Enable recents"
+msgstr "Activer les récents"
 
 msgid "Enter MTU"
 msgstr "Saisir le MTU"
@@ -3061,6 +3119,9 @@ msgstr "Permet de s'assurer que l'appareil est toujours sur le tunnel VPN."
 msgid "Manage devices"
 msgstr "Gérer les appareils"
 
+msgid "More actions"
+msgstr "Plus d'actions"
+
 msgid "Mullvad services unavailable"
 msgstr "Services Mullvad indisponibles"
 
@@ -3087,6 +3148,9 @@ msgstr "Aucune connexion à Internet"
 
 msgid "No locations found"
 msgstr "Aucune localisation trouvée"
+
+msgid "No recent selection history"
+msgstr "Aucun historique des sélections récentes"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Aucun résultat pour « %s ». Veuillez essayer une autre recherche"
@@ -3126,6 +3190,12 @@ msgstr "Confidentialité"
 
 msgid "Privacy policy"
 msgstr "Politique de confidentialité"
+
+msgid "Recents"
+msgstr "Récents"
+
+msgid "Recents disabled and history cleared"
+msgstr "Récents désactivés et historique effacé"
 
 msgid "Recursion limit"
 msgstr "Limite de récursion"
@@ -3229,11 +3299,11 @@ msgstr "Déjà définie comme méthode actuelle"
 msgid "Time added"
 msgstr "Temps ajouté"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Pour ajouter des localisations à une liste, appuyez sur la touche « ︙ » ou appuyez longuement sur un pays, une ville ou un serveur."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Pour ajouter des localisations à une liste, appuyez sur le stylo ou appuyez longuement sur un pays, une ville ou un serveur."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Appuyez sur « ︙ » pour créer une liste personnalisée"
+msgid "To create a custom list press the \"+\""
+msgstr "Appuyez sur « + » pour créer une liste personnalisée"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Pour vous assurer que vous disposez de la version la plus sécurisée et pour vous informer de tout problème lié à la version en cours d'exécution, l'application effectue automatiquement des vérifications de version. Elle envoie ainsi la version de l'application et la version du système Android aux serveurs de Mullvad. Mullvad tient des compteurs sur le nombre de versions d'applications et de versions d'Android utilisées. Les données ne sont jamais stockées ou utilisées de manière à vous identifier."
@@ -3312,6 +3382,9 @@ msgstr "Nous n'avons pas pu lancer le processus de paiement, merci de vérifier 
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Nous n'avons pas pu lancer le processus de paiement, merci de réessayer plus tard."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Bienvenue, cet appareil est maintenant appelé <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "MTU WireGuard"

--- a/desktop/packages/mullvad-vpn/locales/fr/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/fr/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/it/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/it/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Italian\n"
 "Language: it_IT\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "Altri %(amount)d..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Il programma di installazione si è chiuso inaspettatamente. Riprova o invia una segnalazione del problema."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Il programma di installazione verrà scaricato in <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,42 +1399,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Benvenuto, questo dispositivo ora si chiama <b>%(deviceName)s</b>. Per maggiori dettagli, premi il pulsante delle informazioni in Account."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Connessione al servizio del sistema Mullvad..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Disabilita software antivirus di terze parti."
+msgid "Details"
+msgstr "Dettagli"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Disabilitare software antivirus di terze parti"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Impossibile avviare l'app, riprova o clicca su \"Dettagli\" per maggiori informazioni"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Se questi passaggi non funzionano, invia una segnalazione del problema."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "L'autorizzazione per il servizio VPN Mullvad è stata revocata. Vai a Impostazioni di sistema e autorizza Mullvad VPN sotto l'impostazione \"Consenti in background\"."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Reinstallazione dell'app."
+msgid "Reinstalling the app"
+msgstr "Reinstallare l'app"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Riavvio del computer."
+msgid "Restarting the Mullvad background process"
+msgstr "Riavvio del processo in background di Mullvad"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Riavviare il processo in background di Mullvad cliccando su \"Indietro\", quindi su \"Riprova\""
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Riavviare il computer"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Invia segnalazione problema"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Il componente del servizio di sistema dell'app non è stato avviato o non può essere contattato. Il servizio di sistema è responsabile della sicurezza, del kill switch e del tunnel VPN. Per risolvere il problema, prova:"
+msgid "Starting up...."
+msgstr "Avvio..."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Impossibile contattare il servizio di sistema Mullvad, la connessione potrebbe non essere sicura. Risolvi il problema o invia una segnalazione del problema cliccando sul pulsante Scopri di più."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Impossibile avviare il processo in background di Mullvad. Il processo in background è responsabile della sicurezza, del kill switch e del tunnel VPN. Prova a:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Riprova"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Impossibile contattare il servizio di sistema Mullvad, la connessione potrebbe non essere sicura. Risolvi il problema o invia una segnalazione del problema cliccando sul pulsante \"Scopri di più\"."
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1911,6 +1953,13 @@ msgstr "I nomi degli elenchi devono essere univoci."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Il nome è già preso."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Offuscamento: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (rimosso)"
 msgid "%s custom port"
 msgstr "Porta personalizzata %s"
 
+msgid "%s is unavailable"
+msgstr "%s non disponibile"
+
 msgid "%s was added to your account."
 msgstr "%s aggiunto al tuo account."
 
@@ -2923,6 +2975,9 @@ msgstr "Disabilita \"%s\" di seguito per attivare queste impostazioni."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Disabilita tutti i \"%s\" sopra per attivare questa impostazione."
 
+msgid "Disable recents"
+msgstr "Disabilita recenti"
+
 msgid "Discard"
 msgstr "Ignora modifiche"
 
@@ -2961,6 +3016,9 @@ msgstr "Abilita %1$s"
 
 msgid "Enable method"
 msgstr "Abilita metodo"
+
+msgid "Enable recents"
+msgstr "Abilita recenti"
 
 msgid "Enter MTU"
 msgstr "Inserisci MTU"
@@ -3061,6 +3119,9 @@ msgstr "Assicurati che il dispositivo sia sempre collegato al tunnel VPN."
 msgid "Manage devices"
 msgstr "Gestisci dispositivi"
 
+msgid "More actions"
+msgstr "Più azioni"
+
 msgid "Mullvad services unavailable"
 msgstr "Servizi Mullvad non disponibili"
 
@@ -3087,6 +3148,9 @@ msgstr "Nessuna connessione Internet"
 
 msgid "No locations found"
 msgstr "Nessuna posizione trovata"
+
+msgid "No recent selection history"
+msgstr "Nessuna cronologia di selezioni recente"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Nessun risultato per \"%s\", prova una ricerca diversa"
@@ -3126,6 +3190,12 @@ msgstr "Privacy"
 
 msgid "Privacy policy"
 msgstr "Informativa sulla privacy"
+
+msgid "Recents"
+msgstr "Recenti"
+
+msgid "Recents disabled and history cleared"
+msgstr "Recenti disabilitati e cronologia cancellata"
 
 msgid "Recursion limit"
 msgstr "Limite di ricorsione"
@@ -3229,11 +3299,11 @@ msgstr "È già impostato come attuale"
 msgid "Time added"
 msgstr "Tempo aggiunto"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Per aggiungere posizioni a un elenco, premi \"︙\" o tieni premuto su un Paese, una città o un server."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Per aggiungere posizioni a un elenco, premi il simbolo della penna o tieni premuto su un Paese, una città o un server."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Per creare un elenco personalizzato, premi \"︙\""
+msgid "To create a custom list press the \"+\""
+msgstr "Per creare un elenco personalizzato, premi \"+\""
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Per assicurarti di avere la versione più sicura e per informarti di eventuali problemi con la versione attualmente in esecuzione, l'app esegue automaticamente i controlli di versione. Questa operazione invia la versione dell'app e la versione del sistema Android ai server Mullvad. Mullvad mantiene traccia dei numeri di versione dell'app utilizzati e delle versioni di Android. I dati non vengono mai archiviati o utilizzati in alcun modo che possa identificarti."
@@ -3312,6 +3382,9 @@ msgstr "Non siamo riusciti ad avviare il processo di pagamento, assicurati di av
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Non siamo riusciti ad avviare il processo di pagamento, riprova più tardi."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Ti diamo il benvenuto, questo dispositivo ora si chiama <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "MTU WireGuard"

--- a/desktop/packages/mullvad-vpn/locales/it/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/it/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Italian\n"
 "Language: it_IT\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ja/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ja/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "その他%(amount)d件..."
@@ -753,6 +753,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "インストーラーが予期せず終了しました。再試行するか、問題の報告を送信してください。"
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "インストーラーは <b>%(cacheDir)s</b> にダウンロードされます。"
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1389,42 +1393,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "ようこそ。このデバイスの名前は<b>%(deviceName)s</b>です。詳細はアカウントの情報ボタンで確認してください。"
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Mullvad システムサービスに接続中..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "サードパーティのウイルス対策ソフトウェアを無効にしてください。"
+msgid "Details"
+msgstr "詳細"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "サードパーティのウイルス対策ソフトウェアを無効にする"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "アプリを起動できませんでした。再試行するか、[詳細] をクリックして詳細情報を確認してください"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "これらの手順で解決できない場合は、問題の報告を送信してください。"
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Mullvad VPNサービスの許可が無効化されました。システム設定に移動して、「バックグラウンドでの実行を許可」設定でMullvad VPNを許可してください。"
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "アプリを再インストールする。"
+msgid "Reinstalling the app"
+msgstr "アプリを再インストールする"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "コンピューターを再起動する。"
+msgid "Restarting the Mullvad background process"
+msgstr "Mullvadのバックグラウンドプロセスを再起動する"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "[戻る] と [再試行] を続けてクリックし、Mullvadのバックグラウンドプロセスを再起動する"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "コンピューターを再起動する"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "問題の報告を送信"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "アプリのシステムサービスコンポーネントが起動していないか、通信不可能です。システムサービスはセキュリティ、キルスイッチ、およびVPNトンネルを管理しています。次の方法でトラブルシューティングしてください。"
+msgid "Starting up...."
+msgstr "起動中...."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Mullvadシステムサービスと通信できません。接続が安全でない可能性があります。トラブルシューティングするか、「詳細」ボタンをクリックして問題の報告を送信してください。"
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvadのバックグラウンドプロセスを起動できませんでした。バックグラウンドプロセスはセキュリティ、キルスイッチ、およびVPNトンネルを管理しています。以下をお試しください。"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "再試行"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Mullvadシステムサービスと通信できません。接続が安全でない可能性があります。トラブルシューティングするか、[詳細] ボタンをクリックして問題の報告を送信してください。"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1905,6 +1947,13 @@ msgstr "リスト名は一意である必要があります。"
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "名前はすでに使用されています。"
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "難読化: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2749,6 +2798,9 @@ msgstr "%s (削除済み)"
 msgid "%s custom port"
 msgstr "%sカスタムポート"
 
+msgid "%s is unavailable"
+msgstr "%sは使用できません"
+
 msgid "%s was added to your account."
 msgstr "ご利用のアカウントに %s が追加されました。"
 
@@ -2917,6 +2969,9 @@ msgstr "これらの設定を有効にするには、下の [%s] を無効にし
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "この設定を有効にするには、上の [%s] をすべて無効にしてください。"
 
+msgid "Disable recents"
+msgstr "最近の項目を無効化"
+
 msgid "Discard"
 msgstr "破棄"
 
@@ -2955,6 +3010,9 @@ msgstr "%1$sを有効にする"
 
 msgid "Enable method"
 msgstr "方法を有効化する"
+
+msgid "Enable recents"
+msgstr "最近の項目を有効化"
 
 msgid "Enter MTU"
 msgstr "MTU を入力"
@@ -3055,6 +3113,9 @@ msgstr "デバイスが必ずVPNトンネルを使用するようにします。
 msgid "Manage devices"
 msgstr "デバイスを管理する"
 
+msgid "More actions"
+msgstr "その他の操作"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvadサービスを使用できません"
 
@@ -3081,6 +3142,9 @@ msgstr "インターネット接続がありません"
 
 msgid "No locations found"
 msgstr "場所が見つかりませんでした"
+
+msgid "No recent selection history"
+msgstr "最近の選択履歴はありません"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "「%s」の結果はありません。別の検索をお試しください。"
@@ -3120,6 +3184,12 @@ msgstr "プライバシー"
 
 msgid "Privacy policy"
 msgstr "プライバシーポリシー"
+
+msgid "Recents"
+msgstr "最近の項目"
+
+msgid "Recents disabled and history cleared"
+msgstr "最近の項目を無効化し、履歴を消去しました"
 
 msgid "Recursion limit"
 msgstr "繰り返しの制限"
@@ -3223,11 +3293,11 @@ msgstr "これはすでに現在の設定として設定されています"
 msgid "Time added"
 msgstr "時間が追加されました"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "リストに場所を追加するには、\"︙\" を押すか、または、国、都市、サーバーを長押ししてください。"
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "リストに場所を追加するには鉛筆アイコンをタップするか、国、都市、サーバーを長押ししてください。"
 
-msgid "To create a custom list press the \"︙\""
-msgstr "カスタムリストを作成するには、\"︙\" を押してください"
+msgid "To create a custom list press the \"+\""
+msgstr "カスタムリストを作成するには [+] を押してください"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "このアプリは最も安全なバージョンを使用していることを確認し、実行中の現在のバージョンに関する問題を通知できるよう、バージョンチェックを自動的に実行します。このチェックによってアプリのバージョンとAndroidシステムのバージョンがMullvadサーバーに送信されます。Mullvadは使用されているアプリのバージョンとAndroidのバージョンの数字を記憶しています。このデータがユーザーを特定できる方法で保存されたり、使用されたりすることはありません。"
@@ -3306,6 +3376,9 @@ msgstr "決済処理を開始できませんでした。最新バージョンの
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "決済処理を開始できませんでした。後でもう一度お試しください。"
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "ようこそ。このデバイス名は<b>%s</b>です。"
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/ja/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ja/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ko/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ko/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Korean\n"
 "Language: ko_KR\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d개 더 보기..."
@@ -753,6 +753,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "설치 프로그램이 예기치 않게 종료되었습니다. 다시 시도하거나 문제 보고서를 전송하세요."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "설치 프로그램은 <b>%(cacheDir)s</b>에 다운로드됩니다."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1389,42 +1393,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "환영합니다! 이제 이 장치의 이름은 <b>%(deviceName)s</b>입니다. 자세한 내용을 보려면 계정의 정보 버튼을 누르세요."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Mullvad 시스템 서비스에 연결하는 중..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "타사 안티바이러스 소프트웨어를 비활성화합니다."
+msgid "Details"
+msgstr "세부 정보"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "타사 안티바이러스 소프트웨어를 비활성화합니다"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "앱을 시작하지 못했습니다. 다시 시도하거나 \"세부 정보\"를 클릭해 자세한 정보를 확인하세요"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "이러한 단계로 문제가 해결되지 않으면 문제 보고서를 보내주세요."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Mullvad VPN 서비스에 대한 권한이 취소되었습니다. 시스템 설정으로 이동한 다음, \"백그라운드에서 허용\" 설정에서 Mullvad VPN을 허용하세요."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "앱을 다시 설치합니다."
+msgid "Reinstalling the app"
+msgstr "앱을 다시 설치합니다"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "컴퓨터를 다시 시작합니다."
+msgid "Restarting the Mullvad background process"
+msgstr "Mullvad 백그라운드 프로세스를 다시 시작합니다"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "\"뒤로\", \"다시 시도\"를 차례로 클릭하여 Mullvad 백그라운드 프로세스를 다시 시작합니다"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "컴퓨터를 다시 시작합니다"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "문제 보고서 보내기"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "앱의 시스템 서비스 구성요소가 시작되지 않았거나 연결할 수 없습니다. 시스템 서비스는 보안, 킬 스위치 및 VPN 터널을 담당합니다. 문제를 해결하려면 다음과 같이 해보세요."
+msgid "Starting up...."
+msgstr "시작하는 중...."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Mullvad 시스템 서비스에 연결할 수 없습니다. 연결이 안전하지 않을 수 있습니다. '자세히 알아보기' 버튼을 클릭하여 문제를 해결하거나 문제 보고서를 보내주세요."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvad 백그라운드 프로세스를 시작하지 못했습니다. 해당 백그라운드 프로세스는 보안, 킬 스위치, VPN 터널을 담당합니다. 다음을 시도해 보세요:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "다시 시도"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Mullvad 시스템 서비스에 연결할 수 없습니다. 연결이 안전하지 않을 수 있습니다. \"자세히 알아보기\" 버튼을 클릭하여 문제를 해결하거나 문제 보고서를 보내주세요."
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1905,6 +1947,13 @@ msgstr "목록 이름은 고유해야 합니다."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "이미 사용 중인 이름입니다."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "난독 처리: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2749,6 +2798,9 @@ msgstr "%s(제거됨)"
 msgid "%s custom port"
 msgstr "%s 사용자 지정 포트"
 
+msgid "%s is unavailable"
+msgstr "%s 사용 불가"
+
 msgid "%s was added to your account."
 msgstr "%s이(가) 계정에 추가되었습니다."
 
@@ -2917,6 +2969,9 @@ msgstr "이 설정을 활성화하려면 아래의 \"%s\"를 비활성화하세�
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "이 설정을 활성화하려면 위의 모든 \"%s\"를 비활성화하세요."
 
+msgid "Disable recents"
+msgstr "최근 항목 비활성화"
+
 msgid "Discard"
 msgstr "취소"
 
@@ -2955,6 +3010,9 @@ msgstr "%1$s 활성화"
 
 msgid "Enable method"
 msgstr "방법 활성화"
+
+msgid "Enable recents"
+msgstr "최근 항목 활성화"
 
 msgid "Enter MTU"
 msgstr "MTU 입력"
@@ -3055,6 +3113,9 @@ msgstr "장치가 항상 VPN 터널에 있어야 합니다."
 msgid "Manage devices"
 msgstr "장치 관리"
 
+msgid "More actions"
+msgstr "추가 작업"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad 서비스 사용 불가"
 
@@ -3081,6 +3142,9 @@ msgstr "인터넷에 연결되지 않음"
 
 msgid "No locations found"
 msgstr "위치를 찾을 수 없음"
+
+msgid "No recent selection history"
+msgstr "최근 선택 내역이 없습니다"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "\"%s\" 검색 결과가 없습니다. 다른 검색어를 시도하세요"
@@ -3120,6 +3184,12 @@ msgstr "개인 정보 보호"
 
 msgid "Privacy policy"
 msgstr "개인정보 보호정책"
+
+msgid "Recents"
+msgstr "최근 항목"
+
+msgid "Recents disabled and history cleared"
+msgstr "최근 항목이 비활성화되고 내역이 삭제되었습니다"
 
 msgid "Recursion limit"
 msgstr "반복 제한"
@@ -3223,11 +3293,11 @@ msgstr "이미 현재로 설정되어 있습니다"
 msgid "Time added"
 msgstr "시간 추가됨"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "목록에 위치를 추가하려면 \"︙\"를 누르거나 국가, 도시 또는 서버를 길게 누릅니다."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "목록에 위치를 추가하려면 펜을 누르거나 국가, 도시 또는 서버를 길게 누릅니다."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "사용자 지정 목록을 생성하려면 \"︙\"를 누릅니다"
+msgid "To create a custom list press the \"+\""
+msgstr "사용자 지정 목록을 생성하려면 \"+\"를 누릅니다"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "가장 안전한 버전인지 확인하고 현재 실행 중인 버전에 문제가 있으면 알려드리기 위해 앱에서 자동으로 버전 확인을 수행합니다. 그러면 앱 버전과 Android 시스템 버전이 Mullvad 서버로 전송됩니다. Mullvad는 사용된 앱 버전 및 Android 버전 수에 대한 카운터를 유지합니다. 이 데이터는 귀하를 식별할 수 있는 어떤 방식으로도 저장되거나 사용되지 않습니다."
@@ -3306,6 +3376,9 @@ msgstr "결제 프로세스를 시작할 수 없습니다. Google Play가 최신
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "결제 프로세스를 시작할 수 없습니다. 나중에 다시 시도해 주세요."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "환영합니다. 이 장치의 호칭은 이제 <b>%s</b>입니다."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/ko/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ko/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Korean\n"
 "Language: ko_KR\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/my/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/my/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Burmese\n"
 "Language: my_MM\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "နောက်ထပ် %(amount)d လုံး..."
@@ -753,6 +753,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "ထည့်သွင်းမှုဆော့ဖ်ဝဲမှ မမျှော်လင့်ဘဲ ရုတ်တရက် ထွက်သွားသည်၊ ထပ်ကြိုးစားကြည့်ပါ သို့မဟုတ် ပြဿနာ ရီပို့တ်တစ်ခုကို ပေးပို့ပေးပါ။"
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "ထည့်သွင်းမှုဆော့ဖ်ဝဲကို <b>%(cacheDir)s</b> သို့ ဒေါင်းလုဒ်လုပ်မည်။"
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1389,42 +1393,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "ကြိုဆိုပါသည်၊ ယခုမှစ၍ ဤစက်ကို <b>%(deviceName)s</b> ဟု ခေါ်ဆိုပါမည်။ နောက်ထပ်အသေးစိတ်တို့အတွက် အကောင့်တွင် အချက်အလက် ခလုတ်ကို နှိပ်၍ ကြည့်နိုင်သည်။"
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Mullvad စနစ် ဝန်ဆောင်မှုနှင့် ချိတ်ဆက်နေဆဲ..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "ပြင်ပအဖွဲ့အစည်း ဗိုင်းရပ်စ် ကာကွယ်ရေး ဆော့ဖ်ဝဲကို ပိတ်ပါ။"
+msgid "Details"
+msgstr "အသေးစိတ်"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr " ပြင်ပအဖွဲ့အစည်း ဗိုင်းရပ်စ် ကာကွယ်ရေး ဆော့ဖ်ဝဲကို ပိတ်ခြင်း"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "အက်ပ်ကို စတင်၍ မရပါ၊ ထပ်ကြိုးစားကြည့်ပါ သို့မဟုတ် နောက်ထပ်အချက်အလက်များအတွက် “အသေးစိတ်များ” ကိုနှိပ်ပါ"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "ဤအဆင့်များ အလုပ်မဖြစ်ပါက ပြဿနာ ရီပို့တ်ကို ပေးပို့ကြည့်ပါ။"
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Mullvad VPN ဝန်ဆောင်မှုအတွက် ခွင့်ပြုချက်ကို ရုပ်သိမ်းထားပါသည်။ System Settings သို့ သွားပြီး “Allow in the Background” ဆက်တင်အောက်တွင် Mullvad VPN ကို ခွင့်ပြုပါ။"
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "အက်ပ်ကို ပြန်လည် ထည့်သွင်းနေပါသည်။"
+msgid "Reinstalling the app"
+msgstr "အက်ပ်ကို ပြန်လည် ထည့်သွင်းနေပါသည်"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "သင်ကွန်ပျူတာကို ပြန်လည်စတင်နေပါသည်။"
+msgid "Restarting the Mullvad background process"
+msgstr "Mullvad နောက်ခံလုပ်ငန်းစဉ်ကို ပြန်လည်စတင်ခြင်း"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "\"နောက်သို့\"၊ ထို့နောက်\"ထပ်ကြိုးစားရန်\"ကို နှိပ်ခြင်းဖြင့် Mullvad နောက်ခံလုပ်ငန်းစဉ်ကို ပြန်လည်စတင်ခြင်း"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "သင်ကွန်ပျူတာကို ပြန်လည်စတင်နေခြင်း"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "ပြဿနာ ရီပို့တ် ပေးပို့ရန်"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "အက်ပ်၏ စနစ်ဝန်ဆောင်မှု အစိတ်အပိုင်းကို စတင် မလုပ်ဆောင်ထားပါ သို့မဟုတ် မဆက်သွယ်နိုင်ပါ။ စနစ်ဝန်ဆောင်မှုသည် လုံခြုံရေး၊ Kill Switch နှင့် VPN Tunnel တို့ အတွက် တာဝန်ရှိပါသည်။ ပြစ်ချက်ရှာဖွေ ဖယ်ရှားရန် ဤအရာများကို ကြိုးစားကြည့်ပါ-"
+msgid "Starting up...."
+msgstr "စက် စတင်နေသည်...."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Mullvad စနစ် ဝန်ဆောင်မှုကို ဆက်သွယ်၍ မရနိုင်ပါ၊ သင့်ချိတ်ဆက်မှုသည် မလုံခြုံနိုင်ပါ။ နောက်ထပ် လေ့လာရန် ခလုတ်ကို နှိပ်ခြင်းဖြင့် ပြဿနာ ရီပို့တ်ကို ပေးပို့ပါ သို့မဟုတ် ပြစ်ချက် ရှာဖွေ ဖယ်ရှားပါ။"
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvad နောက်ခံလုပ်ငန်းစဉ်ကို စတင်၍ မရပါ။ နောက်ခံလုပ်ငန်းစဉ်က လုံခြုံရေး၊ kill switch နှင့် VPN tunnel ကို စီမံထိန်းချုပ်ပါသည်။ ဤသည်ကို လုပ်ကြည့်ပါ-"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "ထပ်ကြိုးစားရန်"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Mullvad စနစ် ဝန်ဆောင်မှုကို ဆက်သွယ်၍ မရနိုင်သဖြင့် သင့်ချိတ်ဆက်မှုသည် လုံခြုံမှု မရှိနိုင်ပါ။ ပြစ်ချက် ရှာဖွေ ဖယ်ရှားကြည့်ပါ သို့မဟုတ် \"နောက်ထပ် လေ့လာရန်\" ခလုတ်ကို နှိပ်ခြင်း၍ ပြဿနာ ရီပို့တ်ကို ပေးပို့ပါ။"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1905,6 +1947,13 @@ msgstr "စာရင်းအမည်များသည် တမူထူး�
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "အမည်သည် ရှိနှင့်ပြီး ဖြစ်သည်။"
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Obfuscation - %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2749,6 +2798,9 @@ msgstr "%s (ဖယ်ရှားထား)"
 msgid "%s custom port"
 msgstr "%s စိတ်ကြိုက်ပေါ့တ်"
 
+msgid "%s is unavailable"
+msgstr "%s ကို မရရှိနိုင်ပါ"
+
 msgid "%s was added to your account."
 msgstr "%s ကို သင့်အကောင့်တွင် ထည့်လိုက်ပြီ။"
 
@@ -2917,6 +2969,9 @@ msgstr "ဤဆက်တင်များကို ဖွင့်ရန် အ�
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "ဤဆက်တင်ကိုဖွင့်ရန် အထက်ရှိ \"%s\" အားလုံးကို ပိတ်ပါ။"
 
+msgid "Disable recents"
+msgstr "လတ်တလောအရာများကို ပိတ်ပါ"
+
 msgid "Discard"
 msgstr "ပယ်ဖျက်မည်"
 
@@ -2955,6 +3010,9 @@ msgstr "%1$s ကို ဖွင့်ရန်"
 
 msgid "Enable method"
 msgstr "နည်းလမ်းကို ဖွင့်ရန်"
+
+msgid "Enable recents"
+msgstr "လတ်တလောအရာများကို ဖွင့်ရန်"
 
 msgid "Enter MTU"
 msgstr "MTU ကို ရိုက်ထည့်ရန်"
@@ -3055,6 +3113,9 @@ msgstr "စက်သည် VPN Tunnel ကို အမြဲဖွင့်ထ�
 msgid "Manage devices"
 msgstr "စက်များကို စီမံရန်"
 
+msgid "More actions"
+msgstr "နောက်ထပ်လုပ်ဆောင်ချက်များ"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad ဝန်ဆောင်မှုများကို မရရှိနိုင်ပါ"
 
@@ -3081,6 +3142,9 @@ msgstr "အင်တာနက် ချိတ်ဆက်မှု မရှိ�
 
 msgid "No locations found"
 msgstr "တည်နေရာများကို ရှာမတွေ့ပါ"
+
+msgid "No recent selection history"
+msgstr "လတ်တလောရွေးချယ်မှု မှတ်တမ်း မရှိပါ"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "\"%s\" အတွက် ရလဒ်မရှိပါ၊ အခြားရှာဖွေမှုတစ်ခုကို စမ်းလုပ်ကြည့်ပါ"
@@ -3120,6 +3184,12 @@ msgstr "ကိုယ်ရေးအချက်အလက် လုံခြု�
 
 msgid "Privacy policy"
 msgstr "ကိုယ်ပိုင်အချက်အလက် မူဝါဒ"
+
+msgid "Recents"
+msgstr "လတ်တလောအရာများ"
+
+msgid "Recents disabled and history cleared"
+msgstr "လတ်တလောအရာများကို ပိတ်ထားပြီး မှတ်တမ်းကို ရှင်းထားသည်"
 
 msgid "Recursion limit"
 msgstr "ထပ်တလဲလဲ လုပ်ဆောင်မှု ကန့်သတ်ချက်"
@@ -3223,11 +3293,11 @@ msgstr "၎င်းကို လက်ရှိအဖြစ် သတ်မှ�
 msgid "Time added"
 msgstr "အချိန်တိုးထားသည်"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "စာရင်းထဲသို့ တည်နေရာများကို ပေါင်းထည့်ရန် \"︙\" ကို နှိပ်ပါ သို့မဟုတ် နိုင်ငံ၊ မြို့၊ ဆာဗာကို နှိပ်ပါ။"
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "တည်နေရာများကို စာရင်းတစ်ခုတွင် ထည့်ရန် ဘောပင်ပုံကို နှိပ်ပါ သို့မဟုတ် နိုင်ငံ၊ မြို့ သို့မဟုတ် ဆာဗာပေါ်တွင် ကြာကြာနှိပ်ပါ။"
 
-msgid "To create a custom list press the \"︙\""
-msgstr "စိတ်ကြိုက် စာရင်းများကို ဖန်တီးရန် \"︙\" ကို နှိပ်ပါ"
+msgid "To create a custom list press the \"+\""
+msgstr "စိတ်ကြိုက်စာရင်းတစ်ခု ဖန်တီးရန် \"+\" ကိုနှိပ်ပါ"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "အလုံခြုံဆုံး ဗားရှင်းကို ရရှိကြောင်း သေချာစေရန်နှင့် လုပ်ဆောင်နေသည့် လက်ရှိဗားရှင်းနှင့်ပတ်သက်သော ပြဿနာများအကြောင်း သင့်အား အသိပေးရန် အက်ပ်သည် ဗားရှင်း စစ်ဆေးမှုများကို အော်တိုလုပ်ဆောင်ပါသည်။ ၎င်းသည် Mullvad ဆာဗာများသို့ အက်ပ် ဗားရှင်းနှင့် Android စနစ်ဗားရှင်းတို့ကို ပေးပို့ပါသည်။ အသုံးပြုထားသည့် အက်ပ် ဗားရှင်းများနှင့် Android ဗားရှင်းများ၏ အရေအတွက်ကို Mullvad က ရေတွက်ထားပါသည်။ ဒေတာကို မည်သည့်အခါမျှ မသိမ်းဆည်းထားပါ သို့မဟုတ် သင့်အား ခွဲခြားဖော်ထုတ်နိုင်သော မည်သည့်နည်းလမ်းတွင်မျှ အသုံးမပြုထားပါ။"
@@ -3306,6 +3376,9 @@ msgstr "လက်ရှိတွင် ပေးချေမှု လုပ်�
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "လက်ရှိတွင် ပေးချေမှု လုပ်ငန်းစဉ်ကို စတင်၍ မရနိုင်ပါ၊ နောက်မှ ထပ်ကြိုးစားကြည့်ပါ။"
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "ကြိုဆိုပါတယ်၊ ဤစက်ကို ယခု <b>%s</b> ဟု ခေါ်ပါသည်။"
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/my/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/my/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Burmese\n"
 "Language: my_MM\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/nb/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/nb/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb_NO\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d til …"
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Installasjonsprogrammet avsluttet uventet. Prøv på nytt eller send en problemrapport."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Installasjonsrogrammet lastes ned til <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,41 +1399,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Velkommen. Denne enheten har fått navnet <b>%(deviceName)s</b>. For å finne ut mer kan du bruke informasjonsknappen under Konto."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Kobler til Mullvads systemtjeneste ..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Deaktiver antivirus fra tredjepart."
+msgid "Details"
+msgstr "Detaljer"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Deaktiverer antivirusprogramvare fra tredjepart"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Kunne ikke starte appen. Prøv igjen eller klikk på «Detaljer» for mer informasjon"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Hvis disse trinnene ikke løser noe, kan du sende inn en problemrapport."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Tillatelsen til Mullvad VPN-tjenesten er trukket tilbake. Gå til Systeminnstillinger og gi tillatelse til Mullvad VPN under innstillingen «Tillat i bakgrunnen»."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "å starte appen på nytt"
+msgid "Reinstalling the app"
+msgstr "Installere appen på nytt"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "å starte datamaskinen på nytt."
+msgid "Restarting the Mullvad background process"
+msgstr "Starte Mullvad-bakgrunnsprosessen på nytt"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Starte Mullvad-bakgrunnsprosessen på nytt ved å klikke på «Tilbake» og deretter «Prøv igjen»"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Starte datamaskinen på nytt"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Send problemrapport"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Tjenestekomponenten i systemet til appen har ikke startet eller kan ikke kontaktes. Systemtjenesten har ansvaret for sikkerheten, «kill switch» og VPN-tunnelen. Prøv følgende for å feilsøke:"
+msgid "Starting up...."
+msgstr "Starter …"
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvad-bakgrunnsprosessen kunne ikke starte. Bakgrunnsprosessen er ansvarlig for sikkerheten, avbruddsbryteren og VPN-tunnelen. Prøv:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Prøv igjen"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "Kunne ikke kontakte Mullvad-systemtjenesten. Tilkoblingen din er kan være usikker. Feilsøk eller send en problemrapport ved å trykke på «Finn ut mer»."
 
 #. This is a warning message shown when the app is blocking the users
@@ -1911,6 +1953,13 @@ msgstr "Listenavnene må være unike."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Navn allerede i bruk."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Forvirring: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (fjernet)"
 msgid "%s custom port"
 msgstr "tilpasset %s-port"
 
+msgid "%s is unavailable"
+msgstr "%s er utilgjengelig"
+
 msgid "%s was added to your account."
 msgstr "%s ble lagt til kontoen din."
 
@@ -2923,6 +2975,9 @@ msgstr "Deaktiver «%s» nedenfor for å aktivere innstillingene."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deaktiver alle «%s» ovenfor for å aktivere denne innstillingen."
 
+msgid "Disable recents"
+msgstr "Deaktiver nylige"
+
 msgid "Discard"
 msgstr "Forkast"
 
@@ -2961,6 +3016,9 @@ msgstr "Aktiver %1$s"
 
 msgid "Enable method"
 msgstr "Aktiver metoden"
+
+msgid "Enable recents"
+msgstr "Aktiver nylige"
 
 msgid "Enter MTU"
 msgstr "Angi MTU"
@@ -3061,6 +3119,9 @@ msgstr "Sørger for at enheten alltid er på VPN-tunnelen."
 msgid "Manage devices"
 msgstr "Behandle enheter"
 
+msgid "More actions"
+msgstr "Flere handlinger"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad-tjenester utilgjengelig"
 
@@ -3087,6 +3148,9 @@ msgstr "Ingen internettforbindelse"
 
 msgid "No locations found"
 msgstr "Ingen plasseringer funnet"
+
+msgid "No recent selection history"
+msgstr "Ingen nylig valghistorikk"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Ingen resultater for «%s». Prøv et annet søk"
@@ -3126,6 +3190,12 @@ msgstr "Personvern"
 
 msgid "Privacy policy"
 msgstr "Retningslinjer for personvern"
+
+msgid "Recents"
+msgstr "Nylige"
+
+msgid "Recents disabled and history cleared"
+msgstr "Nylige er deaktivert og historikken er slettet"
 
 msgid "Recursion limit"
 msgstr "Rekursjonsgrense"
@@ -3229,11 +3299,11 @@ msgstr "Denne er allerede angitt som gjeldende"
 msgid "Time added"
 msgstr "Tid lagt til"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Hvis du vil legge til plasseringer i en liste, trykker du på ︙ eller trykker på og holder inne et land, en by eller en server."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Hvis du vil legge til plasseringer i en liste, kan du trykke på pennen eller hold inne på et land, en by eller en server."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "For å opprette en egendefinert liste trykker du på ︙"
+msgid "To create a custom list press the \"+\""
+msgstr "For å opprette en egendefinert liste, kan du trykke på «+»"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "For å sørge for at du har den sikreste appversjonen, og informere deg om eventuelle problemer med den versjonen som kjøres, vil appen automatisk sjekke appversjonen. Appversjonen og Android-systemversjonen blir da sendt til Mullvad-servere. Mullvad registrerer antallet brukte appversjoner og Android-versjoner. Dataen blir aldri lagret eller brukt på noen som helst måte som kan identifisere deg."
@@ -3312,6 +3382,9 @@ msgstr "Vi kunne ikke starte betalingsprosessen. Kontroller om du har siste vers
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Vi kunne ikke starte betalingsprosessen. Prøv igjen senere."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Velkommen. Denne enheten har fått navnet <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/nb/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/nb/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb_NO\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/nl/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/nl/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 msgid "%(amount)d more..."
 msgstr "Nog %(amount)d..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Het installatieprogramma is onverwacht gestopt. Probeer het opnieuw of verstuur een melding van het probleem."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Het installatieprogramma wordt gedownload naar <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,42 +1399,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Welkom, dit apparaat heet nu <b>%(deviceName)s</b>. Zie voor meer informatie de infoknop in Account."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Verbinden met Mullvad-systeemdienst..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Schakel antivirussoftware van derden uit."
+msgid "Details"
+msgstr "Details"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Antivirussoftware van derden uitschakelen"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Starten van app is mislukt. Probeer het opnieuw of klik op \"Details\" voor meer informatie"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Als deze stappen niet werken, stuur dan een probleemrapport."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "De toestemming voor de Mullvad VPN-service is ingetrokken. Ga naar Systeeminstellingen en sta Mullvad VPN toe onder de instelling \"Sta toe op de achtergrond\"."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "App opnieuw installeren."
+msgid "Reinstalling the app"
+msgstr "App opnieuw installeren"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Computer opnieuw opstarten."
+msgid "Restarting the Mullvad background process"
+msgstr "Achtergrondproces van Mullvad opnieuw starten"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Achtergrondproces van Mullvad opnieuw starten door te klikken op \"Terug\" en vervolgens op \"Opnieuw proberen\""
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Computer opnieuw opstarten"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Probleemrapport sturen"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "De systeemservicecomponent van de app is niet gestart of is niet bereikbaar. De systeemservice is verantwoordelijk voor de beveiliging, de killswitch en de VPN-tunnel. Probeer het volgende om het probleem op te lossen:"
+msgid "Starting up...."
+msgstr "Bezig met opstarten...."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Kan geen contact maken met de Mullvad-systeemservice, je verbinding is mogelijk niet beveiligd. Los problemen op of stuur een probleemrapport door op de knop Meer informatie te klikken."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Kan het achtergrondproces van Mullvad niet starten. Het achtergrondproces is verantwoordelijk voor de beveiliging, de killswitch en de VPN-tunnel. Probeer het volgende:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Opnieuw proberen"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Kan geen contact maken met de systeemservice van Mullvad, mogelijk is uw verbinding niet beveiligd. Los het probleem op of meld het door te klikken op de knop Meer informatie."
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1911,6 +1953,13 @@ msgstr "Lijstnamen moeten uniek zijn."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Naam wordt al gebruikt."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Obfuscatie: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (verwijderd)"
 msgid "%s custom port"
 msgstr "Aangepaste %s-poort"
 
+msgid "%s is unavailable"
+msgstr "%s is niet beschikbaar"
+
 msgid "%s was added to your account."
 msgstr "%s is toegevoegd aan uw account."
 
@@ -2923,6 +2975,9 @@ msgstr "Schakel \"%s\" hieronder uit om deze instellingen te activeren."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Schakel alle \"%s\" hierboven uit om deze instelling te activeren."
 
+msgid "Disable recents"
+msgstr "Recente uitschakelen"
+
 msgid "Discard"
 msgstr "Verwerpen"
 
@@ -2961,6 +3016,9 @@ msgstr "%1$s inschakelen"
 
 msgid "Enable method"
 msgstr "Methode inschakelen"
+
+msgid "Enable recents"
+msgstr "Recente inschakelen"
 
 msgid "Enter MTU"
 msgstr "Voer MTU in"
@@ -3061,6 +3119,9 @@ msgstr "Zorg dat het apparaat altijd de VPN-tunnel gebruikt."
 msgid "Manage devices"
 msgstr "Apparaten beheren"
 
+msgid "More actions"
+msgstr "Andere acties"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad-diensten niet beschikbaar"
 
@@ -3087,6 +3148,9 @@ msgstr "Geen internetverbinding"
 
 msgid "No locations found"
 msgstr "Geen locaties gevonden"
+
+msgid "No recent selection history"
+msgstr "Geen recente selectiegeschiedenis"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Geen resultaat voor \"%s\", probeer een andere zoekopdracht"
@@ -3126,6 +3190,12 @@ msgstr "Privacy"
 
 msgid "Privacy policy"
 msgstr "Privacybeleid"
+
+msgid "Recents"
+msgstr "Recente"
+
+msgid "Recents disabled and history cleared"
+msgstr "Recente uitgeschakeld en geschiedenis gewist"
 
 msgid "Recursion limit"
 msgstr "Recursielimiet"
@@ -3229,11 +3299,11 @@ msgstr "Deze is al ingesteld als huidige"
 msgid "Time added"
 msgstr "Tijd van toevoegen"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Druk op de \"︙\" of druk lang op een land, plaats of server om locaties toe te voegen."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Druk op het potlood of houd een land, plaats of server ingedrukt om locaties toe te voegen aan de lijst."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Druk op de \"︙\" om een aangepaste lijst te maken"
+msgid "To create a custom list press the \"+\""
+msgstr "Druk op \"+\" om een aangepaste lijst te maken"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Om zeker te zijn dat u de meest veilige versie hebt en om u te informeren over eventuele problemen met de huidige geactiveerde versie, voert de app automatisch versiecontroles uit. Hierbij worden de appversie en de Android-systeemversie naar de servers van Mullvad gestuurd. Mullvad houdt tellers bij voor gebruikte appversies en Android-versies. De gegevens worden nooit opgeslagen of gebruikt op een manier die u kan identificeren."
@@ -3312,6 +3382,9 @@ msgstr "We kunnen het betalingsproces niet starten. Controleer of u de nieuwste 
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "We kunnen het betalingsproces niet starten, probeer het later opnieuw."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Welkom. De naam van dit apparaat is nu <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard-MTU"

--- a/desktop/packages/mullvad-vpn/locales/nl/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/nl/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/pl/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/pl/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Polish\n"
 "Language: pl_PL\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 13:58\n"
 
 msgid "%(amount)d more..."
 msgstr "Jeszcze %(amount)d"
@@ -771,6 +771,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Instalator został nieoczekiwanie zamknięty. Spróbuj ponownie lub wyślij zgłoszenie problemu."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Instalator zostanie pobrany do <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1407,41 +1411,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Witaj, to urządzenie nazywa się teraz <b>%(deviceName)s</b>. Więcej szczegółów znajdziesz, korzystając z przycisku Informacje na koncie."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Łączenie z usługą systemową Mullvad..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Wyłącz oprogramowanie antywirusowe innych firm."
+msgid "Details"
+msgstr "Szczegóły"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Wyłączanie oprogramowania antywirusowego innych firm"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Nie udało się uruchomić aplikacji. Spróbuj ponownie lub kliknij przycisk „Szczegóły”, aby uzyskać więcej informacji"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Jeśli te kroki nie zadziałają, wyślij zgłoszenie problemu."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Uprawnienie usługi Mullvad VPN zostało cofnięte. Przejdź do sekcji Ustawienia systemowe i zezwól na działanie usługi Mullvad VPN w ustawieniu „Pozwalaj w tle”."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Ponownie zainstalować aplikację."
+msgid "Reinstalling the app"
+msgstr "Ponowna instalacja aplikacji"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Ponownie uruchomić komputer."
+msgid "Restarting the Mullvad background process"
+msgstr "Ponowne uruchamianie działającego w tle procesu Mullvad"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Ponowne uruchomienie działającego w tle procesu Mullvad przez kliknięcie przycisków Wróć i Spróbuj ponownie"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Ponowne uruchomienie komputera"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Wyślij zgłoszenie problemu"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Składnik usługi systemowej aplikacji nie został uruchomiony lub nie odpowiada. Usługa systemowa odpowiada za zabezpieczenia, kill switch i tunel VPN. Aby rozwiązać problem, spróbuj:"
+msgid "Starting up...."
+msgstr "Uruchamianie..."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Nie udało się uruchomić działającego w tle procesu Mullvad. Proces ten odpowiada za zabezpieczenia, kill switch i tunel VPN. Spróbuj wykonać jedną ze wskazanych czynności."
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Spróbuj ponownie"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "Usługa systemowa Mullvad nie odpowiada. Połączenie może być niezabezpieczone. Rozwiąż problem lub wyślij zgłoszenie problemu, klikając przycisk Więcej informacji."
 
 #. This is a warning message shown when the app is blocking the users
@@ -1923,6 +1965,13 @@ msgstr "Nazwy list muszą być unikalne."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Nazwa jest już zajęta."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Zaciemnianie: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2767,6 +2816,9 @@ msgstr "%s (usunięto)"
 msgid "%s custom port"
 msgstr "Port niestandardowy %s"
 
+msgid "%s is unavailable"
+msgstr "%s: niedostępne"
+
 msgid "%s was added to your account."
 msgstr "Do konta dodano %s."
 
@@ -2935,6 +2987,9 @@ msgstr "Aby aktywować te ustawienia, wyłącz opcję „%s” poniżej."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Aby aktywować to ustawienie, wyłącz powyżej wszystkie „%s”."
 
+msgid "Disable recents"
+msgstr "Wyłącz ostatnie"
+
 msgid "Discard"
 msgstr "Odrzuć"
 
@@ -2973,6 +3028,9 @@ msgstr "Włącz %1$s"
 
 msgid "Enable method"
 msgstr "Włącz metodę"
+
+msgid "Enable recents"
+msgstr "Włącz ostatnie"
 
 msgid "Enter MTU"
 msgstr "Wprowadź MTU"
@@ -3073,6 +3131,9 @@ msgstr "Zapewnia, że urządzenie zawsze działa za pośrednictwem tunelu VPN."
 msgid "Manage devices"
 msgstr "Zarządzaj urządzeniami"
 
+msgid "More actions"
+msgstr "Więcej działań"
+
 msgid "Mullvad services unavailable"
 msgstr "Usługi Mullvad są niedostępne"
 
@@ -3099,6 +3160,9 @@ msgstr "Brak połączenia z Internetem"
 
 msgid "No locations found"
 msgstr "Nie znaleziono lokalizacji"
+
+msgid "No recent selection history"
+msgstr "Brak historii ostatnich wyborów"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Brak wyników dla hasła „%s”, spróbuj innego wyszukiwania"
@@ -3138,6 +3202,12 @@ msgstr "Prywatność"
 
 msgid "Privacy policy"
 msgstr "Polityka prywatności"
+
+msgid "Recents"
+msgstr "Ostatnie"
+
+msgid "Recents disabled and history cleared"
+msgstr "Ostatnie: wyłączono i wyczyszczono historię"
 
 msgid "Recursion limit"
 msgstr "Limit rekursji"
@@ -3241,11 +3311,11 @@ msgstr "Już ustawiona jako bieżąca"
 msgid "Time added"
 msgstr "Dodano czas"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Aby dodać lokalizacje do listy, naciśnij przycisk „︙” lub naciśnij i przytrzymaj kraj, miasto albo serwer."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Aby dodać lokalizacje do listy, naciśnij przycisk ołówka lub naciśnij i przytrzymaj kraj, miasto albo serwer."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Aby utworzyć listę niestandardową, naciśnij przycisk „︙”"
+msgid "To create a custom list press the \"+\""
+msgstr "Aby utworzyć listę niestandardową, naciśnij przycisk „+”"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Aby upewnić się, że masz najbezpieczniejszą wersję i poinformować Cię o wszelkich problemach z aktualnie uruchomioną wersją, aplikacja automatycznie sprawdza wersję. Powoduje to wysłanie wersji aplikacji i wersji systemu Android na serwery Mullvad. Mullvad prowadzi liczniki używanych wersji aplikacji i wersji systemu Android. Dane te nigdy nie są przechowywane ani wykorzystywane w żaden sposób, który umożliwiłby zidentyfikowanie Ciebie jako osoby."
@@ -3324,6 +3394,9 @@ msgstr "Nie mogliśmy rozpocząć procesu płatności. Upewnij się, że masz na
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Nie mogliśmy rozpocząć procesu płatności. Spróbuj ponownie później."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "To urządzenie ma teraz nazwę <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "MTU WireGuard"

--- a/desktop/packages/mullvad-vpn/locales/pl/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/pl/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Polish\n"
 "Language: pl_PL\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 13:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/pt/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/pt/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Portuguese\n"
 "Language: pt_PT\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "Mais %(amount)d..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "O instalador fechou inesperadamente. Tente novamente ou envie um relatório do problema."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "O instalador será transferido para <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,42 +1399,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Bem-vindo, este dispositivo é agora chamado <b>%(deviceName)s</b>. Para mais detalhes consulte o botão de informação na Conta."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "A ligar-se ao serviço de sistema Mulvad..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Desativar software antivírus de terceiros."
+msgid "Details"
+msgstr "Detalhes"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Desativar software antivírus de terceiros"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Erro ao iniciar a aplicação. Tente novamente ou clique em \"Detalhes\" para mais informações"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Se estes passos não funcionarem, envie um relatório do problema."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "A permissão para o serviço Mullvad VPN foi revogada. Aceda às definições do sistema e permita a Mullvad VPN, abaixo da definição \"Permitir em segundo plano\"."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Reinstalar a app."
+msgid "Reinstalling the app"
+msgstr "Reinstalar a aplicação"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Reiniciar o seu computador."
+msgid "Restarting the Mullvad background process"
+msgstr "Reiniciar o processo em segundo plano do Mullvad"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Reiniciar o processo em segundo plano do Mullvad clicando em \"Voltar\", e depois em \"Tentar novamente\""
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Reiniciar o seu computador"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Enviar relatório do problema"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "O componente de serviço do sistema da app não foi iniciado ou não pode ser contactado. O serviço do sistema é responsável pela segurança, pelo kill switch e pelo túnel VPN. Para resolver o problema, experimente:"
+msgid "Starting up...."
+msgstr "A iniciar..."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Não foi possível contactar o serviço do sistema Mullvad, a sua ligação pode ser insegura. Tente resolver o problema ou envie um relatório do problema clicando no botão Mais informações."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Erro ao iniciar o processo em segundo plano do Mullvad. O processo em segundo plano é responsável pela segurança, pelo kill switch e pelo túnel VPN. Tente o seguinte:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Tentar novamente"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Não foi possível contactar o serviço do sistema Mullvad, a sua ligação pode ser insegura. Tente resolver o problema ou envie um relatório do problema clicando no botão \"Mais informações\"."
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1911,6 +1953,13 @@ msgstr "Os nomes de listas devem ser únicos."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "O nome já está a ser utilizado."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Ofuscação: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (removido)"
 msgid "%s custom port"
 msgstr "Porta personalizada %s"
 
+msgid "%s is unavailable"
+msgstr "%s não está disponível"
+
 msgid "%s was added to your account."
 msgstr "%s adicionado(s) à sua conta."
 
@@ -2923,6 +2975,9 @@ msgstr "Desative \"%s\" abaixo para ativar estas definições."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Desative todos os \"%s\" acima para ativar esta definição."
 
+msgid "Disable recents"
+msgstr "Desativar recentes"
+
 msgid "Discard"
 msgstr "Descartar"
 
@@ -2961,6 +3016,9 @@ msgstr "Ativar %1$s"
 
 msgid "Enable method"
 msgstr "Ativar método"
+
+msgid "Enable recents"
+msgstr "Ativar recentes"
 
 msgid "Enter MTU"
 msgstr "Introduzir MTU"
@@ -3061,6 +3119,9 @@ msgstr "Assegura que o dispositivo está sempre no túnel VPN."
 msgid "Manage devices"
 msgstr "Gerir dispositivos"
 
+msgid "More actions"
+msgstr "Mais ações"
+
 msgid "Mullvad services unavailable"
 msgstr "Serviços Mullvad indisponíveis"
 
@@ -3087,6 +3148,9 @@ msgstr "Sem ligação à internet"
 
 msgid "No locations found"
 msgstr "Nenhuma localização encontrada"
+
+msgid "No recent selection history"
+msgstr "Sem histórico de seleção recente"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Nenhum resultado para \"%s\", tente uma pesquisa diferente"
@@ -3126,6 +3190,12 @@ msgstr "Privacidade"
 
 msgid "Privacy policy"
 msgstr "Política de privacidade"
+
+msgid "Recents"
+msgstr "Recentes"
+
+msgid "Recents disabled and history cleared"
+msgstr "Recentes desativados e histórico eliminado"
 
 msgid "Recursion limit"
 msgstr "Limite de recursão"
@@ -3229,11 +3299,11 @@ msgstr "Este já está definido como o atual"
 msgid "Time added"
 msgstr "Tempo adicionado"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Para adicionar localizações a uma lista, prima o botão \"︙\" ou mantenha premido um país, uma cidade ou um servidor."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Para adicionar localizações a uma lista, prima a caneta ou mantenha premido um país, uma cidade ou um servidor."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Para criar uma lista personalizada prima o botão \"︙\""
+msgid "To create a custom list press the \"+\""
+msgstr "Para criar uma lista personalizada prima o botão \"+\""
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Para se certificar de que tem a versão mais segura e para o informar de quaisquer problemas com a versão atual em execução, a app efetua verificações de versão automaticamente. Esta envia a versão da app e a versão do sistema Android para os servidores da Mullvad. A Mullvad mantém um registo do número de versões da app e de versões do Android utilizadas. Os dados nunca são armazenados ou utilizados de forma a identificar o utilizador."
@@ -3312,6 +3382,9 @@ msgstr "Não foi possível iniciar o processo de pagamento. Verifique se tem a v
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Não foi possível iniciar o processo de pagamento, tente novamente mais tarde."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "As boas-vindas, este dispositivo tem agora o nome <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/pt/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/pt/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Portuguese\n"
 "Language: pt_PT\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ru/google_play.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/google_play.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "Mullvad VPN – a service, for a monthly fee, that helps keep your online activity, identity, and location private."
 msgstr "Mullvad VPN — сервис с ежемесячной оплатой, который помогает сохранить в секрете вашу личность, местоположение и действия в сети."

--- a/desktop/packages/mullvad-vpn/locales/ru/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "Еще %(amount)d..."
@@ -771,6 +771,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Установщик неожиданно завершил работу. Повторите попытку или отправьте сообщение о проблеме."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Установщик будет скачан в папку <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1407,41 +1411,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Добро пожаловать, теперь это устройство называется <b>%(deviceName)s</b>. Для получения более подробной нажмите на кнопку «Информация» в учетной записи."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Подключение к системному сервису Mullvad..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Отключите сторонние антивирусы."
+msgid "Details"
+msgstr "Подробности"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Отключение сторонних антивирусных программ"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Не удалось запустить приложение. Попробуйте еще раз или нажмите «Подробности», чтобы узнать больше"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Если эти действия не помогли, отправьте сообщение о проблеме."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Разрешение для службы Mullvad VPN было отозвано. Зайдите в системные настройки и включите для Mullvad VPN параметр «Разрешить в фоновом режиме»."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Переустановите приложение."
+msgid "Reinstalling the app"
+msgstr "Переустановить приложение"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Перезагрузите компьютер."
+msgid "Restarting the Mullvad background process"
+msgstr "Перезапустить фоновый процесс Mullvad"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Перезапустить фоновый процесс Mullvad: для этого нажмите «Назад», затем — «Повторить попытку»"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Перезагрузить компьютер"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Отправить сообщение о проблеме"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Компонент системной службы приложения не запущен или с ним невозможно связаться. Системная служба отвечает за безопасность, аварийное отключение и туннель VPN. Чтобы устранить неполадки, попробуйте следующее:"
+msgid "Starting up...."
+msgstr "Запуск..."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Не удалось запустить фоновый процесс Mullvad. Он отвечает за безопасность, аварийное отключение и VPN-туннель. Попробуйте следующее:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Повторить попытку"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "Не удается связаться с системной службой Mullvad. Возможно, ваше подключение не защищено. Устраните неполадки или отправьте сообщение о проблеме, нажав кнопку «Подробнее»."
 
 #. This is a warning message shown when the app is blocking the users
@@ -1923,6 +1965,13 @@ msgstr "Названия списков должны быть уникальны
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Такое название уже используется."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Обфускация: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2767,6 +2816,9 @@ msgstr "%s (удалено)"
 msgid "%s custom port"
 msgstr "Пользовательский порт %s"
 
+msgid "%s is unavailable"
+msgstr "%s недоступно"
+
 msgid "%s was added to your account."
 msgstr "На учетную запись добавлено время: %s."
 
@@ -2935,6 +2987,9 @@ msgstr "Чтобы активировать эти параметры, откл�
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Чтобы активировать этот параметр, отключите все %s выше."
 
+msgid "Disable recents"
+msgstr "Отключить недавние"
+
 msgid "Discard"
 msgstr "Сбросить"
 
@@ -2973,6 +3028,9 @@ msgstr "Включить режим %1$s"
 
 msgid "Enable method"
 msgstr "Включить метод"
+
+msgid "Enable recents"
+msgstr "Включить недавние"
 
 msgid "Enter MTU"
 msgstr "Введите MTU"
@@ -3073,6 +3131,9 @@ msgstr "Обеспечивает постоянное подключение у�
 msgid "Manage devices"
 msgstr "Управление устройствами"
 
+msgid "More actions"
+msgstr "Дополнительные действия"
+
 msgid "Mullvad services unavailable"
 msgstr "Службы Mullvad недоступны"
 
@@ -3099,6 +3160,9 @@ msgstr "Нет подключения к Интернету"
 
 msgid "No locations found"
 msgstr "Местоположения не найдены"
+
+msgid "No recent selection history"
+msgstr "Нет истории недавнего выбора"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "По запросу «%s» ничего не найдено — попробуйте другой запрос"
@@ -3138,6 +3202,12 @@ msgstr "Конфиденциальность"
 
 msgid "Privacy policy"
 msgstr "Политика конфиденциальности"
+
+msgid "Recents"
+msgstr "Недавние"
+
+msgid "Recents disabled and history cleared"
+msgstr "Недавние отключены, история очищена"
 
 msgid "Recursion limit"
 msgstr "Предел рекурсии"
@@ -3241,11 +3311,11 @@ msgstr "Этот метод уже установлен как текущий"
 msgid "Time added"
 msgstr "Время добавлено"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Чтобы добавить местоположения в список, нажмите «︙» или нажмите и удерживайте страну, город или сервер."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Чтобы добавить местоположения в список, нажмите значок карандаша или нажмите и удерживайте страну, город или сервер."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Чтобы создать свой список, нажмите «︙»"
+msgid "To create a custom list press the \"+\""
+msgstr "Чтобы создать свой список, нажмите «+»"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Чтобы удостовериться, что вы используете наиболее безопасную версию приложения, и сообщить вам о возможных проблемах в ней, приложение автоматически проверяет свою версию. При этом на серверы Mullvad передаются данные о версии приложения и системы Android. Mullvad ведет учет количества пользователей с определенными версиями приложения и ОС Android. Эти данные не хранятся и не используются каким бы то ни было образом, позволяющим вас идентифицировать."
@@ -3324,6 +3394,9 @@ msgstr "Не удалось начать процесс оплаты — убе
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Не удалось начать процесс оплаты. Повторите попытку позже."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Добро пожаловать! Это устройство теперь называется <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "MTU для WireGuard"

--- a/desktop/packages/mullvad-vpn/locales/ru/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/sv/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/sv/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Swedish\n"
 "Language: sv_SE\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d till ..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Installationsprogrammet avslutades oväntat. Försök igen eller skicka en problemrapport."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Installationsprogrammet kan laddas ner till <b>%(cacheDir)s</b>."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,42 +1399,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Välkommen! Den här enheten heter nu <b>%(deviceName)s</b>. Använd informationsknappen i Konto för mer information."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Ansluter till Mullvads systemtjänst..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Inaktivera antivirusprogram från tredje part."
+msgid "Details"
+msgstr "Detaljer"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Inaktivera antivirusprogram från tredje part"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Det gick inte att starta appen. Försök igen eller klicka på \"Detaljer\" för mer information"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Skicka en problemrapport om dessa steg inte fungerar."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Behörighet för Mullvad VPN-tjänsten har återkallats. Gå till systeminställningarna och tillåt Mullvad VPN under inställningen \"Tillåt i bakgrunden\"."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Installera om appen."
+msgid "Reinstalling the app"
+msgstr "Installera om appen"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Starta om din dator."
+msgid "Restarting the Mullvad background process"
+msgstr "Starta om Mullvad-bakgrundsprocessen"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "Starta om Mullvad-bakgrundsprocessen genom att klicka på \"Tillbaka\" och sedan \"Försök igen\""
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Starta om din dator"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Skicka problemrapport"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Systemtjänsten i appen har inte startat eller kan inte kontaktas. Systemtjänsten ansvarar för säkerhet, Kill Switch och VPN-tunnel. Så här felsöker du:"
+msgid "Starting up...."
+msgstr "Startar ..."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "Det går inte att kontakta Mullvads systemtjänst och din anslutning kanske inte är säker. Felsök eller skicka en problemrapport genom att klicka på knappen Läs mer."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Det gick inte att starta Mullvad-bakgrundsprocessen. Bakgrundsprocessen är ansvarig för säkerheten, kill switch och VPN-tunneln. Prova följande:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Försök igen"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "Det går inte att kontakta Mullvads systemtjänst och din anslutning kanske inte är säker. Felsök eller skicka en problemrapport genom att klicka på knappen \"Läs mer\"."
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1911,6 +1953,13 @@ msgstr "Listnamnen måste vara unika."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "Namnet används redan."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Obfuskering: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (har tagits bort)"
 msgid "%s custom port"
 msgstr "Anpassad %s-port"
 
+msgid "%s is unavailable"
+msgstr "%s är inte tillgänglig"
+
 msgid "%s was added to your account."
 msgstr "%s har lagts till i ditt konto."
 
@@ -2923,6 +2975,9 @@ msgstr "Inaktivera \"%s\" nedan för att aktivera dessa inställningar."
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Inaktivera alla \"%s\" ovan för att aktivera inställningen."
 
+msgid "Disable recents"
+msgstr "Inaktivera senaste"
+
 msgid "Discard"
 msgstr "Ignorera"
 
@@ -2961,6 +3016,9 @@ msgstr "Aktivera %1$s"
 
 msgid "Enable method"
 msgstr "Aktivera metod"
+
+msgid "Enable recents"
+msgstr "Aktivera senaste"
 
 msgid "Enter MTU"
 msgstr "Ange MTU"
@@ -3061,6 +3119,9 @@ msgstr "Ser till att enheten alltid är i VPN-tunneln."
 msgid "Manage devices"
 msgstr "Hantera enheter"
 
+msgid "More actions"
+msgstr "Fler åtgärder"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad-tjänster är inte tillgängliga"
 
@@ -3087,6 +3148,9 @@ msgstr "Ingen internetanslutning"
 
 msgid "No locations found"
 msgstr "Inga platser hittades"
+
+msgid "No recent selection history"
+msgstr "Ingen historik av senaste val"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "Inga resultat hittades för \"%s\", försök med en annan sökning"
@@ -3126,6 +3190,12 @@ msgstr "Sekretess"
 
 msgid "Privacy policy"
 msgstr "Sekretesspolicy"
+
+msgid "Recents"
+msgstr "Senaste"
+
+msgid "Recents disabled and history cleared"
+msgstr "Senaste har inaktiverats och historiken har rensats"
 
 msgid "Recursion limit"
 msgstr "Rekursionsgräns"
@@ -3229,11 +3299,11 @@ msgstr "Den har redan ställts in som aktuell"
 msgid "Time added"
 msgstr "Tid har lagts till"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Om du vill lägga till platser i en lista kan du trycka på \"︙\" eller trycka länge på ett land, en stad eller en server."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Om du vill lägga till platser i en lista kan du trycka på pennan eller trycka länge på ett land, en stad eller en server."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Om du vill skapa en anpassad lista trycker du på \"︙\""
+msgid "To create a custom list press the \"+\""
+msgstr "Om du vill skapa en anpassad lista trycker du på \"+\""
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Appen genomför automatiska versionskontroller för att se till att du har den säkraste versionen och för att informera dig om problem med den nuvarande versionen. Appversionen och Android-systemversionen skickas till Mullvad-servrarna. Mullvad registrerar antalet använda appversioner och Android-versioner. Dessa data lagras aldrig och används inte på något sätt som kan identifiera dig."
@@ -3312,6 +3382,9 @@ msgstr "Vi kunde inte starta betalningsprocessen. Se till att du har den senaste
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Vi kunde inte starta betalningsprocessen, försök igen senare."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Välkommen. Den här enheten har fått namnet <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/sv/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/sv/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Swedish\n"
 "Language: sv_SE\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 07:47\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/th/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/th/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Thai\n"
 "Language: th_TH\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "อีก %(amount)d..."
@@ -753,6 +753,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "โปรแกรมติดตั้งหยุดทำงานอย่างไม่คาดคิด โปรดลองอีกครั้งหรือส่งรายงานปัญหา"
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "ตัวติดตั้งจะถูกดาวน์โหลดไปที่ <b>%(cacheDir)s</b>"
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1389,41 +1393,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "ยินดีต้อนรับ ขณะนี้อุปกรณ์นี้จะมีชื่อว่า <b>%(deviceName)s</b> สำหรับข้อมูลเพิ่มเติม โปรดกดปุ่มข้อมูลในบัญชี"
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "กำลังเชื่อมต่อบริการของระบบ Mullvad..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
+msgid "Details"
+msgstr "รายละเอียด"
+
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
 msgstr "ปิดใช้งานซอฟต์แวร์ป้องกันไวรัสของบริษัทอื่น"
 
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "ไม่สามารถเริ่มแอปได้ โปรดลองอีกครั้งหรือคลิก \"รายละเอียด\" เพื่อดูข้อมูลเพิ่มเติม"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "หากขั้นตอนเหล่านี้ใช้ไม่ได้ผล โปรดส่งรายงานปัญหา"
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "สิทธิ์การเข้าถึงบริการ Mullvad VPN ได้ถูกเพิกถอนแล้ว โปรดเข้าไปยังการตั้งค่าระบบ แล้วให้สิทธิ์อนุญาต Mullvad VPN ภายใต้การตั้งค่า \"อนุญาตในพื้นหลัง\""
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "ติดตั้งแอปใหม่"
+msgid "Reinstalling the app"
+msgstr "การติดตั้งแอปใหม่อีกครั้ง"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "รีสตาร์ตคอมพิวเตอร์ของคุณ"
+msgid "Restarting the Mullvad background process"
+msgstr "การเริ่มกระบวนการเบื้องหลัง Mullvad ใหม่"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "การเริ่มกระบวนการเบื้องหลัง Mullvad ใหม่โดยคลิก \"ย้อนกลับ\" จากนั้นคลิก \"ลองอีกครั้ง\""
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "การรีสตาร์ทคอมพิวเตอร์ของคุณ"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "ส่งรายงานปัญหา"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "องค์ประกอบบริการระบบของแอปยังไม่เริ่มต้นขึ้น หรือไม่สามารถติดต่อได้ บริการของระบบมีหน้าที่รับผิดชอบด้านความปลอดภัย คิลสวิตช์ และช่องทาง VPN หากต้องการแก้ไขปัญหา โปรดลอง:"
+msgid "Starting up...."
+msgstr "เริ่มต้นแล้ว...."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "กระบวนการเบื้องหลังของ Mullvad ไม่สามารถเริ่มต้นได้ กระบวนการเบื้องหลังนี้รับผิดชอบด้านความปลอดภัย สวิตช์ปิดการทำงาน และอุโมงค์ VPN โปรดลอง:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "ลองอีกครั้ง"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "ไม่สามารถติดต่อบริการระบบ Mullvad ได้ การเชื่อมต่อของคุณอาจไม่ปลอดภัย โปรดแก้ไขปัญหาหรือส่งรายงานปัญหา โดยคลิกปุ่มเรียนรู้เพิ่มเติม"
 
 #. This is a warning message shown when the app is blocking the users
@@ -1905,6 +1947,13 @@ msgstr "ชื่อรายการจะต้องไม่ซ้ำกั
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "ชื่อนี้ถูกใช้ไปแล้ว"
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "การทำให้สับสน: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2749,6 +2798,9 @@ msgstr "%s (ลบแล้ว)"
 msgid "%s custom port"
 msgstr "พอร์ต %s แบบกำหนดเอง"
 
+msgid "%s is unavailable"
+msgstr "%s ไม่พร้อมใช้งาน"
+
 msgid "%s was added to your account."
 msgstr "%s ถูกเพิ่มลงในบัญชีของคุณแล้ว"
 
@@ -2917,6 +2969,9 @@ msgstr "ปิดใช้งาน \"%s\" ด้านล่าง เพื่
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "ปิดใช้งาน \"%s\" ด้านบนทั้งหมด เพื่อเปิดใช้งานการตั้งค่านี้"
 
+msgid "Disable recents"
+msgstr "ปิดใช้งานล่าสุด"
+
 msgid "Discard"
 msgstr "ละทิ้ง"
 
@@ -2955,6 +3010,9 @@ msgstr "เปิดใช้งาน %1$s"
 
 msgid "Enable method"
 msgstr "เปิดใช้งานวิธีการ"
+
+msgid "Enable recents"
+msgstr "เปิดใช้งานล่าสุด"
 
 msgid "Enter MTU"
 msgstr "ป้อน MTU"
@@ -3055,6 +3113,9 @@ msgstr "ตรวจสอบให้แน่ใจว่า อุปกร�
 msgid "Manage devices"
 msgstr "จัดการอุปกรณ์"
 
+msgid "More actions"
+msgstr "การดำเนินการเพิ่มเติม"
+
 msgid "Mullvad services unavailable"
 msgstr "บริการ Mullavad ไม่พร้อมใช้งาน"
 
@@ -3081,6 +3142,9 @@ msgstr "ไม่มีการเชื่อมต่ออินเทอร
 
 msgid "No locations found"
 msgstr "ไม่พบตำแหน่งที่ตั้ง"
+
+msgid "No recent selection history"
+msgstr "ไม่มีประวัติการเลือกล่าสุด"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "ไม่พบผลลัพธ์สำหรับ \"%s\" โปรดลองใช้คำค้นหาอื่น"
@@ -3120,6 +3184,12 @@ msgstr "ความเป็นส่วนตัว"
 
 msgid "Privacy policy"
 msgstr "นโยบายความเป็นส่วนตัว"
+
+msgid "Recents"
+msgstr "ล่าสุด"
+
+msgid "Recents disabled and history cleared"
+msgstr "ปิดใช้งานล่าสุดและล้างประวัติแล้ว"
 
 msgid "Recursion limit"
 msgstr "ขีดจำกัดการเรียกซ้ำ"
@@ -3223,11 +3293,11 @@ msgstr "นี่ได้รับการตั้งค่าเป็นป
 msgid "Time added"
 msgstr "เพิ่มเวลาแล้ว"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "กด \"︙\" หรือกดประเทศ เมือง หรือเซิร์ฟเวอร์ค้างไว้ เพื่อเพิ่มตำแหน่งที่ตั้งลงในรายการ"
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "หากต้องการเพิ่มตำแหน่งลงในรายการ ให้กดปากกาหรือกดค้างที่ประเทศ เมือง หรือเซิร์ฟเวอร์"
 
-msgid "To create a custom list press the \"︙\""
-msgstr "กด \"︙\" เพื่อสร้างรายการแบบกำหนดเอง"
+msgid "To create a custom list press the \"+\""
+msgstr "หากต้องการสร้างรายการที่กำหนดเอง ให้กด \"+\""
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "แอปจะตรวจสอบเวอร์ชันโดยอัตโนมัติ เพื่อให้แน่ใจว่า คุณใช้งานเวอร์ชันที่ปลอดภัยที่สุด และเพื่อแจ้งปัญหาใดๆ ของเวอร์ชันปัจจุบันที่ใช้งานอยู่ให้คุณทราบ โดยระบบจะส่งเวอร์ชันแอปและเวอร์ชันระบบ Android ไปยังเซิร์ฟเวอร์ Mullavid ซึ่ง Mullvad จะติดตามจำนวนเวอร์ชันแอปที่ใช้และเวอร์ชัน Android ทั้งนี้ข้อมูลจะไม่ถูกจัดเก็บ หรือนำไปใช้ในลักษณะใดๆ ที่สามารถระบุตัวตนคุณได้"
@@ -3306,6 +3376,9 @@ msgstr "เราไม่สามารถเริ่มกระบวนก
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "เราไม่สามารถเริ่มกระบวนการชำระเงินได้ โปรดลองอีกครั้งในภายหลัง"
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "ยินดีต้อนรับ อุปกรณ์นี้มีชื่อว่า <b>%s</b> แล้ว"
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/th/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/th/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Thai\n"
 "Language: th_TH\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/tr/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/tr/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Turkish\n"
 "Language: tr_TR\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d tane daha..."
@@ -759,6 +759,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "Yükleyici beklenmedik şekilde sonlandı. Lütfen tekrar deneyin veya bir hata raporu gönderin."
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "Yükleyici <b>%(cacheDir)s</b> konumuna indirilecek."
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1395,41 +1399,79 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "Hoş geldiniz, bu cihazın adı artık <b>%(deviceName)s</b>. Daha fazla ayrıntı için Hesap içinden bilgi düğmesine bakın."
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "Mullvad sistem hizmetlerine bağlanılıyor..."
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "Üçüncü taraf antivirüs yazılımı devre dışı bırakın."
+msgid "Details"
+msgstr "Ayrıntılar"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "Üçüncü taraf antivirüs yazılımı devre dışı bırakın"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "Uygulama başlatılamadı, lütfen tekrar deneyin veya daha fazla bilgi için “Ayrıntılar”a tıklayın"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "Bu adımlar işe yaramazsa lütfen bir hata raporu gönderin."
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Mullvad VPN hizmetinin izni iptal edildi. Lütfen Sistem Ayarları'na giderek \"Arka Planda İzin Ver\" seçeneğinden Mullvad VPN'e izin verin."
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "Uygulamayı yeniden yükleme."
+msgid "Reinstalling the app"
+msgstr "Uygulamayı yeniden yükleyin"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "Bilgisayarınızı yeniden başlatma."
+msgid "Restarting the Mullvad background process"
+msgstr "Mullvad arka plan işlemini yeniden başlatın"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "“Geri”ye ve ardından “Yeniden dene”ye tıklayarak Mullvad arka plan işlemini yeniden başlatın"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "Bilgisayarınızı yeniden başlatın"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "Hata raporu gönder"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "Uygulamanın sistem hizmeti bileşeni başlatılmadı veya bağlantı kurulamıyor. Sistem hizmeti güvenlikten, kill switch'ten ve VPN tünelinden sorumludur. Sorunu gidermek için lütfen şu işlemleri deneyin:"
+msgid "Starting up...."
+msgstr "Başlatılıyor..."
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvad arka plan işlemi başlatılamadı. Arka plan işlemi; güvenlik, kill switch ve VPN tüneli gibi işlevlerden sorumludur. Lütfen aşağıdakileri deneyin:"
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "Tekrar deneyin"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
 msgstr "Mullvad sistem hizmetiyle bağlantı kurulamıyor, bağlantınız güvenli olmayabilir. Lütfen \"Daha fazla bilgi\" düğmesine tıklayarak sorunu gidermeyi deneyin veya bir hata raporu gönderin."
 
 #. This is a warning message shown when the app is blocking the users
@@ -1911,6 +1953,13 @@ msgstr "Liste adları benzersiz olmalıdır."
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "İsim zaten kullanılıyor."
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "Gizleme: %(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2755,6 +2804,9 @@ msgstr "%s (kaldırıldı)"
 msgid "%s custom port"
 msgstr "%s özel portu"
 
+msgid "%s is unavailable"
+msgstr "%s kullanılamıyor"
+
 msgid "%s was added to your account."
 msgstr "%s, hesabınıza eklendi."
 
@@ -2923,6 +2975,9 @@ msgstr "Bu ayarları etkinleştirmek için aşağıdaki \"%s\" seçeneğini devr
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Bu ayarı etkinleştirmek için yukarıdaki \"%s\" seçeneklerinin tümünü devre dışı bırakın."
 
+msgid "Disable recents"
+msgstr "Son filtreleri devre dışı bırak"
+
 msgid "Discard"
 msgstr "İptal et"
 
@@ -2961,6 +3016,9 @@ msgstr "%1$s ayarını etkinleştir"
 
 msgid "Enable method"
 msgstr "Yöntemi etkinleştir"
+
+msgid "Enable recents"
+msgstr "Son filtreleri etkinleştir"
 
 msgid "Enter MTU"
 msgstr "MTU'yu girin"
@@ -3061,6 +3119,9 @@ msgstr "Cihazın her zaman VPN tünelinde olduğundan emin olun."
 msgid "Manage devices"
 msgstr "Cihazları yönet"
 
+msgid "More actions"
+msgstr "Diğer işlemler"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad hizmetleri kullanılamıyor"
 
@@ -3087,6 +3148,9 @@ msgstr "İnternet bağlantısı yok"
 
 msgid "No locations found"
 msgstr "Konum bulunamadı"
+
+msgid "No recent selection history"
+msgstr "Son seçim geçmişi yok"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "\"%s\" için sonuç yok, lütfen farklı bir arama yapın"
@@ -3126,6 +3190,12 @@ msgstr "Gizlilik"
 
 msgid "Privacy policy"
 msgstr "Gizlilik politikası"
+
+msgid "Recents"
+msgstr "Son kullanılanlar"
+
+msgid "Recents disabled and history cleared"
+msgstr "Son kullanılanlar devre dışı bırakıldı ve geçmiş temizlendi"
 
 msgid "Recursion limit"
 msgstr "Yineleme sınırı"
@@ -3229,11 +3299,11 @@ msgstr "Bu, zaten geçerli olarak ayarlı yöntemdir"
 msgid "Time added"
 msgstr "Süre eklendi"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "Listeye konum eklemek için \"︙\" düğmesine basın veya bir ülke, şehir veya sunucunun üzerine uzun basın."
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "Konumları bir listeye eklemek için kalem simgesine dokunun veya bir ülkeye, şehre ya da sunucuya uzun basın."
 
-msgid "To create a custom list press the \"︙\""
-msgstr "Özel bir liste oluşturmak için \"︙\" düğmesine basın"
+msgid "To create a custom list press the \"+\""
+msgstr "Özel bir liste oluşturmak için “+” simgesine dokunun"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "Uygulama, en güvenli sürüme sahip olduğunuzdan emin olmak ve çalışan mevcut sürümle ilgili sorunları size bildirmek için sürüm kontrollerini otomatik olarak gerçekleştirir. Bu işlem, uygulama sürümünü ve Android sistem sürümünü Mullvad sunucularına gönderir. Mullvad, kullanılan uygulama sürümlerinin ve Android sürümlerinin numarasını kaydeder. Veriler asla sizi tanımlayacak şekilde saklanmaz veya kullanılmaz."
@@ -3312,6 +3382,9 @@ msgstr "Ödeme işlemini başlatamadık. Lütfen Google Play'in en son sürümü
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "Ödeme işlemini başlatamadık, lütfen daha sonra tekrar deneyin."
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "Hoş geldiniz, bu cihazın yeni adı artık <b>%s</b>."
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/tr/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/tr/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Turkish\n"
 "Language: tr_TR\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/zh-CN/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-CN/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 21:06\n"
 
 msgid "%(amount)d more..."
 msgstr "其他 %(amount)d 个…"
@@ -753,6 +753,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "安装程序意外退出，请重试或发送问题报告。"
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "安装程序将下载到 <b>%(cacheDir)s</b>。"
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1389,42 +1393,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "欢迎，此设备现在名为 <b>%(deviceName)s</b>。有关详情，请点击“帐户”中的信息按钮。"
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "正在连接到 Mullvad 系统服务…"
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "禁用第三方防病毒软件。"
+msgid "Details"
+msgstr "详细信息"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "禁用第三方防病毒软件"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "无法启动应用，请重试或点击“详细信息”了解更多信息"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "如果这些步骤不起作用，请发送问题报告。"
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Mullvad VPN 服务的权限已被撤销。请前往“系统设置”，并在“允许在后台”设置下允许 Mullvad VPN。"
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "重新安装应用。"
+msgid "Reinstalling the app"
+msgstr "重新安装应用"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "重新启动计算机。"
+msgid "Restarting the Mullvad background process"
+msgstr "重新启动 Mullvad 后台进程"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "通过点击“返回”再点击“重试”来重新启动 Mullvad 后台进程"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "重新启动计算机"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "发送问题报告"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "应用的系统服务组件尚未启动或无法联系。系统服务负责安全、安全开关和 VPN 隧道。要排查故障，请尝试："
+msgid "Starting up...."
+msgstr "正在启动…"
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "无法联系 Mulvad 系统服务，您的连接可能不安全。请点击“了解详情”按钮进行故障排查或发送问题报告。"
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "Mullvad 后台进程启动失败。后台进程负责安全、终止开关和 VPN 隧道。请尝试："
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "重试"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "无法联系 Mullvad 系统服务，您的连接可能不安全。请点击“了解详情”按钮进行故障排除或发送问题报告。"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1502,7 +1544,7 @@ msgstr "登录失败"
 #. internet connection while logged out.
 msgctxt "login-view"
 msgid "Our kill switch is currently blocking your connection."
-msgstr "我们的安全开关当前正在阻止您的连接。"
+msgstr "我们的终止开关当前正在阻止您的连接。"
 
 msgctxt "login-view"
 msgid "Please wait"
@@ -1905,6 +1947,13 @@ msgstr "列表名称必须唯一。"
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "名称已被占用。"
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "混淆：%(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2460,7 +2509,7 @@ msgstr "此功能通过允许隧道以外到本地组播和广播范围以及与
 
 msgctxt "vpn-settings-view"
 msgid "Kill switch"
-msgstr "安全开关"
+msgstr "终止开关"
 
 msgctxt "vpn-settings-view"
 msgid "Launch app on start-up"
@@ -2496,15 +2545,15 @@ msgstr "社交媒体"
 
 msgctxt "vpn-settings-view"
 msgid "The app’s built-in kill switch is always on. This setting will additionally block the internet if clicking Disconnect or Quit."
-msgstr "应用的内置安全开关始终处于开启状态。如果点击“断开连接”或“退出”，此设置还将阻止您的网络连接。"
+msgstr "应用的内置终止开关始终处于开启状态。如果点击“断开连接”或“退出”，此设置还将阻止您的网络连接。"
 
 msgctxt "vpn-settings-view"
 msgid "The difference between the Kill Switch and Lockdown Mode is that the Kill Switch will prevent any leaks from happening during automatic tunnel reconnects, software crashes and similar accidents."
-msgstr "安全开关与锁定模式之间的区别在于，安全开关将防止在自动隧道重新连接、软件崩溃和类似事故期间发生任何泄漏。"
+msgstr "终止开关与锁定模式之间的区别在于，终止开关将防止在自动隧道重新连接、软件崩溃和类似事故期间发生任何泄漏。"
 
 msgctxt "vpn-settings-view"
 msgid "The difference between the Kill Switch and Lockdown Mode is that the Kill Switch will prevent any leaks from happening during automatic tunnel reconnects, software crashes and similar accidents. With Lockdown Mode enabled, you must be connected to a Mullvad VPN server to be able to reach the internet. Manually disconnecting or quitting the app will block your connection."
-msgstr "安全开关与锁定模式之间的区别在于，安全开关将防止在自动隧道重新连接、软件崩溃和类似事故期间发生任何泄漏。启用锁定模式后，您必须连接到 Mullvad VPN 服务器才能访问网络。手动断开或退出应用程序将阻止您的连接。"
+msgstr "终止开关与锁定模式之间的区别在于，终止开关将防止在自动隧道重新连接、软件崩溃和类似事故期间发生任何泄漏。启用锁定模式后，您必须连接到 Mullvad VPN 服务器才能访问网络。手动断开或退出应用程序将阻止您的连接。"
 
 msgctxt "vpn-settings-view"
 msgid "The DNS server you want to add is a private IP. You must ensure that your network interfaces are configured to use it."
@@ -2749,6 +2798,9 @@ msgstr "%s（已移除）"
 msgid "%s custom port"
 msgstr "%s 自定义端口"
 
+msgid "%s is unavailable"
+msgstr "%s 不可用"
+
 msgid "%s was added to your account."
 msgstr "%s已添加到您的帐户中。"
 
@@ -2917,6 +2969,9 @@ msgstr "禁用下方的“%s”以激活这些设置。"
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "禁用上方的所有“%s”以激活此设置。"
 
+msgid "Disable recents"
+msgstr "禁用最近使用"
+
 msgid "Discard"
 msgstr "舍弃"
 
@@ -2955,6 +3010,9 @@ msgstr "启用“%1$s”"
 
 msgid "Enable method"
 msgstr "启用方法"
+
+msgid "Enable recents"
+msgstr "启用最近使用"
 
 msgid "Enter MTU"
 msgstr "输入 MTU"
@@ -3055,6 +3113,9 @@ msgstr "确保设备始终位于 VPN 隧道上。"
 msgid "Manage devices"
 msgstr "管理设备"
 
+msgid "More actions"
+msgstr "更多操作"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad 服务不可用"
 
@@ -3081,6 +3142,9 @@ msgstr "没有互联网连接"
 
 msgid "No locations found"
 msgstr "找不到位置"
+
+msgid "No recent selection history"
+msgstr "无最近选择历史记录"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "“%s”无结果，请尝试其他搜索"
@@ -3120,6 +3184,12 @@ msgstr "隐私"
 
 msgid "Privacy policy"
 msgstr "隐私政策"
+
+msgid "Recents"
+msgstr "最近使用"
+
+msgid "Recents disabled and history cleared"
+msgstr "最近使用已禁用，历史记录已清除"
 
 msgid "Recursion limit"
 msgstr "递归限制"
@@ -3223,11 +3293,11 @@ msgstr "它已被设置为当前方法"
 msgid "Time added"
 msgstr "时间已添加"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "要将位置添加到列表中，请按“︙”或长按国家/地区、城市或服务器。"
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "要将位置添加到列表中，请按笔形图标或长按国家/地区、城市或服务器。"
 
-msgid "To create a custom list press the \"︙\""
-msgstr "要创建自定义列表，请按“︙”"
+msgid "To create a custom list press the \"+\""
+msgstr "要创建自定义列表，请按“+”"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "为确保您使用的是最安全的版本并通知您当前运行的版本存在的任何问题，应用会自动执行版本检查。此操作会将应用版本和 Android 系统版本发送到 Mullvad 服务器。Mullvad 会统计使用的应用版本和 Android 版本。数据永远不会通过任何可以识别您身份的方式存储或使用。"
@@ -3306,6 +3376,9 @@ msgstr "我们无法启动付款流程，请确保拥有最新版本的 Google P
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "我们无法启动付款流程，请稍后再试。"
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "欢迎，此设备现已命名为 <b>%s</b>。"
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/zh-CN/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-CN/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-06 21:06\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/zh-TW/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-TW/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 msgid "%(amount)d more..."
 msgstr "其他 %(amount)d 個…"
@@ -753,6 +753,10 @@ msgctxt "app-upgrade-view"
 msgid "Installer quit unexpectedly, please try again or send a problem report."
 msgstr "安裝程式意外退出，請再試一次或傳送問題回報。"
 
+msgctxt "app-upgrade-view"
+msgid "Installer will be downloaded to <b>%(cacheDir)s</b>."
+msgstr "安裝程式將下載至 <b>%(cacheDir)s</b>。"
+
 #. Text displayed when there are no updates for this platform in the next app version
 msgctxt "app-upgrade-view"
 msgid "No updates or changes were made in this release for this platform."
@@ -1389,42 +1393,80 @@ msgctxt "in-app-notifications"
 msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
 msgstr "歡迎，此裝置現在稱為 <b>%(deviceName)s</b>。如需詳細資訊，請點按「帳戶」中的資訊按鈕。"
 
+#. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
 msgid "Connecting to Mullvad system service..."
 msgstr "連線 Mullvad 系統服務中…"
 
+#. Button label for opening dialog with troubleshooting details.
 msgctxt "launch-view"
-msgid "Disable third party antivirus software."
-msgstr "停用第三方防毒軟體。"
+msgid "Details"
+msgstr "詳細資訊"
 
+#. List item in troubleshooting modal advising user disable third party antivirus.
+msgctxt "launch-view"
+msgid "Disabling third party antivirus software"
+msgstr "停用第三方防毒軟體"
+
+#. Status text shown when app fails to start.
+msgctxt "launch-view"
+msgid "Failed to start the app, please try again or click “Details” for more info"
+msgstr "無法啟動應用程式，請再試一次或按一下「詳細資訊」進一步瞭解"
+
+#. Message in troubleshooting modal advising user to send a problem report if the steps do not work.
 msgctxt "launch-view"
 msgid "If these steps do not work please send a problem report."
 msgstr "如果以上步驟仍無法解決問題，請傳送問題回報。"
 
+#. Message in launch view when the background process permissions have been revoked.
 msgctxt "launch-view"
 msgid "Permission for the Mullvad VPN service has been revoked. Please go to System Settings and allow Mullvad VPN under the “Allow in the Background” setting."
 msgstr "Mullvad VPN 服務的權限已遭到撤銷。請前往「系統設定」，並在「允許在背景中執行」設定下允許 Mullvad VPN。"
 
+#. List item in troubleshooting modal advising user to reinstall the app.
 msgctxt "launch-view"
-msgid "Reinstalling the app."
-msgstr "重新安裝應用程式。"
+msgid "Reinstalling the app"
+msgstr "重新安裝應用程式"
 
+#. List item in troubleshooting modal advising user to restart background process.
 msgctxt "launch-view"
-msgid "Restarting your computer."
-msgstr "重新啟動您的電腦。"
+msgid "Restarting the Mullvad background process"
+msgstr "重新啟動 Mullvad 背景程序"
 
-#. Button label for problem report view.
+#. List item in troubleshooting modal instructing user how to restart the background process.
+msgctxt "launch-view"
+msgid "Restarting the Mullvad background process by clicking \"Back\", then \"Try again\""
+msgstr "按一下「返回」，再按「再試一次」，即可重新啟動 Mullvad 背景程序"
+
+#. List item in troubleshooting modal advising user to restart their computer.
+msgctxt "launch-view"
+msgid "Restarting your computer"
+msgstr "重新啟動您的電腦"
+
+#. Button label for sending a problem report.
 msgctxt "launch-view"
 msgid "Send problem report"
 msgstr "傳送問題回報"
 
+#. Status text shown when app is starting.
 msgctxt "launch-view"
-msgid "The system service component of the app hasn’t started or can’t be contacted. The system service is responsible for the security, kill switch, and the VPN tunnel. To troubleshoot please try:"
-msgstr "應用程式的系統服務組件尚未啟動或無法通訊。系統服務負責安全、終止開關和 VPN 通道等項目。如果要排除故障，請嘗試："
+msgid "Starting up...."
+msgstr "正在啟動……"
 
+#. Message in troubleshooting modal when the background process failed to start.
 msgctxt "launch-view"
-msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the Learn more button."
-msgstr "無法與 Mulvad 系統服務通訊，您的連線可能不安全。請按一下「瞭解更多」按鈕進行故障排除，或是傳送問題回報。"
+msgid "The Mullvad background process failed to start. The background process is responsible for the security, kill switch, and the VPN tunnel. Please try:"
+msgstr "啟動 Mullvad 背景程序失敗。此背景程序負責安全、終止開關和 VPN 通道。請嘗試："
+
+#. Button label for trying to restart the daemon again.
+msgctxt "launch-view"
+msgid "Try again"
+msgstr "再試一次"
+
+#. Message in launch view when the mullvad service cannot be contacted.
+msgctxt "launch-view"
+msgid "Unable to contact the Mullvad system service, your connection might be unsecure. Please troubleshoot or send a problem report by clicking the \"Learn more\" button."
+msgstr "無法連線至 Mullvad 系統服務，您的連線可能不安全。請按一下「瞭解更多」按鈕進行故障排除或傳送問題報告。"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1905,6 +1947,13 @@ msgstr "清單名稱不可重複。"
 msgctxt "select-location-view"
 msgid "Name is already taken."
 msgstr "名稱已在別處使用。"
+
+#. Label for indicator that shows that obfuscation is being used as a filter.
+#. Available placeholders:
+#. %(obfuscation)s - type of obfuscation in use
+msgctxt "select-location-view"
+msgid "Obfuscation: %(obfuscation)s"
+msgstr "混淆：%(obfuscation)s"
 
 msgctxt "select-location-view"
 msgid "Open %(daita)s settings"
@@ -2749,6 +2798,9 @@ msgstr "%s (已移除)"
 msgid "%s custom port"
 msgstr "%s 自訂連接埠"
 
+msgid "%s is unavailable"
+msgstr "%s 無法使用"
+
 msgid "%s was added to your account."
 msgstr "%s 已新增至您的帳戶。"
 
@@ -2917,6 +2969,9 @@ msgstr "停用下方的「%s」以啟動這些設定。"
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "停用上方所有「%s」以啟動此設定。"
 
+msgid "Disable recents"
+msgstr "停用最近使用"
+
 msgid "Discard"
 msgstr "捨棄"
 
@@ -2955,6 +3010,9 @@ msgstr "啟用 %1$s"
 
 msgid "Enable method"
 msgstr "啟用方式"
+
+msgid "Enable recents"
+msgstr "啟用最近使用"
 
 msgid "Enter MTU"
 msgstr "輸入 MTU"
@@ -3055,6 +3113,9 @@ msgstr "請確認裝置始終位於 VPN 通道上。"
 msgid "Manage devices"
 msgstr "管理裝置"
 
+msgid "More actions"
+msgstr "更多操作"
+
 msgid "Mullvad services unavailable"
 msgstr "Mullvad 服務無法使用"
 
@@ -3081,6 +3142,9 @@ msgstr "沒有網際網路連線"
 
 msgid "No locations found"
 msgstr "找不到位置"
+
+msgid "No recent selection history"
+msgstr "無最近選擇歷史"
 
 msgid "No result for \"%s\", please try a different search"
 msgstr "找不到「%s」的結果，請使改用其他搜尋條件。"
@@ -3120,6 +3184,12 @@ msgstr "隱私權"
 
 msgid "Privacy policy"
 msgstr "隱私權政策"
+
+msgid "Recents"
+msgstr "最近使用"
+
+msgid "Recents disabled and history cleared"
+msgstr "已停用最近使用，並已清除歷史"
 
 msgid "Recursion limit"
 msgstr "遞迴限制"
@@ -3223,11 +3293,11 @@ msgstr "已將其設定為目前方式"
 msgid "Time added"
 msgstr "已增加時間"
 
-msgid "To add locations to a list, press the \"︙\" or long press on a country, city, or server."
-msgstr "若要在清單中新增位置，請按下「︙」，或是長按下國家/地區、城市或伺服器。"
+msgid "To add locations to a list, press the pen or long press on a country, city, or server."
+msgstr "若要在清單中新增位置，請按筆的圖示，或是長按國家/地區、城市或伺服器。"
 
-msgid "To create a custom list press the \"︙\""
-msgstr "若要建立自訂清單，請按下「︙」"
+msgid "To create a custom list press the \"+\""
+msgstr "若要建立自訂清單，請按「+」"
 
 msgid "To make sure that you have the most secure version and to inform you of any issues with the current version that is running, the app performs version checks automatically. This sends the app version and Android system version to Mullvad servers. Mullvad keeps counters on number of used app versions and Android versions. The data is never stored or used in any way that can identify you."
 msgstr "為確保您擁有最安全的版本，並告知您目前執行的版本有無任何問題，該應用程式會自動進行版本檢查。為此，應用程式會將其版本和 Android 系統版本傳送至 Mullvad 伺服器，以便讓 Mullvad 統計已使用的應用程式版本和 Android 版本的數量。這些資料永遠不會以任何方式儲存或用來辨識您的身分。"
@@ -3306,6 +3376,9 @@ msgstr "我們無法啟動付款流程，請確認您是否擁有最新版本的
 
 msgid "We were unable to start the payment process, please try again later."
 msgstr "我們無法啟動付款流程，請稍後再試一次。"
+
+msgid "Welcome, this device is now called <b>%s</b>."
+msgstr "歡迎，此裝置現在名為 <b>%s</b>。"
 
 msgid "WireGuard MTU"
 msgstr "WireGuard MTU"

--- a/desktop/packages/mullvad-vpn/locales/zh-TW/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-TW/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-06-27 06:04\n"
+"PO-Revision-Date: 2025-08-08 07:35\n"
 
 #. AU ADL
 msgid "Adelaide"


### PR DESCRIPTION
This PR backports https://github.com/mullvad/mullvadvpn-app/pull/8567 to the 2025.8 release branch in preparation of the next stable release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8596)
<!-- Reviewable:end -->
