### PR TITLE
Add support for multihop entry filters in daemon

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -48,6 +48,7 @@ mod device;
 mod v1;
 mod v10;
 mod v11;
+mod v12;
 mod v2;
 mod v3;
 mod v4;
@@ -210,8 +211,8 @@ async fn migrate_settings(
     )?;
 
     v10::migrate(settings)?;
-
     v11::migrate(settings)?;
+    v12::migrate(settings)?;
 
     Ok(migration_data)
 }

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v12_to_v13_migration.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v12_to_v13_migration.snap
@@ -1,0 +1,57 @@
+---
+source: mullvad-daemon/src/migrations/v12.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "fr"
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      },
+      "ownership": {
+        "only": "MullvadOwned"
+      },
+      "providers": {
+        "only": {
+          "providers": [
+            "Blix",
+            "Creanova"
+          ]
+        }
+      },
+      "tunnel_protocol": "wireguard",
+      "wireguard_constraints": {
+        "allowed_ips": "any",
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        },
+        "entry_ownership": {
+          "only": "MullvadOwned"
+        },
+        "entry_providers": {
+          "only": {
+            "providers": [
+              "Blix",
+              "Creanova"
+            ]
+          }
+        },
+        "ip_version": "any",
+        "port": "any",
+        "use_multihop": true
+      }
+    }
+  },
+  "settings_version": 13
+}

