### PR TITLE
Improve xor_bytes performance

### DIFF
--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -244,10 +244,10 @@ fn header_mut(packet: &mut [u8], key_byte: u8) -> Option<&mut [u8]> {
     }
 }
 
-fn xor_bytes(data: &mut [u8], key: &[u8]) {
-    data.iter_mut()
-        .zip(key.iter().cycle())
-        .for_each(|(byte, key_byte)| *byte ^= key_byte);
+fn xor_bytes(data: &mut [u8], key: &[u8; 32]) {
+    for (i, byte) in data.iter_mut().enumerate() {
+        *byte ^= key[i % key.len()];
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
This is probably not a bottleneck. Still, rewriting the loop made it 35% faster in the cargo benchmarks, from ~38 GiB/s to ~51 GiB/s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8804)
<!-- Reviewable:end -->
