### PR TITLE
Make David G code owner for a lot of the stuff Albin had

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,12 +3,12 @@
 # they would if you listed the entire repository as a tree.
 
 # Container images used for building the app are owned by respective team leads and tech lead
-/building/android-container-image.txt @faern @albin-mullvad
+/building/android-container-image.txt @faern @albin-mullvad @rawa
 /building/linux-container-image.txt @faern @raksooo
 
 # Developer signing keys must be approved by team/tech leads
-/ci/keys/ @faern @raksooo @pinkisemils @albin-mullvad
-/mullvad-update/trusted-metadata-signing-pubkeys @faern @raksooo @pinkisemils @albin-mullvad
+/ci/keys/ @faern @raksooo @pinkisemils @rawa
+/mullvad-update/trusted-metadata-signing-pubkeys @faern @raksooo @pinkisemils @rawa
 
 # Desktop build server files owned by desktop leads
 /ci/buildserver* @faern @raksooo
@@ -18,15 +18,15 @@
 **/deny.toml @faern @raksooo
 
 # Changes to what CVEs are ignored must be approved by leads
-**/osv-scanner.toml @faern @raksooo @pinkisemils @albin-mullvad
-/.github/workflows/osv-scanner*.yml @faern @raksooo @pinkisemils @albin-mullvad
+**/osv-scanner.toml @faern @raksooo @pinkisemils @albin-mullvad @rawa
+/.github/workflows/osv-scanner*.yml @faern @raksooo @pinkisemils @rawa
 
 # Security related github action workflow changes must be approved by leads
-/.github/workflows/verify-locked-down-signatures.yml @faern @raksooo @pinkisemils @albin-mullvad
-/ci/verify-locked-down-signatures.sh @faern @raksooo @pinkisemils @albin-mullvad
-/.github/workflows/unicop.yml @faern @raksooo @pinkisemils @albin-mullvad
+/.github/workflows/verify-locked-down-signatures.yml @faern @raksooo @pinkisemils @rawa
+/ci/verify-locked-down-signatures.sh @faern @raksooo @pinkisemils @rawa
+/.github/workflows/unicop.yml @faern @raksooo @pinkisemils @rawa
 
 # The CODEOWNERS itself must be protected from unauthorized changes,
 # otherwise the protection becomes quite moot.
 # Keep this entry last, so it is sure to override any existing previous wildcard match
-/.github/CODEOWNERS @faern @raksooo @pinkisemils @albin-mullvad
+/.github/CODEOWNERS @faern @raksooo @pinkisemils @rawa


### PR DESCRIPTION
As new team lead for the Android team I re-assign most of the team lead code ownership responsibilities from Albin to @Rawa.

I kept Albin on the only file tightly related to Android building: The container name file. But please suggest other files where you think it makes sense that Albin keeps code owner status as well, if any.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8713)
<!-- Reviewable:end -->
