### PR TITLE
Pin Rust nightly compiler to 2025-08-11 to avoid compiler regression

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -62,7 +62,9 @@ jobs:
 
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        # TODO: Revert to using the regular 'nightly' channel as soon as https://github.com/rust-lang/rust/issues/145151
+        # has been closed and the fix is in the nightly channel.
+        rust: [stable, beta, nightly-2025-08-11]
     continue-on-error: true
     steps:
       # Fix for HOME path overridden by GH runners when building in containers, see:


### PR DESCRIPTION
Our CI started failing recently due to a type error showing up when using the rust compiler from the nightly channel: https://github.com/mullvad/mullvadvpn-app/actions/runs/16933448883/job/47984313311

This has been confirmed to be a regression in the compiler itself, and a fix has seemingly been merged already. Pinning the nightly compiler to the last known working version in our CI for now, but this should be reverted ASAP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8598)
<!-- Reviewable:end -->
