### PR TITLE
Bump Mullvad VPN loader version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "installer-downloader"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/installer-downloader/CHANGELOG.md
+++ b/installer-downloader/CHANGELOG.md
@@ -21,6 +21,11 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-09-30
+### Changed
+- Ignore releases with a rollout of `0`.
+
+
 ## [1.1.0] - 2025-06-16
 ### Added
 #### Windows

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "installer-downloader"
 description = "A secure minimal web installer for the Mullvad app"
-version = "1.1.0"
+version = "1.2.0"
 publish = false
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
The only meaningful change since the last release is this PR: https://github.com/mullvad/mullvadvpn-app/pull/8680

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8859)
<!-- Reviewable:end -->
