### PR TITLE
Add a UDS for wiresharking gotatun multihop traffic 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "log",
  "nix 0.30.1",
  "parking_lot",
+ "pcap-file",
  "pnet_packet 0.35.0",
  "rand 0.9.2",
  "rand_core 0.6.4",
@@ -492,6 +493,15 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "bytes"
@@ -1104,6 +1114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-into-owned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3980,6 +4001,17 @@ dependencies = [
  "regex",
  "tokio",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "pcap-file"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+dependencies = [
+ "byteorder_slice",
+ "derive-into-owned",
+ "thiserror 1.0.59",
 ]
 
 [[package]]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 api-override = ["mullvad-api/api-override"]
 boringtun = ["talpid-core/boringtun"]
 staggered-obfuscation = ["mullvad-relay-selector/staggered-obfuscation"]
+multihop-pcap = ["talpid-core/multihop-pcap"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [features]
 boringtun = ["talpid-wireguard/boringtun"]
+multihop-pcap = ["talpid-wireguard/multihop-pcap"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [features]
 boringtun = ["dep:boringtun", "dep:tun07", "talpid-tunnel/boringtun"]
+multihop-pcap = ["boringtun/pcap"]
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
if compiled with `--features pcap`, the daemon will create a unix socket when connecting with multihop, and dump all traffic to the exit peer on that socket. This is useful for debugging userspace multihop.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8882)
<!-- Reviewable:end -->
