### PR TITLE
Ignore files in dist-assets/aarch64-unknown-linux-gnu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@
 /dist-assets/openvpn
 /dist-assets/openvpn.exe
 /dist-assets/aarch64-apple-darwin/
-/dist-assets/x86_64-apple-darwin/
 /dist-assets/aarch64-pc-windows-msvc/
+/dist-assets/aarch64-unknown-linux-gnu/
+/dist-assets/x86_64-apple-darwin/
 /windows/version.h
 /windows/winfw/src/winfw/lannetworks.h
 /windows/**/bin/


### PR DESCRIPTION
We were already ignoring `dist-assets/$target` in general. Just missing ARM64 Linux? This made the working directory on the Linux build server dirty. So we have to ignore it to make it clean again :sparkles: 

I also made sure they are sorted alphabetically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9115)
<!-- Reviewable:end -->
