### PR TITLE
Update translations for 2025.10 desktop release

### DIFF
--- a/android/lib/resource/src/main/res/values-es/strings.xml
+++ b/android/lib/resource/src/main/res/values-es/strings.xml
@@ -94,8 +94,8 @@
     <string name="create_account">Crear cuenta</string>
     <string name="create_custom_list_message">Se ha creado «%1$s»</string>
     <string name="create_new_account">Crear nueva cuenta</string>
-    <string name="create_new_account_warning_paragraph1">Ya tiene un número de cuenta guardado, al crear una nueva cuenta el número de cuenta guardado se eliminará de este dispositivo. Esto no se puede deshacer.</string>
-    <string name="create_new_account_warning_paragraph2">¿Desea crear una nueva cuenta?</string>
+    <string name="create_new_account_warning_paragraph1">Ya tiene un número de cuenta guardado. Al crear una nueva cuenta, el número de cuenta guardado se eliminará de este dispositivo. Esto no se puede deshacer.</string>
+    <string name="create_new_account_warning_paragraph2">¿Quiere crear una nueva cuenta?</string>
     <string name="create_new_list">Crear nueva lista</string>
     <string name="created_x">Creado: %1$s</string>
     <string name="creating_new_account">Creando cuenta…</string>

--- a/android/lib/resource/src/main/res/values-fi/strings.xml
+++ b/android/lib/resource/src/main/res/values-fi/strings.xml
@@ -94,7 +94,7 @@
     <string name="create_account">Luo tili</string>
     <string name="create_custom_list_message">\"%1$s\" luotiin</string>
     <string name="create_new_account">Luo uusi tili</string>
-    <string name="create_new_account_warning_paragraph1">Laitteellesi on jo tallennettu tilinumero, ja jos luot uuden tilin, numero poistetaan laitteelta. Toimintoa ei voi kumota.</string>
+    <string name="create_new_account_warning_paragraph1">Sinulla on jo tallennettu tilin numero. Kun luot uuden tilin, tallennettu tilin numero poistetaan tältä laitteelta. Toimintoa ei voi kumota.</string>
     <string name="create_new_account_warning_paragraph2">Haluatko luoda uuden tilin?</string>
     <string name="create_new_list">Luo uusi luettelo</string>
     <string name="created_x">Luotu: %1$s</string>
@@ -154,7 +154,7 @@
     <string name="dns_content_blockers_info">Kun tämä ominaisuus on käytössä, se estää laitetta ottamasta yhteyttä tiettyihin verkkotunnuksiin tai -sivustoihin, jotka tunnetaan mainosten, haittaohjelmien, seurantaohjelmien tai muiden vastaavien jakelijoina.</string>
     <string name="dns_content_blockers_subtitle">Ota nämä asetukset käyttöön poistamalla \"%1$s\" käytöstä alta.</string>
     <string name="dns_content_blockers_warning">Tämä voi aiheuttaa ongelmia tietyillä verkkosivustoilla, palveluissa ja sovelluksissa.</string>
-    <string name="dont_have_an_account">Eikö sinulla ole tilinumeroa?</string>
+    <string name="dont_have_an_account">Eikö sinulla ole tilin numeroa?</string>
     <string name="duplicate_address_warning">Tämä osoite on annettu jo.</string>
     <string name="edit_custom_lists">Muokkaa mukautettuja luetteloita</string>
     <string name="edit_list">Muokkaa luetteloa</string>

--- a/android/lib/resource/src/main/res/values-ja/strings.xml
+++ b/android/lib/resource/src/main/res/values-ja/strings.xml
@@ -91,7 +91,7 @@
     <string name="copy">コピー</string>
     <string name="copy_account_number">アカウント番号のコピー</string>
     <string name="create">作成</string>
-    <string name="create_account">アカウントを作成する</string>
+    <string name="create_account">アカウントを作成</string>
     <string name="create_custom_list_message">\"%1$s\" が作成されました</string>
     <string name="create_new_account">新規アカウントを作成</string>
     <string name="create_new_account_warning_paragraph1">すでに保存済みのアカウント番号があります。新規アカウントを作成すると、保存済みのアカウント番号がこのデバイスから削除されます。この操作は取り消せません。</string>

--- a/android/lib/resource/src/main/res/values-ko/strings.xml
+++ b/android/lib/resource/src/main/res/values-ko/strings.xml
@@ -94,7 +94,7 @@
     <string name="create_account">계정 생성</string>
     <string name="create_custom_list_message">\"%1$s\"이(가) 생성되었습니다</string>
     <string name="create_new_account">새 계정 생성</string>
-    <string name="create_new_account_warning_paragraph1">이미 저장한 계정 번호가 있습니다. 새 계정을 생성하면 저장된 계정 번호가 이 장치에서 삭제됩니다. 이 작업은 되돌릴 수 없습니다.</string>
+    <string name="create_new_account_warning_paragraph1">저장한 계정 번호가 이미 있습니다. 새 계정을 생성하면 저장된 계정 번호가 이 장치에서 삭제됩니다. 이 작업은 되돌릴 수 없습니다.</string>
     <string name="create_new_account_warning_paragraph2">새 계정을 만들고 싶으신가요?</string>
     <string name="create_new_list">새 목록 생성</string>
     <string name="created_x">생성 날짜: %1$s</string>

--- a/android/lib/resource/src/main/res/values-my/strings.xml
+++ b/android/lib/resource/src/main/res/values-my/strings.xml
@@ -91,11 +91,11 @@
     <string name="copy">ကူးယူရန်</string>
     <string name="copy_account_number">အကောင့်နံပါတ်ကို ကူးရန်</string>
     <string name="create">ဖန်တီးမည်</string>
-    <string name="create_account">အကောင့် ဖန်တီးရန်</string>
+    <string name="create_account">အကောင့် ဖွင့်ရန်</string>
     <string name="create_custom_list_message">\"%1$s\" ကို ဖန်တီးလိုက်ပြီ</string>
-    <string name="create_new_account">အကောင့်သစ် ဖန်တီးရန်</string>
-    <string name="create_new_account_warning_paragraph1">သင့်တွင် သိမ်းဆည်းထားသော အကောင့်နံပါတ်တစ်ခုရှိပြီး အကောင့်အသစ်တစ်ခုဖန်တီးခြင်းဖြင့် သိမ်းဆည်းထားသော အကောင့်နံပါတ်ကို ဤစက်မှ ဖယ်ရှားမည်ဖြစ်သည်။ ၎င်းကို ပြန်ပြင်လို့ မရပါ။</string>
-    <string name="create_new_account_warning_paragraph2">အကောင့်သစ်တစ်ခု ဖန်တီးလိုပါသလား။</string>
+    <string name="create_new_account">အကောင့်သစ် ဖွင့်ရန်</string>
+    <string name="create_new_account_warning_paragraph1">သင့်တွင် အကောင့်နံပါတ်တစ်ခု သိမ်းထားပြီးသားဖြစ်သောကြောင့် အကောင့်သစ်ဖွင့်လျှင် သိမ်းထားသော အကောင့်နံပါတ်ကို ဤစက်မှ ဖြုတ်ပစ်ပါမည်။ ၎င်းကို ပြန်ယူ၍မရပါ။</string>
+    <string name="create_new_account_warning_paragraph2">အကောင့်သစ် ဖွင့်လိုပါသလား။</string>
     <string name="create_new_list">စာရင်းသစ် ဖန်တီးမည်</string>
     <string name="created_x">ဖန်တီးသည့် အချိန်- %1$s</string>
     <string name="creating_new_account">အကောင့် ဖန်တီးနေဆဲ...</string>
@@ -154,7 +154,7 @@
     <string name="dns_content_blockers_info">ဤလုပ်ဆောင်ချက်ကို ဖွင့်ထားသည့်အခါ အနှောင့်အယှက်ဖြစ်စေသည့် ကြော်ငြာများ၊ မဲလ်ဝဲရ်၊ ခြေရာခံများနှင့် အစရှိသည်တို့နှင့်စပ်လျဉ်း၍ သိရှိထားသော အချို့သော Domain များ သို့မဟုတ် ဝဘ်ဆိုက်များနှင့် ဆက်သွယ်ခြင်းမှ စက်ကို ရပ်တန့်ပေးပါသည်။</string>
     <string name="dns_content_blockers_subtitle">ဤဆက်တင်များကို ဖွင့်ရန် အောက်ပါ \"%1$s\" ကို ပိတ်ပါ။</string>
     <string name="dns_content_blockers_warning">၎င်းသည် အချို့သော ဝဘ်ဆိုက်များ၊ ဝန်ဆောင်မှုများနှင့် အက်ပ်များတွင် ပြဿနာများကို ဖြစ်စေနိုင်သည်။</string>
-    <string name="dont_have_an_account">အကောင့်နံပါတ် မရှိ ဖြစ်နေပါသလား။</string>
+    <string name="dont_have_an_account">အကောင့်နံပါတ် မရှိသေးဘူးလား။</string>
     <string name="duplicate_address_warning">ဤလိပ်စာကို ရိုက်ထည့်ထားပြီး ဖြစ်ပါသည်။</string>
     <string name="edit_custom_lists">စိတ်ကြိုက် စာရင်းများ ဖန်တီးရန်</string>
     <string name="edit_list">စာရင်းကို တည်းဖြတ်ရန်</string>

