### PR TITLE
Ignore failure to remove empty directory during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Line wrap the file at 100 chars.                                              Th
 - Add QUIC obfuscation (WireGuard only). It will be used automatically when connecting fails with
   other methods.
 
+### Changed
+#### Windows
+- Ignore non-empty install directory if removing it fails during upgrades. This attempts to work
+  around an issue of some processes hogging the install directory.
+
 ### Fixed
 #### macOS
 - Add support for parsing eslogger output version 10. This fixes split tunneling on macOS 26.

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -865,6 +865,40 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 !macroend
 
 #
+# RemoveInstallDirContents
+#
+# Deletes $INSTDIR without failing if the directory still exists but is empty.
+# This works around an annoying issue where apps keep open file handles to the directory.
+#
+!macro RemoveInstallDirContents
+
+	Push $0
+	Push $1
+
+	RMDir /r "$INSTDIR"
+	IfErrors 0 RemoveInstallDirContents_done
+	ClearErrors
+
+	FindFirst $0 $1 "$INSTDIR\*"
+	StrCmp $1 "" 0 RemoveInstallDirContents_findClose
+
+	# The directory is empty, so clear errors
+	ClearErrors
+
+RemoveInstallDirContents_findClose:
+
+	FindClose $0
+
+RemoveInstallDirContents_done:
+
+	Pop $1
+	Pop $0
+
+!macroend
+
+!define RemoveInstallDirContents '!insertmacro "RemoveInstallDirContents"'
+
+#
 # customUnInstallCheck
 #
 # This is called from the installer during an upgrade after the old version
@@ -1138,7 +1172,7 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 	# Remove application files
 	log::Log "Deleting $INSTDIR"
 	ClearErrors
-	RMDir /r $INSTDIR
+	RemoveInstallDirContents
 	IfErrors 0 customRemoveFiles_final_cleanup
 
 	log::Log "Failed to remove application files"

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -699,8 +699,6 @@ RemoveInstallDirContents_check:
 	${If} $1 != "."
 	${AndIf} $1 != ".."
 		log::Log "Failed to remove non-empty directory"
-		log::Log "thing: $1"
-		MessageBox MB_ICONSTOP|MB_TOPMOST|MB_OK "Thing: $1."
 		SetErrors
 		Goto RemoveInstallDirContents_findClose
 	${EndIf}

--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -388,7 +388,14 @@ async fn reinstall_locked_install_dir(rpc: ServiceClient, dir: &str) -> anyhow::
     let Ok(pid) = rpc
         .spawn(SpawnOpts {
             path: r"C:\Windows\System32\cmd.exe".into(),
-            args: vec![r"/K".into(), format!(r#"cd "{dir}"#)],
+            // open a new console window and cd into `dir`
+            args: vec![
+                "/C".into(),
+                "start".into(),
+                "cmd".into(),
+                "/K".into(),
+                format!(r#"cd "{dir}"#),
+            ],
             env: Default::default(),
             attach_stdin: false,
             attach_stdout: false,
@@ -403,7 +410,7 @@ async fn reinstall_locked_install_dir(rpc: ServiceClient, dir: &str) -> anyhow::
         .await;
 
     if let Err(err) = rpc.kill_child(pid).await {
-        log::error!("Failed to kill hogging process: {err}");
+        bail!("Failed to kill hogging process: {err}");
     }
 
     result?;

--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -389,13 +389,7 @@ async fn reinstall_locked_install_dir(rpc: ServiceClient, dir: &str) -> anyhow::
         .spawn(SpawnOpts {
             path: r"C:\Windows\System32\cmd.exe".into(),
             // open a new console window and cd into `dir`
-            args: vec![
-                "/C".into(),
-                "start".into(),
-                "cmd".into(),
-                "/K".into(),
-                format!(r#"cd "{dir}"#),
-            ],
+            args: vec!["/K".into(), "cd".into(), dir.into()],
             env: Default::default(),
             attach_stdin: false,
             attach_stdout: false,

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -434,6 +434,12 @@ impl ServiceClient {
         self.client.spawn(tarpc::context::current(), opts).await?
     }
 
+    pub async fn kill_child(&self, pid: u32) -> Result<(), Error> {
+        self.client
+            .kill_child(tarpc::context::current(), pid)
+            .await?
+    }
+
     pub async fn read_child_stdout(&self, pid: u32) -> Result<Option<String>, Error> {
         self.client
             .read_child_stdout(tarpc::context::current(), pid)


### PR DESCRIPTION
This is a workaround for the rare issue where a process holds a file handle to the application directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8643)
<!-- Reviewable:end -->
