### PR TITLE
[gotatun] Patch allowed IPs during tunnel setup on Android

### DIFF
--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -472,6 +472,7 @@ impl WireguardMonitor {
                 &config,
                 args.tun_provider.clone(),
                 args.route_manager,
+                should_negotiate_ephemeral_peer,
             ))
             .map(Box::new)? as Box<dyn Tunnel>;
 

--- a/talpid-wireguard/src/wireguard_go/mod.rs
+++ b/talpid-wireguard/src/wireguard_go/mod.rs
@@ -13,8 +13,6 @@ use crate::connectivity;
 use crate::logging::{clean_up_logging, initialize_logging};
 #[cfg(all(unix, not(target_os = "android")))]
 use ipnetwork::IpNetwork;
-#[cfg(target_os = "android")]
-use std::borrow::Cow;
 #[cfg(daita)]
 use std::ffi::CString;
 #[cfg(unix)]
@@ -114,7 +112,10 @@ pub(crate) async fn open_wireguard_go_tunnel(
     //
     // Refer to `docs/architecture.md` for details on how to use multihop + PQ.
     #[cfg(target_os = "android")]
-    let config = patch_allowed_ips(config, gateway_only);
+    let config = match gateway_only {
+        true => config::patch_allowed_ips(config.clone()),
+        false => config.clone(),
+    };
 
     #[cfg(target_os = "android")]
     let tunnel = if let Some(exit_peer) = &config.exit_peer {
@@ -140,44 +141,6 @@ pub(crate) async fn open_wireguard_go_tunnel(
     };
 
     Ok(tunnel)
-}
-
-/// Replace `0.0.0.0/0`/`::/0` with the gateway IPs when `gateway_only` is true.
-/// Used to block traffic to other destinations while connecting on Android.
-#[cfg(target_os = "android")]
-fn patch_allowed_ips(config: &Config, gateway_only: bool) -> Cow<'_, Config> {
-    use std::net::IpAddr;
-
-    if gateway_only {
-        let mut patched_config = config.clone();
-        let gateway_net_v4 =
-            ipnetwork::IpNetwork::from(std::net::IpAddr::from(config.ipv4_gateway));
-        let gateway_net_v6 = config
-            .ipv6_gateway
-            .map(|net| ipnetwork::IpNetwork::from(IpAddr::from(net)));
-        for peer in patched_config.peers_mut() {
-            peer.allowed_ips = peer
-                .allowed_ips
-                .iter()
-                .cloned()
-                .filter_map(|mut allowed_ip| {
-                    if allowed_ip.prefix() == 0 {
-                        if allowed_ip.is_ipv4() {
-                            allowed_ip = gateway_net_v4;
-                        } else if let Some(net) = gateway_net_v6 {
-                            allowed_ip = net;
-                        } else {
-                            return None;
-                        }
-                    }
-                    Some(allowed_ip)
-                })
-                .collect();
-        }
-        Cow::Owned(patched_config)
-    } else {
-        Cow::Borrowed(config)
-    }
 }
 
 impl WgGoTunnel {


### PR DESCRIPTION
This PR blocks tunnel traffic when negotiating with an ephemeral peer, such as when configuring DAITA or PQ.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8839)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - BoringTun backend is now enabled by default for WireGuard.
  - Support added to negotiate ephemeral peers, improving connectivity in restrictive networks.

- Bug Fixes
  - Android: Correctly patches allowed IPs in gateway-only mode for more accurate routing and reduced risk of unintended traffic.
  - Improved tunnel start/stop reliability and statistics reporting through streamlined device management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->