--- a/android/lib/resource/src/main/res/values-nb/strings.xml
+++ b/android/lib/resource/src/main/res/values-nb/strings.xml
@@ -93,7 +93,7 @@
     <string name="create">Opprett</string>
     <string name="create_account">Opprett konto</string>
     <string name="create_custom_list_message">«%1$s» ble opprettet</string>
-    <string name="create_new_account">Opprett ny konto</string>
+    <string name="create_new_account">Opprett en ny konto</string>
     <string name="create_new_account_warning_paragraph1">Du har allerede et lagret kontonummer. Når du oppretter en ny konto, blir det lagrede kontonummeret fjernet fra denne enheten. Dette kan ikke angres.</string>
     <string name="create_new_account_warning_paragraph2">Vil du opprette en ny konto?</string>
     <string name="create_new_list">Opprett ny liste</string>

--- a/android/lib/resource/src/main/res/values-pl/strings.xml
+++ b/android/lib/resource/src/main/res/values-pl/strings.xml
@@ -94,7 +94,7 @@
     <string name="create_account">Utwórz konto</string>
     <string name="create_custom_list_message">Utworzono „%1$s”</string>
     <string name="create_new_account">Utwórz nowe konto</string>
-    <string name="create_new_account_warning_paragraph1">Masz już zapisany numer konta, a wskutek utworzenia nowego konta zostanie on usunięty z tego urządzenia. Nie można tego cofnąć.</string>
+    <string name="create_new_account_warning_paragraph1">Masz już zapisany numer konta. Zapisany numer w takiej sytuacji zostanie usunięty z tego urządzenia. Nie można tego cofnąć.</string>
     <string name="create_new_account_warning_paragraph2">Czy chcesz utworzyć nowe konto?</string>
     <string name="create_new_list">Utwórz nową listę</string>
     <string name="created_x">Utworzono: %1$s</string>

--- a/android/lib/resource/src/main/res/values-pt/strings.xml
+++ b/android/lib/resource/src/main/res/values-pt/strings.xml
@@ -95,7 +95,7 @@
     <string name="create_custom_list_message">\"%1$s\" foi criada</string>
     <string name="create_new_account">Criar nova conta</string>
     <string name="create_new_account_warning_paragraph1">Já tem um número de conta guardado. Ao criar uma nova conta, o número de conta guardado será removido deste dispositivo. Esta ação não pode ser anulada.</string>
-    <string name="create_new_account_warning_paragraph2">Pretende criar uma nova conta?</string>
+    <string name="create_new_account_warning_paragraph2">Quer criar uma nova conta?</string>
     <string name="create_new_list">Criar nova lista</string>
     <string name="created_x">Criado: %1$s</string>
     <string name="creating_new_account">A criar conta...</string>

--- a/android/lib/resource/src/main/res/values-ru/strings.xml
+++ b/android/lib/resource/src/main/res/values-ru/strings.xml
@@ -93,9 +93,9 @@
     <string name="create">Создать</string>
     <string name="create_account">Создать учетную запись</string>
     <string name="create_custom_list_message">Список «%1$s» создан</string>
-    <string name="create_new_account">Создать новую учетную запись</string>
-    <string name="create_new_account_warning_paragraph1">У вас уже есть сохраненный номер учетной записи. При создании новой учетной записи сохраненный номер будет удален с этого устройства. Это действие нельзя отменить.</string>
-    <string name="create_new_account_warning_paragraph2">Создать новую учетную запись?</string>
+    <string name="create_new_account">Создать учетную запись</string>
+    <string name="create_new_account_warning_paragraph1">У вас уже есть сохраненный номер учетной записи. При создании новой учетной записи сохраненный номер удалится с этого устройства. Это действие нельзя будет отменить.</string>
+    <string name="create_new_account_warning_paragraph2">Создать учетную запись?</string>
     <string name="create_new_list">Создание нового списка</string>
     <string name="created_x">Создано: %1$s</string>
     <string name="creating_new_account">Создание учетной записи...</string>
@@ -154,7 +154,7 @@
     <string name="dns_content_blockers_info">При включенной опции устройство не будет устанавливать соединение с определенными доменами и сайтами, известными распространением рекламы, вредоносного ПО, трекеров и т. д.</string>
     <string name="dns_content_blockers_subtitle">Чтобы активировать эти параметры, отключите параметр «%1$s».</string>
     <string name="dns_content_blockers_warning">Это может привести к проблемам при использовании некоторых сайтов, служб и приложений.</string>
-    <string name="dont_have_an_account">У вас нет номера учетной записи?</string>
+    <string name="dont_have_an_account">Нет номера учетной записи?</string>
     <string name="duplicate_address_warning">Этот адрес уже введен.</string>
     <string name="edit_custom_lists">Изменение своих списков</string>
     <string name="edit_list">Изменение списка</string>

--- a/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
@@ -94,8 +94,8 @@
     <string name="create_account">创建帐户</string>
     <string name="create_custom_list_message">“%1$s”已创建</string>
     <string name="create_new_account">创建新帐户</string>
-    <string name="create_new_account_warning_paragraph1">您已经拥有保存的帐号，创建新帐户后，保存的帐号将从此设备中移除。此操作无法撤消。</string>
-    <string name="create_new_account_warning_paragraph2">要创建新帐户吗？</string>
+    <string name="create_new_account_warning_paragraph1">您已保存一个帐号，如果创建新帐户，已保存的帐号将从此设备中移除。此操作无法撤消。</string>
+    <string name="create_new_account_warning_paragraph2">是否要创建新帐户？</string>
     <string name="create_new_list">创建新列表</string>
     <string name="created_x">创建日期：%1$s</string>
     <string name="creating_new_account">正在创建帐户…</string>
@@ -154,7 +154,7 @@
     <string name="dns_content_blockers_info">启用此功能后，它将阻止设备与已知的分发广告、恶意软件、跟踪器等内容的特定域或网站联系。</string>
     <string name="dns_content_blockers_subtitle">禁用下方的“%1$s”以激活这些设置。</string>
     <string name="dns_content_blockers_warning">这可能会导致某些网站、服务和应用出现问题。</string>
-    <string name="dont_have_an_account">没有帐号？</string>
+    <string name="dont_have_an_account">还没有帐号？</string>
     <string name="duplicate_address_warning">此地址已输入过。</string>
     <string name="edit_custom_lists">编辑自定义列表</string>
     <string name="edit_list">编辑列表</string>

--- a/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
@@ -94,7 +94,7 @@
     <string name="create_account">建立帳戶</string>
     <string name="create_custom_list_message">已建立「%1$s」</string>
     <string name="create_new_account">建立新帳戶</string>
-    <string name="create_new_account_warning_paragraph1">您已經儲存了一個帳號，如果建立新帳號，則已儲存的帳號將會從此裝置中移除，此動作無法復原。</string>
+    <string name="create_new_account_warning_paragraph1">您已儲存一組帳號。若建立新帳戶，該已儲存的帳號將會從此裝置移除；此動作無法復原。</string>
     <string name="create_new_account_warning_paragraph2">要建立新帳戶嗎？</string>
     <string name="create_new_list">建立新清單</string>
     <string name="created_x">建立日期：%1$s</string>
@@ -154,7 +154,7 @@
     <string name="dns_content_blockers_info">此功能啟用後，便會禁止裝置聯繫某些已知會傳播廣告、惡意軟體、追蹤程式等內容的網域或網站。</string>
     <string name="dns_content_blockers_subtitle">停用下方的「%1$s」以啟動這些設定。</string>
     <string name="dns_content_blockers_warning">這可能會導致某些網站、服務和應用程式出現問題。</string>
-    <string name="dont_have_an_account">沒有帳號？</string>
+    <string name="dont_have_an_account">沒有帳號嗎？</string>
     <string name="duplicate_address_warning">此地址已輸入過。</string>
     <string name="edit_custom_lists">編輯自訂清單</string>
     <string name="edit_list">編輯清單</string>

--- a/desktop/packages/mullvad-vpn/locales/da/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/da/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Danish\n"
 "Language: da_DK\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d mere..."
@@ -246,6 +246,10 @@ msgstr "Afslut"
 
 msgid "Reconnect"
 msgstr "Genopret forbindelse"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Fjern"
 
 msgid "Required"
 msgstr "Påkrævet"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Kontrollerer kontonummer"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Opret konto"
+msgid "Create a new account"
+msgstr "Opret en ny konto"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Opret ny konto"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Opretter konto..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Har du ikke noget kontonummer?"
+msgid "Do you want to create a new account?"
+msgstr "Vil du oprette en ny konto?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Vil du fjerne det gemte kontonummer?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Logger ind..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Log ind"
@@ -1545,6 +1562,13 @@ msgstr "Log ind"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Login mislykkedes"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Eller"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Vores kill-switch blokerer i øjeblikket din forbindelse."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Vent venligst"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Hvis du fjerner det gemte kontonummer fra denne enhed, kan du ikke fortryde det."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Opgraderer..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Gyldigt kontonummer"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Du har allerede et gemt kontonummer, og når du opretter en ny konto, fjernes det gemte kontonummer fra denne enhed. Dette kan ikke fortrydes."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Kopiér"
 msgid "Create"
 msgstr "Opret"
 
-msgid "Create new account"
-msgstr "Opret ny konto"
+msgid "Create account"
+msgstr "Opret konto"
 
 msgid "Create new list"
 msgstr "Opret ny liste"
@@ -3002,8 +3037,8 @@ msgstr "Afbryder..."
 msgid "Dismiss"
 msgstr "Afvis"
 
