### PR TITLE
Terminate build process with an exit code when an npm command exits with an error

### DIFF
--- a/desktop/packages/mullvad-vpn/tasks/utils.js
+++ b/desktop/packages/mullvad-vpn/tasks/utils.js
@@ -52,6 +52,7 @@ async function runNpmScript(scriptName) {
         console.error(new Error(error));
       });
     }
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
Changed so that if a npm command exits with an error when we are building the desktop application we will terminate the entire build process and exit with exit code 1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8694)
<!-- Reviewable:end -->
