### PR TITLE
Store recents in the settings ios 1337

### DIFF
--- a/ios/MullvadSettings/RecentConnection.swift
+++ b/ios/MullvadSettings/RecentConnection.swift
@@ -1,0 +1,24 @@
+//
+//  RecentConnection.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2025-09-22.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+import MullvadTypes
+
+public struct RecentConnection: Codable, Sendable, Equatable {
+    let entry: UserSelectedRelays?
+    let exit: UserSelectedRelays
+    var lastSelected: Date
+
+    public init(entry: UserSelectedRelays? = nil, exit: UserSelectedRelays, lastSelected: Date = Date()) {
+        self.entry = entry
+        self.exit = exit
+        self.lastSelected = Date()
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.entry == rhs.entry && lhs.exit == rhs.exit
+    }
+}

--- a/ios/MullvadSettings/RecentConnectionRepository.swift
+++ b/ios/MullvadSettings/RecentConnectionRepository.swift
@@ -1,0 +1,57 @@
+//
+//  RecentConnectionRepository.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2025-09-24.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+import MullvadLogging
+
+public actor RecentConnectionRepository: RecentConnectionRepositoryProtocol {
+    private let logger = Logger(label: "RecentConnectionRepository")
+
+    private let settingsParser: SettingsParser = {
+        SettingsParser(decoder: JSONDecoder(), encoder: JSONEncoder())
+    }()
+
+    public func add(_ recentConnection: RecentConnection, maxLimit: Int = 50) {
+        do {
+            var recentConnections = all()
+            if let index = recentConnections.firstIndex(of: recentConnection) {
+                recentConnections.remove(at: index)
+            }
+            recentConnections.append(recentConnection)
+
+            // Sort connections descending by `lastSelected` (most recent first)
+            // and keep at most max items (safe even if the list has fewer than max)
+            try write(Array(recentConnections.sorted(by: { $0.lastSelected > $1.lastSelected }).prefix(maxLimit)))
+        } catch {
+            logger.error(error: error)
+        }
+    }
+
+    public func clear() {
+        do {
+            try write([])
+        } catch {
+            logger.error(error: error)
+        }
+    }
+
+    public func all() -> [RecentConnection] {
+        (try? read()) ?? []
+    }
+}
+
+private extension RecentConnectionRepository {
+    private func read() throws -> [RecentConnection] {
+        let data = try SettingsManager.store.read(key: .recentConnections)
+
+        return try settingsParser.parseUnversionedPayload(as: [RecentConnection].self, from: data)
+    }
+
+    private func write(_ list: [RecentConnection]) throws {
+        let data = try settingsParser.produceUnversionedPayload(list)
+        try SettingsManager.store.write(data, for: .recentConnections)
+    }
+}

--- a/ios/MullvadSettings/RecentConnectionRepositoryProtocol.swift
+++ b/ios/MullvadSettings/RecentConnectionRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  RecentConnectionRepositoryProtocol.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2025-09-24.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+public protocol RecentConnectionRepositoryProtocol: Actor {
+    func add(_ recentConnection: RecentConnection, maxLimit: Int)
+    func clear()
+    func all() -> [RecentConnection]
+}

--- a/ios/MullvadSettings/SettingsManager.swift
+++ b/ios/MullvadSettings/SettingsManager.swift
@@ -43,6 +43,24 @@ public enum SettingsManager {
         SettingsParser(decoder: JSONDecoder(), encoder: JSONEncoder())
     }
 
