### PR TITLE
Add documentation about dependencies of localization scripts

### DIFF
--- a/desktop/packages/mullvad-vpn/locales/README.md
+++ b/desktop/packages/mullvad-vpn/locales/README.md
@@ -1,5 +1,14 @@
 This is a folder with gettext translations for Mullvad VPN app.
 
+## Prerequisites
+
+The scripts used to manage translations depend on `node` and some JavaScript dependencies.
+- See [BuildInstructions.md](../../../../BuildInstructions.md#all-platforms) for how to install `node`.
+- Install required JavaScript dependencies by running `npm i` from `mullvad-vpn` node workspace
+```bash
+npm i -w packages/mullvad-vpn/
+```
+
 ## Adding new translations
 
 1. Create a new sub-folder under `../locales`, use the locale identifier for the folder name.


### PR DESCRIPTION
Title. Tried to run `localization sync-local-files` from a fresh distrobox instance, but ran into runtime issues due to missing dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8773)
<!-- Reviewable:end -->