-msgid "Do you want to create a new account?"
-msgstr "Vil du oprette en ny konto?"
+msgid "Don’t have an account number?"
+msgstr "Har du ikke noget kontonummer?"
 
 msgid "Edit custom lists"
 msgstr "Rediger tilpassede lister"
@@ -3215,9 +3250,6 @@ msgstr "Nylige er deaktiveret og historikken ryddet"
 msgid "Recursion limit"
 msgstr "Rekursionsgrænse"
 
-msgid "Remove"
-msgstr "Fjern"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Fjern %1$s fra %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "WireGuard-tilsløring"
 
 msgid "WireGuard port"
 msgstr "WireGuard-port"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Du har allerede et gemt kontonummer, og når du opretter en ny konto, fjernes det gemte kontonummer fra denne enhed. Dette kan ikke fortrydes."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" blev oprettet"

--- a/desktop/packages/mullvad-vpn/locales/da/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/da/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Danish\n"
 "Language: da_DK\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/de/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/de/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d mehr …"
@@ -246,6 +246,10 @@ msgstr "Beenden"
 
 msgid "Reconnect"
 msgstr "Erneut verbinden"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Entfernen"
 
 msgid "Required"
 msgstr "Erforderlich"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Ihre Kontonummer wird geprüft"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Konto erstellen"
+msgid "Create a new account"
+msgstr "Neues Konto erstellen"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Neues Konto erstellen"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Konto wird erstellt ..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Sie haben keine Kontonummer?"
+msgid "Do you want to create a new account?"
+msgstr "Möchten Sie ein neues Konto erstellen?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Möchten Sie die gespeicherte Kontonummer entfernen?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Anmeldung läuft..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Anmelden"
@@ -1545,6 +1562,13 @@ msgstr "Anmelden"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Anmeldung fehlgeschlagen"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Oder"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Unser Killswitch blockiert derzeit Ihre Verbindung."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Bitte warten"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Das Entfernen der gespeicherten Kontonummer von diesem Gerät kann nicht rückgängig gemacht werden."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Upgrade läuft …"
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Gültige Kontonummer"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Sie haben bereits eine gespeicherte Kontonummer. Wenn Sie ein neues Konto erstellen, wird die gespeicherte Kontonummer von diesem Gerät entfernt. Dies kann nicht rückgängig gemacht werden."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2946,8 +2981,8 @@ msgstr "Kopieren"
 msgid "Create"
 msgstr "Erstellen"
 
-msgid "Create new account"
-msgstr "Neues Konto erstellen"
+msgid "Create account"
+msgstr "Konto erstellen"
 
 msgid "Create new list"
 msgstr "Neue Liste erstellen"
@@ -3003,8 +3038,8 @@ msgstr "Verbindung wird getrennt …"
 msgid "Dismiss"
 msgstr "Ausblenden"
 
-msgid "Do you want to create a new account?"
-msgstr "Möchten Sie ein neues Konto erstellen?"
+msgid "Don’t have an account number?"
+msgstr "Sie haben keine Kontonummer?"
 
 msgid "Edit custom lists"
 msgstr "Eigene Listen bearbeiten"
@@ -3216,9 +3251,6 @@ msgstr "Letzte deaktiviert und Verlauf gelöscht"
 msgid "Recursion limit"
 msgstr "Rekursionslimit"
 
-msgid "Remove"
-msgstr "Entfernen"
-
 msgid "Remove %1$s from %2$s"
 msgstr "%1$s von %2$s entfernen"
 
@@ -3410,9 +3442,6 @@ msgstr "WireGuard-Verschleierung"
 
 msgid "WireGuard port"
 msgstr "WireGuard-Port"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Sie haben bereits eine gespeicherte Kontonummer. Wenn Sie ein neues Konto erstellen, wird die gespeicherte Kontonummer von diesem Gerät entfernt. Dies kann nicht rückgängig gemacht werden."
 
 msgid "\"%s\" was created"
 msgstr "„%s“ wurde erstellt"

--- a/desktop/packages/mullvad-vpn/locales/de/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/de/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/es/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/es/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d más..."
@@ -246,6 +246,10 @@ msgstr "Salir"
 
 msgid "Reconnect"
 msgstr "Reconectar"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Quitar"
 
 msgid "Required"
 msgstr "Obligatorio"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Comprobando número de cuenta"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Crear cuenta"
+msgid "Create a new account"
+msgstr "Crear una nueva cuenta"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Crear nueva cuenta"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Creando cuenta…"
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "¿No tiene un número de cuenta?"
+msgid "Do you want to create a new account?"
+msgstr "¿Quiere crear una nueva cuenta?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "¿Quiere eliminar el número de cuenta guardado?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Iniciando la sesión…"
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Iniciar sesión"
@@ -1545,6 +1562,13 @@ msgstr "Iniciar sesión"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Error de inicio de sesión"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "O bien"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "La función de desconexión de seguridad está bloqueando la conexión."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Espere"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "La eliminación del número de cuenta guardado de este dispositivo no se puede deshacer."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Actualizando…"
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Número de cuenta válido"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Ya tiene un número de cuenta guardado. Al crear una nueva cuenta, el número de cuenta guardado se eliminará de este dispositivo. Esto no se puede deshacer."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Copiar"
 msgid "Create"
 msgstr "Crear"
 
-msgid "Create new account"
-msgstr "Crear nueva cuenta"
+msgid "Create account"
+msgstr "Crear cuenta"
 
 msgid "Create new list"
 msgstr "Crear nueva lista"
@@ -3002,8 +3037,8 @@ msgstr "Desconectando..."
 msgid "Dismiss"
 msgstr "Descartar"
 
-msgid "Do you want to create a new account?"
-msgstr "¿Desea crear una nueva cuenta?"
+msgid "Don’t have an account number?"
+msgstr "¿No tiene un número de cuenta?"
 
 msgid "Edit custom lists"
 msgstr "Editar listas personalizadas"
@@ -3215,9 +3250,6 @@ msgstr "Recientes deshabilitados e historial borrado"
 msgid "Recursion limit"
 msgstr "Límite de recursión"
 
-msgid "Remove"
-msgstr "Quitar"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Quitar %1$s de %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "Ofuscación de WireGuard"
 
 msgid "WireGuard port"
 msgstr "Puerto de WireGuard"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Ya tiene un número de cuenta guardado, al crear una nueva cuenta el número de cuenta guardado se eliminará de este dispositivo. Esto no se puede deshacer."
 
 msgid "\"%s\" was created"
 msgstr "Se ha creado «%s»"

--- a/desktop/packages/mullvad-vpn/locales/es/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/es/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/fi/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/fi/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Finnish\n"
 "Language: fi_FI\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d lisää..."
@@ -246,6 +246,10 @@ msgstr "Sulje"
 
 msgid "Reconnect"
 msgstr "Yhdistä uudelleen"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Poista"
 
 msgid "Required"
 msgstr "Pakollinen"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Tarkistetaan tilin numeroa"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Luo tili"
+msgid "Create a new account"
+msgstr "Luo uusi tili"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Luo uusi tili"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Luodaan tiliä..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Eikö sinulla ole tilinumeroa?"
+msgid "Do you want to create a new account?"
+msgstr "Haluatko luoda uuden tilin?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Haluatko poistaa tallennetun tilin numeron?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Kirjaudutaan sisään..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Kirjaudu sisään"
@@ -1545,6 +1562,13 @@ msgstr "Kirjaudu sisään"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Sisäänkirjautuminen epäonnistui"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "tai"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Tappokytkin estää tällä hetkellä yhteytesi."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Odota"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Tallennetun tilin numeron poistamista tältä laitteelta ei voi kumota."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Päivitetään..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Oikea tilin numero"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Sinulla on jo tallennettu tilin numero. Kun luot uuden tilin, tallennettu tilin numero poistetaan tältä laitteelta. Toimintoa ei voi kumota."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Kopioi"
 msgid "Create"
 msgstr "Luo"
 
-msgid "Create new account"
-msgstr "Luo uusi tili"
+msgid "Create account"
+msgstr "Luo tili"
 
 msgid "Create new list"
 msgstr "Luo uusi luettelo"
@@ -3002,8 +3037,8 @@ msgstr "Katkaistaan yhteyttä..."
 msgid "Dismiss"
 msgstr "Jätä huomiotta"
 
-msgid "Do you want to create a new account?"
-msgstr "Haluatko luoda uuden tilin?"
+msgid "Don’t have an account number?"
+msgstr "Eikö sinulla ole tilin numeroa?"
 
 msgid "Edit custom lists"
 msgstr "Muokkaa mukautettuja luetteloita"
@@ -3215,9 +3250,6 @@ msgstr "Viimeisimmät on poistettu käytöstä ja historia on tyhjennetty"
 msgid "Recursion limit"
 msgstr "Toistorajoitus"
 
-msgid "Remove"
-msgstr "Poista"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Poista %1$s luettelosta %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "WireGuard-obfuskointi"
 
 msgid "WireGuard port"
 msgstr "WireGuard-portti"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Laitteellesi on jo tallennettu tilinumero, ja jos luot uuden tilin, numero poistetaan laitteelta. Toimintoa ei voi kumota."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" luotiin"

--- a/desktop/packages/mullvad-vpn/locales/fi/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/fi/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Finnish\n"
 "Language: fi_FI\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/fr/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/fr/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d de plus..."
