### PR TITLE
Fix LWO obfuscator connecting before `bypass` call on Android

### DIFF
--- a/tunnel-obfuscation/src/lib.rs
+++ b/tunnel-obfuscation/src/lib.rs
@@ -53,6 +53,7 @@ pub enum Error {
 
 #[async_trait]
 pub trait Obfuscator: Send {
+    /// NOTE(Android): Make sure to call bypass on the obfuscator socket _before_ invoking run.
     async fn run(self: Box<Self>) -> Result<()>;
 
     /// Returns the address of the local socket.


### PR DESCRIPTION
This PR fixes a race between connecting with the LWO obfuscator and calling `remote_socket_fd` on the obfuscator socket. Now we delay connecting to the moment where `Obfuscator::run` is invoked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9014)
<!-- Reviewable:end -->
