### PR TITLE
Fix failure to initialize a QUIC connection

### DIFF
--- a/mullvad-masque-proxy/src/lib.rs
+++ b/mullvad-masque-proxy/src/lib.rs
@@ -28,7 +28,9 @@ const UDP_HEADER_SIZE: u16 = 8;
 const QUIC_HEADER_SIZE: u16 = 41;
 
 /// The minimum allowed `max_udp_payload_size`-value allowed by [quinn::EndpointConfig].
-const MIN_MAX_UDP_PAYLOAD_SIZE: u16 = 1200;
+/// FIXME: A bug in the proxy server implementation sets the actual minimum value to 1252 instead
+/// of 1200, which would be according to spec.
+const MIN_MAX_UDP_PAYLOAD_SIZE: u16 = 1252;
 
 /// This is the size of the payload that stores QUIC packets
 /// MTU - IP header - UDP header


### PR DESCRIPTION
This PR puts a bandaid on a weird bug in the masque proxy server. The masque proxy client accepts a minimum `max_udp_payload_size` value of 1200 bytes, but the masque proxy server defines the minimum `max_udp_payload_size` to 1252 (lol).

This PR implements `compute_udp_payload_size` properly, but it also enables a temporary hack where we raise the minimum `max_udp_payload_size` to 1252 to match the server's expected minimum value, which fixes connecting over QUIC on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8622)
<!-- Reviewable:end -->