@@ -246,6 +246,10 @@ msgstr "Quitter"
 
 msgid "Reconnect"
 msgstr "Reconnexion"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Supprimer"
 
 msgid "Required"
 msgstr "Requis"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Vérification du numéro de compte"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Créer un compte"
+msgid "Create a new account"
+msgstr "Créer un nouveau compte"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Créer un nouveau compte"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Création du compte…"
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Vous n'avez pas de numéro de compte ?"
+msgid "Do you want to create a new account?"
+msgstr "Voulez-vous créer un nouveau compte ?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Voulez-vous supprimer le numéro de compte enregistré ?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Connexion..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Connexion"
@@ -1545,6 +1562,13 @@ msgstr "Connexion"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Échec de la connexion"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Ou"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Notre coupe-circuit bloque actuellement votre connexion."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Veuillez patienter"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Supprimer le numéro de compte enregistré de cet appareil est irréversible."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Mise à niveau..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Numéro de compte valide"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Vous avez déjà un numéro de compte enregistré. Si vous créez un nouveau compte, le numéro de compte enregistré sera supprimé de cet appareil. Cette action est irréversible."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Copier"
 msgid "Create"
 msgstr "Créer"
 
-msgid "Create new account"
-msgstr "Créer un nouveau compte"
+msgid "Create account"
+msgstr "Créer un compte"
 
 msgid "Create new list"
 msgstr "Créer une nouvelle liste"
@@ -3002,8 +3037,8 @@ msgstr "Déconnexion en cours..."
 msgid "Dismiss"
 msgstr "Ignorer"
 
-msgid "Do you want to create a new account?"
-msgstr "Voulez-vous créer un nouveau compte ?"
+msgid "Don’t have an account number?"
+msgstr "Vous n'avez pas de numéro de compte ?"
 
 msgid "Edit custom lists"
 msgstr "Modifier les listes personnalisées"
@@ -3215,9 +3250,6 @@ msgstr "Récents désactivés et historique effacé"
 msgid "Recursion limit"
 msgstr "Limite de récursion"
 
-msgid "Remove"
-msgstr "Supprimer"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Supprimer %1$s de %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "Obfuscation WireGuard"
 
 msgid "WireGuard port"
 msgstr "Port WireGuard"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Vous avez déjà un numéro de compte enregistré. Si vous créez un nouveau compte, le numéro de compte enregistré sera supprimé de cet appareil. Cette action est irréversible."
 
 msgid "\"%s\" was created"
 msgstr "« %s » a été créé"

--- a/desktop/packages/mullvad-vpn/locales/fr/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/fr/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/it/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/it/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Italian\n"
 "Language: it_IT\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "Altri %(amount)d..."
@@ -246,6 +246,10 @@ msgstr "Esci"
 
 msgid "Reconnect"
 msgstr "Riconnetti"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Rimuovi"
 
 msgid "Required"
 msgstr "Obbligatorio"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Verifica numero di account"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Crea account"
+msgid "Create a new account"
+msgstr "Crea un nuovo account"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Crea nuovo account"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Creazione account..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Non hai un numero di account?"
+msgid "Do you want to create a new account?"
+msgstr "Vuoi creare un nuovo account?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Vuoi rimuovere il numero di account salvato?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Accesso..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Accedi"
@@ -1545,6 +1562,13 @@ msgstr "Accedi"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Accesso non riuscito"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Oppure"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Il nostro kill switch sta attualmente bloccando la tua connessione."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Attendi"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "La rimozione del numero di account salvato da questo dispositivo non può essere annullata."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Aggiornamento..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Numero di account valido"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Hai già un numero di account salvato, creando un nuovo account il numero di account salvato verrà rimosso da questo dispositivo. Questa operazione non può essere annullata."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Copia"
 msgid "Create"
 msgstr "Crea"
 
-msgid "Create new account"
-msgstr "Crea nuovo account"
+msgid "Create account"
+msgstr "Crea account"
 
 msgid "Create new list"
 msgstr "Crea nuovo elenco"
@@ -3002,8 +3037,8 @@ msgstr "Disconnessione..."
 msgid "Dismiss"
 msgstr "Ignora"
 
-msgid "Do you want to create a new account?"
-msgstr "Vuoi creare un nuovo account?"
+msgid "Don’t have an account number?"
+msgstr "Non hai un numero di account?"
 
 msgid "Edit custom lists"
 msgstr "Modifica elenchi personalizzati"
@@ -3215,9 +3250,6 @@ msgstr "Recenti disabilitati e cronologia cancellata"
 msgid "Recursion limit"
 msgstr "Limite di ricorsione"
 
-msgid "Remove"
-msgstr "Rimuovi"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Rimuovi %1$s da %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "Offuscamento WireGuard"
 
 msgid "WireGuard port"
 msgstr "Porta WireGuard"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Hai già un numero di account salvato, creando un nuovo account il numero di account salvato verrà rimosso da questo dispositivo. Questa operazione non può essere annullata."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" creato"

--- a/desktop/packages/mullvad-vpn/locales/it/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/it/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Italian\n"
 "Language: it_IT\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ja/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ja/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "その他%(amount)d件..."
@@ -240,6 +240,10 @@ msgstr "終了"
 
 msgid "Reconnect"
 msgstr "再接続"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "削除"
 
 msgid "Required"
 msgstr "必須"
@@ -1484,17 +1488,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "アカウント番号を確認中"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "アカウントを作成する"
+msgid "Create a new account"
+msgstr "新規アカウントを作成"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "新規アカウントを作成"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "アカウントを作成中..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "アカウント番号を持っていませんか？"
+msgid "Do you want to create a new account?"
+msgstr "新規アカウントを作成しますか？"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "保存済みのアカウント番号を削除しますか？"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1532,6 +1548,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "ログイン中..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "ログイン"
@@ -1539,6 +1556,13 @@ msgstr "ログイン"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "ログインに失敗しました"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "または"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1549,6 +1573,12 @@ msgstr "現在、キルスイッチが接続をブロックしています。"
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "お待ちください"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "このデバイスから保存済みのアカウント番号を削除すると、元には戻せません。"
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1567,6 +1597,11 @@ msgstr "アップグレード中..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "有効なアカウント番号"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "すでに保存済みのアカウント番号があります。新規アカウントを作成すると、保存済みのアカウント番号がこのデバイスから削除されます。この操作は取り消せません。"
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2939,8 +2974,8 @@ msgstr "コピー"
 msgid "Create"
 msgstr "作成"
 
-msgid "Create new account"
-msgstr "新規アカウントを作成"
+msgid "Create account"
+msgstr "アカウントを作成"
 
 msgid "Create new list"
 msgstr "リストの新規作成"
@@ -2996,8 +3031,8 @@ msgstr "接続解除中..."
 msgid "Dismiss"
 msgstr "閉じる"
 
-msgid "Do you want to create a new account?"
-msgstr "新規アカウントを作成しますか？"
+msgid "Don’t have an account number?"
+msgstr "アカウント番号を持っていませんか？"
 
 msgid "Edit custom lists"
 msgstr "カスタムリストを編集する"
@@ -3209,9 +3244,6 @@ msgstr "最近の項目を無効化し、履歴を消去しました"
 msgid "Recursion limit"
 msgstr "繰り返しの制限"
 
-msgid "Remove"
-msgstr "削除"
-
 msgid "Remove %1$s from %2$s"
 msgstr "%1$sを%2$sから削除する"
 
@@ -3403,9 +3435,6 @@ msgstr "WireGuardの難読化"
 
 msgid "WireGuard port"
 msgstr "WireGuardポート"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "すでに保存済みのアカウント番号があります。新規アカウントを作成すると、保存済みのアカウント番号がこのデバイスから削除されます。この操作は取り消せません。"
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" が作成されました"

--- a/desktop/packages/mullvad-vpn/locales/ja/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ja/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ko/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ko/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Korean\n"
 "Language: ko_KR\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d개 더 보기..."
@@ -240,6 +240,10 @@ msgstr "종료"
 
 msgid "Reconnect"
 msgstr "다시 연결"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "제거"
 
 msgid "Required"
 msgstr "필수"
@@ -1484,17 +1488,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "계정 번호 확인 중"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "계정 생성"
+msgid "Create a new account"
+msgstr "새 계정 생성"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "새 계정 생성"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "계정 생성 중..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "계정 번호가 없으신가요?"
+msgid "Do you want to create a new account?"
+msgstr "새 계정을 만들고 싶으신가요?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "저장된 계정 번호를 삭제하고 싶으신가요?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1532,6 +1548,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "로그인 중..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "로그인"
@@ -1539,6 +1556,13 @@ msgstr "로그인"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "로그인 실패"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "또는"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1549,6 +1573,12 @@ msgstr "현재 킬 스위치가 연결을 차단하고 있습니다."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "기다려주세요"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "이 장치에서 저장된 계정 번호를 삭제하면 되돌릴 수 없습니다."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1567,6 +1597,11 @@ msgstr "업그레이드 중..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "유효한 계정 번호"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "저장한 계정 번호가 이미 있습니다. 새 계정을 생성하면 저장된 계정 번호가 이 장치에서 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2939,8 +2974,8 @@ msgstr "복사"
 msgid "Create"
 msgstr "생성"
 
-msgid "Create new account"
-msgstr "새 계정 생성"
+msgid "Create account"
+msgstr "계정 생성"
 
 msgid "Create new list"
 msgstr "새 목록 생성"
