### PR TITLE
Move ConnectionView place/server indicators into scroll view

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
@@ -29,6 +29,7 @@ struct ConnectionView: View {
 
                     Divider()
                         .background(UIColor.secondaryTextColor.color)
+                        .padding(.top, 4)
                         .padding(.bottom, 8)
                         .showIf(isExpanded)
 

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
@@ -27,6 +27,11 @@ struct ConnectionView: View {
                     HeaderView(viewModel: connectionViewModel, isExpanded: $isExpanded)
                         .padding(.bottom, 4)
 
+                    Divider()
+                        .background(UIColor.secondaryTextColor.color)
+                        .padding(.bottom, 8)
+                        .showIf(isExpanded)
+
                     ScrollView {
                         VStack(alignment: .leading, spacing: 2) {
                             if let titleForCountryAndCity = connectionViewModel.titleForCountryAndCity {
@@ -46,11 +51,6 @@ struct ConnectionView: View {
                                     .multilineTextAlignment(.leading)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
-                            Divider()
-                                .background(UIColor.secondaryTextColor.color)
-                                .padding(.top, 6)
-                                .padding(.bottom, 14)
-                                .showIf(isExpanded)
                             HStack {
                                 VStack(alignment: .leading, spacing: 0) {
                                     Text(LocalizedStringKey("Active features"))

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionView.swift
@@ -25,39 +25,59 @@ struct ConnectionView: View {
             VStack(spacing: 16) {
                 VStack(alignment: .leading, spacing: 0) {
                     HeaderView(viewModel: connectionViewModel, isExpanded: $isExpanded)
-                        .padding(.bottom, 8)
-                    Divider()
-                        .background(UIColor.secondaryTextColor.color)
-                        .padding(.bottom, 16)
-                        .showIf(isExpanded)
+                        .padding(.bottom, 4)
 
                     ScrollView {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 0) {
-                                Text(LocalizedStringKey("Active features"))
-                                    .font(.footnote.weight(.semibold))
+                        VStack(alignment: .leading, spacing: 2) {
+                            if let titleForCountryAndCity = connectionViewModel.titleForCountryAndCity {
+                                Text(titleForCountryAndCity)
+                                    .lineLimit(isExpanded ? 2 : 1)
+                                    .font(.title3.weight(.semibold))
+                                    .foregroundStyle(UIColor.primaryTextColor.color)
+                            }
+                            if let titleForServer = connectionViewModel.titleForServer {
+                                Text(titleForServer)
+                                    .lineLimit(isExpanded ? 3 : 1)
+                                    .font(.body)
                                     .foregroundStyle(UIColor.primaryTextColor.color.opacity(0.6))
-                                    .showIf(isExpanded && hasFeatureIndicators)
-
-                                ChipContainerView(
-                                    viewModel: indicatorsViewModel,
-                                    tunnelState: connectionViewModel.tunnelStatus.state,
-                                    isExpanded: $isExpanded
-                                )
-                                .padding(.bottom, isExpanded ? 16 : 0)
-                                .showIf(hasFeatureIndicators)
-
-                                DetailsView(viewModel: connectionViewModel)
-                                    .padding(.bottom, 8)
-                                    .showIf(isExpanded)
+                                    .accessibilityIdentifier(
+                                        AccessibilityIdentifier.connectionPanelServerLabel.asString
+                                    )
+                                    .multilineTextAlignment(.leading)
+                                    .fixedSize(horizontal: false, vertical: true)
                             }
-                            Spacer()
-                        }
-                        .sizeOfView { size in
-                            withAnimation {
-                                scrollViewHeight = size.height
+                            Divider()
+                                .background(UIColor.secondaryTextColor.color)
+                                .padding(.top, 6)
+                                .padding(.bottom, 14)
+                                .showIf(isExpanded)
+                            HStack {
+                                VStack(alignment: .leading, spacing: 0) {
+                                    Text(LocalizedStringKey("Active features"))
+                                        .font(.footnote.weight(.semibold))
+                                        .foregroundStyle(UIColor.primaryTextColor.color.opacity(0.6))
+                                        .showIf(isExpanded && hasFeatureIndicators)
+
+                                    ChipContainerView(
+                                        viewModel: indicatorsViewModel,
+                                        tunnelState: connectionViewModel.tunnelStatus.state,
+                                        isExpanded: $isExpanded
+                                    )
+                                    .padding(.bottom, isExpanded ? 16 : 0)
+                                    .showIf(hasFeatureIndicators)
+
+                                    DetailsView(viewModel: connectionViewModel)
+                                        .padding(.bottom, 8)
+                                        .showIf(isExpanded)
+                                }
+                                Spacer()
                             }
-                        }
+                        }.frame(maxWidth: .infinity, alignment: .leading)
+                            .sizeOfView { size in
+                                withAnimation {
+                                    scrollViewHeight = size.height
+                                }
+                            }
                     }
                     .frame(maxHeight: scrollViewHeight)
                     .apply {

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
@@ -13,9 +13,6 @@ extension ConnectionView {
         @ObservedObject var viewModel: ConnectionViewViewModel
         @Binding var isExpanded: Bool
 
-        @State var titleForCountryAndCity: LocalizedStringKey?
-        @State var titleForServer: LocalizedStringKey?
-
         var body: some View {
             Button {
                 withAnimation {
@@ -46,41 +43,7 @@ extension ConnectionView {
                         }
                         .showIf(viewModel.showsConnectionDetails)
                     }
-                    if let titleForCountryAndCity {
-                        Text(titleForCountryAndCity)
-                            .font(.title3.weight(.semibold))
-                            .foregroundStyle(UIColor.primaryTextColor.color)
-                            .padding(.top, 4)
-                    }
-                    if let titleForServer {
-                        Text(titleForServer)
-                            .font(.body)
-                            .foregroundStyle(UIColor.primaryTextColor.color.opacity(0.6))
-                            .padding(.top, 2)
-                            .accessibilityIdentifier(AccessibilityIdentifier.connectionPanelServerLabel.asString)
-                            .multilineTextAlignment(.leading)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
                 }
-                .onAppear {
-                    titleForServer = viewModel.titleForServer
-                    titleForCountryAndCity = viewModel.titleForCountryAndCity
-                }
-                .onChange(
-                    of: viewModel.titleForCountryAndCity,
-                    perform: { newValue in
-                        withAnimation {
-                            titleForCountryAndCity = newValue
-                        }
-                    }
-                )
-                .onChange(
-                    of: viewModel.titleForServer,
-                    perform: { newValue in
-                        withAnimation {
-                            titleForServer = newValue
-                        }
-                    })
             }
             .disabled(!viewModel.showsConnectionDetails)
         }


### PR DESCRIPTION
Now everything under the CONNECTED indicator is scrollable. 
As a bonus: the Country/City and Server info lines are truncated to one line when not expanded, but expand as needed if the view is scrollable.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8884)
<!-- Reviewable:end -->
