### PR TITLE
Start login ui test with clear account history

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
@@ -7,7 +7,7 @@ import { expectDisconnected } from '../../shared/tunnel-state';
 import { TestUtils } from '../../utils';
 import { startInstalledApp } from '../installed-utils';
 
-// This test expects the daemon to be logged out.
+// This test expects the daemon to be logged out and the account history to be cleared.
 // Env parameters:
 //   `ACCOUNT_NUMBER`: Account number to use when logging in
 

--- a/test/test-manager/src/tests/ui.rs
+++ b/test/test-manager/src/tests/ui.rs
@@ -147,6 +147,7 @@ pub async fn test_ui_login(
     mut mullvad_client: MullvadProxyClient,
 ) -> Result<(), Error> {
     mullvad_client.logout_account().await?;
+    mullvad_client.clear_account_history().await?;
     let ui_result = run_test_env(
         &rpc,
         &["login.spec"],


### PR DESCRIPTION
This PR fixes the broken `login.spec.ts` test by clearing the account history before running it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8712)
<!-- Reviewable:end -->
