### PR TITLE
Bump netlink crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,12 +1983,12 @@ dependencies = [
 
 [[package]]
 name = "htmlize"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e81e415f6d22240930e82ae0f541b2dd494ca37daaf10c1d7b32546f3b1159f"
+checksum = "d347c0de239be20ba0982e4822de3124404281e119ae3e11f5d7425a414e1935"
 dependencies = [
  "memchr",
- "paste",
+ "pastey",
  "phf",
  "phf_codegen",
  "serde_json",
@@ -4043,6 +4043,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pcap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,55 +3493,37 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.4.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+checksum = "745d789fe0958caf7252f5e1e900ce5c09b6a5bf05c7bba02a9cc600866ce31e"
 dependencies = [
- "anyhow",
- "byteorder",
- "libc",
- "netlink-packet-utils",
+ "pastey",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.13.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dee5ed749373c298237fe694eb0a51887f4cc1a27370c8464bac4382348f1a"
+checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.9.0",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.59",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.59",
- "tokio",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -3590,17 +3572,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -4037,12 +4008,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pastey"
@@ -4933,15 +4898,17 @@ checksum = "21efba391745f92fc14a5cccb008e711a1a3708d8dacd2e69d88d5de513c117a"
 
 [[package]]
 name = "rtnetlink"
-version = "0.11.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f1cfa18f8cebe685373a2697915d7e0db3b4554918bba118385e0f71f258a7"
+checksum = "08fd15aa4c64c34d0b3178e45ec6dad313a9f02b193376d501668a7950264bb7"
 dependencies = [
  "futures",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
  "netlink-proto",
- "nix 0.24.3",
+ "netlink-sys",
+ "nix 0.29.0",
  "thiserror 1.0.59",
  "tokio",
 ]
@@ -5776,6 +5743,7 @@ dependencies = [
  "jnix",
  "libc",
  "log",
+ "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
  "nix 0.30.1",
@@ -5884,7 +5852,6 @@ dependencies = [
  "maybenot",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "nix 0.30.1",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,11 @@ tun = { version = "0.5.5", features = ["async"] }
 socket2 = "0.5.7"
 reqwest = { version = "0.12.23", default-features = false, features = ["rustls-tls"] }
 
+netlink-packet-core = "0.4.2"
+netlink-packet-route = "0.13"
+netlink-packet-utils = "0.5.1"
+netlink-proto = "0.10"
+
 # Hickory & DNS
 hickory-proto = "0.24.3"
 hickory-resolver = "0.24.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,10 +105,11 @@ tun = { version = "0.5.5", features = ["async"] }
 socket2 = "0.5.7"
 reqwest = { version = "0.12.23", default-features = false, features = ["rustls-tls"] }
 
-netlink-packet-core = "0.4.2"
-netlink-packet-route = "0.13"
-netlink-packet-utils = "0.5.1"
-netlink-proto = "0.10"
+rtnetlink = "0.18"
+netlink-packet-core = "0.8.0"
+netlink-packet-route = "0.25"
+netlink-proto = "0.12"
+netlink-sys = "0.8.3"
 
 # Hickory & DNS
 hickory-proto = "0.24.3"

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -23,9 +23,10 @@ jnix = { version = "0.5.2", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-rtnetlink = "0.11"
-netlink-packet-route = { version = "0.13", features = ["rich_nlas"] }
-netlink-sys = "0.8.3"
+rtnetlink = { workspace = true }
+netlink-packet-core = { workspace = true }
+netlink-packet-route = { workspace = true, features = ["rich_nlas"] }
+netlink-sys = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 nix = { workspace = true, features = ["socket", "fs", "net"] }

--- a/talpid-routing/src/lib.rs
+++ b/talpid-routing/src/lib.rs
@@ -20,9 +20,6 @@ pub use imp::{CallbackHandle, EventType, InterfaceAndGateway, get_best_default_r
 #[path = "unix/mod.rs"]
 mod imp;
 
-#[cfg(target_os = "linux")]
-use netlink_packet_route::rtnl::constants::RT_TABLE_MAIN;
-
 #[cfg(target_os = "macos")]
 pub use imp::{
     PlatformError,
@@ -99,7 +96,7 @@ impl Route {
             prefix,
             metric: None,
             #[cfg(target_os = "linux")]
-            table_id: u32::from(RT_TABLE_MAIN),
+            table_id: u32::from(libc::RT_TABLE_MAIN),
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             mtu: None,
         }

--- a/talpid-routing/src/unix/linux.rs
+++ b/talpid-routing/src/unix/linux.rs
@@ -700,7 +700,8 @@ impl RouteManagerImpl {
 
                 // Set route MTU
                 if let Some(mtu) = route.mtu {
-                    // TODO: Submit PR upstream for doing this on the builder instead.
+                    // TODO: This can be done before calling `add_message.build()` if
+                    // https://github.com/rust-netlink/rtnetlink/pull/126 is merged & released.
                     let mtu = RouteMetric::Mtu(mtu);
                     msg.attributes.push(RouteAttribute::Metrics(vec![mtu]));
                 }
@@ -872,7 +873,8 @@ impl RouteManagerImpl {
 
             let mut request = builder.build();
             if let Some(mark) = fwmark {
-                // TODO: Upstream setting fwmark directly on the builder
+                // TODO: This can be done before calling `builder.build()` if
+                // https://github.com/rust-netlink/rtnetlink/pull/127 is merged & released.
                 let fwmark = RouteAttribute::Mark(mark);
                 request.attributes.push(fwmark);
             }

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -57,10 +57,10 @@ talpid-net = { path = "../talpid-net" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.11"
-netlink-packet-core = "0.4.2"
-netlink-packet-route = "0.13"
-netlink-packet-utils = "0.5.1"
-netlink-proto = "0.10"
+netlink-packet-core = { workspace = true }
+netlink-packet-route = { workspace = true }
+netlink-packet-utils = { workspace = true }
+netlink-proto = { workspace = true }
 talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(windows)'.dependencies]

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -56,10 +56,9 @@ libc = "0.2.150"
 talpid-net = { path = "../talpid-net" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rtnetlink = "0.11"
+rtnetlink = { workspace = true }
 netlink-packet-core = { workspace = true }
 netlink-packet-route = { workspace = true }
-netlink-packet-utils = { workspace = true }
 netlink-proto = { workspace = true }
 talpid-dbus = { path = "../talpid-dbus" }
 

--- a/talpid-wireguard/src/wireguard_kernel/nl_message.rs
+++ b/talpid-wireguard/src/wireguard_kernel/nl_message.rs
@@ -1,12 +1,10 @@
 use super::parsers;
 use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_core::{
-    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
+    DecodeError, Emitable, Nla, NlaBuffer, NlasIterator, Parseable, parse_u16,
 };
-use netlink_packet_utils::{
-    DecodeError,
-    nla::{Nla, NlaBuffer, NlasIterator},
-    traits::{Emitable, Parseable},
+use netlink_packet_core::{
+    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
 };
 use std::{ffi::CString, io::Write, mem};
 
@@ -125,7 +123,7 @@ impl<'a, T: AsRef<[u8]> + 'a + ?Sized + std::fmt::Debug> Parseable<NlaBuffer<&'a
             libc::CTRL_ATTR_FAMILY_NAME => {
                 ControlNla::FamilyName(parsers::parse_cstring(buf.value())?)
             }
-            libc::CTRL_ATTR_FAMILY_ID => ControlNla::FamilyId(parsers::parse_u16(buf.value())?),
+            libc::CTRL_ATTR_FAMILY_ID => ControlNla::FamilyId(parse_u16(buf.value())?),
             _unknown_kind => ControlNla::Unknown(buf.kind(), buf.value().to_vec()),
         };
         Ok(nla)

--- a/talpid-wireguard/src/wireguard_kernel/parsers.rs
+++ b/talpid-wireguard/src/wireguard_kernel/parsers.rs
@@ -9,8 +9,7 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use netlink_packet_utils::DecodeError;
-pub use netlink_packet_utils::parsers::*;
+use netlink_packet_core::DecodeError;
 
 pub fn parse_ip_addr(bytes: &[u8]) -> Result<IpAddr, DecodeError> {
     if bytes.len() == 4 {

--- a/talpid-wireguard/src/wireguard_kernel/wg_message.rs
+++ b/talpid-wireguard/src/wireguard_kernel/wg_message.rs
@@ -1,13 +1,15 @@
+use crate::wireguard_kernel::parsers::{parse_cstring, parse_inet_sockaddr, parse_ip_addr};
+
 use super::{super::config::Config, Error, parsers};
 use byteorder::{ByteOrder, NativeEndian};
 use ipnetwork::IpNetwork;
 use netlink_packet_core::{
-    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
+    DecodeError, NLA_F_NESTED, Nla, NlaBuffer, NlasIterator, parse_u8, parse_u16, parse_u32,
+    parse_u64,
 };
-use netlink_packet_utils::{
-    DecodeError,
-    nla::{NLA_F_NESTED, Nla, NlaBuffer, NlasIterator},
-    traits::{Emitable, Parseable},
+use netlink_packet_core::{Emitable, Parseable};
+use netlink_packet_core::{
+    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
 };
 use nix::sys::{
     socket::{SockaddrIn, SockaddrIn6},
@@ -269,13 +271,13 @@ impl<'a, T: AsRef<[u8]> + 'a + ?Sized + core::fmt::Debug> Parseable<NlaBuffer<&'
         let value = buf.value();
         let kind = buf.kind();
         let nla = match kind {
-            WGDEVICE_A_IFINDEX => IfIndex(parsers::parse_u32(value)?),
-            WGDEVICE_A_IFNAME => IfName(parsers::parse_cstring(value)?),
+            WGDEVICE_A_IFINDEX => IfIndex(parse_u32(value)?),
+            WGDEVICE_A_IFNAME => IfName(parse_cstring(value)?),
             WGDEVICE_A_PRIVATE_KEY => PrivateKey(parsers::parse_wg_key(value)?),
             WGDEVICE_A_PUBLIC_KEY => PublicKey(parsers::parse_wg_key(value)?),
-            WGDEVICE_A_FLAGS => Flags(parsers::parse_u32(value)?),
-            WGDEVICE_A_LISTEN_PORT => ListenPort(parsers::parse_u16(value)?),
-            WGDEVICE_A_FWMARK => Fwmark(parsers::parse_u32(value)?),
+            WGDEVICE_A_FLAGS => Flags(parse_u32(value)?),
+            WGDEVICE_A_LISTEN_PORT => ListenPort(parse_u16(value)?),
+            WGDEVICE_A_FWMARK => Fwmark(parse_u32(value)?),
             WGDEVICE_A_PEERS => {
                 let peers = NlasIterator::new(value)
                     .map(|nla_bytes| {
@@ -437,15 +439,15 @@ impl<'a, T: AsRef<[u8]> + 'a + ?Sized> Parseable<NlaBuffer<&'a T>> for PeerNla {
         let nla = match buf.kind() {
             WGPEER_A_PUBLIC_KEY => PublicKey(parsers::parse_wg_key(value)?),
             WGPEER_A_PRESHARED_KEY => PresharedKey(parsers::parse_wg_key(value)?),
-            WGPEER_A_FLAGS => Flags(parsers::parse_u32(value)?),
-            WGPEER_A_ENDPOINT => Endpoint(parsers::parse_inet_sockaddr(value)?),
+            WGPEER_A_FLAGS => Flags(parse_u32(value)?),
+            WGPEER_A_ENDPOINT => Endpoint(parse_inet_sockaddr(value)?),
             WGPEER_A_PERSISTENT_KEEPALIVE_INTERVAL => {
-                PersistentKeepaliveInterval(parsers::parse_u16(value)?)
+                PersistentKeepaliveInterval(parse_u16(value)?)
             }
 
             WGPEER_A_LAST_HANDSHAKE_TIME => LastHandshakeTime(parsers::parse_timespec(value)?),
-            WGPEER_A_RX_BYTES => RxBytes(parsers::parse_u64(value)?),
-            WGPEER_A_TX_BYTES => TxBytes(parsers::parse_u64(value)?),
+            WGPEER_A_RX_BYTES => RxBytes(parse_u64(value)?),
+            WGPEER_A_TX_BYTES => TxBytes(parse_u64(value)?),
             WGPEER_A_ALLOWEDIPS => {
                 let nlas = NlasIterator::new(value)
                     .map(|nla_buffer| AllowedIpMessage::parse(&nla_buffer?))
@@ -453,7 +455,7 @@ impl<'a, T: AsRef<[u8]> + 'a + ?Sized> Parseable<NlaBuffer<&'a T>> for PeerNla {
 
                 AllowedIps(nlas)
             }
-            WGPEER_A_PROTOCOL_VERSION => ProtocolVersion(parsers::parse_u32(value)?),
+            WGPEER_A_PROTOCOL_VERSION => ProtocolVersion(parse_u32(value)?),
             WGPEER_A_UNSPEC => Unspec(value.to_vec()),
             _ => {
                 return Err(format!("Unexpected peer attribute kind: {}", buf.kind()).into());
@@ -561,9 +563,9 @@ impl<'a, T: AsRef<[u8]> + 'a + ?Sized> Parseable<NlaBuffer<&'a T>> for AllowedIp
         use AllowedIpNla::*;
         let value = buf.value();
         let nla = match buf.kind() {
-            WGALLOWEDIP_A_FAMILY => AddressFamily(parsers::parse_u16(value)?),
-            WGALLOWEDIP_A_IPADDR => IpAddr(parsers::parse_ip_addr(value)?),
-            WGALLOWEDIP_A_CIDR_MASK => CidrMask(parsers::parse_u8(value)?),
+            WGALLOWEDIP_A_FAMILY => AddressFamily(parse_u16(value)?),
+            WGALLOWEDIP_A_IPADDR => IpAddr(parse_ip_addr(value)?),
+            WGALLOWEDIP_A_CIDR_MASK => CidrMask(parse_u8(value)?),
             WGALLOWEDIP_A_UNSPEC => Unspec(value.to_vec()),
             _ => Err(format!(
                 "Unexpected allowed IP attribute kind: {}",
@@ -694,13 +696,12 @@ mod test {
                                     // 8 bytes of WGALLOWEDIP_A_IPADDR 192.168.40.2
                                     0x08, 0x00, 0x02, 0x00, 0xc0, 0xa8, 0x27, 0x02,
         ];
-        let header = NetlinkHeader {
-            length: payload.len() as u32,
-            message_type: 0,
-            flags: 0,
-            sequence_number: 0,
-            port_number: 0,
+        let header = {
+            let mut header = NetlinkHeader::default();
+            header.length = payload.len() as u32;
+            header
         };
+
         let message = DeviceMessage::deserialize(&header, &payload).unwrap();
 
         let mut serialized_message = vec![0u8; payload.len()];
@@ -862,12 +863,10 @@ mod test {
 
         let mut payload_buffer = vec![0u8; message.buffer_len()];
         message.serialize(&mut payload_buffer);
-        let header = NetlinkHeader {
-            length: payload_buffer.len() as u32,
-            message_type: 0,
-            flags: 0,
-            sequence_number: 0,
-            port_number: 0,
+        let header = {
+            let mut header = NetlinkHeader::default();
+            header.length = payload_buffer.len() as u32;
+            header
         };
         let deserialized_device = DeviceMessage::deserialize(&header, &payload_buffer).unwrap();
 


### PR DESCRIPTION
This PR started out as a quick fix for getting rid of `paste` from our dependency tree, but it kind of spiraled when I had to update the `netlink-packet-*` crates in order to do so. We were quite far behind on this, but this PR fixes that! The changes are contained to `talpid-routing` and `talpid-wireguard`, but they require careful inspection to make sure nothing broke. Most changes were straight forward.

- Upgrade `netlink-packet-core` to `0.8.0`
- Upgrade `netlink-packet-route` to `0.25.1`
- Upgrade `netlink-proto` to `0.12.0`
- Upgrade `rtnetlink` to `0.18.1`
- Remove `netlink-packet-utils`
- Promote `netlink-*` crates & `rtnetlink` to workspace dependencies

E2E test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/17737929406

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8763)
<!-- Reviewable:end -->
