### PR TITLE
Add script for generating and uploading `latest.json` metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,6 +3416,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strum",
  "thiserror 2.0.9",
  "tokio",
  "vec1",
@@ -5464,6 +5465,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strum",
  "tokio",
  "toml 0.8.19",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ serde = "1.0.204"
 serde_json = "1.0.122"
 windows-sys = "0.52.0"
 nix = "0.30.1"
+strum = { version = "0.27" }
 
 # Networking
 pnet_packet = "0.35.0"

--- a/desktop/scripts/release/5-update-and-publish-metadata
+++ b/desktop/scripts/release/5-update-and-publish-metadata
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script downloads the build artifacts along with the signatures, verifies the signatures and
-# publishes new version metadata to Mullvads API.
+# publishes new version metadata to Mullvads API (including latest.json).
 # * This should be run after `4-make-release`.
 # * You need to put the private ed25519 signing key in the clipboard before running this script.
 
@@ -34,19 +34,26 @@ function publish_metadata {
     local platforms
     platforms=(windows macos linux)
     local signed_dir="signed/"
+    local work_dir="work/"
+    local published_dir="currently_published/"
+    local upload_dir="upload/"
+    local latest_path="latest.json"
 
-    rm -rf currently_published/
+    rm -rf "$signed_dir"
+    rm -rf "$upload_dir"
+    rm -rf "$published_dir"
 
     echo ">>> Fetching current version metadata"
-    mullvad-release pull --assume-yes "${platforms[@]}"
+    mullvad-release pull --assume-yes --latest-file "${platforms[@]}"
     echo ""
 
     echo ">>> Backing up released data"
-    cp -r $signed_dir currently_published/
+    cp -r $signed_dir $published_dir
+    cp "$latest_path" "$published_dir"
     echo ""
 
-    echo ">>> Replacing work/ directory with latest published data"
-    cp -rf signed/ work/
+    echo ">>> Replacing $work_dir directory with latest published data"
+    cp -rf "$signed_dir" "$work_dir"
     echo ""
 
     echo ">>> Adding new release $PRODUCT_VERSION (rollout = 1)"
@@ -61,12 +68,20 @@ function publish_metadata {
     mullvad-release verify "${platforms[@]}"
     echo ""
 
-    echo ">>> New metadata including $PRODUCT_VERSION"
-    git --no-pager diff --no-index -- currently_published/ $signed_dir || true
+    echo ">>> Creating upload dir"
+    cp -rf "$signed_dir" "$upload_dir"
     echo ""
 
-    read -rp "Press enter to upload if the diff looks good "
-    ./publish-metadata-to-api $signed_dir "$BUILDSERVER_HOST" "$METADATA_SERVER_HOST"
+    echo ">>> Generating $latest_path for current version metadata"
+    mullvad-release query-latest "${platforms[@]}" > "$upload_dir/$latest_path"
+    echo ""
+
+    echo ">>> New metadata including $PRODUCT_VERSION"
+    git --no-pager diff --no-index -- $published_dir $upload_dir || true
+    echo ""
+
+    read -rp "Press enter to upload if the diffs look good "
+    ./publish-metadata-to-api $upload_dir "$BUILDSERVER_HOST" "$METADATA_SERVER_HOST"
 }
 
 function remove_release_artifacts {

--- a/mullvad-update/Cargo.toml
+++ b/mullvad-update/Cargo.toml
@@ -29,7 +29,7 @@ itertools = { workspace = true }
 
 reqwest = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
-strum = { version = "0.27", features = ["derive"], optional = true }
+strum = { workspace = true, features = ["derive"], optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs", "process", "macros"], optional = true }
 vec1 = { workspace = true }
 

--- a/mullvad-update/Cargo.toml
+++ b/mullvad-update/Cargo.toml
@@ -29,6 +29,7 @@ itertools = { workspace = true }
 
 reqwest = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
+strum = { version = "0.27", features = ["derive"], optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs", "process", "macros"], optional = true }
 vec1 = { workspace = true }
 

--- a/mullvad-update/mullvad-release/Cargo.toml
+++ b/mullvad-update/mullvad-release/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
+strum = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 toml = "0.8"
 

--- a/mullvad-update/mullvad-release/Cargo.toml
+++ b/mullvad-update/mullvad-release/Cargo.toml
@@ -24,4 +24,4 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8"
 
 mullvad-version = { path = "../../mullvad-version", features = ["serde"] }
-mullvad-update = { path = "../", features = ["client", "sign"] }
+mullvad-update = { path = "../", features = ["client", "sign", "strum"] }

--- a/mullvad-update/mullvad-release/src/main.rs
+++ b/mullvad-update/mullvad-release/src/main.rs
@@ -5,16 +5,20 @@
 
 use anyhow::{Context, bail};
 use clap::Parser;
-use std::str::FromStr;
+use std::{path::Path, str::FromStr};
+use tokio::fs;
 
 use config::Config;
 use io_util::create_dir_and_write;
 use platform::Platform;
 
 use mullvad_update::{
+    api::HttpVersionInfoProvider,
     format::{self, SignedResponse, key},
     version::Rollout,
 };
+
+use crate::io_util::wait_for_confirm;
 
 mod artifacts;
 mod config;
@@ -27,6 +31,9 @@ const DEFAULT_EXPIRY_MONTHS: usize = 6;
 
 /// Rollout to use when not specified
 const DEFAULT_ROLLOUT: f32 = 1.;
+
+/// Filename for latest.json metadata
+const LATEST_FILENAME: &str = "latest.json";
 
 /// A tool that generates signed Mullvad version metadata.
 ///
@@ -51,6 +58,10 @@ pub enum Opt {
         /// Replace signed files without asking for confirmation
         #[arg(long, short = 'y')]
         assume_yes: bool,
+
+        /// Also update the latest.json file
+        #[arg(long, default_value_t = false)]
+        latest_file: bool,
     },
 
     /// List releases in `work/`
@@ -151,10 +162,42 @@ async fn main() -> anyhow::Result<()> {
         Opt::Pull {
             platforms,
             assume_yes,
+            latest_file,
         } => {
             for platform in all_platforms_if_empty(platforms) {
                 platform.pull(assume_yes).await?;
             }
+
+            // Download latest.json metadata if available
+            if latest_file {
+                match HttpVersionInfoProvider::get_latest_versions_file()
+                    .await
+                    .and_then(|json| {
+                        serde_json::to_string_pretty(&json).context("Failed to format JSON")
+                    }) {
+                    Ok(json) => {
+                        let path = Path::new(LATEST_FILENAME);
+
+                        if !assume_yes && path.exists() {
+                            let msg = format!(
+                                "This will replace the existing file at {}. Continue?",
+                                path.display()
+                            );
+                            if !wait_for_confirm(&msg).await {
+                                bail!("Aborted");
+                            }
+                        }
+
+                        fs::write(path, json).await.context("Failed to write")?;
+
+                        println!("Updated {}", path.display());
+                    }
+                    Err(err) => {
+                        eprintln!("Failed to retrieve latest.json file: {err}");
+                    }
+                }
+            }
+
             Ok(())
         }
         Opt::Sign {

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -8,6 +8,7 @@ use tokio::fs;
 #[cfg(test)]
 use vec1::Vec1;
 
+use crate::defaults::META_REPOSITORY_URL;
 use crate::format;
 use crate::version::{VersionInfo, VersionParameters};
 
@@ -153,6 +154,20 @@ impl HttpVersionInfoProvider {
                 .context("Failed to save cache")?;
         }
         Ok(signed_response)
+    }
+
+    /// Retrieve the `latest.json` file.
+    ///
+    /// By default, `pinned_certificate` will be set to the LE root certificate. The contents are
+    /// unsigned.
+    pub async fn get_latest_versions_file() -> anyhow::Result<Vec<u8>> {
+        Self::get(
+            &format!("{META_REPOSITORY_URL}/latest.json"),
+            Some(crate::defaults::PINNED_CERTIFICATE.clone()),
+            Some((API_HOST_DEFAULT, API_IP_DEFAULT)),
+        )
+        .await
+        .context("Failed to get latest.json file")
     }
 
     /// Perform a simple GET request, with a size limit, and return it as bytes

--- a/mullvad-update/src/format/mod.rs
+++ b/mullvad-update/src/format/mod.rs
@@ -116,6 +116,7 @@ pub struct Installer {
 /// Installer architecture
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", derive(strum::EnumIter))]
 pub enum Architecture {
     /// x86-64 architecture
     X86,

--- a/mullvad-update/src/format/mod.rs
+++ b/mullvad-update/src/format/mod.rs
@@ -50,9 +50,9 @@ struct PartialSignedResponse {
 }
 
 /// Signed JSON response, not including the signature
-#[derive(Default, Debug, Deserialize, Serialize)]
+#[derive(Default, Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(test, derive(Clone, PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Response {
     /// Version counter
     pub metadata_version: usize,
@@ -63,8 +63,7 @@ pub struct Response {
 }
 
 /// App release
-#[derive(Debug, Deserialize, Serialize)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Release {
     /// Mullvad app version
     pub version: mullvad_version::Version,

--- a/mullvad-update/src/version.rs
+++ b/mullvad-update/src/version.rs
@@ -16,7 +16,7 @@ use crate::format::{self, Installer};
 pub const MIN_VERIFY_METADATA_VERSION: usize = 0;
 
 /// Query type for [VersionInfo]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VersionParameters {
     /// Architecture to retrieve data for
     pub architecture: VersionArchitecture,
@@ -34,6 +34,10 @@ pub type Rollout = f32;
 
 /// Accept *any* version (rollout >= 0) when querying for app info.
 pub const IGNORE: Rollout = 0.;
+
+/// Accept any version (rollout > 0) when querying for app info.
+/// Only versions with a non-zero rollout are supported.
+pub const SUPPORTED_VERSION: Rollout = f32::EPSILON;
 
 /// Accept only fully rolled out versions (rollout >= 1) when querying for app info.
 pub const FULLY_ROLLED_OUT: Rollout = 1.;


### PR DESCRIPTION
This PR adds a `mullvad-release` command for generating a file containing the latest versions, and a script for uploading it.

`latest.json` can be produced by running `mullvad-release query-latest [platform...]`, and the format is 

```
{
  "linux": {
    "stable": {
      "version": "2025.8"
    },
    "beta": {
      "version": "2025.9-beta1"
    }
  },
  "windows": {
    "stable": {
      "version": "2025.8"
    },
    "beta": {
      "version": "2025.9-beta1"
    }
  },
  "macos": {
    "stable": {
      "version": "2025.8"
    },
    "beta": {
      "version": "2025.9-beta1"
    }
  }
}
```

The `beta` fields are nullable.

This data will not be consumed by the app. It is a source for other clients, and the format must be simple and stable.

During a release, running `./desktop/scripts/release/6-update-latest-versions` should take care of keeping this up to date.

Fix DES-2367

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8679)
<!-- Reviewable:end -->
