### PR TITLE
Migrate feature request issues to github discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-requests-ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/feature-requests-ideas.yml
@@ -1,26 +1,9 @@
 ---
-name: "🚀 Feature Request"
-description: This form is to suggest a new feature in the Mullvad VPN app.
-title: "[Feature request] "
-labels: ["feature request"]
 body:
   - type: markdown
     attributes:
       value: >
         Thank you for wanting to help us improve the Mullvad VPN app by suggesting a new feature!
-
-  - type: checkboxes
-    id: checked-other-issues
-    attributes:
-      label: I have checked if others have suggested this already
-      description: >
-        Before you submit a feature request, please look through the existing
-        [feature requests](https://github.com/mullvad/mullvadvpn-app/issues?q=label%3A"feature+request")
-        to see if it has already been suggested by others. If so, please comment in those threads instead
-        of creating new ones.
-      options:
-        - label: I have checked this issue tracker to see if others have reported similar issues.
-          required: true
 
   - type: textarea
     id: new-feature

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,9 @@
 ---
 blank_issues_enabled: false
 contact_links:
+  - name: 💡 Feature requests & Ideas
+    url: https://github.com/mullvad/mullvadvpn-app/discussions/new/choose
+    about: Discuss and suggest new features in the Mullvad VPN app.
   - name: Questions and issues not directly related to our VPN application
     about: >
       If your question is not related to our VPN application specifically,


### PR DESCRIPTION
This PR aims to change our workflow in terms of how we handle feature requests. Feature requests should no longer be "Issues" but rather Discussions.

We do this by:
- Moving the issue template into discussion template. 
- Remove the "I've searched for similar issues" since that is handled automatically by discussions.
- Add link in "New issue" to lead users wanting to post a feature request to the correct discussion.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8907)
<!-- Reviewable:end -->
