### PR TITLE
Fix e2e tests after refactors when implementing quick access to feature settings

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/wireguard-settings/components/obfuscation-settings/ObfuscationSettings.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/wireguard-settings/components/obfuscation-settings/ObfuscationSettings.tsx
@@ -83,7 +83,7 @@ export function ObfuscationSettings() {
           </SettingsListbox.SplitOption.Item>
           <SettingsListbox.SplitOption.NavigateButton
             to={RoutePath.shadowsocks}
-            aria-description={messages.pgettext('accessibility', 'Shadowsocks settings')}
+            aria-label={messages.pgettext('accessibility', 'Shadowsocks settings')}
           />
         </SettingsListbox.SplitOption>
         <SettingsListbox.SplitOption value={ObfuscationType.udp2tcp}>
@@ -101,7 +101,7 @@ export function ObfuscationSettings() {
           </SettingsListbox.SplitOption.Item>
           <SettingsListbox.SplitOption.NavigateButton
             to={RoutePath.udpOverTcp}
-            aria-description={messages.pgettext('accessibility', 'UDP-over-TCP settings')}
+            aria-label={messages.pgettext('accessibility', 'UDP-over-TCP settings')}
           />
         </SettingsListbox.SplitOption>
         <SettingsListbox.BaseOption value={ObfuscationType.quic}>

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/daita-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/daita-settings/selectors.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright';
 
 export const createSelectors = (page: Page) => ({
-  enableDaitaSwitch: () => page.getByLabel('Enable'),
+  enableDaitaSwitch: () => page.getByRole('switch', { name: 'Enable' }),
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/multihop-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/multihop-settings/selectors.ts
@@ -1,5 +1,5 @@
 import { Page } from 'playwright';
 
 export const createSelectors = (page: Page) => ({
-  enableMultihopSwitch: () => page.getByRole('checkbox', { name: 'Enable' }),
+  enableMultihopSwitch: () => page.getByRole('switch', { name: 'Enable' }),
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/routes-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/routes-object-model.ts
@@ -10,6 +10,7 @@ import { MultihopSettingsRouteObjectModel } from './multihop-settings';
 import { SelectLanguageRouteObjectModel } from './select-language';
 import { SelectLocationRouteObjectModel } from './select-location';
 import { SettingsRouteObjectModel } from './settings/settings-route-object-model';
+import { ShadowsocksSettingsRouteObjectModel } from './shadowsocks-settings';
 import { SplitTunnelingSettingsRouteObjectModel } from './split-tunneling-settings';
 import { UdpOverTcpSettingsRouteObjectModel } from './udp-over-tcp-settings';
 import { UserInterfaceSettingsRouteObjectModel } from './user-interface-settings';
@@ -31,6 +32,7 @@ export class RoutesObjectModel {
   readonly multihopSettings: MultihopSettingsRouteObjectModel;
   readonly daitaSettings: DaitaSettingsRouteObjectModel;
   readonly splitTunnelingSettings: SplitTunnelingSettingsRouteObjectModel;
+  readonly shadowsocksSettings: ShadowsocksSettingsRouteObjectModel;
 
   constructor(page: Page, utils: TestUtils) {
     this.selectLanguage = new SelectLanguageRouteObjectModel(page, utils);
@@ -47,5 +49,6 @@ export class RoutesObjectModel {
     this.multihopSettings = new MultihopSettingsRouteObjectModel(page, utils);
     this.daitaSettings = new DaitaSettingsRouteObjectModel(page, utils);
     this.splitTunnelingSettings = new SplitTunnelingSettingsRouteObjectModel(page, utils);
+    this.shadowsocksSettings = new ShadowsocksSettingsRouteObjectModel(page, utils);
   }
 }

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/shadowsocks-settings/index.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/shadowsocks-settings/index.ts
@@ -1,0 +1,2 @@
+export * from './shadowsocks-settings-route-object-model';
+export * from './selectors';

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/shadowsocks-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/shadowsocks-settings/selectors.ts
@@ -1,0 +1,13 @@
+import { Page } from 'playwright';
+
+export const createSelectors = (page: Page) => ({
+  automaticPortOption: () =>
+    page
+      .getByRole('listbox', { name: 'Port' })
+      .getByRole('option', { name: 'Automatic', exact: true }),
+  customPortOption: () =>
+    page
+      .getByRole('listbox', { name: 'Port' })
+      .getByRole('option', { name: 'Custom', exact: true }),
+  portInput: () => page.getByPlaceholder('Port'),
+});

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/shadowsocks-settings/shadowsocks-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/shadowsocks-settings/shadowsocks-settings-route-object-model.ts
@@ -1,0 +1,22 @@
+import { Page } from 'playwright';
+
+import { TestUtils } from '../../utils';
+import { NavigationObjectModel } from '../navigation';
+import { createSelectors } from './selectors';
+
+export class ShadowsocksSettingsRouteObjectModel extends NavigationObjectModel {
+  readonly selectors: ReturnType<typeof createSelectors>;
+
+  constructor(page: Page, utils: TestUtils) {
+    super(page, utils);
+
+    this.selectors = createSelectors(page);
+  }
+
+  async fillPortInput(port: number) {
+    const input = this.selectors.portInput();
+    await input.click();
+    await input.fill(`${port}`);
+    await input.press('Enter');
+  }
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/udp-over-tcp-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/udp-over-tcp-settings/selectors.ts
@@ -2,4 +2,8 @@ import { Page } from 'playwright';
 
 export const createSelectors = (page: Page) => ({
   portNumber: (port: number) => page.getByRole('option', { name: `${port}` }),
+  automaticPortOption: () =>
+    page
+      .getByRole('listbox', { name: 'Port' })
+      .getByRole('option', { name: 'Automatic', exact: true }),
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/vpn-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/vpn-settings/selectors.ts
@@ -2,8 +2,8 @@ import { Page } from 'playwright';
 
 export const createSelectors = (page: Page) => ({
   heading: () => page.getByRole('heading', { name: 'VPN settings' }),
-  launchAppOnStartupSwitch: () => page.getByLabel('Launch app on start-up'),
-  autoConnectSwitch: () => page.getByLabel('Auto-connect'),
-  lanSwitch: () => page.getByLabel('Local network sharing'),
+  launchAppOnStartupSwitch: () => page.getByRole('switch', { name: 'Launch app on start-up' }),
+  autoConnectSwitch: () => page.getByRole('switch', { name: 'Auto-connect' }),
+  lanSwitch: () => page.getByRole('switch', { name: 'Local network sharing' }),
   wireguardSettingsButton: () => page.getByRole('button', { name: 'WireGuard settings' }),
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/wireguard-settings/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/wireguard-settings/selectors.ts
@@ -7,4 +7,6 @@ export const createSelectors = (page: Page) => ({
     page
       .getByRole('listbox', { name: 'Obfuscation' })
       .getByRole('option', { name: 'Automatic', exact: true }),
+  shadowsocksSettingsButton: () => page.getByRole('button', { name: 'Shadowsocks settings' }),
+  shadowsocksOption: () => page.getByRole('option', { name: 'Shadowsocks' }),
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/wireguard-settings/wireguard-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/wireguard-settings/wireguard-settings-route-object-model.ts
@@ -34,4 +34,13 @@ export class WireguardSettingsRouteObjectModel extends NavigationObjectModel {
   async selectUdpOverTcp() {
     await this.getUdpOverTcpOption().click();
   }
+
+  async selectShadowsocks() {
+    await this.selectors.shadowsocksOption().click();
+  }
+
+  async gotoShadowSocksSettings() {
+    await this.selectors.shadowsocksSettingsButton().click();
+    await this.utils.expectRoute(RoutePath.shadowsocks);
+  }
 }


### PR DESCRIPTION
Fixes tests that broke during the implementation of quick access to feature settings and the refactors that were done related to that.

Fixes DES-2555

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8862)
<!-- Reviewable:end -->
