### PR TITLE
Fix link to app update view appearing on Linux in unsupported version notification

### DIFF
--- a/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/notifications/unsupported-version.ts
@@ -4,6 +4,7 @@ import { AppVersionInfoSuggestedUpgrade } from '../daemon-rpc-types';
 import { getDownloadUrl } from '../version';
 import {
   InAppNotification,
+  InAppNotificationAction,
   InAppNotificationProvider,
   SystemNotification,
   SystemNotificationCategory,
@@ -69,21 +70,29 @@ export class UnsupportedVersionNotificationProvider
             // TRANSLATORS: A link in the in-app banner to encourage the user to update the app.
             // TRANSLATORS: The in-app banner is is displayed to the user when the running app becomes unsupported.
             messages.pgettext('notifications', 'Please click here to update now'),
-          action: this.context.suggestedUpgrade
-            ? {
-                type: 'navigate-internal',
-                link: {
-                  to: RoutePath.appUpgrade,
-                },
-              }
-            : {
-                type: 'navigate-external',
-                link: {
-                  to: getDownloadUrl(this.context.suggestedIsBeta ?? false),
-                },
-              },
+          action: this.getInAppNotificationAction(),
         },
       ],
+    };
+  }
+
+  private getInAppNotificationAction(): InAppNotificationAction {
+    if (this.context.suggestedUpgrade) {
+      if (process.platform !== 'linux') {
+        return {
+          type: 'navigate-internal',
+          link: {
+            to: RoutePath.appUpgrade,
+          },
+        };
+      }
+    }
+
+    return {
+      type: 'navigate-external',
+      link: {
+        to: getDownloadUrl(this.context.suggestedIsBeta ?? false),
+      },
     };
   }
 


### PR DESCRIPTION
Linux now gets the external download link.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9145)
<!-- Reviewable:end -->
