### PR TITLE
Fix relay features not present on cached relays

### DIFF
--- a/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
+++ b/ios/MullvadREST/ApiHandlers/ServerRelaysResponse.swift
@@ -108,26 +108,7 @@ extension REST {
             )
         }
 
-        // this is for the legacy DAITA flag, which will be deprecated in favour of a DAITA structure under Features
-        public func override(daita: Bool) -> Self {
-            ServerRelay(
-                hostname: hostname,
-                active: active,
-                owned: owned,
-                location: location,
-                provider: provider,
-                weight: weight,
-                ipv4AddrIn: ipv4AddrIn,
-                ipv6AddrIn: ipv6AddrIn,
-                publicKey: publicKey,
-                includeInCountry: includeInCountry,
-                daita: daita,
-                shadowsocksExtraAddrIn: shadowsocksExtraAddrIn,
-                features: features
-            )
-        }
-
-        public func override(features: ServerRelay.Features) -> Self {
+        public func override(features: ServerRelay.Features?) -> Self {
             ServerRelay(
                 hostname: hostname,
                 active: active,

--- a/ios/MullvadRESTTests/ServerRelayTests.swift
+++ b/ios/MullvadRESTTests/ServerRelayTests.swift
@@ -123,12 +123,16 @@ class ServerRelayTests: XCTestCase {
         )
     }
 
-    func testOverrideDaita() throws {
+    func testOverrideFeatures() throws {
         let overrideRelay: REST.ServerRelay = self.mockServerRelay.override(
-            daita: true
+            features: REST.ServerRelay.Features(
+                daita: REST.ServerRelay.Features.DAITA(),
+                quic: REST.ServerRelay.Features.QUIC(addrIn: [""], domain: "", token: "")
+            )
         )
 
-        XCTAssertEqual(overrideRelay.daita, true)
+        XCTAssertNotNil(overrideRelay.features?.daita)
+        XCTAssertNotNil(overrideRelay.features?.quic)
     }
 
     var shadowSocksExtraAddrIn: [String] {

--- a/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
+++ b/ios/MullvadVPN/RelayCacheTracker/RelayCacheTracker.swift
@@ -64,7 +64,7 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
 
         do {
             cachedRelays = try cache.read().cachedRelays
-            try hotfixRelaysThatDoNotHaveDaita()
+            try hotfixRelaysThatDoNotHaveFeatures()
         } catch {
             logger.error(
                 error: error,
@@ -75,32 +75,31 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
         }
     }
 
-    /// This method updates the cached relay to include daita information
+    /// This method updates the cached relay to include "feature" information
     ///
-    /// This is a hotfix meant to upgrade clients shipped with 2024.5 or before that did not have
-    /// daita information in their representation of `ServerRelay`.
-    /// If a version <= 2024.5 is installed less than an hour before a new upgrade,
-    /// no servers will be shown in locations when filtering for daita relays.
+    /// This is a hotfix meant to upgrade clients shipped with 2025.6 or before that did not have
+    /// feature information in their representation of `ServerRelay`.
+    /// If a version <= 2025.6 is installed less than an hour before a new upgrade,
+    /// no servers will be shown in locations when filtering for relays requiring a certain feature.
     ///
     /// > Info: `relayCacheLock` does not need to be accessed here, this method should be ran from `init` only.
-    private func hotfixRelaysThatDoNotHaveDaita() throws {
+    private func hotfixRelaysThatDoNotHaveFeatures() throws {
         guard let cachedRelays else { return }
-        let daitaPropertyMissing = cachedRelays.relays.wireguard.relays.first { $0.hasDaita } == nil
+        let featurePropertyMissing = cachedRelays.relays.wireguard.relays.first { $0.features != nil } == nil
         // If the cached relays already have daita information, this fix is not necessary
-        guard daitaPropertyMissing else { return }
+        guard featurePropertyMissing else { return }
 
         let preBundledRelays = try cache.readPrebundledRelays().relays
-        let preBundledDaitaRelays = preBundledRelays.wireguard.relays.filter { $0.hasDaita }
-        var cachedRelaysWithFixedDaita = cachedRelays.relays.wireguard.relays
+        let preBundledFeatureRelays = preBundledRelays.wireguard.relays.filter { $0.features != nil }
+        var cachedRelaysWithFixedFeatures = cachedRelays.relays.wireguard.relays
 
-        // For each daita enabled relay in the prebundled relays
-        // Find the corresponding relay in the cache by matching relay hostnames
-        // Then update it to toggle daita
-        for index in 0 ..< cachedRelaysWithFixedDaita.endIndex {
-            let relay = cachedRelaysWithFixedDaita[index]
-            preBundledDaitaRelays.forEach {
+        // For each relay with features in the prebundled relays, find the corresponding relay
+        // in the cache by matching relay hostnames and update it.
+        for index in 0 ..< cachedRelaysWithFixedFeatures.endIndex {
+            let relay = cachedRelaysWithFixedFeatures[index]
+            preBundledFeatureRelays.forEach {
                 if $0.hostname == relay.hostname {
-                    cachedRelaysWithFixedDaita[index] = relay.override(daita: true)
+                    cachedRelaysWithFixedFeatures[index] = relay.override(features: $0.features)
                 }
             }
         }
@@ -110,7 +109,7 @@ final class RelayCacheTracker: RelayCacheTrackerProtocol, @unchecked Sendable {
             cachedRelays.relays.wireguard.ipv4Gateway,
             ipv6Gateway: cachedRelays.relays.wireguard.ipv6Gateway,
             portRanges: cachedRelays.relays.wireguard.portRanges,
-            relays: cachedRelaysWithFixedDaita,
+            relays: cachedRelaysWithFixedFeatures,
             shadowsocksPortRanges: cachedRelays.relays.wireguard.shadowsocksPortRanges
         )
 


### PR DESCRIPTION
When releasing QUIC the relay list will have a slightly different format with somerthing called "features". For users with the app already installing, upgrading to the newest version will not clear/update the relay cache, which hides relays with features until the relay list is updated through a periodic timer. This PR hotfixes this, but a proper solution will be explored in a separate task.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8667)
<!-- Reviewable:end -->
