### PR TITLE
Remove hotfix to force Xcode 16.4

### DIFF
--- a/.github/actions/ios/setup-project-toolchain/action.yml
+++ b/.github/actions/ios/setup-project-toolchain/action.yml
@@ -51,7 +51,7 @@ runs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.1'
+        xcode-version: '16.4'
 
     - name: Configure Xcode project
       run: |

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -43,10 +43,6 @@ jobs:
           brew update
           brew install zip
 
-      - name: Select Xcode version. Remove this step after 25/8 2025, when Xcode 16.4 will be the default version.
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_16.4.app/Contents/Developer"
-
       - name: Run screenshot tests
         run: |
           set -o pipefail && env NSUnbufferedIO=YES xcodebuild \

--- a/.github/workflows/ios-validate-build-schemas.yml
+++ b/.github/workflows/ios-validate-build-schemas.yml
@@ -32,10 +32,6 @@ jobs:
       - name: Setup project
         uses: ./.github/actions/ios/setup-project-toolchain
 
-      - name: Select Xcode version. Remove this step after 25/8 2025, when Xcode 16.4 will be the default version.
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_16.4.app/Contents/Developer"
-
       - name: Run build validation for Staging and MockRelease configurations as well as the MullvadVPNUITests target
         run: |
           set -o pipefail && env NSUnbufferedIO=YES xcodebuild \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -58,10 +58,6 @@ jobs:
       - name: Setup project
         uses: ./.github/actions/ios/setup-project-toolchain
 
-      - name: Select Xcode version. Remove this step after 25/8 2025, when Xcode 16.4 will be the default version.
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_16.4.app/Contents/Developer"
-
       - name: Build for ui tests
         run: |
           set -o pipefail && env NSUnbufferedIO=YES xcodebuild \
@@ -85,10 +81,6 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/ios/setup-project-toolchain
-
-      - name: Select Xcode version. Remove this step after 25/8 2025, when Xcode 16.4 will be the default version.
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_16.4.app/Contents/Developer"
 
       - name: Run unit tests
         run: |


### PR DESCRIPTION
This PR removes the hotfix we added to force using Xcode 16.4 on the CI while Github was making it the default install.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8657)
<!-- Reviewable:end -->
