### PR TITLE
Recreate the resolver loopback interface alias/IP if it is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### macOS
 - Fix apps attempting to use IPv6 with in-tunnel IPv6 disabled.
+- Re-add missing loopback alias if removed. This fixes some issues with DNS resolution.
 
 
 ## [2025.9] - 2025-09-08

--- a/talpid-core/src/resolver.rs
+++ b/talpid-core/src/resolver.rs
@@ -43,6 +43,7 @@ use hickory_server::{
 use rand::random_range;
 use socket2::{Domain, Protocol, Socket, Type};
 use std::sync::LazyLock;
+use talpid_routing::data::RouteSocketMessage;
 use talpid_types::drop_guard::{OnDrop, on_drop};
 use tokio::{
     net::{self, UdpSocket},

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -26,7 +26,7 @@ use netlink_packet_route::rtnl::constants::RT_TABLE_MAIN;
 #[cfg(target_os = "macos")]
 pub use imp::{
     PlatformError,
-    imp::{DefaultRouteEvent, RouteError},
+    imp::{DefaultRouteEvent, RouteError, RoutingTable, data},
 };
 
 pub use imp::{Error, RouteManagerHandle};

--- a/talpid-routing/src/unix/macos/routing_socket.rs
+++ b/talpid-routing/src/unix/macos/routing_socket.rs
@@ -16,7 +16,7 @@ use std::{
     os::fd::{AsRawFd, RawFd},
 };
 
-use super::data::{MessageType, RouteMessage, rt_msghdr_short};
+use super::data::{MessageType, RouteMessage, ffi::rt_msghdr_short};
 
 use tokio::io::{AsyncWrite, AsyncWriteExt, unix::AsyncFd};
 
@@ -136,10 +136,10 @@ impl RoutingSocket {
             std::ptr::copy_nonoverlapping(
                 &header as *const _ as *const u8,
                 msg_buffer.as_mut_ptr(),
-                size_of::<super::data::rt_msghdr>(),
+                size_of::<libc::rt_msghdr>(),
             );
         }
-        let mut sockaddr_buf = &mut msg_buffer[std::mem::size_of::<super::data::rt_msghdr>()..];
+        let mut sockaddr_buf = &mut msg_buffer[std::mem::size_of::<libc::rt_msghdr>()..];
         for socket_addr in payload {
             sockaddr_buf
                 .write_all(socket_addr.as_slice())


### PR DESCRIPTION
This ensures that the loopback interface alias (used by the local DNS resolver) is recreated if it is removed for whatever reason.

Test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/17464404532

Test fails on main: https://github.com/mullvad/mullvadvpn-app/actions/runs/17464879908

Fix DES-2401

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8675)
<!-- Reviewable:end -->
