### PR TITLE
Narrow keep classes in proguard

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,11 +1,14 @@
-# Mullvad
-# Keeping all Mullvad classes etc until the project has been split into multiple sub-projects
-# where it's better defined where the FFI/JNI boundaries are.
--keep class net.mullvad.** { *; }
-
 # Mullvad daemon FFI/JNI
 # See: <repository-root>/mullvad-jni/classes.rs
+# Keep all talpid classes as they are used for JNI calls
+-keep class net.mullvad.talpid.** { *; }
+# These are specific classes used in JNI calls with the daemon
+-keep class net.mullvad.mullvadvpn.lib.endpoint.ApiEndpointOverride { *; }
+-keep class net.mullvad.mullvadvpn.service.MullvadDaemon { *; }
+-keep class net.mullvad.mullvadvpn.service.MullvadVpnService { *; }
+# All classes that are used in JNI calls are subclasses of Parcelable
 -keep class android.os.Parcelable { *; }
+# Common java types used in JNI calls
 -keep class java.lang.Boolean { *; }
 -keep class java.lang.Integer { *; }
 -keep class java.lang.String { *; }
@@ -23,5 +26,8 @@
 -dontwarn com.squareup.okhttp.CipherSuite
 -dontwarn com.squareup.okhttp.ConnectionSpec
 -dontwarn com.squareup.okhttp.TlsVersion
+
+# datastore
+-keep class net.mullvad.mullvadvpn.repository.UserPreferences { *; }
 
 


### PR DESCRIPTION
Instead of just keeping all mullvad classes we are only keeping the ones used by JNI and datastore.

This seems to make the apk somewhat smaller.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
