### PR TITLE
Stop running `rustup update`. Version is handled by `rust-toolchain.toml`

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -189,12 +189,6 @@ function build_ref {
 
     checkout_ref "$ref" || return 1
 
-    # When we build in containers, the updating of toolchains is done by updating containers.
-    if [[ "$(uname -s)" != "Linux" ]]; then
-        echo "Updating Rust toolchain..."
-        rustup update
-    fi
-
     # podman appends a trailing carriage return to the output. So we use `tr` to strip it
     local version=""
     version="$(run_in_build_env cargo run -q --bin mullvad-version | tr -d "\r" || return 1)"

--- a/test/scripts/run/ci.sh
+++ b/test/scripts/run/ci.sh
@@ -22,12 +22,6 @@ fi
 
 TEST_OS=$1
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    # NOTE: We only do this on macOS since we use containers otherwise
-    echo "Updating Rust toolchain"
-    rustup update
-fi
-
 # shellcheck source=test/scripts/utils/lib.sh
 source "../utils/lib.sh"
 


### PR DESCRIPTION
I believe both of these invocations of `rustup update` are outdated and superfluous now. But please correct me if I am wrong. These two scripts are used on desktop only. And for all three desktop OSes we should be handling the Rust version in `rust-toolchain.toml`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9111)
<!-- Reviewable:end -->
