### PR TITLE
Set the default location set flag at login

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1562,6 +1562,19 @@ impl Daemon {
                         error.display_chain_with_msg("Failed to update account history")
                     );
                 }
+                if self.settings.update_default_location {
+                    if let Err(e) = self
+                        .settings
+                        .update(move |settings| settings.update_default_location = false)
+                        .await
+                        .map_err(Error::SettingsError)
+                    {
+                        log::error!(
+                            "{}",
+                            e.display_chain_with_msg("Unable to save has_updated_default_country")
+                        );
+                    }
+                }
                 if *self.target_state == TargetState::Secured {
                     log::debug!("Initiating tunnel restart because the account number changed");
                     self.reconnect_tunnel();


### PR DESCRIPTION
If the user has managed to log in we unconditionally set update_default_location = false. This is done to prevent an edge case where the geolocation request completes after the user has logged in and then the default location could change while the user is in the process of clicking the select location/connect buttons.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8606)
<!-- Reviewable:end -->
