### PR TITLE
Change required device capability to arm64 from armv7

### DIFF
--- a/ios/MullvadVPN/Supporting Files/Info.plist
+++ b/ios/MullvadVPN/Supporting Files/Info.plist
@@ -79,7 +79,7 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>


### PR DESCRIPTION
Apple has rejected the app based the lone `armv7` device capability allegedly not being supported by the 5th gen iPad Air. Ignoring the fact that this has worked for every device under the sun since iOS15 so far, we will try and appease the gods by dancing the rain dance of changing the device capability to `arm64`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8811)
<!-- Reviewable:end -->