+    // MARK: - Show recent connections
+
+    public static func isRecentConnectionsShown() throws -> Bool {
+        let data = try store.read(key: .isRecentConnectionsEnabled)
+        guard let result = String(data: data, encoding: .utf8).flatMap(Bool.init) else {
+            throw StringDecodingError(data: data)
+        }
+        return result
+    }
+
+    public static func enableRecentConnections(_ value: Bool) throws {
+        let stringValue = String(value)
+        guard let data = stringValue.data(using: .utf8) else {
+            throw StringEncodingError(string: stringValue)
+        }
+        try store.write(data, for: .isRecentConnectionsEnabled)
+    }
+
     // MARK: - Last used account
 
     public static func getLastUsedAccount() throws -> String {

--- a/ios/MullvadSettings/SettingsStore.swift
+++ b/ios/MullvadSettings/SettingsStore.swift
@@ -16,6 +16,7 @@ public enum SettingsKey: String, CaseIterable, Sendable {
     case customRelayLists = "CustomRelayLists"
     case lastUsedAccount = "LastUsedAccount"
     case shouldWipeSettings = "ShouldWipeSettings"
+    case recentConnections = "RecentConnections"
 }
 
 public protocol SettingsStore: Sendable {

--- a/ios/MullvadSettings/SettingsStore.swift
+++ b/ios/MullvadSettings/SettingsStore.swift
@@ -17,6 +17,7 @@ public enum SettingsKey: String, CaseIterable, Sendable {
     case lastUsedAccount = "LastUsedAccount"
     case shouldWipeSettings = "ShouldWipeSettings"
     case recentConnections = "RecentConnections"
+    case isRecentConnectionsEnabled = "isRecentConnectionsEnabled"
 }
 
 public protocol SettingsStore: Sendable {

--- a/ios/MullvadTypes/RelayLocation.swift
+++ b/ios/MullvadTypes/RelayLocation.swift
@@ -130,14 +130,3 @@ extension UserSelectedRelays {
         }
     }
 }
-
-@available(*, deprecated, message: "Use UserSelectedRelays instead.")
-public struct RelayLocations: Codable, Equatable {
-    public let locations: [RelayLocation]
-    public let customListId: UUID?
-
-    public init(locations: [RelayLocation], customListId: UUID? = nil) {
-        self.locations = locations
-        self.customListId = customListId
-    }
-}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1088,6 +1088,7 @@
 		F0DDE42A2B220A15006B57A7 /* Haversine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DDE4272B220A15006B57A7 /* Haversine.swift */; };
 		F0DDE42B2B220A15006B57A7 /* RelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DDE4282B220A15006B57A7 /* RelaySelector.swift */; };
 		F0DDE42C2B220A15006B57A7 /* Midpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DDE4292B220A15006B57A7 /* Midpoint.swift */; };
+		F0E28F962E8FFD5900B41BC4 /* SettingsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E28F952E8FFD5300B41BC4 /* SettingsManagerTests.swift */; };
 		F0E3618B2A4ADD2F00AEEF2B /* WelcomeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E3618A2A4ADD2F00AEEF2B /* WelcomeContentView.swift */; };
 		F0E5B2F82C9C68CF0007F78C /* EncryptedDNSTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E5B2F72C9C68CD0007F78C /* EncryptedDNSTransport.swift */; };
 		F0E61CAA2BF2911D000C4A95 /* TunnelSettingsV5.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E61CA82BF2911D000C4A95 /* TunnelSettingsV5.swift */; };
@@ -2548,6 +2549,7 @@
 		F0DDE4282B220A15006B57A7 /* RelaySelector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelaySelector.swift; sourceTree = "<group>"; };
 		F0DDE4292B220A15006B57A7 /* Midpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Midpoint.swift; sourceTree = "<group>"; };
 		F0DEA1FB2E4A326F002275F7 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F0E28F952E8FFD5300B41BC4 /* SettingsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManagerTests.swift; sourceTree = "<group>"; };
 		F0E3618A2A4ADD2F00AEEF2B /* WelcomeContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeContentView.swift; sourceTree = "<group>"; };
 		F0E576BB2E4A324A0079FA27 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F0E5B2F72C9C68CD0007F78C /* EncryptedDNSTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedDNSTransport.swift; sourceTree = "<group>"; };
@@ -3046,6 +3048,7 @@
 				A939661A2CAE6CE1008128CA /* MigrationManagerMultiProcessUpgradeTests.swift */,
 				A9B6AC172ADE8F4300F7802A /* MigrationManagerTests.swift */,
 				F0F313A62E85320D00D55C43 /* RecentConnectionRepositoryTest.swift */,
+				F0E28F952E8FFD5300B41BC4 /* SettingsManagerTests.swift */,
 				F072D3CE2C07122400906F64 /* SettingsUpdaterTests.swift */,
 				449872E32B7CB96300094DDC /* TunnelSettingsUpdateTests.swift */,
 			);
@@ -6225,6 +6228,7 @@
 				7ADCB2DA2B6A730400C88F89 /* IPOverrideRepositoryStub.swift in Sources */,
 				A9A5FA312ACB05160083449F /* MockFileCache.swift in Sources */,
 				44E1F75A2D3FDCCA003A60FF /* DestinationDescriberTests.swift in Sources */,
