### PR TITLE
Update selectors in too many devices e2e test

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/route-object-models/too-many-devices/selectors.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/route-object-models/too-many-devices/selectors.ts
@@ -2,4 +2,6 @@ import { Page } from 'playwright';
 
 export const createSelectors = (page: Page) => ({
   continueButton: () => page.getByRole('button', { name: 'Continue' }),
+  removeDeviceButtons: () => page.getByRole('button', { name: 'Remove device named' }),
+  confirmRemoveDeviceButton: () => page.getByRole('button', { name: 'Remove', exact: true }),
 });


### PR DESCRIPTION
Fixes state dependent e2e test that broke when adding the new device management view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9071)
<!-- Reviewable:end -->
