### PR TITLE
Fix mock ipc handle type

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/mocked-utils.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/mocked-utils.ts
@@ -155,7 +155,7 @@ type IpcMockedTestExtraHandlerKey<
 
 type IpcMockedTestFn<I extends AnyIpcCall> = I['direction'] extends 'main-to-renderer'
   ? Async<NonNullable<ReturnType<I['send']>>>
-  : Async<Parameters<ReturnType<I['receive']>>[0]>;
+  : (response: Awaited<ReturnType<Parameters<ReturnType<I['receive']>>[0]>>) => Promise<void>;
 
 export type IpcMockedTest<S extends Schema> = {
   [G in keyof S]: {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/helpers.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/helpers.ts
@@ -8,7 +8,6 @@ import {
   IRelayListHostname,
   ISettings,
   Ownership,
-  RelaySettings,
 } from '../../../../src/shared/daemon-rpc-types';
 import { RoutePath } from '../../../../src/shared/routes';
 import { RoutesObjectModel } from '../../route-object-models';
@@ -108,7 +107,6 @@ export const createHelpers = (page: Page, routes: RoutesObjectModel, utils: Mock
         settings.relaySettings.normal.providers = providers;
       }
     }
-    await utils.ipc.settings.setRelaySettings.handle({} as RelaySettings);
     await utils.ipc.settings[''].notify(settings);
   };
 


### PR DESCRIPTION
Fixes the type signature of the mock IPC handle. The mock handle should receive the IPC handle's response as the argument of the first parameter, in line with the actual implementation.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8745)
<!-- Reviewable:end -->
