### PR TITLE
Remove test for login screen title when account is created

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
@@ -49,13 +49,6 @@ test('App should create account', async () => {
   await util.expectRoute(RoutePath.login);
 
   await routes.login.createNewAccount();
-
-  const title = page.locator('h1');
-  const subtitle = page.getByTestId('subtitle');
-
-  await expect(title).toHaveText('Account created');
-  await expect(subtitle).toHaveText('Logged in');
-
   await util.expectRoute(RoutePath.expired);
 
   const outOfTimeTitle = page.getByTestId('title');


### PR DESCRIPTION
The title that were previously checked is only visible for one second which leads to flakiness due to playwright sometimes not polling the expect during that second.

Test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/18274540322 :crossed_fingers: 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8968)
<!-- Reviewable:end -->
