### PR TITLE
Do not block exit relays when daita is enabled

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/usecase/SelectedLocationUseCase.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/usecase/SelectedLocationUseCase.kt
@@ -2,22 +2,34 @@ package net.mullvad.mullvadvpn.usecase
 
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import net.mullvad.mullvadvpn.lib.model.Constraint
 import net.mullvad.mullvadvpn.lib.model.RelayItemSelection
 import net.mullvad.mullvadvpn.repository.RelayListRepository
-import net.mullvad.mullvadvpn.repository.WireguardConstraintsRepository
+import net.mullvad.mullvadvpn.repository.SettingsRepository
+import net.mullvad.mullvadvpn.util.entryLocation
+import net.mullvad.mullvadvpn.util.isDaitaDirectOnly
+import net.mullvad.mullvadvpn.util.isDaitaEnabled
+import net.mullvad.mullvadvpn.util.isMultihopEnabled
 
 class SelectedLocationUseCase(
     private val relayListRepository: RelayListRepository,
-    private val wireguardConstraintsRepository: WireguardConstraintsRepository,
+    private val settingsRepository: SettingsRepository,
 ) {
     operator fun invoke() =
         combine(
             relayListRepository.selectedLocation.filterNotNull(),
-            wireguardConstraintsRepository.wireguardConstraints.filterNotNull(),
-        ) { selectedLocation, wireguardConstraints ->
-            if (wireguardConstraints.isMultihopEnabled) {
+            settingsRepository.settingsUpdates.filterNotNull(),
+        ) { selectedLocation, settings ->
+            if (settings.isMultihopEnabled()) {
                 RelayItemSelection.Multiple(
-                    entryLocation = wireguardConstraints.entryLocation,
+                    entryLocation =
+                        if (settings.isDaitaEnabled() && !settings.isDaitaDirectOnly()) {
+                            // If Daita is enabled without direct only the app acts as though any
+                            // entry location with DAITA is allowed
+                            Constraint.Any
+                        } else {
+                            settings.entryLocation()
+                        },
                     exitLocation = selectedLocation,
                 )
             } else {

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/Settings.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/Settings.kt
@@ -16,6 +16,8 @@ fun Settings.selectedObfuscationMode() = obfuscationSettings.selectedObfuscation
 
 fun Settings.wireguardPort() = relaySettings.relayConstraints.wireguardConstraints.port
 
+fun Settings.entryLocation() = relaySettings.relayConstraints.wireguardConstraints.entryLocation
+
 fun Settings.deviceIpVersion() = relaySettings.relayConstraints.wireguardConstraints.ipVersion
 
 fun Settings.isDaitaAndDirectOnly() = isDaitaEnabled() && isDaitaDirectOnly()

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/location/LocationUtil.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/location/LocationUtil.kt
@@ -19,7 +19,7 @@ internal fun RelayListType.isEntryAndBlocked(settings: Settings?): Boolean {
     return settings?.entryBlocked() == true
 }
 
-private fun Settings.entryBlocked() =
+internal fun Settings.entryBlocked() =
     isDaitaEnabled() && !isDaitaDirectOnly() && isMultihopEnabled()
 
 private fun RelayListType.isMultihopEntry() =

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/location/SelectLocationListViewModel.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/viewmodel/location/SelectLocationListViewModel.kt
@@ -94,7 +94,7 @@ class SelectLocationListViewModel(
                         selectedItem.selectedByOtherEntryExitList(relayListType, customLists),
                     expandedItems = expandedItems,
                     isEntryBlocked =
-                        relayListType.isEntryAndBlocked(settingsRepository.settingsUpdates.value),
+                        settingsRepository.settingsUpdates.value?.entryBlocked() == true,
                 )
             }
         }


### PR DESCRIPTION
If a entry relay is selected it should be blocked in the exit list when daia is enabled and direct only is disabled.

This is because the entry realy is automatically selected in these circumstances.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
