### PR TITLE
Stop using old version check endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,6 +2986,7 @@ dependencies = [
  "mullvad-fs",
  "mullvad-types",
  "mullvad-update",
+ "mullvad-version",
  "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",

--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -53,6 +53,7 @@ mullvad-api-constants = { path = "./mullvad-api-constants" }
 mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-fs = { path = "../mullvad-fs" }
 mullvad-types = { path = "../mullvad-types" }
+mullvad-version = { path = "../mullvad-version" }
 talpid-types = { path = "../talpid-types" }
 talpid-time = { path = "../talpid-time" }
 

--- a/mullvad-daemon/src/version/check.rs
+++ b/mullvad-daemon/src/version/check.rs
@@ -63,7 +63,7 @@ pub(super) struct VersionCache {
     pub current_version_supported: bool,
     /// The latest available versions
     pub version_info: mullvad_update::version::VersionInfo,
-    #[cfg(in_app_upgrade)]
+    #[cfg(not(target_os = "android"))]
     pub metadata_version: usize,
 }
 
@@ -120,7 +120,7 @@ impl VersionUpdaterInner {
         self.last_app_version_info.as_ref().map(|(info, _)| info)
     }
 
-    #[cfg(in_app_upgrade)]
+    #[cfg(not(target_os = "android"))]
     pub fn get_min_metadata_version(&self) -> usize {
         self.last_app_version_info
             .as_ref()
@@ -131,7 +131,7 @@ impl VersionUpdaterInner {
             .unwrap_or(mullvad_update::version::MIN_VERIFY_METADATA_VERSION)
     }
 
-    #[cfg(not(in_app_upgrade))]
+    #[cfg(target_os = "android")]
     pub fn get_min_metadata_version(&self) -> usize {
         mullvad_update::version::MIN_VERIFY_METADATA_VERSION
     }
@@ -144,7 +144,7 @@ impl VersionUpdaterInner {
         update: &impl Fn(VersionCache) -> BoxFuture<'static, Result<(), Error>>,
         mut new_version_info: VersionCache,
     ) {
-        #[cfg(in_app_upgrade)]
+        #[cfg(not(target_os = "android"))]
         if let Some((current_cache, _)) = self.last_app_version_info.as_ref() {
             if current_cache.metadata_version == new_version_info.metadata_version {
                 log::trace!("Ignoring version info with same metadata version");
@@ -377,7 +377,7 @@ fn do_version_check_in_background(
 }
 
 /// Combine the old version and new version endpoint
-#[cfg(any(in_app_upgrade, target_os = "linux"))]
+#[cfg(not(target_os = "android"))]
 fn version_check_inner(
     api: &ApiContext,
     min_metadata_version: usize,
@@ -405,7 +405,6 @@ fn version_check_inner(
             cache_version: APP_VERSION.clone(),
             current_version_supported: result.current_version_supported,
             version_info: result.version_info,
-            #[cfg(in_app_upgrade)]
             metadata_version: result.metadata_version,
         })
     }
@@ -526,7 +525,7 @@ fn dev_version_cache() -> VersionCache {
             },
             beta: None,
         },
-        #[cfg(in_app_upgrade)]
+        #[cfg(not(target_os = "android"))]
         metadata_version: 0,
     }
 }
@@ -586,7 +585,7 @@ mod test {
                     sha256: [0u8; 32],
                 }),
             },
-            #[cfg(in_app_upgrade)]
+            #[cfg(not(target_os = "android"))]
             metadata_version: 0,
         }
     }
@@ -760,7 +759,7 @@ mod test {
                 },
                 beta: None,
             },
-            #[cfg(in_app_upgrade)]
+            #[cfg(not(target_os = "android"))]
             metadata_version: 0,
         }
     }

--- a/mullvad-daemon/src/version/check.rs
+++ b/mullvad-daemon/src/version/check.rs
@@ -377,27 +377,11 @@ fn do_version_check_in_background(
 }
 
 /// Combine the old version and new version endpoint
