### PR TITLE
Change license identifier from `GPL-3.0` to `GPL-3.0-only`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/mullvadvpn-app/"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 edition = "2024"
 # Must be less than or equal to `channel` in `rust-toolchain.toml`
 rust-version = "1.88.0"

--- a/deny.toml
+++ b/deny.toml
@@ -42,7 +42,7 @@ version = 2 # https://github.com/EmbarkStudios/cargo-deny/pull/611
 
 # Adding a license here has to be done carefully. Should only be done by team leads.
 allow = [
-    "GPL-3.0",
+    "GPL-3.0-only",
     "Apache-2.0",
     "MIT",
     "MPL-2.0",


### PR DESCRIPTION
I saw in the output of `cargo deny check license` that our `GPL-3.0` license identifier is deprecated. So this PR updates it to the new equivalent. This should mean the same thing according to my understanding. See https://spdx.org/licenses/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8735)
<!-- Reviewable:end -->
