### PR TITLE
Fix panic while checking launch daemon authorization for installed dev builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,8 +2957,8 @@ dependencies = [
  "mullvad-version",
  "nix 0.30.1",
  "notify 8.0.0",
- "objc2 0.5.2",
  "objc2-foundation 0.3.1",
+ "objc2-service-management",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -3578,9 +3578,6 @@ name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "objc2"
@@ -3706,6 +3703,30 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f8e0ef3ab66b08c42644dcb34dba6ec0a574bbd8adbb8bdbdc7a2779731a44"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ca650c581044d08572b3c21d9ce8c730f2eefdc1683f033849f305ea8212be"
+dependencies = [
+ "block2 0.6.1",
+ "objc2 0.6.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.1",
+ "objc2-security",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
+dependencies = [
+ "objc2 0.6.2",
 ]
 
 [[package]]
@@ -1085,6 +1094,16 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.2",
+]
 
 [[package]]
 name = "displaydoc"
@@ -2938,7 +2957,8 @@ dependencies = [
  "mullvad-version",
  "nix 0.30.1",
  "notify 8.0.0",
- "objc2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.3.1",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -3513,7 +3533,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 name = "nseventforwarder"
 version = "0.0.0"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "neon",
  "objc2-app-kit",
 ]
@@ -3573,18 +3593,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
 ]
 
@@ -3595,9 +3624,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+ "dispatch2",
+ "objc2 0.6.2",
 ]
 
 [[package]]
@@ -3606,17 +3646,17 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -3625,9 +3665,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
+ "block2 0.5.1",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2 0.6.1",
+ "libc",
+ "objc2 0.6.2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3637,9 +3690,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3649,9 +3702,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.9.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -72,6 +72,7 @@ talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(target_os="macos")'.dependencies]
 objc2 = { version = "0.5.2", features = ["exception"] }
+objc2-foundation = { version = "0.3.1", features = ["NSProcessInfo"] }
 notify = "8.0.0"
 talpid-macos = { path = "../talpid-macos" }
 

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -71,8 +71,8 @@ simple-signal = "1.1"
 talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(target_os="macos")'.dependencies]
-objc2 = { version = "0.5.2", features = ["exception"] }
-objc2-foundation = { version = "0.3.1", features = ["NSProcessInfo"] }
+objc2-foundation = { version = "0.3.1", features = ["NSProcessInfo", "NSString", "NSURL"] }
+objc2-service-management = { version = "0.3.1", features = [ "SMAppService", "objc2" ] }
 notify = "8.0.0"
 talpid-macos = { path = "../talpid-macos" }
 

--- a/mullvad-daemon/src/macos_launch_daemon.rs
+++ b/mullvad-daemon/src/macos_launch_daemon.rs
@@ -5,19 +5,13 @@
 //! must be checked so that the user can be directed to approve the launch
 //! daemon in the system settings.
 
-#![allow(clippy::undocumented_unsafe_blocks)] // Remove me if you dare.
+use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo, NSURL, ns_string};
+use objc2_service_management::{SMAppService, SMAppServiceStatus};
 
-use std::ffi::CStr;
-
-use objc2::{class, msg_send, runtime::AnyObject};
-use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
-
-type Id = *mut AnyObject;
-
-// TODO: Replace with obcj2-service-management
-// Framework that contains `SMAppService`.
-#[link(name = "ServiceManagement", kind = "framework")]
-unsafe extern "C" {}
+/// Path to the plist that defines the Mullvad launch daemon.
+/// It must be kept in sync with the path defined in
+/// `dist-assets/pkg-scripts/postinstall`.
+const DAEMON_PLIST_PATH: &str = "/Library/LaunchDaemons/net.mullvad.daemon.plist";
 
 /// Authorization status of the Mullvad daemon.
 #[repr(i32)]
@@ -37,20 +31,29 @@ pub fn get_status() -> LaunchDaemonStatus {
     if os_version.majorVersion < 13 {
         return LaunchDaemonStatus::Ok;
     }
-    get_status_for_url(&daemon_plist_url())
+
+    // SAFETY: daemon_plist_path has is a well-formed url according to RFC 3986 & is not null.
+    let daemon_plist_url = unsafe {
+        NSURL::URLWithString_encodingInvalidCharacters(ns_string!(DAEMON_PLIST_PATH), false)
+    };
+
+    match daemon_plist_url {
+        Some(url) => get_status_for_url(&url),
+        // TODO: Technically, this is an error in allocating an URL, not checking the
+        // launch daemon status ..
+        None => LaunchDaemonStatus::Unknown,
+    }
 }
 
