### PR TITLE
Fix incorrect element being focused when navigating via feature indicators

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/SearchBar.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useLayoutEffect } from 'react';
 import styled from 'styled-components';
 
 import { messages } from '../../shared/gettext';
@@ -101,7 +101,7 @@ export default function SearchBar(props: ISearchBarProps) {
   // Enable these rules again when eslint can lint useEffectEvent properly.
   // eslint-disable-next-line react-compiler/react-compiler
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => focusInput(), []);
+  useLayoutEffect(() => focusInput(), []);
 
   return (
     <StyledSearchContainer className={props.className}>

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
@@ -10,4 +10,5 @@ export * from './useMeasure';
 export * from './useScrollToReference';
 export * from './useScrollToListItem';
 export * from './useInitialFocus';
-export * from './useFocusReference';
+export * from './useFocusReferenceAfterPaint';
+export * from './useFocusReferenceBeforePaint';

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/index.ts
@@ -4,7 +4,7 @@ export * from './useHasAppUpgradeError';
 export * from './useHasAppUpgradeEvent';
 export * from './useHasAppUpgradeInitiated';
 export * from './useHasAppUpgradeVerifiedInstallerPath';
-export * from './useIsDefaultActiveElementAfterMount';
+export * from './useIsDefaultActiveElementAfterPaint';
 export * from './useIsPlatformLinux';
 export * from './useMeasure';
 export * from './useScrollToReference';

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useFocusReferenceAfterPaint.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useFocusReferenceAfterPaint.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const useFocusReferenceAfterPaint = <T extends HTMLElement>(
+  ref?: React.RefObject<T | null>,
+  focus?: boolean,
+) => {
+  React.useEffect(() => {
+    if (focus) {
+      ref?.current?.focus({ preventScroll: true });
+    }
+  }, [ref, focus]);
+};

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useFocusReferenceBeforePaint.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useFocusReferenceBeforePaint.ts
@@ -1,10 +1,10 @@
 import React from 'react';
 
-export const useFocusReference = <T extends HTMLElement>(
+export const useFocusReferenceBeforePaint = <T extends HTMLElement>(
   ref?: React.RefObject<T | null>,
   focus?: boolean,
 ) => {
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (focus) {
       ref?.current?.focus({ preventScroll: true });
     }

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useInitialFocus.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useInitialFocus.ts
@@ -1,14 +1,14 @@
 import React from 'react';
 
 import { useFocusReferenceAfterPaint } from './useFocusReferenceAfterPaint';
-import { useIsDefaultActiveElementAfterMount } from './useIsDefaultActiveElementAfterMount';
+import { useIsDefaultActiveElementAfterPaint } from './useIsDefaultActiveElementAfterPaint';
 
 export const useInitialFocus = <T extends HTMLElement = HTMLDivElement>(): {
   ref?: React.RefObject<T | null>;
 } => {
   const ref = React.useRef<T>(null);
 
-  const isDefaultFocus = useIsDefaultActiveElementAfterMount();
+  const isDefaultFocus = useIsDefaultActiveElementAfterPaint();
   const shouldFocus = isDefaultFocus === true;
 
   useFocusReferenceAfterPaint(ref, shouldFocus);

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useInitialFocus.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useInitialFocus.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useFocusReference } from './useFocusReference';
+import { useFocusReferenceAfterPaint } from './useFocusReferenceAfterPaint';
 import { useIsDefaultActiveElementAfterMount } from './useIsDefaultActiveElementAfterMount';
 
 export const useInitialFocus = <T extends HTMLElement = HTMLDivElement>(): {
@@ -11,7 +11,7 @@ export const useInitialFocus = <T extends HTMLElement = HTMLDivElement>(): {
   const isDefaultFocus = useIsDefaultActiveElementAfterMount();
   const shouldFocus = isDefaultFocus === true;
 
-  useFocusReference(ref, shouldFocus);
+  useFocusReferenceAfterPaint(ref, shouldFocus);
 
   if (!isDefaultFocus)
     return {

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useIsDefaultActiveElementAfterPaint.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useIsDefaultActiveElementAfterPaint.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const useIsDefaultActiveElementAfterMount = () => {
+export const useIsDefaultActiveElementAfterPaint = () => {
   const [isDefaultActiveElementAfterMount, setIsDefaultActiveElementAfterMount] = React.useState<
     boolean | undefined
   >(undefined);

--- a/desktop/packages/mullvad-vpn/src/renderer/hooks/useScrollToListItem.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/hooks/useScrollToListItem.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { ScrollToAnchorId } from '../../shared/ipc-types';
 import { ListItemAnimation } from '../lib/components/list-item';
 import { useHistory } from '../lib/history';
-import { useFocusReference } from './useFocusReference';
+import { useFocusReferenceBeforePaint } from './useFocusReferenceBeforePaint';
 import { useScrollToReference } from './useScrollToReference';
 
 export const useScrollToListItem = <T extends HTMLElement = HTMLDivElement>(
@@ -36,7 +36,7 @@ export const useScrollToListItem = <T extends HTMLElement = HTMLDivElement>(
   }, [history, location, scrollToAnchorOption?.id, state]);
 
   useScrollToReference(ref, shouldScroll, handleScrolled);
-  useFocusReference(ref, shouldScroll);
+  useFocusReferenceBeforePaint(ref, shouldScroll);
 
   if (scrollToAnchorOption === undefined) {
     return {
@@ -44,6 +44,7 @@ export const useScrollToListItem = <T extends HTMLElement = HTMLDivElement>(
       animation: undefined,
     };
   }
+
   return {
     ref,
     animation: shouldScroll ? 'flash' : 'dim',


### PR DESCRIPTION
The issue was caused by a timing issue between `useInitialFocus` and `useScrollToListItem`. `useInitialFocus` would check what the focus is **before** it was set by `useScrollToListItem`. It would see that it is on a default element and then determine that it should focus the view header. Then both hooks tries to focus their respective elements and the one that runs last gets to set the final focus.
In strict mode we would then render a second time, and this time `useInitialFocus` would see that the focus is not on a default element but on the header, and thus not try to focus again, allowing `useScrollToListItem` to focus.

Separates `useFocusReference`, which is used by both hooks mentioned above, into two separate hooks with different timings, allowing us to control what triggers first.