### PR TITLE
Speed up tests

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/mocked-utils.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/mocked-utils.ts
@@ -8,7 +8,7 @@ import { startApp, TestUtils } from '../utils';
 // This option can be removed in the future when/if we're able to tun the tests with the sandbox
 // enabled in GitHub actions (frontend.yml).
 const noSandbox = process.env.NO_SANDBOX === '1';
-const showWindow = process.env.SHOW_WINDOW === '1';
+const showWindow = process.env.TEST_SHOW_WINDOW === '1';
 
 interface StartMockedAppResponse extends Awaited<ReturnType<typeof startApp>> {
   util: MockedTestUtils;

--- a/desktop/packages/mullvad-vpn/test/e2e/setup/main.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/setup/main.ts
@@ -18,6 +18,8 @@ import { ICurrentAppVersionInfo } from '../../../src/shared/ipc-types';
 import { mockData } from '../mock-data';
 
 const DEBUG = false;
+const TEST_SHOW_WINDOW = process.env.TEST_SHOW_WINDOW === '1';
+const CI_E2E = process.env.CI === 'e2e';
 
 class ApplicationMain {
   private guiSettings: IGuiSettingsState = {
@@ -97,6 +99,7 @@ class ApplicationMain {
       show: DEBUG,
       frame: true,
       webPreferences: {
+        offscreen: CI_E2E && !TEST_SHOW_WINDOW,
         preload: path.join(__dirname, 'preload.js'),
         nodeIntegration: false,
         nodeIntegrationInWorker: false,


### PR DESCRIPTION
- Set `webPreferences.offscreen` to true when running CI tests
  - This setting significantly boost performance when running tests without a visible window.
  - Can be disabled by setting TEST_SHOW_WINDOW=1
- Rename `SHOW_WINDOW` to `TEST_SHOW_WINDOW` to make test envs more consistent



<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
