### PR TITLE
Remove string plist from packet tunnel

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1091,7 +1091,6 @@
 		F0DDE42A2B220A15006B57A7 /* Haversine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DDE4272B220A15006B57A7 /* Haversine.swift */; };
 		F0DDE42B2B220A15006B57A7 /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DDE4282B220A15006B57A7 /* RelaySelector.swift */; };
 		F0DDE42C2B220A15006B57A7 /* Midpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DDE4292B220A15006B57A7 /* Midpoint.swift */; };
-		F0DEBB5C2E4E1927001B5624 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F0DEBB5A2E4E1927001B5624 /* InfoPlist.strings */; };
 		F0E3618B2A4ADD2F00AEEF2B /* WelcomeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E3618A2A4ADD2F00AEEF2B /* WelcomeContentView.swift */; };
 		F0E5B2F82C9C68CF0007F78C /* EncryptedDNSTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E5B2F72C9C68CD0007F78C /* EncryptedDNSTransport.swift */; };
 		F0E61CAA2BF2911D000C4A95 /* TunnelSettingsV5.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E61CA82BF2911D000C4A95 /* TunnelSettingsV5.swift */; };
@@ -2427,7 +2426,6 @@
 		F01765962E4A324F00262F54 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F017F8DF2D78ABE90076EC01 /* RelayFilterDataSourceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayFilterDataSourceItem.swift; sourceTree = "<group>"; };
 		F01DAE322C2B032A00521E46 /* RelaySelection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelaySelection.swift; sourceTree = "<group>"; };
-		F025C63B2E4E1934007B93FF /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F027E0982E4A325C00090D26 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F028A5692A34D4E700C0CAA3 /* RedeemVoucherViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedeemVoucherViewController.swift; sourceTree = "<group>"; };
 		F028A56B2A34D8E600C0CAA3 /* AddCreditSucceededViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddCreditSucceededViewController.swift; sourceTree = "<group>"; };
@@ -2537,7 +2535,6 @@
 		F0C6FA842A6A733700F521F0 /* InAppPurchaseInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchaseInteractor.swift; sourceTree = "<group>"; };
 		F0CB96302E4A324000206149 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F0D5591D2D3805050072B63F /* LatestChangesNotificationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestChangesNotificationProvider.swift; sourceTree = "<group>"; };
-		F0D8061B2E4E193A009E3392 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F0D8825A2B04F53600D3EF9A /* OutgoingConnectionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingConnectionData.swift; sourceTree = "<group>"; };
 		F0DA87462A9CB9A2006044F1 /* AccountExpiryRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountExpiryRow.swift; sourceTree = "<group>"; };
 		F0DA87482A9CBA9F006044F1 /* AccountDeviceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeviceRow.swift; sourceTree = "<group>"; };
@@ -2550,7 +2547,6 @@
 		F0DDE4282B220A15006B57A7 /* RelaySelector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelaySelector.swift; sourceTree = "<group>"; };
 		F0DDE4292B220A15006B57A7 /* Midpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Midpoint.swift; sourceTree = "<group>"; };
 		F0DEA1FB2E4A326F002275F7 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		F0DEBB5B2E4E1927001B5624 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F0E3618A2A4ADD2F00AEEF2B /* WelcomeContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeContentView.swift; sourceTree = "<group>"; };
 		F0E576BB2E4A324A0079FA27 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F0E5B2F72C9C68CD0007F78C /* EncryptedDNSTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedDNSTransport.swift; sourceTree = "<group>"; };
@@ -4050,7 +4046,6 @@
 			children = (
 				58915D662A25F9F20066445B /* DeviceCheck */,
 				58CE5E7D224146470008646E /* Info.plist */,
-				F0DEBB5A2E4E1927001B5624 /* InfoPlist.strings */,
 				58CE5E7E224146470008646E /* PacketTunnel.entitlements */,
 				58F3F3682AA08E2200D3B0A4 /* PacketTunnelProvider */,
 				F059197A2C45404500C301F3 /* PostQuantum */,
