### PR TITLE
Add license check for iOS to prevent GPL3 dependencies

### DIFF
--- a/.github/workflows/rust-supply-chain.yml
+++ b/.github/workflows/rust-supply-chain.yml
@@ -28,3 +28,12 @@ jobs:
           log-level: warn
           rust-version: stable
           command: check all
+
+      # Run an additional license check for the iOS crate to catch GPL3 issues
+      - name: Run cargo deny for iOS (GPL3 check)
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: mullvad-ios/Cargo.toml
+          log-level: error
+          rust-version: stable
+          command: check licenses

--- a/.github/workflows/verify-locked-down-signatures.yml
+++ b/.github/workflows/verify-locked-down-signatures.yml
@@ -13,6 +13,7 @@ on:
       - test/Cargo.lock
       - deny.toml
       - test/deny.toml
+      - mullvad-ios/deny.toml
       - rust-toolchain.toml
       - desktop/package-lock.json
       - wireguard-go-rs/libwg/go.sum

--- a/mullvad-ios/deny.toml
+++ b/mullvad-ios/deny.toml
@@ -1,0 +1,42 @@
+# This file is for an additional check to prevent GPL-3.0 licensed crates
+# from being introduced into the iOS app's Rust dependency tree, due to
+# App Store restrictions.
+# It does not override the main deny.toml file and needs to be run separately.
+# See .github/workflows/rust-supply-chain.yml for the workflow that runs this check.
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "MPL-2.0",
+    "WTFPL",
+    "ISC",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "CC0-1.0",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+]
+
+# Allow GPL3 licensed crates with permission to relicense like Mullvads own.
+exceptions = [
+    { crate = "intersection-derive", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-api", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-api-constants", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-encrypted-dns-proxy", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-fs", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-ios", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-masque-proxy", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-types", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-update", allow = ["GPL-3.0-only"] },
+    { crate = "mullvad-version", allow = ["GPL-3.0-only"] },
+    { crate = "talpid-future", allow = ["GPL-3.0-only"] },
+    { crate = "talpid-routing", allow = ["GPL-3.0-only"] },
+    { crate = "talpid-time", allow = ["GPL-3.0-only"] },
+    { crate = "talpid-tunnel", allow = ["GPL-3.0-only"] },
+    { crate = "talpid-tunnel-config-client", allow = ["GPL-3.0-only"] },
+    { crate = "talpid-types", allow = ["GPL-3.0-only"] },
+    { crate = "talpid-windows", allow = ["GPL-3.0-only"] },
+    { crate = "tunnel-obfuscation", allow = ["GPL-3.0-only"] },
+]


### PR DESCRIPTION
Publishing an app with third party GPL3 licensed dependencies to Apples App Store can be problematic.
This PR adds an additional license check to prevent third party GPL3 code to enter the iOS rust dependency tree. Code owned by Mullvad is allowed.

Note that this restriction only applies to the iOS app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8715)
<!-- Reviewable:end -->
