### PR TITLE
Fix enable missing feature of `nix` crate in `tunnel-obfuscation`

### DIFF
--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -22,4 +22,4 @@ mullvad-masque-proxy = { path = "../mullvad-masque-proxy" }
 socket2 = { workspace = true, features = ["all"] }
 
 [target.'cfg(target_os="linux")'.dependencies]
-nix = { workspace = true }
+nix = { workspace = true, features = ["socket"] }


### PR DESCRIPTION
This PR fixes https://github.com/mullvad/mullvadvpn-app/issues/8749. Try it out by building just the `tunnel-obfuscation` crate on Linux.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8752)
<!-- Reviewable:end -->
