### PR TITLE
Bump major version for iOS to 2025.7

### DIFF
--- a/ios/Configurations/Version.xcconfig
+++ b/ios/Configurations/Version.xcconfig
@@ -2,7 +2,7 @@
 VERSIONING_SYSTEM = apple-generic
 
 // Marketing version, aka major.minor
-MARKETING_VERSION = 2025.6
+MARKETING_VERSION = 2025.7
 
 // Build number
 // Normally we reset the build number to 1 after bumping MARKETING_VERSION.


### PR DESCRIPTION
We need to bump the major version in the app repo.