@@ -2996,8 +3031,8 @@ msgstr "연결 해제 중..."
 msgid "Dismiss"
 msgstr "해제"
 
-msgid "Do you want to create a new account?"
-msgstr "새 계정을 만들고 싶으신가요?"
+msgid "Don’t have an account number?"
+msgstr "계정 번호가 없으신가요?"
 
 msgid "Edit custom lists"
 msgstr "사용자 지정 목록 편집"
@@ -3209,9 +3244,6 @@ msgstr "최근 항목이 비활성화되고 내역이 삭제되었습니다"
 msgid "Recursion limit"
 msgstr "반복 제한"
 
-msgid "Remove"
-msgstr "제거"
-
 msgid "Remove %1$s from %2$s"
 msgstr "%2$s에서 %1$s 제거"
 
@@ -3403,9 +3435,6 @@ msgstr "WireGuard 난독화"
 
 msgid "WireGuard port"
 msgstr "WireGuard 포트"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "이미 저장한 계정 번호가 있습니다. 새 계정을 생성하면 저장된 계정 번호가 이 장치에서 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\"이(가) 생성되었습니다"

--- a/desktop/packages/mullvad-vpn/locales/ko/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ko/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Korean\n"
 "Language: ko_KR\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/my/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/my/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Burmese\n"
 "Language: my_MM\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "နောက်ထပ် %(amount)d လုံး..."
@@ -240,6 +240,10 @@ msgstr "ထွက်ရန်"
 
 msgid "Reconnect"
 msgstr "ပြန်ချိတ်ဆက်ရန်"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "ဖယ်ရှားရန်"
 
 msgid "Required"
 msgstr "ဖြည့်ရန် လိုအပ်သည်"
@@ -1484,17 +1488,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "အကောင့်နံပါတ်ကို စစ်နေပါသည်"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "အကောင့် ဖန်တီးရန်"
+msgid "Create a new account"
+msgstr "အကောင့်သစ် ဖွင့်ရန်"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "အကောင့်သစ် ဖွင့်ရန်"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "အကောင့် ဖန်တီးနေဆဲ..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "အကောင့်နံပါတ် မရှိ ဖြစ်နေပါသလား။"
+msgid "Do you want to create a new account?"
+msgstr "အကောင့်သစ် ဖွင့်လိုပါသလား။"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "သိမ်းထားသည့် အကောင့်နံပါတ်ကို ဖြုတ်လိုပါသလား။"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1532,6 +1548,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "ဝင်ရောက်နေဆဲ..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "ဝင်ရန်"
@@ -1539,6 +1556,13 @@ msgstr "ဝင်ရန်"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "ဝင်ရောက်မှု မအောင်မြင်ပါ"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "သို့မဟုတ်"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1549,6 +1573,12 @@ msgstr "ကျွန်ုပ်တို့၏ Kill Switch သည် လက်�
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "ကျေးဇူးပြု၍ စောင့်ပေးပါ"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "ဤစက်မှ အကောင့်နံပါတ်ကို ဖြုတ်ပြီးသွားလျှင် ပြန်ယူ၍မရပါ။"
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1567,6 +1597,11 @@ msgstr "အဆင့်မြှင့်တင်နေဆဲ..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "မှန်ကန်သည့် အကောင့်နံပါတ်"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "သင့်တွင် အကောင့်နံပါတ်တစ်ခု သိမ်းထားပြီးသားဖြစ်သောကြောင့် အကောင့်သစ်ဖွင့်လျှင် သိမ်းထားသော အကောင့်နံပါတ်ကို ဤစက်မှ ဖြုတ်ပစ်ပါမည်။ ၎င်းကို ပြန်ယူ၍မရပါ။"
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2939,8 +2974,8 @@ msgstr "ကူးယူရန်"
 msgid "Create"
 msgstr "ဖန်တီးမည်"
 
-msgid "Create new account"
-msgstr "အကောင့်သစ် ဖန်တီးရန်"
+msgid "Create account"
+msgstr "အကောင့် ဖွင့်ရန်"
 
 msgid "Create new list"
 msgstr "စာရင်းသစ် ဖန်တီးမည်"
@@ -2996,8 +3031,8 @@ msgstr "ချိတ်ဆက်မှုဖြုတ်နေသည်..."
 msgid "Dismiss"
 msgstr "ဖယ်ပစ်ရန်"
 
-msgid "Do you want to create a new account?"
-msgstr "အကောင့်သစ်တစ်ခု ဖန်တီးလိုပါသလား။"
+msgid "Don’t have an account number?"
+msgstr "အကောင့်နံပါတ် မရှိသေးဘူးလား။"
 
 msgid "Edit custom lists"
 msgstr "စိတ်ကြိုက် စာရင်းများ ဖန်တီးရန်"
@@ -3209,9 +3244,6 @@ msgstr "လတ်တလောအရာများကို ပိတ်ထာ�
 msgid "Recursion limit"
 msgstr "ထပ်တလဲလဲ လုပ်ဆောင်မှု ကန့်သတ်ချက်"
 
-msgid "Remove"
-msgstr "ဖယ်ရှားရန်"
-
 msgid "Remove %1$s from %2$s"
 msgstr "%2$s မှ %1$s ကို ဖယ်ရှားရန်"
 
@@ -3403,9 +3435,6 @@ msgstr "WireGuard Obfuscation\n"
 
 msgid "WireGuard port"
 msgstr "WireGuard ပေါ့တ်"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "သင့်တွင် သိမ်းဆည်းထားသော အကောင့်နံပါတ်တစ်ခုရှိပြီး အကောင့်အသစ်တစ်ခုဖန်တီးခြင်းဖြင့် သိမ်းဆည်းထားသော အကောင့်နံပါတ်ကို ဤစက်မှ ဖယ်ရှားမည်ဖြစ်သည်။ ၎င်းကို ပြန်ပြင်လို့ မရပါ။"
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" ကို ဖန်တီးလိုက်ပြီ"

--- a/desktop/packages/mullvad-vpn/locales/my/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/my/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Burmese\n"
 "Language: my_MM\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/nb/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/nb/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb_NO\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d til …"
@@ -246,6 +246,10 @@ msgstr "Avslutt"
 
 msgid "Reconnect"
 msgstr "Koble til på nytt"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Fjern"
 
 msgid "Required"
 msgstr "Nødvendig"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Kontrollerer kontonummer"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Opprett konto"
+msgid "Create a new account"
+msgstr "Opprett en ny konto"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Opprett en ny konto"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Oppretter konto ..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Har du ikke et kontonummer?"
+msgid "Do you want to create a new account?"
+msgstr "Vil du opprette en ny konto?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Vil du fjerne det lagrede kontonummeret?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Logger inn ..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Logg inn"
@@ -1545,6 +1562,13 @@ msgstr "Logg inn"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Kunne ikke logge inn"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Eller"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Vår avbruddsbryter blokkerer tilkoblingen din for øyeblikket."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Vennligst vent"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Hvis du fjerner det lagrede kontonummeret fra denne enheten, kan det ikke angres."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Oppgraderer …"
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Gyldig kontonummer"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Du har allerede et lagret kontonummer. Når du oppretter en ny konto, blir det lagrede kontonummeret fjernet fra denne enheten. Dette kan ikke angres."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Kopier"
 msgid "Create"
 msgstr "Opprett"
 
-msgid "Create new account"
-msgstr "Opprett ny konto"
+msgid "Create account"
+msgstr "Opprett konto"
 
 msgid "Create new list"
 msgstr "Opprett ny liste"
@@ -3002,8 +3037,8 @@ msgstr "Kobler fra …"
 msgid "Dismiss"
 msgstr "Ignorer"
 
-msgid "Do you want to create a new account?"
-msgstr "Vil du opprette en ny konto?"
+msgid "Don’t have an account number?"
+msgstr "Har du ikke et kontonummer?"
 
 msgid "Edit custom lists"
 msgstr "Endre egendefinerte lister"
@@ -3215,9 +3250,6 @@ msgstr "Nylige er deaktivert og historikken er slettet"
 msgid "Recursion limit"
 msgstr "Rekursjonsgrense"
 
-msgid "Remove"
-msgstr "Fjern"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Fjern %1$s fra %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "Tilsløring av WireGuard"
 
 msgid "WireGuard port"
 msgstr "WireGuard-port"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Du har allerede et lagret kontonummer. Når du oppretter en ny konto, blir det lagrede kontonummeret fjernet fra denne enheten. Dette kan ikke angres."
 
 msgid "\"%s\" was created"
 msgstr "«%s» ble opprettet"

--- a/desktop/packages/mullvad-vpn/locales/nb/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/nb/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb_NO\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/nl/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/nl/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "Nog %(amount)d..."
@@ -246,6 +246,10 @@ msgstr "Afsluiten"
 
 msgid "Reconnect"
 msgstr "Opnieuw verbinden"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Verwijderen"
 
 msgid "Required"
 msgstr "Verplicht"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Accountnummer wordt gecontroleerd"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Account aanmaken"
