### PR TITLE
Update code owners file

### DIFF
--- a/code-owners.json
+++ b/code-owners.json
@@ -2,14 +2,17 @@
   "appteam-desktop": [
     "building/Dockerfile",
     "building/linux-container-image.txt",
-    "ci/**",
-    "!ci/buildserver-build-android.sh",
-    "!ci/ios/**",
+    "ci/buildserver-build.sh",
+    "ci/buildserver-config.sh",
+    "ci/check-rust.sh",
+    "ci/linux-repository-builder/**",
+    "ci/publish-app-to-repositories.sh",
     "desktop/**",
     "!desktop/packages/mullvad-vpn/locales",
     "installer-downloader/**",
     "mullvad-*/**",
     "!mullvad-ios/**",
+    "!mullvad-jni/**",
     "rustfmt.toml",
     "rust-toolchain.toml",
     "talpid-*/**",
@@ -27,6 +30,7 @@
   "appteam-android": [
     "android/**",
     "building/android-container-image.txt",
-    "ci/buildserver-build-android.sh"
+    "ci/buildserver-build-android.sh",
+    "mullvad-jni/**"
   ]
 }


### PR DESCRIPTION
This PR updates the code owner file to:
1. Reflect the decision that the Android team should own `mullvad-jni`
2. Be more detailed on what parts of the `ci`-directory is owned by desktop

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9015)
<!-- Reviewable:end -->
