### PR TITLE
Fix code owner double trigger

### DIFF
--- a/.github/workflows/code-owner-approval.yml
+++ b/.github/workflows/code-owner-approval.yml
@@ -2,8 +2,6 @@
 name: Code Owner Approval
 description: Ensure that someone from each team that owns code changed in the PR has approved the PR
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
 
 jobs:

--- a/.github/workflows/code-owner-approval.yml
+++ b/.github/workflows/code-owner-approval.yml
@@ -5,7 +5,7 @@ on:
   pull_request_review:
 
 jobs:
-  check-team-approvals:
+  check-code-owner-approvals:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This is an attempt to fix an issue with the new code owner check workflow. It ran first on `pull_request` and failed obviously. Then it ran again on `pull_request_review` when the first review came in. The problem was that the runs count as different jobs, since they have different triggers. So even if the later succeeded, the former stayed in the status check as failed.

I'm trying to fix this by not triggering on the `pull_request` at all. This means the job will not run until the first review is submitted. But by adding this job to the branch protection ruleset, saying it *must* pass for a PR to be mergable, I think we still enforce it. This implicitly requires that any PR must have at least one review, but that makes sense.

I also renamed the workflow job name to a more logical name. That is unrelated to the fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8869)
<!-- Reviewable:end -->
