### PR TITLE
Add tiny padding to ListItem to improve look for long texts

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/list-item/components/list-item-content/ListItemContent.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/list-item/components/list-item-content/ListItemContent.tsx
@@ -23,6 +23,8 @@ const StyledFlex = styled(Flex)<{
       height: 100%;
       padding-left: ${$paddingLeft};
       padding-right: ${spacings.medium};
+      padding-top: ${spacings.tiny};
+      padding-bottom: ${spacings.tiny};
       &&:has(> :last-child:nth-child(1)) {
         &&:has(img) {
           justify-content: center;


### PR DESCRIPTION
Adds a tiny padding to the ListItemContent component to improve look for localizations with long texts, such as Spanish.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8836)
<!-- Reviewable:end -->