-fn get_status_for_url(url: &Object) -> LaunchDaemonStatus {
-    let status: libc::c_long =
-        unsafe { msg_send![class!(SMAppService), statusForLegacyURL: url.0] };
-
+fn get_status_for_url(url: &NSURL) -> LaunchDaemonStatus {
+    // SAFETY: url points to a valid instance of an NSURL.
+    let status = unsafe { SMAppService::statusForLegacyURL(url) };
     match status {
-        // SMAppServiceStatusNotRegistered | SMAppServiceStatusNotFound
-        0 | 3 => LaunchDaemonStatus::NotFound,
-        // SMAppServiceStatusEnabled
-        1 => LaunchDaemonStatus::Ok,
-        // SMAppServiceStatusRequiresApproval
-        2 => LaunchDaemonStatus::NotAuthorized,
+        SMAppServiceStatus::NotRegistered | SMAppServiceStatus::NotFound => {
+            LaunchDaemonStatus::NotFound
+        }
+        SMAppServiceStatus::Enabled => LaunchDaemonStatus::Ok,
+        SMAppServiceStatus::RequiresApproval => LaunchDaemonStatus::NotAuthorized,
         // Unknown status
         _ => LaunchDaemonStatus::Unknown,
     }
@@ -59,34 +62,4 @@ fn get_status_for_url(url: &Object) -> LaunchDaemonStatus {
 fn get_os_version() -> NSOperatingSystemVersion {
     let process_info = NSProcessInfo::processInfo();
     process_info.operatingSystemVersion()
-}
-
-/// Returns an `NSURL` instance for `DAEMON_PLIST_PATH`.
-fn daemon_plist_url() -> Object {
-    /// Path to the plist that defines the Mullvad launch daemon.
-    /// It must be kept in sync with the path defined in
-    /// `dist-assets/pkg-scripts/postinstall`.
-    const DAEMON_PLIST_PATH: &CStr = c"/Library/LaunchDaemons/net.mullvad.daemon.plist";
-
-    let nsstr_inst: Id = unsafe { msg_send![class!(NSString), alloc] };
-    let nsstr_inst: Id =
-        unsafe { msg_send![nsstr_inst, initWithUTF8String: DAEMON_PLIST_PATH.as_ptr()] };
-
-    let nsurl_inst: Id = unsafe { msg_send![class!(NSURL), alloc] };
-    let nsurl_inst: Id = unsafe { msg_send![nsurl_inst, initWithString: nsstr_inst] };
-
-    let _: () = unsafe { msg_send![nsstr_inst, release] };
-
-    assert!(!nsurl_inst.is_null());
-
-    Object(nsurl_inst)
-}
-
-/// Calls `[self.0 release]` when the wrapped instance is dropped.
-struct Object(Id);
-
-impl Drop for Object {
-    fn drop(&mut self) {
-        let _: () = unsafe { msg_send![self.0, release] };
-    }
 }

--- a/mullvad-daemon/src/macos_launch_daemon.rs
+++ b/mullvad-daemon/src/macos_launch_daemon.rs
@@ -7,38 +7,17 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)] // Remove me if you dare.
 
-use libc::c_longlong;
-use objc2::{Encode, Encoding, RefEncode, class, msg_send, runtime::AnyObject};
 use std::ffi::CStr;
+
+use objc2::{class, msg_send, runtime::AnyObject};
+use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
 
 type Id = *mut AnyObject;
 
+// TODO: Replace with obcj2-service-management
 // Framework that contains `SMAppService`.
 #[link(name = "ServiceManagement", kind = "framework")]
 unsafe extern "C" {}
-
-/// Returned by `[NSProcessInfo operatingSystemVersion]`. Contains the current
-#[repr(C)]
-#[derive(Debug)]
-struct NSOperatingSystemVersion {
-    major_version: c_longlong,
-    minor_version: c_longlong,
-    patch_version: c_longlong,
-}
-
-/// Implement Objective-C type encoding for the struct. Allows the `objc2` crate
-/// to perform function signature matching before performing calls into the Objective-C
-/// runtime.
-unsafe impl Encode for NSOperatingSystemVersion {
-    const ENCODING: Encoding = Encoding::Struct(
-        "NSOperatingSystemVersion",
-        &[Encoding::LongLong, Encoding::LongLong, Encoding::LongLong],
-    );
-}
-
-unsafe impl RefEncode for NSOperatingSystemVersion {
-    const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
-}
 
 /// Authorization status of the Mullvad daemon.
 #[repr(i32)]
@@ -53,7 +32,9 @@ pub enum LaunchDaemonStatus {
 /// NOTE: On macos < 13, this function always returns `LaunchDaemonStatus::Ok`.
 pub fn get_status() -> LaunchDaemonStatus {
     // `SMAppService` does not exist if the major version is less than 13.
-    if get_os_version().major_version < 13 {
+    // TODO: Could as well use processInfo.isOperatingSystemAtLeast
+    let os_version = get_os_version();
+    if os_version.majorVersion < 13 {
         return LaunchDaemonStatus::Ok;
     }
     get_status_for_url(&daemon_plist_url())
@@ -76,9 +57,8 @@ fn get_status_for_url(url: &Object) -> LaunchDaemonStatus {
 }
 
 fn get_os_version() -> NSOperatingSystemVersion {
-    // the object is lazily instantiated, so we don't release it
-    let proc_info: Id = unsafe { msg_send![class!(NSProcessInfo), processInfo] };
-    unsafe { msg_send![proc_info, operatingSystemVersion] }
+    let process_info = NSProcessInfo::processInfo();
+    process_info.operatingSystemVersion()
 }
 
 /// Returns an `NSURL` instance for `DAEMON_PLIST_PATH`.


### PR DESCRIPTION
This PR fixes an annoying bug that caused a panic in the daemon when checking the operating system version at launch while running an installed dev build on macOS. Below I've attached logs showing the error (`frontend-main.old.log`) and logs post-fix (`frontend-main.log`) 👇 

```bash
====================
Log: ~/Library/Logs/Mullvad VPN/frontend-main.log
====================
[2025-08-15 13:35:46.549][verbose] Chromium sandbox is enabled
[2025-08-15 13:35:46.550][info] Running version 2025.8-dev-c1e6fc
[2025-08-15 13:35:46.605][info] Detected locale: en-US
[2025-08-15 13:35:46.614][info] Verified socket ownership
[2025-08-15 13:35:46.614][info] Connected to the daemon
[2025-08-15 13:35:46.779][info] Skip autoconnect because account number is not set
[2025-08-15 13:35:49.635][error] Failed to login: too-many-devices

====================
Log: ~/Library/Logs/Mullvad VPN/frontend-main.old.log
====================
[2025-07-09 13:19:02.628][verbose] Chromium sandbox is enabled
[2025-07-09 13:19:02.629][info] Running version 2025.8-beta1-dev-abae10
[2025-07-09 13:19:02.677][info] Detected locale: en-US
[2025-07-09 13:19:02.686][info] Connected to the daemon
[2025-07-09 13:19:02.686][info] Verified daemon ownership
[2025-07-09 13:19:02.697][error] Error while checking launch daemon authorization status.
                Stdout: 
                Stderr: Note: This command may not work on non-notarized builds.
thread 'main' panicked at mullvad-daemon/src/macos_launch_daemon.rs:81:14:
invalid message send to -[_NSSwiftProcessInfo operatingSystemVersion]: expected return to have type code '{?=qqq}', but found '{NSOperatingSystemVersion=qqq}'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The bug would render the daemon unable to run.

The fix was to use the macOS API correcly (undocumented `unsafe` lol). This was easily achieved by replacing our manual use of `objc2` to invoke macOS APIs in favor of crates exposing those APIs while taking care of the lower level `objc2` plumbing for us.

I discovered that we were using two Apple frameworks: `Foundation` and `Service Management`. The bug fix came from using the `Foundation` wrapper crate, but we could get rid of *a lot* of unsafe by also using the `Service Management` wrapper crate - so I went ahead and did that. It was straight forward enough.

The remaining `unsafe` is kind of trivially safe in the sense that the crates expose wrapper functions that only take validated input. The functions also do not throw exceptions (such functions are always considered `unsafe` by the `objc2` author). I/we could get rid of all `unsafe` by contributing a patch upstream marking these functions as safe, it's just that no one has bothered to yet.

An annoyance is that we now depend on multiple versions of `objc2`. The appropriate fix is to update `nseventforwarder` to use a newer version. I haven't checked, but it might be the case that the macOS API we are wrapping there is exposed by another `objc2-*` crate already.