### PR TITLE
Add staggered obfuscator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -1777,7 +1777,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -1818,7 +1818,7 @@ dependencies = [
  "h3-datagram",
  "quinn",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -1939,7 +1939,7 @@ dependencies = [
  "thiserror 1.0.59",
  "time",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -6116,7 +6116,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -6152,16 +6152,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -6264,7 +6264,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6432,7 +6432,7 @@ dependencies = [
  "nix 0.29.0",
  "thiserror 2.0.9",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "windows-sys 0.59.0",
  "wintun-bindings",
 ]
@@ -6452,7 +6452,7 @@ dependencies = [
  "talpid-types",
  "thiserror 2.0.9",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "udp-over-tcp",
 ]
 

--- a/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
@@ -445,13 +445,19 @@ function convertFromObfuscationEndpoint(
     case grpcTypes.ObfuscationEndpoint.ObfuscationType.QUIC:
       obfuscationType = 'quic';
       break;
+    case grpcTypes.ObfuscationEndpoint.ObfuscationType.MULTIPLEXER:
+      obfuscationType = 'multiplexer';
+      break;
     default:
       throw new Error('unsupported obfuscation protocol');
   }
 
+  // TODO: Handle more than one endpoint here
+  const firstEndpoint = obfuscationEndpoint.endpointsList[0];
+
   return {
-    ...obfuscationEndpoint,
-    protocol: convertFromTransportProtocol(obfuscationEndpoint.protocol),
+    ...firstEndpoint,
+    protocol: convertFromTransportProtocol(firstEndpoint.protocol),
     obfuscationType: obfuscationType,
   };
 }

--- a/desktop/packages/mullvad-vpn/src/renderer/components/main-view/ConnectionDetails.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/main-view/ConnectionDetails.tsx
@@ -193,9 +193,11 @@ function tunnelEndpointToObfuscationEndpoint(
     return undefined;
   }
 
+  const socketAddr = parseSocketAddress(endpoint.obfuscationEndpoint.address);
+
   return {
-    ip: endpoint.obfuscationEndpoint.address,
-    port: endpoint.obfuscationEndpoint.port,
+    ip: socketAddr.host,
+    port: socketAddr.port,
     protocol: endpoint.obfuscationEndpoint.protocol,
     obfuscationType: endpoint.obfuscationEndpoint.obfuscationType,
   };

--- a/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
@@ -114,7 +114,7 @@ export function tunnelTypeToString(tunnel: TunnelType): string {
 }
 
 export type RelayProtocol = 'tcp' | 'udp';
-export type EndpointObfuscationType = 'udp2tcp' | 'shadowsocks' | 'quic';
+export type EndpointObfuscationType = 'udp2tcp' | 'shadowsocks' | 'quic' | 'multiplexer';
 
 export type Constraint<T> = 'any' | { only: T };
 export type LiftedConstraint<T> = 'any' | T;
@@ -157,7 +157,6 @@ export interface IEndpoint {
 
 export interface IObfuscationEndpoint {
   address: string;
-  port: number;
   protocol: RelayProtocol;
   obfuscationType: EndpointObfuscationType;
 }

--- a/mullvad-cli/src/format.rs
+++ b/mullvad-cli/src/format.rs
@@ -224,12 +224,12 @@ fn format_relay_connection(
     verbose: bool,
 ) -> String {
     let first_hop = endpoint.entry_endpoint.as_ref().map(|entry| {
-        let endpoint = format_endpoint(
+        let endpoint = format_endpoints(
             location.and_then(|l| l.entry_hostname.as_deref()),
             // Check if we *actually* want to print an obfuscator endpoint ..
             match endpoint.obfuscation {
-                Some(ref obfuscation) => &obfuscation.endpoint,
-                _ => entry,
+                Some(ref obfuscation) => &obfuscation.endpoints,
+                _ => std::slice::from_ref(entry),
             },
             verbose,
         );
@@ -246,13 +246,13 @@ fn format_relay_connection(
         format!(" via {proxy_endpoint}")
     });
 
-    let exit_endpoint = format_endpoint(
+    let exit_endpoint = format_endpoints(
         location.and_then(|l| l.hostname.as_deref()),
         // Check if we *actually* want to print an obfuscator endpoint ..
         // The obfuscator information should be printed for the exit relay if multihop is disabled
-        match (endpoint.obfuscation, &first_hop) {
-            (Some(ref obfuscation), None) => &obfuscation.endpoint,
-            _ => &endpoint.endpoint,
+        match (&endpoint.obfuscation, &first_hop) {
+            (Some(obfuscation), None) => &obfuscation.endpoints,
+            _ => std::slice::from_ref(&endpoint.endpoint),
         },
         verbose,
     );
@@ -262,6 +262,26 @@ fn format_relay_connection(
         first_hop = first_hop.unwrap_or_default(),
         bridge = bridge.unwrap_or_default(),
     )
+}
+
+fn format_endpoints(hostname: Option<&str>, endpoints: &[Endpoint], verbose: bool) -> String {
+    if endpoints.len() == 1 {
+        return format_endpoint(hostname, &endpoints[0], verbose);
+    }
+
+    let mut endpoints_str = String::new();
+    for (i, endpoint) in endpoints.iter().enumerate() {
+        if i > 0 {
+            endpoints_str.push_str(" | ");
+        }
+        endpoints_str.push_str(&endpoint.to_string());
+    }
+
+    match (hostname, verbose) {
+        (Some(hostname), true) => format!("{hostname} ({endpoints_str})"),
+        (None, _) => endpoints_str,
+        (Some(hostname), false) => hostname.to_string(),
+    }
 }
 
 fn format_endpoint(hostname: Option<&str>, endpoint: &Endpoint, verbose: bool) -> String {

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override"]
 boringtun = ["talpid-core/boringtun"]
-
+staggered-obfuscation = ["mullvad-relay-selector/staggered-obfuscation"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -338,12 +338,11 @@ message ObfuscationEndpoint {
     SHADOWSOCKS = 1;
     QUIC = 2;
     LWO = 3;
+    MULTIPLEXER = 4;
   }
 
-  string address = 1;
-  uint32 port = 2;
-  TransportProtocol protocol = 3;
-  ObfuscationType obfuscation_type = 4;
+  repeated Endpoint endpoints = 1;
+  ObfuscationType obfuscation_type = 2;
 }
 
 message Endpoint {

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+staggered-obfuscation = []
+
 [dependencies]
 chrono = { workspace = true }
 thiserror = { workspace = true }

--- a/mullvad-relay-selector/src/relay_selector/helpers.rs
+++ b/mullvad-relay-selector/src/relay_selector/helpers.rs
@@ -16,7 +16,7 @@ use rand::{
     seq::{IteratorRandom, SliceRandom},
     thread_rng,
 };
-use talpid_types::net::{Endpoint, IpVersion, obfuscation::ObfuscatorConfig};
+use talpid_types::net::{IpVersion, obfuscation::ObfuscatorConfig};
 
 use crate::SelectedObfuscator;
 
@@ -84,12 +84,15 @@ pub fn pick_random_relay_weighted<'a, RelayType>(
     }
 }
 
+#[cfg(feature = "staggered-obfuscation")]
 pub fn get_multiplexer_obfuscator(
     udp2tcp_ports: &[u16],
     shadowsocks_ports: &[RangeInclusive<u16>],
     obfuscator_relay: Relay,
     endpoint: &MullvadWireguardEndpoint,
 ) -> Result<SelectedObfuscator, Error> {
+    use talpid_types::net::Endpoint;
+
     // Add direct (no obfuscation) method
     let direct = Some(Endpoint::from_socket_address(
         endpoint.peer.endpoint,

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -924,7 +924,21 @@ impl RelaySelector {
         let box_obfsucation_error = |error: helpers::Error| Error::NoObfuscator(Box::new(error));
 
         match &query.wireguard_constraints().obfuscation {
-            ObfuscationQuery::Off | ObfuscationQuery::Auto => Ok(None),
+            ObfuscationQuery::Off => Ok(None),
+            // TODO: Hide behind flag
+            ObfuscationQuery::Auto => {
+                // TODO: do not use multiplexer on first attempt
+                let shadowsocks_ports = &parsed_relays.wireguard.shadowsocks_port_ranges;
+                let udp2tcp_ports = &parsed_relays.wireguard.udp2tcp_ports;
+                helpers::get_multiplexer_obfuscator(
+                    udp2tcp_ports,
+                    shadowsocks_ports,
+                    obfuscator_relay,
+                    endpoint,
+                )
+                .map(Some)
+                .map_err(box_obfsucation_error)
+            }
             ObfuscationQuery::Udp2tcp(settings) => {
                 let udp2tcp_ports = &parsed_relays.wireguard.udp2tcp_ports;
 

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -925,7 +925,9 @@ impl RelaySelector {
 
         match &query.wireguard_constraints().obfuscation {
             ObfuscationQuery::Off => Ok(None),
-            // TODO: Hide behind flag
+            #[cfg(not(feature = "staggered-obfuscation"))]
+            ObfuscationQuery::Auto => Ok(None),
+            #[cfg(feature = "staggered-obfuscation")]
             ObfuscationQuery::Auto => {
                 // TODO: do not use multiplexer on first attempt
                 let shadowsocks_ports = &parsed_relays.wireguard.shadowsocks_port_ranges;

--- a/mullvad-types/src/features.rs
+++ b/mullvad-types/src/features.rs
@@ -360,10 +360,10 @@ mod tests {
         );
 
         endpoint.obfuscation = Some(ObfuscationEndpoint {
-            endpoint: Endpoint {
+            endpoints: vec![Endpoint {
                 address: SocketAddr::from(([1, 2, 3, 4], 443)),
                 protocol: TransportProtocol::Tcp,
-            },
+            }],
             obfuscation_type: ObfuscationType::Udp2Tcp,
         });
         expected_indicators.0.insert(FeatureIndicator::Udp2Tcp);

--- a/talpid-core/src/firewall/linux.rs
+++ b/talpid-core/src/firewall/linux.rs
@@ -561,13 +561,15 @@ impl<'a> PolicyBatch<'a> {
     fn add_policy_specific_rules(&mut self, policy: &FirewallPolicy, fwmark: u32) -> Result<()> {
         let allow_lan = match policy {
             FirewallPolicy::Connecting {
-                peer_endpoint,
+                peer_endpoints,
                 tunnel,
                 allow_lan,
                 allowed_endpoint,
                 allowed_tunnel_traffic,
             } => {
-                self.add_allow_tunnel_endpoint_rules(peer_endpoint, fwmark);
+                for endpoint in peer_endpoints {
+                    self.add_allow_tunnel_endpoint_rules(endpoint, fwmark);
+                }
                 self.add_allow_endpoint_rules(allowed_endpoint);
 
                 // Important to block DNS after allow relay rule (so the relay can operate
@@ -595,12 +597,14 @@ impl<'a> PolicyBatch<'a> {
                 *allow_lan
             }
             FirewallPolicy::Connected {
-                peer_endpoint,
+                peer_endpoints,
                 tunnel,
                 allow_lan,
                 dns_config,
             } => {
-                self.add_allow_tunnel_endpoint_rules(peer_endpoint, fwmark);
+                for endpoint in peer_endpoints {
+                    self.add_allow_tunnel_endpoint_rules(endpoint, fwmark);
+                }
 
                 for server in dns_config.tunnel_config() {
                     self.add_allow_tunnel_dns_rule(

--- a/talpid-core/src/firewall/windows/mod.rs
+++ b/talpid-core/src/firewall/windows/mod.rs
@@ -124,7 +124,7 @@ impl Firewall {
 
         let apply_result = match policy {
             FirewallPolicy::Connecting {
-                peer_endpoint,
+                peer_endpoints,
                 exit_endpoint_ip,
                 tunnel,
                 allow_lan,
@@ -133,7 +133,7 @@ impl Firewall {
             } => {
                 let cfg = &WinFwSettings::new(allow_lan);
                 self.set_connecting_state(
-                    &peer_endpoint,
+                    &peer_endpoints,
                     exit_endpoint_ip,
                     cfg,
                     tunnel.as_ref(),
@@ -142,7 +142,7 @@ impl Firewall {
                 )
             }
             FirewallPolicy::Connected {
-                peer_endpoint,
+                peer_endpoints,
                 exit_endpoint_ip,
                 tunnel,
                 allow_lan,
@@ -150,7 +150,7 @@ impl Firewall {
             } => {
                 let cfg = &WinFwSettings::new(allow_lan);
                 self.set_connected_state(
-                    &peer_endpoint,
+                    &peer_endpoints,
                     exit_endpoint_ip,
                     cfg,
                     &tunnel,
@@ -199,7 +199,7 @@ impl Firewall {
 
     fn set_connecting_state(
         &mut self,
-        peer_endpoint: &AllowedEndpoint,
+        peer_endpoints: &[AllowedEndpoint],
         exit_endpoint_ip: Option<IpAddr>,
         winfw_settings: &WinFwSettings,
         tunnel_metadata: Option<&TunnelMetadata>,
@@ -209,7 +209,7 @@ impl Firewall {
         log::trace!("Applying 'connecting' firewall policy");
         let tunnel_interface = tunnel_metadata.map(|metadata| metadata.interface.as_ref());
         winfw::apply_policy_connecting(
-            peer_endpoint,
+            peer_endpoints,
             exit_endpoint_ip,
             winfw_settings,
             tunnel_interface,
@@ -221,7 +221,7 @@ impl Firewall {
 
     fn set_connected_state(
         &mut self,
-        endpoint: &AllowedEndpoint,
+        peer_endpoints: &[AllowedEndpoint],
         exit_endpoint_ip: Option<IpAddr>,
         winfw_settings: &WinFwSettings,
         tunnel_metadata: &TunnelMetadata,
@@ -230,7 +230,7 @@ impl Firewall {
         log::trace!("Applying 'connected' firewall policy");
         let tunnel_interface = &tunnel_metadata.interface;
         winfw::apply_policy_connected(
-            endpoint,
+            peer_endpoints,
             exit_endpoint_ip,
             winfw_settings,
             tunnel_interface,

--- a/talpid-core/src/firewall/windows/winfw/mod.rs
+++ b/talpid-core/src/firewall/windows/winfw/mod.rs
@@ -175,6 +175,7 @@ pub(super) fn apply_policy_connecting(
     let res = unsafe {
         WinFw_ApplyPolicyConnecting(
             winfw_settings,
+            1,
             &winfw_relay,
             exit_endpoint_ip_ptr,
             relay_client_wstr_ptrs.as_ptr(),
@@ -255,6 +256,7 @@ pub(super) fn apply_policy_connected(
     let result = unsafe {
         WinFw_ApplyPolicyConnected(
             winfw_settings,
+            1,
             &winfw_relay,
             exit_endpoint_ip_ptr,
             relay_client_wstr_ptrs.as_ptr(),

--- a/talpid-core/src/firewall/windows/winfw/mod.rs
+++ b/talpid-core/src/firewall/windows/winfw/mod.rs
@@ -85,22 +85,42 @@ pub(super) fn apply_policy_blocked(
 }
 
 pub(super) fn apply_policy_connecting(
-    peer_endpoint: &AllowedEndpoint,
+    peer_endpoints: &[AllowedEndpoint],
     exit_endpoint_ip: Option<IpAddr>,
     winfw_settings: &WinFwSettings,
     tunnel_interface: Option<&str>,
     allowed_endpoint: AllowedEndpoint,
     allowed_tunnel_traffic: &AllowedTunnelTraffic,
 ) -> Result<(), FirewallPolicyError> {
-    let ip_str = widestring_ip(peer_endpoint.endpoint.address.ip());
-    let winfw_relay = WinFwEndpoint {
-        ip: ip_str.as_ptr(),
-        port: peer_endpoint.endpoint.address.port(),
-        protocol: WinFwProt::from(peer_endpoint.endpoint.protocol),
-    };
+    let mut winfw_relays = vec![];
+    let mut ip_strs = vec![];
+    let mut clients = None;
 
-    let relay_client_wstrs: Vec<_> = peer_endpoint
-        .clients
+    for peer in peer_endpoints {
+        if clients.is_none() {
+            clients = Some(peer.clients.clone());
+        } else if clients.as_ref() != Some(&peer.clients) {
+            log::error!("Relay endpoints must have same allowed clients");
+            return Err(FirewallPolicyError::Generic);
+        }
+
+        let ip_str = widestring_ip(peer.endpoint.address.ip());
+        let ip_str_ptr = ip_str.as_ptr();
+        // Keep pointer valid for the duration of this function
+        ip_strs.push(ip_str);
+
+        winfw_relays.push(WinFwEndpoint {
+            ip: ip_str_ptr,
+            port: peer.endpoint.address.port(),
+            protocol: WinFwProt::from(peer.endpoint.protocol),
+        });
+    }
+
+    let relay_client_wstrs: Vec<_> = clients
+        .ok_or_else(|| {
+            log::error!("Allowed clients missing. Zero peer endpoints?");
+            FirewallPolicyError::Generic
+        })?
         .iter()
         .map(WideCString::from_os_str_truncate)
         .collect();
@@ -175,8 +195,8 @@ pub(super) fn apply_policy_connecting(
     let res = unsafe {
         WinFw_ApplyPolicyConnecting(
             winfw_settings,
-            1,
-            &winfw_relay,
+            winfw_relays.len(),
+            winfw_relays.as_ptr(),
             exit_endpoint_ip_ptr,
             relay_client_wstr_ptrs.as_ptr(),
             relay_client_wstr_ptrs_len,
@@ -194,31 +214,51 @@ pub(super) fn apply_policy_connecting(
     drop(endpoint2);
     drop(relay_client_wstrs);
     drop(exit_endpoint_ip_wstr);
+    drop(winfw_relays);
+    drop(ip_strs);
     res.into_result()
 }
 
 pub(super) fn apply_policy_connected(
-    endpoint: &AllowedEndpoint,
+    peer_endpoints: &[AllowedEndpoint],
     exit_endpoint_ip: Option<IpAddr>,
     winfw_settings: &WinFwSettings,
     tunnel_interface: &str,
     dns_config: &crate::dns::ResolvedDnsConfig,
 ) -> Result<(), FirewallPolicyError> {
-    let ip_str = widestring_ip(endpoint.endpoint.address.ip());
+    let mut winfw_relays = vec![];
+    let mut ip_strs = vec![];
+    let mut clients = None;
+
+    for peer in peer_endpoints {
+        if clients.is_none() {
+            clients = Some(peer.clients.clone());
+        } else if clients.as_ref() != Some(&peer.clients) {
+            log::error!("Relay endpoints must have same allowed clients");
+            return Err(FirewallPolicyError::Generic);
+        }
+
+        let ip_str = widestring_ip(peer.endpoint.address.ip());
+        let ip_str_ptr = ip_str.as_ptr();
+        // Keep pointer valid for the duration of this function
+        ip_strs.push(ip_str);
+
+        winfw_relays.push(WinFwEndpoint {
+            ip: ip_str_ptr,
+            port: peer.endpoint.address.port(),
+            protocol: WinFwProt::from(peer.endpoint.protocol),
+        });
+    }
 
     let tunnel_alias = WideCString::from_str_truncate(tunnel_interface);
 
-    // ip_str, gateway_str and tunnel_alias have to outlive winfw_relay
-    let winfw_relay = WinFwEndpoint {
-        ip: ip_str.as_ptr(),
-        port: endpoint.endpoint.address.port(),
-        protocol: WinFwProt::from(endpoint.endpoint.protocol),
-    };
-
     // SAFETY: `relay_client_wstrs` must not be dropped until `WinFw_ApplyPolicyConnected` has
     // returned.
-    let relay_client_wstrs: Vec<_> = endpoint
-        .clients
+    let relay_client_wstrs: Vec<_> = clients
+        .ok_or_else(|| {
+            log::error!("Allowed clients missing. Zero peer endpoints?");
+            FirewallPolicyError::Generic
+        })?
         .iter()
         .map(WideCString::from_os_str_truncate)
         .collect();
@@ -256,8 +296,8 @@ pub(super) fn apply_policy_connected(
     let result = unsafe {
         WinFw_ApplyPolicyConnected(
             winfw_settings,
-            1,
-            &winfw_relay,
+            winfw_relays.len(),
+            winfw_relays.as_ptr(),
             exit_endpoint_ip_ptr,
             relay_client_wstr_ptrs.as_ptr(),
             relay_client_wstr_ptrs_len,
@@ -271,7 +311,8 @@ pub(super) fn apply_policy_connected(
 
     // SAFETY: All of these must remain allocated until `WinFw_ApplyPolicyConnected` has returned.
     drop(exit_endpoint_ip_wstr);
-    drop(ip_str);
+    drop(ip_strs);
+    drop(winfw_relays);
     drop(relay_client_wstrs);
     result.into_result()
 }

--- a/talpid-core/src/firewall/windows/winfw/sys.rs
+++ b/talpid-core/src/firewall/windows/winfw/sys.rs
@@ -132,7 +132,7 @@ unsafe extern "system" {
     pub fn WinFw_ApplyPolicyConnecting(
         settings: &WinFwSettings,
         numRelays: usize,
-        relays: &WinFwEndpoint,
+        relays: *const WinFwEndpoint,
         exitEndpointIp: *const libc::wchar_t,
         relayClient: *const *const libc::wchar_t,
         relayClientLen: usize,
@@ -145,7 +145,7 @@ unsafe extern "system" {
     pub fn WinFw_ApplyPolicyConnected(
         settings: &WinFwSettings,
         numRelays: usize,
-        relays: &WinFwEndpoint,
+        relays: *const WinFwEndpoint,
         exitEndpointIp: *const libc::wchar_t,
         relayClient: *const *const libc::wchar_t,
         relayClientLen: usize,

--- a/talpid-core/src/firewall/windows/winfw/sys.rs
+++ b/talpid-core/src/firewall/windows/winfw/sys.rs
@@ -131,7 +131,8 @@ unsafe extern "system" {
     #[link_name = "WinFw_ApplyPolicyConnecting"]
     pub fn WinFw_ApplyPolicyConnecting(
         settings: &WinFwSettings,
-        relay: &WinFwEndpoint,
+        numRelays: usize,
+        relays: &WinFwEndpoint,
         exitEndpointIp: *const libc::wchar_t,
         relayClient: *const *const libc::wchar_t,
         relayClientLen: usize,
@@ -143,7 +144,8 @@ unsafe extern "system" {
     #[link_name = "WinFw_ApplyPolicyConnected"]
     pub fn WinFw_ApplyPolicyConnected(
         settings: &WinFwSettings,
-        relay: &WinFwEndpoint,
+        numRelays: usize,
+        relays: &WinFwEndpoint,
         exitEndpointIp: *const libc::wchar_t,
         relayClient: *const *const libc::wchar_t,
         relayClientLen: usize,

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -21,11 +21,11 @@ pub struct TunnelParameters {
 
 impl TunnelParameters {
     /// Returns the endpoint that will be connected to
-    pub fn get_next_hop_endpoint(&self) -> Endpoint {
+    pub fn get_next_hop_endpoints(&self) -> Vec<Endpoint> {
         self.obfuscation
             .as_ref()
             .map(|proxy| proxy.get_obfuscator_endpoint())
-            .unwrap_or_else(|| self.connection.get_endpoint())
+            .unwrap_or_else(|| vec![self.connection.get_endpoint()])
     }
 }
 

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -9,6 +9,7 @@ use futures::future::Future;
 use obfuscation::ObfuscatorHandle;
 #[cfg(windows)]
 use std::io;
+use std::net::IpAddr;
 use std::{
     convert::Infallible,
     path::Path,
@@ -167,7 +168,11 @@ impl WireguardMonitor {
         let mut config = crate::config::Config::from_parameters(params, tunnel_mtu)
             .map_err(Error::WireguardConfigError)?;
 
-        let endpoint_addrs = [params.get_next_hop_endpoint().address.ip()];
+        let endpoint_addrs: Vec<IpAddr> = params
+            .get_next_hop_endpoints()
+            .iter()
+            .map(|ep| ep.address.ip())
+            .collect();
 
         let (close_obfs_sender, close_obfs_listener) = sync_mpsc::channel();
         // Start obfuscation server and patch the WireGuard config to point the endpoint to it.

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -15,7 +15,7 @@ log = { workspace = true }
 async-trait = "0.1"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util"] }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "87936ac29b68b902565955f138ab02294bcc8593" }
 shadowsocks = { workspace = true }
 mullvad-masque-proxy = { path = "../mullvad-masque-proxy" }

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -31,7 +31,7 @@ pub enum Error {
     PeekUdpSender(#[source] io::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     /// Remote LWO/WG server
     pub server_addr: SocketAddr,

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -1,0 +1,255 @@
+use std::{
+    collections::{BTreeMap, VecDeque},
+    io,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use tokio::{net::UdpSocket, task::JoinHandle, time::Instant};
+use tokio_util::task::AbortOnDropHandle;
+
+use crate::socket::create_remote_socket;
+
+const MAX_DATAGRAM_SIZE: usize = u16::MAX as usize;
+
+pub struct Multiplexer {
+    client_socket: Arc<UdpSocket>,
+    proxy_socket: Arc<UdpSocket>,
+    client_socket_addr: SocketAddr,
+    running_endpoints: BTreeMap<SocketAddr, Transport>,
+    transports: VecDeque<Transport>,
+    initial_packets_to_send: Vec<Vec<u8>>,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl Multiplexer {
+    pub async fn new(settings: &Settings) -> crate::Result<Self> {
+        let client_socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .map_err(crate::Error::CreateMultiplexerObfuscator)?;
+
+        let client_socket_addr = client_socket
+            .local_addr()
+            .map_err(crate::Error::CreateMultiplexerObfuscator)?;
+
+        // TODO: Support IPv6
+        let proxy_socket = create_remote_socket(
+            true,
+            #[cfg(target_os = "linux")]
+            settings.fwmark,
+        )
+        .await?;
+
+        Ok(Self {
+            client_socket: Arc::new(client_socket),
+            proxy_socket: Arc::new(proxy_socket),
+            client_socket_addr,
+            running_endpoints: BTreeMap::new(),
+            transports: VecDeque::from(settings.transports.clone()),
+            tasks: vec![],
+            initial_packets_to_send: vec![],
+        })
+    }
+
+    async fn start(mut self) -> io::Result<()> {
+        log::debug!("Running multiplexer obfuscation");
+
+        let mut wg_recv_buf = vec![0u8; MAX_DATAGRAM_SIZE];
+        let mut obfuscator_recv_buf = vec![0u8; MAX_DATAGRAM_SIZE];
+
+        // let mut last_wg_packet: Option<Vec<u8>> = None;
+        let delay = tokio::time::interval_at(Instant::now(), Duration::from_secs(1));
+        let mut wg_addr = None;
+        tokio::pin!(delay);
+        loop {
+            tokio::select! {
+                socket_recv = self.client_socket.recv_from(&mut wg_recv_buf) => {
+
+                    match socket_recv {
+                        Ok((bytes_received, from_addr)) => {
+                            wg_addr = Some(from_addr);
+                            let received_packet = &wg_recv_buf[..bytes_received];
+                            self.initial_packets_to_send.push(received_packet.to_vec());
+
+                            // last_wg_packet = Some(received_packet.clone());
+                            for (addr, obfs) in &self.running_endpoints {
+                                log::info!("Sending received packet to proxy {obfs:?}");
+                               if let Err(err) = self.proxy_socket.send_to(received_packet, addr).await{
+                                log::error!("Failed to send received packet to proxy {addr}: {err}");
+                               } else {
+                                log::info!("Successfully sent traffic to obfuscator {addr}");
+                               }
+                            }
+                        },
+                        Err(err) => {
+                            log::error!("Failed to receive traffic from local WireGuard instance: {err}");
+                            return Ok(());
+                        }
+                    };
+
+                },
+                obfuscator_recv = self.proxy_socket.recv_from(&mut obfuscator_recv_buf) => {
+                    log::info!("Did receive local socket: {obfuscator_recv:?}");
+
+                    match obfuscator_recv {
+                        Ok((bytes_received, obfuscator_addr)) => {
+                            let Some(wg_addr) = wg_addr else {
+                                log::error!("Received from proxy before ever receiving any traffic from local WireGuard");
+                                return Ok(());
+                            };
+
+                            log::info!("Did receive bytes from obfuscator: °{obfuscator_addr:?}");
+
+                            let _ = self.client_socket.send_to(&obfuscator_recv_buf[..bytes_received], wg_addr).await;
+                            if let Some(transport_config) = self.running_endpoints.get(&obfuscator_addr) {
+                                log::debug!("Selecting {:?} as valid transport configuration, via {}",  transport_config, obfuscator_addr);
+                            }
+
+                            // run proxy in _connected_ mode
+                            self.run_connected(wg_addr, obfuscator_addr).await?;
+                            return Ok(())
+                        },
+                        Err(err) => {
+                            log::error!("Failed to receive traffic from obfuscators: {err}");
+                            return Err(err);
+                        }
+                    }
+
+                },
+               _ = delay.tick() => {
+                let Some(transport) = self.transports.pop_front() else {
+                    continue;
+                };
+
+                if let Err(err) = self.spawn_new_transport(transport).await {
+                    log::error!("Failed to spawn new transport: {err}");
+                }
+
+                }
+            }
+        }
+    }
+
+    async fn run_connected(
+        self,
+        local_address: SocketAddr,
+        proxy_address: SocketAddr,
+    ) -> io::Result<()> {
+        let mut wg_recv_buf: Vec<u8> = vec![0u8; MAX_DATAGRAM_SIZE];
+        let mut obfuscator_recv_buf: Vec<u8> = vec![0u8; MAX_DATAGRAM_SIZE];
+
+        self.client_socket
+            .connect(local_address)
+            .await
+            .inspect_err(|err| {
+                log::error!("Failed to connect client socket: {err}");
+            })?;
+
+        let tx_client_socket = self.client_socket.clone();
+        let tx_proxy_socket = self.proxy_socket.clone();
+
+        let tx_task: JoinHandle<io::Result<()>> = tokio::spawn(async move {
+            loop {
+                let n = tx_client_socket.recv(&mut wg_recv_buf).await?;
+                tx_proxy_socket
+                    .send_to(&wg_recv_buf[..n], proxy_address)
+                    .await?;
+            }
+        });
+        let mut tx_task = AbortOnDropHandle::new(tx_task);
+
+        let rx_task: JoinHandle<io::Result<()>> = tokio::spawn(async move {
+            loop {
+                let (n, _src) = self
+                    .proxy_socket
+                    .recv_from(&mut obfuscator_recv_buf)
+                    .await?;
+                self.client_socket.send(&obfuscator_recv_buf[..n]).await?;
+            }
+        });
+        let mut rx_task = AbortOnDropHandle::new(rx_task);
+
+        tokio::select! {
+            Ok(result) = &mut tx_task => result,
+            Ok(result) = &mut rx_task => result,
+            else => Ok(()),
+        }
+    }
+
+    async fn spawn_new_transport(&mut self, transport: Transport) -> crate::Result<()> {
+        let endpoint = match transport {
+            settings @ Transport::Direct(addr) => {
+                self.running_endpoints.insert(addr, settings);
+                log::info!("Spawning direct forwarder");
+                Ok(addr)
+            }
+            Transport::Obfuscated(obfuscator_settings) => {
+                let obfuscator = crate::create_obfuscator(&obfuscator_settings).await?;
+                let endpoint = obfuscator.endpoint();
+                self.running_endpoints
+                    .insert(endpoint, Transport::Obfuscated(obfuscator_settings));
+                self.tasks.push(tokio::spawn(async move {
+                    log::info!("Spawning new obfuscator");
+                    let _ = obfuscator.run().await;
+                }));
+                Ok(endpoint)
+            }
+        }?;
+
+        // Send initial packets
+        for packet in &self.initial_packets_to_send {
+            if let Err(err) = self.proxy_socket.send_to(packet, endpoint).await {
+                log::error!("Failed to forward packet to new obfuscator: {err}");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for Multiplexer {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Settings {
+    /// Transports to use, ordered by highest to lowest priority
+    pub transports: Vec<Transport>,
+    #[cfg(target_os = "linux")]
+    pub fwmark: Option<u32>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Transport {
+    Direct(SocketAddr),
+    Obfuscated(crate::Settings),
+}
+
+#[tokio::test]
+async fn test_multi_sleep() {
+    let sleep = tokio::time::sleep(Duration::from_secs(0));
+    sleep.await;
+}
+
+#[async_trait]
+impl crate::Obfuscator for Multiplexer {
+    fn endpoint(&self) -> SocketAddr {
+        self.client_socket_addr
+    }
+
+    fn packet_overhead(&self) -> u16 {
+        60
+    }
+
+    async fn run(self: Box<Self>) -> crate::Result<()> {
+        self.start()
+            .await
+            .map_err(crate::Error::RunMultiplexerObfuscator)
+    }
+}

--- a/tunnel-obfuscation/src/multiplexer.rs
+++ b/tunnel-obfuscation/src/multiplexer.rs
@@ -252,4 +252,9 @@ impl crate::Obfuscator for Multiplexer {
             .await
             .map_err(crate::Error::RunMultiplexerObfuscator)
     }
+
+    #[cfg(target_os = "android")]
+    fn remote_socket_fd(&self) -> std::os::unix::io::RawFd {
+        unimplemented!("note that we must punch a hole for all obfuscators")
+    }
 }

--- a/tunnel-obfuscation/src/quic.rs
+++ b/tunnel-obfuscation/src/quic.rs
@@ -27,7 +27,7 @@ pub struct Quic {
     config: ClientConfig,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     /// Remote Quic endpoint
     quic_endpoint: SocketAddr,

--- a/tunnel-obfuscation/src/shadowsocks.rs
+++ b/tunnel-obfuscation/src/shadowsocks.rs
@@ -51,7 +51,7 @@ pub struct Shadowsocks {
     outbound_fd: i32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     /// Remote Shadowsocks endpoint
     pub shadowsocks_endpoint: SocketAddr,

--- a/tunnel-obfuscation/src/udp2tcp.rs
+++ b/tunnel-obfuscation/src/udp2tcp.rs
@@ -6,7 +6,7 @@ use udp_over_tcp::{
     udp2tcp::{self, Udp2Tcp as Udp2TcpImpl},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Settings {
     pub peer: SocketAddr,
     #[cfg(target_os = "linux")]

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -191,7 +191,7 @@ FwContext::FwContext
 bool FwContext::applyPolicyConnecting
 (
 	const WinFwSettings &settings,
-	const WinFwEndpoint &relay,
+	const std::vector<WinFwEndpoint> &relays,
 	const std::optional<wfp::IpAddress> &exitEndpointIp,
 	const std::vector<std::wstring> &relayClients,
 	const std::optional<std::wstring> &tunnelInterfaceAlias,
@@ -203,7 +203,11 @@ bool FwContext::applyPolicyConnecting
 
 	AppendNetBlockedRules(ruleset);
 	AppendSettingsRules(ruleset, settings);
-	AppendRelayRules(ruleset, relay, relayClients);
+
+	for (const auto &relay : relays)
+	{
+		AppendRelayRules(ruleset, relay, relayClients);
+	}
 
 	if (allowedEndpoint.has_value())
 	{
@@ -299,9 +303,9 @@ bool FwContext::applyPolicyConnecting
 bool FwContext::applyPolicyConnected
 (
 	const WinFwSettings &settings,
-	const WinFwEndpoint &relay,
+	const std::vector<WinFwEndpoint> &relays,
 	const std::optional<wfp::IpAddress> &exitEndpointIp,
-	const std::vector<std::wstring> &relayClient,
+	const std::vector<std::wstring> &relayClients,
 	const std::wstring &tunnelInterfaceAlias,
 	const std::vector<wfp::IpAddress> &tunnelDnsServers,
 	const std::vector<wfp::IpAddress> &nonTunnelDnsServers
@@ -311,7 +315,11 @@ bool FwContext::applyPolicyConnected
 
 	AppendNetBlockedRules(ruleset);
 	AppendSettingsRules(ruleset, settings);
-	AppendRelayRules(ruleset, relay, relayClient);
+
+	for (const auto &relay : relays)
+	{
+		AppendRelayRules(ruleset, relay, relayClients);
+	}
 
 	if (!tunnelDnsServers.empty())
 	{
@@ -327,14 +335,14 @@ bool FwContext::applyPolicyConnected
 	}
 
 	ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnel>(
-		relayClient,
+		relayClients,
 		tunnelInterfaceAlias,
 		std::nullopt,
 		exitEndpointIp
 	));
 
 	ruleset.emplace_back(std::make_unique<baseline::PermitVpnTunnelService>(
-		relayClient,
+		relayClients,
 		tunnelInterfaceAlias,
 		std::nullopt,
 		exitEndpointIp

--- a/windows/winfw/src/winfw/fwcontext.h
+++ b/windows/winfw/src/winfw/fwcontext.h
@@ -27,7 +27,7 @@ public:
 	bool applyPolicyConnecting
 	(
 		const WinFwSettings &settings,
-		const WinFwEndpoint &relay,
+		const std::vector<WinFwEndpoint> &relays,
 		const std::optional<wfp::IpAddress> &exitEndpointIp,
 		const std::vector<std::wstring> &relayClients,
 		const std::optional<std::wstring> &tunnelInterfaceAlias,
@@ -38,7 +38,7 @@ public:
 	bool applyPolicyConnected
 	(
 		const WinFwSettings &settings,
-		const WinFwEndpoint &relay,
+		const std::vector<WinFwEndpoint> &relays,
 		const std::optional<wfp::IpAddress> &exitEndpointIp,
 		const std::vector<std::wstring> &relayClients,
 		const std::wstring &tunnelInterfaceAlias,

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -159,7 +159,7 @@ enum WINFW_POLICY_STATUS
 //
 // Apply restrictions in the firewall that block all traffic, except:
 // - What is specified by settings
-// - Communication with the relay server
+// - Communication with the relay server(s)
 // - Specified in-tunnel traffic, except DNS.
 //
 // Parameters:
@@ -174,7 +174,8 @@ WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyConnecting(
 	const WinFwSettings *settings,
-	const WinFwEndpoint *relay,
+	size_t numRelays,
+	const WinFwEndpoint *relays,
 	const wchar_t *exitEndpointIp,
 	const wchar_t **relayClient,
 	size_t relayClientLen,
@@ -188,7 +189,7 @@ WinFw_ApplyPolicyConnecting(
 //
 // Apply restrictions in the firewall that block all traffic, except:
 // - What is specified by settings
-// - Communication with the relay server
+// - Communication with the relay server(s)
 // - Non-DNS traffic inside the VPN tunnel
 // - DNS requests inside the VPN tunnel to any server in 'tunnelDnsServers'
 // - DNS requests outside the VPN tunnel to any server in 'nonTunnelDnsServers'
@@ -208,7 +209,8 @@ WINFW_POLICY_STATUS
 WINFW_API
 WinFw_ApplyPolicyConnected(
 	const WinFwSettings *settings,
-	const WinFwEndpoint *relay,
+	size_t numRelays,
+	const WinFwEndpoint *relays,
 	const wchar_t *exitEndpointIp,
 	const wchar_t **relayClient,
 	size_t relayClientLen,


### PR DESCRIPTION
Adds a POC for the new obfuscation type. Some changes:
* Add `multiplexer` tunnel obfuscation module
* Select the `multiplexer` module by default in the relay selector. That is, when the obfuscation mode is `auto`.
  This is only enabled when `mullvad-daemon` is built with the feature flag `staggered-obfuscation`.
* Make it possible to punch holes for multiple entry endpoints (this is what #8739 was about).
  The current implementation is leakier than necessary. It punches a hole for every possible entry and keeps them even when a final obfuscation mehtod has been selected.

Fix DES-2260
Fix DES-2262