### PR TITLE
Update ports in IP override tests

### DIFF
--- a/test/test-manager/src/tests/relay_ip_overrides.rs
+++ b/test/test-manager/src/tests/relay_ip_overrides.rs
@@ -11,7 +11,7 @@ use crate::{
 use anyhow::{Context, anyhow, bail, ensure};
 use futures::FutureExt;
 use mullvad_management_interface::MullvadProxyClient;
-use mullvad_relay_selector::query::builder::{RelayQueryBuilder, TransportProtocol};
+use mullvad_relay_selector::query::builder::{IpVersion, RelayQueryBuilder, TransportProtocol};
 use mullvad_types::{
     location::CountryCode,
     relay_constraints::{
@@ -63,7 +63,10 @@ pub async fn test_wireguard_ip_override(
     };
 
     // pick any wireguard_constraints relay to use with the test
-    let query = RelayQueryBuilder::wireguard().port(TUNNEL_PORT).build();
+    let query = RelayQueryBuilder::wireguard()
+        .port(TUNNEL_PORT)
+        .ip_version(IpVersion::V4)
+        .build();
     let relay = helpers::constrain_to_relay(&mut mullvad_client, query)
         .await
         .context("Failed to set WireGuard")?;


### PR DESCRIPTION
`test_wireguard_ip_override` is failing with port 443 not being in the retry order for WG anymore. Another fix was forcing IPv4 to be used, since it could otherwise succeed by not using the override and instead connecting over IPv6. Constraining the port in the relay constraints should also make it a bit faster

Test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/17159041587

Fix DES-2399

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8649)
<!-- Reviewable:end -->
