### PR TITLE
Update feature table to include LWO

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,22 +51,23 @@ in other DEs, but we don't regularly test those.
 Here is a table containing the features of the app across platforms. This is intended to reflect
 the current state of the latest code in git, not necessarily any existing release.
 
-|                               | Windows | Linux | macOS | Android | iOS |
-|-------------------------------|:-------:|:-----:|:-----:|:-------:|:---:|
-| OpenVPN                       |    ✓    |   ✓   |   ✓   |         |     |
-| WireGuard                     |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| Quantum-resistant tunnels     |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| [DAITA]                       |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| WireGuard multihop            |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| WireGuard over TCP            |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| WireGuard over Shadowsocks    |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| WireGuard over QUIC           |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| OpenVPN over Shadowsocks      |    ✓    |   ✓   |   ✓   |         |     |
-| Split tunneling               |    ✓    |   ✓   |   ✓   |    ✓    |     |
-| Custom DNS server             |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| Content blockers (Ads etc)    |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
-| Optional local network access |    ✓    |   ✓   |   ✓   |    ✓    |  ✓\* |
-| [Externally audited](./audits)|    ✓    |   ✓   |   ✓   |    ✓    |  ✓ |
+|                                         | Windows | Linux | macOS | Android | iOS |
+|-----------------------------------------|:-------:|:-----:|:-----:|:-------:|:---:|
+| OpenVPN                                 |    ✓    |   ✓   |   ✓   |         |     |
+| WireGuard                               |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| Quantum-resistant tunnels               |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| [DAITA]                                 |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| WireGuard multihop                      |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| WireGuard over TCP                      |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| WireGuard over Shadowsocks              |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| WireGuard over QUIC                     |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| Lightweight WireGuard Obfuscation (LWO) |    ✓    |   ✓   |   ✓   |    ✓    |     |
+| OpenVPN over Shadowsocks                |    ✓    |   ✓   |   ✓   |         |     |
+| Split tunneling                         |    ✓    |   ✓   |   ✓   |    ✓    |     |
+| Custom DNS server                       |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| Content blockers (Ads etc)              |    ✓    |   ✓   |   ✓   |    ✓    |  ✓  |
+| Optional local network access           |    ✓    |   ✓   |   ✓   |    ✓    |  ✓\* |
+| [Externally audited](./audits)          |    ✓    |   ✓   |   ✓   |    ✓    |  ✓ |
 
 \* The local network is always accessible on iOS with the current implementation
 


### PR DESCRIPTION
This PR adds Lightweight WireGuard obfuscation to the feature table and marks it as available on all platforms except iOS.

Technically not true until https://github.com/mullvad/mullvadvpn-app/pull/8887 has been merged, but seeing that it is already approved I figured we could save a PR if I just marked LWO as available on Android right away.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9008)
<!-- Reviewable:end -->
