### PR TITLE
Bump MACOSX_DEPLOYMENT_TARGET to 10.12

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -14,7 +14,7 @@ case "$ENV_TARGET" in
     export LIBNFTNL_LIB_DIR="$SCRIPT_DIR/dist-assets/binaries/$ENV_TARGET"
     ;;
   x86_64-*-darwin*)
-    export MACOSX_DEPLOYMENT_TARGET="10.7"
+    export MACOSX_DEPLOYMENT_TARGET="10.12"
 
     if [[ $HOST != "$ENV_TARGET" ]]; then
         # Required for building daemon


### PR DESCRIPTION
10.12 is the oldest that rustc supports right now. 10.7 was emitting a warning at build time. 10.12 is much older than what we run app tests on or officially supports. But some users run older macOS versions and are happy, so we should not lock them out for no good reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8597)
<!-- Reviewable:end -->
