### PR TITLE
Fix broken direct only warning when toggling

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITATunnelSettingsViewModel.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/DAITA/DAITATunnelSettingsViewModel.swift
@@ -92,19 +92,16 @@ extension DAITATunnelSettingsViewModel {
 
         var compatibilityError: DAITASettingsCompatibilityError?
 
-        do {
-            _ = try tunnelManager.selectRelays(tunnelSettings: tunnelSettings)
-        } catch let error as NoRelaysSatisfyingConstraintsError where error.reason == .noDaitaRelaysFound {
-            // Return error if no relays could be selected due to DAITA constraints.
-            compatibilityError = tunnelSettings.tunnelMultihopState.isEnabled ? .multihop : .singlehop
-        } catch _ as NoRelaysSatisfyingConstraintsError {
-            // Even if the constraints error is not DAITA specific, if both DAITA and Direct only are enabled,
-            // we should return a DAITA related error since the current settings would have resulted in the
-            // relay selector not being able to select a DAITA relay anyway.
-            if settings.isDirectOnly {
+        if settings.isDirectOnly {
+            let relays = try? tunnelManager.selectRelays(tunnelSettings: tunnelSettings)
+
+            // Even if the reason for not finding any relays is not DAITA specific, if both DAITA and Direct
+            // only are enabled, we should return a DAITA related error since the current settings would have
+            // resulted in the relay selector not being able to select a DAITA relay anyway.
+            if relays == nil {
                 compatibilityError = tunnelSettings.tunnelMultihopState.isEnabled ? .multihop : .singlehop
             }
-        } catch {}
+        }
 
         return compatibilityError
     }


### PR DESCRIPTION
The dialog for warning the user if they would be blocked by toggling Direct only is also shown if you would still be blocked by disabling it. Essentially, this happens if you have DAITA incompatible filters set before enabling DAITA and Direct Only.

Steps to reproduce:
- Set filter to Blix
- Connect to Finland
- Enable DAITA
- Toggling Direct only now prompts the dialog both ways

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9024)
<!-- Reviewable:end -->
