### PR TITLE
Set content compression to maximum for switches in API methods

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Cells/SwitchCellContentView.swift
@@ -83,6 +83,7 @@ class SwitchCellContentView: UIView, UIContentView, UITextFieldDelegate {
     }
 
     private func addSubviews() {
+        switchContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
         addConstrainedSubviews([textLabel, switchContainer]) {
             textLabel.pinEdgesToSuperviewMargins(.all().excluding(.trailing))
             switchContainer.centerYAnchor.constraint(equalTo: centerYAnchor)


### PR DESCRIPTION
This PR guarantees that switches in API access methods are always fully displayed

Video demo

https://github.com/user-attachments/assets/c1c3e179-03dd-4151-a6c2-02b4cfe67ca6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8800)
<!-- Reviewable:end -->
