### PR TITLE
Do not query `max_datagram_size` for every packet.

### DIFF
--- a/mullvad-masque-proxy/examples/masque-client.rs
+++ b/mullvad-masque-proxy/examples/masque-client.rs
@@ -94,7 +94,6 @@ async fn main() {
         .server_addr(server_addr)
         .server_host(server_hostname)
         .target_addr(target_addr)
-        .mtu(mtu)
         .tls_config(tls_config)
         .idle_timeout(idle_timeout)
         .auth_header(auth);

--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -29,8 +29,7 @@ use quinn::{
 };
 
 use crate::{
-    MASQUE_WELL_KNOWN_PATH, MAX_INFLIGHT_PACKETS, MIN_IPV4_MTU, MIN_IPV6_MTU,
-    compute_udp_payload_size,
+    MASQUE_WELL_KNOWN_PATH, MAX_INFLIGHT_PACKETS,
     fragment::{self, DefragReceived, Fragments},
     stats::Stats,
 };
@@ -58,9 +57,6 @@ pub struct Client {
     /// Request stream for the currently open request, must not be dropped, otherwise proxy
     /// connection is terminated
     request_stream: client::RequestStream<h3_quinn::BidiStream<bytes::Bytes>, bytes::Bytes>,
-
-    /// Maximum UDP payload size (packet size including QUIC overhead)
-    max_udp_payload_size: u16,
 
     stats: Arc<Stats>,
 }
@@ -153,10 +149,6 @@ pub struct ClientConfig {
     /// Remote QUIC endpoint hostname
     pub server_host: String,
 
-    /// MTU (includes IP header)
-    #[builder(default = 1500)]
-    pub mtu: u16,
-
     /// QUIC TLS config
     #[builder(default = default_tls_config())]
     pub tls_config: Arc<rustls::ClientConfig>,
@@ -191,14 +183,8 @@ impl Client {
         // better performance.
         client_config.transport_config(Arc::new(transport_config));
 
-        Self::validate_mtu(config.mtu, config.target_addr)?;
-
-        let max_udp_payload_size = compute_udp_payload_size(config.mtu, config.server_addr);
-
-        let endpoint = Self::setup_quic_endpoint(
-            config.quinn_socket.into_std().map_err(Error::Endpoint)?,
-            max_udp_payload_size,
-        )?;
+        let endpoint =
+            Self::setup_quic_endpoint(config.quinn_socket.into_std().map_err(Error::Endpoint)?)?;
 
         let connecting =
             endpoint.connect_with(client_config, config.server_addr, &config.server_host)?;
@@ -209,7 +195,6 @@ impl Client {
             connection.clone(),
             config.target_addr,
             &config.server_host,
-            max_udp_payload_size,
             config.auth_header,
         )
         .await?;
@@ -220,36 +205,22 @@ impl Client {
             client_socket: Arc::new(config.client_socket),
             request_stream,
             send_stream,
-            max_udp_payload_size,
             stats: Arc::default(),
         })
     }
 
-    const fn validate_mtu(mtu: u16, target_addr: SocketAddr) -> Result<()> {
-        let min_mtu = if target_addr.is_ipv4() {
-            MIN_IPV4_MTU
-        } else {
-            MIN_IPV6_MTU
-        };
-        if mtu >= min_mtu {
-            Ok(())
-        } else {
-            Err(Error::InvalidMtu { min_mtu })
-        }
-    }
-
     // `socket` is a UDP socket which quinn will read/write from/to.
-    fn setup_quic_endpoint(
-        socket: std::net::UdpSocket,
-        max_udp_payload_size: u16,
-    ) -> Result<Endpoint> {
-        let endpoint_config = {
-            let mut endpoint_config = EndpointConfig::default();
-            endpoint_config
-                .max_udp_payload_size(max_udp_payload_size)
-                .map_err(Error::InvalidMaxUdpPayload)?;
-            endpoint_config
+    fn setup_quic_endpoint(socket: std::net::UdpSocket) -> Result<Endpoint> {
+        let mut endpoint_config = EndpointConfig::default();
+
+        // this is the default, but the server requires the field to be set.
+        let max_udp_payload_size = match socket.peer_addr() {
+            Ok(SocketAddr::V4(..)) => 1472,
+            Ok(SocketAddr::V6(..)) | Err(_) => 1452,
         };
+        endpoint_config
+            .max_udp_payload_size(max_udp_payload_size)
+            .expect("max_udp_payload_size is within bounds");
 
         Endpoint::new(endpoint_config, None, socket, Arc::new(TokioRuntime))
             .map_err(Error::Endpoint)
@@ -260,7 +231,6 @@ impl Client {
         connection: quinn::Connection,
         target: SocketAddr,
         server_host: &str,
-        mtu: u16,
         auth_header: Option<String>,
     ) -> Result<(
         client::Connection<h3_quinn::Connection, bytes::Bytes>,
@@ -275,16 +245,8 @@ impl Client {
             .await
             .map_err(Error::CreateClient)?;
 
-        Self::send_connect_request(
-            connection,
-            send_stream,
-            server_host,
-            target,
-            mtu,
-            0,
-            auth_header,
-        )
-        .await
+        Self::send_connect_request(connection, send_stream, server_host, target, 0, auth_header)
+            .await
     }
 
     /// Send an HTTP CONNECT request and set up the h3 connection for sending datagrams.
@@ -295,7 +257,6 @@ impl Client {
         mut send_stream: client::SendRequest<h3_quinn::OpenStreams, bytes::Bytes>,
         server_host: &str,
         target: SocketAddr,
-        mtu: u16,
         redirect_count: usize,
         auth_header: Option<String>,
     ) -> Result<(
@@ -303,7 +264,7 @@ impl Client {
         client::SendRequest<h3_quinn::OpenStreams, bytes::Bytes>,
         client::RequestStream<h3_quinn::BidiStream<bytes::Bytes>, bytes::Bytes>,
     )> {
-        let request = new_connect_request(target, &server_host, mtu, auth_header.as_deref())?;
+        let request = new_connect_request(target, &server_host, auth_header.as_deref())?;
 
         let request_future = async move {
             let mut request_stream = send_stream.send_request(request).await?;
@@ -356,7 +317,6 @@ impl Client {
                     send_stream,
                     &server_host,
                     target,
-                    mtu,
                     redirect_count + 1,
                     auth_header,
                 ))
@@ -410,7 +370,6 @@ impl Client {
 
         spawn!(server_socket_task(
             stream_id,
-            self.max_udp_payload_size,
             self.quinn_conn,
             self.connection,
             server_tx,
@@ -460,7 +419,6 @@ impl RunningClient {
 
 async fn server_socket_task(
     stream_id: StreamId,
-    _max_udp_payload_size: u16,
     quinn_conn: quinn::Connection,
     mut connection: h3::client::Connection<h3_quinn::Connection, bytes::Bytes>,
     server_tx: mpsc::Sender<Datagram>,
@@ -472,12 +430,14 @@ async fn server_socket_task(
 
     // Maximum size of a datagram passed to send_datagram.
     // Based on quinns path MTU detection, and updated throughout the lifetime of the connection.
-    let mut max_datagram_size: u16 = 1500;
-
+    // Start with the smallest allowed value.
+    let mut max_datagram_size: u16 = 1200;
     let mut max_datagram_size_timer = interval(Duration::from_secs(1));
 
+    // Update `max_datagram_size`, returning true if the value changed.
     let update_max_datagram_size = |max_datagram_size: &mut u16| -> bool {
         let mut value_changed = false;
+
         if let Some(new) = quinn_conn.max_datagram_size() {
             let new = u16::try_from(new).expect("max_datagram_size fits in a u16");
 
@@ -502,7 +462,7 @@ async fn server_socket_task(
         let packet = select! {
             _ = max_datagram_size_timer.tick() => {
                 if update_max_datagram_size(&mut max_datagram_size) {
-                    log::warn!("mtu updated from timer")
+                    log::warn!("mtu updated from timer") // todo: remove me
                 };
                 continue;
             }
@@ -825,7 +785,6 @@ async fn fragment_reassembly_task(
 fn new_connect_request(
     socket_addr: SocketAddr,
     authority: &dyn AsRef<str>,
-    mtu: u16,
     authorization: Option<&str>,
 ) -> Result<http::Request<()>> {
     let host = socket_addr.ip();
@@ -848,15 +807,7 @@ fn new_connect_request(
         builder = builder.header(header::AUTHORIZATION, auth);
     }
 
-    let mut request = builder
-        // TODO: Not needed since we set the max_udp_payload_size transport param
-        .header(
-            b"X-Mullvad-Uplink-Mtu".as_slice(),
-            format!("{mtu}"),
-        )
-        .body(())
-        .expect("failed to construct a body");
-
+    let mut request = builder.body(()).expect("failed to construct a body");
     request.extensions_mut().insert(Protocol::CONNECT_UDP);
     Ok(request)
 }

--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -14,7 +14,7 @@ use std::{
 use tokio::{
     net::UdpSocket,
     select,
-    sync::{broadcast, mpsc, watch},
+    sync::{mpsc, oneshot, watch},
     task::JoinSet,
     time::interval,
 };

--- a/mullvad-masque-proxy/src/client/mod.rs
+++ b/mullvad-masque-proxy/src/client/mod.rs
@@ -14,8 +14,9 @@ use std::{
 use tokio::{
     net::UdpSocket,
     select,
-    sync::{mpsc, oneshot, watch},
+    sync::{broadcast, mpsc, watch},
     task::JoinSet,
+    time::interval,
 };
 use typed_builder::TypedBuilder;
 
@@ -28,7 +29,7 @@ use quinn::{
 };
 
 use crate::{
-    MASQUE_WELL_KNOWN_PATH, MAX_INFLIGHT_PACKETS, MIN_IPV4_MTU, MIN_IPV6_MTU, QUIC_HEADER_SIZE,
+    MASQUE_WELL_KNOWN_PATH, MAX_INFLIGHT_PACKETS, MIN_IPV4_MTU, MIN_IPV6_MTU,
     compute_udp_payload_size,
     fragment::{self, DefragReceived, Fragments},
     stats::Stats,
@@ -459,7 +460,7 @@ impl RunningClient {
 
 async fn server_socket_task(
     stream_id: StreamId,
-    max_udp_payload_size: u16,
+    _max_udp_payload_size: u16,
     quinn_conn: quinn::Connection,
     mut connection: h3::client::Connection<h3_quinn::Connection, bytes::Bytes>,
     server_tx: mpsc::Sender<Datagram>,
@@ -469,8 +470,42 @@ async fn server_socket_task(
     let mut fragment_id = 0u16;
     let stream_id_size = VarInt::from(stream_id).size() as u16;
 
+    // Maximum size of a datagram passed to send_datagram.
+    // Based on quinns path MTU detection, and updated throughout the lifetime of the connection.
+    let mut max_datagram_size: u16 = 1500;
+
+    let mut max_datagram_size_timer = interval(Duration::from_secs(1));
+
+    let update_max_datagram_size = |max_datagram_size: &mut u16| -> bool {
+        let mut value_changed = false;
+        if let Some(new) = quinn_conn.max_datagram_size() {
+            let new = u16::try_from(new).expect("max_datagram_size fits in a u16");
+
+            // quinn will prepend the stream id to the datagram, we must account for this.
+            let new = new.saturating_sub(stream_id_size);
+
+            debug_assert!(new > 0);
+
+            value_changed = new != *max_datagram_size;
+
+            if cfg!(debug_assertions) && value_changed {
+                log::debug!("new path mtu, max_datagram_size {max_datagram_size}->{new}");
+            }
+
+            *max_datagram_size = new;
+        }
+
+        value_changed
+    };
+
     loop {
         let packet = select! {
+            _ = max_datagram_size_timer.tick() => {
+                if update_max_datagram_size(&mut max_datagram_size) {
+                    log::warn!("mtu updated from timer")
+                };
+                continue;
+            }
             datagram = connection.read_datagram() => {
                 match datagram {
                     Ok(Some(response)) => {
@@ -487,35 +522,53 @@ async fn server_socket_task(
             packet = client_rx.recv() => packet,
         };
 
-        let Some(mut packet) = packet else { break };
+        let Some(packet) = packet else { break };
+        let packet_len = packet.len();
 
-        // Maximum QUIC payload (including fragmentation headers)
-        let maximum_packet_size = if let Some(max_datagram_size) = quinn_conn.max_datagram_size() {
-            max_datagram_size as u16 - stream_id_size
-        } else {
-            max_udp_payload_size - QUIC_HEADER_SIZE - stream_id_size
-        };
+        // loop, because we want to try to re-send the packet if path mtu has changed.
+        'retry: loop {
+            let mut packet = packet.clone(); // cheap clone
 
-        if packet.len() <= usize::from(maximum_packet_size) {
-            stats.tx(packet.len(), false);
-            connection
-                .send_datagram(stream_id, packet)
-                .map_err(Error::SendDatagram)?;
-        } else {
-            // drop the added context ID, since packet will have to be fragmented.
-            let _ = VarInt::decode(&mut packet);
+            if packet_len <= usize::from(max_datagram_size) {
+                if let Err(e) = connection.send_datagram(stream_id, packet) {
+                    // TODO: if possible, check that error is TooLarge
+                    log::error!("send_datagram err: {e}"); // TODO: remove me
+                    if update_max_datagram_size(&mut max_datagram_size) {
+                        log::error!("Failed to send packet that was too large, retrying");
+                        continue 'retry;
+                    } else {
+                        return Err(Error::SendDatagram(e));
+                    }
+                }
+                stats.tx(packet_len, false);
+            } else {
+                // drop the added context ID, since packet will have to be fragmented.
+                let _ = VarInt::decode(&mut packet);
 
-            for fragment in fragment::fragment_packet(maximum_packet_size, &mut packet, fragment_id)
-                .map_err(Error::PacketTooLarge)?
-            {
-                debug_assert!(fragment.len() <= maximum_packet_size as usize);
+                for fragment in
+                    fragment::fragment_packet(max_datagram_size, &mut packet, fragment_id)
+                        .map_err(Error::PacketTooLarge)?
+                {
+                    let fragment_len = fragment.len();
+                    debug_assert!(fragment_len <= usize::from(max_datagram_size));
 
-                stats.tx(fragment.len(), true);
-                connection
-                    .send_datagram(stream_id, fragment)
-                    .map_err(Error::SendDatagram)?;
+                    if let Err(e) = connection.send_datagram(stream_id, fragment) {
+                        // TODO: if possible, check that error is TooLarge
+                        log::error!("send_datagram err: {e}"); // TODO: remove me
+                        if update_max_datagram_size(&mut max_datagram_size) {
+                            fragment_id = fragment_id.wrapping_add(1);
+                            log::error!("Failed to send packet that was too large, retrying");
+                            continue 'retry;
+                        } else {
+                            return Err(Error::SendDatagram(e));
+                        }
+                    }
+
+                    stats.tx(fragment_len, true);
+                }
+                fragment_id = fragment_id.wrapping_add(1);
             }
-            fragment_id = fragment_id.wrapping_add(1);
+            break;
         }
     }
 

--- a/mullvad-masque-proxy/src/server/mod.rs
+++ b/mullvad-masque-proxy/src/server/mod.rs
@@ -54,6 +54,7 @@ pub struct ServerParams {
     pub hostname: Option<String>,
 
     /// Maximum transfer unit
+    // TODO: remove this
     #[builder(default = 1500)]
     pub mtu: u16,
 

--- a/mullvad-masque-proxy/tests/proxy.rs
+++ b/mullvad-masque-proxy/tests/proxy.rs
@@ -180,7 +180,6 @@ async fn setup_masque(mtu: u16) -> anyhow::Result<(UdpSocket, UdpSocket)> {
         .server_addr(masque_server_addr)
         .server_host(HOST.to_owned())
         .target_addr(target_udp_addr)
-        .mtu(mtu)
         .idle_timeout(Some(Duration::from_secs(10)))
         .auth_header(Some("Bearer test".to_owned()))
         .build();

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -140,8 +140,7 @@ impl Quic {
             .server_addr(settings.quic_endpoint)
             .server_host(settings.hostname.clone())
             .target_addr(settings.wireguard_endpoint)
-            .auth_header(Some(settings.auth_header()))
-            .mtu(settings.mtu.unwrap_or(1500));
+            .auth_header(Some(settings.auth_header()));
 
         let config = config_builder.build();
 


### PR DESCRIPTION
`max_datagram_size` is guarded by a lock. Calling it for every packet wastes a fair amount of cycles on acquiring it.

Instead, we do the following:
* Periodically call max_datagram_size.
* Call max_datagram_size whenever send_datagram errors. Quinn will internally check whether the packet is too large and throw an error in such case.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8673)
<!-- Reviewable:end -->