+msgid "Create a new account"
+msgstr "Nieuw account aanmaken"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Nieuw account aanmaken"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Account aanmaken..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Hebt u geen accountnummer?"
+msgid "Do you want to create a new account?"
+msgstr "Wilt u een nieuw account aanmaken?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Wilt u het opgeslagen accountnummer verwijderen?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Aanmelden..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Aanmelden"
@@ -1545,6 +1562,13 @@ msgstr "Aanmelden"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Aanmelden mislukt"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "of"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Uw verbinding wordt momenteel geblokkeerd door onze kill-switch."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Een moment geduld"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Als u het opgeslagen accountnummer van dit apparaat verwijdert, kan dat niet ongedaan worden gemaakt."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Upgraden..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Geldig accountnummer"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "U hebt al een opgeslagen accountnummer. Als u een nieuw account aanmaakt, wordt het opgeslagen accountnummer verwijderd van dit apparaat. Dit kan niet ongedaan worden gemaakt."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Kopiëren"
 msgid "Create"
 msgstr "Maken"
 
-msgid "Create new account"
-msgstr "Nieuw account aanmaken"
+msgid "Create account"
+msgstr "Account aanmaken"
 
 msgid "Create new list"
 msgstr "Nieuwe lijst maken"
@@ -3002,8 +3037,8 @@ msgstr "Verbinding wordt verbroken..."
 msgid "Dismiss"
 msgstr "Negeren"
 
-msgid "Do you want to create a new account?"
-msgstr "Wilt u een nieuw account aanmaken?"
+msgid "Don’t have an account number?"
+msgstr "Hebt u geen accountnummer?"
 
 msgid "Edit custom lists"
 msgstr "Aangepaste lijsten bewerken"
@@ -3215,9 +3250,6 @@ msgstr "Recente uitgeschakeld en geschiedenis gewist"
 msgid "Recursion limit"
 msgstr "Recursielimiet"
 
-msgid "Remove"
-msgstr "Verwijderen"
-
 msgid "Remove %1$s from %2$s"
 msgstr "%1$s verwijderen uit %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "WireGuard-obfuscatie"
 
 msgid "WireGuard port"
 msgstr "WireGuard-poort"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "U hebt al een opgeslagen accountnummer. Als u een nieuw account aanmaakt, wordt het opgeslagen accountnummer verwijderd van dit apparaat. Dit kan niet ongedaan worden gemaakt."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" is gemaakt"

--- a/desktop/packages/mullvad-vpn/locales/nl/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/nl/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/pl/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/pl/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Polish\n"
 "Language: pl_PL\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "Jeszcze %(amount)d"
@@ -258,6 +258,10 @@ msgstr "Wyjdź"
 
 msgid "Reconnect"
 msgstr "Połącz ponownie"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Usuń"
 
 msgid "Required"
 msgstr "Wymagane"
@@ -1502,17 +1506,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Sprawdzanie numeru konta"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Utwórz konto"
+msgid "Create a new account"
+msgstr "Utwórz nowe konto"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Utwórz nowe konto"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Tworzenie konta..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Nie masz numeru konta?"
+msgid "Do you want to create a new account?"
+msgstr "Czy chcesz utworzyć nowe konto?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Czy chcesz usunąć zapisany numer konta?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1550,6 +1566,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Logowanie..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Logowanie"
@@ -1557,6 +1574,13 @@ msgstr "Logowanie"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Błąd logowania"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Lub"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1567,6 +1591,12 @@ msgstr "Nasz kill switch blokuje połączenie."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Czekaj"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Usunięcia zapisanego numeru konta z tego urządzenia nie można cofnąć."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1585,6 +1615,11 @@ msgstr "Uaktualnianie..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Prawidłowy numer konta"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Masz już zapisany numer konta. Zapisany numer w takiej sytuacji zostanie usunięty z tego urządzenia. Nie można tego cofnąć."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2957,8 +2992,8 @@ msgstr "Kopiuj"
 msgid "Create"
 msgstr "Utwórz"
 
-msgid "Create new account"
-msgstr "Utwórz nowe konto"
+msgid "Create account"
+msgstr "Utwórz konto"
 
 msgid "Create new list"
 msgstr "Utwórz nową listę"
@@ -3014,8 +3049,8 @@ msgstr "Rozłączanie..."
 msgid "Dismiss"
 msgstr "Odrzuć"
 
-msgid "Do you want to create a new account?"
-msgstr "Czy chcesz utworzyć nowe konto?"
+msgid "Don’t have an account number?"
+msgstr "Nie masz numeru konta?"
 
 msgid "Edit custom lists"
 msgstr "Edytuj listy niestandardowe"
@@ -3227,9 +3262,6 @@ msgstr "Ostatnie: wyłączono i wyczyszczono historię"
 msgid "Recursion limit"
 msgstr "Limit rekursji"
 
-msgid "Remove"
-msgstr "Usuń"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Usuń %1$s z %2$s"
 
@@ -3421,9 +3453,6 @@ msgstr "Zaciemnianie WireGuard"
 
 msgid "WireGuard port"
 msgstr "Port WireGuard"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Masz już zapisany numer konta, a wskutek utworzenia nowego konta zostanie on usunięty z tego urządzenia. Nie można tego cofnąć."
 
 msgid "\"%s\" was created"
 msgstr "Utworzono „%s”"

--- a/desktop/packages/mullvad-vpn/locales/pl/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/pl/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Polish\n"
 "Language: pl_PL\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/pt/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/pt/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Portuguese\n"
 "Language: pt_PT\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "Mais %(amount)d..."
@@ -246,6 +246,10 @@ msgstr "Sair"
 
 msgid "Reconnect"
 msgstr "Religar"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Remover"
 
 msgid "Required"
 msgstr "Obrigatório"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "A verificar o número da conta"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Criar conta"
+msgid "Create a new account"
+msgstr "Criar uma nova conta"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Criar nova conta"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "A criar conta..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Não tem um número de conta?"
+msgid "Do you want to create a new account?"
+msgstr "Quer criar uma nova conta?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Quer remover o número de conta guardado?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "A iniciar sessão..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Iniciar sessão"
@@ -1545,6 +1562,13 @@ msgstr "Iniciar sessão"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Erro ao iniciar sessão"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Ou"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "De momento, o nosso kill switch está a bloquear a sua ligação."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Por favor, aguarde"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "A remoção do número de conta guardado deste dispositivo não pode ser anulada."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "A atualizar..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Número de conta válido"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Já tem um número de conta guardado. Ao criar uma nova conta, o número de conta guardado será removido deste dispositivo. Esta ação não pode ser anulada."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Copiar"
 msgid "Create"
 msgstr "Criar"
 
-msgid "Create new account"
-msgstr "Criar nova conta"
+msgid "Create account"
+msgstr "Criar conta"
 
 msgid "Create new list"
 msgstr "Criar nova lista"
@@ -3002,8 +3037,8 @@ msgstr "A desligar..."
 msgid "Dismiss"
 msgstr "Dispensar"
 
-msgid "Do you want to create a new account?"
-msgstr "Pretende criar uma nova conta?"
+msgid "Don’t have an account number?"
+msgstr "Não tem um número de conta?"
 
 msgid "Edit custom lists"
 msgstr "Editar listas personalizadas"
@@ -3215,9 +3250,6 @@ msgstr "Recentes desativados e histórico eliminado"
 msgid "Recursion limit"
 msgstr "Limite de recursão"
 
-msgid "Remove"
-msgstr "Remover"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Remover %1$s de %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "Ofuscação WireGuard"
 
 msgid "WireGuard port"
 msgstr "Porta WireGuard"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Já tem um número de conta guardado. Ao criar uma nova conta, o número de conta guardado será removido deste dispositivo. Esta ação não pode ser anulada."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" foi criada"

--- a/desktop/packages/mullvad-vpn/locales/pt/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/pt/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Portuguese\n"
 "Language: pt_PT\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ru/google_play.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/google_play.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "Mullvad VPN – a service, for a monthly fee, that helps keep your online activity, identity, and location private."
 msgstr "Mullvad VPN — сервис с ежемесячной оплатой, который помогает сохранить в секрете вашу личность, местоположение и действия в сети."

--- a/desktop/packages/mullvad-vpn/locales/ru/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "Еще %(amount)d..."
@@ -258,6 +258,10 @@ msgstr "Выйти"
 
 msgid "Reconnect"
 msgstr "Переподключить"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Удалить"
 
 msgid "Required"
 msgstr "Обязательно"
@@ -1502,17 +1506,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Проверка номера учетной записи"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
+msgid "Create a new account"
+msgstr "Создать учетную запись"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
 msgstr "Создать учетную запись"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Создание учетной записи..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "У вас нет номера учетной записи?"
+msgid "Do you want to create a new account?"
+msgstr "Создать учетную запись?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Удалить сохраненный номер учетной записи?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1550,6 +1566,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Выполняется вход..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Вход"
@@ -1557,6 +1574,13 @@ msgstr "Вход"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Ошибка входа"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "или"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1567,6 +1591,12 @@ msgstr "Функция аварийного отключения блокиру�
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Подождите"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Удаление с этого устройства сохраненного номера учетной записи нельзя будет отменить."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1585,6 +1615,11 @@ msgstr "Обновление…"
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Действительный номер учетной записи"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "У вас уже есть сохраненный номер учетной записи. При создании новой учетной записи сохраненный номер удалится с этого устройства. Это действие нельзя будет отменить."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2957,8 +2992,8 @@ msgstr "Копировать"
 msgid "Create"
 msgstr "Создать"
 
-msgid "Create new account"
-msgstr "Создать новую учетную запись"
+msgid "Create account"
+msgstr "Создать учетную запись"
 
 msgid "Create new list"
 msgstr "Создание нового списка"
@@ -3014,8 +3049,8 @@ msgstr "Отключение..."
 msgid "Dismiss"
 msgstr "Закрыть"
 
