### PR TITLE
Refactoring iOS Rust build script (enforcing --locked on release builds)

### DIFF
--- a/ios/build-rust-library.sh
+++ b/ios/build-rust-library.sh
@@ -23,8 +23,10 @@ fi
 
 
 RELFLAG=
+LOCKEDFLAG=
 if [[ "$CONFIGURATION" == "Release" || "$CONFIGURATION" == "MockRelease" ]]; then
     RELFLAG=--release
+    LOCKEDFLAG=--locked
 fi
 
 # For whatever reason, Xcode includes its toolchain paths in the PATH variable such as
@@ -47,8 +49,8 @@ fi
 for arch in $ARCHS; do
     case "$arch" in
         arm64)
-            "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib $RELFLAG --target $TARGET ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
-            "$HOME"/.cargo/bin/cargo build -p "$FFI_TARGET" --lib --target $TARGET ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
+            "$HOME"/.cargo/bin/cargo build $LOCKEDFLAG -p "$FFI_TARGET" --lib $RELFLAG --target $TARGET ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
+            "$HOME"/.cargo/bin/cargo build $LOCKEDFLAG -p "$FFI_TARGET" --lib --target $TARGET ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
             ;;
     esac
 done


### PR DESCRIPTION
My initial motive was to enforce `--locked` on release builds, like on other platforms. When building actual build server artifacts we should never do that with outdated lockfiles, as it becomes really hard to later reproduce the same results, and it can be a supply chain attack vector.

However, I also saw other potential improvements to the iOS Rust build script. I went ahead and did some refactoring/cleanup. I have only tested this very limited on my Linux machine, not yet tried it from xcode on a mac. This of course has to be done before anything can be merged. Thus I'm marking this as a WIP PR for now.

Remaining questions I'd like to work together with the iOS team to answer and maybe fix:
* [ ] Do we really need to build everything twice (depending on `RELFLAG` we either build in debug mode twice or once in release mode and once in debug mode. This seems weird and slow
* [ ] The `arch` for loop case statement only has one branch: `arm64`. Is the script ever called with anything else? Can we have a catch-all branch `*)` where we print an error, or should other archs just be silently ignored?
* [ ] Do we really need to hardcode the full path to the `cargo` binary: `"$HOME"/.cargo/bin/cargo`?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9088)
<!-- Reviewable:end -->
