### PR TITLE
Fix bug where relay pickers would mix obfuscations when creating relay configs

### DIFF
--- a/ios/MullvadREST/Relay/RelayPicking/MultihopPicker.swift
+++ b/ios/MullvadREST/Relay/RelayPicking/MultihopPicker.swift
@@ -47,11 +47,13 @@ struct MultihopPicker: RelayPicking {
             daitaEnabled: false
         )
 
+        // Create a new picker so that it can use the new obfuscation object.
         let picker = MultihopPicker(
             obfuscation: supportedObfuscation,
             tunnelSettings: tunnelSettings,
             connectionAttemptCount: connectionAttemptCount
         )
+
         /*
          Relay selection is prioritised in the following order:
          1. Both entry and exit constraints match only a single relay. Both relays are selected.

--- a/ios/MullvadREST/Relay/RelayPicking/SinglehopPicker.swift
+++ b/ios/MullvadREST/Relay/RelayPicking/SinglehopPicker.swift
@@ -15,8 +15,30 @@ struct SinglehopPicker: RelayPicking {
     let connectionAttemptCount: UInt
 
     func pick() throws -> SelectedRelays {
+        // Guarantee that the chosen relay supports selected obfuscation
+        let obfuscationBypass = UnsupportedObfuscationProvider(
+            relayConstraint: tunnelSettings.relayConstraints.exitLocations,
+            relays: obfuscation.obfuscatedRelays,
+            filterConstraint: tunnelSettings.relayConstraints.filter,
+            daitaEnabled: tunnelSettings.daita.daitaState.isEnabled
+        )
+
+        let supportedObfuscation = RelayObfuscator(
+            relays: obfuscation.allRelays,
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: connectionAttemptCount,
+            obfuscationBypass: obfuscationBypass
+        ).obfuscate()
+
+        // Create a new picker so that it can use the new obfuscation object.
+        let picker = SinglehopPicker(
+            obfuscation: supportedObfuscation,
+            tunnelSettings: tunnelSettings,
+            connectionAttemptCount: connectionAttemptCount
+        )
+
         do {
-            return try pick(from: obfuscation.obfuscatedRelays)
+            return try picker.pickRelays()
         } catch let error as NoRelaysSatisfyingConstraintsError where error.reason == .noDaitaRelaysFound {
             // If DAITA is on, Direct only is off and obfuscation has been ruled out, and no supported relays are found,
             // we should try to find the nearest available relay that supports DAITA and use it as entry in a multihop selection.
@@ -32,38 +54,21 @@ struct SinglehopPicker: RelayPicking {
         }
     }
 
-    private func pick(from obfuscatedRelays: REST.ServerRelaysResponse) throws -> SelectedRelays {
-        let constraints = tunnelSettings.relayConstraints
-        let daitaSettings = tunnelSettings.daita
-
-        // Guarantee that the chosen relay supports selected obfuscation
-        let obfuscationBypass = UnsupportedObfuscationProvider(
-            relayConstraint: constraints.exitLocations,
-            relays: obfuscatedRelays,
-            filterConstraint: constraints.filter,
-            daitaEnabled: daitaSettings.daitaState.isEnabled
-        )
-
-        let supportedObfuscation = RelayObfuscator(
-            relays: obfuscation.allRelays,
-            tunnelSettings: tunnelSettings,
-            connectionAttemptCount: connectionAttemptCount,
-            obfuscationBypass: obfuscationBypass
-        ).obfuscate()
-
+    private func pickRelays() throws -> SelectedRelays {
         let exitCandidates = try RelaySelector.WireGuard.findCandidates(
             by: tunnelSettings.relayConstraints.exitLocations,
-            in: supportedObfuscation.obfuscatedRelays,
-            filterConstraint: constraints.filter,
-            daitaEnabled: daitaSettings.daitaState.isEnabled
+            in: obfuscation.obfuscatedRelays,
+            filterConstraint: tunnelSettings.relayConstraints.filter,
+            daitaEnabled: tunnelSettings.daita.daitaState.isEnabled
         )
 
         let match = try findBestMatch(from: exitCandidates, useObfuscatedPortIfAvailable: true)
+
         return SelectedRelays(
             entry: nil,
             exit: match,
             retryAttempt: connectionAttemptCount,
-            obfuscation: supportedObfuscation.method
+            obfuscation: obfuscation.method
         )
     }
 }


### PR DESCRIPTION
Ways to reproduce:

- Turn on Link conditioner to 100% loss
- Set shadowsocks port to 1
- Select automatic obfuscation
- Select a relay without extra shadowsocks ip e.g. se-got-wg-002
- Click connect
- Expand the connection view
- In-IP will show :1 TCP eventually

After fix:

Test with e.g. se-got-wg-002, which is a relay that supports QUIC. The connection view should show TCP fallback with correct port (80 or 5001) for shadowsocks retry (since it's not supported), but not for other obfuscation methods (or .off).

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8879)
<!-- Reviewable:end -->