-msgid "Do you want to create a new account?"
-msgstr "Создать новую учетную запись?"
+msgid "Don’t have an account number?"
+msgstr "Нет номера учетной записи?"
 
 msgid "Edit custom lists"
 msgstr "Изменение своих списков"
@@ -3227,9 +3262,6 @@ msgstr "Недавние отключены, история очищена"
 msgid "Recursion limit"
 msgstr "Предел рекурсии"
 
-msgid "Remove"
-msgstr "Удалить"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Удалить местоположение %1$s из списка «%2$s»"
 
@@ -3421,9 +3453,6 @@ msgstr "Обфускация WireGuard"
 
 msgid "WireGuard port"
 msgstr "Порт WireGuard"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "У вас уже есть сохраненный номер учетной записи. При создании новой учетной записи сохраненный номер будет удален с этого устройства. Это действие нельзя отменить."
 
 msgid "\"%s\" was created"
 msgstr "Список «%s» создан"

--- a/desktop/packages/mullvad-vpn/locales/ru/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/sv/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/sv/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Swedish\n"
 "Language: sv_SE\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d till ..."
@@ -246,6 +246,10 @@ msgstr "Avsluta"
 
 msgid "Reconnect"
 msgstr "Återanslut"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Ta bort"
 
 msgid "Required"
 msgstr "Obligatoriskt"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Kontrollerar kontonummer"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Skapa konto"
+msgid "Create a new account"
+msgstr "Skapa ett nytt konto"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Skapa nytt konto"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Skapar konto..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Har du inget kontonummer?"
+msgid "Do you want to create a new account?"
+msgstr "Vill du skapa ett nytt konto?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Vill du ta bort det sparade kontonumret?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Loggar in..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Logga in"
@@ -1545,6 +1562,13 @@ msgstr "Logga in"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Inloggningen misslyckades"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "eller"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Vår Kill Switch blockerar din anslutning just nu."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Vänta"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Det går inte att ångra borttagningen av det sparade kontonumret från den här enheten."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Uppgraderar ..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Giltigt kontonummer"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Du har redan ett sparat kontonummer. Om du skapar ett nytt konto tas det sparade kontonumret bort från enheten. Det går inte att ångra detta."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Kopiera"
 msgid "Create"
 msgstr "Skapa"
 
-msgid "Create new account"
-msgstr "Skapa nytt konto"
+msgid "Create account"
+msgstr "Skapa konto"
 
 msgid "Create new list"
 msgstr "Skapa ny lista"
@@ -3002,8 +3037,8 @@ msgstr "Kopplar från ..."
 msgid "Dismiss"
 msgstr "Ignorera"
 
-msgid "Do you want to create a new account?"
-msgstr "Vill du skapa ett nytt konto?"
+msgid "Don’t have an account number?"
+msgstr "Har du inget kontonummer?"
 
 msgid "Edit custom lists"
 msgstr "Redigera anpassade listor"
@@ -3215,9 +3250,6 @@ msgstr "Senaste har inaktiverats och historiken har rensats"
 msgid "Recursion limit"
 msgstr "Rekursionsgräns"
 
-msgid "Remove"
-msgstr "Ta bort"
-
 msgid "Remove %1$s from %2$s"
 msgstr "Ta bort %1$s från %2$s"
 
@@ -3409,9 +3441,6 @@ msgstr "WireGuard-obfuskering"
 
 msgid "WireGuard port"
 msgstr "WireGuard-port"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Du har redan ett sparat kontonummer. Om du skapar ett nytt konto tas det sparade kontonumret bort från enheten. Det går inte att ångra detta."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" har skapats"

--- a/desktop/packages/mullvad-vpn/locales/sv/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/sv/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Swedish\n"
 "Language: sv_SE\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/th/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/th/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Thai\n"
 "Language: th_TH\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "อีก %(amount)d..."
@@ -240,6 +240,10 @@ msgstr "ออก"
 
 msgid "Reconnect"
 msgstr "เชื่อมต่อใหม่"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "ลบ"
 
 msgid "Required"
 msgstr "จำเป็น"
@@ -1484,17 +1488,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "กำลังตรวจสอบหมายเลขบัญชี"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "สร้างบัญชี"
+msgid "Create a new account"
+msgstr "สร้างบัญชีใหม่"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "สร้างบัญชีใหม่"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "กำลังสร้างบัญชี..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "ยังไม่มีหมายเลขบัญชีใช่ไหม"
+msgid "Do you want to create a new account?"
+msgstr "คุณต้องการสร้างบัญชีใหม่หรือไม่"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "คุณต้องการลบหมายเลขบัญชีที่บันทึกไว้หรือไม่"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1532,6 +1548,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "กำลังเข้าสู่ระบบ..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "เข้าสู่ระบบ"
@@ -1539,6 +1556,13 @@ msgstr "เข้าสู่ระบบ"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "การเข้าสู่ระบบล้มเหลว"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "หรือ"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1549,6 +1573,12 @@ msgstr "คิลสวิตช์ของเราได้บล็อกก
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "โปรดรอ"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "การลบหมายเลขบัญชีที่บันทึกไว้จากอุปกรณ์นี้ไม่สามารถย้อนกลับได้"
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1567,6 +1597,11 @@ msgstr "กำลังอัปเกรด…"
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "หมายเลขบัญชีที่ถูกต้อง"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "คุณมีหมายเลขบัญชีที่บันทึกไว้แล้ว การสร้างบัญชีใหม่จะเป็นการลบหมายเลขบัญชีที่บันทึกไว้ออกจากอุปกรณ์นี้ การดำเนินการนี้ไม่สามารถย้อนกลับได้"
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2939,8 +2974,8 @@ msgstr "คัดลอก"
 msgid "Create"
 msgstr "สร้าง"
 
-msgid "Create new account"
-msgstr "สร้างบัญชีใหม่"
+msgid "Create account"
+msgstr "สร้างบัญชี"
 
 msgid "Create new list"
 msgstr "สร้างรายการใหม่"
@@ -2996,8 +3031,8 @@ msgstr "กำลังตัดการเชื่อมต่อ..."
 msgid "Dismiss"
 msgstr "ละทิ้ง"
 
-msgid "Do you want to create a new account?"
-msgstr "คุณต้องการสร้างบัญชีใหม่หรือไม่"
+msgid "Don’t have an account number?"
+msgstr "ยังไม่มีหมายเลขบัญชีใช่ไหม"
 
 msgid "Edit custom lists"
 msgstr "แก้ไขรายการแบบกำหนดเอง"
@@ -3209,9 +3244,6 @@ msgstr "ปิดใช้งานล่าสุดและล้างปร
 msgid "Recursion limit"
 msgstr "ขีดจำกัดการเรียกซ้ำ"
 
-msgid "Remove"
-msgstr "ลบ"
-
 msgid "Remove %1$s from %2$s"
 msgstr "ลบ %1$s จาก %2$s"
 
@@ -3403,9 +3435,6 @@ msgstr "การทำให้ข้อมูลยุ่งเหยิงข
 
 msgid "WireGuard port"
 msgstr "พอร์ต WireGuard"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "คุณมีหมายเลขบัญชีที่บันทึกไว้แล้ว การสร้างบัญชีใหม่จะเป็นการลบหมายเลขบัญชีที่บันทึกไว้ออกจากอุปกรณ์นี้ การดำเนินการนี้ไม่สามารถย้อนกลับได้"
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" ถูกสร้างแล้ว"

--- a/desktop/packages/mullvad-vpn/locales/th/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/th/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Thai\n"
 "Language: th_TH\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/tr/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/tr/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Turkish\n"
 "Language: tr_TR\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d tane daha..."
@@ -246,6 +246,10 @@ msgstr "Çık"
 
 msgid "Reconnect"
 msgstr "Yeniden Bağlan"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "Kaldır"
 
 msgid "Required"
 msgstr "Gerekli"
@@ -1490,17 +1494,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "Hesap numarası kontrol ediliyor"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "Hesap oluştur"
+msgid "Create a new account"
+msgstr "Yeni hesap oluştur"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "Yeni hesap oluştur"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "Hesap oluşturuluyor..."
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "Hesap numaranız yok mu?"
+msgid "Do you want to create a new account?"
+msgstr "Yeni bir hesap oluşturmak istiyor musunuz?"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "Kayıtlı hesap numarasını kaldırmak istiyor musunuz?"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1538,6 +1554,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "Oturum açılıyor..."
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "Oturum Aç"
@@ -1545,6 +1562,13 @@ msgstr "Oturum Aç"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "Oturum açma başarısız"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "Ya da"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1555,6 +1579,12 @@ msgstr "Kill Switch özelliğimiz şu anda bağlantınızı engelliyor."
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "Lütfen bekleyin"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "Kayıtlı hesap numarası bu cihazdan kaldırıldığında işlem geri alınamaz."
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1573,6 +1603,11 @@ msgstr "Yükseltiliyor..."
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "Geçerli hesap numarası"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "Zaten kayıtlı bir hesap numaranız var. Yeni bir hesap oluşturduğunuzda kayıtlı hesap numarası bu cihazdan kaldırılır. Bu işlem geri alınamaz."
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2945,8 +2980,8 @@ msgstr "Kopyala"
 msgid "Create"
 msgstr "Oluştur"
 
-msgid "Create new account"
-msgstr "Yeni hesap oluştur"
+msgid "Create account"
+msgstr "Hesap oluştur"
 
 msgid "Create new list"
 msgstr "Yeni liste oluştur"
