### PR TITLE
Fix login spinner weirdness on large sizes

### DIFF
--- a/ios/MullvadVPN/Views/StatusActivityView.swift
+++ b/ios/MullvadVPN/Views/StatusActivityView.swift
@@ -42,7 +42,7 @@ class StatusActivityView: UIView {
         addSubview(activityIndicator)
 
         NSLayoutConstraint.activate([
-            activityIndicator.widthAnchor.constraint(equalTo: widthAnchor),
+            activityIndicator.widthAnchor.constraint(equalTo: activityIndicator.heightAnchor),
             activityIndicator.heightAnchor.constraint(equalTo: statusImageView.heightAnchor),
             statusImageView.topAnchor.constraint(equalTo: topAnchor),
             statusImageView.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/ios/MullvadVPN/Views/StatusActivityView.swift
+++ b/ios/MullvadVPN/Views/StatusActivityView.swift
@@ -42,7 +42,7 @@ class StatusActivityView: UIView {
         addSubview(activityIndicator)
 
         NSLayoutConstraint.activate([
-            activityIndicator.widthAnchor.constraint(equalTo: statusImageView.widthAnchor),
+            activityIndicator.widthAnchor.constraint(equalTo: widthAnchor),
             activityIndicator.heightAnchor.constraint(equalTo: statusImageView.heightAnchor),
             statusImageView.topAnchor.constraint(equalTo: topAnchor),
             statusImageView.bottomAnchor.constraint(equalTo: bottomAnchor),


### PR DESCRIPTION
For some reason, on large accessibility sizes, the status image assets' intrinsic widths are doubled. Which doesn't affect the status image (which is centred), but wrought havoc with the spinner. This PR changes the spinner's width constraint to depend on its superview, fixing this issue.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8844)
<!-- Reviewable:end -->
