### PR TITLE
Fix querying of latest version on Linux

### DIFF
--- a/installer-downloader/src/controller.rs
+++ b/installer-downloader/src/controller.rs
@@ -215,6 +215,7 @@ where
             architecture,
             // For the downloader, the rollout version is always preferred
             rollout: mullvad_update::version::IGNORE,
+            allow_empty: false,
             // The downloader allows any version
             lowest_metadata_version: mullvad_update::version::MIN_VERIFY_METADATA_VERSION,
         };

--- a/mullvad-api/src/version.rs
+++ b/mullvad-api/src/version.rs
@@ -85,6 +85,8 @@ impl AppVersionProxy {
             let params = VersionParameters {
                 architecture,
                 rollout,
+                // NOTE: On Linux, version metadata contains no installers
+                allow_empty: cfg!(target_os = "linux"),
                 lowest_metadata_version,
             };
 

--- a/mullvad-update/src/client/snapshots/mullvad_update__client__api__test__http_version_provider.snap
+++ b/mullvad-update/src/client/snapshots/mullvad_update__client__api__test__http_version_provider.snap
@@ -6,10 +6,10 @@ snapshot_kind: text
 signatures:
   - keytype: ed25519
     keyid: bb4ef63ffdcc6bd5a19c30cd23b9de03099407a04463418f17ae338b98aa09d4
-    sig: 253ec37846dcd909bfc5119c0e0d06535767e179eb8b4465015eaa95f4bed362c8c9186311192c987871722bf7d319d44e4f04eaf79c269820bc13ff1a901f0b
+    sig: fb0f0d608f82101ca294c9150ce268c29bdaf99d4a726541e59523ef00b0d534d65cac277f1355e2838f5ac1b1f1e7013411da70049ba19a208515c67a97de06
 signed:
   metadata_version: 0
-  metadata_expiry: "2025-07-02T15:33:00Z"
+  metadata_expiry: "2025-10-02T15:33:00Z"
   releases:
     - version: "2025.2"
       changelog: "[macos] Adding support for quicfuscator\n[windows] Less bugs"
@@ -64,3 +64,6 @@ signed:
             - "https://releases.mullvad.net/desktop/releases/2025.3-beta1/MullvadVPN-2025.3-beta1_arm64.exe"
           size: 111488248
           sha256: 82948D3DB5B869EE5F0D246DB557A81B72B68DFDDD2267872B7B8A5B19A05444
+    - version: "2026.10"
+      changelog: ""
+      installers: []

--- a/mullvad-update/src/snapshots/mullvad_update__version__test__version_info_empty.snap
+++ b/mullvad-update/src/snapshots/mullvad_update__version__test__version_info_empty.snap
@@ -1,0 +1,44 @@
+---
+source: mullvad-update/src/version.rs
+expression: info
+snapshot_kind: text
+---
+stable:
+  version: "2026.10"
+  urls: []
+  size: 0
+  changelog: ""
+  sha256:
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+beta: ~

--- a/mullvad-update/test-version-response.json
+++ b/mullvad-update/test-version-response.json
@@ -3,12 +3,12 @@
     {
       "keytype": "ed25519",
       "keyid": "bb4ef63ffdcc6bd5a19c30cd23b9de03099407a04463418f17ae338b98aa09d4",
-      "sig": "253ec37846dcd909bfc5119c0e0d06535767e179eb8b4465015eaa95f4bed362c8c9186311192c987871722bf7d319d44e4f04eaf79c269820bc13ff1a901f0b"
+      "sig": "fb0f0d608f82101ca294c9150ce268c29bdaf99d4a726541e59523ef00b0d534d65cac277f1355e2838f5ac1b1f1e7013411da70049ba19a208515c67a97de06"
     }
   ],
   "signed": {
     "metadata_version": 0,
-    "metadata_expiry": "2025-07-02T15:33:00Z",
+    "metadata_expiry": "2025-10-02T15:33:00Z",
     "releases": [
       {
         "version": "2025.2",
@@ -98,6 +98,11 @@
             "sha256": "82948D3DB5B869EE5F0D246DB557A81B72B68DFDDD2267872B7B8A5B19A05444"
           }
         ]
+      },
+      {
+        "version": "2026.10",
+        "changelog": "",
+        "installers": []
       }
     ]
   }


### PR DESCRIPTION
We currently do not use the V2 version check endpoint on Linux. Doing so fails since the metadata contains no installers for any architecture.

This PR adds a "query" parameter that allows versions to be returned even if there are no installers for the target architecture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8678)
<!-- Reviewable:end -->