--- a/mullvad-daemon/src/migrations/v12.rs
+++ b/mullvad-daemon/src/migrations/v12.rs
@@ -1,0 +1,102 @@
+use super::Result;
+use mullvad_types::settings::SettingsVersion;
+
+/// This version introduces 2 new fields to the [mullvad_constraints::WireguardConstraints] struct:
+/// pub entry_providers: Constraint<Providers>,
+/// pub entry_ownership: Constraint<Ownership>,
+/// When set, these filters apply to the entry relay when multihop is used.
+/// A migration is needed to transfer the current providers and ownership to these new fields
+/// so that the user's current filters don't change.
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to V13");
+
+    migrate_filters_to_new_entry_only_filters(settings);
+
+    settings["settings_version"] = serde_json::json!(SettingsVersion::V13);
+
+    Ok(())
+}
+
+fn version_matches(settings: &serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V12 as u64)
+        .unwrap_or(false)
+}
+
+fn migrate_filters_to_new_entry_only_filters(settings: &mut serde_json::Value) -> Option<()> {
+    let normal = settings.get_mut("relay_settings")?.get_mut("normal")?;
+    let providers = normal.get("providers")?.clone();
+    let ownership = normal.get("ownership")?.clone();
+
+    let wireguard_constraints = normal.get_mut("wireguard_constraints")?.as_object_mut()?;
+
+    wireguard_constraints.insert("entry_providers".to_string(), providers);
+    wireguard_constraints.insert("entry_ownership".to_string(), ownership);
+
+    Some(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::{migrate, version_matches};
+
+    const V12_SETTINGS: &str = r#"
+{
+  "relay_settings": {
+    "normal": {
+      "location": {
+        "only": {
+          "location": {
+            "country": "fr"
+          }
+        }
+      },
+      "providers": {
+        "only": {
+          "providers": [
+            "Blix",
+            "Creanova"
+          ]
+        }
+      },
+      "ownership": {
+        "only": "MullvadOwned"
+      },
+      "tunnel_protocol": "wireguard",
+      "wireguard_constraints": {
+        "port": "any",
+        "ip_version": "any",
+        "allowed_ips": "any",
+        "use_multihop": true,
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      },
+      "openvpn_constraints": {
+        "port": "any"
+      }
+    }
+  },
+  "settings_version": 12
+}
+"#;
+
+    #[test]
+    fn test_v12_to_v13_migration() {
+        let mut old_settings = serde_json::from_str(V12_SETTINGS).unwrap();
+
+        assert!(version_matches(&old_settings));
+
+        migrate(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+}

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -604,6 +604,8 @@ message WireguardConstraints {
   repeated string allowed_ips = 3;
   bool use_multihop = 4;
   LocationConstraint entry_location = 5;
+  repeated string entry_providers = 6;
+  Ownership entry_ownership = 7;
 }
 
 message CustomRelaySettings {

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -350,6 +350,8 @@ impl<'a> TryFrom<NormalSelectorConfig<'a>> for RelayQuery {
                 allowed_ips,
                 use_multihop,
                 entry_location,
+                entry_providers,
+                entry_ownership,
             } = wireguard_constraints;
             let AdditionalWireguardConstraints {
                 daita,
@@ -362,6 +364,8 @@ impl<'a> TryFrom<NormalSelectorConfig<'a>> for RelayQuery {
                 allowed_ips,
                 use_multihop: Constraint::Only(use_multihop),
                 entry_location,
+                entry_providers,
+                entry_ownership,
                 obfuscation: ObfuscationQuery::from(obfuscation_settings),
                 daita: Constraint::Only(daita),
                 daita_use_multihop_if_necessary: Constraint::Only(daita_use_multihop_if_necessary),
@@ -829,10 +833,12 @@ impl RelaySelector {
     ) -> Result<Multihop, Error> {
         // Here, we modify the original query just a bit.
         // The actual query for an entry relay is identical as for an exit relay, with the
-        // exception that the location is different. It is simply the location as dictated by
-        // the query's multihop constraint.
+        // exception that the location is different and that the entry filters may be different.
+        // The location is dictated by the query's multihop constraint.
         let mut entry_relay_query = query.clone();
         entry_relay_query.set_location(query.wireguard_constraints().entry_location.clone())?;
+        entry_relay_query.set_providers(query.wireguard_constraints().entry_providers.clone());
+        entry_relay_query.set_ownership(query.wireguard_constraints().entry_ownership);
         // After we have our two queries (one for the exit relay & one for the entry relay),
         // we can query for all exit & entry candidates! All candidates are needed for the next
         // step.

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -139,8 +139,16 @@ impl RelayQuery {
         &self.providers
     }
 
+    pub fn set_providers(&mut self, providers: Constraint<Providers>) {
+        self.providers = providers;
+    }
+
     pub fn ownership(&self) -> Constraint<Ownership> {
         self.ownership
+    }
+
+    pub fn set_ownership(&mut self, ownership: Constraint<Ownership>) {
+        self.ownership = ownership;
     }
 
     pub fn tunnel_protocol(&self) -> TunnelType {
@@ -276,6 +284,8 @@ pub struct WireguardRelayQuery {
     pub allowed_ips: Constraint<AllowedIps>,
     pub use_multihop: Constraint<bool>,
     pub entry_location: Constraint<LocationConstraint>,
+    pub entry_providers: Constraint<Providers>,
+    pub entry_ownership: Constraint<Ownership>,
     pub obfuscation: ObfuscationQuery,
     pub daita: Constraint<bool>,
     pub daita_use_multihop_if_necessary: Constraint<bool>,
@@ -375,6 +385,8 @@ impl WireguardRelayQuery {
             allowed_ips: Constraint::Any,
             use_multihop: Constraint::Any,
             entry_location: Constraint::Any,
+            entry_providers: Constraint::Any,
+            entry_ownership: Constraint::Any,
             obfuscation: ObfuscationQuery::Auto,
             daita: Constraint::Any,
             daita_use_multihop_if_necessary: Constraint::Any,
@@ -389,6 +401,8 @@ impl WireguardRelayQuery {
             ip_version: self.ip_version,
             allowed_ips: self.allowed_ips,
             entry_location: self.entry_location,
+            entry_providers: self.entry_providers,
+            entry_ownership: self.entry_ownership,
             use_multihop: self.use_multihop.unwrap_or(false),
         }
     }
@@ -408,6 +422,8 @@ impl From<WireguardRelayQuery> for WireguardConstraints {
             ip_version: value.ip_version,
             allowed_ips: value.allowed_ips,
             entry_location: value.entry_location,
+            entry_providers: value.entry_providers,
+            entry_ownership: value.entry_ownership,
             use_multihop: value.use_multihop.unwrap_or(false),
         }
     }
@@ -763,6 +779,20 @@ pub mod builder {
         /// multihop to be enabled.
         pub fn entry(mut self, location: impl Into<LocationConstraint>) -> Self {
             self.query.wireguard_constraints.entry_location = Constraint::Only(location.into());
+            self
+        }
+
+        /// Set the entry location in a multihop configuration. This requires
+        /// multihop to be enabled.
+        pub fn entry_providers(mut self, providers: Providers) -> Self {
+            self.query.wireguard_constraints.entry_providers = Constraint::Only(providers);
+            self
+        }
+
+        /// Set the entry location in a multihop configuration. This requires
+        /// multihop to be enabled.
+        pub fn entry_ownership(mut self, ownership: Ownership) -> Self {
+            self.query.wireguard_constraints.entry_ownership = Constraint::Only(ownership);
             self
         }
     }

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -410,6 +410,8 @@ pub struct WireguardConstraints {
     pub allowed_ips: Constraint<AllowedIps>,
     pub use_multihop: bool,
     pub entry_location: Constraint<LocationConstraint>,
+    pub entry_providers: Constraint<Providers>,
+    pub entry_ownership: Constraint<Ownership>,
 }
 
 pub use allowed_ip::AllowedIps;

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -20,7 +20,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V12;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V13;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -36,6 +36,7 @@ pub enum SettingsVersion {
     V10 = 10,
     V11 = 11,
     V12 = 12,
+    V13 = 13,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -55,6 +56,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V10 as u32 => Ok(SettingsVersion::V10),
             v if v == SettingsVersion::V11 as u32 => Ok(SettingsVersion::V11),
             v if v == SettingsVersion::V12 as u32 => Ok(SettingsVersion::V12),
+            v if v == SettingsVersion::V13 as u32 => Ok(SettingsVersion::V13),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),


### PR DESCRIPTION
In the upcoming re-design of select location, separate sets of filters can now be picked for the entry and the exit relays. This commit adds support for that in the relay selector.

In order to not affect the current behavior of the desktop and Android apps before the new UI is implemented, the entry filters are set to the same as the exit filters when the relay settings are updated via gRPC.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9105)
<!-- Reviewable:end -->
