### PR TITLE
Fix hover and active states for disabled IconButton component

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
@@ -1,14 +1,14 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { colors, Radius, spacings } from '../../foundations';
 import { ButtonProvider } from './ButtonContext';
 import { ButtonIcon, ButtonText, StyledButtonIcon, StyledButtonText } from './components';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export type ButtonProps = React.ComponentPropsWithRef<'button'> & {
   variant?: 'primary' | 'success' | 'destructive';
   width?: 'fill' | 'fit';
-}
+};
 
 const styles = {
   radius: Radius.radius4,
@@ -123,18 +123,15 @@ export const StyledButton = styled.button<ButtonProps>`
   }}
 `;
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { children, disabled = false, style, ...props },
-  ref,
-) {
+function Button({ children, disabled = false, ...props }: ButtonProps) {
   return (
     <ButtonProvider disabled={disabled}>
-      <StyledButton ref={ref} disabled={disabled} {...props}>
+      <StyledButton disabled={disabled} {...props}>
         {children}
       </StyledButton>
     </ButtonProvider>
   );
-});
+}
 
 const ButtonNamespace = Object.assign(Button, {
   Text: ButtonText,

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-icon/ButtonIcon.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-icon/ButtonIcon.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
-import { Icon, IconProps } from '../../icon';
-import { useButtonContext } from '../ButtonContext';
+import { Icon, IconProps } from '../../../icon';
+import { useButtonContext } from '../../ButtonContext';
 
 type ButtonIconProps = Omit<IconProps, 'size'>;
 

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-icon/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-icon/index.ts
@@ -1,0 +1,1 @@
+export * from './ButtonIcon';

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-text/ButtonText.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-text/ButtonText.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { BodySmallSemiBold, BodySmallSemiBoldProps } from '../../typography';
-import { useButtonContext } from '../ButtonContext';
+import { BodySmallSemiBold, BodySmallSemiBoldProps } from '../../../typography';
+import { useButtonContext } from '../../ButtonContext';
 
 export type ButtonTextProps<T extends React.ElementType = 'span'> = BodySmallSemiBoldProps<T>;
 export const StyledButtonText = styled(BodySmallSemiBold)``;

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-text/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/button-text/index.ts
@@ -1,0 +1,1 @@
+export * from './ButtonText';

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/components/index.ts
@@ -1,2 +1,2 @@
-export * from './ButtonIcon';
-export * from './ButtonText';
+export * from './button-icon';
+export * from './button-text';

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/IconButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/IconButton.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { colors } from '../../foundations';
 import { IconProps, iconSizes } from '../icon/Icon';
-import { IconButtonIcon } from './components/IconButtonIcon';
+import { IconButtonIcon, StyledIconButtonIcon } from './components';
 import { IconButtonProvider } from './IconButtonContext';
 
 export type IconButtonVariant = 'primary' | 'secondary';
@@ -13,19 +13,74 @@ export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   size?: IconProps['size'];
 }
 
-const StyledButton = styled.button<{ $size: IconButtonProps['size'] }>`
-  ${({ $size = 'medium' }) => {
+const variants: Record<
+  IconButtonVariant,
+  {
+    background: string;
+    hover: string;
+    pressed: string;
+    disabled: string;
+  }
+> = {
+  primary: {
+    background: colors.white,
+    hover: colors.whiteAlpha60,
+    pressed: colors.whiteAlpha40,
+    disabled: colors.whiteAlpha40,
+  },
+  secondary: {
+    background: colors.whiteAlpha60,
+    hover: colors.whiteAlpha80,
+    pressed: colors.white,
+    disabled: colors.whiteAlpha40,
+  },
+} as const;
+
+const StyledButton = styled.button<{
+  $size: IconButtonProps['size'];
+  $variant: IconButtonVariant;
+}>`
+  ${({ $size = 'medium', $variant = 'primary' }) => {
     const size = iconSizes[$size];
+    const variant = variants[$variant];
     return css`
       --size: ${size}px;
+
+      --background: ${variant.background};
+      --hover: ${variant.hover};
+      --pressed: ${variant.pressed};
+      --disabled: ${variant.disabled};
+      --transition-duration: 0.15s;
 
       background: ${colors.transparent};
       height: var(--size);
       width: var(--size);
       border-radius: 100%;
-      &:focus-visible {
+
+      &&:focus-visible {
         outline: 2px solid ${colors.white};
         outline-offset: 1px;
+      }
+
+      ${StyledIconButtonIcon} {
+        background-color: var(--background);
+        @media (prefers-reduced-motion: no-preference) {
+          transition: background-color var(--transition-duration) ease;
+        }
+      }
+
+      &&:not(:disabled):hover ${StyledIconButtonIcon} {
+        --transition-duration: 0s;
+        background-color: var(--hover);
+      }
+
+      &&:not(:disabled):active ${StyledIconButtonIcon} {
+        --transition-duration: 0s;
+        background-color: var(--pressed);
+      }
+
+      &&:disabled ${StyledIconButtonIcon} {
+        background-color: var(--disabled);
       }
     `;
   }}
@@ -35,7 +90,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   ({ variant = 'primary', size = 'medium', disabled, style, ...props }, ref) => {
     return (
       <IconButtonProvider size={size} variant={variant} disabled={disabled}>
-        <StyledButton ref={ref} disabled={disabled} $size={size} {...props} />
+        <StyledButton ref={ref} disabled={disabled} $variant={variant} $size={size} {...props} />
       </IconButtonProvider>
     );
   },

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/IconButton.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 import { colors } from '../../foundations';
@@ -8,10 +8,10 @@ import { IconButtonProvider } from './IconButtonContext';
 
 export type IconButtonVariant = 'primary' | 'secondary';
 
-export interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export type IconButtonProps = React.ComponentPropsWithRef<'button'> & {
   variant?: IconButtonVariant;
   size?: IconProps['size'];
-}
+};
 
 const variants: Record<
   IconButtonVariant,
