### PR TITLE
Remove duplicate Windows BSOD fix entry from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,6 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Fix high CPU usage on macOS 26 by updating Electron. This affected the app when it was visible.
 
-#### Windows
-- Mitigate BSOD caused by split tunnel driver during boot.
-
-
 #### Linux
 - Install AppArmor profile on all Linux distributions that support AppArmor abi 4.0.
 


### PR DESCRIPTION
Title. This is already included under the (correct) `2025.12-beta` heading.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9161)
<!-- Reviewable:end -->
