### PR TITLE
Fix `error C1076` when building Windows modules in CI

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -205,7 +205,7 @@ jobs:
         # https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
         #
         # Cap the number of concurrent processes to something less than 4 to avoid OOM issues.
-        run: ./build-windows-modules.sh --max-concurrent-processes 3
+        run: ./build-windows-modules.sh --max-concurrent-processes 2
 
       - name: Build and test crates
         shell: bash


### PR DESCRIPTION
This PR lowers the cap of concurrent processes when building Windows modules in CI.

Follow-up to https://github.com/mullvad/mullvadvpn-app/pull/8672 due to https://github.com/mullvad/mullvadvpn-app/actions/runs/17824271993/job/50673646319 showing that the current cap might still be an issue.