### PR TITLE
Improve navigation utilities for e2e tests

### DIFF
--- a/desktop/packages/mullvad-vpn/scripts/build-test-executable.sh
+++ b/desktop/packages/mullvad-vpn/scripts/build-test-executable.sh
@@ -15,6 +15,7 @@ ASSETS=(
     "build-standalone/src/shared/constants/*.js"
     "build-standalone/src/shared/routes.js"
     "build-standalone/test/e2e/utils.js"
+    "build-standalone/test/e2e/lib/*.js"
     "build-standalone/test/e2e/route-object-models/**/*.js"
     "build-standalone/test/e2e/shared/*.js"
     "build-standalone/test/e2e/installed/**/*.js"

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/api-access-methods.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/api-access-methods.spec.ts
@@ -25,7 +25,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {
@@ -34,9 +34,9 @@ test.afterAll(async () => {
 
 async function navigateToAccessMethods() {
   await page.click('button[aria-label="Settings"]');
-  await util.waitForRoute(RoutePath.settings);
+  await util.expectRoute(RoutePath.settings);
   await page.getByText('API access').click();
-  await util.waitForRoute(RoutePath.apiAccessMethods);
+  await util.expectRoute(RoutePath.apiAccessMethods);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('API access');
@@ -59,7 +59,7 @@ test('App should display access methods', async () => {
 
 test('App should add invalid access method', async () => {
   await page.locator('button:has-text("Add")').click();
-  await util.waitForRoute(RoutePath.editApiAccessMethods);
+  await util.expectRoute(RoutePath.editApiAccessMethods);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Add method');
@@ -84,7 +84,7 @@ test('App should add invalid access method', async () => {
   await expect(page.getByText('API unreachable, add anyway?')).toBeVisible();
 
   await page.locator('button:has-text("Save")').click();
-  await util.waitForRoute(RoutePath.apiAccessMethods);
+  await util.expectRoute(RoutePath.apiAccessMethods);
 
   const accessMethods = page.getByTestId('access-method');
   // Direct, Bridges, Encrypted DNS Proxy & the non-functioning access method.
@@ -113,7 +113,7 @@ test('App should edit access method', async () => {
   const customMethod = page.getByTestId('access-method').last();
   await customMethod.locator('button').last().click();
   await customMethod.getByText('Edit').click();
-  await util.waitForRoute(RoutePath.editApiAccessMethods);
+  await util.expectRoute(RoutePath.editApiAccessMethods);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Edit method');
@@ -138,7 +138,7 @@ test('App should edit access method', async () => {
     .click();
 
   await page.locator('button:has-text("Save")').last().click();
-  await util.waitForRoute(RoutePath.apiAccessMethods);
+  await util.expectRoute(RoutePath.apiAccessMethods);
 
   const accessMethods = page.getByTestId('access-method');
   // Direct, Bridges, Encrypted DNS Proxy & the custom access method.

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/api-access-methods.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/api-access-methods.spec.ts
@@ -59,7 +59,7 @@ test('App should display access methods', async () => {
 
 test('App should add invalid access method', async () => {
   await page.locator('button:has-text("Add")').click();
-  await util.waitForNextRoute();
+  await util.waitForRoute(RoutePath.editApiAccessMethods);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Add method');
@@ -113,7 +113,7 @@ test('App should edit access method', async () => {
   const customMethod = page.getByTestId('access-method').last();
   await customMethod.locator('button').last().click();
   await customMethod.getByText('Edit').click();
-  await util.waitForNextRoute();
+  await util.waitForRoute(RoutePath.editApiAccessMethods);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Edit method');

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/custom-bridge.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/custom-bridge.spec.ts
@@ -18,7 +18,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {
@@ -27,14 +27,14 @@ test.afterAll(async () => {
 
 test('App should enable bridge mode', async () => {
   await page.click('button[aria-label="Settings"]');
-  await util.waitForRoute(RoutePath.settings);
+  await util.expectRoute(RoutePath.settings);
 
   await page.getByText('VPN settings').click();
-  await util.waitForRoute(RoutePath.vpnSettings);
+  await util.expectRoute(RoutePath.vpnSettings);
 
   await page.getByRole('option', { name: 'OpenVPN' }).click();
   await page.getByText('OpenVPN settings').click();
-  await util.waitForRoute(RoutePath.openVpnSettings);
+  await util.expectRoute(RoutePath.openVpnSettings);
 
   const bridgeModeListox = page.getByRole('listbox', { name: 'Bridge mode' });
   const bridgeModeOnButton = bridgeModeListox.getByRole('option', { name: 'On', exact: true });
@@ -42,18 +42,18 @@ test('App should enable bridge mode', async () => {
   await expect(bridgeModeOnButton).toHaveAttribute('aria-selected', 'true');
 
   await page.click('button[aria-label="Back"]');
-  await util.waitForRoute(RoutePath.vpnSettings);
+  await util.expectRoute(RoutePath.vpnSettings);
 
   await page.click('button[aria-label="Back"]');
-  await util.waitForRoute(RoutePath.settings);
+  await util.expectRoute(RoutePath.settings);
 
   await page.click('button[aria-label="Close"]');
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test('App display disabled custom bridge', async () => {
   await page.click('button[aria-label^="Select location"]');
-  await util.waitForRoute(RoutePath.selectLocation);
+  await util.expectRoute(RoutePath.selectLocation);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Select location');
@@ -66,7 +66,7 @@ test('App display disabled custom bridge', async () => {
 
 test('App should add new custom bridge', async () => {
   await page.click('button[aria-label="Add new custom bridge"]');
-  await util.waitForRoute(RoutePath.editCustomBridge);
+  await util.expectRoute(RoutePath.editCustomBridge);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Add custom bridge');
@@ -90,7 +90,7 @@ test('App should add new custom bridge', async () => {
     .click();
 
   await addButton.click();
-  await util.waitForRoute(RoutePath.selectLocation);
+  await util.expectRoute(RoutePath.selectLocation);
 
   const customBridgeButton = page.locator('button:has-text("Custom bridge")');
   await expect(customBridgeButton).toBeEnabled();
@@ -118,7 +118,7 @@ test('App should edit custom bridge', async () => {
   await page.getByText(/^Entry$/).click();
 
   await page.click('button[aria-label="Edit custom bridge"]');
-  await util.waitForRoute(RoutePath.editCustomBridge);
+  await util.expectRoute(RoutePath.editCustomBridge);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Edit custom bridge');
@@ -132,7 +132,7 @@ test('App should edit custom bridge', async () => {
   await expect(saveButton).toBeEnabled();
 
   await saveButton.click();
-  await util.waitForRoute(RoutePath.selectLocation);
+  await util.expectRoute(RoutePath.selectLocation);
 
   const customBridgeButton = page.locator('button:has-text("Custom bridge")');
   await expect(customBridgeButton).toBeEnabled();
@@ -141,7 +141,7 @@ test('App should edit custom bridge', async () => {
 
 test('App should delete custom bridge', async () => {
   await page.click('button[aria-label="Edit custom bridge"]');
-  await util.waitForRoute(RoutePath.editCustomBridge);
+  await util.expectRoute(RoutePath.editCustomBridge);
 
   const deleteButton = page.locator('button:has-text("Delete")');
   await expect(deleteButton).toBeVisible();
@@ -152,7 +152,7 @@ test('App should delete custom bridge', async () => {
 
   const confirmButton = page.getByTestId('delete-confirm');
   await confirmButton.click();
-  await util.waitForRoute(RoutePath.selectLocation);
+  await util.expectRoute(RoutePath.selectLocation);
 
   const customBridgeButton = page.locator('button:has-text("Custom bridge")');
   await expect(customBridgeButton).toBeDisabled();

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/device-revoked.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/device-revoked.spec.ts
@@ -19,10 +19,10 @@ test.afterAll(async () => {
 });
 
 test('App should fail to login', async () => {
-  await util.waitForRoute(RoutePath.deviceRevoked);
+  await util.expectRoute(RoutePath.deviceRevoked);
 
   await expect(page.getByTestId('title')).toHaveText('Device is inactive');
 
   await page.getByText('Go to login').click();
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/disconnected.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/disconnected.spec.ts
@@ -18,7 +18,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
@@ -28,7 +28,7 @@ test.afterAll(async () => {
 });
 
 test('App should fail to login', async () => {
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 
   const title = page.locator('h1');
   const subtitle = page.getByTestId('subtitle');
@@ -46,7 +46,7 @@ test('App should fail to login', async () => {
 });
 
 test('App should create account', async () => {
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 
   await routes.login.createNewAccount();
 
@@ -56,7 +56,7 @@ test('App should create account', async () => {
   await expect(title).toHaveText('Account created');
   await expect(subtitle).toHaveText('Logged in');
 
-  await util.waitForRoute(RoutePath.expired);
+  await util.expectRoute(RoutePath.expired);
 
   const outOfTimeTitle = page.getByTestId('title');
   await expect(outOfTimeTitle).toHaveText('Congrats!');
@@ -68,11 +68,11 @@ test('App should create account', async () => {
 
 test('App should become logged out', async () => {
   exec('mullvad account logout');
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 });
 
 test('App should log in', async () => {
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 
   const title = page.locator('h1');
   const subtitle = page.getByTestId('subtitle');
@@ -86,7 +86,7 @@ test('App should log in', async () => {
   await expect(title).toHaveText('Logged in');
   await expect(subtitle).toHaveText('Valid account number');
 
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 
   await expectDisconnected(page);
 });
@@ -94,10 +94,10 @@ test('App should log in', async () => {
 test('App should log out', async () => {
   await page.getByTestId('account-button').click();
 
-  await util.waitForRoute(RoutePath.account);
+  await util.expectRoute(RoutePath.account);
 
   await page.getByText('Log out').click();
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 
   const title = page.locator('h1');
   const subtitle = page.getByTestId('subtitle');
@@ -106,7 +106,7 @@ test('App should log out', async () => {
 });
 
 test('App should log in to expired account', async () => {
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 
   const title = page.locator('h1');
   const subtitle = page.getByTestId('subtitle');
@@ -117,7 +117,7 @@ test('App should log in to expired account', async () => {
   await routes.login.fillAccountNumber(accountNumber);
 
   await routes.login.loginByPressingEnter();
-  await util.waitForRoute(RoutePath.expired);
+  await util.expectRoute(RoutePath.expired);
 
   const outOfTimeTitle = page.getByTestId('title');
   await expect(outOfTimeTitle).toHaveText('Out of time');

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/macos-split-tunneling.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/macos-split-tunneling.spec.ts
@@ -14,7 +14,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {
@@ -23,10 +23,10 @@ test.afterAll(async () => {
 
 async function navigateToSplitTunneling() {
   await page.click('button[aria-label="Settings"]');
-  await util.waitForRoute(RoutePath.settings);
+  await util.expectRoute(RoutePath.settings);
 
   await page.getByText('Split tunneling').click();
-  await util.waitForRoute(RoutePath.splitTunneling);
+  await util.expectRoute(RoutePath.splitTunneling);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Split tunneling');

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
@@ -18,7 +18,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {
@@ -27,13 +27,13 @@ test.afterAll(async () => {
 
 test('App should have automatic obfuscation', async () => {
   await page.click('button[aria-label="Settings"]');
-  await util.waitForRoute(RoutePath.settings);
+  await util.expectRoute(RoutePath.settings);
 
   await page.getByText('VPN settings').click();
-  await util.waitForRoute(RoutePath.vpnSettings);
+  await util.expectRoute(RoutePath.vpnSettings);
 
   await page.getByText('WireGuard settings').click();
-  await util.waitForRoute(RoutePath.wireguardSettings);
+  await util.expectRoute(RoutePath.wireguardSettings);
 
   const obfuscationListbox = page.getByRole('listbox', { name: 'Obfuscation' });
   await obfuscationListbox.highlight();
@@ -51,7 +51,7 @@ test('App should have automatic obfuscation', async () => {
 
 test('App should set obfuscation to shadowsocks with custom port', async () => {
   await page.click('button[aria-label="Shadowsocks settings"]');
-  await util.waitForRoute(RoutePath.shadowsocks);
+  await util.expectRoute(RoutePath.shadowsocks);
 
   const automatic = page.locator('button', { hasText: 'Automatic' });
   await expect(automatic).toHaveCSS('background-color', colorTokens.green);
@@ -65,7 +65,7 @@ test('App should set obfuscation to shadowsocks with custom port', async () => {
   await expect(customItem).toHaveCSS('background-color', colorTokens.green);
 
   await page.click('button[aria-label="Back"]');
-  await util.waitForRoute(RoutePath.wireguardSettings);
+  await util.expectRoute(RoutePath.wireguardSettings);
 
   const shadowsocksItem = page.locator('button', { hasText: 'Shadowsocks' });
   await shadowsocksItem.click();
@@ -78,18 +78,18 @@ test('App should set obfuscation to shadowsocks with custom port', async () => {
 
 test('App should still have shadowsocks custom port', async () => {
   await page.click('button[aria-label="Shadowsocks settings"]');
-  await util.waitForRoute(RoutePath.shadowsocks);
+  await util.expectRoute(RoutePath.shadowsocks);
 
   const customItem = page.locator('div[role="option"]', { hasText: 'Custom' });
   await expect(customItem).toHaveCSS('background-color', colorTokens.green);
 
   await page.click('button[aria-label="Back"]');
-  await util.waitForRoute(RoutePath.wireguardSettings);
+  await util.expectRoute(RoutePath.wireguardSettings);
 });
 
 test('App should set obfuscation to UDP-over-TCP with port', async () => {
   await page.click('button[aria-label="UDP-over-TCP settings"]');
-  await util.waitForRoute(RoutePath.udpOverTcp);
+  await util.expectRoute(RoutePath.udpOverTcp);
 
   const automatic = page.locator('button', { hasText: 'Automatic' });
   await expect(automatic).toHaveCSS('background-color', colorTokens.green);
@@ -100,7 +100,7 @@ test('App should set obfuscation to UDP-over-TCP with port', async () => {
   await expect(portButton).toHaveCSS('background-color', colorTokens.green);
 
   await page.click('button[aria-label="Back"]');
-  await util.waitForRoute(RoutePath.wireguardSettings);
+  await util.expectRoute(RoutePath.wireguardSettings);
 
   const udpOverTcpItem = page.locator('button', { hasText: 'UDP-over-TCP' });
   await udpOverTcpItem.click();

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
@@ -18,7 +18,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/settings-import.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/settings-import.spec.ts
@@ -24,7 +24,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {
@@ -33,13 +33,13 @@ test.afterAll(async () => {
 
 async function navigateToSettingsImport() {
   await page.click('button[aria-label="Settings"]');
-  await util.waitForRoute(RoutePath.settings);
+  await util.expectRoute(RoutePath.settings);
 
   await page.getByRole('button', { name: 'VPN settings' }).click();
-  await util.waitForRoute(RoutePath.vpnSettings);
+  await util.expectRoute(RoutePath.vpnSettings);
 
   await page.getByRole('button', { name: 'Server IP override' }).click();
-  await util.waitForRoute(RoutePath.settingsImport);
+  await util.expectRoute(RoutePath.settingsImport);
 
   const title = page.locator('h1');
   await expect(title).toHaveText('Server IP override');
@@ -53,11 +53,11 @@ test('App should display no overrides', async () => {
 
 test('App should fail to import text', async () => {
   await page.getByRole('button', { name: 'Import via text' }).click();
-  await util.waitForRoute(RoutePath.settingsTextImport);
+  await util.expectRoute(RoutePath.settingsTextImport);
 
   await page.locator('textarea').fill(INVALID_JSON);
   await page.click('button[aria-label="Save"]');
-  await util.waitForRoute(RoutePath.settingsImport);
+  await util.expectRoute(RoutePath.settingsImport);
 
   await expect(page.getByTestId('status-title')).toHaveText('NO OVERRIDES IMPORTED');
   await expect(page.getByTestId('status-subtitle')).toBeVisible();
@@ -67,14 +67,14 @@ test('App should fail to import text', async () => {
 
 test('App should succeed to import text', async () => {
   await page.getByRole('button', { name: 'Import via text' }).click();
-  await util.waitForRoute(RoutePath.settingsTextImport);
+  await util.expectRoute(RoutePath.settingsTextImport);
 
   const textarea = page.locator('textarea');
   await expect(textarea).toHaveValue(INVALID_JSON);
   await textarea.fill(VALID_JSON);
 
   await page.click('button[aria-label="Save"]');
-  await util.waitForRoute(RoutePath.settingsImport);
+  await util.expectRoute(RoutePath.settingsImport);
 
   await expect(page.getByTestId('status-title')).toHaveText('IMPORT SUCCESSFUL');
   await expect(page.getByTestId('status-subtitle')).toBeVisible();
@@ -84,20 +84,20 @@ test('App should succeed to import text', async () => {
   await expect(page.getByTestId('status-title')).toHaveText('OVERRIDES ACTIVE');
 
   await page.getByRole('button', { name: 'Import via text' }).click();
-  await util.waitForRoute(RoutePath.settingsTextImport);
+  await util.expectRoute(RoutePath.settingsTextImport);
 
   await expect(textarea).toHaveValue('');
 
   await page.click('button[aria-label="Close"]');
-  await util.waitForRoute(RoutePath.settingsImport);
+  await util.expectRoute(RoutePath.settingsImport);
 });
 
 test('App should show active overrides', async () => {
   await page.click('button[aria-label="Back"]');
-  await util.waitForRoute(RoutePath.vpnSettings);
+  await util.expectRoute(RoutePath.vpnSettings);
 
   await page.getByRole('button', { name: 'Server IP override' }).click();
-  await util.waitForRoute(RoutePath.settingsImport);
+  await util.expectRoute(RoutePath.settingsImport);
 
   await expect(page.getByTestId('status-title')).toHaveText('OVERRIDES ACTIVE');
   await expect(page.getByText('Clear all overrides')).toBeEnabled();

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/too-many-devices.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/too-many-devices.spec.ts
@@ -15,7 +15,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startInstalledApp());
-  await util.waitForRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.login);
 });
 
 test.afterAll(async () => {
@@ -27,7 +27,7 @@ test('App should show too many devices', async () => {
   await loginInput.fill(process.env.ACCOUNT_NUMBER!);
 
   await loginInput.press('Enter');
-  await util.waitForRoute(RoutePath.tooManyDevices);
+  await util.expectRoute(RoutePath.tooManyDevices);
 
   const loginButton = page.getByText('Continue with login');
 
@@ -43,8 +43,8 @@ test('App should show too many devices', async () => {
 
   // Trigger transition: too-many-devices -> login -> main
   await loginButton.click();
-  await util.waitForRoute(RoutePath.login);
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.login);
+  await util.expectRoute(RoutePath.main);
 });
 
 function getInput(page: Page): Locator {

--- a/desktop/packages/mullvad-vpn/test/e2e/lib/path-helpers.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/lib/path-helpers.ts
@@ -1,0 +1,42 @@
+import { expect } from '@playwright/test';
+
+// Match the actual path against against the expected path where the expected can contain parameters
+function toMatchPath(actual: string, expected: string | null) {
+  const pass = matchPaths(expected, actual);
+  const message = () =>
+    pass
+      ? `Expected path to be "${expected}"`
+      : `Expected path "${expected}", but found "${actual}"`;
+  return { pass, message };
+}
+
+expect.extend({ toMatchPath });
+
+function trimTrailingSlash(value: string): string {
+  return value.replaceAll(/\/$/g, '');
+}
+
+// Match b against a where a can contain parameters
+export function matchPaths(a: string | null, b: string | null): boolean {
+  if (b?.includes(':')) {
+    throw new Error('Only a is allowed to contain parameters');
+  }
+
+  if (a === null || b === null) {
+    return a === b;
+  }
+
+  const aParts = trimTrailingSlash(a).split('/');
+  const bParts = trimTrailingSlash(b).split('/');
+
+  return (
+    aParts.length >= bParts.length &&
+    aParts.every((aPart, i) => {
+      if (aPart.startsWith(':')) {
+        return aPart.endsWith('?') ? true : bParts[i] !== undefined;
+      } else {
+        return aPart === bParts[i];
+      }
+    })
+  );
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/app-upgrade/app-upgrade.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/app-upgrade/app-upgrade.spec.ts
@@ -28,7 +28,7 @@ test.describe('App upgrade', () => {
     upgradeEventIpc = createAppUpgradeEventIpcHelper(util);
     selectors = createSelectors(page);
 
-    await util.waitForRoute(RoutePath.main);
+    await util.expectRoute(RoutePath.main);
 
     await util.ipc.upgradeVersion[''].notify({
       supported: true,
@@ -42,11 +42,11 @@ test.describe('App upgrade', () => {
     await util.ipc.app.getUpgradeCacheDir.ignore();
 
     await page.click('button[aria-label="Settings"]');
-    await util.waitForRoute(RoutePath.settings);
+    await util.expectRoute(RoutePath.settings);
     await page.getByRole('button', { name: 'App info' }).click();
-    await util.waitForRoute(RoutePath.appInfo);
+    await util.expectRoute(RoutePath.appInfo);
     await page.getByRole('button', { name: 'Update available' }).click();
-    await util.waitForRoute(RoutePath.appUpgrade);
+    await util.expectRoute(RoutePath.appUpgrade);
   };
 
   const restart = async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/expired-account-error-view.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/expired-account-error-view.spec.ts
@@ -11,7 +11,7 @@ let util: MockedTestUtils;
 
 test.beforeEach(async () => {
   ({ page, util } = await startMockedApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterEach(async () => {
@@ -38,5 +38,5 @@ test('App should show out of time view after running out of time', async () => {
   expiryDate.setSeconds(expiryDate.getSeconds() + 2);
 
   await util.ipc.account[''].notify({ expiry: expiryDate.toISOString() });
-  await util.waitForRoute(RoutePath.expired);
+  await util.expectRoute(RoutePath.expired);
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
@@ -141,6 +141,8 @@ const featureIndicatorWithOption: FeatureIndicatorWithOptionTestOption[] = [
   },
 ];
 
+test.describe.configure({ mode: 'parallel' });
+
 test.describe('Feature indicators', () => {
   test.beforeAll(async () => {
     ({ page, util } = await startMockedApp());
@@ -246,8 +248,7 @@ test.describe('Feature indicators', () => {
         await helpers.connectWithFeatures([featureIndicator]);
         await clickFeatureIndicator(featureIndicatorLabel, route);
 
-        const currentRoute = await util.currentRoute();
-        expect(currentRoute).toBe(route);
+        await util.waitForRoute(route);
       });
     },
   );
@@ -271,8 +272,7 @@ test.describe('Feature indicators', () => {
         }
         await expect(element).toBeInViewport();
 
-        const currentRoute = await util.currentRoute();
-        expect(currentRoute).toBe(route);
+        await util.waitForRoute(route);
       });
     },
   );

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
@@ -149,7 +149,7 @@ test.describe('Feature indicators', () => {
     routes = new RoutesObjectModel(page, util);
     helpers = createHelpers({ page, routes, utils: util });
 
-    await util.waitForRoute(RoutePath.main);
+    await util.expectRoute(RoutePath.main);
   });
 
   test.afterAll(async () => {
@@ -159,7 +159,7 @@ test.describe('Feature indicators', () => {
   test.afterEach(async () => {
     await helpers.disconnect();
     await routes.wireguardSettings.gotoRoot();
-    await util.waitForRoute(RoutePath.main);
+    await util.expectRoute(RoutePath.main);
   });
 
   async function expectFeatureIndicators(expectedIndicators: Array<string>, only = true) {
@@ -239,7 +239,7 @@ test.describe('Feature indicators', () => {
     const indicator = routes.main.selectors.featureIndicator(featureIndicatorLabel);
     await expect(indicator).toBeVisible();
     await indicator.click();
-    await util.waitForRoute(route);
+    await util.expectRoute(route);
   };
 
   featureIndicatorWithoutOption.forEach(
@@ -248,7 +248,7 @@ test.describe('Feature indicators', () => {
         await helpers.connectWithFeatures([featureIndicator]);
         await clickFeatureIndicator(featureIndicatorLabel, route);
 
-        await util.waitForRoute(route);
+        await util.expectRoute(route);
       });
     },
   );
@@ -272,7 +272,7 @@ test.describe('Feature indicators', () => {
         }
         await expect(element).toBeInViewport();
 
-        await util.waitForRoute(route);
+        await util.expectRoute(route);
       });
     },
   );

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/launch.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/launch.spec.ts
@@ -13,7 +13,7 @@ test.describe('Launch', () => {
   test.beforeAll(async () => {
     ({ page, util } = await startMockedApp());
     routes = new RoutesObjectModel(page, util);
-    await util.waitForRoute(RoutePath.main);
+    await util.expectRoute(RoutePath.main);
 
     await util.ipc.daemon.disconnected.notify();
     await routes.launch.waitForRoute();

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/main.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/main.spec.ts
@@ -10,7 +10,7 @@ let util: TestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startMockedApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/notifications.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/notifications.spec.ts
@@ -13,7 +13,7 @@ let util: MockedTestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startMockedApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/helpers.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/helpers.ts
@@ -85,7 +85,7 @@ export const createHelpers = (page: Page, routes: RoutesObjectModel, utils: Mock
   };
 
   const resetView = async () => {
-    const currentRoute = await utils.currentRoute();
+    const currentRoute = await utils.getCurrentRoute();
     if (currentRoute === RoutePath.selectLocation) {
       await routes.selectLocation.gotoFilter();
     }

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
@@ -23,11 +23,11 @@ test.describe('Select location', () => {
     routes = new RoutesObjectModel(page, util);
     helpers = createHelpers(page, routes, util);
 
-    await util.waitForRoute(RoutePath.main);
+    await util.expectRoute(RoutePath.main);
   });
 
   test.beforeEach(async () => {
-    if ((await util.currentRoute()) === RoutePath.main) {
+    if ((await util.getCurrentRoute()) === RoutePath.main) {
       await routes.main.gotoSelectLocation();
     }
   });
@@ -169,7 +169,7 @@ test.describe('Select location', () => {
       // Clicking exit relay should navigate to main route
       const exitRelayButton = routes.selectLocation.getRelaysMatching([exitRelay.hostname]);
       await exitRelayButton.click();
-      await util.waitForRoute(RoutePath.main);
+      await util.expectRoute(RoutePath.main);
     });
   });
 
@@ -214,7 +214,7 @@ test.describe('Select location', () => {
           });
 
           await routes.filter.applyFilter();
-          await util.waitForRoute(RoutePath.selectLocation);
+          await util.expectRoute(RoutePath.selectLocation);
           const providerFilterChip = routes.selectLocation.getFilterChip('Providers: 1');
           await expect(providerFilterChip).toBeVisible();
 
@@ -252,7 +252,7 @@ test.describe('Select location', () => {
           });
 
           await routes.filter.applyFilter();
-          await util.waitForRoute(RoutePath.selectLocation);
+          await util.expectRoute(RoutePath.selectLocation);
 
           const ownerFilterChip = routes.selectLocation.getFilterChip('Rented');
           await expect(ownerFilterChip).toBeVisible();

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/settings.spec.ts
@@ -9,7 +9,7 @@ let util: MockedTestUtils;
 
 test.beforeAll(async () => {
   ({ page, util } = await startMockedApp());
-  await util.waitForRoute(RoutePath.main);
+  await util.expectRoute(RoutePath.main);
 });
 
 test.afterAll(async () => {
@@ -53,7 +53,7 @@ test('Headerbar account info should be displayed correctly', async () => {
 
 test('Settings Page', async () => {
   await page.click('button[aria-label="Settings"]');
-  await util.waitForRoute(RoutePath.settings);
+  await util.expectRoute(RoutePath.settings);
 
   const title = page.locator('h1');
   await expect(title).toContainText('Settings');

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/split-tunneling/split-tunneling.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/split-tunneling/split-tunneling.spec.ts
@@ -14,7 +14,7 @@ test.describe('Split tunneling', () => {
     ({ page, util } = await startMockedApp());
     routes = new RoutesObjectModel(page, util);
 
-    await util.waitForRoute(RoutePath.main);
+    await util.expectRoute(RoutePath.main);
     await routes.main.gotoSettings();
     await routes.settings.gotoSplitTunnelingSettings();
   });

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/filter/filter-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/filter/filter-route-object-model.ts
@@ -19,7 +19,7 @@ export class FilterRouteObjectModel {
 
   async gotoSelectLocation() {
     await this.selectors.backButton().click();
-    await this.utils.waitForRoute(RoutePath.selectLocation);
+    await this.utils.expectRoute(RoutePath.selectLocation);
   }
 
   async expandProviders() {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/launch/launch-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/launch/launch-route-object-model.ts
@@ -16,6 +16,6 @@ export class LaunchRouteObjectModel {
   }
 
   async waitForRoute() {
-    await this.utils.waitForRoute(RoutePath.launch);
+    await this.utils.expectRoute(RoutePath.launch);
   }
 }

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/login/login-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/login/login-route-object-model.ts
@@ -15,7 +15,7 @@ export class LoginRouteObjectModel {
   }
 
   async waitForRoute() {
-    await this.utils.waitForRoute(RoutePath.login);
+    await this.utils.expectRoute(RoutePath.login);
   }
 
   fillAccountNumber(accountNumber: string) {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/main-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/main/main-route-object-model.ts
@@ -16,17 +16,17 @@ export class MainRouteObjectModel {
   }
 
   async waitForRoute() {
-    await this.utils.waitForRoute(RoutePath.main);
+    await this.utils.expectRoute(RoutePath.main);
   }
 
   async gotoSettings() {
     await this.selectors.settingsButton().click();
-    await this.utils.waitForRoute(RoutePath.settings);
+    await this.utils.expectRoute(RoutePath.settings);
   }
 
   async gotoSelectLocation() {
     await this.selectors.selectLocationButton().click();
-    await this.utils.waitForRoute(RoutePath.selectLocation);
+    await this.utils.expectRoute(RoutePath.selectLocation);
   }
 
   async expandConnectionPanel() {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/navigation/navigation-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/navigation/navigation-object-model.ts
@@ -14,7 +14,7 @@ export class NavigationObjectModel {
   }
 
   async goBack() {
-    await this.utils.waitForRouteChange(() => this.navigationSelectors.backButton().click());
+    await this.utils.expectRouteChange(() => this.navigationSelectors.backButton().click());
   }
 
   async gotoRoot() {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/navigation/navigation-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/navigation/navigation-object-model.ts
@@ -14,8 +14,7 @@ export class NavigationObjectModel {
   }
 
   async goBack() {
-    await this.navigationSelectors.backButton().click();
-    await this.utils.waitForNextRoute();
+    await this.utils.waitForRouteChange(() => this.navigationSelectors.backButton().click());
   }
 
   async gotoRoot() {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-location/select-location-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/select-location/select-location-route-object-model.ts
@@ -42,6 +42,6 @@ export class SelectLocationRouteObjectModel {
 
   async gotoFilter() {
     await this.selectors.filterButton().click();
-    await this.utils.waitForRoute(RoutePath.filter);
+    await this.utils.expectRoute(RoutePath.filter);
   }
 }

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/settings/settings-route-object-model.ts
@@ -17,26 +17,26 @@ export class SettingsRouteObjectModel {
 
   async gotoUserInterfaceSettings() {
     await this.selectors.userInterfaceButton().click();
-    await this.utils.waitForRoute(RoutePath.userInterfaceSettings);
+    await this.utils.expectRoute(RoutePath.userInterfaceSettings);
   }
 
   async gotoVpnSettings() {
     await this.selectors.vpnSettingsButton().click();
-    await this.utils.waitForRoute(RoutePath.vpnSettings);
+    await this.utils.expectRoute(RoutePath.vpnSettings);
   }
 
   async gotoMultihopSettings() {
     await this.selectors.multihopSettingsButton().click();
-    await this.utils.waitForRoute(RoutePath.multihopSettings);
+    await this.utils.expectRoute(RoutePath.multihopSettings);
   }
 
   async gotoDaitaSettings() {
     await this.selectors.daitaSettingsButton().click();
-    await this.utils.waitForRoute(RoutePath.daitaSettings);
+    await this.utils.expectRoute(RoutePath.daitaSettings);
   }
 
   async gotoSplitTunnelingSettings() {
     await this.selectors.splitTunnelingSettingsButton().click();
-    await this.utils.waitForRoute(RoutePath.splitTunneling);
+    await this.utils.expectRoute(RoutePath.splitTunneling);
   }
 }

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/split-tunneling-settings/split-tunneling-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/split-tunneling-settings/split-tunneling-settings-route-object-model.ts
@@ -16,7 +16,7 @@ export class SplitTunnelingSettingsRouteObjectModel {
   }
 
   async waitForRoute() {
-    await this.utils.waitForRoute(RoutePath.splitTunneling);
+    await this.utils.expectRoute(RoutePath.splitTunneling);
   }
 
   getLinuxApplications() {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/user-interface-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/user-interface-settings/user-interface-settings-route-object-model.ts
@@ -17,11 +17,11 @@ export class UserInterfaceSettingsRouteObjectModel {
 
   async gotoSelectLanguage() {
     await this.selectors.languageButton().click();
-    await this.utils.waitForRoute(RoutePath.selectLanguage);
+    await this.utils.expectRoute(RoutePath.selectLanguage);
   }
 
   async waitForRoute() {
-    await this.utils.waitForRoute(RoutePath.userInterfaceSettings);
+    await this.utils.expectRoute(RoutePath.userInterfaceSettings);
   }
 
   getLocalizedLanguageButton(language: string) {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/vpn-settings/vpn-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/vpn-settings/vpn-settings-route-object-model.ts
@@ -17,7 +17,7 @@ export class VpnSettingsRouteObjectModel {
 
   async gotoWireguardSettings() {
     await this.selectors.wireguardSettingsButton().click();
-    await this.utils.waitForRoute(RoutePath.wireguardSettings);
+    await this.utils.expectRoute(RoutePath.wireguardSettings);
   }
 
   getAutoConnectSwitch() {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/wireguard-settings/wireguard-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/wireguard-settings/wireguard-settings-route-object-model.ts
@@ -16,7 +16,7 @@ export class WireguardSettingsRouteObjectModel extends NavigationObjectModel {
 
   async gotoUdpOverTcpSettings() {
     await this.selectors.udpOverTcpSettingsButton().click();
-    await this.utils.waitForRoute(RoutePath.udpOverTcp);
+    await this.utils.expectRoute(RoutePath.udpOverTcp);
   }
 
   getAutomaticObfuscationOption() {

--- a/desktop/packages/mullvad-vpn/test/e2e/types/index.d.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/types/index.d.ts
@@ -1,0 +1,9 @@
+import '@playwright/test';
+
+declare global {
+  namespace PlaywrightTest {
+    interface Matchers<R> {
+      toMatchPath(template: string | null): Promise<R>;
+    }
+  }
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/utils.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/utils.ts
@@ -13,9 +13,9 @@ export interface StartAppResponse {
 type TriggerFn = () => Promise<void> | void;
 
 export interface TestUtils {
-  currentRoute: () => Promise<string | null>;
-  waitForRoute: (route: RoutePath) => Promise<void>;
-  waitForRouteChange: (trigger: TriggerFn) => Promise<void>;
+  getCurrentRoute: () => Promise<string | null>;
+  expectRoute: (route: RoutePath) => Promise<void>;
+  expectRouteChange: (trigger: TriggerFn) => Promise<void>;
 }
 
 type LaunchOptions = NonNullable<Parameters<typeof electron.launch>[0]>;
@@ -29,9 +29,9 @@ export const startApp = async (options: LaunchOptions): Promise<StartAppResponse
   page.on('console', (msg) => console.log(msg.text()));
 
   const util: TestUtils = {
-    currentRoute: () => currentRoute(page),
-    waitForRoute: (route: RoutePath) => waitForRoute(page, route),
-    waitForRouteChange: (trigger: TriggerFn) => waitForRouteChange(page, trigger),
+    getCurrentRoute: () => getCurrentRoute(page),
+    expectRoute: (route: RoutePath) => expectRoute(page, route),
+    expectRouteChange: (trigger: TriggerFn) => expectRouteChange(page, trigger),
   };
 
   return { app, page, util };
@@ -42,20 +42,20 @@ export const launch = (options: LaunchOptions): Promise<ElectronApplication> => 
   return electron.launch(options);
 };
 
-function currentRoute(page: Page): Promise<string | null> {
+function getCurrentRoute(page: Page): Promise<string | null> {
   return page.evaluate('window.e2e.location');
 }
 
 // Returns a promise which resolves when the provided route is reached.
-async function waitForRoute(page: Page, expectedRoute: RoutePath): Promise<void> {
-  await expect.poll(async () => currentRoute(page)).toBe(expectedRoute);
+async function expectRoute(page: Page, expectedRoute: RoutePath): Promise<void> {
+  await expect.poll(async () => getCurrentRoute(page)).toBe(expectedRoute);
 }
 
 // Returns a promise which resolves when the route changes.
-async function waitForRouteChange(page: Page, trigger: TriggerFn) {
-  const initialRoute = await currentRoute(page);
+async function expectRouteChange(page: Page, trigger: TriggerFn) {
+  const initialRoute = await getCurrentRoute(page);
   await trigger();
-  await expect.poll(async () => currentRoute(page)).not.toBe(initialRoute);
+  await expect.poll(async () => getCurrentRoute(page)).not.toBe(initialRoute);
 }
 
 const getStyleProperty = (locator: Locator, property: string) => {

--- a/desktop/packages/mullvad-vpn/test/e2e/utils.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/utils.ts
@@ -1,3 +1,5 @@
+import './lib/path-helpers';
+
 import { expect } from '@playwright/test';
 import fs from 'fs';
 import { _electron as electron, ElectronApplication, Locator, Page } from 'playwright';
@@ -48,14 +50,14 @@ function getCurrentRoute(page: Page): Promise<string | null> {
 
 // Returns a promise which resolves when the provided route is reached.
 async function expectRoute(page: Page, expectedRoute: RoutePath): Promise<void> {
-  await expect.poll(async () => getCurrentRoute(page)).toBe(expectedRoute);
+  await expect.poll(async () => getCurrentRoute(page)).toMatchPath(expectedRoute);
 }
 
 // Returns a promise which resolves when the route changes.
 async function expectRouteChange(page: Page, trigger: TriggerFn) {
   const initialRoute = await getCurrentRoute(page);
   await trigger();
-  await expect.poll(async () => getCurrentRoute(page)).not.toBe(initialRoute);
+  await expect.poll(async () => getCurrentRoute(page)).not.toMatchPath(initialRoute);
 }
 
 const getStyleProperty = (locator: Locator, property: string) => {

--- a/desktop/packages/mullvad-vpn/test/unit/path-helpers.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/unit/path-helpers.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { matchPaths } from '../e2e/lib/path-helpers';
+
+describe('E2E test path helper', () => {
+  it('should identify matching paths', () => {
+    expect(matchPaths('/a/b/c', '/a/b/c')).to.be.true;
+    expect(matchPaths('/a/b/c', '/a/b/c/')).to.be.true;
+    expect(matchPaths('/a/b/:param', '/a/b/c')).to.be.true;
+    expect(matchPaths('/a/:param/:param', '/a/b/c')).to.be.true;
+    expect(matchPaths('/a/:param/:param?', '/a/b/c')).to.be.true;
+    expect(matchPaths('/a/:param/:param?', '/a/b')).to.be.true;
+    expect(matchPaths('/a/:param?/:param?', '/a')).to.be.true;
+
+    expect(matchPaths('/a/b/c', '/a/b')).to.be.false;
+    expect(matchPaths('/a/b/c', '/a/b/d')).to.be.false;
+    expect(matchPaths('/a/b/c', '/a/b/c/d')).to.be.false;
+    expect(matchPaths('/a/b/c', 'a/b/c')).to.be.false;
+    expect(matchPaths('/a/b/:param', '/a/b')).to.be.false;
+
+    expect(() => matchPaths('/a/b/c', '/a/b/:param')).to.throw();
+  });
+});

--- a/desktop/packages/mullvad-vpn/tsconfig.json
+++ b/desktop/packages/mullvad-vpn/tsconfig.json
@@ -17,6 +17,7 @@
     ],
     "typeRoots": [
       "./types",
+      "./test/e2e/types",
       "node_modules/@types",
       "../../node_modules/@types"
     ]


### PR DESCRIPTION
This PR improves navigation utilities for e2e tests by:
- **Improve navigation utils**
- **Rename test navigation util functions**
- **Add path matcher for tests**

Tests (attempt 1): https://github.com/mullvad/mullvadvpn-app/actions/runs/18097138611
Tests (attempt 2): https://github.com/mullvad/mullvadvpn-app/actions/runs/18098366888

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8856)
<!-- Reviewable:end -->
