### PR TITLE
Only fallback in auto case

### DIFF
--- a/ios/MullvadREST/Relay/ObfuscationMethodSelector.swift
+++ b/ios/MullvadREST/Relay/ObfuscationMethodSelector.swift
@@ -23,21 +23,22 @@ public struct ObfuscationMethodSelector {
         tunnelSettings: LatestTunnelSettings,
         obfuscationBypass: any ObfuscationProviding
     ) -> WireGuardObfuscationState {
-        let selectedObfuscation: WireGuardObfuscationState =
-            if tunnelSettings.wireGuardObfuscation.state == .automatic {
-                if connectionAttemptCount.isOrdered(nth: 2, forEverySetOf: 4) {
-                    .shadowsocks
-                } else if connectionAttemptCount.isOrdered(nth: 3, forEverySetOf: 4) {
-                    .quic
-                } else if connectionAttemptCount.isOrdered(nth: 4, forEverySetOf: 4) {
-                    .udpOverTcp
-                } else {
-                    .off
-                }
+        if tunnelSettings.wireGuardObfuscation.state == .automatic {
+            let selectedObfuscation: WireGuardObfuscationState = if connectionAttemptCount.isOrdered(
+                nth: 2,
+                forEverySetOf: 4
+            ) {
+                .shadowsocks
+            } else if connectionAttemptCount.isOrdered(nth: 3, forEverySetOf: 4) {
+                .quic
+            } else if connectionAttemptCount.isOrdered(nth: 4, forEverySetOf: 4) {
+                .udpOverTcp
             } else {
-                tunnelSettings.wireGuardObfuscation.state
+                .off
             }
-        return obfuscationBypass.bypassUnsupportedObfuscation(selectedObfuscation)
+            return obfuscationBypass.bypassUnsupportedObfuscation(selectedObfuscation)
+        }
+        return tunnelSettings.wireGuardObfuscation.state
     }
 }
 

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
@@ -244,7 +244,7 @@ final class RelayObfuscatorTests: XCTestCase {
     // MARK: Obfuscation Bypass
 
     func testObfuscatorBypass() throws {
-        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(state: .quic)
+        tunnelSettings.wireGuardObfuscation = WireGuardObfuscationSettings(state: .automatic)
 
         let obfuscationResult = RelayObfuscator(
             relays: sampleRelays,


### PR DESCRIPTION
Instead of falling back to a known good obfuscator at all times, we should only do this when the setting is set to `.automatic`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8785)
<!-- Reviewable:end -->
