### PR TITLE
Add Fedora 43 VM to end-to-end tests

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -16,11 +16,12 @@ on:
         description: "Space-delimited list of targets to run tests on, e.g. `debian12 ubuntu2004`. \
           Available images:\n
           `debian11 debian12 debian13 ubuntu2004 ubuntu2204 ubuntu2404 ubuntu2410 ubuntu2504 \
-          fedora39 fedora40 fedora41 fedora42 windows10 windows11 \
+          fedora39 fedora40 fedora41 fedora42 fedora43 \
+          windows10 windows11 \
           macos12 macos13 macos14 macos15 macos26`.\n
           Default images:\n
           `debian13 ubuntu2004 ubuntu2204 ubuntu2404 ubuntu2410 ubuntu2504 \
-          fedora39 fedora40 fedora41 fedora42 windows10 windows11 \
+          fedora41 fedora42 fedora43 windows10 windows11 \
           macos13 macos14 macos15 macos26`."
         default: ''
         required: false
@@ -43,8 +44,8 @@ jobs:
         run: |
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
-          all='["debian11","debian12","debian13","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","ubuntu2504","fedora39","fedora40","fedora41","fedora42"]'
-          default='["debian13","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","ubuntu2504","fedora40","fedora41","fedora42"]'
+          all='["debian11","debian12","debian13","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","ubuntu2504","fedora39","fedora40","fedora41","fedora42","fedora43"]'
+          default='["debian13","ubuntu2004","ubuntu2204","ubuntu2404","ubuntu2410","ubuntu2504","fedora41","fedora42","fedora43"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then


### PR DESCRIPTION
This PR adds Fedora 43 to the arsenal of VMs used in our desktop E2E tests.

Test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/17788352428/job/50560906769

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8790)
<!-- Reviewable:end -->
