### PR TITLE
Fix crash in Problem Report

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
@@ -12,6 +12,7 @@ import net.mullvad.mullvadvpn.lib.common.constant.GRPC_SOCKET_FILE_NAME
 import net.mullvad.mullvadvpn.lib.common.constant.GRPC_SOCKET_FILE_NAMED_ARGUMENT
 import net.mullvad.mullvadvpn.lib.daemon.grpc.ManagementService
 import net.mullvad.mullvadvpn.lib.endpoint.ApiEndpointFromIntentHolder
+import net.mullvad.mullvadvpn.lib.endpoint.ApiEndpointOverride
 import net.mullvad.mullvadvpn.lib.model.BuildVersion
 import net.mullvad.mullvadvpn.lib.model.NotificationChannel
 import net.mullvad.mullvadvpn.lib.shared.AccountRepository
@@ -85,6 +86,14 @@ val appModule = module {
     } bind NotificationProvider::class
     single { AccountExpiryNotificationProvider(get<NotificationChannel.AccountUpdates>().id) } bind
         NotificationProvider::class
+    if (net.mullvad.mullvadvpn.service.BuildConfig.FLAVOR_infrastructure != "prod") {
+        single<ApiEndpointOverride> {
+            ApiEndpointOverride(
+                net.mullvad.mullvadvpn.service.BuildConfig.API_ENDPOINT,
+                net.mullvad.mullvadvpn.service.BuildConfig.API_IP,
+            )
+        }
+    }
 }
 
 private val Context.userPreferencesStore: DataStore<UserPreferences> by

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -27,7 +27,6 @@ import net.mullvad.mullvadvpn.repository.SettingsRepository
 import net.mullvad.mullvadvpn.repository.SplashCompleteRepository
 import net.mullvad.mullvadvpn.repository.SplitTunnelingRepository
 import net.mullvad.mullvadvpn.repository.WireguardConstraintsRepository
-import net.mullvad.mullvadvpn.service.DaemonConfig
 import net.mullvad.mullvadvpn.ui.MainActivity
 import net.mullvad.mullvadvpn.ui.serviceconnection.AppVersionInfoRepository
 import net.mullvad.mullvadvpn.ui.serviceconnection.ServiceConnectionManager
@@ -130,7 +129,7 @@ val uiModule = module {
     single {
         MullvadProblemReport(
             context = androidContext(),
-            apiEndpointOverride = get<DaemonConfig>().apiEndpointOverride,
+            apiEndpointOverride = getOrNull(),
             apiEndpointFromIntentHolder = get(),
         )
     }

--- a/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/di/VpnServiceModule.kt
+++ b/android/service/src/main/kotlin/net/mullvad/mullvadvpn/service/di/VpnServiceModule.kt
@@ -3,8 +3,6 @@ package net.mullvad.mullvadvpn.service.di
 import net.mullvad.mullvadvpn.lib.common.constant.CACHE_DIR_NAMED_ARGUMENT
 import net.mullvad.mullvadvpn.lib.common.constant.FILES_DIR_NAMED_ARGUMENT
 import net.mullvad.mullvadvpn.lib.common.constant.GRPC_SOCKET_FILE_NAMED_ARGUMENT
-import net.mullvad.mullvadvpn.lib.endpoint.ApiEndpointOverride
-import net.mullvad.mullvadvpn.service.BuildConfig
 import net.mullvad.mullvadvpn.service.DaemonConfig
 import net.mullvad.mullvadvpn.service.migration.MigrateSplitTunneling
 import org.koin.android.ext.koin.androidContext
@@ -22,12 +20,7 @@ val vpnServiceModule = module {
             rpcSocket = get(named(GRPC_SOCKET_FILE_NAMED_ARGUMENT)),
             filesDir = get(named(FILES_DIR_NAMED_ARGUMENT)),
             cacheDir = get(named(CACHE_DIR_NAMED_ARGUMENT)),
-            apiEndpointOverride =
-                if (BuildConfig.FLAVOR_infrastructure != "prod") {
-                    ApiEndpointOverride(BuildConfig.API_ENDPOINT, BuildConfig.API_IP)
-                } else {
-                    null
-                },
+            apiEndpointOverride = getOrNull(),
         )
     }
 }


### PR DESCRIPTION
Based on crash reports on Google Play it seems possible that the problem report screen is created before the mullvad vpn service is started. Since the problem report screen relies on `DaemonConfig` this will cause a crash since it cannot find that bean.

As a fix we move out the instantiation of `ApiEndpointOverride` to the app module so that we can make sure that it always can be created and that `MullvadProblemReport` use it directly instead of accessing it via `DaemonConfig`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8741)
<!-- Reviewable:end -->
