### PR TITLE
Fix backports to `prepare-2025.10` not applying cleanly

### DIFF
--- a/mullvad-management-interface/src/types/conversions/relay_constraints.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_constraints.rs
@@ -65,7 +65,7 @@ impl TryFrom<&proto::OpenvpnConstraints> for mullvad_types::relay_constraints::O
 
         Ok(mullvad_constraints::OpenVpnConstraints {
             port: Constraint::from(match &constraints.port {
-                Some(port) => Some(mullvad_constraints::TransportPort::try_from(*port)?),
+                Some(port) => Some(mullvad_constraints::TransportPort::try_from(port.clone())?),
                 None => None,
             }),
         })

--- a/mullvad-relay-selector/src/relay_selector/helpers.rs
+++ b/mullvad-relay-selector/src/relay_selector/helpers.rs
@@ -150,7 +150,7 @@ pub fn get_quic_obfuscator(relay: Relay, ip_version: IpVersion) -> Option<Select
             IpVersion::V4 => quic.in_ipv4().map(IpAddr::from).collect(),
             IpVersion::V6 => quic.in_ipv6().map(IpAddr::from).collect(),
         };
-        let &in_ip = addrs.iter().choose(&mut rand::rng())?;
+        let &in_ip = addrs.iter().choose(&mut thread_rng())?;
         let endpoint = SocketAddr::from((in_ip, quic.port()));
         let auth_token = quic.auth_token().to_string();
         ObfuscatorConfig::Quic {


### PR DESCRIPTION
This PR fixes some discrepancies between `main` and the release branch that arose when backport https://github.com/mullvad/mullvadvpn-app/pull/8838 to the release branch. 