+				F0E28F962E8FFD5900B41BC4 /* SettingsManagerTests.swift in Sources */,
 				A9A5FA322ACB05160083449F /* RelayCacheTests.swift in Sources */,
 				A9A5FA332ACB05160083449F /* RelaySelectorTests.swift in Sources */,
 				A9BD4D552CA58C3700C8A0E6 /* RESTTransportStub.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1099,6 +1099,10 @@
 		F0E8E4C32A602E0D00ED26A3 /* AccountDeletionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E8E4C22A602E0D00ED26A3 /* AccountDeletionViewModel.swift */; };
 		F0EF50D52A949F8E0031E8DF /* ChangeLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EF50D42A949F8E0031E8DF /* ChangeLogViewModel.swift */; };
 		F0F146942D9462E100BF78E7 /* RustProblemReportRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F146912D94491200BF78E7 /* RustProblemReportRequestTests.swift */; };
+		F0F313A12E8420B500D55C43 /* RecentConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F3139F2E81928F00D55C43 /* RecentConnection.swift */; };
+		F0F313A32E8420CB00D55C43 /* RecentConnectionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F313A22E8420C800D55C43 /* RecentConnectionRepositoryProtocol.swift */; };
+		F0F313A52E84212E00D55C43 /* RecentConnectionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F313A42E84212E00D55C43 /* RecentConnectionRepository.swift */; };
+		F0F313A72E85321D00D55C43 /* RecentConnectionRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F313A62E85320D00D55C43 /* RecentConnectionRepositoryTest.swift */; };
 		F0F316192BF3572B0078DBCF /* RelaySelectorResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F316182BF3572B0078DBCF /* RelaySelectorResult.swift */; };
 		F0F3161B2BF358590078DBCF /* NoRelaysSatisfyingConstraintsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F3161A2BF358590078DBCF /* NoRelaysSatisfyingConstraintsError.swift */; };
 		F0F56B092C0E058A009D676B /* ObserverList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CC40EE24A601900019D96E /* ObserverList.swift */; };
@@ -2559,6 +2563,10 @@
 		F0EF50D42A949F8E0031E8DF /* ChangeLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeLogViewModel.swift; sourceTree = "<group>"; };
 		F0F146912D94491200BF78E7 /* RustProblemReportRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustProblemReportRequestTests.swift; sourceTree = "<group>"; };
 		F0F1EF8C2BE8FF0A00CED01D /* LaunchArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArguments.swift; sourceTree = "<group>"; };
+		F0F3139F2E81928F00D55C43 /* RecentConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentConnection.swift; sourceTree = "<group>"; };
+		F0F313A22E8420C800D55C43 /* RecentConnectionRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentConnectionRepositoryProtocol.swift; sourceTree = "<group>"; };
+		F0F313A42E84212E00D55C43 /* RecentConnectionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentConnectionRepository.swift; sourceTree = "<group>"; };
+		F0F313A62E85320D00D55C43 /* RecentConnectionRepositoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentConnectionRepositoryTest.swift; sourceTree = "<group>"; };
 		F0F316182BF3572B0078DBCF /* RelaySelectorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySelectorResult.swift; sourceTree = "<group>"; };
 		F0F3161A2BF358590078DBCF /* NoRelaysSatisfyingConstraintsError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoRelaysSatisfyingConstraintsError.swift; sourceTree = "<group>"; };
 		F0FA16082D7F0413007E2546 /* FilterDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterDescriptorTests.swift; sourceTree = "<group>"; };
@@ -3037,6 +3045,7 @@
 				7A516C3B2B712F0B00BBD33D /* IPOverrideWrapperTests.swift */,
 				A939661A2CAE6CE1008128CA /* MigrationManagerMultiProcessUpgradeTests.swift */,
 				A9B6AC172ADE8F4300F7802A /* MigrationManagerTests.swift */,
+				F0F313A62E85320D00D55C43 /* RecentConnectionRepositoryTest.swift */,
 				F072D3CE2C07122400906F64 /* SettingsUpdaterTests.swift */,
 				449872E32B7CB96300094DDC /* TunnelSettingsUpdateTests.swift */,
 			);
