### PR TITLE
Ignore CVE-2025-55305

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -23,3 +23,9 @@ reason = "This is just a dev dependency, and we don't have untrusted input to mi
 id = "CVE-2024-21528" # GHSA-g974-hxvm-x689
 ignoreUntil = 2025-10-17
 reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"
+
+# electron: Electron has ASAR Integrity Bypass via resource modification
+[[IgnoredVulns]]
+id = "CVE-2025-55305" # GHSA-vmqv-hx8q-j7mg
+ignoreUntil = 2025-12-04
+reason = "The embeddedAsarIntegrityValidation and onlyLoadAppFromAsar fuses aren't enabled"


### PR DESCRIPTION
Ignore CVE-2025-55305 since we're not affected. We use neither of the two fuses described in the vulnerability description: https://osv.dev/vulnerability/GHSA-vmqv-hx8q-j7mg

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8711)
<!-- Reviewable:end -->
