### PR TITLE
Clean up nixpkgs protoc

### DIFF
--- a/android/flake.lock
+++ b/android/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753647747,
-        "narHash": "sha256-Sh339Czv6XtpOmMDWqQhS2GEAlqevz3bfDqzrvIueD0=",
+        "lastModified": 1759868461,
+        "narHash": "sha256-25Jy39J1/aTjUiSU4zZF44x19ZTmmsLFH/B9UawXk0c=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d7eb36518bab45d29815a763965a0c5d9dff69e2",
+        "rev": "023a70642315854ac38cf7053ba77fbaba4c16f1",
         "type": "github"
       },
       "original": {
@@ -115,16 +115,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1753549186,
-        "narHash": "sha256-Znl7rzuxKg/Mdm6AhimcKynM7V3YeNDIcLjBuoBcmNs=",
+        "lastModified": 1759826507,
+        "narHash": "sha256-vwXL9H5zDHEQA0oFpww2one0/hkwnPAjc47LRph6d0I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17f6bd177404d6d43017595c5264756764444ab8",
+        "rev": "bce5fe2bb998488d8e7e7856315f90496723793c",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "type": "indirect"
       }
     },
@@ -144,11 +144,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753671061,
-        "narHash": "sha256-IU4eBWfe9h2QejJYST+EAlhg8a1H6mh9gbcmWgZ2/mQ=",
+        "lastModified": 1759890791,
+        "narHash": "sha256-KN1xkrQ4x6u8plgg43ZiYbQmESxeCKKOzALKjqbn4LM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "40065d17ee4dbec3ded8ca61236132aede843fab",
+        "rev": "74fcbc183aa6685f86008606bb7824bf2f40adbd",
         "type": "github"
       },
       "original": {

--- a/android/flake.nix
+++ b/android/flake.nix
@@ -31,15 +31,6 @@
         overlays = [
           (import rust-overlay)
           devshell.overlays.default
-          # Fix that disables autoPatchelfHook on macOS.
-          # Should be addressed upstream in nixpkgs.
-          (final: prev: {
-            protoc-gen-grpc-java = prev.protoc-gen-grpc-java.overrideAttrs (old: {
-              nativeBuildInputs =
-                pkgs.lib.remove prev.autoPatchelfHook (old.nativeBuildInputs or [])
-                ++ pkgs.lib.optionals prev.stdenv.isLinux [prev.autoPatchelfHook];
-            });
-          })
         ];
       };
 

--- a/android/flake.nix
+++ b/android/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     # Unstable is currently needed for protoc-gen-grpc-java.
     # We should switch to a stable channel once it's avaiable on those.
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
     devshell.url = "github:numtide/devshell";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {

--- a/android/flake.nix
+++ b/android/flake.nix
@@ -104,7 +104,7 @@
             pkgs.gnumake
             pkgs.protobuf
             pkgs.jdk17
-            pkgs.python3Full
+            pkgs.python314
           ]
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [pkgs.libiconv];
 


### PR DESCRIPTION
The fix has instead been included in the upstream nix package: https://github.com/NixOS/nixpkgs/pull/449117

Pending release in `nixpkgs-unstable`. See channel release status [here](https://status.nixos.org/).

Fixes: DROID-2233

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8981)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the base package source to a newer unstable channel for consistency across environments.
  * Removed a platform-specific build workaround to simplify cross-platform builds.
  * Standardized the development shell to Python 3.14 for a unified developer experience.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->