@@ -5718,7 +5713,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9BA08322BA32FB6005A7A2D /* PrivacyInfo.xcprivacy in Resources */,
-				F0DEBB5C2E4E1927001B5624 /* InfoPlist.strings in Resources */,
 				F04A66FA2E4B44EC0081C89C /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7350,16 +7344,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		F0DEBB5A2E4E1927001B5624 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				F0DEBB5B2E4E1927001B5624 /* de */,
-				F025C63B2E4E1934007B93FF /* fr */,
-				F0D8061B2E4E193A009E3392 /* sv */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
 		F0EE6E762E4A321B0089DFF3 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/ios/MullvadVPN/Supporting Files/de.lproj/InfoPlist.strings
+++ b/ios/MullvadVPN/Supporting Files/de.lproj/InfoPlist.strings
@@ -1,9 +1,3 @@
-/* Bundle display name */
-"CFBundleDisplayName" = "Mullvad VPN";
-
-/* Bundle name */
-"CFBundleName" = "MullvadVPN";
-
 /* Privacy - Local Network Usage Description */
 "NSLocalNetworkUsageDescription" = "Die App benötigt dies, um sich zu verbinden und eine neue Methode zu testen.";
 

--- a/ios/MullvadVPN/Supporting Files/fr.lproj/InfoPlist.strings
+++ b/ios/MullvadVPN/Supporting Files/fr.lproj/InfoPlist.strings
@@ -1,9 +1,3 @@
-/* Bundle display name */
-"CFBundleDisplayName" = "Mullvad VPN";
-
-/* Bundle name */
-"CFBundleName" = "MullvadVPN";
-
 /* Privacy - Local Network Usage Description */
 "NSLocalNetworkUsageDescription" = "L'application a besoin de cela pour se connecter et tester une nouvelle méthode.";
 

--- a/ios/MullvadVPN/Supporting Files/sv.lproj/InfoPlist.strings
+++ b/ios/MullvadVPN/Supporting Files/sv.lproj/InfoPlist.strings
@@ -1,9 +1,3 @@
-/* Bundle display name */
-"CFBundleDisplayName" = "Mullvad VPN";
-
-/* Bundle name */
-"CFBundleName" = "MullvadVPN";
-
 /* Privacy - Local Network Usage Description */
 "NSLocalNetworkUsageDescription" = "Appen behöver detta för att ansluta och testa en ny metod.";
 

--- a/ios/PacketTunnel/de.lproj/InfoPlist.strings
+++ b/ios/PacketTunnel/de.lproj/InfoPlist.strings
@@ -1,6 +1,0 @@
-/* Bundle display name */
-"CFBundleDisplayName" = "Packettunnel";
-
-/* Bundle name */
-"CFBundleName" = "Packettunnel";
-

--- a/ios/PacketTunnel/fr.lproj/InfoPlist.strings
+++ b/ios/PacketTunnel/fr.lproj/InfoPlist.strings
@@ -1,6 +1,0 @@
-/* Bundle display name */
-"CFBundleDisplayName" = "Tunnel de paquets";
-
-/* Bundle name */
-"CFBundleName" = "Tunnel de paquets";
-

--- a/ios/PacketTunnel/sv.lproj/InfoPlist.strings
+++ b/ios/PacketTunnel/sv.lproj/InfoPlist.strings
@@ -1,6 +1,0 @@
-/* Bundle display name */
-"CFBundleDisplayName" = "Pakettunnel";
-
-/* Bundle name */
-"CFBundleName" = "Pakettunnel";
-

--- a/ios/translation/locales/de.xliff
+++ b/ios/translation/locales/de.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Assets/Localizable.xcstrings" source-language="en" target-language="de" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
       <trans-unit id="%@" xml:space="preserve">
@@ -1828,21 +1828,119 @@ Möchten Sie weiterhin "Lokales Netzwerkteilen" aktivieren?</target>
       </trans-unit>
     </body>
   </file>
-  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+  <file original="Assets/MullvadMockData-InfoPlist.xcstrings" source-language="en" target-language="de" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>Mullvad VPN</source>
-        <target state-qualifier="leveraged-mt">Mullvad VPN</target>
-        <note>Bundle display name</note>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>MullvadVPN</source>
-        <target state-qualifier="leveraged-mt">MullvadVPN</target>
-        <note>Bundle name</note>
+    </body>
+  </file>
+  <file original="Assets/MullvadRustRuntime-InfoPlist.xcstrings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadLogging-InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadSettings-InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadTypes-InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Operations-InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/PacketTunnelCore-InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Routing-InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadREST/en.lproj/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>The app needs this to connect and test a new method.</source>
         <target state-qualifier="leveraged-mt">Die App benötigt dies, um sich zu verbinden und eine neue Methode zu testen.</target>