@@ -3002,8 +3037,8 @@ msgstr "Bağlantı kesiliyor..."
 msgid "Dismiss"
 msgstr "Reddet"
 
-msgid "Do you want to create a new account?"
-msgstr "Yeni bir hesap oluşturmak istiyor musunuz?"
+msgid "Don’t have an account number?"
+msgstr "Hesap numaranız yok mu?"
 
 msgid "Edit custom lists"
 msgstr "Özel listeleri düzenle"
@@ -3215,9 +3250,6 @@ msgstr "Son kullanılanlar devre dışı bırakıldı ve geçmiş temizlendi"
 msgid "Recursion limit"
 msgstr "Yineleme sınırı"
 
-msgid "Remove"
-msgstr "Kaldır"
-
 msgid "Remove %1$s from %2$s"
 msgstr "%1$s, %2$s listesinden kaldırılsın"
 
@@ -3409,9 +3441,6 @@ msgstr "WireGuard gizlemesi"
 
 msgid "WireGuard port"
 msgstr "WireGuard portu"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "Zaten kayıtlı bir hesap numaranız var. Yeni bir hesap oluşturduğunuzda kayıtlı hesap numarası bu cihazdan kaldırılır. Bu işlem geri alınamaz."
 
 msgid "\"%s\" was created"
 msgstr "\"%s\" oluşturuldu"

--- a/desktop/packages/mullvad-vpn/locales/tr/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/tr/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Turkish\n"
 "Language: tr_TR\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/zh-CN/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-CN/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "其他 %(amount)d 个…"
@@ -240,6 +240,10 @@ msgstr "退出"
 
 msgid "Reconnect"
 msgstr "重新连接"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "移除"
 
 msgid "Required"
 msgstr "必填"
@@ -1484,17 +1488,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "正在检查帐号"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "创建帐户"
+msgid "Create a new account"
+msgstr "创建新帐户"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "创建新帐户"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "正在创建帐户…"
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "没有帐号？"
+msgid "Do you want to create a new account?"
+msgstr "是否要创建新帐户？"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "是否要移除已保存的帐号？"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1532,6 +1548,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "登录中…"
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "登录"
@@ -1539,6 +1556,13 @@ msgstr "登录"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "登录失败"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "或者"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1549,6 +1573,12 @@ msgstr "我们的终止开关当前正在阻止您的连接。"
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "请稍候"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "从此设备移除已保存的帐号的操作无法撤消。"
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1567,6 +1597,11 @@ msgstr "正在升级…"
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "有效帐号"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "您已保存一个帐号，如果创建新帐户，已保存的帐号将从此设备中移除。此操作无法撤消。"
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2939,8 +2974,8 @@ msgstr "复制"
 msgid "Create"
 msgstr "创建"
 
-msgid "Create new account"
-msgstr "创建新帐户"
+msgid "Create account"
+msgstr "创建帐户"
 
 msgid "Create new list"
 msgstr "创建新列表"
@@ -2996,8 +3031,8 @@ msgstr "正在断开连接…"
 msgid "Dismiss"
 msgstr "关闭"
 
-msgid "Do you want to create a new account?"
-msgstr "要创建新帐户吗？"
+msgid "Don’t have an account number?"
+msgstr "还没有帐号？"
 
 msgid "Edit custom lists"
 msgstr "编辑自定义列表"
@@ -3209,9 +3244,6 @@ msgstr "最近使用已禁用，历史记录已清除"
 msgid "Recursion limit"
 msgstr "递归限制"
 
-msgid "Remove"
-msgstr "移除"
-
 msgid "Remove %1$s from %2$s"
 msgstr "将%1$s从“%2$s”中移除"
 
@@ -3403,9 +3435,6 @@ msgstr "WireGuard 混淆"
 
 msgid "WireGuard port"
 msgstr "WireGuard 端口"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "您已经拥有保存的帐号，创建新帐户后，保存的帐号将从此设备中移除。此操作无法撤消。"
 
 msgid "\"%s\" was created"
 msgstr "“%s”已创建"

--- a/desktop/packages/mullvad-vpn/locales/zh-CN/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-CN/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/zh-TW/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-TW/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 msgid "%(amount)d more..."
 msgstr "其他 %(amount)d 個…"
@@ -240,6 +240,10 @@ msgstr "結束"
 
 msgid "Reconnect"
 msgstr "重新連線"
+
+#. Button label in confirmation dialog that confirms a remove action.
+msgid "Remove"
+msgstr "移除"
 
 msgid "Required"
 msgstr "必填"
@@ -1484,17 +1488,29 @@ msgctxt "login-view"
 msgid "Checking account number"
 msgstr "檢查帳號中"
 
+#. Text in button that allows user to create a new account.
 msgctxt "login-view"
-msgid "Create account"
-msgstr "建立帳戶"
+msgid "Create a new account"
+msgstr "建立新帳戶"
+
+#. Button which confirms the action to create a new account.
+msgctxt "login-view"
+msgid "Create new account"
+msgstr "建立新帳戶"
 
 msgctxt "login-view"
 msgid "Creating account..."
 msgstr "正在建立帳戶…"
 
+#. Text that asks the user if they really want to create a new account.
 msgctxt "login-view"
-msgid "Don’t have an account number?"
-msgstr "沒有帳號？"
+msgid "Do you want to create a new account?"
+msgstr "要建立新帳戶嗎？"
+
+#. Text that asks the user if they really want to remove the saved account.
+msgctxt "login-view"
+msgid "Do you want to remove the saved account number?"
+msgstr "要移除已儲存的帳號嗎？"
 
 msgctxt "login-view"
 msgid "Enter your account number"
@@ -1532,6 +1548,7 @@ msgctxt "login-view"
 msgid "Logging in..."
 msgstr "登入中…"
 
+#. Label for the login button.
 msgctxt "login-view"
 msgid "Login"
 msgstr "登入"
@@ -1539,6 +1556,13 @@ msgstr "登入"
 msgctxt "login-view"
 msgid "Login failed"
 msgstr "登入失敗"
+
+#. Text shown between two horizontal lines above the "create account" button.
+#. In this context it is used to separate the users alternative of logging in
+#. or creating a new account, "Login or Create a new account".
+msgctxt "login-view"
+msgid "Or"
+msgstr "還是"
 
 #. This is a warning message shown when the app is blocking the users
 #. internet connection while logged out.
@@ -1549,6 +1573,12 @@ msgstr "我們的終止開關目前正在封鎖您的連線。"
 msgctxt "login-view"
 msgid "Please wait"
 msgstr "請稍候"
+
+#. Text that informs the user about the consequences of clearing the saved
+#. account number.
+msgctxt "login-view"
+msgid "Removing the saved account number from this device cannot be undone."
+msgstr "從此裝置移除已儲存的帳號後，將無法復原。"
 
 #. Error message shown above login input when trying to login to an account
 #. with too many registered devices.
@@ -1567,6 +1597,11 @@ msgstr "正在升級…"
 msgctxt "login-view"
 msgid "Valid account number"
 msgstr "有效帳號"
+
+#. Text that informs the users about consequences of creating a new account.
+msgctxt "login-view"
+msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
+msgstr "您已儲存一組帳號。若建立新帳戶，該已儲存的帳號將會從此裝置移除；此動作無法復原。"
 
 #. Title label in navigation bar
 msgctxt "navigation-bar"
@@ -2939,8 +2974,8 @@ msgstr "複製"
 msgid "Create"
 msgstr "建立"
 
-msgid "Create new account"
-msgstr "建立新帳戶"
+msgid "Create account"
+msgstr "建立帳戶"
 
 msgid "Create new list"
 msgstr "建立新清單"
@@ -2996,8 +3031,8 @@ msgstr "正在中斷連線…"
 msgid "Dismiss"
 msgstr "取消"
 
-msgid "Do you want to create a new account?"
-msgstr "要建立新帳戶嗎？"
+msgid "Don’t have an account number?"
+msgstr "沒有帳號嗎？"
 
 msgid "Edit custom lists"
 msgstr "編輯自訂清單"
@@ -3209,9 +3244,6 @@ msgstr "已停用最近使用，並已清除歷史"
 msgid "Recursion limit"
 msgstr "遞迴限制"
 
-msgid "Remove"
-msgstr "移除"
-
 msgid "Remove %1$s from %2$s"
 msgstr "將 %1$s 從 %2$s 中移除"
 
@@ -3403,9 +3435,6 @@ msgstr "WireGuard 混淆"
 
 msgid "WireGuard port"
 msgstr "WireGuard 連接埠"
-
-msgid "You already have a saved account number, by creating a new account the saved account number will be removed from this device. This cannot be undone."
-msgstr "您已經儲存了一個帳號，如果建立新帳號，則已儲存的帳號將會從此裝置中移除，此動作無法復原。"
 
 msgid "\"%s\" was created"
 msgstr "已建立「%s」"

--- a/desktop/packages/mullvad-vpn/locales/zh-TW/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-TW/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-09-03 14:39\n"
+"PO-Revision-Date: 2025-09-30 07:30\n"
 
 #. AU ADL
 msgid "Adelaide"


### PR DESCRIPTION
This PR simply ports https://github.com/mullvad/mullvadvpn-app/pull/8861 to `main`, bar the following point:
```
* Sync some Android strings with main
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8866)
<!-- Reviewable:end -->