-#[cfg(in_app_upgrade)]
+#[cfg(any(in_app_upgrade, target_os = "linux"))]
 fn version_check_inner(
     api: &ApiContext,
     min_metadata_version: usize,
 ) -> impl Future<Output = Result<VersionCache, Error>> + use<> {
-    use futures::future::Either;
-    use mullvad_api::version::AppVersionResponse2;
-
-    let supported_fut = if !APP_VERSION.is_dev() {
-        let v1_endpoint = api.version_proxy.version_check(
-            mullvad_version::VERSION.to_owned(),
-            PLATFORM,
-            api.platform_version.clone(),
-        );
-        Either::Left(async { Ok(v1_endpoint.await?.supported) })
-    } else {
-        // NOTE: Treat all dev versions as unsupported. The old endpoint returns 404 for dev
-        // versions.
-        Either::Right(async { Ok(false) })
-    };
-
     let architecture = match talpid_platform_metadata::get_native_arch()
         .expect("IO error while getting native architecture")
         .expect("Failed to get native architecture")
@@ -407,31 +391,27 @@ fn version_check_inner(
             mullvad_update::format::Architecture::Arm64
         }
     };
-    let v2_endpoint = api.version_proxy.version_check_2(
+    let endpoint = api.version_proxy.version_check_2(
         PLATFORM,
         architecture,
         mullvad_update::version::SUPPORTED_VERSION,
         min_metadata_version,
+        api.platform_version.clone(),
     );
     async move {
-        let (
-            current_version_supported,
-            AppVersionResponse2 {
-                version_info,
-                metadata_version,
-            },
-        ) = tokio::try_join!(supported_fut, v2_endpoint).map_err(Error::Download)?;
+        let result = endpoint.await.map_err(Error::Download)?;
 
         Ok(VersionCache {
             cache_version: APP_VERSION.clone(),
-            current_version_supported,
-            version_info,
-            metadata_version,
+            current_version_supported: result.current_version_supported,
+            version_info: result.version_info,
+            #[cfg(in_app_upgrade)]
+            metadata_version: result.metadata_version,
         })
     }
 }
 
-#[cfg(not(in_app_upgrade))]
+#[cfg(target_os = "android")]
 fn version_check_inner(
     api: &ApiContext,
     // NOTE: This is unused when `update` is disabled

--- a/mullvad-update/src/version.rs
+++ b/mullvad-update/src/version.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use itertools::Itertools;
 use mullvad_version::PreStableType;
 
-use crate::format::{self, Installer};
+use crate::format::{self, Installer, Response};
 
 /// Lowest version to accept using 'verify'
 pub const MIN_VERIFY_METADATA_VERSION: usize = 0;
@@ -141,8 +141,22 @@ impl VersionInfo {
     }
 }
 
+/// A version is considered supported if the version exists in the metadata. Versions with a
+/// rollout of 0 is still considered supported.
+pub fn is_version_supported(
+    current_version: mullvad_version::Version,
+    response: &Response,
+) -> bool {
+    response
+        .releases
+        .iter()
+        .any(|release| release.version.eq(&current_version))
+}
+
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use insta::assert_yaml_snapshot;
 
     use super::*;
@@ -247,6 +261,29 @@ mod test {
 
         // Expect: There is an even higher version where the rollout is zero.
         assert_yaml_snapshot!(info);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_is_version_supported() -> anyhow::Result<()> {
+        let response = format::SignedResponse::deserialize_insecure(include_bytes!(
+            "../test-version-response.json"
+        ))?;
+
+        let supported_version = mullvad_version::Version::from_str("2025.3").unwrap();
+        let supported_rollout_zero_version = mullvad_version::Version::from_str("2030.3").unwrap();
+        let non_supported_version = mullvad_version::Version::from_str("2025.5").unwrap();
+
+        assert!(is_version_supported(supported_version, &response.signed));
+        assert!(is_version_supported(
+            supported_rollout_zero_version,
+            &response.signed
+        ));
+        assert!(!is_version_supported(
+            non_supported_version,
+            &response.signed
+        ));
 
         Ok(())
     }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -2046,6 +2046,7 @@ dependencies = [
  "mullvad-fs",
  "mullvad-types",
  "mullvad-update",
+ "mullvad-version",
  "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",


### PR DESCRIPTION
This PR is not ready to be merged. It needs to be manually tested first.

This PR replaces the use of the remaining uses of the old version check endpoint for the desktop app with the new one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8681)
<!-- Reviewable:end -->
