### PR TITLE
Link version cache (and the `supported` bool) to app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Line wrap the file at 100 chars.                                              Th
   encrypted once, but leave the entry node unencrypted, if and only if the destination were the exit
   node. E.g., this might occur if a browser tries to open a TCP connection to the exit node IP.
 
+### Fixed
+- Fix version being labeled unsupported unexpectedly. So far, this only an issue when using
+  development builds.
+
 
 ## [2025.9-beta1] - 2025-08-25
 ### Added

--- a/mullvad-daemon/src/version/router.rs
+++ b/mullvad-daemon/src/version/router.rs
@@ -763,6 +763,7 @@ mod test {
         let mut version: mullvad_version::Version = mullvad_version::VERSION.parse().unwrap();
         version.incremental += 1;
         VersionCache {
+            cache_version: version.clone(),
             current_version_supported: true,
             version_info: VersionInfo {
                 beta: None,
@@ -791,6 +792,7 @@ mod test {
         beta.version.pre_stable = Some(mullvad_version::PreStableType::Beta(1));
         beta.version.incremental += 1;
         VersionCache {
+            cache_version: stable.version.clone(),
             current_version_supported: true,
             version_info: VersionInfo {
                 beta: Some(beta),


### PR DESCRIPTION
This prevents the app from erroneously being labeled unsupported after upgrades/downgrades.

I've solved it by just adding a version to the cache itself (like we did have previously), as this seemed simpler and more robust than relying totally on the install scripts.

Fix DES-2408

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8687)
<!-- Reviewable:end -->