@@ -1852,19 +1950,9 @@ Möchten Sie weiterhin "Lokales Netzwerkteilen" aktivieren?</target>
   </file>
   <file original="PacketTunnel/en.lproj/InfoPlist.strings" source-language="en" target-language="de" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target state-qualifier="leveraged-mt">Packettunnel</target>
-        <note>Bundle display name</note>
-      </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target state-qualifier="leveraged-mt">Packettunnel</target>
-        <note>Bundle name</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/ios/translation/locales/en.xliff
+++ b/ios/translation/locales/en.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Assets/Localizable.xcstrings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
       <trans-unit id="%@" xml:space="preserve">
@@ -1828,21 +1828,119 @@ Would you like to continue to enable “Local network sharing”?</target>
       </trans-unit>
     </body>
   </file>
-  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+  <file original="Assets/MullvadMockData-InfoPlist.xcstrings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>Mullvad VPN</source>
-        <target>Mullvad VPN</target>
-        <note>Bundle display name</note>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="new">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>MullvadVPN</source>
-        <target>MullvadVPN</target>
-        <note>Bundle name</note>
+    </body>
+  </file>
+  <file original="Assets/MullvadRustRuntime-InfoPlist.xcstrings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="new">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadLogging-InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target>Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadSettings-InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target>Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadTypes-InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target>Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Operations-InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target>Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/PacketTunnelCore-InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target>Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Routing-InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target>Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadREST/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target>Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>The app needs this to connect and test a new method.</source>
         <target>The app needs this to connect and test a new method.</target>
@@ -1852,19 +1950,9 @@ Would you like to continue to enable “Local network sharing”?</target>
   </file>
   <file original="PacketTunnel/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target>PacketTunnel</target>
-        <note>Bundle display name</note>
-      </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target>PacketTunnel</target>
-        <note>Bundle name</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/ios/translation/locales/fr.xliff
+++ b/ios/translation/locales/fr.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Assets/Localizable.xcstrings" source-language="en" target-language="fr" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
       <trans-unit id="%@" xml:space="preserve">
@@ -1828,21 +1828,119 @@ Voulez-vous continuer à activer le « Partage de réseau local»?</target>
       </trans-unit>
     </body>
   </file>
-  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+  <file original="Assets/MullvadMockData-InfoPlist.xcstrings" source-language="en" target-language="fr" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>Mullvad VPN</source>
-        <target state-qualifier="leveraged-mt">Mullvad VPN</target>
-        <note>Bundle display name</note>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>MullvadVPN</source>
-        <target state-qualifier="leveraged-mt">MullvadVPN</target>
-        <note>Bundle name</note>
+    </body>
+  </file>
+  <file original="Assets/MullvadRustRuntime-InfoPlist.xcstrings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadLogging-InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadSettings-InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadTypes-InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Operations-InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/PacketTunnelCore-InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Routing-InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadREST/en.lproj/InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>The app needs this to connect and test a new method.</source>
         <target state-qualifier="leveraged-mt">L'application a besoin de cela pour se connecter et tester une nouvelle méthode.</target>
@@ -1852,19 +1950,9 @@ Voulez-vous continuer à activer le « Partage de réseau local»?</target>
   </file>
   <file original="PacketTunnel/en.lproj/InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target state-qualifier="leveraged-mt">Tunnel de paquets</target>
-        <note>Bundle display name</note>
-      </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target state-qualifier="leveraged-mt">Tunnel de paquets</target>
-        <note>Bundle name</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/ios/translation/locales/sv.xliff
+++ b/ios/translation/locales/sv.xliff
@@ -2,7 +2,7 @@
 <xliff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Assets/Localizable.xcstrings" source-language="en" target-language="sv" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
       <trans-unit id="%@" xml:space="preserve">
