### PR TITLE
Revert "Pin Rust nightly compiler to 2025-08-11 to avoid compiler regressions"

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -62,9 +62,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: Revert to using the regular 'nightly' channel as soon as https://github.com/rust-lang/rust/issues/145151
-        # has been closed and the fix is in the nightly channel.
-        rust: [stable, beta, nightly-2025-08-11]
+        rust: [stable, beta, nightly]
     continue-on-error: true
     steps:
       # Fix for HOME path overridden by GH runners when building in containers, see:


### PR DESCRIPTION
This PR reverts https://github.com/mullvad/mullvadvpn-app/pull/8598 since the bug in `rustc` has been fixed. Nightly compilers from `2025-08-17` and newer should be fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8642)
<!-- Reviewable:end -->
