### PR TITLE
Prevent ST driver unload unless a successful reset occurs

### DIFF
--- a/talpid-core/src/split_tunnel/windows/service.rs
+++ b/talpid-core/src/split_tunnel/windows/service.rs
@@ -81,7 +81,14 @@ pub fn install_driver_if_required(resource_dir: &Path) -> Result<(), Error> {
     start_and_wait_for_service(&service)
 }
 
-pub fn stop_driver_service() -> Result<(), Error> {
+/// Stop the split tunnel driver service if it is running.
+///
+/// # Safety
+///
+/// The driver must be reset before calling this function. Failing to do so prevents
+/// the driver from freeing resources and unregistering its callbacks.
+// TODO: This is due to a bug in the driver. `unsafe` may be removed when this is fixed.
+pub unsafe fn stop_driver_service() -> Result<(), Error> {
     let scm = ServiceManager::local_computer(None::<OsString>, ServiceManagerAccess::CONNECT)
         .map_err(Error::OpenServiceControlManager)?;
 


### PR DESCRIPTION
There are two cases where an unload can occur without a reset by closing the channel in `spawn_request_thread`:
- `spawn_event_listener` fails. This would drop the sender without sending a `Request::Stop`.
- In `SpawnTunnel::drop`, the sender could be dropped if `Request::Stop` timed out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9154)
<!-- Reviewable:end -->
