### PR TITLE
Add LWO to UI obfuscation types

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
@@ -445,6 +445,9 @@ function convertFromObfuscationEndpoint(
     case grpcTypes.ObfuscationEndpoint.ObfuscationType.QUIC:
       obfuscationType = 'quic';
       break;
+    case grpcTypes.ObfuscationEndpoint.ObfuscationType.LWO:
+      obfuscationType = 'lwo';
+      break;
     default:
       throw new Error('unsupported obfuscation protocol');
   }

--- a/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
@@ -114,7 +114,7 @@ export function tunnelTypeToString(tunnel: TunnelType): string {
 }
 
 export type RelayProtocol = 'tcp' | 'udp';
-export type EndpointObfuscationType = 'udp2tcp' | 'shadowsocks' | 'quic';
+export type EndpointObfuscationType = 'udp2tcp' | 'shadowsocks' | 'quic' | 'lwo';
 
 export type Constraint<T> = 'any' | { only: T };
 export type LiftedConstraint<T> = 'any' | T;


### PR DESCRIPTION
The GUI misbehaves a bit when LWO is enabled. This isn't too bad since it's hidden behind a feature flag, but preventing this exception fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8777)
<!-- Reviewable:end -->