@@ -86,20 +86,16 @@ const StyledButton = styled.button<{
   }}
 `;
 
-const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ variant = 'primary', size = 'medium', disabled, style, ...props }, ref) => {
-    return (
-      <IconButtonProvider size={size} variant={variant} disabled={disabled}>
-        <StyledButton ref={ref} disabled={disabled} $variant={variant} $size={size} {...props} />
-      </IconButtonProvider>
-    );
-  },
-);
+function IconButton({ variant = 'primary', size = 'medium', disabled, ...props }: IconButtonProps) {
+  return (
+    <IconButtonProvider size={size} variant={variant} disabled={disabled}>
+      <StyledButton disabled={disabled} $variant={variant} $size={size} {...props} />
+    </IconButtonProvider>
+  );
+}
 
 const IconButtonNamespace = Object.assign(IconButton, {
   Icon: IconButtonIcon,
 });
 
 export { IconButtonNamespace as IconButton };
-
-IconButton.displayName = 'Button';

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/IconButtonIcon.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/IconButtonIcon.tsx
@@ -1,68 +1,12 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-import { colors } from '../../../foundations';
 import { Icon, IconProps } from '../../icon/Icon';
-import { IconButtonVariant } from '../IconButton';
 import { useIconButtonContext } from '../IconButtonContext';
 export type IconButtonIconProps = IconProps;
 
-const variants: Record<
-  IconButtonVariant,
-  {
-    background: string;
-    hover: string;
-    pressed: string;
-    disabled: string;
-  }
-> = {
-  primary: {
-    background: colors.white,
-    hover: colors.whiteAlpha60,
-    pressed: colors.whiteAlpha40,
-    disabled: colors.whiteAlpha40,
-  },
-  secondary: {
-    background: colors.whiteAlpha60,
-    hover: colors.whiteAlpha80,
-    pressed: colors.white,
-    disabled: colors.whiteAlpha40,
-  },
-} as const;
-
-const StyledIconButtonIcon = styled(Icon)<{ $variant: IconButtonVariant }>(({ $variant }) => {
-  const variant = variants[$variant];
-  return css`
-    --background: ${variant.background};
-    --hover: ${variant.hover};
-    --pressed: ${variant.pressed};
-    --disabled: ${variant.disabled};
-    --transition-duration: 0.15s;
-
-    @media (prefers-reduced-motion: no-preference) {
-      transition: background-color var(--transition-duration) ease;
-    }
-
-    background-color: var(--background);
-
-    &&:not([data-disabled='true']):hover {
-      --transition-duration: 0s;
-      background-color: var(--hover);
-    }
-
-    &&:not([data-disabled='true']):active {
-      --transition-duration: 0s;
-      background-color: var(--pressed);
-    }
-
-    &&[data-disabled='true'] {
-      background-color: var(--disabled);
-    }
-  `;
-});
+export const StyledIconButtonIcon = styled(Icon)``;
 
 export const IconButtonIcon = (props: IconButtonIconProps) => {
-  const { variant = 'primary', size, disabled } = useIconButtonContext();
-  return (
-    <StyledIconButtonIcon size={size} data-disabled={disabled} $variant={variant} {...props} />
-  );
+  const { size } = useIconButtonContext();
+  return <StyledIconButtonIcon size={size} {...props} />;
 };

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/IconButtonIcon.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/IconButtonIcon.tsx
@@ -44,17 +44,17 @@ const StyledIconButtonIcon = styled(Icon)<{ $variant: IconButtonVariant }>(({ $v
 
     background-color: var(--background);
 
-    &&:not([data-disabled]):hover {
+    &&:not([data-disabled='true']):hover {
       --transition-duration: 0s;
       background-color: var(--hover);
     }
 
-    &&:not([data-disabled]):active {
+    &&:not([data-disabled='true']):active {
       --transition-duration: 0s;
       background-color: var(--pressed);
     }
 
-    &[data-disabled='true'] {
+    &&[data-disabled='true'] {
       background-color: var(--disabled);
     }
   `;

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/icon-button-icon/IconButtonIcon.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/icon-button-icon/IconButtonIcon.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
-import { Icon, IconProps } from '../../icon/Icon';
-import { useIconButtonContext } from '../IconButtonContext';
+import { Icon, IconProps } from '../../../icon/Icon';
+import { useIconButtonContext } from '../../IconButtonContext';
 export type IconButtonIconProps = IconProps;
 
 export const StyledIconButtonIcon = styled(Icon)``;

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/icon-button-icon/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/icon-button-icon/index.ts
@@ -1,0 +1,1 @@
+export * from './IconButtonIcon';

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/index.ts
@@ -1,0 +1,1 @@
+export * from './IconButtonIcon';

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/icon-button/components/index.ts
@@ -1,1 +1,1 @@
-export * from './IconButtonIcon';
+export * from './icon-button-icon';


### PR DESCRIPTION
Fix hover and active states for IconButton to check that data-disabled is actually set to true on an element, not just existing.

Also refactors IconButton and Button components to use new structure from our style guide and remove forwardRef.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8824)
<!-- Reviewable:end -->
