### PR TITLE
Remove autogenerated locale config due to crash

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -62,7 +62,11 @@ android {
 
     androidResources {
         @Suppress("UnstableApiUsage")
-        generateLocaleConfig = true
+        // Due to a bug in the Android platform we need to disable this as the auto-generated local
+        // config causes a crash on some versions of android.
+        // See: https://issuetracker.google.com/issues/399131926#comment29
+        // Restoring this behavior when the issue has been resolved is tracked in: DROID-2163
+        generateLocaleConfig = false
     }
 
     if (keystorePropertiesFile.exists()) {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
     <application android:name=".MullvadApplication"
                  android:banner="@mipmap/ic_banner"
                  android:allowBackup="false"
-                 tools:targetApi="31"
+                 tools:targetApi="33"
                  android:memtagMode="async"
                  android:fullBackupContent="@xml/full_backup_content"
                  android:dataExtractionRules="@xml/data_extraction_rules"
@@ -35,6 +35,7 @@
                  android:label="@string/app_name"
                  android:roundIcon="@mipmap/ic_launcher"
                  android:theme="@style/Theme.App.Starting"
+                 android:localeConfig="@xml/locales_config"
                  tools:ignore="CredManMissingDal,CredentialDependency,GoogleAppIndexingWarning">
 
         <!--

--- a/android/lib/resource/src/main/res/xml/locales_config.xml
+++ b/android/lib/resource/src/main/res/xml/locales_config.xml
@@ -1,0 +1,22 @@
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en-US"/>
+    <locale android:name="da"/>
+    <locale android:name="de"/>
+    <locale android:name="es"/>
+    <locale android:name="fi"/>
+    <locale android:name="fr"/>
+    <locale android:name="it"/>
+    <locale android:name="ja"/>
+    <locale android:name="ko"/>
+    <locale android:name="my"/>
+    <locale android:name="nb"/>
+    <locale android:name="nl"/>
+    <locale android:name="pl"/>
+    <locale android:name="pt"/>
+    <locale android:name="ru"/>
+    <locale android:name="sv"/>
+    <locale android:name="th"/>
+    <locale android:name="tr"/>
+    <locale android:name="zh-CN"/>
+    <locale android:name="zh-TW"/>
+</locale-config>


### PR DESCRIPTION
We will use a static file instead.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
