### PR TITLE
Add instruction to remove `unattended-upgrades` from Ubuntu test VMs

### DIFF
--- a/test/docs/BUILD_OS_IMAGE.md
+++ b/test/docs/BUILD_OS_IMAGE.md
@@ -66,6 +66,14 @@ Make sure that `sshd.service` is enabled on boot.
 systemctl enable sshd.service
 ```
 
+### Ubuntu
+
+Stop `unattended-upgrades` by uninstalling it
+
+```
+sudo apt remove unattended-upgrades
+```
+
 ## Finishing setup
 
 Now you are done! If the VM was configured correctly, `test-manager` will be able to install the required dependencies and run the test suite using the new OS image.


### PR DESCRIPTION
`unattended-upgrades` can block a VM from installing the app when running end-to-end tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8639)
<!-- Reviewable:end -->
