### PR TITLE
Add `skip` attribute to `test_function` macro

### DIFF
--- a/test/test-manager/src/tests/test_metadata.rs
+++ b/test/test-manager/src/tests/test_metadata.rs
@@ -10,6 +10,8 @@ pub struct TestMetadata {
     pub priority: Option<i32>,
     /// A list of location that will be used for by the test
     pub location: Option<Vec<String>>,
+    /// If the current test should be skipped.
+    pub skip: bool,
 }
 
 // Register our test metadata struct with inventory to allow submitting tests of this type.


### PR DESCRIPTION
Add a new attribute to the `test_function` macro: `skip`. If `skip` is set, the test will not be run by default.

This is useful if we want to check in test cases that are either expensive to run by default, or when we are stuck waiting for relay features to be rolled out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8855)
<!-- Reviewable:end -->
