### PR TITLE
Run e2e tests with reduced motion

### DIFF
--- a/desktop/packages/mullvad-vpn/playwright.config.ts
+++ b/desktop/packages/mullvad-vpn/playwright.config.ts
@@ -1,18 +1,7 @@
 import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   testDir: './test/e2e',
-  maxFailures: 2,
-  timeout: 60000,
-  expect: {
-    toMatchSnapshot: {
-      threshold: 0.1,
-      maxDiffPixelRatio: 0.01,
-    },
-  },
-  use: {
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
-  },
+  maxFailures: 1,
 };
 
 export default config;

--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -681,10 +681,6 @@ export default class AppRenderer {
 
   public setNavigationHistory(history: IHistoryObject) {
     IpcRendererEventChannel.navigation.setHistory(history);
-
-    if (window.env.e2e) {
-      window.e2e.location = history.entries[history.index].pathname;
-    }
   }
 
   // If the installer has just been downloaded and verified we want to automatically

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/transition-hooks.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/transition-hooks.ts
@@ -35,8 +35,11 @@ export function useViewTransitions(onTransition?: () => void): Location<Location
   const reduceMotion = getReduceMotion();
 
   const updateView = useEffectEvent((location: Location<LocationState>) => {
-    setNavigationHistory(history.asObject);
     setCurrentLocation(location);
+    setTimeout(() => {
+      setNavigationHistory(history.asObject);
+      onTransition?.();
+    });
   });
 
   const transitionToView = useEffectEvent(

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/transition-hooks.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/transition-hooks.ts
@@ -32,20 +32,23 @@ export function useViewTransitions(onTransition?: () => void): Location<Location
   const queuedLocationRef = useRef<QueueItem>(undefined);
   const { setNavigationHistory } = useAppContext();
 
-  const reduceMotion = getReduceMotion();
-
   const updateView = useEffectEvent((location: Location<LocationState>) => {
     setCurrentLocation(location);
-    setTimeout(() => {
-      setNavigationHistory(history.asObject);
-      onTransition?.();
-    });
+    setNavigationHistory(history.asObject);
+  });
+
+  const onTransitionEnd = useEffectEvent((location: Location<LocationState>) => {
+    if (window.env.e2e) {
+      window.e2e.location = location.pathname;
+    }
+    onTransition?.();
   });
 
   const transitionToView = useEffectEvent(
     (location: Location<LocationState>, transition: TransitionType) => {
-      if (reduceMotion) {
+      if (getReduceMotion()) {
         updateView(location);
+        setTimeout(() => onTransitionEnd(location));
         return;
       }
 
@@ -63,7 +66,7 @@ export function useViewTransitions(onTransition?: () => void): Location<Location
         if (queueLocation) {
           transitionToView(queueLocation.location, queueLocation.transition);
         } else {
-          onTransition?.();
+          onTransitionEnd?.(location);
         }
       });
     },

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/api-access-methods.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/api-access-methods.spec.ts
@@ -29,7 +29,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 async function navigateToAccessMethods() {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/custom-bridge.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/custom-bridge.spec.ts
@@ -22,7 +22,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('App should enable bridge mode', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/daita-settings/daita-settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/daita-settings/daita-settings.spec.ts
@@ -25,7 +25,7 @@ test.describe('DAITA settings', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.afterEach(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/device-revoked.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/device-revoked.spec.ts
@@ -15,7 +15,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('App should fail to login', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/disconnected.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/disconnected.spec.ts
@@ -22,7 +22,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('App should show disconnected tunnel state', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/login.spec.ts
@@ -24,7 +24,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('App should fail to login', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/macos-split-tunneling.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/macos-split-tunneling.spec.ts
@@ -18,7 +18,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 async function navigateToSplitTunneling() {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/multihop-settings/multihop-settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/multihop-settings/multihop-settings.spec.ts
@@ -24,7 +24,7 @@ test.describe('Multihop settings', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.afterEach(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
@@ -27,7 +27,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('App should have automatic obfuscation', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/openvpn-tunnel-state.spec.ts
@@ -22,7 +22,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('App should show correct tunnel protocol', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/settings-import.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/settings-import.spec.ts
@@ -28,7 +28,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 async function navigateToSettingsImport() {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/too-many-devices.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/too-many-devices.spec.ts
@@ -19,7 +19,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('App should show too many devices', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -36,7 +36,7 @@ test.describe('Tunnel state and settings', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test('App should show disconnected tunnel state', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/vpn-settings/vpn-settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/vpn-settings/vpn-settings.spec.ts
@@ -27,7 +27,7 @@ test.describe('VPN settings', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test('Should focus header heading on load', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/account-expiry.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/account-expiry.spec.ts
@@ -32,7 +32,7 @@ test.describe('Account expiry', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.beforeEach(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/account-expiry.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/account-expiry.spec.ts
@@ -20,8 +20,6 @@ const FUTURE_EXPIRY = {
   expiry: new Date(START_DATE.getTime() + FUTURE_EXPIRY_DIFF).toISOString(),
 };
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('Account expiry', () => {
   const startup = async () => {
     ({ page, util } = await startMockedApp());

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/app-upgrade/app-upgrade.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/app-upgrade/app-upgrade.spec.ts
@@ -50,7 +50,7 @@ test.describe('App upgrade', () => {
   };
 
   const restart = async () => {
-    await page.close();
+    await util?.closePage();
     await startup();
   };
 
@@ -59,7 +59,7 @@ test.describe('App upgrade', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.describe('Should display changelog', () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/device-revoked.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/device-revoked.spec.ts
@@ -8,8 +8,6 @@ let page: Page;
 let util: MockedTestUtils;
 let routes: RoutesObjectModel;
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('Device revoked', () => {
   test.beforeAll(async () => {
     ({ page, util } = await startMockedApp());

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/device-revoked.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/device-revoked.spec.ts
@@ -16,7 +16,7 @@ test.describe('Device revoked', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   async function revokeDevice() {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
@@ -159,13 +159,13 @@ test.describe('Feature indicators', () => {
     await util.expectRoute(RoutePath.main);
   });
 
-  test.afterAll(async () => {
-    await page.close();
-  });
-
-  test.afterEach(async () => {
+  test.beforeEach(async () => {
     await helpers.disconnect();
     await routes.wireguardSettings.goBackToRoute(RoutePath.main);
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
   });
 
   async function expectFeatureIndicators(expectedIndicators: Array<string>, only = true) {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
@@ -165,7 +165,7 @@ test.describe('Feature indicators', () => {
   });
 
   test.afterAll(async () => {
-    await page?.close();
+    await util?.closePage();
   });
 
   async function expectFeatureIndicators(expectedIndicators: Array<string>, only = true) {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/feature-indicators/feature-indicators.spec.ts
@@ -150,8 +150,6 @@ const featureIndicatorWithOption: FeatureIndicatorWithOptionTestOption[] = [
   },
 ];
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('Feature indicators', () => {
   test.beforeAll(async () => {
     ({ page, util } = await startMockedApp());

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/forced-motion.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/forced-motion.spec.ts
@@ -20,7 +20,7 @@ test.describe('Transitions and animations', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test('Should navigate with transitions', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/forced-motion.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/forced-motion.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { Page } from 'playwright';
+
+import { RoutesObjectModel } from '../route-object-models';
+import { MockedTestUtils, startMockedApp } from './mocked-utils';
+
+let page: Page;
+let util: MockedTestUtils;
+let routes: RoutesObjectModel;
+
+test.describe('Transitions and animations', () => {
+  test.skip(process.platform !== 'linux');
+
+  test.beforeAll(async () => {
+    ({ page, util } = await startMockedApp());
+    await page.emulateMedia({ reducedMotion: null });
+    routes = new RoutesObjectModel(page, util);
+
+    await routes.main.waitForRoute();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test('Should navigate with transitions', async () => {
+    await expectToTakeTime(() => routes.main.gotoSettings(), 450);
+    await expectToTakeTime(() => routes.vpnSettings.goBack(), 450);
+
+    await expectToTakeTime(async () => {
+      await util.ipc.account.device.notify({
+        type: 'logged out',
+        deviceState: { type: 'logged out' },
+      });
+      await routes.login.waitForRoute();
+    }, 450);
+  });
+});
+
+async function expectToTakeTime(action: () => Promise<void> | void, minimumDuration: number) {
+  const startTime = Date.now();
+  await action();
+  const duration = Date.now() - startTime;
+  expect(duration).toBeGreaterThan(minimumDuration);
+}

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/launch.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/launch.spec.ts
@@ -19,7 +19,7 @@ test.describe('Launch', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.describe('Linux', () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/login.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/login.spec.ts
@@ -40,7 +40,7 @@ test.describe('Login view', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   const setAccountHistory = async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/login.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/login.spec.ts
@@ -14,8 +14,6 @@ let page: Page;
 let util: MockedTestUtils;
 let routes: RoutesObjectModel;
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('Login view', () => {
   const startup = async () => {
     ({ page, util } = await startMockedApp());

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/main.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/main.spec.ts
@@ -14,7 +14,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('Validate title', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/notifications.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/notifications.spec.ts
@@ -17,7 +17,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 /**

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
@@ -303,8 +303,7 @@ test.describe('Select location', () => {
         // Expect all filtered relays to have a button
         await expect(buttons).toHaveCount(relays.length);
       });
-    });
-    test.describe('Filter by LWO', () => {
+
       test('Should apply filter when LWO obfuscation is selected', async () => {
         const settings = getDefaultSettings();
         if ('normal' in settings.relaySettings) {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
@@ -17,16 +17,11 @@ let util: MockedTestUtils;
 let routes: RoutesObjectModel;
 let helpers: SelectLocationHelpers;
 
-test.describe.configure({ mode: 'parallel' });
-
 test.describe('Select location', () => {
   test.beforeAll(async () => {
     ({ page, util } = await startMockedApp());
     routes = new RoutesObjectModel(page, util);
     helpers = createHelpers(page, routes, util);
-
-    await util.ipc.tunnel.connect.ignore();
-    await util.ipc.settings.setRelaySettings.ignore();
 
     await util.expectRoute(RoutePath.main);
   });
@@ -135,6 +130,9 @@ test.describe('Select location', () => {
     });
 
     test('Should disable entry server in exit list', async () => {
+      await util.ipc.tunnel.connect.ignore();
+      await util.ipc.settings.setRelaySettings.ignore();
+
       const settings = await helpers.updateMockSettings({
         multihop: true,
         daita: true,
@@ -305,7 +303,8 @@ test.describe('Select location', () => {
         // Expect all filtered relays to have a button
         await expect(buttons).toHaveCount(relays.length);
       });
-
+    });
+    test.describe('Filter by LWO', () => {
       test('Should apply filter when LWO obfuscation is selected', async () => {
         const settings = getDefaultSettings();
         if ('normal' in settings.relaySettings) {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/select-location/select-location.spec.ts
@@ -33,7 +33,7 @@ test.describe('Select location', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test('Should focus search input on load', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/settings.spec.ts
@@ -13,7 +13,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await page.close();
+  await util?.closePage();
 });
 
 test('Account button should be displayed correctly', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/split-tunneling/split-tunneling.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/split-tunneling/split-tunneling.spec.ts
@@ -28,7 +28,7 @@ test.describe('Linux Split tunneling unsupported', () => {
   }
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.beforeAll(async () => {
@@ -74,7 +74,7 @@ test.describe('Linux Split tunneling supported', () => {
   }
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.beforeAll(async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/split-tunneling/split-tunneling.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/split-tunneling/split-tunneling.spec.ts
@@ -10,11 +10,14 @@ let page: Page;
 let util: MockedTestUtils;
 let routes: RoutesObjectModel;
 
-const startup = async () => {
+const startup = async (postLaunch?: () => Promise<void>) => {
   ({ page, util } = await startMockedApp());
   routes = new RoutesObjectModel(page, util);
 
   await util.expectRoute(RoutePath.main);
+
+  await postLaunch?.();
+
   await routes.main.gotoSettings();
   await routes.settings.gotoSplitTunnelingSettings();
 };
@@ -29,12 +32,10 @@ test.describe('Linux Split tunneling unsupported', () => {
   });
 
   test.beforeAll(async () => {
-    await startup();
-  });
-
-  test.beforeAll(async () => {
-    await util.ipc.linuxSplitTunneling.isSplitTunnelingSupported.handle(false);
-    await util.ipc.linuxSplitTunneling.getApplications.handle(linuxApplicationsList);
+    await startup(async () => {
+      await util.ipc.linuxSplitTunneling.isSplitTunnelingSupported.handle(false);
+      await util.ipc.linuxSplitTunneling.getApplications.handle(linuxApplicationsList);
+    });
   });
 
   test('App should show unsupported dialog when link in header is clicked', async () => {
@@ -77,12 +78,10 @@ test.describe('Linux Split tunneling supported', () => {
   });
 
   test.beforeAll(async () => {
-    await startup();
-  });
-
-  test.beforeAll(async () => {
-    await util.ipc.linuxSplitTunneling.isSplitTunnelingSupported.handle(true);
-    await util.ipc.linuxSplitTunneling.getApplications.handle(linuxApplicationsList);
+    await startup(async () => {
+      await util.ipc.linuxSplitTunneling.isSplitTunnelingSupported.handle(true);
+      await util.ipc.linuxSplitTunneling.getApplications.handle(linuxApplicationsList);
+    });
   });
 
   test('App list items should be shown', async () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/too-many-devices.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/too-many-devices.spec.ts
@@ -33,7 +33,7 @@ test.describe('Too many devices', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.describe('Navigation', () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/tunnel-state.spec.ts
@@ -93,10 +93,6 @@ test.describe('Connection states', () => {
       });
     });
 
-    test.afterEach(async () => {
-      await util.ipc.tunnel[''].notify({ state: 'disconnecting', details: 'nothing' });
-    });
-
     test('App should show connected tunnel state', async () => {
       await expectConnected(page);
     });

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/tunnel-state.spec.ts
@@ -34,7 +34,7 @@ test.describe('Connection states', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   /**

--- a/desktop/packages/mullvad-vpn/test/e2e/mocked/user-interface-settings/user-interface-settings.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/mocked/user-interface-settings/user-interface-settings.spec.ts
@@ -24,7 +24,7 @@ test.describe('User interface settings', () => {
   });
 
   test.afterAll(async () => {
-    await page.close();
+    await util?.closePage();
   });
 
   test.describe('Select language', () => {

--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/vpn-settings/vpn-settings-route-object-model.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/vpn-settings/vpn-settings-route-object-model.ts
@@ -2,16 +2,17 @@ import { Page } from 'playwright';
 
 import { RoutePath } from '../../../../src/shared/routes';
 import { TestUtils } from '../../utils';
+import { NavigationObjectModel } from '../navigation';
 import { createSelectors } from './selectors';
 
-export class VpnSettingsRouteObjectModel {
-  readonly page: Page;
-  readonly utils: TestUtils;
+export class VpnSettingsRouteObjectModel extends NavigationObjectModel {
   readonly selectors: ReturnType<typeof createSelectors>;
 
-  constructor(page: Page, utils: TestUtils) {
-    this.page = page;
-    this.utils = utils;
+  constructor(
+    public readonly page: Page,
+    public readonly utils: TestUtils,
+  ) {
+    super(page, utils);
     this.selectors = createSelectors(page);
   }
 

--- a/desktop/packages/mullvad-vpn/test/e2e/utils.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/utils.ts
@@ -4,6 +4,8 @@ import { expect } from '@playwright/test';
 import fs from 'fs';
 import { _electron as electron, ElectronApplication, Locator, Page } from 'playwright';
 
+const forceMotion = process.env.TEST_FORCE_MOTION === '1';
+
 export interface StartAppResponse {
   app: ElectronApplication;
   page: Page;
@@ -23,6 +25,11 @@ type LaunchOptions = NonNullable<Parameters<typeof electron.launch>[0]>;
 export const startApp = async (options: LaunchOptions): Promise<StartAppResponse> => {
   const app = await launch(options);
   const page = await app.firstWindow();
+
+  if (!forceMotion) {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+  }
+
   await page.waitForEvent('load');
 
   page.on('pageerror', (error) => console.log(error));


### PR DESCRIPTION
This PR sets the Electron app e2e tests to run with `reduced-motion: reduce`.  It also fixes some things to make the tests more stable.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->
