### PR TITLE
Count PR author as approving code in code owner check

### DIFF
--- a/.github/workflows/code-owner-approval.yml
+++ b/.github/workflows/code-owner-approval.yml
@@ -137,7 +137,16 @@ jobs:
               // Set of teams that have approved this PR
               const approvedTeams = new Set();
 
+              // Get array of github usernames that have approved the PR
               const approvers = await getApprovers();
+
+              // PR author automatically counts as an approver. A code owner changing
+              // their own code does not need extra code owner approval. They still
+              // need the code reviewed, but that's not part of code ownership approval.
+              const prAuthor = context.payload.pull_request.user.login;
+              if (!approvers.includes(prAuthor)) {
+                approvers.push(prAuthor);
+              }
               console.log(`👍 PR approved by the following accounts: ${approvers.join(', ')}`);
 
               for (const approver of approvers) {


### PR DESCRIPTION
This relaxes our custom code ownership approval check. The PR author is now regarded as leaving code ownership approval for the change automatically. This means that if someone in team A submits a PR only changing code owned by team A, the code ownership approval check will not fail, since the author is counted as approval from code owner. The PR will still need a review by someone else according to our branch protection rules around reviews in general, but that is not dictated by our code ownership. This means that someone from team B could approve the example PR described.

If someone from team A submits a PR that touches code owned by both team A and B, only team B needs to approve the change before the code ownership check passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9025)
<!-- Reviewable:end -->
