### PR TITLE
Add missing feature in talpid-windows

### DIFF
--- a/talpid-windows/Cargo.toml
+++ b/talpid-windows/Cargo.toml
@@ -27,6 +27,7 @@ features = [
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_IO",
     "Win32_System_SystemInformation",
+    "Win32_System_Threading",
     "Win32_Networking_WinSock",
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",


### PR DESCRIPTION
Fixes the error here: https://github.com/mullvad/mullvadvpn-app/actions/runs/18313376305/job/52147232566

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/8987)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded Windows build configuration to include additional threading capabilities. On Windows, users may see improved stability, responsiveness, and compatibility in multi-threaded operations and background tasks. This enhances support across a broader range of Windows environments and reduces potential issues with concurrent execution. No action is required from users. Available in the next Windows release build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->