@@ -1828,21 +1828,119 @@ Vill du fortsätta att aktivera “Lokalt nätverk delning”?</target>
       </trans-unit>
     </body>
   </file>
-  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+  <file original="Assets/MullvadMockData-InfoPlist.xcstrings" source-language="en" target-language="sv" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>Mullvad VPN</source>
-        <target state-qualifier="leveraged-mt">Mullvad VPN</target>
-        <note>Bundle display name</note>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>MullvadVPN</source>
-        <target state-qualifier="leveraged-mt">MullvadVPN</target>
-        <note>Bundle name</note>
+    </body>
+  </file>
+  <file original="Assets/MullvadRustRuntime-InfoPlist.xcstrings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
       </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadLogging-InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadSettings-InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/MullvadTypes-InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Operations-InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/PacketTunnelCore-InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="en.lproj/Routing-InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadREST/en.lproj/InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
+      <trans-unit id="NSHumanReadableCopyright" translate="no" xml:space="preserve">
+        <source>Copyright © 2025 Mullvad VPN AB. All rights reserved.</source>
+        <target state="needs-translation">Copyright © 2025 Mullvad VPN AB. All rights reserved.</target>
+        <note>Copyright (human-readable)</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="MullvadVPN/Supporting Files/en.lproj/InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
+    </header>
+    <body>
       <trans-unit id="NSLocalNetworkUsageDescription" xml:space="preserve">
         <source>The app needs this to connect and test a new method.</source>
         <target state-qualifier="leveraged-tm">Appen behöver detta för att ansluta och testa en ny metod.</target>
@@ -1852,19 +1950,9 @@ Vill du fortsätta att aktivera “Lokalt nätverk delning”?</target>
   </file>
   <file original="PacketTunnel/en.lproj/InfoPlist.strings" source-language="en" target-language="sv" datatype="plaintext">
     <header>
-      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.1" build-num="16B40"/>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="16.4" build-num="16F6"/>
     </header>
     <body>
-      <trans-unit id="CFBundleDisplayName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target state-qualifier="leveraged-tm">Pakettunnel</target>
-        <note>Bundle display name</note>
-      </trans-unit>
-      <trans-unit id="CFBundleName" xml:space="preserve">
-        <source>PacketTunnel</source>
-        <target state-qualifier="leveraged-tm">Pakettunnel</target>
-        <note>Bundle name</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/ios/translation/scripts/localizations.sh
+++ b/ios/translation/scripts/localizations.sh
@@ -95,6 +95,34 @@ export_localizations() {
   done
 }
 
+clean_xliff_translations() {
+  xliff_dir="$LOCALIZATION_DIR"
+  if [[ ! -d "$xliff_dir" ]]; then
+    echo "❌ Directory not found: $xliff_dir"
+    return 1
+  fi
+
+  # Dictionary of keys to ignore for translation
+  declare -A UNNEEDED_KEYS=(
+    ["CFBundleName"]=1
+    ["CFBundleDisplayName"]=1
+    # Add more keys here if needed
+  )
+
+  echo "🧹 Cleaning unneeded keys from XLIFFs in $xliff_dir"
+  for xliff in "$xliff_dir"/*.xliff; do
+    if [[ -f "$xliff" ]]; then
+      for key in "${!UNNEEDED_KEYS[@]}"; do
+        sed -i '' -E "/<trans-unit[^>]*id=\"$key\"[^>]*>/,/<\/trans-unit>/d" "$xliff"
+      done
+      echo "✔️ Cleaned $xliff"
+    else
+      echo "⚠️ File not found: $xliff, skipping"
+    fi
+  done
+
+}
+
 import_localizations() {
   # Directory where the .xliff files are stored
   XLIFF_DIR="$LOCALIZATION_DIR"
@@ -129,6 +157,7 @@ localization_to_export() {
   echo "📝 Export script started at: $(date)"
   build_project
   export_localizations
+  clean_xliff_translations
   cleanup_build_folder
   cleanup_temp_folder
   echo "🎉 Export complete. Crowdin-ready .xliff files are in: $LOCALIZATION_DIR"


### PR DESCRIPTION
This PR removes localization from the plist file in the packet tunnel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8625)
<!-- Reviewable:end -->
