### PR TITLE
Change the ad domain used for tests to one that is actually blocked

### DIFF
--- a/ios/Configurations/UITests.xcconfig.template
+++ b/ios/Configurations/UITests.xcconfig.template
@@ -22,7 +22,7 @@ HAS_TIME_ACCOUNT_NUMBER =
 // the Debug configuration is provided for developer convenience, and uses real accounts.
 
 // Ad serving domain used when testing ad blocking. Note that we are assuming there's an HTTP server running on the host.
-AD_SERVING_DOMAIN = vpnlist.to
+AD_SERVING_DOMAIN = analytics.google.com
 
 // A domain which should be reachable. Used to verify Internet connectivity. Must be running a server on port 80.
 SHOULD_BE_REACHABLE_DOMAIN = mullvad.net


### PR DESCRIPTION
Small PR that fixes the `testAdBlockingViaDNS` test by using a domain that is actually blocked, the previous one having been bought recently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8702)
<!-- Reviewable:end -->
