### PR TITLE
Fix separators in access methods list

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/DAITA/SettingsDAITAView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DAITA/SettingsDAITAView.swift
@@ -18,7 +18,7 @@ struct SettingsDAITAView<ViewModel>: View where ViewModel: TunnelSettingsObserva
                 if isAutomaticRoutingActive {
                     DAITAMultihopNotice()
                         .padding(EdgeInsets(
-                            top: -UIMetrics.contentInsets.top,
+                            top: -8,
                             leading: UIMetrics.contentInsets.toEdgeInsets.leading,
                             bottom: 8,
                             trailing: UIMetrics.contentInsets.toEdgeInsets.trailing
@@ -34,7 +34,7 @@ struct SettingsDAITAView<ViewModel>: View where ViewModel: TunnelSettingsObserva
                             text: NSLocalizedString("Enable", comment: ""),
                             accessibilityId: .daitaSwitch
                         )
-                        RowSeparator()
+                        RowSeparator(edgeInsets: .init(top: 0, leading: 16, bottom: 0, trailing: 16))
                         SwitchRowView(
                             isOn: directOnlyIsEnabled,
                             disabled: !daitaIsEnabled.wrappedValue,

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceListView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceListView.swift
@@ -41,7 +41,6 @@ struct DeviceListView: View {
                     Spacer()
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
 
         MullvadList(

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementView.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManagementView.swift
@@ -65,10 +65,7 @@ struct DeviceManagementView: View {
             "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
         case .tooManyDevices:
             if canLoginNewDevice {
-                """
-                You can now continue logging in on this device.
-                """
-
+                "You can now continue logging in on this device."
             } else {
                 "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
             }
@@ -172,9 +169,7 @@ struct DeviceManagementView: View {
                             .foregroundColor(.mullvadTextPrimary)
                             .opacity(0.6)
                             .font(.mullvadTinySemiBold)
-                            .padding(.bottom, 16.0)
-                    }
-                    )
+                    })
                 }
             )
             Spacer()
@@ -187,14 +182,7 @@ struct DeviceManagementView: View {
                 }
                 .accessibilityIdentifier(AccessibilityIdentifier.continueWithLoginButton)
                 .disabled(!canLoginNewDevice)
-                .padding(
-                    EdgeInsets(
-                        top: UIMetrics.contentLayoutMargins.top,
-                        leading: UIMetrics.contentLayoutMargins.leading,
-                        bottom: UIMetrics.contentLayoutMargins.bottom,
-                        trailing: UIMetrics.contentLayoutMargins.trailing
-                    )
-                )
+                .padding(EdgeInsets(UIMetrics.contentLayoutMargins))
             }
         }
         .mullvadAlert(item: $deviceManagementAlert)

--- a/ios/MullvadVPN/Views/List/MullvadList.swift
+++ b/ios/MullvadVPN/Views/List/MullvadList.swift
@@ -40,27 +40,43 @@ struct MullvadList<Content: View, Data: RandomAccessCollection<ID>, ID: Hashable
             List {
                 if let headerView = header?() {
                     headerView
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(UIMetrics.contentHeadingLayoutMargins))
+                        .listRowStyling(insets: EdgeInsets(UIMetrics.contentHeadingLayoutMargins))
                 }
 
+                let lastItem = data.last
                 ForEach(data, id: id) { item in
-                    content(item)
-                        .listRowInsets(.init())
-                        .listRowSeparator(.hidden)
+                    VStack(spacing: 0) {
+                        content(item)
+                        if item != lastItem {
+                            RowSeparator()
+                        }
+                    }
+                    .listRowStyling()
                 }
 
                 if let footerView = footer?() {
                     footerView
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(UIMetrics.contentFooterLayoutMargins))
+                        .listRowStyling(insets: EdgeInsets(UIMetrics.contentFooterLayoutMargins))
                 }
             }
             .listStyle(.plain)
-            .listRowSpacing(UIMetrics.TableView.separatorHeight)
+            .listRowSpacing(.zero)
             .environment(\.defaultMinListRowHeight, 0)
+        }
+    }
+}
+
+extension View {
+    func listRowStyling(
+        background: Color = .clear,
+        separator: Visibility = .hidden,
+        insets: EdgeInsets = .init()
+    ) -> some View {
+        apply {
+            $0
+                .listRowBackground(background)
+                .listRowSeparator(separator)
+                .listRowInsets(insets)
         }
     }
 }

--- a/ios/MullvadVPN/Views/RowSeparator.swift
+++ b/ios/MullvadVPN/Views/RowSeparator.swift
@@ -9,12 +9,18 @@
 import SwiftUI
 
 struct RowSeparator: View {
-    var color = Color(.secondaryColor)
+    let color: Color
+    let edgeInsets: EdgeInsets
+
+    init(color: Color = Color(.secondaryColor), edgeInsets: EdgeInsets = .init()) {
+        self.color = color
+        self.edgeInsets = edgeInsets
+    }
 
     var body: some View {
         color
             .frame(height: UIMetrics.TableView.separatorHeight)
-            .padding(.leading, 16)
+            .padding(edgeInsets)
     }
 }
 


### PR DESCRIPTION
In manage devices and API access, which are both new SwiftUI views, some list items have gaps between them, some don't.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8818)
<!-- Reviewable:end -->
