### PR TITLE
Make `dirs` a workspace dependency and upgrade to 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,23 +1185,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4762,13 +4762,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.14",
  "libredox",
- "thiserror 1.0.59",
+ "thiserror 2.0.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ undocumented_unsafe_blocks = "warn"
 implicit_clone = "warn"
 
 [workspace.dependencies]
+dirs = "6.0.0"
 tokio = { version = "1.44" }
 tokio-util = "0.7"
 parity-tokio-ipc = "0.9"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -80,7 +80,7 @@ talpid-macos = { path = "../talpid-macos" }
 ctrlc = "3.0"
 windows-service = "0.6.0"
 winapi = { version = "0.3", features = ["winnt", "excpt", "winerror"] }
-dirs = "5.0.1"
+dirs = { workspace = true }
 talpid-windows = { path = "../talpid-windows" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/mullvad-problem-report/Cargo.toml
+++ b/mullvad-problem-report/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-dirs = "5.0.1"
+dirs = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 regex = "1.0"

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -690,23 +690,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2948,13 +2948,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.14",
  "libredox",
- "thiserror 1.0.59",
+ "thiserror 2.0.3",
 ]
 
 [[package]]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -37,6 +37,7 @@ unused_async = "deny"
 implicit_clone = "warn"
 
 [workspace.dependencies]
+dirs = "6.0.0"
 futures = "0.3"
 tokio = { version = "1.44", features = [
   "macros",

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "4.1", features = ["derive"] }
 async-tempfile = "0.2"
 async-trait = { workspace = true }
 uuid = "1.3"
-dirs = "5.0.1"
+dirs = { workspace = true }
 scopeguard = "1.2"
 glob = "0.3"
 

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-dirs = "5.0.1"
+dirs = { workspace = true }
 futures = { workspace = true }
 tarpc = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Very minor dependency upgrade. `dirs` seems to be unmaintained, given that the git repository is archived since February. But they have released a 6.0.0 release, which transitively upgrades the `windows-sys` dependency. This does not really help us much in practice. It neither removes, nor adds, any duplicate `windows-sys` version to our dependency tree. But just minor cleanup to use the latest version and get newer windows bindings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8832)
<!-- Reviewable:end -->
