### PR TITLE
Use new product IDs for store kit 2

### DIFF
--- a/ios/MullvadVPN/StorePaymentManager/StoreSubscription.swift
+++ b/ios/MullvadVPN/StorePaymentManager/StoreSubscription.swift
@@ -10,9 +10,8 @@ import Foundation
 import StoreKit
 
 enum StoreSubscription: String, CaseIterable {
-    /// Thirty days non-renewable subscription
-    case thirtyDays = "net.mullvad.MullvadVPN.subscription.30days"
-    case ninetyDays = "net.mullvad.MullvadVPN.subscription.90days"
+    case thirtyDays = "net.mullvad.MullvadVPN.subscription.storekit2.30days"
+    case ninetyDays = "net.mullvad.MullvadVPN.subscription.storekit2.90days"
 
     var localizedTitle: String {
         switch self {


### PR DESCRIPTION
To enable services to deprecate the old API, we should use different product IDs with StoreKit2. This will allow us to remove the original payment IDs from the store, which then disables the ability to pay for the old subscription IDs in the app. This allows services to remove the old API.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9022)
<!-- Reviewable:end -->