@@ -3076,8 +3085,8 @@
 		581943F228F8014500B0CB5E /* MullvadTypes */ = {
 			isa = PBXGroup;
 			children = (
-				F0DDE4132B220458006B57A7 /* ShadowsocksConfiguration.swift */,
 				588D7ED72AF3A533005DF40A /* AccessMethodKind.swift */,
+				A97687C72DD60D5D000D96E8 /* AddressCacheProviding.swift */,
 				584D26BE270C550B004EA533 /* AnyIPAddress.swift */,
 				586A951329013235007BAF2B /* AnyIPEndpoint.swift */,
 				06AC113628F83FD70037AF9A /* Cancellable.swift */,
@@ -3110,14 +3119,14 @@
 				5898D2AF2902A67C00EB5EBA /* RelayLocation.swift */,
 				581DA2722A1E227D0046ED47 /* RESTTypes.swift */,
 				58F1311427E0B2AB007AC5BC /* Result+Extensions.swift */,
+				A98207EE2D9192A300654558 /* ShadowsocksBridgeProviding.swift */,
 				58DFF7D92B02862E00F864E0 /* ShadowsocksCipherOptions.swift */,
+				F0DDE4132B220458006B57A7 /* ShadowsocksConfiguration.swift */,
 				F924C5A32DA65F28001F4660 /* Storekit2.swift */,
 				F0ADF1CC2CFDFF3100299F09 /* StringConversionError.swift */,
+				A9711B2A2D662AE3003DA71D /* SwiftConnectionModeProvider.swift */,
 				A91614D02B108D1B00F416EB /* TransportLayer.swift */,
 				58E511E028DDB7F100B0BCDE /* WrappingError.swift */,
-				A9711B2A2D662AE3003DA71D /* SwiftConnectionModeProvider.swift */,
-				A98207EE2D9192A300654558 /* ShadowsocksBridgeProviding.swift */,
-				A97687C72DD60D5D000D96E8 /* AddressCacheProviding.swift */,
 			);
 			path = MullvadTypes;
 			sourceTree = "<group>";
@@ -3810,6 +3819,9 @@
 				58B2FDD52AA71D2A003EB5C6 /* MullvadSettings.h */,
 				F0E61CA92BF2911D000C4A95 /* MultihopSettings.swift */,
 				44DD7D2C2B74E44A0005F67F /* QuantumResistanceSettings.swift */,
+				F0F3139F2E81928F00D55C43 /* RecentConnection.swift */,
+				F0F313A42E84212E00D55C43 /* RecentConnectionRepository.swift */,
+				F0F313A22E8420C800D55C43 /* RecentConnectionRepositoryProtocol.swift */,
 				58FF2C02281BDE02009EF542 /* SettingsManager.swift */,
 				06410E03292D0F7100AFC18C /* SettingsParser.swift */,
 				06410E06292D108E00AFC18C /* SettingsStore.swift */,
@@ -6219,6 +6231,7 @@
 				F073FCB32C6617D70062EA1D /* TunnelStore+Stubs.swift in Sources */,
 				58DFF7D32B02570000F864E0 /* MarkdownStylingOptions.swift in Sources */,
 				A9A5FA342ACB05160083449F /* StringTests.swift in Sources */,
+				F0F313A72E85321D00D55C43 /* RecentConnectionRepositoryTest.swift in Sources */,
 				7A52F96C2C17450C00B133B9 /* RelaySelectorWrapperTests.swift in Sources */,
 				A9A5FA352ACB05160083449F /* WgKeyRotationTests.swift in Sources */,
 				F0A7EBB62CF092CC005BB671 /* ApplicationConfiguration.swift in Sources */,
@@ -6245,6 +6258,7 @@
 				58B2FDDF2AA71D5C003EB5C6 /* DNSSettings.swift in Sources */,
 				58B2FDE02AA71D5C003EB5C6 /* TunnelSettings.swift in Sources */,
 				A988DF2A2ADE880300D807EF /* TunnelSettingsV3.swift in Sources */,
+				F0F313A52E84212E00D55C43 /* RecentConnectionRepository.swift in Sources */,
 				7A9F293D2CAD2FD5005F2089 /* InfoModalConfig.swift in Sources */,
 				58B2FDE42AA71D5C003EB5C6 /* SettingsManager.swift in Sources */,
 				F0164EBC2B482E430020268D /* AppStorage.swift in Sources */,
@@ -6252,10 +6266,12 @@
 				A93181A12B727ED700E341D2 /* TunnelSettingsV4.swift in Sources */,
 				58FE25BF2AA72311003D1918 /* MigrationManager.swift in Sources */,
 				58B2FDEF2AA720C4003EB5C6 /* ApplicationTarget.swift in Sources */,
+				F0F313A12E8420B500D55C43 /* RecentConnection.swift in Sources */,
 				A988DF272ADE86ED00D807EF /* WireGuardObfuscationSettings.swift in Sources */,
 				58B2FDDE2AA71D5C003EB5C6 /* Migration.swift in Sources */,
 				F05769BB2C6661EE00D9778B /* TunnelSettingsStrategy.swift in Sources */,
 				F0D7FF8F2B31DF5900E0FDE5 /* AccessMethodRepository.swift in Sources */,
+				F0F313A32E8420CB00D55C43 /* RecentConnectionRepositoryProtocol.swift in Sources */,
 				F910A8572D523812002FF3BB /* TunnelSettingsV7.swift in Sources */,
 				58B2FDE12AA71D5C003EB5C6 /* TunnelSettingsV1.swift in Sources */,
 				449872E12B7BBC5400094DDC /* TunnelSettingsUpdate.swift in Sources */,

--- a/ios/MullvadVPNTests/MullvadSettings/RecentConnectionRepositoryTest.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/RecentConnectionRepositoryTest.swift
@@ -1,0 +1,96 @@
+//
+//  RecentConnectionRepositoryTest.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2025-09-25.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+import Testing
+@testable import MullvadSettings
+@testable import MullvadTypes
+
+@Suite("RecentConnectionRepositoryTest")
+struct RecentConnectionRepositoryTest {
+    enum Scenario: Sendable, CustomTestStringConvertible {
+        case add([RecentConnection])
+        case exceedLimit([RecentConnection], max: Int)
+        case addDuplicate([RecentConnection])
+        case cleanup
+
+        var testDescription: String {
+            switch self {
+            case .add: "Adds items up to the default limit (50)"
+            case .exceedLimit: "Enforces a max limit by deleting the oldest"
+            case .addDuplicate: "Should not store duplicate RecentConnection items"
+            case .cleanup: "Clear removes all RecentConnection items"
+            }
+        }
+    }
+
+    @Test(
+        .serialized,
+        arguments: [
+            Scenario.add([
+                RecentConnection(
+                    entry: UserSelectedRelays(locations: [.country("se")]),
+                    exit: UserSelectedRelays(locations: [.city("al", "tia")])
+                )
+            ]),
+            Scenario.exceedLimit(
+                [
+                    RecentConnection(
+                        entry: .init(locations: [.country("se")]),
+                        exit: .init(locations: [.city("al", "tia")])
+                    ),
+                    RecentConnection(
+                        entry: .init(locations: [.country("se")]),
+                        exit: .init(locations: [.country("fr")])
+                    ),
+                    RecentConnection(
+                        entry: .init(locations: [.country("de")]),
+                        exit: .init(locations: [.country("nl")])
+                    ),
+                ], max: 2),
+            Scenario.addDuplicate([
+                RecentConnection(exit: .init(locations: [.country("se")])),
+                RecentConnection(exit: .init(locations: [.country("sp")])),
+                RecentConnection(exit: .init(locations: [.country("se")])),
+                RecentConnection(
+                    entry: .init(locations: [.country("se")]),
+                    exit: .init(locations: [.country("nl")])
+                ),
+            ]),
+            Scenario.cleanup,
+        ]
+    )
+    func run(_ scenario: Scenario) async {
+        let store = InMemorySettingsStore<SettingNotFound>()
+        SettingsManager.unitTestStore = store
+
+        let repository = RecentConnectionRepository()
+        await repository.clear()
+
+        switch scenario {
+        case let .add(recentConnections):
+            for recentConnection in recentConnections { await repository.add(recentConnection) }
+            let all = await repository.all()
+            #expect(all.count == recentConnections.count)
+
+        case let .exceedLimit(recentConnections, max):
+            for recentConnection in recentConnections { await repository.add(recentConnection, maxLimit: max) }
+
+            let all = await repository.all()
+            #expect(all.count == max)
+            #expect(all.contains(recentConnections.first!) == false)
+
+        case let .addDuplicate(params):
+            for recentConnection in params { await repository.add(recentConnection) }
+            let all = await repository.all()
+            #expect(all.count == params.count - 1)
+
+        case .cleanup:
+            let all = await repository.all()
+            #expect(all.isEmpty)
+        }
+    }
+}

--- a/ios/MullvadVPNTests/MullvadSettings/SettingsManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/SettingsManagerTests.swift
@@ -1,0 +1,27 @@
+//
+//  SettingsManagerTests.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2025-10-03.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+import Testing
+
+@testable import MullvadSettings
+@testable import MullvadTypes
+
+@Suite("SettingsManagerTests")
+struct SettingsManagerTests {
+
+    @Test(
+        .serialized,
+        arguments: [true, false, true])
+    func enableRecentConnections(_ value: Bool) throws {
+        let store = InMemorySettingsStore<SettingNotFound>()
+        SettingsManager.unitTestStore = store
+        try SettingsManager.enableRecentConnections(value)
+        let storedValue = try SettingsManager.isRecentConnectionsShown()
+        #expect(storedValue == value)
+    }
+}


### PR DESCRIPTION
This PR stores recent connections on the disk for further usages. in addition it keeps a flag which indicates the feature is enabled.