### PR TITLE
Update translations

### DIFF
--- a/android/lib/resource/src/main/res/values-da/strings.xml
+++ b/android/lib/resource/src/main/res/values-da/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Alle udbydere</string>
     <string name="always_on_vpn_error_notification_content">Kunne ikke starte tunnelforbindelse. Deaktiver Altid-til VPN for &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="always_on_vpn_error_notification_title">Altid-til VPN tildelt %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Når en VPN-app er blevet opdateret på Android 16, kan enheder ende i en tilstand, hvor VPN-apps ikke længere kan få kontakt til internettet.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Genstart din enhed, og prøv at oprette forbindelse igen. Hvis det ikke hjælper, kan du skrive en e-mail til %1$s på svensk eller engelsk.</string>
+    <string name="android_16_upgrade_warning_message">Android 16 har et kendt problem. Genstart din enhed, og prøv igen. For at få mere at vide</string>
+    <string name="android_16_upgrade_warning_title">Kan du ikke oprette forbindelse?</string>
     <string name="any">Enhver</string>
     <string name="api_access_description">Administrer og tilføj brugerdefinerede metoder for at få adgang til Mullvad API.</string>
     <string name="api_access_method_info_first_line">Appen skal kommunikere med en Mullvad API-server for at kunne logge dig på, hente serverlister og andre kritiske operationer.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Nyheder</string>
     <string name="cipher">Chiffer</string>
     <string name="clear_input">Ryd input</string>
+    <string name="click_here">klik her</string>
     <string name="close">Luk</string>
     <string name="collapse">Skjul</string>
     <string name="confirm_ipv6_dns">IPv6 DNS-serveren fungerer ikke, medmindre du aktiverer \"IPv6\" under VPN-indstillinger.</string>
@@ -249,7 +254,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Fjern %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Enheden fjernes fra listen og logges ud.</string>
     <string name="manage_devices_description">Vis og administrer alle dine enheder, der er logget på. Du kan have op til 5 enheder på en konto ad gangen. Hver enhed tildeles et navn, når du logger på, så du let kan se forskel på dem.</string>
-    <string name="max_devices_confirm_removal_description">Er du sikker på, at du vil logge &lt;b&gt;%1$s&lt;/b&gt; ud?</string>
+    <string name="max_devices_confirm_removal_description">Er du sikker på, at du vil logge &lt;b&gt;%1$s&lt;/b&gt; af?</string>
     <string name="max_devices_resolved_description">Du kan nu fortsætte med at logge ind på denne enhed.</string>
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Log ud af mindst én ved at fjerne den fra listen nedenfor. Du kan finde det tilsvarende enhedsnavn under enhedens kontoindstillinger.</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Ingen brugerdefinerede lister tilgængelige</string>
     <string name="no_internet_connection">Ingen internetforbindelse</string>
     <string name="no_matching_relay">Ingen servere matcher dine indstillinger. Prøv at ændre server eller andre indstillinger.</string>
+    <string name="no_matching_servers_found_first_line">Der blev ikke fundet nogen matchende servere.</string>
+    <string name="no_matching_servers_found_second_line">Prøv at ændre dine filtre.</string>
     <string name="no_recent_selection">Ingen nylig valghistorik</string>
     <string name="no_wireguard_key">Gyldig WireGuard-nøgle mangler. Administrer nøgler under Avancerede indstillinger.</string>
     <string name="not_found">Ikke fundet</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Genopret forbindelse</string>
     <string name="redeem">Indløs</string>
     <string name="redeem_voucher">Indløs kupon</string>
+    <string name="refresh_server_list">Opdater serverlisten</string>
     <string name="relay_item_already_selected_as_entry">%1$s er allerede valgt som indgangsrelæ</string>
     <string name="relay_item_already_selected_as_exit">%1$s er allerede valgt som udgangsrelæ</string>
     <string name="relayitem_is_inactive">%1$s er ikke tilgængelig</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">Opdater DNS-server</string>
     <string name="update_list_name">Opdater listenavn</string>
+    <string name="updating_server_list_in_the_background">Opdaterer serverlisten i baggrunden ...</string>
     <string name="uri_browser_app_not_found">Der er ikke installeret nogen browser-app, så linket kunne ikke åbnes</string>
     <string name="uri_market_app_not_found">Der er ikke installeret nogen Android-appbutik, og linket kunne ikke åbnes</string>
     <string name="use_method">Brug metode</string>

--- a/android/lib/resource/src/main/res/values-de/strings.xml
+++ b/android/lib/resource/src/main/res/values-de/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Alle Anbieter</string>
     <string name="always_on_vpn_error_notification_content">Tunnelverbindung kann nicht gestartet werden. Bitte deaktivieren Sie Always-on VPN für &lt;b&gt;%1$s&lt;/b&gt;, bevor Sie Mullvad VPN verwenden.</string>
     <string name="always_on_vpn_error_notification_title">Always-on VPN ist %1$s zugeordnet</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Nach dem Update einer VPN-App auf Android 16 kann es vorkommen, dass die VPN-Apps auf diesen Geräten nicht länger auf das Internet zugreifen können.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Bitte starten Sie Ihr Gerät neu und versuchen Sie erneut, sich zu verbinden. Wenn dies nicht funktioniert, schreiben Sie bitte eine E-Mail an %1$s auf Schwedisch oder Englisch.</string>
+    <string name="android_16_upgrade_warning_message">Android 16 hat einen bekannten Fehler. Bitte starten Sie Ihr Gerät neu und versuchen Sie es erneut. Um mehr darüber zu erfahren,</string>
+    <string name="android_16_upgrade_warning_title">Keine Verbindung möglich?</string>
     <string name="any">Beliebige</string>
     <string name="api_access_description">Verwaltung und Hinzufügen benutzerdefinierter Methoden für den Zugriff auf die Mullvad-API.</string>
     <string name="api_access_method_info_first_line">Die App muss mit einem Mullvad API-Server kommunizieren, um Sie anzumelden, Serverlisten abzurufen und andere wichtige Vorgänge durchzuführen.</string>
@@ -67,12 +71,13 @@
     <string name="changelog_title">Was ist neu?</string>
     <string name="cipher">Chiffre</string>
     <string name="clear_input">Eingabe löschen</string>
+    <string name="click_here">klicken Sie hier</string>
     <string name="close">Schließen</string>
     <string name="collapse">Zuklappen</string>
     <string name="confirm_ipv6_dns">Der IPv6-DNS-Server wird nicht funktionieren, solange „IPv6“ nicht in den VPN-Einstellungen aktiviert ist.</string>
     <string name="confirm_local_dns">Der lokale DNS-Server wird nicht funktionieren, solange „Teilen im lokalen Netzwerk“ nicht in den VPN-Einstellungen aktiviert ist.</string>
     <string name="confirm_no_email">Sie wollen einen Problembericht senden, ohne uns die Möglichkeit zu geben, Sie zu erreichen. Wenn Sie sich eine Antwort zu Ihrem Problem wünschen, müssen Sie eine E-Mail-Adresse eingeben.</string>
-    <string name="confirm_removal">Ja, von Gerät abmelden</string>
+    <string name="confirm_removal">Ja, Gerät abmelden</string>
     <string name="congrats">Glückwunsch!</string>
     <string name="connect">Verbinden</string>
     <string name="connect_on_start">Verbinden beim Einschalten des Geräts</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Keine eigenen Listen verfügbar</string>
     <string name="no_internet_connection">Keine Internetverbindung</string>
     <string name="no_matching_relay">Kein Server entspricht Ihren Einstellungen. Versuchen Sie, den Server oder andere Einstellungen zu ändern.</string>
+    <string name="no_matching_servers_found_first_line">Keine passenden Server gefunden.</string>
+    <string name="no_matching_servers_found_second_line">Bitte versuchen Sie, Ihre Filter anzupassen.</string>
     <string name="no_recent_selection">Kein aktueller Auswahlverlauf</string>
     <string name="no_wireguard_key">Gültiger WireGuard-Schlüssel fehlt. Sie können Ihre Schlüssel in den erweiterten Einstellungen verwalten.</string>
     <string name="not_found">Nicht gefunden</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Erneut verbinden</string>
     <string name="redeem">Einlösen</string>
     <string name="redeem_voucher">Gutschein einlösen</string>
+    <string name="refresh_server_list">Serverliste aktualisieren</string>
     <string name="relay_item_already_selected_as_entry">%1$s wurde bereits als Eingangs-Relay ausgewählt</string>
     <string name="relay_item_already_selected_as_exit">%1$s wurde bereits als Ausgangs-Relay ausgewählt</string>
     <string name="relayitem_is_inactive">%1$s ist nicht verfügbar</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP über TCP</string>
     <string name="update_dns_server_dialog_title">DNS-Server aktualisieren</string>
     <string name="update_list_name">Name der Liste ändern</string>
+    <string name="updating_server_list_in_the_background">Serverliste wird im Hintergrund aktiviert …</string>
     <string name="uri_browser_app_not_found">Keine Browser-App installiert, Link konnte nicht geöffnet werden</string>
     <string name="uri_market_app_not_found">Kein Android-App-Store installiert, Link konnte nicht geöffnet werden</string>
     <string name="use_method">Methode verwenden</string>

--- a/android/lib/resource/src/main/res/values-es/strings.xml
+++ b/android/lib/resource/src/main/res/values-es/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Todos los proveedores</string>
     <string name="always_on_vpn_error_notification_content">No se puede iniciar la conexión de túnel. Deshabilite la VPN siempre activa en &lt;b&gt;%1$s&lt;/b&gt; antes de utilizar la VPN de Mullvad.</string>
     <string name="always_on_vpn_error_notification_title">La VPN siempre activa se ha asignado a %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Tras actualizar una aplicación VPN en Android 16, los dispositivos podrían terminar en un estado en el que las aplicaciones VPN ya no puedan conectarse a Internet.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Reinicie su dispositivo e intente conectarse de nuevo. Si esto no funciona, escriba un correo electrónico a %1$s en sueco o inglés.</string>
+    <string name="android_16_upgrade_warning_message">Android 16 tiene un problema conocido. Reinicie su dispositivo e inténtelo de nuevo. Para obtener más información,</string>
+    <string name="android_16_upgrade_warning_title">¿No se puede conectar?</string>
     <string name="any">Cualquiera</string>
     <string name="api_access_description">Gestione y añada métodos personalizados para acceder a la API de Mullvad.</string>
     <string name="api_access_method_info_first_line">La aplicación necesita comunicarse con un servidor API de Mullvad para iniciar su sesión, obtener las listas de servidores y otras operaciones críticas.</string>
@@ -67,12 +71,13 @@
     <string name="changelog_title">Novedades</string>
     <string name="cipher">Cifrado</string>
     <string name="clear_input">Borrar entrada</string>
+    <string name="click_here">haga clic aquí</string>
     <string name="close">Cerrar</string>
     <string name="collapse">Contraer</string>
     <string name="confirm_ipv6_dns">El servidor IPv6 DNS no funcionará a no ser que habilite la opción «IPv6» en la configuración de la VPN.</string>
     <string name="confirm_local_dns">El servidor DNS local no funcionará a no ser que habilite la opción «Uso compartido de red local» en la configuración de la VPN.</string>
     <string name="confirm_no_email">Va a enviar el informe de problemas sin indicar una forma de contacto. Para obtener una respuesta sobre el informe, necesita especificar su dirección de correo electrónico.</string>
-    <string name="confirm_removal">Sí, cerrar sesión</string>
+    <string name="confirm_removal">Sí, cerrar sesión en el dispositivo</string>
     <string name="congrats">¡Enhorabuena!</string>
     <string name="connect">Conectar</string>
     <string name="connect_on_start">Conectar al iniciar el dispositivo</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">No hay listas personalizadas disponibles</string>
     <string name="no_internet_connection">No hay conexión a Internet</string>
     <string name="no_matching_relay">Ningún servidor coincide con su configuración, pruebe con otro servidor u otra configuración.</string>
+    <string name="no_matching_servers_found_first_line">No se han encontrado servidores coincidentes.</string>
+    <string name="no_matching_servers_found_second_line">Intente cambiar los filtros.</string>
     <string name="no_recent_selection">No hay historial de selecciones recientes</string>
     <string name="no_wireguard_key">Falta una clave de WireGuard válida. Para administrar las claves, vaya a Configuración avanzada.</string>
     <string name="not_found">No encontrado</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Reconectar</string>
     <string name="redeem">Canjear</string>
     <string name="redeem_voucher">Canjear cupón</string>
+    <string name="refresh_server_list">Actualizar lista de servidores</string>
     <string name="relay_item_already_selected_as_entry">%1$s ya está seleccionado como retransmisor de entrada</string>
     <string name="relay_item_already_selected_as_exit">%1$s ya está seleccionado como retransmisor de salida</string>
     <string name="relayitem_is_inactive">%1$s no está disponible</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP sobre TCP</string>
     <string name="update_dns_server_dialog_title">Actualizar servidor DNS</string>
     <string name="update_list_name">Actualizar nombre de la lista</string>
+    <string name="updating_server_list_in_the_background">Actualizando lista de servidores en segundo plano...</string>
     <string name="uri_browser_app_not_found">No hay ninguna aplicación de navegador instalada. No se ha podido abrir el enlace</string>
     <string name="uri_market_app_not_found">No hay ninguna tienda de aplicaciones de Android instalada. No se ha podido abrir el enlace</string>
     <string name="use_method">Utilizar método</string>

--- a/android/lib/resource/src/main/res/values-fi/strings.xml
+++ b/android/lib/resource/src/main/res/values-fi/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Kaikki palveluntarjoajat</string>
     <string name="always_on_vpn_error_notification_content">Tunneliyhteyden käynnistäminen ei onnistu. Poista aina päällä oleva VPN käytöstä sovellukselle &lt;b&gt;%1$s&lt;/b&gt; ennen Mullvad VPN:n käyttämistä.</string>
     <string name="always_on_vpn_error_notification_title">%1$s on määritetty aina päällä olevan VPN:n asetukseksi</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Kun VPN-sovellus päivitetään Android 16:ssa, laitteen saattavat päätyä tilaan, jossa VPN-sovellukset eivät voi enää muodostaa yhteyttä internetiin.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Käynnistä laitteesi uudelleen ja yritä muodostaa yhteys uudelleen. Jos tämä ei toimi, lähetä sähköpostiviesti osoitteeseen %1$s ruotsiksi tai englanniksi.</string>
+    <string name="android_16_upgrade_warning_message">Android 16:ssa on tunnettu ongelma. Käynnistä laitteesi uudelleen ja yritä uudelleen. Saat lisätietoja</string>
+    <string name="android_16_upgrade_warning_title">Eikö yhteyden muodostaminen onnistu?</string>
     <string name="any">Mikä tahansa</string>
     <string name="api_access_description">Hallitse ja lisää mukautettuja menetelmiä Mullvadin ohjelmointirajapinnan käyttämiseksi.</string>
     <string name="api_access_method_info_first_line">Sovelluksen on kommunikoitava Mullvadin ohjelmointirajapinnan palvelimen kanssa, jotta sinut voidaan kirjata sisään, palvelinluetteloiden hakemiseksi sekä muiden tärkeiden toimintojen suorittamiseksi.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Uutta</string>
     <string name="cipher">Salaus</string>
     <string name="clear_input">Tyhjennä syöte</string>
+    <string name="click_here">painamalla tästä</string>
     <string name="close">Sulje</string>
     <string name="collapse">Näytä vähemmän</string>
     <string name="confirm_ipv6_dns">IPv6-DNS-palvelin ei toimi, ellet ota IPv6:ta käyttöön VPN-asetuksista.</string>
@@ -152,7 +157,7 @@
     <string name="dns_content_blockers">DNS-sisällönestotoiminnot</string>
     <string name="dns_content_blockers_custom_dns_warning">Huomio: asetusta ei voi käyttää yhdessä \"Käytä mukautettua DNS-palvelinta\" -asetuksen kanssa.</string>
     <string name="dns_content_blockers_info">Kun tämä ominaisuus on käytössä, se estää laitetta ottamasta yhteyttä tiettyihin verkkotunnuksiin tai -sivustoihin, jotka tunnetaan mainosten, haittaohjelmien, seurantaohjelmien tai muiden vastaavien jakelijoina.</string>
-    <string name="dns_content_blockers_subtitle">Ota nämä asetukset käyttöön poistamalla \"%1$s\" käytöstä alta.</string>
+    <string name="dns_content_blockers_subtitle">Poista \"%1$s\" käytöstä alla näiden asetusten aktivoimiseksi.</string>
     <string name="dns_content_blockers_warning">Tämä voi aiheuttaa ongelmia tietyillä verkkosivustoilla, palveluissa ja sovelluksissa.</string>
     <string name="dont_have_an_account">Eikö sinulla ole tilin numeroa?</string>
     <string name="duplicate_address_warning">Tämä osoite on annettu jo.</string>
@@ -247,9 +252,9 @@
     <string name="malware_info">Varoitus: haittaohjelmien estotoiminto ei ole virustorjuntaohjelma, eikä sitä pidä käyttää sellaisena – kyseessä on vain ylimääräinen suojauskerros.</string>
     <string name="manage_devices">Hallitse laitteita</string>
     <string name="manage_devices_confirm_removal_description_line1">Poistetaanko %1$s?</string>
-    <string name="manage_devices_confirm_removal_description_line2">Laite poistetaan luettelosta, ja sinut kirjataan ulos laitteelta.</string>
-    <string name="manage_devices_description">Tarkastele ja hallinnoi kaikkia kirjautuneita laitteitasi. Sinulla voi olla enintään viisi laitetta yhdellä tilillä samaan aikaan. Kukin laite saa nimen, kun se kirjataan sisään, jotta erotat ne helposti.</string>
-    <string name="max_devices_confirm_removal_description">Haluatko varmasti kirjautua ulos laitteelta &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="manage_devices_confirm_removal_description_line2">Laite poistetaan luettelosta ja kirjataan ulos.</string>
+    <string name="manage_devices_description">Tarkastele ja hallitse kaikkia kirjautuneita laitteitasi. Sinulla voi olla enintään viisi laitetta yhdellä tilillä samaan aikaan. Jokainen laite saa nimen, kun se kirjataan sisään, jotta erotat ne helposti.</string>
+    <string name="max_devices_confirm_removal_description">Haluatko varmasti kirjata laitteen &lt;b&gt;%1$s&lt;/b&gt; ulos?</string>
     <string name="max_devices_resolved_description">Voit nyt jatkaa kirjautumista tällä laitteella.</string>
     <string name="max_devices_resolved_title">Mahtavaa!</string>
     <string name="max_devices_warning_description">Kirjaudu ulos vähintään yhdestä luettelon laitteesta poistamalla se. Löydät vastaavan laitteen nimen laitteen tiliasetuksista.</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Mukautettuja luetteloita ei löytynyt</string>
     <string name="no_internet_connection">Ei verkkoyhteyttä</string>
     <string name="no_matching_relay">Mikään palvelin ei vastaa asetuksiasi. Kokeile vaihtaa palvelinta tai muuttaa muita asetuksia.</string>
+    <string name="no_matching_servers_found_first_line">Vastaavia palvelimia ei löytynyt.</string>
+    <string name="no_matching_servers_found_second_line">Kokeile muuttaa suodattimiasi.</string>
     <string name="no_recent_selection">Ei viimeisimpien valintojen historiaa</string>
     <string name="no_wireguard_key">Käypä WireGuard-avain puuttuu. Voit hallinnoida avaimia lisäasetuksissa.</string>
     <string name="not_found">Ei löydy</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Yhdistä uudelleen</string>
     <string name="redeem">Lunasta</string>
     <string name="redeem_voucher">Lunasta kuponki</string>
+    <string name="refresh_server_list">Päivitä palvelinluettelo</string>
     <string name="relay_item_already_selected_as_entry">%1$s on jo valittu tulovälityspalvelimeksi</string>
     <string name="relay_item_already_selected_as_exit">%1$s on jo valittu lähtövälityspalvelimeksi</string>
     <string name="relayitem_is_inactive">%1$s ei ole käytettävissä</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP TCP:n kautta</string>
     <string name="update_dns_server_dialog_title">Päivitä DNS-palvelin</string>
     <string name="update_list_name">Päivitä luettelon nimi</string>
+    <string name="updating_server_list_in_the_background">Palvelinluetteloa päivitetään taustalla...</string>
     <string name="uri_browser_app_not_found">Selainsovellusta ei ole asennettu, joten linkin avaaminen ei onnistu</string>
     <string name="uri_market_app_not_found">Androidin sovelluskauppaa ei ole asennettu, joten linkin avaaminen ei onnistu</string>
     <string name="use_method">Käytä menetelmä</string>

--- a/android/lib/resource/src/main/res/values-fr/strings.xml
+++ b/android/lib/resource/src/main/res/values-fr/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Tous les fournisseurs</string>
     <string name="always_on_vpn_error_notification_content">Impossible de démarrer la connexion au tunnel. Veuillez désactiver « Toujours exiger un VPN « pour &lt;b&gt;%1$s&lt;/b&gt; avant d\'utiliser Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">« Toujours exiger un VPN » est assigné à %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Après la mise à jour d\'une application de VPN sur Android 16, les appareils peuvent se retrouver dans un état où ces applications de VPN ne sont plus en mesure d\'accéder à Internet.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Veuillez redémarrer votre appareil et réessayer de vous connecter. Si cela ne fonctionne pas, veuillez envoyer un e-mail à %1$s en suédois ou en anglais.</string>
+    <string name="android_16_upgrade_warning_message">Android 16 présente un problème connu. Veuillez redémarrer votre appareil et réessayer. Pour en savoir plus,</string>
+    <string name="android_16_upgrade_warning_title">Connexion impossible ?</string>
     <string name="any">N\'importe lequel</string>
     <string name="api_access_description">Gérez et ajoutez des modes d\'accès personnalisés à l\'API Mullvad.</string>
     <string name="api_access_method_info_first_line">L\'application doit communiquer avec un serveur d\'API Mullvad pour vous connecter, récupérer des listes de serveurs et effectuer d\'autres opérations critiques.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Quoi de neuf</string>
     <string name="cipher">Chiffre</string>
     <string name="clear_input">Effacer la saisie</string>
+    <string name="click_here">cliquez ici</string>
     <string name="close">Fermer</string>
     <string name="collapse">Réduire</string>
     <string name="confirm_ipv6_dns">Le serveur DNS IPv6 ne fonctionnera pas si vous n\'activez pas « IPv6 » dans les paramètres VPN.</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Aucune liste personnalisée disponible</string>
     <string name="no_internet_connection">Aucune connexion à Internet</string>
     <string name="no_matching_relay">Aucun serveur ne correspond à vos paramètres, essayez de modifier les paramètres du serveur ou d\'autres paramètres.</string>
+    <string name="no_matching_servers_found_first_line">Aucun serveur correspondant trouvé.</string>
+    <string name="no_matching_servers_found_second_line">Veuillez essayer de changer vos filtres.</string>
     <string name="no_recent_selection">Aucun historique des sélections récentes</string>
     <string name="no_wireguard_key">Une clé WireGuard valide manque. Gérez les clés dans les paramètres avancés.</string>
     <string name="not_found">Introuvable</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Reconnexion</string>
     <string name="redeem">Échanger</string>
     <string name="redeem_voucher">Échanger un bon</string>
+    <string name="refresh_server_list">Mettre à jour la liste des serveurs</string>
     <string name="relay_item_already_selected_as_entry">%1$s est déjà sélectionné en tant que relai d\'entrée</string>
     <string name="relay_item_already_selected_as_exit">%1$s est déjà sélectionné en tant que relai de sortie</string>
     <string name="relayitem_is_inactive">%1$s est indisponible</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">Mettre à jour le serveur DNS</string>
     <string name="update_list_name">Mettre à jour le nom de la liste</string>
+    <string name="updating_server_list_in_the_background">Mise à jour en arrière-plan de la liste des serveurs…</string>
     <string name="uri_browser_app_not_found">Aucune application de navigateur n\'est installée, le lien ne peut pas être ouvert</string>
     <string name="uri_market_app_not_found">Aucune boutique d\'applications Android n\'est installée, le lien n\'a pas pu être ouvert</string>
     <string name="use_method">Utiliser la méthode</string>

--- a/android/lib/resource/src/main/res/values-it/strings.xml
+++ b/android/lib/resource/src/main/res/values-it/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Tutti i fornitori</string>
     <string name="always_on_vpn_error_notification_content">Impossibile avviare la connessione tunnel. Disabilita VPN sempre attiva per &lt;b&gt;%1$s&lt;/b&gt; prima di utilizzare Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">VPN sempre attiva assegnata a %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Dopo aver aggiornato un\'app VPN su Android 16, i dispositivi potrebbero trovarsi in uno stato in cui le app VPN non sono più in grado di accedere a Internet.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Riavvia il dispositivo e riprova a connetterti. Se non funziona, scrivi un\'e-mail a %1$s in svedese o in inglese.</string>
+    <string name="android_16_upgrade_warning_message">Android 16 presenta un problema noto. Riavvia il dispositivo e riprova. Per saperne di più,</string>
+    <string name="android_16_upgrade_warning_title">Impossibile connetterti?</string>
     <string name="any">Qualsiasi</string>
     <string name="api_access_description">Gestisci e aggiungi metodi personalizzati per accedere all\'API Mullvad.</string>
     <string name="api_access_method_info_first_line">L\'app deve comunicare con un server API Mullvad per accedere, recuperare elenchi di server e altre operazioni critiche.</string>
@@ -67,12 +71,13 @@
     <string name="changelog_title">Novità</string>
     <string name="cipher">Codice</string>
     <string name="clear_input">Cancella inserimento</string>
+    <string name="click_here">clicca qui</string>
     <string name="close">Chiudi</string>
     <string name="collapse">Comprimi</string>
     <string name="confirm_ipv6_dns">Il server DNS IPv6 non funzionerà a meno che non abiliti \"IPv6\" nelle impostazioni VPN.</string>
     <string name="confirm_local_dns">Il server DNS locale non funzionerà a meno che non abiliti \"Condivisione rete locale\" nelle impostazioni VPN.</string>
     <string name="confirm_no_email">Stai inviando la segnalazione di un problema senza averci indicato un modo per ricontattarti. Se desideri ricevere risposta, inserisci un indirizzo e-mail.</string>
-    <string name="confirm_removal">Sì, disconnetti dal dispositivo</string>
+    <string name="confirm_removal">Sì, disconnetti il dispositivo</string>
     <string name="congrats">Complimenti!</string>
     <string name="connect">Connetti</string>
     <string name="connect_on_start">Connetti all\'avvio del dispositivo</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Nessun elenco personalizzato disponibile</string>
     <string name="no_internet_connection">Nessuna connessione Internet</string>
     <string name="no_matching_relay">Nessun server corrispondente alle tue impostazioni, prova a cambiare server o impostazioni.</string>
+    <string name="no_matching_servers_found_first_line">Nessun server corrispondente trovato.</string>
+    <string name="no_matching_servers_found_second_line">Prova a cambiare i filtri.</string>
     <string name="no_recent_selection">Nessuna cronologia di selezioni recente</string>
     <string name="no_wireguard_key">Manca una chiave WireGuard valida. Gestisci le chiavi da Impostazioni avanzate.</string>
     <string name="not_found">Non trovato</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Riconnetti</string>
     <string name="redeem">Riscatta</string>
     <string name="redeem_voucher">Riscatta voucher</string>
+    <string name="refresh_server_list">Aggiorna elenco server</string>
     <string name="relay_item_already_selected_as_entry">%1$s già selezionato come entry relay</string>
     <string name="relay_item_already_selected_as_exit">%1$s già selezionato come exit relay</string>
     <string name="relayitem_is_inactive">%1$s non disponibile</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">Aggiorna server DNS</string>
     <string name="update_list_name">Aggiorna nome elenco</string>
+    <string name="updating_server_list_in_the_background">Aggiornamento dell\'elenco server in background...</string>
     <string name="uri_browser_app_not_found">Nessuna app browser installata, impossibile aprire il link</string>
     <string name="uri_market_app_not_found">Nessun app store Android installato, impossibile aprire il link</string>
     <string name="use_method">Usa metodo</string>

--- a/android/lib/resource/src/main/res/values-ja/strings.xml
+++ b/android/lib/resource/src/main/res/values-ja/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">すべてのプロバイダ</string>
     <string name="always_on_vpn_error_notification_content">トンネル接続を開始できません。Mullvad VPNを使用する前に&lt;b&gt;%1$s&lt;/b&gt;のAlways-on VPNを無効にしてください。</string>
     <string name="always_on_vpn_error_notification_title">Always-on VPNは%1$sに割り当てられました</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Android 16でVPNアプリを更新すると、デバイス上のVPNアプリがインターネットにアクセス不可能な状態になる可能性があります。</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">デバイスを再起動して再接続してください。それでも問題が解決しない場合は、%1$sにスウェーデン語か英語のメールでお問い合わせください。</string>
+    <string name="android_16_upgrade_warning_message">Android 16には既知の問題があります。デバイスを再起動して再試行してください。詳細は、</string>
+    <string name="android_16_upgrade_warning_title">接続できませんか？</string>
     <string name="any">すべて</string>
     <string name="api_access_description">Mullvad APIへのカスタムのアクセス方法を管理・追加します。</string>
     <string name="api_access_method_info_first_line">アプリはユーザーのログイン、サーバーリストの取得、およびその他の重要な操作を行うためにMullvad APIサーバーと通信する必要があります。</string>
@@ -67,12 +71,13 @@
     <string name="changelog_title">新機能</string>
     <string name="cipher">暗号化</string>
     <string name="clear_input">入力をクリア</string>
+    <string name="click_here">ここをクリックしてください</string>
     <string name="close">閉じる</string>
     <string name="collapse">折りたたむ</string>
     <string name="confirm_ipv6_dns">VPN設定で [IPv6] を有効にしない限り、IPv6 DNSサーバーは機能しません。</string>
     <string name="confirm_local_dns">VPN設定で [ローカルネットワーク共有] を有効にしない限り、ローカルDNSサーバーは機能しません。</string>
     <string name="confirm_no_email">お客様への返信先を入力せずに問題の報告を送信しようとしています。ご報告に対する返信が必要な場合は、返信先のメールアドレスを入力する必要があります。</string>
-    <string name="confirm_removal">はい。デバイスをログアウトさせます</string>
+    <string name="confirm_removal">はい。デバイスをログアウトします</string>
     <string name="congrats">おめでとうございます！</string>
     <string name="connect">接続</string>
     <string name="connect_on_start">デバイス起動時に接続</string>
@@ -245,7 +250,7 @@
     <string name="login_fail_title">ログインに失敗しました</string>
     <string name="login_title">ログイン</string>
     <string name="malware_info">警告: マルウェアブロッカーはウィルス対策ではありませんので、そのような用途には使用しないでください。あくまで追加の保護レイヤーに過ぎません。</string>
-    <string name="manage_devices">デバイスを管理する</string>
+    <string name="manage_devices">デバイスを管理</string>
     <string name="manage_devices_confirm_removal_description_line1">%1$sを削除しますか？</string>
     <string name="manage_devices_confirm_removal_description_line2">リストからデバイスが削除され、ログアウトされます。</string>
     <string name="manage_devices_description">ログイン中のすべてのデバイスを表示・管理します。1つのアカウントで最大5台のデバイスを同時に利用できます。各デバイスは識別しやすくするため、ログイン時に名前が付けられます。</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">利用可能なカスタムリストはありません</string>
     <string name="no_internet_connection">インターネット接続がありません</string>
     <string name="no_matching_relay">設定に一致するサーバーはありません。サーバーまたは他の設定を変更してみてください。</string>
+    <string name="no_matching_servers_found_first_line">一致するサーバーが見つかりません。</string>
+    <string name="no_matching_servers_found_second_line">条件を変更してみてください。</string>
     <string name="no_recent_selection">最近の選択履歴はありません</string>
     <string name="no_wireguard_key">有効なWireGuard鍵が見つかりません。詳細設定で鍵を管理してください。</string>
     <string name="not_found">見つかりませんでした</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">再接続</string>
     <string name="redeem">使用する</string>
     <string name="redeem_voucher">バウチャーを使用する</string>
+    <string name="refresh_server_list">サーバーリストを更新</string>
     <string name="relay_item_already_selected_as_entry">%1$sはすでに入口中継サーバーとして選択されています</string>
     <string name="relay_item_already_selected_as_exit">%1$sはすでに出口中継サーバーとして選択されています</string>
     <string name="relayitem_is_inactive">%1$sは使用できません</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">DNS サーバーを更新</string>
     <string name="update_list_name">リスト名の更新</string>
+    <string name="updating_server_list_in_the_background">サーバーリストをバックグラウンドで更新中...</string>
     <string name="uri_browser_app_not_found">ブラウザアプリがインストールされていないため、リンクを開けませんでした</string>
     <string name="uri_market_app_not_found">Androidアプリストアがインストールされていないため、リンクを開けませんでした</string>
     <string name="use_method">この方法を使用する</string>

--- a/android/lib/resource/src/main/res/values-ko/strings.xml
+++ b/android/lib/resource/src/main/res/values-ko/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">모든 제공업체</string>
     <string name="always_on_vpn_error_notification_content">터널 연결을 시작할 수 없습니다. Mullvad VPN을 사용하기 전에 &lt;b&gt;%1$s&lt;/b&gt;에 대한 상시 접속 VPN을 비활성화하세요.</string>
     <string name="always_on_vpn_error_notification_title">상시 접속 VPN이 %1$s에 할당됨</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Android 16에서 VPN 앱을 업데이트하면 VPN 앱이 더 이상 인터넷에 연결되지 않는 상태가 될 수 있습니다.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">장치를 재시작하고 다시 연결해 주세요. 그래도 해결되지 않는다면 %1$s에 스웨덴어 또는 영어로 이메일을 보내주세요.</string>
+    <string name="android_16_upgrade_warning_message">Android 16에는 알려진 문제가 있습니다. 장치를 재시작한 후 다시 시도해 주세요. 자세한 내용을 알아보려면</string>
+    <string name="android_16_upgrade_warning_title">연결이 되지 않나요?</string>
     <string name="any">모두</string>
     <string name="api_access_description">Mullvad API에 액세스하기 위한 사용자 지정 방법을 관리하고 추가합니다.</string>
     <string name="api_access_method_info_first_line">이 앱은 로그인, 서버 목록 가져오기 및 기타 중요한 작업을 위해 Mullvad API 서버와 통신해야 합니다.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">새로운 기능</string>
     <string name="cipher">암호</string>
     <string name="clear_input">입력 지우기</string>
+    <string name="click_here">여기를 클릭하세요</string>
     <string name="close">닫기</string>
     <string name="collapse">접기</string>
     <string name="confirm_ipv6_dns">VPN 설정에서 \"IPv6\"를 활성화하지 않으면 IPv6 DNS 서버가 작동하지 않습니다.</string>
@@ -152,7 +157,7 @@
     <string name="dns_content_blockers">DNS 콘텐츠 차단기</string>
     <string name="dns_content_blockers_custom_dns_warning">주의: 이 설정은 \"사용자 지정 DNS 서버 사용\"과 함께 사용할 수 없습니다.</string>
     <string name="dns_content_blockers_info">이 기능이 활성화되면 광고, 맬웨어, 트래커 등을 배포하는 것으로 알려진 특정 도메인이나 웹사이트에 장치가 연결하지 않게 방지됩니다.</string>
-    <string name="dns_content_blockers_subtitle">이 설정을 활성화하려면 아래의 \"%1$s\"를 비활성화하세요.</string>
+    <string name="dns_content_blockers_subtitle">이 설정을 활성화하려면 아래의 \"%1$s\"을(를) 비활성화하세요.</string>
     <string name="dns_content_blockers_warning">이 기능을 사용하면 특정 웹 사이트, 서비스 및 앱에서 문제가 발생할 수 있습니다.</string>
     <string name="dont_have_an_account">계정 번호가 없으신가요?</string>
     <string name="duplicate_address_warning">이 주소는 이미 입력되었습니다.</string>
@@ -248,7 +253,7 @@
     <string name="manage_devices">장치 관리</string>
     <string name="manage_devices_confirm_removal_description_line1">%1$s을(를) 제거하시겠습니까?</string>
     <string name="manage_devices_confirm_removal_description_line2">장치가 목록에서 제거되고 로그아웃됩니다.</string>
-    <string name="manage_devices_description">로그인된 모든 장치를 보고 관리하세요. 한 계정에서 최대 5대의 장치를 동시에 보유할 수 있습니다. 사용자가 쉽게 구분할 수 있도록 각 장치에는 로그인 시 이름이 부여됩니다.</string>
+    <string name="manage_devices_description">로그인된 모든 장치를 보고 관리하세요. 한 계정에서 최대 5대의 장치를 동시에 보유할 수 있습니다. 사용자가 쉽게 구분할 수 있도록 로그인 시 각 장치에 이름이 부여됩니다.</string>
     <string name="max_devices_confirm_removal_description">&lt;b&gt;%1$s&lt;/b&gt;에서 로그아웃하시겠습니까?</string>
     <string name="max_devices_resolved_description">이제 이 장치에 계속 로그인할 수 있습니다.</string>
     <string name="max_devices_resolved_title">좋습니다!</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">이용 가능한 사용자 지정 목록 없음</string>
     <string name="no_internet_connection">인터넷에 연결되지 않음</string>
     <string name="no_matching_relay">설정과 일치하는 서버가 없습니다. 서버 또는 기타 설정을 변경해 보세요.</string>
+    <string name="no_matching_servers_found_first_line">일치하는 서버를 찾을 수 없습니다.</string>
+    <string name="no_matching_servers_found_second_line">필터를 변경해 보세요.</string>
     <string name="no_recent_selection">최근 선택 내역이 없습니다</string>
     <string name="no_wireguard_key">유효한 WireGuard 키가 없습니다. 고급 설정에서 키를 관리하세요.</string>
     <string name="not_found">찾을 수 없음</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">다시 연결</string>
     <string name="redeem">사용</string>
     <string name="redeem_voucher">바우처 사용</string>
+    <string name="refresh_server_list">서버 목록 업데이트</string>
     <string name="relay_item_already_selected_as_entry">%1$s이(가) 이미 진입 릴레이로 선택되었습니다</string>
     <string name="relay_item_already_selected_as_exit">%1$s이(가) 이미 출구 릴레이로 선택되었습니다</string>
     <string name="relayitem_is_inactive">%1$s 사용 불가</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">DNS 서버 업데이트</string>
     <string name="update_list_name">목록 이름 업데이트</string>
+    <string name="updating_server_list_in_the_background">백그라운드에서 서버 목록을 업데이트하는 중...</string>
     <string name="uri_browser_app_not_found">설치되어 있는 브라우저 앱이 없습니다. 링크를 열 수 없습니다</string>
     <string name="uri_market_app_not_found">설치되어 있는 Android 앱 스토어가 없습니다. 링크를 열 수 없습니다</string>
     <string name="use_method">방법 사용</string>

--- a/android/lib/resource/src/main/res/values-my/strings.xml
+++ b/android/lib/resource/src/main/res/values-my/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">ပံ့ပိုးသူအားလုံး</string>
     <string name="always_on_vpn_error_notification_content">Tunnel ချိတ်ဆက်မှုကို စတင်၍ မရနိုင်ပါ။ Mullvad VPN ကို မသုံးမီ &lt;b&gt;%1$s&lt;/b&gt; အတွက် VPN အမြဲဖွင့်ထားမှုကို ပိတ်ပေးပါ။</string>
     <string name="always_on_vpn_error_notification_title">အမြဲဖွင့် VPN ကို %1$s သို့ သတ်မှတ်ထားပါသည်</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Android 16 တွင် VPN အက်ပ်ကို အပ်ဒိတ်လုပ်ပြီးနောက် စက်များတွင် VPN အက်ပ်များက အင်တာနက်ချိတ်မပေးနိုင်တော့သည့် အခြေအနေမျိုး ကြုံရတတ်သည်။</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">စက်ကို ရီစတက်ချပြီး ထပ်မံချိတ်ဆက်ကြည့်ပါ။ ချိတ်၍မရသေးလျှင် %1$s သို့ ဆွီဒင် သို့မဟုတ် အင်္ဂလိပ်ဘာသာစကားဖြင့် အီးမေးလ်ပို့ပါ။</string>
+    <string name="android_16_upgrade_warning_message">Android 16 တွင် သိထားပြီးသား ပြဿနာရှိသည်။ သင့်စက်ကို ရီစတက်ချပြီး ထပ်မံကြိုးစားပါ။ ပိုမိုလေ့လာရန်၊ </string>
+    <string name="android_16_upgrade_warning_title">ချိတ်မရဘူးလား။</string>
     <string name="any">တစ်ခုခု</string>
     <string name="api_access_description">Mullvad API ကို ရယူသုံးစွဲရန် စိတ်ကြိုက် နည်းလမ်းများကို ပေါင်းထည့်၍ စီမံပါ။</string>
     <string name="api_access_method_info_first_line">Mullvad API ဆာဗာသို့ သင်ဝင်ရောက်ရန်၊ ဆာဗာစာရင်းများ ရယူရန်နှင့် အလွန်အရေးပါသည့် အခြားလုပ်ဆောင်မှုများအတွက် ဤအက်ပ်သည် ၎င်းနှင့်ဆက်သွယ်ရန် လိုအပ်ပါသည်။</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">အသစ်ပါလာသော အကြောင်းအရာများ</string>
     <string name="cipher">ဝှက်စာ</string>
     <string name="clear_input">ထည့်သွင်းမှုကို ရှင်းရန်</string>
+    <string name="click_here">ဤနေရာကိုနှိပ်ပါ</string>
     <string name="close">ပိတ်ရန်</string>
     <string name="collapse">ချုံ့ရန်</string>
     <string name="confirm_ipv6_dns">VPN ဆက်တင်များအောက်ရှိ \"IPv6\" ကို မဖွင့်ထားပါက IPv6 DNS ဆာဗာသည် အလုပ်လုပ်မည်မဟုတ်ပါ။</string>
@@ -183,7 +188,7 @@
     <string name="expand">ဖြန့်ရန်</string>
     <string name="failed_to_block_internet">ကွန်ရက် ကူးလူးမှု အားလုံးကို ပိတ်ဆို့၍ မရနိုင်ပါ။ ပြစ်ချက် ရှာဖွေဖယ်ရှားပေးပါ သို့မဟုတ် ပြဿနာ ရီပို့တ်တစ်ခု ပေးပို့ပါ။</string>
     <string name="failed_to_create_account">အကောင့် ဖန်တီးရန် မအောင်မြင်ခဲ့ပါ</string>
-    <string name="failed_to_fetch_devices">စက်စာရင်းကို ယူရန် မအောင်မြင်ခဲ့ပါ</string>
+    <string name="failed_to_fetch_devices">စက်စာရင်းကို ယူ၍မရခဲ့ပါ</string>
     <string name="failed_to_load_products">ထုတ်ကုန်များကို လုပ်ဆောင်၍ မရပါ၊ ထပ်ကြိုးစားကြည့်ပါ</string>
     <string name="failed_to_remove_device">စက်ကို ဖယ်ရှားရန် မအောင်မြင်ခဲ့ပါ</string>
     <string name="failed_to_send">ပို့ရန် မအောင်မြင်ခဲ့ပါ</string>
@@ -248,7 +253,7 @@
     <string name="manage_devices">စက်များကို စီမံရန်</string>
     <string name="manage_devices_confirm_removal_description_line1">%1$s ကို ဖယ်ရှားမလား။</string>
     <string name="manage_devices_confirm_removal_description_line2">စက်ကို စာရင်းမှ ဖယ်ရှားပြီး စနစ်မှ ထွက်သွားလိမ့်မည်။</string>
-    <string name="manage_devices_description">သင်ဝင်ရောက်ထားသည့် စက်ပစ္စည်းအားလုံးကို ကြည့်ရှုစီမံပါ။ အကောင့်တစ်ခုဖြင့် တစ်ချိန်တည်းတွင် စက်ပစ္စည်း ၅ ခုအထိသုံးနိုင်သည်။ စက်ပစ္စည်းတစ်ခုစီသည် ၎င်းတို့ကို အလွယ်တကူခွဲ၍သိနိုင်ရန် လော့ဂ်အင်ဝင်သည့်အခါ အမည်တစ်ခုရရှိမည်ဖြစ်သည်။</string>
+    <string name="manage_devices_description">သင်ဝင်ရောက်ထားသည့် စက်အားလုံးကို ကြည့်ရှုစီမံပါ။ အကောင့်တစ်ခုလျှင် စက် ၅ လုံးအထိ တစ်ပြိုင်နက်ဝင်ထားနိုင်သည်။ ဝင်ရောက်သည့်အခါတိုင်း ခွဲခြားရလွယ်ကူစေရန် စက်တစ်လုံးချင်းကို အမည်ပေးထားသည်။</string>
     <string name="max_devices_confirm_removal_description">&lt;b&gt;%1$s&lt;/b&gt; မှ ထွက်လိုသည်မှာ သေချာပါသလား။</string>
     <string name="max_devices_resolved_description">သင်သည် ယခု ဤစက်တွင် ဆက်လက် ဝင်ရောက်နိုင်သည်။</string>
     <string name="max_devices_resolved_title">အလွန်ကောင်း။</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">စိတ်ကြိုက် စာရင်းများကို မရရှိနိုင်ပါ</string>
     <string name="no_internet_connection">အင်တာနက် ချိတ်ဆက်မှု မရှိပါ</string>
     <string name="no_matching_relay">သင့်ဆက်တင်နှင့် ကိုက်ညီသော ဆာဗာများ မရှိပါ၊ ဆာဗာ သို့မဟုတ် အခြားဆက်တင်တို့ကို ပြောင်းလဲရန် ကြိုးစားကြည့်ပါ။</string>
+    <string name="no_matching_servers_found_first_line">ကိုက်ညီသည့် ဆာဗာများ မတွေ့ပါ။</string>
+    <string name="no_matching_servers_found_second_line">စစ်ထုတ်မှုများကို ပြောင်းကြည့်ပါ။</string>
     <string name="no_recent_selection">လတ်တလောရွေးချယ်မှု မှတ်တမ်း မရှိပါ</string>
     <string name="no_wireguard_key">အကျုံးဝင်သည့် WireGuard ကီး မရှိပါ။ အဆင့်မြင့်ဆက်တင် အောက်တွင် ကီးများကို စီမံခန့်ခွဲပါ။</string>
     <string name="not_found">ရှာမတွေ့ပါ</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">ပြန်ချိတ်ဆက်ရန်</string>
     <string name="redeem">လဲယူရန်</string>
     <string name="redeem_voucher">ဘောက်ချာဖြင့် လဲယူရန်</string>
+    <string name="refresh_server_list">ဆာဗာစာရင်းကို အပ်ဒိတ်လုပ်ရန်</string>
     <string name="relay_item_already_selected_as_entry">%1$s ကို ထပ်ဆင့်ဝင်ပေါက်အဖြစ် ရွေးထားပြီးဖြစ်သည်</string>
     <string name="relay_item_already_selected_as_exit">%1$s ကို ထပ်ဆင့်ထွက်ပေါက်အဖြစ် ရွေးထားပြီးဖြစ်သည်</string>
     <string name="relayitem_is_inactive">%1$s ကို မရရှိနိုင်ပါ</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">DNS ဆာဗာကို အပ်ဒိတ်လုပ်ရန်</string>
     <string name="update_list_name">စာရင်း အမည်ကို အပ်ဒိတ်လုပ်ရန်</string>
+    <string name="updating_server_list_in_the_background">နောက်ခံတွင် ဆာဗာစာရင်းကို အပ်ဒိတ်လုပ်နေသည်...</string>
     <string name="uri_browser_app_not_found">ဘရောက်ဇာအက်ပ် တစ်ခုမျှ ထည့်သွင်းထားခြင်း မရှိပါ၊ လင့်ခ်ကို ဖွင့်၍မရပါ</string>
     <string name="uri_market_app_not_found">Android အက်ပ်စတိုး တစ်ခုမျှ ထည့်သွင်းထားခြင်း မရှိပါ၊ လင့်ခ်ကို ဖွင့်၍မရပါ</string>
     <string name="use_method">နည်းလမ်းကို သုံးရန်</string>

--- a/android/lib/resource/src/main/res/values-nb/strings.xml
+++ b/android/lib/resource/src/main/res/values-nb/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Alle leverandører</string>
     <string name="always_on_vpn_error_notification_content">Kunne ikke starte tunneltilkobling. Deaktiver VPN som alltid er på, for &lt;b&gt;%1$s&lt;/b&gt; før du bruker Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">VPN som alltid er på, er tilordnet %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Etter å ha oppdatert en VPN-app på Android 16, kan enhetene havne i en tilstand der VPN-appene ikke lenger får tilgang til internett.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Start enheten på nytt og prøv å koble til igjen. Hvis dette ikke fungerer, kan du skrive en e-post til %1$s på svensk eller engelsk.</string>
+    <string name="android_16_upgrade_warning_message">Android 16 har en kjent feil. Start enheten på nytt og prøv igjen. For å finne ut mer,</string>
+    <string name="android_16_upgrade_warning_title">Kan du ikke koble til?</string>
     <string name="any">Hvilken som helst</string>
     <string name="api_access_description">Administrer og legg til tilpassede metoder for tilgang til Mullvad API.</string>
     <string name="api_access_method_info_first_line">Appen må kunne kommunisere med en Mullvad API-server for å logge deg inn, hente serverlister og utføre andre kritiske operasjoner.</string>
@@ -67,12 +71,13 @@
     <string name="changelog_title">Dette er nytt</string>
     <string name="cipher">Chiffer</string>
     <string name="clear_input">Fjern inndata</string>
+    <string name="click_here">klikk her</string>
     <string name="close">Lukk</string>
     <string name="collapse">Skjul</string>
     <string name="confirm_ipv6_dns">IPv6 DNS-serveren fungerer ikke med mindre du aktiverer «IPv6» under VPN-innstillinger.</string>
     <string name="confirm_local_dns">Den lokale DNS-serveren fungerer ikke med mindre du aktiverer «Deling av lokalt nettverk» under VPN-innstillinger.</string>
     <string name="confirm_no_email">Problemrapporten blir nå sendt uten en måte for oss å kontakte deg på. Hvis du ønsker svar på rapporten, må du oppgi en e-postadresse.</string>
-    <string name="confirm_removal">Ja, logg av enhet</string>
+    <string name="confirm_removal">Ja, logg ut av enheten</string>
     <string name="congrats">Gratulerer!</string>
     <string name="connect">Koble til</string>
     <string name="connect_on_start">Koble til når enheten startes</string>
@@ -183,7 +188,7 @@
     <string name="expand">Utvid</string>
     <string name="failed_to_block_internet">Kunne ikke blokkere all nettverkstrafikk. Feilsøk eller send inn en problemrapport.</string>
     <string name="failed_to_create_account">Kunne ikke opprette konto</string>
-    <string name="failed_to_fetch_devices">Kunne ikke hente liste over enheter</string>
+    <string name="failed_to_fetch_devices">Kunne ikke hente listen over enheter</string>
     <string name="failed_to_load_products">Kunne ikke laste opp produkter. Prøv på nytt</string>
     <string name="failed_to_remove_device">Kunne ikke fjerne enhet</string>
     <string name="failed_to_send">Kunne ikke sende</string>
@@ -249,7 +254,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Fjerne %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Enheten blir fjernet fra listen og logget ut.</string>
     <string name="manage_devices_description">Se og administrer alle innloggede enheter. Du kan ha opptil fem enheter på én konto om gangen. Hver enhet får et navn når du logger inn, slik at du enkelt kan skille dem fra hverandre.</string>
-    <string name="max_devices_confirm_removal_description">Vil du virkelig logge av &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="max_devices_confirm_removal_description">Vil du virkelig logge &lt;b&gt;%1$s&lt;/b&gt; av?</string>
     <string name="max_devices_resolved_description">Du kan nå fortsette med å logge på denne enheten.</string>
     <string name="max_devices_resolved_title">Supert!</string>
     <string name="max_devices_warning_description">Logg ut av minst én ved å fjerne den fra listen nedenfor. Du finner det tilsvarende enhetsnavnet under enhetens kontoinnstillinger.</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Ingen tilgjengelige egendefinerte lister</string>
     <string name="no_internet_connection">Ingen internettforbindelse</string>
     <string name="no_matching_relay">Ingen servere passer til innstillingene dine. Prøv å endre server eller andre innstillinger.</string>
+    <string name="no_matching_servers_found_first_line">Fant ingen matchende servere.</string>
+    <string name="no_matching_servers_found_second_line">Prøv å endre filtrene.</string>
     <string name="no_recent_selection">Ingen nylig valghistorikk</string>
     <string name="no_wireguard_key">Det mangler en gyldig WireGuard-nøkkel. Du kan behandle nøklene under avanserte innstillinger.</string>
     <string name="not_found">Ikke funnet</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Koble til på nytt</string>
     <string name="redeem">Løs inn</string>
     <string name="redeem_voucher">Løs inn kupong</string>
+    <string name="refresh_server_list">Oppdater serverlisten</string>
     <string name="relay_item_already_selected_as_entry">%1$s er allerede valgt som inngangsrelé</string>
     <string name="relay_item_already_selected_as_exit">%1$s er allerede valgt som utgangsrelé</string>
     <string name="relayitem_is_inactive">%1$s er utilgjengelig</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">Oppdater DNS-serveren</string>
     <string name="update_list_name">Oppdater listenavn</string>
+    <string name="updating_server_list_in_the_background">Oppdater serverlisten i bakgrunnen …</string>
     <string name="uri_browser_app_not_found">Ingen nettleserapp installert. Kunne ikke åpne koblingen.</string>
     <string name="uri_market_app_not_found">Ingen Android-appbutikk installert. Kunne ikke åpne koblingen.</string>
     <string name="use_method">Bruk metode</string>

--- a/android/lib/resource/src/main/res/values-nl/strings.xml
+++ b/android/lib/resource/src/main/res/values-nl/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Alle aanbieders</string>
     <string name="always_on_vpn_error_notification_content">Kan de tunnelverbinding niet starten. Schakel Altijd-aan VPN uit voor &lt;b&gt;%1$s&lt;/b&gt; voordat u Mullvad VPN gebruikt.</string>
     <string name="always_on_vpn_error_notification_title">Altijd-aan VPN toegewezen aan %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Na het bijwerken van een VPN-app in Android 16 kan het apparaat in een toestand raken waarin de VPN-apps het internet niet meer kunnen bereiken.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Start uw apparaat opnieuw op en probeer het opnieuw. Als dat niet werkt, kun u een e-mail schrijven naar %1$s (in het Zweeds of in het Engels).</string>
+    <string name="android_16_upgrade_warning_message">Er is een bekend probleem met Android 16. Start uw apparaat opnieuw op en probeer het opnieuw. Voor meer informatie:</string>
+    <string name="android_16_upgrade_warning_title">Krijgt u geen verbinding?</string>
     <string name="any">Elke</string>
     <string name="api_access_description">Beheer en voeg aangepaste methoden toe om toegang te krijgen tot de Mullvad-API.</string>
     <string name="api_access_method_info_first_line">De app moet communiceren met een Mullvad-API-server om u aan te melden, serverlijsten op te halen en andere belangrijke handelingen uit te voeren.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Wat is er nieuw</string>
     <string name="cipher">Versleuteling</string>
     <string name="clear_input">Invoer wissen</string>
+    <string name="click_here">klik hier</string>
     <string name="close">Sluiten</string>
     <string name="collapse">Samenvouwen</string>
     <string name="confirm_ipv6_dns">De IPv6-DNS-server werkt niet, tenzij u \"IPv6\" inschakelt in de VPN-instellingen.</string>
@@ -152,7 +157,7 @@
     <string name="dns_content_blockers">DNS-contentblokkeringen</string>
     <string name="dns_content_blockers_custom_dns_warning">Let op: deze instelling kan niet worden gebruikt in combinatie met \"Aangepaste DNS-server gebruiken\".</string>
     <string name="dns_content_blockers_info">Als deze functie is ingeschakeld, maakt het apparaat geen contact meer met bepaalde domeinen of websites waarvan bekend is dat ze advertenties, malware, trackers en meer verspreiden.</string>
-    <string name="dns_content_blockers_subtitle">Schakel \"%1$s\" hieronder uit om deze instellingen te activeren.</string>
+    <string name="dns_content_blockers_subtitle">Schakel hieronder \"%1$s\" uit om deze instellingen te activeren.</string>
     <string name="dns_content_blockers_warning">Dit kan problemen veroorzaken met bepaalde websites, diensten en apps.</string>
     <string name="dont_have_an_account">Hebt u geen accountnummer?</string>
     <string name="duplicate_address_warning">Dit adres is al ingevoerd.</string>
@@ -247,8 +252,8 @@
     <string name="malware_info">Waarschuwing: de malwareblocker is geen antivirus en mag niet als zodanig behandeld worden. Dit is slechts een extra beschermingslaag.</string>
     <string name="manage_devices">Apparaten beheren</string>
     <string name="manage_devices_confirm_removal_description_line1">%1$s verwijderen?</string>
-    <string name="manage_devices_confirm_removal_description_line2">Het apparaat wordt uit de lijst verwijderd en wordt uitgelogd.</string>
-    <string name="manage_devices_description">Bekijk en beheer al uw ingelogde apparaten. U kunt per account maximaal 5 apparaten tegelijkertijd hebben. Elk apparaat krijgt een naam bij het inloggen, zodat u ze eenvoudig uit elkaar kunt houden.</string>
+    <string name="manage_devices_confirm_removal_description_line2">Het apparaat wordt verwijderd uit de lijst en afgemeld.</string>
+    <string name="manage_devices_description">Bekijk en beheer al uw aangemelde apparaten. Eén account kan maximaal 5 apparaten tegelijkertijd bevatten. Elk apparaat krijgt bij aanmelding een naam, zodat u ze eenvoudig uit elkaar kunt houden.</string>
     <string name="max_devices_confirm_removal_description">Weet u zeker dat u &lt;b&gt;%1$s&lt;/b&gt; wilt afmelden?</string>
     <string name="max_devices_resolved_description">U kunt nu doorgaan met het aanmelden bij dit apparaat.</string>
     <string name="max_devices_resolved_title">Super!</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Geen aangepaste lijsten beschikbaar</string>
     <string name="no_internet_connection">Geen internetverbinding</string>
     <string name="no_matching_relay">Er zijn geen servers die overeenkomen met uw instellingen. Probeer een andere server of andere instellingen.</string>
+    <string name="no_matching_servers_found_first_line">Geen overeenkomende servers gevonden.</string>
+    <string name="no_matching_servers_found_second_line">Probeer de filters te veranderen.</string>
     <string name="no_recent_selection">Geen recente selectiegeschiedenis</string>
     <string name="no_wireguard_key">Geldige WireGuard-sleutel ontbreekt. Beheer sleutels onder Geavanceerde instellingen.</string>
     <string name="not_found">Niet gevonden</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Opnieuw verbinden</string>
     <string name="redeem">Inwisselen</string>
     <string name="redeem_voucher">Voucher inwisselen</string>
+    <string name="refresh_server_list">Serverlijst bijwerken</string>
     <string name="relay_item_already_selected_as_entry">%1$s is al geselecteerd als ingangsrelais</string>
     <string name="relay_item_already_selected_as_exit">%1$s is al geselecteerd als uitgangsrelais</string>
     <string name="relayitem_is_inactive">%1$s is niet beschikbaar</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">DNS-server bijwerken</string>
     <string name="update_list_name">Lijstnaam bijwerken</string>
+    <string name="updating_server_list_in_the_background">Serverlijst wordt bijgewerkt op de achtergrond...</string>
     <string name="uri_browser_app_not_found">Er is geen browserapp geïnstalleerd of de link kan niet worden geopend</string>
     <string name="uri_market_app_not_found">Er is geen Android-appstore geïnstalleerd of de link kan niet worden geopend</string>
     <string name="use_method">Methode gebruiken</string>

--- a/android/lib/resource/src/main/res/values-pl/strings.xml
+++ b/android/lib/resource/src/main/res/values-pl/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Wszyscy dostawcy</string>
     <string name="always_on_vpn_error_notification_content">Nie można uruchomić połączenia tunelowego. Przed rozpoczęciem użytkowania usługi Mullvad VPN wyłącz opcję „Zawsze włączony VPN” w &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="always_on_vpn_error_notification_title">Opcja „Zawsze włączony VPN” przypisana jest do %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Po zaktualizowaniu aplikacji VPN w systemie Android 16 urządzenia mogą znaleźć się w stanie, w którym aplikacje VPN nie będą już miały dostępu do Internetu.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Ponownie uruchom urządzenie i ponów próbę połączenia. Jeśli to nie zadziała, wyślij wiadomość e-mail na adres %1$s w języku szwedzkim lub angielskim.</string>
+    <string name="android_16_upgrade_warning_message">System Android 16 ma znany nam problem. Uruchom ponownie urządzenie i spróbuj jeszcze raz. Aby dowiedzieć się więcej,</string>
+    <string name="android_16_upgrade_warning_title">Nie możesz się połączyć?</string>
     <string name="any">Dowolny</string>
     <string name="api_access_description">Zarządzaj i dodawaj niestandardowe metody dostępu do interfejsu API Mullvad.</string>
     <string name="api_access_method_info_first_line">Aplikacja musi komunikować się z serwerem API Mullvad, aby można było się zalogować, pobrać listy serwerów i wykonywać inne krytyczne operacje.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Co nowego</string>
     <string name="cipher">Szyfrowanie</string>
     <string name="clear_input">Wyczyść dane wejściowe</string>
+    <string name="click_here">kliknij tutaj</string>
     <string name="close">Zamknij</string>
     <string name="collapse">Zwiń</string>
     <string name="confirm_ipv6_dns">Serwer DNS protokołu IPv6 nie będzie działać, jeśli nie włączysz opcji „IPv6” w ustawieniach VPN.</string>
@@ -152,7 +157,7 @@
     <string name="dns_content_blockers">Funkcje blokowania treści DNS</string>
     <string name="dns_content_blockers_custom_dns_warning">Uwaga: tego ustawienia nie można używać w połączeniu z opcją „Użyj niestandardowego serwera DNS”.</string>
     <string name="dns_content_blockers_info">Po włączeniu funkcja ta uniemożliwia urządzeniu kontakt z określonymi domenami lub witrynami internetowymi, które rozpowszechniają reklamy, złośliwe oprogramowanie itd.</string>
-    <string name="dns_content_blockers_subtitle">Aby aktywować te ustawienia, wyłącz opcję „%1$s” poniżej.</string>
+    <string name="dns_content_blockers_subtitle">Wyłącz poniżej funkcję „%1$s”, aby aktywować te ustawienia.</string>
     <string name="dns_content_blockers_warning">Może to powodować problemy z niektórymi witrynami internetowymi, usługami i aplikacjami.</string>
     <string name="dont_have_an_account">Nie masz numeru konta?</string>
     <string name="duplicate_address_warning">Ten adres został już wprowadzony.</string>
@@ -248,7 +253,7 @@
     <string name="manage_devices">Zarządzaj urządzeniami</string>
     <string name="manage_devices_confirm_removal_description_line1">Usunąć %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Urządzenie zostanie usunięte z listy i wylogowane.</string>
-    <string name="manage_devices_description">Wyświetlaj wszystkie zalogowane urządzenia i zarządzaj nimi. Na jednym koncie możesz mieć do 5 urządzeń naraz. Każde urządzenie otrzymuje nazwę po zalogowaniu, co ułatwia ich rozróżnienie.</string>
+    <string name="manage_devices_description">Wyświetlaj wszystkie zalogowane urządzenia i zarządzaj nimi. Na jednym koncie możesz mieć do 5 urządzeń naraz. Każde zalogowane urządzenie otrzymuje nazwę, co ułatwia ich rozróżnienie.</string>
     <string name="max_devices_confirm_removal_description">Czy na pewno chcesz wylogować &lt;b&gt;%1$s&lt;/b&gt;?</string>
     <string name="max_devices_resolved_description">Teraz można kontynuować logowanie się na tym urządzeniu.</string>
     <string name="max_devices_resolved_title">Super!</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Brak dostępnych list niestandardowych</string>
     <string name="no_internet_connection">Brak połączenia z Internetem</string>
     <string name="no_matching_relay">Żaden serwer nie odpowiada ustawieniom. Spróbuj zmienić serwer lub inne ustawienia.</string>
+    <string name="no_matching_servers_found_first_line">Nie znaleziono pasujących serwerów.</string>
+    <string name="no_matching_servers_found_second_line">Spróbuj zmienić filtry.</string>
     <string name="no_recent_selection">Brak historii ostatnich wyborów</string>
     <string name="no_wireguard_key">Brak prawidłowego klucza WireGuard. Zarządzaj kluczami w Ustawieniach zaawansowanych.</string>
     <string name="not_found">Nie znaleziono</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Połącz ponownie</string>
     <string name="redeem">Zrealizuj</string>
     <string name="redeem_voucher">Zrealizuj kupon</string>
+    <string name="refresh_server_list">Zaktualizuj listę serwerów</string>
     <string name="relay_item_already_selected_as_entry">%1$s: wybrano już jako przekaźnik wejściowy</string>
     <string name="relay_item_already_selected_as_exit">%1$s już wybrano jako przekaźnik wyjściowy</string>
     <string name="relayitem_is_inactive">%1$s: niedostępne</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-przez-TCP</string>
     <string name="update_dns_server_dialog_title">Zaktualizuj serwer DNS</string>
     <string name="update_list_name">Zaktualizuj nazwę listy</string>
+    <string name="updating_server_list_in_the_background">Aktualizowanie listy serwerów w tle...</string>
     <string name="uri_browser_app_not_found">Nie zainstalowano żadnej aplikacji przeglądarki, nie można otworzyć linku</string>
     <string name="uri_market_app_not_found">Nie zainstalowano żadnego sklepu z aplikacjami dla systemu Android, nie można otworzyć linku</string>
     <string name="use_method">Użyj metody</string>

--- a/android/lib/resource/src/main/res/values-pt/strings.xml
+++ b/android/lib/resource/src/main/res/values-pt/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Todos os fornecedores</string>
     <string name="always_on_vpn_error_notification_content">Não foi possível iniciar a ligação de túnel. Desative a VPN sempre ligada para &lt;b&gt;%1$s&lt;/b&gt; antes de utilizar a Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">VPN sempre ligada atribuída a %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Após atualizar uma aplicação de VPN no Android 16, os dispositivos podem ficar num estado em que as aplicações de VPN deixam de conseguir aceder à internet.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Reinicie o seu dispositivo e tente estabelecer a ligação novamente. Se isto não funcionar, escreva um e-mail para %1$s em sueco ou inglês.</string>
+    <string name="android_16_upgrade_warning_message">O Android 16 tem um problema conhecido. Reinicie o seu dispositivo e tente novamente. Para saber mais,</string>
+    <string name="android_16_upgrade_warning_title">Não consegue ligar?</string>
     <string name="any">Qualquer</string>
     <string name="api_access_description">Gerir e adicionar métodos personalizados para aceder à Mullvad API.</string>
     <string name="api_access_method_info_first_line">A app precisa de comunicar com um servidor da Mullvad API para iniciar a sua sessão, obter listas de servidores e outras operações críticas.</string>
@@ -67,12 +71,13 @@
     <string name="changelog_title">Novidades</string>
     <string name="cipher">Cifra</string>
     <string name="clear_input">Limpar entrada</string>
+    <string name="click_here">clique aqui</string>
     <string name="close">Fechar</string>
     <string name="collapse">Colapsar</string>
     <string name="confirm_ipv6_dns">O servidor DNS IPv6 não funcionará a menos que ative a \"IPv6\" nas definições de VPN.</string>
     <string name="confirm_local_dns">O servidor DNS local não funcionará a menos que ative a \"Partilha de rede local\" nas definições de VPN.</string>
     <string name="confirm_no_email">Está prestes a enviar o relatório de problema sem que tenhamos uma forma de lhe responder. Se pretender uma resposta ao seu relatório, tem de introduzir um endereço de email.</string>
-    <string name="confirm_removal">Sim, desligar o dispositivo</string>
+    <string name="confirm_removal">Sim, terminar sessão do dispositivo</string>
     <string name="congrats">Parabéns!</string>
     <string name="connect">Ligar</string>
     <string name="connect_on_start">Ligar no arranque do dispositivo</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Nenhuma lista personalizada disponível</string>
     <string name="no_internet_connection">Sem ligação à internet</string>
     <string name="no_matching_relay">Nenhum servidor corresponde às suas definições. Tente alterar o servidor ou outras definições.</string>
+    <string name="no_matching_servers_found_first_line">Nenhum servidor correspondente encontrado.</string>
+    <string name="no_matching_servers_found_second_line">Tente alterar os seus filtros.</string>
     <string name="no_recent_selection">Sem histórico de seleção recente</string>
     <string name="no_wireguard_key">Chave WireGuard válida em falta. Faça a gestão das chaves em Definições Avançadas.</string>
     <string name="not_found">Não encontrada</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Religar</string>
     <string name="redeem">Reclamar</string>
     <string name="redeem_voucher">Reclamar voucher</string>
+    <string name="refresh_server_list">Atualizar lista de servidores</string>
     <string name="relay_item_already_selected_as_entry">%1$s já está selecionado como retransmissor de entrada</string>
     <string name="relay_item_already_selected_as_exit">%1$s já está selecionado como retransmissor de saída</string>
     <string name="relayitem_is_inactive">%1$s não está disponível</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP sobre TCP</string>
     <string name="update_dns_server_dialog_title">Atualizar servidor DNS</string>
     <string name="update_list_name">Atualizar nome da lista</string>
+    <string name="updating_server_list_in_the_background">A atualizar a lista de servidores em segundo plano...</string>
     <string name="uri_browser_app_not_found">Nenhuma aplicação de navegador Android instalada. Não foi possível abrir a ligação</string>
     <string name="uri_market_app_not_found">Nenhuma loja de aplicações Android instalada. Não foi possível abrir a ligação</string>
     <string name="use_method">Utilizar método</string>

--- a/android/lib/resource/src/main/res/values-ru/strings.xml
+++ b/android/lib/resource/src/main/res/values-ru/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Все провайдеры</string>
     <string name="always_on_vpn_error_notification_content">Не удалось запустить туннельное подключение. Перед использованием Mullvad VPN отключите опцию «Постоянная VPN» для приложения &lt;b&gt;%1$s&lt;/b&gt;.</string>
     <string name="always_on_vpn_error_notification_title">Опция «Постоянная VPN» назначена приложению «%1$s»</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">После обновления VPN-приложения на Android 16 VPN-приложения иногда теряют доступ к Интернету.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Перезагрузите устройство и снова попробуйте подключиться. Если это не поможет, отправьте письмо на %1$s на английском или шведском.</string>
+    <string name="android_16_upgrade_warning_message">В Android 16 есть известная проблема. Перезагрузите устройство и попробуйте снова. Чтобы узнать больше,</string>
+    <string name="android_16_upgrade_warning_title">Проблемы с подключением?</string>
     <string name="any">Все</string>
     <string name="api_access_description">Добавление пользовательских методов для доступа к API Mullvad и управление ими.</string>
     <string name="api_access_method_info_first_line">Приложение должно взаимодействовать с сервером API Mullvad для входа в учетную запись, получения списков серверов и других важных операций.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Что нового</string>
     <string name="cipher">Шифр</string>
     <string name="clear_input">Очистить поле ввода</string>
+    <string name="click_here">нажмите здесь</string>
     <string name="close">Закрыть</string>
     <string name="collapse">Свернуть</string>
     <string name="confirm_ipv6_dns">DNS-сервер IPv6 не будет работать, если не включить IPv6 в разделе «Настройки VPN».</string>
@@ -152,7 +157,7 @@
     <string name="dns_content_blockers">DNS-блокировщики контента</string>
     <string name="dns_content_blockers_custom_dns_warning">Внимание! Этот параметр нельзя использовать вместе с параметром «Пользовательский DNS-сервер».</string>
     <string name="dns_content_blockers_info">При включенной опции устройство не будет устанавливать соединение с определенными доменами и сайтами, известными распространением рекламы, вредоносного ПО, трекеров и т. д.</string>
-    <string name="dns_content_blockers_subtitle">Чтобы активировать эти параметры, отключите параметр «%1$s».</string>
+    <string name="dns_content_blockers_subtitle">Чтобы активировать эти настройки, отключите параметр «%1$s».</string>
     <string name="dns_content_blockers_warning">Это может привести к проблемам при использовании некоторых сайтов, служб и приложений.</string>
     <string name="dont_have_an_account">Нет номера учетной записи?</string>
     <string name="duplicate_address_warning">Этот адрес уже введен.</string>
@@ -247,8 +252,8 @@
     <string name="malware_info">Внимание! Блокировщик вредоносного ПО — это просто дополнительный уровень защиты, а не антивирус.</string>
     <string name="manage_devices">Управление устройствами</string>
     <string name="manage_devices_confirm_removal_description_line1">Удалить устройство «%1$s»?</string>
-    <string name="manage_devices_confirm_removal_description_line2">Устройство будет удалено из списка. На нем будет выполнен выход из системы.</string>
-    <string name="manage_devices_description">Просмотр подключенных устройств и управление ими. К одной учетной записи можно подключить 5 устройств. При входе каждому устройству присваивается имя, чтобы помочь различать их.</string>
+    <string name="manage_devices_confirm_removal_description_line2">Устройство выйдет из профиля и будет удалено из списка.</string>
+    <string name="manage_devices_description">Просмотр подключенных устройств и управление ими. К одной учетной записи можно подключить 5 устройств. При входе каждому устройству присваивается имя, чтобы их было легче различать.</string>
     <string name="max_devices_confirm_removal_description">Действительно выйти из профиля на устройстве &lt;b&gt;%1$s&lt;/b&gt;?</string>
     <string name="max_devices_resolved_description">Теперь можно войти в учетную запись на этом устройстве.</string>
     <string name="max_devices_resolved_title">Отлично!</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Нет своих списков</string>
     <string name="no_internet_connection">Нет подключения к Интернету</string>
     <string name="no_matching_relay">Нет серверов, соответствующих вашим настройкам. Попробуйте изменить сервер или задайте другие настройки.</string>
+    <string name="no_matching_servers_found_first_line">Подходящих серверов не найдено.</string>
+    <string name="no_matching_servers_found_second_line">Попробуйте изменить фильтры.</string>
     <string name="no_recent_selection">Нет истории недавнего выбора</string>
     <string name="no_wireguard_key">Не найден действительный ключ WireGuard. Управлять ключами можно в дополнительных настройках.</string>
     <string name="not_found">Не найдено</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Переподключить</string>
     <string name="redeem">Погасить</string>
     <string name="redeem_voucher">Погасить ваучер</string>
+    <string name="refresh_server_list">Обновить список серверов</string>
     <string name="relay_item_already_selected_as_entry">%1$s уже используется как входной сервер ретрансляции</string>
     <string name="relay_item_already_selected_as_exit">%1$s уже используется как выходной сервер ретрансляции</string>
     <string name="relayitem_is_inactive">%1$s недоступно</string>
@@ -386,7 +394,7 @@
     <string name="toggle_vpn">Включение VPN</string>
     <string name="top_bar_device_name">Имя устройства: %1$s</string>
     <string name="top_bar_time_left">Осталось времени: %1$s</string>
-    <string name="try_again">Повторить попытку</string>
+    <string name="try_again">Повторить</string>
     <string name="type">Тип</string>
     <string name="udp">UDP</string>
     <string name="udp_over_tcp_port_info">TCP-порт, к которому должен подключаться протокол обфускации UDP через TCP на VPN-сервере.</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP через TCP</string>
     <string name="update_dns_server_dialog_title">Обновить DNS-сервер</string>
     <string name="update_list_name">Обновление названия списка</string>
+    <string name="updating_server_list_in_the_background">Фоновое обновление списка серверов...</string>
     <string name="uri_browser_app_not_found">Не удалось открыть ссылку: браузер не установлен</string>
     <string name="uri_market_app_not_found">Не удалось открыть ссылку: магазин приложений Android не установлен</string>
     <string name="use_method">Использовать метод</string>

--- a/android/lib/resource/src/main/res/values-sv/strings.xml
+++ b/android/lib/resource/src/main/res/values-sv/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Alla leverantörer</string>
     <string name="always_on_vpn_error_notification_content">Det går inte att starta tunnelanslutning. Inaktivera Alltid på-VPN för &lt;b&gt;%1$s&lt;/b&gt; innan du använder Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">Alltid på-VPN har tilldelats %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">När en VPN-app har uppdaterats på Android 16 kan enheterna hamna i ett tillstånd där VPN-apparna inte längre har åtkomst till internet.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Starta om enheten och försök att ansluta igen. Om det inte fungerar kan du skicka ett e-postmeddelande till %1$s på svenska eller engelska.</string>
+    <string name="android_16_upgrade_warning_message">Android 16 har ett känt fel. Starta om din enhet och försök igen. Om du vill veta mer</string>
+    <string name="android_16_upgrade_warning_title">Kan du inte ansluta?</string>
     <string name="any">Valfri</string>
     <string name="api_access_description">Hantera och lägg till anpassade metoder för att komma åt Mullvad API.</string>
     <string name="api_access_method_info_first_line">Appen måste kommunicera med en Mullvad API-server för att logga in dig, hämta serverlistor och andra viktiga åtgärder.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Nyheter</string>
     <string name="cipher">Chiffrering</string>
     <string name="clear_input">Rensa inmatning</string>
+    <string name="click_here">klicka här</string>
     <string name="close">Stäng</string>
     <string name="collapse">Dölj</string>
     <string name="confirm_ipv6_dns">IPv6 DNS-servern fungerar inte om du inte aktiverar \"IPv6\" under VPN-inställningar.</string>
@@ -247,7 +252,7 @@
     <string name="malware_info">Varning! Blockering av skadlig kod är inte ett antivirusprogram och bör inte behandlas som ett. Det här är bara ett extra skyddslager.</string>
     <string name="manage_devices">Hantera enheter</string>
     <string name="manage_devices_confirm_removal_description_line1">Ta bort %1$s?</string>
-    <string name="manage_devices_confirm_removal_description_line2">Enheten kommer att tas bort från listan och loggas ut.</string>
+    <string name="manage_devices_confirm_removal_description_line2">Enheten tas bort från listan och loggas ut.</string>
     <string name="manage_devices_description">Visa och hantera alla dina inloggade enheter. Du kan ha upp till fem enheter åt gången på ett konto. Varje enhet får ett namn när den loggas in så att du enklare kan skilja dem åt.</string>
     <string name="max_devices_confirm_removal_description">Vill du verkligen logga ut &lt;b&gt;%1$s&lt;/b&gt;?</string>
     <string name="max_devices_resolved_description">Du kan nu fortsätta med att logga in på den här enheten.</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Inga anpassade listor är tillgängliga</string>
     <string name="no_internet_connection">Ingen internetanslutning</string>
     <string name="no_matching_relay">Inga servrar matchar dina inställningar. Försök att byta server eller ändra inställningarna.</string>
+    <string name="no_matching_servers_found_first_line">Inga överensstämmande servrar hittades.</string>
+    <string name="no_matching_servers_found_second_line">Prova att ändra dina filter.</string>
     <string name="no_recent_selection">Ingen historik av senaste val</string>
     <string name="no_wireguard_key">Giltig WireGuard-nyckel saknas. Hantera nycklar i Avancerade inställningar.</string>
     <string name="not_found">Hittades inte</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Återanslut</string>
     <string name="redeem">Lös in</string>
     <string name="redeem_voucher">Lös in kupong</string>
+    <string name="refresh_server_list">Uppdatera serverlistan</string>
     <string name="relay_item_already_selected_as_entry">%1$s har redan valts som ingångsrelä</string>
     <string name="relay_item_already_selected_as_exit">%1$s har redan valts som utgångsrelä</string>
     <string name="relayitem_is_inactive">%1$s är inte tillgänglig</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP över TCP</string>
     <string name="update_dns_server_dialog_title">Uppdatera DNS-server</string>
     <string name="update_list_name">Uppdatera listnamn</string>
+    <string name="updating_server_list_in_the_background">Uppdaterar serverlistan i bakgrunden ...</string>
     <string name="uri_browser_app_not_found">Ingen webbläsarapp är installerad, det gick inte att öppna länken</string>
     <string name="uri_market_app_not_found">Ingen Android-appbutik är installerad, det gick inte att öppna länken</string>
     <string name="use_method">Använd metod</string>

--- a/android/lib/resource/src/main/res/values-th/strings.xml
+++ b/android/lib/resource/src/main/res/values-th/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">ผู้ให้บริการทั้งหมด</string>
     <string name="always_on_vpn_error_notification_content">ไม่สามารถเริ่มการเชื่อมต่ออุโมงค์ได้ โปรดปิดใช้งาน Always-on VPN เป็นเวลา &lt;b&gt;%1$s&lt;/b&gt; ก่อนที่จะใช้งาน Mullvad VPN</string>
     <string name="always_on_vpn_error_notification_title">VPN เปิดอยู่เสมอ ได้รับการมอบหมายไปยัง %1$s แล้ว</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">หลังจากอัปเดตแอป VPN บน Android 16 อุปกรณ์อาจอยู่ในสถานะที่แอป VPN ไม่สามารถเข้าถึงอินเทอร์เน็ตได้อีกต่อไป</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">โปรดรีสตาร์ทอุปกรณ์ของคุณและลองเชื่อมต่ออีกครั้ง หากวิธีนี้ไม่ได้ผล โปรดเขียนอีเมลถึง %1$s เป็นภาษาสวีเดนหรืออังกฤษ</string>
+    <string name="android_16_upgrade_warning_message">Android 16 มีปัญหาที่ทราบแล้ว โปรดรีสตาร์ทอุปกรณ์ของคุณแล้วลองอีกครั้ง หากต้องการเรียนรู้เพิ่มเติม</string>
+    <string name="android_16_upgrade_warning_title">ไม่สามารถเชื่อมต่อได้ใช่ไหม</string>
     <string name="any">อะไรก็ได้</string>
     <string name="api_access_description">จัดการและเพิ่มวิธีแบบกำหนดเอง เพื่อเข้าถึง Mullvad API</string>
     <string name="api_access_method_info_first_line">แอปจำเป็นต้องสื่อสารกับเซิร์ฟเวอร์ Mullvad API เพื่อนำคุณเข้าสู่ระบบ ดึงข้อมูลรายการเซิร์ฟเวอร์ และการดำเนินการที่สำคัญอื่นๆ</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">มีอะไรใหม่</string>
     <string name="cipher">เข้ารหัส</string>
     <string name="clear_input">ล้างข้อมูลอินพุต</string>
+    <string name="click_here">คลิกที่นี่</string>
     <string name="close">ปิด</string>
     <string name="collapse">ยุบ</string>
     <string name="confirm_ipv6_dns">เซิร์ฟเวอร์ DNS IPv6 จะไม่ทำงาน เว้นแต่คุณจะเปิดใช้งาน \"IPv6\" ภายใต้การตั้งค่า VPN</string>
@@ -152,7 +157,7 @@
     <string name="dns_content_blockers">ตัวบล็อกเนื้อหา DNS</string>
     <string name="dns_content_blockers_custom_dns_warning">โปรดทราบ: การตั้งค่านี้ไม่สามารถใช้ร่วมกับ \"ใช้เซิร์ฟเวอร์ DNS แบบกำหนดเองได้\"</string>
     <string name="dns_content_blockers_info">ในขณะที่เปิดใช้งานคุณลักษณะนี้ คุณลักษณะนี้จะหยุดไม่ให้อุปกรณ์ติดต่อโดเมน หรือเว็บไซต์ใดๆ ที่เป็นที่ทราบกันว่า ใช้ในการเผยแพร่โฆษณา มัลแวร์ ตัวติดตาม และอื่นๆ</string>
-    <string name="dns_content_blockers_subtitle">ปิดใช้งาน \"%1$s\" ด้านล่าง เพื่อเปิดใช้การตั้งค่าเหล่านี้</string>
+    <string name="dns_content_blockers_subtitle">ปิดใช้งาน \"%1$s\" ด้านล่างเพื่อเปิดใช้งานการตั้งค่าเหล่านี้</string>
     <string name="dns_content_blockers_warning">นี่อาจก่อให้เกิดปัญหากับบางเว็บไซต์ บริการ และแอปได้</string>
     <string name="dont_have_an_account">ยังไม่มีหมายเลขบัญชีใช่ไหม</string>
     <string name="duplicate_address_warning">ที่อยู่นี้ได้รับการป้อนไปแล้ว</string>
@@ -249,7 +254,7 @@
     <string name="manage_devices_confirm_removal_description_line1">ลบ %1$s หรือไม่</string>
     <string name="manage_devices_confirm_removal_description_line2">อุปกรณ์จะถูกลบออกจากรายการและออกจากระบบ</string>
     <string name="manage_devices_description">ดูและจัดการอุปกรณ์ทั้งหมดที่คุณลงชื่อเข้าใช้ คุณสามารถมีอุปกรณ์ได้สูงสุด 5 เครื่องในหนึ่งบัญชีในเวลาเดียวกัน แต่ละอุปกรณ์จะได้รับชื่อในขณะที่ลงชื่อเข้าใช้ เพื่อช่วยให้คุณแยกแยะอุปกรณ์แต่ละเครื่องได้อย่างง่ายดาย</string>
-    <string name="max_devices_confirm_removal_description">คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบบน &lt;b&gt;%1$s&lt;/b&gt;</string>
+    <string name="max_devices_confirm_removal_description">คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบ &lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="max_devices_resolved_description">คุณสามารถดำเนินการเข้าสู่ระบบต่อบนอุปกรณ์เครื่องนี้ได้แล้ว</string>
     <string name="max_devices_resolved_title">เยี่ยมยอด!</string>
     <string name="max_devices_warning_description">โปรดลงชื่อออกจากระบบบนอุปกรณ์อย่างน้อยหนึ่งเครื่อง เพื่อนำอุปกรณ์ออกจากรายการด้านล่าง คุณสามารถดูชื่ออุปกรณ์ที่เกี่ยวข้องได้ ภายใต้การตั้งค่าบัญชีของอุปกรณ์</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">ไม่มีรายการแบบกำหนดเองที่พร้อมใช้งาน</string>
     <string name="no_internet_connection">ไม่มีการเชื่อมต่ออินเทอร์เน็ต</string>
     <string name="no_matching_relay">ไม่มีเซิร์ฟเวอร์ที่ตรงกับการตั้งค่าของคุณ โปรดลองเปลี่ยนเซิร์ฟเวอร์ หรือการตั้งค่าอื่นๆ</string>
+    <string name="no_matching_servers_found_first_line">ไม่พบเซิร์ฟเวอร์ที่ตรงกัน</string>
+    <string name="no_matching_servers_found_second_line">โปรดลองเปลี่ยนตัวกรองของคุณ</string>
     <string name="no_recent_selection">ไม่มีประวัติการเลือกล่าสุด</string>
     <string name="no_wireguard_key">คีย์ WireGuard ที่ใช้ได้ขาดหายไป จัดการคีย์ภายใต้การตั้งค่าขั้นสูง</string>
     <string name="not_found">ไม่พบ</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">เชื่อมต่อใหม่</string>
     <string name="redeem">แลกรับ</string>
     <string name="redeem_voucher">แลกบัตรกำนัล</string>
+    <string name="refresh_server_list">อัปเดตรายการเซิร์ฟเวอร์</string>
     <string name="relay_item_already_selected_as_entry">%1$s ถูกเลือกเป็น Entry Relay อยู่แล้ว</string>
     <string name="relay_item_already_selected_as_exit">%1$s ถูกเลือกเป็น Exit Relay อยู่แล้ว</string>
     <string name="relayitem_is_inactive">%1$s ไม่พร้อมใช้งาน</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-ผ่าน-TCP</string>
     <string name="update_dns_server_dialog_title">อัปเดตเซิร์ฟเวอร์ DNS</string>
     <string name="update_list_name">อัปเดตชื่อรายการ</string>
+    <string name="updating_server_list_in_the_background">กำลังอัปเดตรายชื่อเซิร์ฟเวอร์ในพื้นหลัง...</string>
     <string name="uri_browser_app_not_found">ไม่ได้ติดตั้งแอปเบราว์เซอร์ ไม่สามารถเปิดลิงก์ได้</string>
     <string name="uri_market_app_not_found">ไม่มีการติดตั้ง App Store ของ Android ไม่สามารถเปิดลิงก์ได้</string>
     <string name="use_method">ใช้วิธีการ</string>

--- a/android/lib/resource/src/main/res/values-tr/strings.xml
+++ b/android/lib/resource/src/main/res/values-tr/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">Tüm hizmet sağlayıcılar</string>
     <string name="always_on_vpn_error_notification_content">Tünel bağlantısı başlatılamıyor. Mullvad VPN\'i kullanmadan önce lütfen Her zaman açık VPN\'i &lt;b&gt;%1$s&lt;/b&gt; için devre dışı bırakın.</string>
     <string name="always_on_vpn_error_notification_title">Her zaman açık VPN %1$s uygulamasına atandı</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">Android 16\'da bir VPN uygulaması güncellendikten sonra, cihazlar VPN uygulamalarının artık internete erişemediği bir duruma geçebilir.</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">Lütfen cihazınızı yeniden başlatın ve tekrar bağlanmayı deneyin. Bu işe yaramazsa lütfen %1$s adresine İsveççe veya İngilizce bir e-posta yazın.</string>
+    <string name="android_16_upgrade_warning_message">Android 16\'da bilinen bir sorun mevcut. Lütfen cihazınızı yeniden başlatıp tekrar deneyin. Daha fazla bilgi için</string>
+    <string name="android_16_upgrade_warning_title">Bağlanamıyor musunuz?</string>
     <string name="any">Tümü</string>
     <string name="api_access_description">Mullvad API\'sine erişim için özel yöntemler ekleyip yönetin.</string>
     <string name="api_access_method_info_first_line">Uygulamanın oturumunuzu açmak, sunucu listelerini almak ve diğer kritik işlemleri yapmak için bir Mullvad API sunucusuyla iletişim kurması gerekir.</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">Yenilikler</string>
     <string name="cipher">Şifre</string>
     <string name="clear_input">Girişi temizle</string>
+    <string name="click_here">buraya tıklayın</string>
     <string name="close">Kapat</string>
     <string name="collapse">Daralt</string>
     <string name="confirm_ipv6_dns">VPN ayarlarındaki \"IPv6\" seçeneğini etkinleştirmediğiniz sürece IPv6 DNS sunucusu çalışmaz.</string>
@@ -248,7 +253,7 @@
     <string name="manage_devices">Cihazları yönet</string>
     <string name="manage_devices_confirm_removal_description_line1">%1$s kaldırılsın mı?</string>
     <string name="manage_devices_confirm_removal_description_line2">Cihaz listeden kaldırılacak ve oturum kapatılacak.</string>
-    <string name="manage_devices_description">Oturum açtığınız tüm cihazlarınızı görüntüleyin ve yönetin. Bir hesapta aynı anda en fazla 5 cihaz bulunabilir. Kolayca ayırt edebilmeniz için her cihaza giriş sırasında bir ad atanır.</string>
+    <string name="manage_devices_description">Oturum açtığınız tüm cihazları görüntüleyin ve yönetin. Bir hesapta aynı anda en fazla 5 cihaz bulunabilir. Kolayca ayırt edebilmeniz için her cihaza giriş sırasında bir ad atanır.</string>
     <string name="max_devices_confirm_removal_description">&lt;b&gt;%1$s&lt;/b&gt; adlı cihazdan çıkış yapmak istediğinizden emin misiniz?</string>
     <string name="max_devices_resolved_description">Artık bu cihazda oturum açmaya devam edebilirsiniz.</string>
     <string name="max_devices_resolved_title">Süper!</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">Özel listeler mevcut değil</string>
     <string name="no_internet_connection">İnternet bağlantısı yok</string>
     <string name="no_matching_relay">Ayarlarınızla eşleşen sunucu yok. Sunucuyu veya diğer ayarları değiştirmeyi deneyin.</string>
+    <string name="no_matching_servers_found_first_line">Eşleşen sunucu bulunamadı.</string>
+    <string name="no_matching_servers_found_second_line">Lütfen filtrelerinizi değiştirmeyi deneyin.</string>
     <string name="no_recent_selection">Son seçim geçmişi yok</string>
     <string name="no_wireguard_key">Geçerli WireGuard anahtarı eksik. Gelişmiş ayarlardan anahtarları yönetin.</string>
     <string name="not_found">Bulunamadı</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">Yeniden Bağlan</string>
     <string name="redeem">Kullan</string>
     <string name="redeem_voucher">Kuponu kullan</string>
+    <string name="refresh_server_list">Sunucu listesini güncelle</string>
     <string name="relay_item_already_selected_as_entry">%1$s zaten giriş aktarıcısı olarak seçildi</string>
     <string name="relay_item_already_selected_as_exit">%1$s zaten çıkış aktarıcısı olarak seçildi</string>
     <string name="relayitem_is_inactive">%1$s kullanılamıyor</string>
@@ -386,7 +394,7 @@
     <string name="toggle_vpn">VPN\'i aç/kapat</string>
     <string name="top_bar_device_name">Cihaz adı: %1$s</string>
     <string name="top_bar_time_left">Kalan süre: %1$s</string>
-    <string name="try_again">Tekrar deneyin</string>
+    <string name="try_again">Tekrar dene</string>
     <string name="type">Tür</string>
     <string name="udp">UDP</string>
     <string name="udp_over_tcp_port_info">TCP üzerinden UDP gizleme protokolünün VPN sunucusunda hangi TCP portuna bağlanması gerekiyor.</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">TCP üzerinden UDP</string>
     <string name="update_dns_server_dialog_title">DNS sunucusunu güncelle</string>
     <string name="update_list_name">Liste adını güncelle</string>
+    <string name="updating_server_list_in_the_background">Sunucu listesi arka planda güncelleniyor...</string>
     <string name="uri_browser_app_not_found">Hiçbir tarayıcı uygulaması yüklü olmadığından bağlantı açılamadı</string>
     <string name="uri_market_app_not_found">Android uygulama mağazası yüklü olmadığından bağlantı açılamadı</string>
     <string name="use_method">Yöntemi kullan</string>

--- a/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rCN/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">所有提供商</string>
     <string name="always_on_vpn_error_notification_content">无法启动隧道连接。在使用 Mullvad VPN 之前，请为 &lt;b&gt;%1$s&lt;/b&gt; 禁用“始终开启 VPN”。</string>
     <string name="always_on_vpn_error_notification_title">“始终开启 VPN”已分配给 %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">在 Android 16 上更新 VPN 应用后，设备可能会出现 VPN 应用无法连接互联网的情况。</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">请重新启动您的设备，然后再次尝试连接。如果仍然无法连接，请用瑞典语或英语发送电子邮件至 %1$s。</string>
+    <string name="android_16_upgrade_warning_message">Android 16 存在已知问题。请重启您的设备并重试。如需了解详情，</string>
+    <string name="android_16_upgrade_warning_title">无法连接？</string>
     <string name="any">任何</string>
     <string name="api_access_description">管理和添加访问 Mulvad API 的自定义方法。</string>
     <string name="api_access_method_info_first_line">该应用需要与 Mulvad API 服务器通信，以便您登录、获取服务器列表和执行其他关键操作。</string>
@@ -67,12 +71,13 @@
     <string name="changelog_title">最新变化</string>
     <string name="cipher">加密方式</string>
     <string name="clear_input">清除输入</string>
+    <string name="click_here">点击此处</string>
     <string name="close">关闭</string>
     <string name="collapse">收起</string>
     <string name="confirm_ipv6_dns">除非您在 VPN 设置中启用“IPv6”，否则 IPv6 DNS 服务器将不会运行。</string>
     <string name="confirm_local_dns">除非您在 VPN 设置下启用“本地网络共享”，否则本地 DNS 服务器将不会运行。</string>
     <string name="confirm_no_email">您即将发送问题报告，但没有提供让我们可以联系到您的方式。如果您希望获得回复，必须输入您的电子邮件地址。</string>
-    <string name="confirm_removal">是，退出设备</string>
+    <string name="confirm_removal">是，退出登录设备</string>
     <string name="congrats">恭喜！</string>
     <string name="connect">连接</string>
     <string name="connect_on_start">设备启动时连接</string>
@@ -249,7 +254,7 @@
     <string name="manage_devices_confirm_removal_description_line1">是否移除“%1$s”？</string>
     <string name="manage_devices_confirm_removal_description_line2">该设备将从列表中移除并退出登录。</string>
     <string name="manage_devices_description">查看和管理您所有已登录的设备。一个帐户最多可以同时登录 5 台设备。每台设备登录时都会获得一个名称，以便您能够轻松区分。</string>
-    <string name="max_devices_confirm_removal_description">确定要退出&lt;b&gt;%1$s&lt;/b&gt;吗？</string>
+    <string name="max_devices_confirm_removal_description">确定要退出 &lt;b&gt;%1$s&lt;/b&gt; 吗？</string>
     <string name="max_devices_resolved_description">您现在可以继续在此设备上登录。</string>
     <string name="max_devices_resolved_title">太棒了！</string>
     <string name="max_devices_warning_description">请通过从以下列表中移除的方式退出至少一个帐户。您可以在设备的帐户设置下找到相应设备名称。</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">有可用的自定义列表</string>
     <string name="no_internet_connection">没有互联网连接</string>
     <string name="no_matching_relay">没有与您的设置匹配的服务器，请尝试更改服务器或其他设置。</string>
+    <string name="no_matching_servers_found_first_line">找不到匹配的服务器。</string>
+    <string name="no_matching_servers_found_second_line">请更改您的筛选器。</string>
     <string name="no_recent_selection">无最近选择历史记录</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 密钥。在“高级”设置下管理密钥。</string>
     <string name="not_found">找不到</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">重新连接</string>
     <string name="redeem">兑换</string>
     <string name="redeem_voucher">兑换优惠券</string>
+    <string name="refresh_server_list">更新服务器列表</string>
     <string name="relay_item_already_selected_as_entry">%1$s 已被选为入口中继</string>
     <string name="relay_item_already_selected_as_exit">%1$s 已被选为出口中继</string>
     <string name="relayitem_is_inactive">%1$s 不可用</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">更新 DNS 服务器</string>
     <string name="update_list_name">更新列表名称</string>
+    <string name="updating_server_list_in_the_background">正在后台更新服务器列表…</string>
     <string name="uri_browser_app_not_found">未安装浏览器应用，无法打开链接</string>
     <string name="uri_market_app_not_found">未安装 Android 应用商店，无法打开链接</string>
     <string name="use_method">使用方法</string>

--- a/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
+++ b/android/lib/resource/src/main/res/values-zh-rTW/strings.xml
@@ -24,6 +24,10 @@
     <string name="all_providers">所有供應商</string>
     <string name="always_on_vpn_error_notification_content">無法啟動通道連線。在使用 Mullvad VPN 之前，請先為 &lt;b&gt;%1$s&lt;/b&gt; 停用「始終啟用 VPN」。</string>
     <string name="always_on_vpn_error_notification_title">「一律啟用 VPN」已指派給 %1$s</string>
+    <string name="android_16_upgrade_warning_dialog_first_message">在 Android 16 更新 VPN 應用程式後，裝置可能會出現 VPN 應用程式無法連線至網際網路的情況。</string>
+    <string name="android_16_upgrade_warning_dialog_second_message">請重新啟動您的裝置並嘗試重新連線。若不成功，請以瑞典語或英語撰寫電子郵件並寄至 %1$s。</string>
+    <string name="android_16_upgrade_warning_message">Android 16 存在已知問題。請重新啟動您的裝置並再試一次。如需更多資訊，</string>
+    <string name="android_16_upgrade_warning_title">無法連線嗎？</string>
     <string name="any">任何</string>
     <string name="api_access_description">管理並新增自訂方式以存取 Mullvad API。</string>
     <string name="api_access_method_info_first_line">該應用程式需要與 Mulvad API 伺服器通訊，以便您登入、取得伺服器清單並執行其他重要作業。</string>
@@ -67,6 +71,7 @@
     <string name="changelog_title">最新動態</string>
     <string name="cipher">加密方式</string>
     <string name="clear_input">清除輸入</string>
+    <string name="click_here">按一下此處</string>
     <string name="close">關閉</string>
     <string name="collapse">折疊</string>
     <string name="confirm_ipv6_dns">若要執行 IPv6 DNS 伺服器，需先在 VPN 設定下啟用「IPv6」。</string>
@@ -270,6 +275,8 @@
     <string name="no_custom_lists_available">有可用的自訂清單</string>
     <string name="no_internet_connection">沒有網際網路連線</string>
     <string name="no_matching_relay">沒有與您的設定相符的伺服器，請嘗試變更伺服器或其他設定。</string>
+    <string name="no_matching_servers_found_first_line">找不到相符的伺服器。</string>
+    <string name="no_matching_servers_found_second_line">請變更您的篩選器試試。</string>
     <string name="no_recent_selection">無最近選擇歷史</string>
     <string name="no_wireguard_key">缺少有效的 WireGuard 金鑰。在「進階」設定下管理金鑰。</string>
     <string name="not_found">找不到</string>
@@ -316,6 +323,7 @@
     <string name="reconnect">重新連線</string>
     <string name="redeem">兌換</string>
     <string name="redeem_voucher">兌換憑證</string>
+    <string name="refresh_server_list">更新伺服器清單</string>
     <string name="relay_item_already_selected_as_entry">已選取 %1$s 為入口節點</string>
     <string name="relay_item_already_selected_as_exit">已選取 %1$s 為出口節點</string>
     <string name="relayitem_is_inactive">%1$s 無法使用</string>
@@ -396,6 +404,7 @@
     <string name="upd_over_tcp">UDP-over-TCP</string>
     <string name="update_dns_server_dialog_title">更新 DNS 伺服器</string>
     <string name="update_list_name">更新清單名稱</string>
+    <string name="updating_server_list_in_the_background">正在背景更新伺服器清單……</string>
     <string name="uri_browser_app_not_found">未安裝瀏覽器應用程式，無法開啟連結</string>
     <string name="uri_market_app_not_found">未安裝 Android 應用程式商店，無法開啟連結</string>
     <string name="use_method">使用方式</string>

--- a/desktop/packages/mullvad-vpn/locales/da/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/da/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Danish\n"
 "Language: da_DK\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d mere..."
@@ -168,6 +168,11 @@ msgstr "Aktivér alligevel"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Aktiver kun direkte"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Kunne ikke hente listen over enheder"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "KUNNE IKKE SIKRE FORBINDELSEN"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCP-indstillinger"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Brug højre pil til at fokusere indstillingsknappen."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Ikke tilgængelig i øjeblikket"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Log af"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Administrer enheder"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Indtast en gyldig localhost-port."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Indtast en gyldig fjernserverport."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Vælg et navn til den adgangsmetode, der ikke allerede er i brug."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Rediger tilpasset bro"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Er du sikker på, at du vil logge <b>%(deviceName)s</b> ud?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Fortsæt med login"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Oprettet: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Nuværende enhed"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Hvis du logger ud, fjernes enheden og enhedsnavnet. Når du logger på igen, får enheden et nyt navn."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Administrer enheder"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Log ud af mindst én ved at fjerne den fra listen nedenfor. Du kan finde det tilsvarende enhedsnavn under enhedens kontoindstillinger."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Fjern"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Fjern <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Super!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Enheden fjernes fra listen og logges ud."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "For mange enheder"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Ja, log enhed af"
+msgid "Try again"
+msgstr "Prøv igen"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Vis og administrer alle dine enheder, der er logget på. Du kan have op til 5 enheder på en konto ad gangen. Hver enhed tildeles et navn, når du logger på, så du let kan se forskel på dem."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Den valgte %(wireGuard)s-port understøttes ikke, ændr den under "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Denne enhed har nu navnet <em>%(deviceName)s</em>. Få mere at vide under \"Administrer enheder\" under Konto."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "BEKRÆFTELSE FULDFØRT! STARTER INSTALLATIONSPROGRAMMET ..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "BEKRÆFTELSE MISLYKKEDES"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Velkommen! Denne enhed hedder nu <b>%(deviceName)s</b>. Se info-knappen i Konto for at flere oplysninger."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Fejl"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Kunne ikke oprette konto"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Kunne ikke hente listen over enheder"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s er problematisk og kan ikke udelukkes fra VPN-tunnelen."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s understøttes ikke af dit system."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Tilføj"
@@ -2148,6 +2197,11 @@ msgstr "Alle apps"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Vælg de apps, du vil ekskludere fra VPN-tunnelen."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Klik her for at få mere at vide"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Prøv igen, eller indsend en problemrapport."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Genstart Mullvad-tjenesten"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "For at bruge %(splitTunneling)s skal du skifte til en Linux-kerneversion, der understøtter cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Opret automatisk forbindelse til en server, når appen starter."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Deaktiver <b>%(customDnsFeatureName)s</b> nedenfor for at aktivere disse indstillinger."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Deaktiver \"%(customDnsFeatureName)s\" nedenfor for at aktivere disse indstillinger."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Hvis en observatør overvåger disse datapakker, gør %(daita)s det betydeligt sværere for dem at identificere, hvilke hjemmesider du besøger, eller hvem du kommunikerer med."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP-version"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Det gør den ved at udføre en ekstra nøgleudveksling ved hjælp af en kvantesikker algoritme og blande resultatet med WireGuards almindelige kryptering. Dette ekstra trin bruger cirka 500 kB trafik, hver gang en ny tunnel etableres."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihop"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Multihop bruges til at aktivere DAITA for din valgte placering"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Ikke alle vores servere er %(daita)s-kompatible. Derfor bruger vi automatisk multihop til at aktivere %(daita)s med enhver server."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Tilsløring"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Tilsløring skjuler WireGuard-trafikken inden i en anden protokol. Det kan bruges til at hjælpe med at omgå censur og andre typer filtrering, hvor en almindelig WireGuard-forbindelse ville blive blokeret."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Port"
@@ -2803,10 +2879,6 @@ msgstr "Denne funktion gør WireGuard-tunnelen modstandsdygtig over for potentie
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCP-port"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Tilføj tid"
 msgid "Adding method..."
 msgstr "Tilføjer metode..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Når en VPN-app er blevet opdateret på Android 16, kan enheder ende i en tilstand, hvor VPN-apps ikke længere kan få kontakt til internettet."
+
 msgid "Agree and continue"
 msgstr "Accepter og fortsæt"
 
@@ -2918,6 +2993,12 @@ msgstr "Altid-til VPN tildelt %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Altid-til VPN tildelt en anden VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 har et kendt problem. Genstart din enhed, og prøv igen. For at få mere at vide"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Er du sikker på, at du vil logge <b>%s</b> af?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Mindst én metode skal aktiveres"
@@ -2951,6 +3032,9 @@ msgstr "Blokering af internet (enhed offline)"
 
 msgid "Blocking..."
 msgstr "Blokerer ..."
+
+msgid "Can't connect?"
+msgstr "Kan du ikke oprette forbindelse?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Ændringer af DNS-relaterede indstillinger træder muligvis ikke i kraft med det samme på grund af cachelagrede resultater."
@@ -2988,9 +3072,6 @@ msgstr "Opret ny liste"
 msgid "Critical error (your attention is required)"
 msgstr "Kritisk fejl (som kræver din opmærksomhed)"
 
-msgid "Current device"
-msgstr "Nuværende enhed"
-
 msgid "Current: %s"
 msgstr "Aktuel: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Vil du slette metoden?"
 
 msgid "Device IP version"
 msgstr "Enhedens IP-version"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Deaktiver \"%s\" nedenfor for at aktivere disse indstillinger."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deaktiver alle \"%s\" ovenfor for at aktivere denne indstilling."
@@ -3093,9 +3171,6 @@ msgstr "Kunne ikke indstilles til aktuel - Ukendt årsag"
 msgid "File"
 msgstr "Fil"
 
-msgid "Filters:"
-msgstr "Filtre:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "For at VPN kan forbindes automatisk, når enheden startes, skal appen have VPN-tilladelser. Du kan tildele disse ved at klikke på \"Forbind\" i kortvisningen og vælge \"OK\", hvis du bliver bedt om det. Sørg desuden for, at appen er installeret på interne lager ved at tjekke lageroplysninger i appdetaljerne i systemindstillinger."
 
@@ -3162,9 +3237,6 @@ msgstr "Placeringer blev ændret for \"%s\""
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Sørger for, at enheden altid er på VPN-tunnelen."
 
-msgid "Manage devices"
-msgstr "Administrer enheder"
-
 msgid "More actions"
 msgstr "Flere handlinger"
 
@@ -3192,8 +3264,8 @@ msgstr "Ingen brugerdefinerede lister tilgængelige"
 msgid "No internet connection"
 msgstr "Ingen internetforbindelse"
 
-msgid "No locations found"
-msgstr "Ingen placeringer fundet"
+msgid "No matching servers found."
+msgstr "Der blev ikke fundet nogen matchende servere."
 
 msgid "No recent selection history"
 msgstr "Ingen nylig valghistorik"
@@ -3233,6 +3305,12 @@ msgstr "Indtast en gyldig fjernserverport"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Tryk på Opret forbindelse for at anmode om VPN-tilladelse"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Genstart din enhed, og prøv at oprette forbindelse igen. Hvis det ikke hjælper, kan du skrive en e-mail til %s på svensk eller engelsk."
+
+msgid "Please try changing your filters."
+msgstr "Prøv at ændre dine filtre."
 
 msgid "Privacy"
 msgstr "Privatliv"
@@ -3321,9 +3399,6 @@ msgstr "Den \"aktuelle\" metode er den metode, som appen bruger til at nå API'e
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Appen blokerer for internet, afbryd først forbindelsen"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Enheden fjernes fra listen og logges ud."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Den lokale DNS-server fungerer ikke, medmindre du aktiverer \"Lokal netværksdeling\" under VPN-indstillinger."
 
@@ -3381,6 +3456,12 @@ msgstr "Opdater DNS-server"
 msgid "Update list name"
 msgstr "Opdater listenavn"
 
+msgid "Update server list"
+msgstr "Opdater serverlisten"
+
+msgid "Updating server list in the background..."
+msgstr "Opdaterer serverlisten i baggrunden ..."
+
 msgid "Use method"
 msgstr "Brug metode"
 
@@ -3417,9 +3498,6 @@ msgstr "Bekræfter køb..."
 msgid "Verifying voucher…"
 msgstr "Bekræfter kupon…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Vis og administrer alle dine enheder, der er logget på. Du kan have op til 5 enheder på en konto ad gangen. Hver enhed tildeles et navn, når du logger på, så du let kan se forskel på dem."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Vi er stadig ved at bekræfte dit køb, det kan tage noget tid. Din tid vil blive tilføjet, hvis bekræftelsen lykkes."
 
@@ -3441,11 +3519,17 @@ msgstr "WireGuard-tilsløring"
 msgid "WireGuard port"
 msgstr "WireGuard-port"
 
+msgid "Yes, log out device"
+msgstr "Ja, log enhed af"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" blev oprettet"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" blev slettet"
+
+msgid "click here"
+msgstr "klik her"
 
 msgid "here"
 msgstr "her"

--- a/desktop/packages/mullvad-vpn/locales/da/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/da/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Danish\n"
 "Language: da_DK\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/de/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/de/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d mehr …"
@@ -168,6 +168,11 @@ msgstr "Trotzdem aktivieren"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Nur direkt aktivieren"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Fehler beim Abrufen der Geräteliste"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "SICHERE VERBINDUNG KONNTE NICHT HERGESTELLT WERDEN"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-über-TCP-Einstellungen"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Verwenden Sie die rechte Pfeiltaste, um die Schaltfläche „Einstellungen“ zu fokussieren."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Derzeit nicht verfügbar"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Abmelden"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Geräte verwalten"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Bitte geben Sie einen gültigen Localhost-Port ein."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Bitte geben Sie einen gültigen Remote-Server-Port ein."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Bitte wählen Sie einen noch nicht verwendeten Namen für die Zugriffsmethode."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Eigene Brücke bearbeiten"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Möchten Sie <b>%(deviceName)s</b> wirklich abmelden?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Weiter mit Anmeldung"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Erstellt: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Aktuelles Gerät"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Wenn Sie sich abmelden, werden das Gerät und der Gerätename entfernt. Wenn Sie sich wieder anmelden, erhält das Gerät einen neuen Namen."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Geräte verwalten"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Bitte melden Sie sich von mindestens einem Gerät ab, indem Sie es aus der Liste unten entfernen. Sie finden den entsprechenden Gerätenamen unter den Kontoeinstellungen des Geräts."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Entfernen"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "<em>%(deviceName)s</em> entfernen?"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Super!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Das Gerät wird aus der Liste entfernt und abgemeldet."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Zu viele Geräte"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Ja, von Gerät abmelden"
+msgid "Try again"
+msgstr "Erneut versuchen"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Lassen Sie all Ihre angemeldeten Geräte anzeigen und verwalten Sie sie. Sie können bis zu fünf Geräte gleichzeitig bei einem Konto haben. Jedes Gerät bekommt beim Anmelden einen Namen, damit Sie sie leicht unterscheiden können."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Der ausgewählte %(wireGuard)s-Port wird nicht unterstützt, bitte ändern Sie ihn unter "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Dieses Gerät heißt jetzt <em>%(deviceName)s</em>. Weitere Informationen finden Sie in Ihrem Konto unter „Geräte verwalten”."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "VERIFIZIERUNG ABGESCHLOSSEN! INSTALLATIONSPROGRAMM WIRD GESTARTET …"
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "VERIFIZIERUNG FEHLGESCHLAGEN"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Dieses Gerät heißt jetzt <b>%(deviceName)s</b>. Weitere Details finden Sie über die Info-Schaltfläche in Ihrem Konto."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Fehler"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Konto konnte nicht erstellt werden"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Fehler beim Abrufen der Geräteliste"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s ist problematisch und kann nicht vom VPN-Tunnel ausgeschlossen werden."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s wird von Ihrem System nicht unterstützt."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Hinzufügen"
@@ -2148,6 +2197,11 @@ msgstr "Alle Apps"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Wählen Sie die Apps aus, die Sie aus dem VPN-Tunnel ausschließen möchten."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Klicken Sie hier, um mehr zu erfahren"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2196,6 +2250,14 @@ msgstr "Bitte versuchen Sie es erneut oder senden Sie einen Problembericht."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Mullvad-Dienst neu starten"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Um %(splitTunneling)s zu verwenden, wechseln Sie bitte zu einer Linux-Kernel-Version, die cgroup v1 unterstützt."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2511,8 +2573,8 @@ msgstr "Stellt automatisch eine Verbindung zum Server her, wenn die App startet.
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Deaktivieren Sie unten <b>%(customDnsFeatureName)s</b>, um diese Einstellungen zu aktivieren."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Deaktivieren Sie unten „%(customDnsFeatureName)s“, um diese Einstellungen zu aktivieren."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2704,6 +2766,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Wenn ein Beobachter diese Datenpakete überwacht, macht %(daita)s es für ihn wesentlich schwieriger zu erkennen, welche Websites Sie besuchen oder mit wem Sie kommunizieren."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP-Version"
@@ -2713,12 +2776,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Dazu wird ein zusätzlicher Schlüsselaustausch mit einem quantensicheren Algorithmus durchgeführt und das Ergebnis mit der regulären Verschlüsselung von WireGuard vermischt. Dieser zusätzliche Schritt verbraucht jedes Mal, wenn ein neuer Tunnel aufgebaut wird, etwa 500 KiB an Datenverkehr."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihop"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Multihop wird verwendet, um DAITA für den von Ihnen ausgewählten Standort zu aktivieren"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2733,6 +2807,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Nicht alle unsere Server sind %(daita)s-fähig. Daher verwenden wir automatisch Multihop, um %(daita)s mit jedem Server zu aktivieren."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Verschleierung"
@@ -2743,6 +2818,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Bei der Verschleierung wird der WireGuard-Datenverkehr in einem anderen Protokoll versteckt. Sie kann dazu verwendet werden, Zensur und andere Arten von Filtern zu umgehen, bei denen eine reine WireGuard-Verbindung blockiert würde."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Port"
@@ -2804,10 +2880,6 @@ msgstr "Diese Funktion macht den WireGuard-Tunnel resistent gegen mögliche Angr
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP über TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Port für UDP über TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2905,6 +2977,9 @@ msgstr "Zeit hinzufügen"
 msgid "Adding method..."
 msgstr "Methode hinzufügen …"
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Nach dem Update einer VPN-App auf Android 16 kann es vorkommen, dass die VPN-Apps auf diesen Geräten nicht länger auf das Internet zugreifen können."
+
 msgid "Agree and continue"
 msgstr "Akzeptieren und weiter"
 
@@ -2919,6 +2994,12 @@ msgstr "Always-on VPN ist %s zugeordnet"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Always-on VPN ist einem anderen VPN zugeordnet"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 hat einen bekannten Fehler. Bitte starten Sie Ihr Gerät neu und versuchen Sie es erneut. Um mehr darüber zu erfahren,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Möchten Sie <b>%s</b> wirklich abmelden?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Mindestens eine Methode muss aktiviert sein"
@@ -2952,6 +3033,9 @@ msgstr "Internet sperren (Gerät offline)"
 
 msgid "Blocking..."
 msgstr "Blockieren …"
+
+msgid "Can't connect?"
+msgstr "Keine Verbindung möglich?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Änderungen an DNS-Einstellungen werden aufgrund von zwischengespeicherten Daten möglicherweise nicht sofort wirksam."
@@ -2989,9 +3073,6 @@ msgstr "Neue Liste erstellen"
 msgid "Critical error (your attention is required)"
 msgstr "Kritischer Fehler (Ihre Aufmerksamkeit ist erforderlich)"
 
-msgid "Current device"
-msgstr "Aktuelles Gerät"
-
 msgid "Current: %s"
 msgstr "Aktuell: %s"
 
@@ -3012,9 +3093,6 @@ msgstr "Methode löschen?"
 
 msgid "Device IP version"
 msgstr "Geräte-IP-Version"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Deaktivieren Sie unten „%s“, um diese Einstellungen zu aktivieren."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deaktivieren Sie oben alle „%s“, um diese Einstellung zu aktivieren."
@@ -3094,9 +3172,6 @@ msgstr "Konnte nicht als aktuelle gesetzt werden – Unbekannter Grund"
 msgid "File"
 msgstr "Datei"
 
-msgid "Filters:"
-msgstr "Filter:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Damit sich das VPN beim Start des Geräts automatisch verbindet, muss die App über VPN-Berechtigungen verfügen. Sie können diese erteilen, indem Sie in der Kartenansicht auf „Verbinden“ klicken und „OK“ auswählen, wenn Sie dazu aufgefordert werden. Stellen Sie außerdem sicher, dass die App im internen Speicher installiert ist, indem Sie die Speicherinformationen in den App-Details in den Systemeinstellungen überprüfen."
 
@@ -3163,9 +3238,6 @@ msgstr "Standorte wurden geändert für „%s“"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Gewährleistet, dass sich das Gerät immer im VPN-Tunnel befindet."
 
-msgid "Manage devices"
-msgstr "Geräte verwalten"
-
 msgid "More actions"
 msgstr "Weitere Aktionen"
 
@@ -3193,8 +3265,8 @@ msgstr "Keine eigenen Listen verfügbar"
 msgid "No internet connection"
 msgstr "Keine Internetverbindung"
 
-msgid "No locations found"
-msgstr "Keine Standorte gefunden"
+msgid "No matching servers found."
+msgstr "Keine passenden Server gefunden."
 
 msgid "No recent selection history"
 msgstr "Kein aktueller Auswahlverlauf"
@@ -3234,6 +3306,12 @@ msgstr "Bitte geben Sie einen gültigen Remote-Server-Port ein"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Drücken Sie auf „Verbinden“, um die VPN-Berechtigung anzufordern"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Bitte starten Sie Ihr Gerät neu und versuchen Sie erneut, sich zu verbinden. Wenn dies nicht funktioniert, schreiben Sie bitte eine E-Mail an %s auf Schwedisch oder Englisch."
+
+msgid "Please try changing your filters."
+msgstr "Bitte versuchen Sie, Ihre Filter anzupassen."
 
 msgid "Privacy"
 msgstr "Datenschutz"
@@ -3322,9 +3400,6 @@ msgstr "Die „aktuelle“ Methode gibt an, welche Methode die App verwendet, um
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Die App blockiert das Internet, bitte trennen Sie zuerst die Verbindung"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Das Gerät wird aus der Liste entfernt und abgemeldet."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Der lokale DNS-Server wird nicht funktionieren, solange „Teilen im lokalen Netzwerk“ nicht in den VPN-Einstellungen aktiviert ist."
 
@@ -3382,6 +3457,12 @@ msgstr "DNS-Server aktualisieren"
 msgid "Update list name"
 msgstr "Name der Liste ändern"
 
+msgid "Update server list"
+msgstr "Serverliste aktualisieren"
+
+msgid "Updating server list in the background..."
+msgstr "Serverliste wird im Hintergrund aktiviert …"
+
 msgid "Use method"
 msgstr "Methode verwenden"
 
@@ -3418,9 +3499,6 @@ msgstr "Kauf verifizieren …"
 msgid "Verifying voucher…"
 msgstr "Gutschein verifizieren …"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Lassen Sie all Ihre angemeldeten Geräte anzeigen und verwalten Sie sie. Sie können bis zu fünf Geräte gleichzeitig bei einem Konto haben. Jedes Gerät bekommt beim Anmelden einen Namen, damit Sie sie leicht unterscheiden können."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Wir verifizieren gerade noch Ihren Kauf, dies kann einige Zeit dauern. Ihre Zeit wird hinzugefügt, wenn die Verifizierung erfolgreich ist."
 
@@ -3442,11 +3520,17 @@ msgstr "WireGuard-Verschleierung"
 msgid "WireGuard port"
 msgstr "WireGuard-Port"
 
+msgid "Yes, log out device"
+msgstr "Ja, Gerät abmelden"
+
 msgid "\"%s\" was created"
 msgstr "„%s“ wurde erstellt"
 
 msgid "\"%s\" was deleted"
 msgstr "„%s“ wurde gelöscht"
+
+msgid "click here"
+msgstr "klicken Sie hier"
 
 msgid "here"
 msgstr "hier"

--- a/desktop/packages/mullvad-vpn/locales/de/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/de/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/es/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/es/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d más..."
@@ -168,6 +168,11 @@ msgstr "Habilitar de todos modos"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Habilitar conexión directa"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "No se pudo obtener la lista de dispositivos"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "NO SE PUDO PROTEGER LA CONEXIÓN"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "Ajustes de UDP sobre TCP"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Utilice la tecla de flecha derecha para enfocar el botón de ajustes."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "No disponible actualmente"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Cerrar sesión"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Gestionar dispositivos"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Introduzca un puerto localhost válido."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Introduzca un puerto de servidor remoto válido."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Seleccione un nombre para el método de acceso que no se esté usando ya."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Editar puente personalizado"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "¿Seguro que quiere cerrar la sesión de <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Iniciar sesión"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Creado: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Dispositivo actual"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Si cierra sesión, se quita el dispositivo y el nombre del dispositivo. Cuando vuelve a iniciar sesión, el dispositivo recibirá un nombre nuevo."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Gestionar dispositivos"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Cierre la sesión como mínimo en un dispositivo (para hacerlo, quítelo de la lista siguiente). Consulte el nombre del dispositivo en la configuración de la cuenta del dispositivo."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Quitar"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "¿Quitar <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "¡Genial!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "El dispositivo se quitará de la lista y se cerrará la sesión en él."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Demasiados dispositivos"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Sí, cerrar sesión"
+msgid "Try again"
+msgstr "Volver a intentarlo"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Vea y gestione todos los dispositivos con sesión iniciada. Puede tener hasta 5 dispositivos en una cuenta a la vez. Cada dispositivo recibe un nombre al iniciar sesión para ayudarle a distinguirlo fácilmente."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "No se admite el puerto de %(wireGuard)s seleccionado. Cámbielo en la "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Este dispositivo ahora se llama <em>%(deviceName)s</em>. Encontrará más información en «Gestionar dispositivos» en la Cuenta."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "¡VERIFICACIÓN COMPLETADA! INICIANDO EL INSTALADOR..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "ERROR EN LA VERIFICACIÓN"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Hola, este dispositivo se llama ahora <b>%(deviceName)s</b>. Para más información, consulte el botón de información en la Cuenta."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Error"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "No se puede crear la cuenta"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "No se pudo obtener la lista de dispositivos"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s suele causar problemas y no puede excluirse del túnel VPN."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "Su sistema no admite %(splitTunneling)s."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Agregar"
@@ -2148,6 +2197,11 @@ msgstr "Todas las aplicaciones"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Seleccione las aplicaciones que quiera excluir del túnel VPN."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Haga clic aquí para obtener más información"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Inténtelo de nuevo o envíe un informe de problemas."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Reiniciar el servicio de Mullvad"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Para utilizar %(splitTunneling)s, cambie a una versión de kernel de Linux que admita cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Al iniciarse la aplicación, se conecta automáticamente a un servidor."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Deshabilite <b>%(customDnsFeatureName)s</b> abajo para activar estos ajustes."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Deshabilite «%(customDnsFeatureName)s» abajo para activar estos ajustes."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Si un observador supervisa estos paquetes de datos, %(daita)s les dificulta notablemente la tarea de identificar qué sitios web está visitando o con quién se está comunicando."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "Versión de IP"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Lo hace al realizar un intercambio de claves adicional usando un algoritmo cuántico seguro y combinando el resultado en el cifrado normal de WireGuard. Este paso extra utiliza aproximadamente 500 kiB de tráfico cada vez que se establece un nuevo túnel."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Salto múltiple"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Se está utilizando salto múltiple para habilitar DAITA en la ubicación que ha seleccionado"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "No todos nuestros servidores están habilitados para %(daita)s. Por lo tanto, utilizamos el salto múltiple de forma automática para habilitar %(daita)s con cualquier servidor."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Ofuscación"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "La ofuscación oculta el tráfico de WireGuard dentro de otro protocolo. Puede usarse para sortear la censura y otros tipos de filtrado donde podría bloquearse una conexión de WireGuard normal."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Puerto"
@@ -2803,10 +2879,6 @@ msgstr "Esta característica permite que el túnel de WireGuard resista posibles
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP sobre TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Puerto de UDP sobre TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Añadir tiempo"
 msgid "Adding method..."
 msgstr "Añadiendo método..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Tras actualizar una aplicación VPN en Android 16, los dispositivos podrían terminar en un estado en el que las aplicaciones VPN ya no puedan conectarse a Internet."
+
 msgid "Agree and continue"
 msgstr "Aceptar y continuar"
 
@@ -2918,6 +2993,12 @@ msgstr "La VPN siempre activa se ha asignado a %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "La VPN siempre activa se ha asignado a otra VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 tiene un problema conocido. Reinicie su dispositivo e inténtelo de nuevo. Para obtener más información,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "¿Seguro que quiere cerrar la sesión de <b>%s</b>?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Se debe habilitar al menos un método"
@@ -2951,6 +3032,9 @@ msgstr "Bloqueo de Internet (dispositivo sin conexión)"
 
 msgid "Blocking..."
 msgstr "Bloqueando..."
+
+msgid "Can't connect?"
+msgstr "¿No se puede conectar?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Los cambios en la configuración relacionada con el DNS no surtirán efecto inmediatamente debido a los resultados en caché."
@@ -2988,9 +3072,6 @@ msgstr "Crear nueva lista"
 msgid "Critical error (your attention is required)"
 msgstr "Error crítico (precisa su atención)"
 
-msgid "Current device"
-msgstr "Dispositivo actual"
-
 msgid "Current: %s"
 msgstr "Actual: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "¿Eliminar el método?"
 
 msgid "Device IP version"
 msgstr "Versión de IP del dispositivo"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Deshabilite «%s» abajo para activar estos ajustes."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deshabilite todos los «%s» de arriba para activar este ajuste."
@@ -3093,9 +3171,6 @@ msgstr "Error al establecer el método como actual: Razón desconocida"
 msgid "File"
 msgstr "Archivo"
 
-msgid "Filters:"
-msgstr "Filtros:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Para que la VPN se conecte automáticamente al iniciarse el dispositivo, la aplicación debe tener permisos de VPN. Puede concederlos haciendo clic en «Conectar» en la vista de mapa y seleccionando «Aceptar» si se le indica. Además, asegúrese de que la aplicación esté instalada en el almacenamiento interno consultando la información de almacenamiento en los detalles de la aplicación en la configuración del sistema."
 
@@ -3162,9 +3237,6 @@ msgstr "Se han cambiado las ubicaciones para «%s»"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Asegura que el dispositivo esté siempre activado en el túnel de la VPN."
 
-msgid "Manage devices"
-msgstr "Gestionar dispositivos"
-
 msgid "More actions"
 msgstr "Más acciones"
 
@@ -3192,8 +3264,8 @@ msgstr "No hay listas personalizadas disponibles"
 msgid "No internet connection"
 msgstr "No hay conexión a Internet"
 
-msgid "No locations found"
-msgstr "No se ha encontrado ninguna ubicación"
+msgid "No matching servers found."
+msgstr "No se han encontrado servidores coincidentes."
 
 msgid "No recent selection history"
 msgstr "No hay historial de selecciones recientes"
@@ -3233,6 +3305,12 @@ msgstr "Introduzca un puerto de servidor remoto válido"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Pulse conectar para solicitar el permiso de VPN"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Reinicie su dispositivo e intente conectarse de nuevo. Si esto no funciona, escriba un correo electrónico a %s en sueco o inglés."
+
+msgid "Please try changing your filters."
+msgstr "Intente cambiar los filtros."
 
 msgid "Privacy"
 msgstr "Privacidad"
@@ -3321,9 +3399,6 @@ msgstr "El método «Actual» representa el método que la aplicación utiliza p
 msgid "The app is blocking internet, please disconnect first"
 msgstr "La aplicación está bloqueando Internet. Primero desconéctela"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "El dispositivo se quitará de la lista y se cerrará la sesión en él."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "El servidor DNS local no funcionará a no ser que habilite la opción «Uso compartido de red local» en la configuración de la VPN."
 
@@ -3381,6 +3456,12 @@ msgstr "Actualizar servidor DNS"
 msgid "Update list name"
 msgstr "Actualizar nombre de la lista"
 
+msgid "Update server list"
+msgstr "Actualizar lista de servidores"
+
+msgid "Updating server list in the background..."
+msgstr "Actualizando lista de servidores en segundo plano..."
+
 msgid "Use method"
 msgstr "Utilizar método"
 
@@ -3417,9 +3498,6 @@ msgstr "Verificando la compra…"
 msgid "Verifying voucher…"
 msgstr "Verificando el cupón…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Vea y gestione todos los dispositivos con sesión iniciada. Puede tener hasta 5 dispositivos en una cuenta a la vez. Cada dispositivo recibe un nombre al iniciar sesión para ayudarle a distinguirlo fácilmente."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Seguimos verificando su compra. Esto podría tardar algún tiempo. Su tiempo se añadirá si pasa la verificación."
 
@@ -3441,11 +3519,17 @@ msgstr "Ofuscación de WireGuard"
 msgid "WireGuard port"
 msgstr "Puerto de WireGuard"
 
+msgid "Yes, log out device"
+msgstr "Sí, cerrar sesión en el dispositivo"
+
 msgid "\"%s\" was created"
 msgstr "Se ha creado «%s»"
 
 msgid "\"%s\" was deleted"
 msgstr "Se ha eliminado «%s»"
+
+msgid "click here"
+msgstr "haga clic aquí"
 
 msgid "here"
 msgstr "aquí"

--- a/desktop/packages/mullvad-vpn/locales/es/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/es/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/fi/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/fi/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Finnish\n"
 "Language: fi_FI\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d lisää..."
@@ -168,6 +168,11 @@ msgstr "Ota silti käyttöön"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Salli vain suora"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Laiteluettelon nouto epäonnistui"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "YHTEYDEN SUOJAAMINEN EPÄONNISTUI"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP TCP:n kautta -asetukset"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Kohdista asetuspainike oikealla nuolinäppäimellä."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Ei saatavilla"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Kirjaudu ulos"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Hallitse laitteita"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Anna kelvollinen localhost-portti."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Anna kelvollinen etäpalvelimen portti."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Valitse käyttötavalle nimi, joka ei ole käytössä."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Mukautetun siltauksen muokkaus"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Haluatko varmasti kirjautua ulos laitteelta <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Jatka kirjautumista"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Luotu: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Nykyinen laite"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Jos kirjaudut ulos, laite ja laitteen nimi poistetaan. Kun kirjaudut sisään uudelleen, laitteelle annetaan uusi nimi."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Hallitse laitteita"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Kirjaudu ulos vähintään yhdestä luettelon laitteesta poistamalla se. Löydät vastaavan laitteen nimen laitteen tiliasetuksista."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Poista"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Poistetaanko <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Mahtavaa!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Laite poistetaan luettelosta ja kirjataan ulos."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Liikaa laitteita"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Kyllä, kirjaa laite ulos"
+msgid "Try again"
+msgstr "Yritä uudelleen"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Tarkastele ja hallitse kaikkia kirjautuneita laitteitasi. Sinulla voi olla enintään viisi laitetta yhdellä tilillä samaan aikaan. Jokainen laite saa nimen, kun se kirjataan sisään, jotta erotat ne helposti."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Valittua %(wireGuard)s-porttia ei tueta, vaihda se "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Tämän laitteen nimi on nyt <em>%(deviceName)s</em>. Katso lisää tililtä kohdasta Hallitse laitteita."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "VAHVISTUS ON SUORITETTU! KÄYNNISTETÄÄN ASENNUSOHJELMAA..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "VAHVISTUS EPÄONNISTUI"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Tervetuloa! Tämän laitteen nimi on nyt <b>%(deviceName)s</b>. Katso lisätietoja tilin infopainikkeesta."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Virhe"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Tilin luonti epäonnistui"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Laiteluettelon nouto epäonnistui"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s on ongelmallinen, eikä sitä voida sulkea pois VPN-tunnelista."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s ei ole tuettu järjestelmässäsi."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Lisää"
@@ -2148,6 +2197,11 @@ msgstr "Kaikki sovellukset"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Valitse sovellukset, jotka haluat sulkea pois VPN-tunnelista."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Lue lisää napsauttamalla tätä"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Yritä uudelleen tai lähetä ongelmaraportti."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Käynnistä Mullvad Service uudelleen"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Vaihda Linuxin ydinversioon, joka tukee cgroup v1:tä, jotta %(splitTunneling)s on käytettävissä."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Muodosta yhteys palvelimeen automaattisesti, kun sovellus avataan."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Ota nämä asetukset käyttöön poistamalla <b>%(customDnsFeatureName)s</b> käytöstä alta."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Poista \"%(customDnsFeatureName)s\" käytöstä alla näiden asetusten aktivoimiseksi."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Jos havaitsija valvoo näitä datapaketteja, %(daita)s tekee hänelle huomattavasti hankalammaksi tunnistaa, millä verkkosivuilla käyt tai kenen kanssa viestit."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP-versio"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Tunneli torjuu hyökkäykset suorittamalla ylimääräisen avaimenvaihdon käyttämällä ensin kvanttiturvallista algoritmia, jonka tuloksen se sekoittaa WireGuardin tavalliseen salaukseen. Tämä ylimääräinen vaihe käyttää noin 500 kiB liikennettä joka kerta, kun uusi tunneli luodaan."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihop"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Multihopia käytetään, jotta DAITA on käytettävissä valitsemassasi sijainnissa"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Kaikissa palvelimissamme ei ole %(daita)s-tukea. Siksi käytämme multihopia automaattisesti mahdollistaaksemme %(daita)s:n millä tahansa palvelimella."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Hämäysteknologia"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Hämäysteknologian käyttäminen piilottaa WireGuard-liikenteen toisen protokollan sisään. Sitä voidaan käyttää kiertämään sensuuria ja muita suodatuksia niissä tapauksissa, kun tavallinen WireGuard-yhteys muutoin estettäisi."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Portti"
@@ -2803,10 +2879,6 @@ msgstr "Tämä ominaisuus tekee WireGuard-tunnelista kestävän kvanttitietokone
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP TCP:n kautta"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Portti: UDP TPC:n kautta"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Lisää käyttöaikaa"
 msgid "Adding method..."
 msgstr "Lisätään menetelmää..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Kun VPN-sovellus päivitetään Android 16:ssa, laitteen saattavat päätyä tilaan, jossa VPN-sovellukset eivät voi enää muodostaa yhteyttä internetiin."
+
 msgid "Agree and continue"
 msgstr "Hyväksy ja jatka"
 
@@ -2918,6 +2993,12 @@ msgstr "%s on määritetty aina päällä olevan VPN:n asetukseksi"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Aina päällä oleva VPN on määritetty toiselle VPN:lle"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16:ssa on tunnettu ongelma. Käynnistä laitteesi uudelleen ja yritä uudelleen. Saat lisätietoja"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Haluatko varmasti kirjata laitteen <b>%s</b> ulos?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Vähintään yhden menetelmän on oltava käytössä"
@@ -2951,6 +3032,9 @@ msgstr "Internetyhteys on estetty (laite on offline-tilassa)"
 
 msgid "Blocking..."
 msgstr "Estetään..."
+
+msgid "Can't connect?"
+msgstr "Eikö yhteyden muodostaminen onnistu?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "DNS-asetuksiin tehdyt muutokset eivät välttämättä astu voimaan välittömästi välimuistissa olevien tulosten vuoksi."
@@ -2988,9 +3072,6 @@ msgstr "Luo uusi luettelo"
 msgid "Critical error (your attention is required)"
 msgstr "Vakava virhe (vaatii huomiotasi)"
 
-msgid "Current device"
-msgstr "Nykyinen laite"
-
 msgid "Current: %s"
 msgstr "Nykyinen: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Poista menetelmä?"
 
 msgid "Device IP version"
 msgstr "Laitteen IP-versio"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Ota nämä asetukset käyttöön poistamalla \"%s\" käytöstä alta."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Ota tämä asetus käyttöön poistamalla kaikki %s käytöstä yllä."
@@ -3093,9 +3171,6 @@ msgstr "Nykyisen asetus epäonnistui – Tuntematon syy"
 msgid "File"
 msgstr "Tiedosto"
 
-msgid "Filters:"
-msgstr "Suodattimet:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Jotta VPN voi muodostaa yhteyden automaattisesti kun laite käynnistetään, sovelluksella täytyy olla VPN-oikeudet. Voit antaa ne napsauttamalla \"Yhdistä\" karttanäkymässä ja valitsemalla OK kysyttäessä. Varmista lisäksi, että sovellus on asennettu sisäiseen tallennustilaan, tarkistamalla tallennustilatiedot sovelluksen tiedoista järjestelmäasetuksista."
 
@@ -3162,9 +3237,6 @@ msgstr "Kohteen \"%s\" sijainteja vaihdettiin"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Varmistaa, että laite on aina yhteydessä VPN-tunnelin kautta."
 
-msgid "Manage devices"
-msgstr "Hallitse laitteita"
-
 msgid "More actions"
 msgstr "Lisää toimintoja"
 
@@ -3192,8 +3264,8 @@ msgstr "Mukautettuja luetteloita ei löytynyt"
 msgid "No internet connection"
 msgstr "Ei verkkoyhteyttä"
 
-msgid "No locations found"
-msgstr "Sijainteja ei löytynyt"
+msgid "No matching servers found."
+msgstr "Vastaavia palvelimia ei löytynyt."
 
 msgid "No recent selection history"
 msgstr "Ei viimeisimpien valintojen historiaa"
@@ -3233,6 +3305,12 @@ msgstr "Anna kelvollinen etäpalvelimen portti"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Pyydä VPN:n käyttölupa yhteydenluontipainiketta painamalla"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Käynnistä laitteesi uudelleen ja yritä muodostaa yhteys uudelleen. Jos tämä ei toimi, lähetä sähköpostiviesti osoitteeseen %s ruotsiksi tai englanniksi."
+
+msgid "Please try changing your filters."
+msgstr "Kokeile muuttaa suodattimiasi."
 
 msgid "Privacy"
 msgstr "Tietosuoja"
@@ -3321,9 +3399,6 @@ msgstr "\"Nykyinen\" menetelmä edustaa sitä, mitä menetelmää sovellus käyt
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Sovellus estää internetyhteyden, katkaise sen yhteys ensin"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Laite poistetaan luettelosta, ja sinut kirjataan ulos laitteelta."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Paikallinen DNS-palvelin ei toimi, ellet ota paikallisen verkon jakamista käyttöön VPN-asetuksista."
 
@@ -3381,6 +3456,12 @@ msgstr "Päivitä DNS-palvelin"
 msgid "Update list name"
 msgstr "Päivitä luettelon nimi"
 
+msgid "Update server list"
+msgstr "Päivitä palvelinluettelo"
+
+msgid "Updating server list in the background..."
+msgstr "Palvelinluetteloa päivitetään taustalla..."
+
 msgid "Use method"
 msgstr "Käytä menetelmä"
 
@@ -3417,9 +3498,6 @@ msgstr "Ostosta vahvistetaan..."
 msgid "Verifying voucher…"
 msgstr "Kuponkia vahvistetaan…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Tarkastele ja hallinnoi kaikkia kirjautuneita laitteitasi. Sinulla voi olla enintään viisi laitetta yhdellä tilillä samaan aikaan. Kukin laite saa nimen, kun se kirjataan sisään, jotta erotat ne helposti."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Vahvistamme vielä ostostasi. Siinä saattaa vierähtää jonkin aikaa. Tilillesi lisätään käyttöaikaa, kunhan ostoksen vahvistus onnistuu."
 
@@ -3441,11 +3519,17 @@ msgstr "WireGuard-obfuskointi"
 msgid "WireGuard port"
 msgstr "WireGuard-portti"
 
+msgid "Yes, log out device"
+msgstr "Kyllä, kirjaa laite ulos"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" luotiin"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" poistettiin"
+
+msgid "click here"
+msgstr "painamalla tästä"
 
 msgid "here"
 msgstr "täältä"

--- a/desktop/packages/mullvad-vpn/locales/fi/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/fi/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Finnish\n"
 "Language: fi_FI\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/fr/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/fr/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d de plus..."
@@ -168,6 +168,11 @@ msgstr "Activer quand même"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Activer Directe uniquement"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Impossible de récupérer la liste des appareils"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "ÉCHEC DE LA SÉCURISATION DE LA CONNEXION"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "Paramètres UDP-over-TCP"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Utilisez la flèche de droite pour mettre en évidence le bouton « Paramètres »."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Actuellement indisponible"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Déconnexion"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Gérer les appareils"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Merci de saisir un port localhost valide."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Merci de saisir un port de serveur distant valide."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Veuillez sélectionner un nom pour la méthode d'accès qui n'est pas en cours d'utilisation."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Modifier le pont personnalisé"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Voulez-vous vraiment déconnecter <b>%(deviceName)s</b> ?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Continuer avec la connexion"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Création : %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Appareil actuel"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Si vous vous déconnectez, l'appareil et son nom sont supprimés. Lorsque vous vous reconnectez, l'appareil reçoit un nouveau nom."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Gérer les appareils"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Merci de vous déconnecter d'au moins un appareil en le supprimant de la liste ci-dessous. Vous trouverez le nom de l'appareil correspondant dans les paramètres du compte de l'appareil."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Supprimer"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Supprimer <em>%(deviceName)s ?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Super !"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "L'appareil sera supprimé de la liste et déconnecté."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Trop d'appareils"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Oui, déconnecter l'appareil"
+msgid "Try again"
+msgstr "Réessayer"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Affichez et gérez tous vos appareils connectés. Vous pouvez avoir jusqu'à 5 appareils sur un même compte. Chaque appareil reçoit un nom lorsqu'il est connecté, ce qui vous permet de le distinguer facilement."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Le port %(wireGuard)s sélectionné n'est pas pris en charge. Veuillez le modifier sous "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Cet appareil s'appelle à présent <em>%(deviceName)s</em>. Retrouvez plus d'informations sous « Gérer les appareils » dans Compte."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "VÉRIFICATION TERMINÉE ! DÉMARRAGE DE L'INSTALLATEUR…"
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "ÉCHEC DE LA VÉRIFICATION"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Bienvenue, cet appareil s'appelle désormais <b>%(deviceName)s</b>. Pour plus d'informations, consultez le bouton d'information sous Compte."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Erreur"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Échec de la création du compte"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Impossible de récupérer la liste des appareils"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "L'application %(applicationName)s pose problème et ne peut pas être exclue du tunnel VPN."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "Le %(splitTunneling)s n'est pas pris en charge par votre système."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Ajouter"
@@ -2148,6 +2197,11 @@ msgstr "Toutes les applications"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Choisissez les applications que vous souhaitez exclure du tunnel VPN."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Cliquez ici pour en apprendre plus"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Veuillez réessayer ou envoyer un rapport de problème."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Redémarrer le service Mullvad"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Pour utiliser le %(splitTunneling)s, veuillez passer sur une version de noyau de Linux qui prend en charge cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Connexion automatique à un serveur dès le démarrage de l'application.
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Désactivez <b>%(customDnsFeatureName)s</b> ci-dessous pour activer ces paramètres."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Désactivez « %(customDnsFeatureName)s » ci-dessous pour activer ces paramètres."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Si un observateur surveille ces paquets de données, %(daita)s rend beaucoup plus difficile l'identification des sites web que vous visitez ou des personnes avec lesquelles vous communiquez."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "Version IP"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Pour ce faire, il effectue un échange de clés supplémentaire à l'aide d'un algorithme à sécurité quantique et mélange le résultat au chiffrement habituel de WireGuard. Cette étape supplémentaire utilise environ 500 kiB de trafic chaque fois qu'un nouveau tunnel est établi."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihop"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Le multihop est utilisé pour activer DAITA pour la localisation que vous avez sélectionnée"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Tous nos serveurs ne sont pas compatibles %(daita)s. C'est pourquoi nous utilisons automatiquement le multihop pour activer %(daita)s avec n'importe quel serveur."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Dissimulation"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "La dissimulation cache le trafic WireGuard à l'intérieur d'un autre protocole. Elle peut être utilisée pour aider à contourner la censure et d'autres types de filtrage, où une connexion WireGuard simple serait bloquée."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Port"
@@ -2803,10 +2879,6 @@ msgstr "Cette fonctionnalité rend le tunnel WireGuard résistant aux attaques p
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Port UDP sur TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Ajouter du temps"
 msgid "Adding method..."
 msgstr "Ajout de la méthode..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Après la mise à jour d'une application de VPN sur Android 16, les appareils peuvent se retrouver dans un état où ces applications de VPN ne sont plus en mesure d'accéder à Internet."
+
 msgid "Agree and continue"
 msgstr "Accepter et continuer"
 
@@ -2918,6 +2993,12 @@ msgstr "« Toujours exiger un VPN » est assigné à %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "« Toujours exiger un VPN » est assigné à un autre VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 présente un problème connu. Veuillez redémarrer votre appareil et réessayer. Pour en savoir plus,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Voulez-vous vraiment déconnecter <b>%s</b> ?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Au moins une méthode doit être activée"
@@ -2951,6 +3032,9 @@ msgstr "Internet bloqué (appareil hors ligne)"
 
 msgid "Blocking..."
 msgstr "Blocage..."
+
+msgid "Can't connect?"
+msgstr "Connexion impossible ?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Les modifications apportées aux paramètres liés au DNS peuvent ne pas prendre effet immédiatement en raison de la mise en cache des résultats."
@@ -2988,9 +3072,6 @@ msgstr "Créer une nouvelle liste"
 msgid "Critical error (your attention is required)"
 msgstr "Erreur critique (votre attention est requise)"
 
-msgid "Current device"
-msgstr "Appareil actuel"
-
 msgid "Current: %s"
 msgstr "Actuel : %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Supprimer la méthode ?"
 
 msgid "Device IP version"
 msgstr "Version de l'IP de l'appareil"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Désactivez « %s » ci-dessous pour activer ces paramètres."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Désactivez tous les « %s » ci-dessus pour activer ce paramètre."
@@ -3093,9 +3171,6 @@ msgstr "Impossible de définir sur la méthode actuelle - Raison inconnue"
 msgid "File"
 msgstr "Fichier"
 
-msgid "Filters:"
-msgstr "Filtres :"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Pour permettre au VPN de se connecter automatiquement au démarrage de l'appareil, l'application doit disposer des autorisations VPN. Vous pouvez les accorder en cliquant sur « Connecter » dans la vue de la carte et en sélectionnant « OK » si vous y êtes invité. De plus, assurez-vous que l'application est installée sur le stockage interne en en vérifiant les informations dans les détails de l'application dans les paramètres système."
 
@@ -3162,9 +3237,6 @@ msgstr "Les localisations ont été modifiées pour « %s »"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Permet de s'assurer que l'appareil est toujours sur le tunnel VPN."
 
-msgid "Manage devices"
-msgstr "Gérer les appareils"
-
 msgid "More actions"
 msgstr "Plus d'actions"
 
@@ -3192,8 +3264,8 @@ msgstr "Aucune liste personnalisée disponible"
 msgid "No internet connection"
 msgstr "Aucune connexion à Internet"
 
-msgid "No locations found"
-msgstr "Aucune localisation trouvée"
+msgid "No matching servers found."
+msgstr "Aucun serveur correspondant trouvé."
 
 msgid "No recent selection history"
 msgstr "Aucun historique des sélections récentes"
@@ -3233,6 +3305,12 @@ msgstr "Merci de saisir un port de serveur distant valide"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Veuillez appuyer sur connexion pour demander l'autorisation VPN"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Veuillez redémarrer votre appareil et réessayer de vous connecter. Si cela ne fonctionne pas, veuillez envoyer un e-mail à %s en suédois ou en anglais."
+
+msgid "Please try changing your filters."
+msgstr "Veuillez essayer de changer vos filtres."
 
 msgid "Privacy"
 msgstr "Confidentialité"
@@ -3321,9 +3399,6 @@ msgstr "La méthode « Actuelle » représente la méthode utilisée par l'appli
 msgid "The app is blocking internet, please disconnect first"
 msgstr "L'application bloque Internet. Veuillez d'abord vous déconnecter"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "L'appareil sera supprimé de la liste et déconnecté."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Le serveur DNS local ne fonctionnera pas si vous n'activez pas le « Partage du réseau local » dans les paramètres VPN."
 
@@ -3381,6 +3456,12 @@ msgstr "Mettre à jour le serveur DNS"
 msgid "Update list name"
 msgstr "Mettre à jour le nom de la liste"
 
+msgid "Update server list"
+msgstr "Mettre à jour la liste des serveurs"
+
+msgid "Updating server list in the background..."
+msgstr "Mise à jour en arrière-plan de la liste des serveurs…"
+
 msgid "Use method"
 msgstr "Utiliser la méthode"
 
@@ -3417,9 +3498,6 @@ msgstr "Vérification de l'achat..."
 msgid "Verifying voucher…"
 msgstr "Vérification du bon…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Affichez et gérez tous vos appareils connectés. Vous pouvez avoir jusqu'à 5 appareils sur un même compte. Chaque appareil reçoit un nom lorsqu'il est connecté, ce qui vous permet de le distinguer facilement."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Nous vérifions encore votre achat, ce qui peut prendre un certain temps. Votre temps sera ajouté si la vérification réussit."
 
@@ -3441,11 +3519,17 @@ msgstr "Obfuscation WireGuard"
 msgid "WireGuard port"
 msgstr "Port WireGuard"
 
+msgid "Yes, log out device"
+msgstr "Oui, déconnecter l'appareil"
+
 msgid "\"%s\" was created"
 msgstr "« %s » a été créé"
 
 msgid "\"%s\" was deleted"
 msgstr "« %s » a été supprimé"
+
+msgid "click here"
+msgstr "cliquez ici"
 
 msgid "here"
 msgstr "ici"

--- a/desktop/packages/mullvad-vpn/locales/fr/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/fr/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/it/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/it/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Italian\n"
 "Language: it_IT\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "Altri %(amount)d..."
@@ -168,6 +168,11 @@ msgstr "Abilita comunque"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Abilita Solo diretta"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Impossibile recuperare l'elenco dei dispositivi"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "IMPOSSIBILE STABILIRE UNA CONNESSIONE PROTETTA"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "Impostazioni UDP-over-TCP"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Usa il tasto freccia destra per evidenziare il pulsante delle impostazioni."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Attualmente non disponibile"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Esci"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Gestisci dispositivi"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Inserisci una porta localhost valida."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Inserisci una porta di server remoto valida."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Seleziona un nome per il metodo di accesso non ancora in uso."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Modifica bridge personalizzato"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Vuoi davvero disconnettere <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Continua con il login"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Creazione: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Dispositivo corrente"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Se ti disconnetti, il dispositivo e il relativo nome verranno rimossi. Quando accedi nuovamente, il dispositivo assumerà un nuovo nome."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Gestisci dispositivi"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Disconnettiti da almeno un dispositivo rimuovendolo dall'elenco seguente. Puoi trovare il nome del dispositivo corrispondente nelle impostazioni dell'account del dispositivo."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Rimuovi"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Rimuovere <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Fantastico!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Il dispositivo verrà rimosso dall'elenco e disconnesso."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Troppi dispositivi"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Sì, disconnetti dal dispositivo"
+msgid "Try again"
+msgstr "Riprova"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Visualizza e gestisci tutti i dispositivi da cui effettui l'accesso. Puoi avere contemporaneamente fino a 5 dispositivi su un account. Ogni dispositivo riceve un nome quando si effettua l'accesso per aiutarti a distinguerli facilmente."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "La porta %(wireGuard)s selezionata non è supportata, cambiala in "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Questo dispositivo ora si chiama <em>%(deviceName)s</em>. Per maggiori informazioni, consulta la sezione \"Gestisci dispositivi\" in Account."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "VERIFICA COMPLETA! AVVIO DEL PROGRAMMA DI INSTALLAZIONE..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "VERIFICA NON RIUSCITA"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Benvenuto, questo dispositivo ora si chiama <b>%(deviceName)s</b>. Per maggiori dettagli, premi il pulsante delle informazioni in Account."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Errore"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Impossibile creare l'account"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Impossibile recuperare l'elenco dei dispositivi"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "L'applicazione %(applicationName)s causa problemi e non può essere esclusa dal tunnel VPN."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s non supportato dal tuo sistema."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Aggiungi"
@@ -2148,6 +2197,11 @@ msgstr "Tutte le app"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Scegli le app che desideri escludere dal tunnel VPN."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Clicca qui per scoprire di più"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Riprova o invia una segnalazione del problema."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Riavvia il servizio Mullvad"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Per utilizzare %(splitTunneling)s, passa a una versione del kernel Linux che supporti cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Connettiti automaticamente al server all'avvio dell'app."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Disabilita <b>%(customDnsFeatureName)s</b> di seguito per attivare queste impostazioni."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Disabilita \"%(customDnsFeatureName)s\" di seguito per attivare queste impostazioni."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Se un osservatore monitora questi pacchetti di dati, %(daita)s rende molto più difficile per lui identificare quali siti web stai visitando o con chi stai comunicando."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "Versione IP"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "L'operazione viene effettuata eseguendo uno scambio di chiavi aggiuntivo con un algoritmo di sicurezza quantistica e mescolando il risultato nella normale crittografia di WireGuard. Questo passaggio aggiuntivo utilizza circa 500 kiB di traffico ogni volta che viene stabilito un nuovo tunnel."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihop"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Il multihop viene utilizzato per abilitare DAITA per la posizione selezionata"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Non tutti i nostri server sono abilitati per %(daita)s. Pertanto, utilizziamo automaticamente il multihop per abilitare %(daita)s con un server qualsiasi."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Offuscamento"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "L'offuscamento nasconde il traffico WireGuard all'interno di un altro protocollo. Può essere utilizzato per aggirare la censura e altri tipi di filtraggio, in cui una semplice connessione WireGuard verrebbe bloccata."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Porta"
@@ -2803,10 +2879,6 @@ msgstr "Questa funzionalità rende il tunnel WireGuard resistente ai potenziali 
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Porta UDP-over-TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Aggiungi tempo"
 msgid "Adding method..."
 msgstr "Aggiunta metodo..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Dopo aver aggiornato un'app VPN su Android 16, i dispositivi potrebbero trovarsi in uno stato in cui le app VPN non sono più in grado di accedere a Internet."
+
 msgid "Agree and continue"
 msgstr "Accetta e continua"
 
@@ -2918,6 +2993,12 @@ msgstr "VPN sempre attiva assegnata a %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "VPN sempre attiva assegnata a un'altra VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 presenta un problema noto. Riavvia il dispositivo e riprova. Per saperne di più,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Vuoi davvero disconnettere <b>%s</b>?"
 
 msgid "At least one method needs to be enabled"
 msgstr "È necessario abilitare almeno un metodo"
@@ -2951,6 +3032,9 @@ msgstr "Blocco di Internet (dispositivo offline)"
 
 msgid "Blocking..."
 msgstr "Blocco..."
+
+msgid "Can't connect?"
+msgstr "Impossibile connetterti?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Le modifiche alle impostazioni relative al DNS potrebbero non avere effetto immediato a causa dei risultati memorizzati nella cache."
@@ -2988,9 +3072,6 @@ msgstr "Crea nuovo elenco"
 msgid "Critical error (your attention is required)"
 msgstr "Errore critico (è necessario intervenire)"
 
-msgid "Current device"
-msgstr "Dispositivo corrente"
-
 msgid "Current: %s"
 msgstr "Attuale: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Eliminare il metodo?"
 
 msgid "Device IP version"
 msgstr "Versione IP dispositivo"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Disabilita \"%s\" di seguito per attivare queste impostazioni."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Disabilita tutti i \"%s\" sopra per attivare questa impostazione."
@@ -3093,9 +3171,6 @@ msgstr "Impossibile impostare il valore attuale: motivo sconosciuto"
 msgid "File"
 msgstr "File"
 
-msgid "Filters:"
-msgstr "Filtri:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Affinché la VPN si connetta automaticamente all'avvio del dispositivo, l'app deve disporre delle autorizzazioni VPN. Puoi concederle cliccando su \"Connetti\" nella vista mappa e selezionando \"OK\" se richiesto. Inoltre, assicurati che l'app sia installata nella memoria interna controllando le informazioni di archiviazione nei dettagli dell'app, dalle impostazioni di sistema."
 
@@ -3162,9 +3237,6 @@ msgstr "Le posizioni sono state modificate per \"%s\""
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Assicurati che il dispositivo sia sempre collegato al tunnel VPN."
 
-msgid "Manage devices"
-msgstr "Gestisci dispositivi"
-
 msgid "More actions"
 msgstr "Più azioni"
 
@@ -3192,8 +3264,8 @@ msgstr "Nessun elenco personalizzato disponibile"
 msgid "No internet connection"
 msgstr "Nessuna connessione Internet"
 
-msgid "No locations found"
-msgstr "Nessuna posizione trovata"
+msgid "No matching servers found."
+msgstr "Nessun server corrispondente trovato."
 
 msgid "No recent selection history"
 msgstr "Nessuna cronologia di selezioni recente"
@@ -3233,6 +3305,12 @@ msgstr "Inserisci una porta di server remoto valida"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Premi Connetti per richiedere l'autorizzazione VPN"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Riavvia il dispositivo e riprova a connetterti. Se non funziona, scrivi un'e-mail a %s in svedese o in inglese."
+
+msgid "Please try changing your filters."
+msgstr "Prova a cambiare i filtri."
 
 msgid "Privacy"
 msgstr "Privacy"
@@ -3321,9 +3399,6 @@ msgstr "Il metodo \"Attuale\" rappresenta il metodo utilizzato dall'app per ragg
 msgid "The app is blocking internet, please disconnect first"
 msgstr "L'app sta bloccando Internet, effettua prima la disconnessione"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Il dispositivo verrà rimosso dall'elenco e disconnesso."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Il server DNS locale non funzionerà a meno che non abiliti \"Condivisione rete locale\" nelle impostazioni VPN."
 
@@ -3381,6 +3456,12 @@ msgstr "Aggiorna server DNS"
 msgid "Update list name"
 msgstr "Aggiorna nome elenco"
 
+msgid "Update server list"
+msgstr "Aggiorna elenco server"
+
+msgid "Updating server list in the background..."
+msgstr "Aggiornamento dell'elenco server in background..."
+
 msgid "Use method"
 msgstr "Usa metodo"
 
@@ -3417,9 +3498,6 @@ msgstr "Verifica dell'acquisto..."
 msgid "Verifying voucher…"
 msgstr "Verifica del voucher…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Visualizza e gestisci tutti i dispositivi da cui effettui l'accesso. Puoi avere contemporaneamente fino a 5 dispositivi su un account. Ogni dispositivo riceve un nome quando si effettua l'accesso per aiutarti a distinguerli facilmente."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Stiamo ancora verificando il tuo acquisto, l'operazione potrebbe richiedere del tempo. Il tuo tempo verrà aggiunto quando la verifica avrà avuto esito positivo."
 
@@ -3441,11 +3519,17 @@ msgstr "Offuscamento WireGuard"
 msgid "WireGuard port"
 msgstr "Porta WireGuard"
 
+msgid "Yes, log out device"
+msgstr "Sì, disconnetti il dispositivo"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" creato"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" eliminato"
+
+msgid "click here"
+msgstr "clicca qui"
 
 msgid "here"
 msgstr "qui"

--- a/desktop/packages/mullvad-vpn/locales/it/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/it/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Italian\n"
 "Language: it_IT\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ja/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ja/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "その他%(amount)d件..."
@@ -162,6 +162,11 @@ msgstr "それでも有効にする"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "ダイレクトのみ有効化"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "デバイスのリストを取得できませんでした"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "セキュリティ保護接続を確立できませんでした"
@@ -430,6 +435,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCPの設定"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "右矢印キーを使用して設定ボタンにフォーカスを移動します。"
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -447,6 +456,11 @@ msgstr "現在使用不可"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "ログアウト"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "デバイスを管理"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -552,6 +566,10 @@ msgstr "有効な localhost のポートを入力してください。"
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "有効なリモートサーバーのポートを入力してください。"
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "まだ使用されていないアクセス方法の名前を選択してください。"
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1002,14 +1020,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "カスタムブリッジの編集"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "本当に<b>%(deviceName)s</b>をログアウトしますか？"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1021,6 +1031,11 @@ msgstr "ログインを続ける"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "作成日: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "現在のデバイス"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1055,15 +1070,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "ログアウトすると、デバイスとデバイス名が削除されます。もう一度ログインすると、デバイスに新しい名前が付けられます。"
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "デバイスを管理"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "以下のリストから少なくとも1つを削除してログアウトしてください。対応するデバイス名はデバイスのアカウント設定で確認できます。"
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "削除"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "<em>%(deviceName)s</em>を削除しますか？"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "素晴らしい！"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "リストからデバイスが削除され、ログアウトされます。"
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1079,10 +1117,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "デバイスが多すぎます"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "はい。デバイスをログアウトさせます"
+msgid "Try again"
+msgstr "再試行"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "ログイン中のすべてのデバイスを表示・管理します。1つのアカウントで最大5台のデバイスを同時に利用できます。各デバイスは識別しやすくするため、ログイン時に名前が付けられます。"
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1357,6 +1401,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "選択した%(wireGuard)sポートには対応していません。"
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "このデバイスの名前が<em>%(deviceName)s</em>になりました。詳細はアカウントの [デバイスを管理] でご確認ください。"
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1392,10 +1443,6 @@ msgstr "検証が完了しました！インストーラーを起動中..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "検証に失敗しました"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "ようこそ。このデバイスの名前は<b>%(deviceName)s</b>です。詳細はアカウントの情報ボタンで確認してください。"
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1523,11 +1570,6 @@ msgstr "エラー"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "アカウントを作成できませんでした"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "デバイスのリストを取得できませんでした"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2131,6 +2173,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)sには問題があるため、VPNトンネルから除外できません。"
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)sはお使いのシステムではサポートされていません。"
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "追加"
@@ -2142,6 +2191,11 @@ msgstr "すべてのアプリ"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "VPNトンネルから除外するアプリを選択してください。"
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "ここをクリックすると詳細が表示されます"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2189,6 +2243,14 @@ msgstr "再試行するか、問題の報告を送信してください。"
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Mullvadサービスを再起動"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "%(splitTunneling)sを使用するには、cgroup v1をサポートしているLinuxカーネルバージョンに変更してください。"
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2504,8 +2566,8 @@ msgstr "アプリ起動時に自動的にサーバーに接続します。"
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "これらの設定を有効にするには、以下で<b>%(customDnsFeatureName)s</b>を無効にしてください。"
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "これらの設定を有効にするには、下の [%(customDnsFeatureName)s] を無効にしてください。"
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2697,6 +2759,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "%(daita)sはこのようなデータパケットが監視されている場合でも、訪問先ウェブサイトや通信相手を特定するのを極めて困難にします。"
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IPバージョン"
@@ -2706,12 +2769,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "耐量子アルゴリズムで追加の鍵の交換を実行し、結果をWireGuardの通常の暗号化に混合させることで行われます。この追加ステップでは、新しいトンネルが確立されるたびに約500kiBのトラフィックが使用されます。"
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "マルチホップ"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "選択した場所でDAITAを有効にするためにマルチホップが使用されています"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2726,6 +2800,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "すべてのサーバーが%(daita)sに対応しているわけではないため、どのサーバーでも%(daita)sが有効になるようにマルチホップを自動的に使用しています。"
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "難読化"
@@ -2736,6 +2811,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "難読化は、WireGuardトラフィックを別のプロトコル内に隠します。プレーンなWireGuard接続がブロックされる検閲やその他のフィルタリングを回避するために使用できます。"
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "ポート"
@@ -2797,10 +2873,6 @@ msgstr "この機能は、WireGuardトンネルに量子コンピューターか
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCPポート"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2898,6 +2970,9 @@ msgstr "時間を追加"
 msgid "Adding method..."
 msgstr "方法を追加しています..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Android 16でVPNアプリを更新すると、デバイス上のVPNアプリがインターネットにアクセス不可能な状態になる可能性があります。"
+
 msgid "Agree and continue"
 msgstr "同意して続行"
 
@@ -2912,6 +2987,12 @@ msgstr "Always-on VPNは%sに割り当てられました"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Always-on VPNは他のVPNに割り当てられました"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16には既知の問題があります。デバイスを再起動して再試行してください。詳細は、"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "本当に<b>%s</b>をログアウトしますか？"
 
 msgid "At least one method needs to be enabled"
 msgstr "方法は少なくとも 1 つは有効化する必要があります"
@@ -2945,6 +3026,9 @@ msgstr "インターネットをブロック中 (デバイスがオフライン)
 
 msgid "Blocking..."
 msgstr "ブロック中…"
+
+msgid "Can't connect?"
+msgstr "接続できませんか？"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "結果がキャッシュされているため、DNS関連の設定の変更はすぐには適用されない可能性があります。"
@@ -2982,9 +3066,6 @@ msgstr "リストの新規作成"
 msgid "Critical error (your attention is required)"
 msgstr "重大なエラー (ご注意ください)"
 
-msgid "Current device"
-msgstr "現在のデバイス"
-
 msgid "Current: %s"
 msgstr "現在の設定: %s"
 
@@ -3005,9 +3086,6 @@ msgstr "方法を削除しますか？"
 
 msgid "Device IP version"
 msgstr "デバイスのIPバージョン"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "これらの設定を有効にするには、下の [%s] を無効にしてください。"
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "この設定を有効にするには、上の [%s] をすべて無効にしてください。"
@@ -3087,9 +3165,6 @@ msgstr "現在の設定に設定できません。原因は不明です"
 msgid "File"
 msgstr "ファイル"
 
-msgid "Filters:"
-msgstr "絞り込み:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "デバイスの起動時にVPNを自動接続するには、アプリにVPNへのアクセス許可が必要です。このアクセス許可は、地図表示で [接続] をクリックし、プロンプトが表示されたら [OK] を選択すると付与できます。また、システム設定のアプリの詳細でストレージ情報を調べ、内部ストレージにアプリがインストールされていることも確認してください。"
 
@@ -3156,9 +3231,6 @@ msgstr "\"%s\" の場所が変更されました"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "デバイスが必ずVPNトンネルを使用するようにします。"
 
-msgid "Manage devices"
-msgstr "デバイスを管理する"
-
 msgid "More actions"
 msgstr "その他の操作"
 
@@ -3186,8 +3258,8 @@ msgstr "利用可能なカスタムリストはありません"
 msgid "No internet connection"
 msgstr "インターネット接続がありません"
 
-msgid "No locations found"
-msgstr "場所が見つかりませんでした"
+msgid "No matching servers found."
+msgstr "一致するサーバーが見つかりません。"
 
 msgid "No recent selection history"
 msgstr "最近の選択履歴はありません"
@@ -3227,6 +3299,12 @@ msgstr "有効なリモートサーバーのポートを入力してください
 
 msgid "Please press connect to request VPN permission"
 msgstr "[接続] を押してVPNへのアクセス許可をリクエストしてください"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "デバイスを再起動して再接続してください。それでも問題が解決しない場合は、%sにスウェーデン語か英語のメールでお問い合わせください。"
+
+msgid "Please try changing your filters."
+msgstr "条件を変更してみてください。"
 
 msgid "Privacy"
 msgstr "プライバシー"
@@ -3315,9 +3393,6 @@ msgstr "\"現在の設定\" の方法は、アプリが API に到達するた�
 msgid "The app is blocking internet, please disconnect first"
 msgstr "アプリがインターネットをブロックしています。先に切断してください"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "リストからデバイスが削除され、ログアウトされます。"
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "VPN設定で [ローカルネットワーク共有] を有効にしない限り、ローカルDNSサーバーは機能しません。"
 
@@ -3375,6 +3450,12 @@ msgstr "DNS サーバーを更新"
 msgid "Update list name"
 msgstr "リスト名の更新"
 
+msgid "Update server list"
+msgstr "サーバーリストを更新"
+
+msgid "Updating server list in the background..."
+msgstr "サーバーリストをバックグラウンドで更新中..."
+
 msgid "Use method"
 msgstr "この方法を使用する"
 
@@ -3411,9 +3492,6 @@ msgstr "購入を確認中..."
 msgid "Verifying voucher…"
 msgstr "バウチャーを確認中…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "ログイン中のすべてのデバイスを表示・管理します。1つのアカウントで最大5台のデバイスを同時に利用できます。各デバイスは識別しやすくするため、ログイン時に名前が付けられます。"
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "現在購入の確認を行っており、これには時間がかかる場合があります。確認が完了すると、時間が追加されます。"
 
@@ -3435,11 +3513,17 @@ msgstr "WireGuardの難読化"
 msgid "WireGuard port"
 msgstr "WireGuardポート"
 
+msgid "Yes, log out device"
+msgstr "はい。デバイスをログアウトします"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" が作成されました"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" は削除されました"
+
+msgid "click here"
+msgstr "ここをクリックしてください"
 
 msgid "here"
 msgstr "こちらをご覧ください。"

--- a/desktop/packages/mullvad-vpn/locales/ja/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ja/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Japanese\n"
 "Language: ja_JP\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ko/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ko/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Korean\n"
 "Language: ko_KR\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d개 더 보기..."
@@ -162,6 +162,11 @@ msgstr "그래도 사용"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "직접 전용 활성화"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "장치 목록을 가져오지 못함"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "보안 연결 실패"
@@ -430,6 +435,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCP 설정"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "오른쪽 화살표 키를 사용하여 설정 버튼에 포커스를 맞추세요."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -447,6 +456,11 @@ msgstr "현재 사용 가능"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "로그아웃"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "장치 관리"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -552,6 +566,10 @@ msgstr "유효한 localhost 포트를 입력하세요."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "유효한 원격 서버 포트를 입력하세요."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "아직 사용되지 않은 액세스 방법의 이름을 선택하세요."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1002,14 +1020,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "사용자 지정 브리지 편집"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "<b>%(deviceName)s</b>에서 로그아웃하시겠습니까?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1021,6 +1031,11 @@ msgstr "로그인 계속하기"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "생성 날짜: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "현재 장치"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1055,15 +1070,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "로그아웃하면 해당 장치와 장치 이름이 제거됩니다. 다시 로그인하면 장치에 새 이름이 부여됩니다."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "장치 관리"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "하나 이상의 항목을 아래 목록에서 제거하여 로그아웃하세요. 장치의 계정 설정에서 해당 장치 이름을 찾을 수 있습니다."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "제거"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "<em>%(deviceName)s</em> 장치를 제거하시겠습니까?"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "좋습니다!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "장치가 목록에서 제거되고 로그아웃됩니다."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1079,10 +1117,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "장치가 너무 많음"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "예, 장치에서 로그아웃"
+msgid "Try again"
+msgstr "다시 시도"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "로그인된 모든 장치를 보고 관리하세요. 한 계정에서 최대 5대의 장치를 동시에 보유할 수 있습니다. 사용자가 쉽게 구분할 수 있도록 로그인 시 각 장치에 이름이 부여됩니다."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1357,6 +1401,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "선택한 %(wireGuard)s 포트는 지원되지 않습니다. 다음에서 변경하세요: "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "이 장치의 현재 이름은 <em>%(deviceName)s</em>입니다. 자세한 내용은 계정의 \"장치 관리\"에서 확인할 수 있습니다."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1392,10 +1443,6 @@ msgstr "확인 완료! 설치 프로그램을 실행하는 중..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "확인 실패"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "환영합니다! 이제 이 장치의 이름은 <b>%(deviceName)s</b>입니다. 자세한 내용을 보려면 계정의 정보 버튼을 누르세요."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1523,11 +1570,6 @@ msgstr "오류"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "계정을 만들지 못함"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "장치 목록을 가져오지 못함"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2131,6 +2173,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s에 문제가 있으며 VPN 터널에서 제외할 수 없습니다."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "시스템에서 %(splitTunneling)s을(를) 지원하지 않습니다."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "추가"
@@ -2142,6 +2191,11 @@ msgstr "모든 앱"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "VPN 터널에서 제외할 앱을 선택하세요."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "자세한 내용은 여기를 클릭하세요"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2189,6 +2243,14 @@ msgstr "다시 시도하거나 문제 보고서를 보내주세요."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Mullvad 서비스 다시 시작"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "%(splitTunneling)s을(를) 사용하려면 cgroup v1을 지원하는 Linux 커널 버전으로 변경하세요."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2504,8 +2566,8 @@ msgstr "앱이 시작되면 자동으로 서버에 연결합니다."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "이 설정을 활성화하려면 아래의 <b>%(customDnsFeatureName)s</b>을(를) 비활성화하세요."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "이 설정을 활성화하려면 아래의 \"%(customDnsFeatureName)s\"을(를) 비활성화하세요."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2697,6 +2759,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "이러한 데이터 패킷을 모니터링하고 있는 관찰자가 있는 경우, %(daita)s는 사용자가 어느 웹사이트를 방문하고 있는지, 누구와 대화하고 있는지 아주 식별하기 어렵게 만듭니다."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP 버전"
@@ -2706,12 +2769,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "이를 위해 양자 안전 알고리즘을 사용하여 추가 키 교환을 수행하고 결과를 WireGuard의 일반 암호화에 혼합하는 방법이 이용됩니다. 이 추가 단계는 새 터널이 설정될 때마다 약 500kiB의 트래픽을 사용합니다."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "멀티홉"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "선택한 위치의 DAITA를 활성화하기 위해 멀티홉을 사용 중입니다"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2726,6 +2800,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "일부 서버에는 %(daita)s가 활성화되어 있지 않습니다. 따라서 당사는 모든 서버에서 %(daita)s를 활성화하기 위해 자동으로 멀티홉을 사용합니다."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "난독 처리"
@@ -2736,6 +2811,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "난독 처리는 다른 프로토콜 내에서 WireGuard 트래픽을 숨깁니다. 일반 WireGuard 연결이 차단되는 상황에서 검열 및 기타 유형의 필터링을 우회하는 데 사용할 수 있습니다."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "포트"
@@ -2797,10 +2873,6 @@ msgstr "이 기능은 WireGuard 터널이 양자 컴퓨터의 잠재적인 공�
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCP 포트"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2898,6 +2970,9 @@ msgstr "시간 추가"
 msgid "Adding method..."
 msgstr "방법 추가 중..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Android 16에서 VPN 앱을 업데이트하면 VPN 앱이 더 이상 인터넷에 연결되지 않는 상태가 될 수 있습니다."
+
 msgid "Agree and continue"
 msgstr "동의하고 계속하기"
 
@@ -2912,6 +2987,12 @@ msgstr "상시 접속 VPN이 %s에 할당됨"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "상시 접속 VPN이 다른 VPN에 할당됨"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16에는 알려진 문제가 있습니다. 장치를 재시작한 후 다시 시도해 주세요. 자세한 내용을 알아보려면"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "<b>%s</b>에서 로그아웃하시겠습니까?"
 
 msgid "At least one method needs to be enabled"
 msgstr "1개 이상의 방법이 활성화되어 있어야 합니다"
@@ -2945,6 +3026,9 @@ msgstr "인터넷 차단(장치 오프라인)"
 
 msgid "Blocking..."
 msgstr "차단 중..."
+
+msgid "Can't connect?"
+msgstr "연결이 되지 않나요?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "DNS 관련 설정에 대한 변경 사항은 캐시된 결과로 인해 즉시 적용되지 않을 수도 있습니다."
@@ -2982,9 +3066,6 @@ msgstr "새 목록 생성"
 msgid "Critical error (your attention is required)"
 msgstr "심각한 오류(주의가 필요함)"
 
-msgid "Current device"
-msgstr "현재 장치"
-
 msgid "Current: %s"
 msgstr "현재: %s"
 
@@ -3005,9 +3086,6 @@ msgstr "이 방법을 삭제하시겠습니까?"
 
 msgid "Device IP version"
 msgstr "장치 IP 버전"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "이 설정을 활성화하려면 아래의 \"%s\"를 비활성화하세요."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "이 설정을 활성화하려면 위의 모든 \"%s\"를 비활성화하세요."
@@ -3087,9 +3165,6 @@ msgstr "현재로 설정하지 못함 - 알 수 없는 이유"
 msgid "File"
 msgstr "파일"
 
-msgid "Filters:"
-msgstr "필터:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "장치 시작 시 VPN이 자동으로 연결되려면 앱에 VPN 권한이 있어야 합니다. 지도 보기에서 \"연결\"을 클릭하고, 메시지가 표시되는 경우 \"확인\"을 선택하면, 해당 권한이 부여됩니다. 또한 시스템 설정의 앱 세부 정보에서 저장소 정보를 보고 앱이 내부 저장소에 설치되어 있는지 확인하세요."
 
@@ -3156,9 +3231,6 @@ msgstr "\"%s\"에 대해 위치가 변경되었습니다"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "장치가 항상 VPN 터널에 있어야 합니다."
 
-msgid "Manage devices"
-msgstr "장치 관리"
-
 msgid "More actions"
 msgstr "추가 작업"
 
@@ -3186,8 +3258,8 @@ msgstr "이용 가능한 사용자 지정 목록 없음"
 msgid "No internet connection"
 msgstr "인터넷에 연결되지 않음"
 
-msgid "No locations found"
-msgstr "위치를 찾을 수 없음"
+msgid "No matching servers found."
+msgstr "일치하는 서버를 찾을 수 없습니다."
 
 msgid "No recent selection history"
 msgstr "최근 선택 내역이 없습니다"
@@ -3227,6 +3299,12 @@ msgstr "유효한 원격 서버 포트를 입력하세요"
 
 msgid "Please press connect to request VPN permission"
 msgstr "VPN 권한을 요청하려면 연결을 누르세요"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "장치를 재시작하고 다시 연결해 주세요. 그래도 해결되지 않는다면 %s에 스웨덴어 또는 영어로 이메일을 보내주세요."
+
+msgid "Please try changing your filters."
+msgstr "필터를 변경해 보세요."
 
 msgid "Privacy"
 msgstr "개인 정보 보호"
@@ -3315,9 +3393,6 @@ msgstr "\"현재\" 방법은 앱이 API에 연결하기 위해 사용하는 방�
 msgid "The app is blocking internet, please disconnect first"
 msgstr "해당 앱이 인터넷을 차단하고 있습니다. 먼저 연결 해제하세요"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "장치가 목록에서 제거되고 로그아웃됩니다."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "VPN 설정에서 \"로컬 네트워크 공유\"를 활성화하지 않으면 로컬 DNS 서버가 작동하지 않습니다."
 
@@ -3375,6 +3450,12 @@ msgstr "DNS 서버 업데이트"
 msgid "Update list name"
 msgstr "목록 이름 업데이트"
 
+msgid "Update server list"
+msgstr "서버 목록 업데이트"
+
+msgid "Updating server list in the background..."
+msgstr "백그라운드에서 서버 목록을 업데이트하는 중..."
+
 msgid "Use method"
 msgstr "방법 사용"
 
@@ -3411,9 +3492,6 @@ msgstr "구매 확인 중..."
 msgid "Verifying voucher…"
 msgstr "바우처 확인 중…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "로그인된 모든 장치를 보고 관리하세요. 한 계정에서 최대 5대의 장치를 동시에 보유할 수 있습니다. 사용자가 쉽게 구분할 수 있도록 각 장치에는 로그인 시 이름이 부여됩니다."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "아직 구매를 확인하고 있으며, 다소 시간이 걸릴 수 있습니다. 확인이 완료되면 시간이 추가됩니다."
 
@@ -3435,11 +3513,17 @@ msgstr "WireGuard 난독화"
 msgid "WireGuard port"
 msgstr "WireGuard 포트"
 
+msgid "Yes, log out device"
+msgstr "예, 장치에서 로그아웃"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\"이(가) 생성되었습니다"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\"이(가) 삭제되었습니다"
+
+msgid "click here"
+msgstr "여기를 클릭하세요"
 
 msgid "here"
 msgstr "여기"

--- a/desktop/packages/mullvad-vpn/locales/ko/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ko/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Korean\n"
 "Language: ko_KR\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/my/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/my/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Burmese\n"
 "Language: my_MM\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "နောက်ထပ် %(amount)d လုံး..."
@@ -162,6 +162,11 @@ msgstr "မည်သို့ပင်ဖြစ်စေ ဖွင့်ရန�
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "တိုက်ရိုက်သီးသန့် ဖွင့်ရန်"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "စက်စာရင်းကို ယူ၍မရခဲ့ပါ"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "ချိတ်ဆက်မှုကို ကာကွယ်ရန် မအောင်မြင်ပါ"
@@ -430,6 +435,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCP ဆက်တင်များ"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "ဆက်တင်ခလုတ်ကို ရွေးချယ်ရန် ညာမြှားကီးကို သုံးပါ။"
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -447,6 +456,11 @@ msgstr "လက်ရှိ၌ မရရှိနိုင်ပါ"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "ထွက်ရန်"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "စက်များကို စီမံရန်"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -552,6 +566,10 @@ msgstr "မှန်ကန်သော စက်တွင်း Host ပေါ�
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "မှန်ကန်သော အဝေးဆာဗာ ပေါ့တ်ကို ရိုက်ထည့်ပါ။"
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "သုံးထားပြီးသားမဟုတ်သည့် ဝင်ခွင့်နည်းလမ်းအတွက် အမည်တစ်ခု ရွေးချယ်ပါ။"
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1002,14 +1020,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "စိတ်ကြိုက် ပေါင်းကူးကို တည်းဖြတ်ရန်"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "<b>%(deviceName)s</b> မှ ထွက်လိုသည်မှာ သေချာပါသလား။"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1021,6 +1031,11 @@ msgstr "ဆက်လက် ဝင်ရောက်ရန်"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "ဖန်တီးသည့် အချိန်- %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "လက်ရှိစက်"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1055,15 +1070,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "ထွက်လိုက်ပါက စက်နှင့် စက်အမည်ကို ဖယ်ရှားပါသည်။ နောက်တစ်ကြိမ် ပြန်ဝင်ရောက်သည့်အခါ စက်သည် အမည်သစ်တစ်ခု ရရှိပါမည်။"
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "စက်များကို စီမံရန်"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "အောက်ပါစာရင်းမှ အနည်းဆုံး တစ်ခုကို ဖယ်ရှားခြင်းဖြင့် ၎င်းမှ ထွက်ပါ။ စက်၏ အကောင့်ဆက်တင်အောက်တွင် သက်ဆိုင်သော စက်အမည်ကို သင် ရှာနိုင်သည်။"
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "ဖယ်ရှားရန်"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "<em>%(deviceName)s</em> ကို ဖယ်ရှားမလား"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "အလွန်ကောင်း။"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "စက်ကို စာရင်းမှ ဖယ်ရှားပြီး စနစ်မှ ထွက်သွားလိမ့်မည်။"
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1079,10 +1117,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "စက်များလွန်းနေသည်"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "စက်မှ ထွက်မည်"
+msgid "Try again"
+msgstr "ထပ်ကြိုးစားရန်"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "သင်ဝင်ရောက်ထားသည့် စက်အားလုံးကို ကြည့်ရှုစီမံပါ။ အကောင့်တစ်ခုလျှင် စက် ၅ လုံးအထိ တစ်ပြိုင်နက်ဝင်ထားနိုင်သည်။ ဝင်ရောက်သည့်အခါတိုင်း ခွဲခြားရလွယ်ကူစေရန် စက်တစ်လုံးချင်းကို အမည်ပေးထားသည်။"
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1357,6 +1401,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "ရွေးထားသည့် %(wireGuard)s ပေါ့တ်ကို ပံ့ပိုးထားခြင်းမရှိပါသဖြင့် ၎င်းကို အောက်တွင် ပြောင်းပေးပါ "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "ဤစက်ကို <em>%(deviceName)s</em> ဟု ယခု အမည်ပေးထားသည်။ အကောင့်အောက်ရှိ \"စက်များ စီမံရန်\" တွင် အသေးစိတ် ကြည့်ရှုပါ။"
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1392,10 +1443,6 @@ msgstr "စစ်ဆေးမှု ပြီးစီးပါပြီ။ ထ�
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "စစ်ဆေးမှု မအောင်မြင်ပါ"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "ကြိုဆိုပါသည်၊ ယခုမှစ၍ ဤစက်ကို <b>%(deviceName)s</b> ဟု ခေါ်ဆိုပါမည်။ နောက်ထပ်အသေးစိတ်တို့အတွက် အကောင့်တွင် အချက်အလက် ခလုတ်ကို နှိပ်၍ ကြည့်နိုင်သည်။"
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1523,11 +1570,6 @@ msgstr "ချို့ယွင်းချက်"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "အကောင့် ဖန်တီးရန် မအောင်မြင်ခဲ့ပါ"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "စက်စာရင်းကို ယူရန် မအောင်မြင်ခဲ့ပါ"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2131,6 +2173,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s သည် ပြဿနာဖြစ်စေပြီး VPN Tunnel မှ ဖယ်၍ မရနိုင်ပါ။"
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s ကို သင့်စနစ်က မပံ့ပိုးပါ။"
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "ပေါင်းထည့်ရန်"
@@ -2142,6 +2191,11 @@ msgstr "အက်ပ်များ အားလုံး"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "VPN Tunnel မှ ဖယ်ထုတ်လိုသည့် အက်ပ်များကို ရွေးချယ်ပါ။"
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "ပိုမိုသိရှိရန် ဤနေရာကိုနှိပ်ပါ"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2189,6 +2243,14 @@ msgstr "ထပ်ကြိုးစားကြည့်ပါ သို့မ�
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Mullvad ဝန်ဆောင်မှုကို ပြန်လည်စတင်ရန်"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "%(splitTunneling)s ကိုသုံးလိုပါက cgroup v1 ကို ပံ့ပိုးပေးသည့် Linux Kernel ဗားရှင်းသို့ ပြောင်းပါ။"
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2504,8 +2566,8 @@ msgstr "အက်ပ် စတင်ဆောင်ရွက်ချိန်�
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "ဤဆက်တင်တို့ကို သက်ဝင်လုပ်ဆောင်ရန် အောက်ပါ <b>%(customDnsFeatureName)s</b> ကို ပိတ်ပါ။"
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "ဤဆက်တင်များကို ဖွင့်ရန် အောက်ပါ \"%(customDnsFeatureName)s\" ကို ပိတ်ပါ။"
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2697,6 +2759,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "အကဲခတ်သူတစ်ဦးက ဤဒေတာပက်ကတ်များကို စောင့်ကြည့်လျှင် %(daita)s သည် သင်သွားရောက်ကြည့်ရှုနေသော ဝဘ်ဆိုက်များ သို့မဟုတ် သင်ဆက်သွယ်နေသည့်သူများကို ခွဲခြားဖော်ထုတ်ရန် ၎င်းတို့အတွက် သိသိသာသာ ခက်ခဲစေသည်။"
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP ဗားရှင်း"
@@ -2706,12 +2769,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Quantum Safe အယ်လဂိုရီသမ်တစ်ခုကို သုံး၍ ထပ်ဆောင်း ကီးဖလှယ်မှုတစ်ခုကို ဆောင်ရွက်ပြီး WireGuard ၏ ပုံမှန် ကုဒ်ပြောင်းဝှက်မှုအတွင်း ရလဒ်ကို ရောနှောခြင်းအားဖြင့် ဤသည်ကို လုပ်ဆောင်ပါသည်။ ဤထပ်ဆောင်းအဆင့်သည် Tunnel အသစ်တစ်ခု တည်ဆောက်တိုင်း ဒေတာ 500 kiB ခန့်ကို သုံးပါသည်။"
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "မာလ်တီဟော့ပ်"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "သင်ရွေးချယ်ထားသည့် တည်နေရာအတွက် DAITA ကိုဖွင့်ရန် မာလ်တီဟော့ပ်ကို သုံးထားသည်"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2726,6 +2800,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "ကျွန်ုပ်တို့၏ဆာဗာအားလုံးတွင် %(daita)s ကိုဖွင့်ထားခြင်းမရှိပါ။ ထို့ကြောင့် ကျွန်ုပ်တို့သည် မည်သည့်ဆာဗာနှင့်မဆို %(daita)s ကိုဖွင့်ရန် မာလ်တီဟော့ပ်ကို အလိုအလျောက်အသုံးပြုပါသည်။"
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Obfuscation"
@@ -2736,6 +2811,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Obfuscation သည် အခြားပရိုတိုကောလ်အတွင်းရှိ WireGuard ကူးလူးမှုကို ဝှက်ထားပေးပါသည်။ သာမန် WireGuard ချိတ်ဆက်မှုကို ပိတ်ဆို့မည့် အခြားသော စစ်ထုတ်မှု အမျိုးအစားများနှင့် ဆင်ဆာဖြတ်တောက်ခြင်းကို ရှောင်လွှဲနိုင်စေရာတွင် ကူညီနိုင်စေရန် ၎င်းကို သုံးနိုင်ပါသည်။"
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "ပေါ့တ်"
@@ -2797,10 +2873,6 @@ msgstr "ဤလုပ်ဆောင်ချက်သည် Quantum ကွန်
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCP ပေါ့တ်"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2898,6 +2970,9 @@ msgstr "အချိန်တိုးရန်"
 msgid "Adding method..."
 msgstr "နည်းလမ်း ထည့်နေဆဲ..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Android 16 တွင် VPN အက်ပ်ကို အပ်ဒိတ်လုပ်ပြီးနောက် စက်များတွင် VPN အက်ပ်များက အင်တာနက်ချိတ်မပေးနိုင်တော့သည့် အခြေအနေမျိုး ကြုံရတတ်သည်။"
+
 msgid "Agree and continue"
 msgstr "သဘောတူပြီး ဆက်လုပ်ရန်"
 
@@ -2912,6 +2987,12 @@ msgstr "အမြဲဖွင့် VPN ကို %s သို့ သတ်မ�
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "အမြဲဖွင့် VPN ကို အခြား VPN တစ်ခုသို့ သတ်မှတ်ထားပါသည်"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 တွင် သိထားပြီးသား ပြဿနာရှိသည်။ သင့်စက်ကို ရီစတက်ချပြီး ထပ်မံကြိုးစားပါ။ ပိုမိုလေ့လာရန်၊ "
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "<b>%s</b> မှ ထွက်လိုသည်မှာ သေချာပါသလား။"
 
 msgid "At least one method needs to be enabled"
 msgstr "အနည်းဆုံး နည်းလမ်းတစ်ခုကို ဖွင့်ရမည်"
@@ -2945,6 +3026,9 @@ msgstr "အင်တာနက် ပိတ်ဆို့နေဆဲ (စက်
 
 msgid "Blocking..."
 msgstr "ပိတ်ဆို့နေဆဲ..."
+
+msgid "Can't connect?"
+msgstr "ချိတ်မရဘူးလား။"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "DNS နှင့်ဆက်စပ်သော ဆက်တင်များ၌ ပြုလုပ်သည့် ပြောင်းလဲမှုများသည် ယာယီသိမ်းထားသော ရလဒ်များကြောင့် ချက်ချင်း အကျိုးမသက်ရောက်နိုင်ပါ။"
@@ -2982,9 +3066,6 @@ msgstr "စာရင်းသစ် ဖန်တီးမည်"
 msgid "Critical error (your attention is required)"
 msgstr "အလွန်အရေးပါသည့် ချို့ယွင်းချက် (သင့်အာရုံစိုက်မှု လိုအပ်ပါသည်)"
 
-msgid "Current device"
-msgstr "လက်ရှိစက်"
-
 msgid "Current: %s"
 msgstr "လက်ရှိ- %s"
 
@@ -3005,9 +3086,6 @@ msgstr "နည်းလမ်းကို ဖျက်မည်လား။"
 
 msgid "Device IP version"
 msgstr "စက် IP ဗားရှင်း"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "ဤဆက်တင်များကို ဖွင့်ရန် အောက်ပါ \"%s\" ကို ပိတ်ပါ။"
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "ဤဆက်တင်ကိုဖွင့်ရန် အထက်ရှိ \"%s\" အားလုံးကို ပိတ်ပါ။"
@@ -3087,9 +3165,6 @@ msgstr "လက်ရှိသို့ သတ်မှတ်၍ မရခဲ့�
 msgid "File"
 msgstr "ဖိုင်"
 
-msgid "Filters:"
-msgstr "စစ်ထုတ်မှုများ-"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "စက်စတင်ချိန်တွင် VPN ကို အလိုအလျောက်ချိတ်ဆက်ရန်အတွက်၊ အက်ပ်တွင် VPN ခွင့်ပြုချက်များ ရှိရမည်။ မြေပုံမြင်ကွင်းရှိ “ချိတ်ဆက်ပါ” ကိုနှိပ်ပြီး “အိုကေ” ကိုရွေးချယ်ခြင်းဖြင့် ခွင့်ပြုချက် ပေးနိုင်သည်။ ထို့အပြင် စနစ်ဆက်တင်များရှိ အက်ပ်အသေးစိတ်တွင် သိုလှောင်သိမ်းဆည်းမှုအချက်အလက်များကို စစ်ဆေးခြင်းဖြင့် အက်ပ်အား စက်တွင်းသိုလှောင်ရာနေရာတွင် ထည့်သွင်းထားကြောင်း သေချာပါစေ။"
 
@@ -3156,9 +3231,6 @@ msgstr "\"%s\" အတွက် တည်နေရာများကို ပြ
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "စက်သည် VPN Tunnel ကို အမြဲဖွင့်ထားကြောင်း သေချာပါစေ။"
 
-msgid "Manage devices"
-msgstr "စက်များကို စီမံရန်"
-
 msgid "More actions"
 msgstr "နောက်ထပ်လုပ်ဆောင်ချက်များ"
 
@@ -3186,8 +3258,8 @@ msgstr "စိတ်ကြိုက် စာရင်းများကို �
 msgid "No internet connection"
 msgstr "အင်တာနက် ချိတ်ဆက်မှု မရှိပါ"
 
-msgid "No locations found"
-msgstr "တည်နေရာများကို ရှာမတွေ့ပါ"
+msgid "No matching servers found."
+msgstr "ကိုက်ညီသည့် ဆာဗာများ မတွေ့ပါ။"
 
 msgid "No recent selection history"
 msgstr "လတ်တလောရွေးချယ်မှု မှတ်တမ်း မရှိပါ"
@@ -3227,6 +3299,12 @@ msgstr "မှန်ကန်သော အဝေးဆာဗာ ပေါ့တ�
 
 msgid "Please press connect to request VPN permission"
 msgstr "VPN ခွင့်ပြုချက်တောင်းရန် ချိတ်ဆက်ရန်ကို နှိပ်ပေးပါ"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "စက်ကို ရီစတက်ချပြီး ထပ်မံချိတ်ဆက်ကြည့်ပါ။ ချိတ်၍မရသေးလျှင် %s သို့ ဆွီဒင် သို့မဟုတ် အင်္ဂလိပ်ဘာသာစကားဖြင့် အီးမေးလ်ပို့ပါ။"
+
+msgid "Please try changing your filters."
+msgstr "စစ်ထုတ်မှုများကို ပြောင်းကြည့်ပါ။"
 
 msgid "Privacy"
 msgstr "ကိုယ်ရေးအချက်အလက် လုံခြုံရေး"
@@ -3315,9 +3393,6 @@ msgstr "\"လက်ရှိ\" စနစ်သည် API နှင့်ချ�
 msgid "The app is blocking internet, please disconnect first"
 msgstr "အက်ပ်သည် အင်တာနက်ကို ပိတ်ပင်နေသည်၊ ဦးစွာ ချိတ်ဆက်မှုဖြုတ်ပေးပါ"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "စက်ကို စာရင်းမှ ဖယ်ရှားပြီး စနစ်မှ ထွက်သွားလိမ့်မည်။"
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "လိုကယ် DNS ဆာဗာသည် VPN ဆက်တင်များအောက်ရှိ \"လိုကယ် ကွန်ရက် ဝေမျှမှု\"ကို မဖွင့်မချင်း အလုပ်လုပ်မည် မဟုတ်ပါ။"
 
@@ -3375,6 +3450,12 @@ msgstr "DNS ဆာဗာကို အပ်ဒိတ်လုပ်ရန်"
 msgid "Update list name"
 msgstr "စာရင်း အမည်ကို အပ်ဒိတ်လုပ်ရန်"
 
+msgid "Update server list"
+msgstr "ဆာဗာစာရင်းကို အပ်ဒိတ်လုပ်ရန်"
+
+msgid "Updating server list in the background..."
+msgstr "နောက်ခံတွင် ဆာဗာစာရင်းကို အပ်ဒိတ်လုပ်နေသည်..."
+
 msgid "Use method"
 msgstr "နည်းလမ်းကို သုံးရန်"
 
@@ -3411,9 +3492,6 @@ msgstr "ဝယ်ယူမှုကို စစ်ဆေးနေဆဲ..."
 msgid "Verifying voucher…"
 msgstr "ဘောက်ချာကို စစ်ဆေးနေဆဲ…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "သင်ဝင်ရောက်ထားသည့် စက်ပစ္စည်းအားလုံးကို ကြည့်ရှုစီမံပါ။ အကောင့်တစ်ခုဖြင့် တစ်ချိန်တည်းတွင် စက်ပစ္စည်း ၅ ခုအထိသုံးနိုင်သည်။ စက်ပစ္စည်းတစ်ခုစီသည် ၎င်းတို့ကို အလွယ်တကူခွဲ၍သိနိုင်ရန် လော့ဂ်အင်ဝင်သည့်အခါ အမည်တစ်ခုရရှိမည်ဖြစ်သည်။"
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "ကျွန်ုပ်တို့သည် သင့်ဝယ်ယူမှုကို စစ်ဆေးနေဆဲ ဖြစ်သည်၊ အချိန်အနည်းငယ် ကြာနိုင်သည်။ စစ်ဆေးမှု အောင်မြင်ပါက သင့်အချိန်ကို တိုးလိုက်ပါမည်။"
 
@@ -3435,11 +3513,17 @@ msgstr "WireGuard Obfuscation\n"
 msgid "WireGuard port"
 msgstr "WireGuard ပေါ့တ်"
 
+msgid "Yes, log out device"
+msgstr "စက်မှ ထွက်မည်"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" ကို ဖန်တီးလိုက်ပြီ"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" ကို ဖျက်ပြီးပါပြီ"
+
+msgid "click here"
+msgstr "ဤနေရာကိုနှိပ်ပါ"
 
 msgid "here"
 msgstr "ဤနေရာတွင် ပိုမိုဖတ်ရှုနိုင်ပါသည်"

--- a/desktop/packages/mullvad-vpn/locales/my/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/my/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Burmese\n"
 "Language: my_MM\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/nb/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/nb/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb_NO\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d til …"
@@ -168,6 +168,11 @@ msgstr "Aktiver uansett"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Aktiver kun direkte"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Kunne ikke hente listen over enheter"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "KUNNE IKKE OPPRETTE SIKKER TILKOBLING"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCP-innstillinger"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Bruk høyre piltast for å fokusere på innstillingsknappen."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "For øyeblikket utilgjengelig"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Logg ut"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Behandle enheter"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Skriv inn en gyldig localhost-port."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Skriv inn en gyldig ekstern server-port."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Velg et navn for tilgangsmetoden som ikke allerede er i bruk."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Endre egendefinert bro"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Vil du virkelig logge av <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Fortsett med pålogging"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Opprettet: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Gjeldende enhet"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Hvis du logger ut, vil enheten og enhetsnavnet bli fjernet. Når du logger inn igjen, vil enheten få et nytt navn."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Behandle enheter"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Logg ut av minst én ved å fjerne den fra listen nedenfor. Du finner det tilsvarende enhetsnavnet under enhetens kontoinnstillinger."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Fjern"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Vil du fjerne <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Supert!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Enheten blir fjernet fra listen og logget ut."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "For mange enheter"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Ja, logg av enhet"
+msgid "Try again"
+msgstr "Prøv igjen"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Se og administrer alle innloggede enheter. Du kan ha opptil fem enheter på én konto om gangen. Hver enhet får et navn når du logger inn, slik at du enkelt kan skille dem fra hverandre."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Valgt %(wireGuard)s-port støttes ikke. Du kan endre i "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Denne enheten heter nå <em>%(deviceName)s</em>. Se mer under «Administrer enheter» i Konto."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "BEKREFTELSEN ER FULLFØRT! STARTER INSTALLASJONSPROGRAMMET …"
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "BEKREFTELSEN MISLYKTES"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Velkommen. Denne enheten har fått navnet <b>%(deviceName)s</b>. For å finne ut mer kan du bruke informasjonsknappen under Konto."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Feil"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Kunne ikke opprette konto"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Kunne ikke hente liste over enheter"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s opplever problemer og kan ikke utelates fra VPN-tunnelen."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s støttes ikke av systemet ditt."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Legg til"
@@ -2148,6 +2197,11 @@ msgstr "Alle apper"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Velg appene du vil ekskludere fra VPN-tunnelen."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Klikk her for å finne ut mer"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Prøv igjen eller send inn en problemrapport."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Start Mullvad-tjenesten på nytt"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "For å bruke %(splitTunneling)s, må du endre til en Linux-kjerneversjon som støtter cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Kobler automatisk til en server når appen starter."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Deaktiver <b>%(customDnsFeatureName)s</b> under for å aktivere innstillingene."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Deaktiver «%(customDnsFeatureName)s» nedenfor for å aktivere innstillingene."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Hvis en observatør overvåker disse datapakkene, gjør %(daita)s det betydelig vanskeligere for dem å identifisere hvilke nettsteder du besøker, eller hvem du kommuniserer med."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP-versjon"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Det gjøres ved at å utføre en ekstra nøkkelutveksling med en kvantesikker algoritme og kombinere resultatet med WireGuard sin vanlige kryptering. Dette ekstratrinnet bruker omtrent 500 kiB trafikk hver gang det opprettes en ny tunnel."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihopp"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Multihop brukes til å aktivere DAITA for den valgte plasseringen"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Ikke alle serverne våre er %(daita)s-aktiverte. Derfor bruker vi automatisk multihopp for å aktivere %(daita)s med alle servere."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Tilsløring"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Tilsløring skjuler WireGuard-trafikken i en annen protokoll. Man kan på den måten omgå sensur og andre typer filter der en vanlig WireGuard-tilkobling ville blitt blokkert."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Port"
@@ -2803,10 +2879,6 @@ msgstr "Denne funksjonen gjør WireGuard-tunnelen motstandsdyktig mot potensiell
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCP-port"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Legg til tid"
 msgid "Adding method..."
 msgstr "Legger til metoden ..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Etter å ha oppdatert en VPN-app på Android 16, kan enhetene havne i en tilstand der VPN-appene ikke lenger får tilgang til internett."
+
 msgid "Agree and continue"
 msgstr "Godta og fortsett"
 
@@ -2918,6 +2993,12 @@ msgstr "VPN som alltid er på, er tilordnet %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "VPN som alltid er på, er tilordnet en annen VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 har en kjent feil. Start enheten på nytt og prøv igjen. For å finne ut mer,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Vil du virkelig logge <b>%s</b> av?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Minst én metode må være aktivert"
@@ -2951,6 +3032,9 @@ msgstr "Blokkerer internett (enhet frakoblet)"
 
 msgid "Blocking..."
 msgstr "Blokkerer …"
+
+msgid "Can't connect?"
+msgstr "Kan du ikke koble til?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Endringer til DNS-relaterte innstillinger vil kanskje ikke tre i kraft umiddelbart på grunn av bufrede resultater."
@@ -2988,9 +3072,6 @@ msgstr "Opprett ny liste"
 msgid "Critical error (your attention is required)"
 msgstr "Kritisk feil (krever din oppmerksomhet)"
 
-msgid "Current device"
-msgstr "Gjeldende enhet"
-
 msgid "Current: %s"
 msgstr "Gjeldende: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Slette metoden?"
 
 msgid "Device IP version"
 msgstr "Enhets-IP-versjon"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Deaktiver «%s» nedenfor for å aktivere innstillingene."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Deaktiver alle «%s» ovenfor for å aktivere denne innstillingen."
@@ -3093,9 +3171,6 @@ msgstr "Kunne ikke angi til gjeldende – ukjent årsak"
 msgid "File"
 msgstr "Fil"
 
-msgid "Filters:"
-msgstr "Filtre:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "For at VPN skal kobles automatisk til ved oppstart av enheten, må appen ha VPN-tillatelser. Du kan gi disse ved å klikke på «Koble til» i kartvisningen og velge «OK» hvis du blir bedt om det. I tillegg må du sørge for at appen er installert på det interne lagringsmediet ved å sjekke lagringsinformasjonen i appdetaljene i systeminnstillingene."
 
@@ -3162,9 +3237,6 @@ msgstr "Plasseringer ble endret for «%s»"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Sørger for at enheten alltid er på VPN-tunnelen."
 
-msgid "Manage devices"
-msgstr "Behandle enheter"
-
 msgid "More actions"
 msgstr "Flere handlinger"
 
@@ -3192,8 +3264,8 @@ msgstr "Ingen tilgjengelige egendefinerte lister"
 msgid "No internet connection"
 msgstr "Ingen internettforbindelse"
 
-msgid "No locations found"
-msgstr "Ingen plasseringer funnet"
+msgid "No matching servers found."
+msgstr "Fant ingen matchende servere."
 
 msgid "No recent selection history"
 msgstr "Ingen nylig valghistorikk"
@@ -3233,6 +3305,12 @@ msgstr "Skriv inn en gyldig ekstern server-port"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Trykk på koble til for å be om VPN-tillatelse"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Start enheten på nytt og prøv å koble til igjen. Hvis dette ikke fungerer, kan du skrive en e-post til %s på svensk eller engelsk."
+
+msgid "Please try changing your filters."
+msgstr "Prøv å endre filtrene."
 
 msgid "Privacy"
 msgstr "Personvern"
@@ -3321,9 +3399,6 @@ msgstr "«Gjeldende» metode betyr den metoden som appen bruker for å nå API."
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Denne appen blokkerer internett. Koble fra først"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Enheten blir fjernet fra listen og logget ut."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Den lokale DNS-serveren fungerer ikke med mindre du aktiverer «Deling av lokalt nettverk» under VPN-innstillinger."
 
@@ -3381,6 +3456,12 @@ msgstr "Oppdater DNS-serveren"
 msgid "Update list name"
 msgstr "Oppdater listenavn"
 
+msgid "Update server list"
+msgstr "Oppdater serverlisten"
+
+msgid "Updating server list in the background..."
+msgstr "Oppdater serverlisten i bakgrunnen …"
+
 msgid "Use method"
 msgstr "Bruk metode"
 
@@ -3417,9 +3498,6 @@ msgstr "Bekrefter kjøp ..."
 msgid "Verifying voucher…"
 msgstr "Bekrefter kupong …"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Se og administrer alle innloggede enheter. Du kan ha opptil fem enheter på én konto om gangen. Hver enhet får et navn når du logger inn, slik at du enkelt kan skille dem fra hverandre."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Vi behandler fortsatt kjøpet ditt. Det kan ta en stund. Hvis kjøpet blir bekreftet, legges tiden til."
 
@@ -3441,11 +3519,17 @@ msgstr "Tilsløring av WireGuard"
 msgid "WireGuard port"
 msgstr "WireGuard-port"
 
+msgid "Yes, log out device"
+msgstr "Ja, logg ut av enheten"
+
 msgid "\"%s\" was created"
 msgstr "«%s» ble opprettet"
 
 msgid "\"%s\" was deleted"
 msgstr "«%s» ble slettet"
+
+msgid "click here"
+msgstr "klikk her"
 
 msgid "here"
 msgstr "her"

--- a/desktop/packages/mullvad-vpn/locales/nb/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/nb/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Norwegian Bokmal\n"
 "Language: nb_NO\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/nl/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/nl/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "Nog %(amount)d..."
@@ -168,6 +168,11 @@ msgstr "Toch inschakelen"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Alleen rechtstreeks inschakelen"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Ophalen van lijst van apparaten mislukt"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "VERBINDING BEVEILIGEN MISLUKT"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCP-instellingen"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Gebruik de pijl naar rechts om de instellingenknop te focussen."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Momenteel niet beschikbaar"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Afmelden"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Apparaten beheren"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Voer een geldige poort op de localhost in."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Voer een geldige poort op de externe server in."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Selecteer een naam voor de toegangsmethode die nog in gebruik is."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Aangepaste bridge bewerken"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Weet u zeker dat u <b>%(deviceName)s</b> wilt afmelden?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Doorgaan met aanmelden"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Gemaakt: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Huidig apparaat"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Als u zich afmeldt, worden het apparaat en de apparaatnaam verwijderd. Wanneer u zich weer aanmeldt, krijgt het apparaat een nieuwe naam."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Apparaten beheren"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Meld u bij minstens één apparaat af door het te verwijderen uit de onderstaande lijst. U kunt de bijbehorende apparaatnaam vinden in de accountinstellingen van het apparaat."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Verwijderen"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "<em>%(deviceName)s</em> verwijderen?"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Super!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Het apparaat wordt verwijderd uit de lijst en afgemeld."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Te veel apparaten"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Ja, apparaat afmelden"
+msgid "Try again"
+msgstr "Opnieuw proberen"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Bekijk en beheer al uw aangemelde apparaten. Eén account kan maximaal 5 apparaten tegelijkertijd bevatten. Elk apparaat krijgt bij aanmelding een naam, zodat u ze eenvoudig uit elkaar kunt houden."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "De geselecteerde %(wireGuard)s-poort wordt niet ondersteund. Wijzig de poort in de "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "De naam van dit apparaat is nu <em>%(deviceName)s</em>. Bekijk er meer onder 'Apparaten beheren' in Account."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "VERIFICATIE AFGEROND! INSTALLATIEPROGRAMMA WORDT GESTART..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "VERIFICATIE MISLUKT"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Welkom, dit apparaat heet nu <b>%(deviceName)s</b>. Zie voor meer informatie de infoknop in Account."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Fout"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Account aanmaken mislukt"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Ophalen van lijst van apparaten mislukt"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s is problematisch en kan niet worden uitgesloten van de VPN-tunnel."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s wordt niet ondersteund in ons systeem."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Toevoegen"
@@ -2148,6 +2197,11 @@ msgstr "Alle apps"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Kies de apps die die u wilt uitsluiten van de VPN-tunnel."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Klik hier voor meer informatie"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Probeer het opnieuw of stuur een probleemrapport."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Mullvad-service opnieuw starten"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Als u %(splitTunneling)s wilt gebruiken, moet u overschakelen naar een versie van de Linux-kernel die cgroup v1 ondersteunt."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Automatisch verbinden met een server wanneer de app wordt gestart."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Schakel <b>%(customDnsFeatureName)s</b> hieronder uit om deze instellingen te activeren."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Schakel hieronder \"%(customDnsFeatureName)s\" uit om deze instellingen te activeren."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Als een waarnemer deze gegevenspakketten in de gaten houdt, maakt %(daita)s het aanzienlijk moeilijker voor diegene om vast te stellen welke websites u bezoekt of met wie u communiceert."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP-versie"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Het doet dit door een extra sleuteluitwisseling uit te voeren met een kwantumveilig algoritme en het resultaat te mengen met de reguliere versleuteling van WireGuard. Deze extra stap gebruikt ongeveer 500 kiB aan verkeer elke keer dat een nieuwe tunnel wordt opgezet."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihop"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Multihop wordt gebruikt om DAITA voor uw locatie in te schakelen"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Niet al onze servers zijn geschikt voor %(daita)s. Daarom gebruiken we automatisch multihop om %(daita)s in te schakelen bij elke server."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Obfuscatie"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Obfuscatie verbergt het WireGuard-verkeer in een ander protocol. Het kan worden gebruikt om censuur en andere soorten filtering te omzeilen, waar een gewone WireGuard-verbinding zou worden geblokkeerd."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Poort"
@@ -2803,10 +2879,6 @@ msgstr "Deze eigenschap maakt de WireGuard-tunnel bestand tegen mogelijke aanval
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCP-poort"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Tijd toevoegen"
 msgid "Adding method..."
 msgstr "Methode toevoegen ..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Na het bijwerken van een VPN-app in Android 16 kan het apparaat in een toestand raken waarin de VPN-apps het internet niet meer kunnen bereiken."
+
 msgid "Agree and continue"
 msgstr "Akkoord en doorgaan"
 
@@ -2918,6 +2993,12 @@ msgstr "Altijd-aan VPN toegewezen aan %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Altijd-aan VPN toegewezen aan andere VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Er is een bekend probleem met Android 16. Start uw apparaat opnieuw op en probeer het opnieuw. Voor meer informatie:"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Weet u zeker dat u <b>%s</b> wilt afmelden?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Er moet minimaal één methode ingeschakeld zijn"
@@ -2951,6 +3032,9 @@ msgstr "Internet wordt geblokkeerd (apparaat offline)"
 
 msgid "Blocking..."
 msgstr "Blokkeren..."
+
+msgid "Can't connect?"
+msgstr "Krijgt u geen verbinding?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Wijzigingen in DNS-gerelateerde instellingen worden mogelijk niet onmiddellijk van kracht vanwege gecachete resultaten."
@@ -2988,9 +3072,6 @@ msgstr "Nieuwe lijst maken"
 msgid "Critical error (your attention is required)"
 msgstr "Kritieke fout (uw aandacht is vereist)"
 
-msgid "Current device"
-msgstr "Huidig apparaat"
-
 msgid "Current: %s"
 msgstr "Huidig: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Methode verwijderen?"
 
 msgid "Device IP version"
 msgstr "IP-versie apparaat"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Schakel \"%s\" hieronder uit om deze instellingen te activeren."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Schakel alle \"%s\" hierboven uit om deze instelling te activeren."
@@ -3093,9 +3171,6 @@ msgstr "Instellen als huidige mislukt. Reden onbekend"
 msgid "File"
 msgstr "Bestand"
 
-msgid "Filters:"
-msgstr "Filters:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Als u wilt dat de VPN automatisch verbinding maakt bij het opstarten van het apparaat, moet de app VPN-rechten hebben. U kent deze rechten toekennen door in de kaartweergave te klikken op \"Verbinden\" en vervolgens te klikken op \"OK\". Daarnaast moet u controleren of de app in de interne opslag is geïnstalleerd. U kunt dit zien in de informatie over opslag in de appgegevens in de systeeminstellingen."
 
@@ -3162,9 +3237,6 @@ msgstr "Locaties zijn gewijzigd voor \"%s\""
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Zorg dat het apparaat altijd de VPN-tunnel gebruikt."
 
-msgid "Manage devices"
-msgstr "Apparaten beheren"
-
 msgid "More actions"
 msgstr "Andere acties"
 
@@ -3192,8 +3264,8 @@ msgstr "Geen aangepaste lijsten beschikbaar"
 msgid "No internet connection"
 msgstr "Geen internetverbinding"
 
-msgid "No locations found"
-msgstr "Geen locaties gevonden"
+msgid "No matching servers found."
+msgstr "Geen overeenkomende servers gevonden."
 
 msgid "No recent selection history"
 msgstr "Geen recente selectiegeschiedenis"
@@ -3233,6 +3305,12 @@ msgstr "Voer een geldige poort op de externe server in"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Druk op Verbinding maken om VPN-toestemming te verzoeken"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Start uw apparaat opnieuw op en probeer het opnieuw. Als dat niet werkt, kun u een e-mail schrijven naar %s (in het Zweeds of in het Engels)."
+
+msgid "Please try changing your filters."
+msgstr "Probeer de filters te veranderen."
 
 msgid "Privacy"
 msgstr "Privacy"
@@ -3321,9 +3399,6 @@ msgstr "De \"Huidige\" methode geeft aan welke methode de app gebruikt om de API
 msgid "The app is blocking internet, please disconnect first"
 msgstr "De app blokkeert internet. Verbreek eerst de verbinding"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Het apparaat wordt uit de lijst verwijderd en wordt uitgelogd."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "De lokale DNS-server werkt niet, tenzij u \"Delen via lokaal netwerk\" inschakelt bij de VPN-instellingen."
 
@@ -3381,6 +3456,12 @@ msgstr "DNS-server bijwerken"
 msgid "Update list name"
 msgstr "Lijstnaam bijwerken"
 
+msgid "Update server list"
+msgstr "Serverlijst bijwerken"
+
+msgid "Updating server list in the background..."
+msgstr "Serverlijst wordt bijgewerkt op de achtergrond..."
+
 msgid "Use method"
 msgstr "Methode gebruiken"
 
@@ -3417,9 +3498,6 @@ msgstr "Aankoop controleren ..."
 msgid "Verifying voucher…"
 msgstr "Voucher verifiëren …"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Bekijk en beheer al uw ingelogde apparaten. U kunt per account maximaal 5 apparaten tegelijkertijd hebben. Elk apparaat krijgt een naam bij het inloggen, zodat u ze eenvoudig uit elkaar kunt houden."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "We zijn nog bezig met het verifiëren van de aankoop, dit kan even duren. De tijd wordt toegevoegd als de verificatie is gelukt."
 
@@ -3441,11 +3519,17 @@ msgstr "WireGuard-obfuscatie"
 msgid "WireGuard port"
 msgstr "WireGuard-poort"
 
+msgid "Yes, log out device"
+msgstr "Ja, apparaat afmelden"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" is gemaakt"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" is verwijderd"
+
+msgid "click here"
+msgstr "klik hier"
 
 msgid "here"
 msgstr "hier"

--- a/desktop/packages/mullvad-vpn/locales/nl/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/nl/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/pl/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/pl/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Polish\n"
 "Language: pl_PL\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "Jeszcze %(amount)d"
@@ -180,6 +180,11 @@ msgstr "Mimo to włącz"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Włącz tylko bezpośrednie"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Nie udało się pobrać listy urządzeń"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "BŁĄD ZABEZPIECZANIA POŁĄCZENIA"
@@ -448,6 +453,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "Ustawienia UDP-przez-TCP"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Naciśnij strzałkę w prawo, aby przenieść fokus na przycisk ustawień."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -465,6 +474,11 @@ msgstr "Obecnie niedostępne"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Wyloguj się"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Zarządzaj urządzeniami"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -570,6 +584,10 @@ msgstr "Wprowadź prawidłowy port localhost."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Wprowadź prawidłowy port serwera zdalnego."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Wybierz nazwę dla metody dostępu, która nie jest jeszcze używana."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1020,14 +1038,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Edytuj most niestandardowy"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Czy na pewno chcesz wylogować <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1039,6 +1049,11 @@ msgstr "Kontynuuj logowanie"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Utworzono: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Bieżące urządzenie"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1073,15 +1088,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Przy wylogowaniu urządzenie i jego nazwa zostają usunięte. Po ponownym zalogowaniu urządzenie otrzymuje nową nazwę."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Zarządzaj urządzeniami"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Wyloguj się z co najmniej jednego urządzenia, usuwając je z poniższej listy. Odpowiednią nazwę urządzenia można znaleźć w ustawieniach konta urządzenia."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Usuń"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Usunąć urządzenie <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Super!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Urządzenie zostanie usunięte z listy i wylogowane."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1097,10 +1135,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Zbyt wiele urządzeń"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Tak, wyloguj urządzenie"
+msgid "Try again"
+msgstr "Spróbuj ponownie"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Wyświetlaj wszystkie zalogowane urządzenia i zarządzaj nimi. Na jednym koncie możesz mieć do 5 urządzeń naraz. Każde zalogowane urządzenie otrzymuje nazwę, co ułatwia ich rozróżnienie."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1375,6 +1419,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Wybrany port %(wireGuard)s nie jest obsługiwany, zmień go w obszarze "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "To urządzenie ma teraz nazwę <em>%(deviceName)s</em>. Więcej informacji można znaleźć w sekcji „Zarządzanie urządzeniami” na koncie."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1410,10 +1461,6 @@ msgstr "UKOŃCZONO WERYFIKACJĘ! URUCHAMIANIE INSTALATORA..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "WERYFIKACJA NIE POWIODŁA SIĘ"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Witaj, to urządzenie nazywa się teraz <b>%(deviceName)s</b>. Więcej szczegółów znajdziesz, korzystając z przycisku Informacje na koncie."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1541,11 +1588,6 @@ msgstr "Błąd"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Nie można utworzyć konta"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Nie udało się pobrać listy urządzeń"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2149,6 +2191,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "Aplikacja %(applicationName)s sprawia problem i nie można jej wykluczyć z tunelu VPN."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "Funkcja %(splitTunneling)s nie jest obsługiwana przez Twój system."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Dodaj"
@@ -2160,6 +2209,11 @@ msgstr "Wszystkie aplikacje"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Wybierz aplikacje, które chcesz wykluczyć z tunelu VPN."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Kliknij tutaj, aby dowiedzieć się więcej"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2207,6 +2261,14 @@ msgstr "Spróbuj ponownie lub wyślij zgłoszenie problemu."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Uruchom ponownie usługę Mullvad"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Aby móc używać funkcji %(splitTunneling)s, należy zmienić wersję jądra systemu Linux na taką, która obsługuje cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2522,8 +2584,8 @@ msgstr "Automatycznie łącz z serwerem po uruchomieniu aplikacji."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Aby aktywować te ustawienia, wyłącz <b>%(customDnsFeatureName)s</b> poniżej."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Wyłącz poniżej funkcję „%(customDnsFeatureName)s”, aby aktywować te ustawienia."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2715,6 +2777,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Jeśli obserwator monitoruje te pakiety danych, %(daita)s znacznie utrudnia mu zidentyfikowanie witryn internetowych, które odwiedzasz lub z którymi się komunikujesz."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "Wersja IP"
@@ -2724,12 +2787,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Jest to wykonywane poprzez dodatkową wymianę kluczy przy użyciu algorytmu odpornego na ataki z użyciem komputerów kwantowych i zmieszanie wyniku ze zwykłym szyfrowaniem WireGuard. Ten dodatkowy krok zużywa około 500 kB ruchu za każdym razem, gdy ustanawiany jest nowy tunel."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Wielokrotny przeskok"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Wielokrotny przeskok jest używany do włączenia DAITA dla wybranej lokalizacji"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2744,6 +2818,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Nie wszystkie nasze serwery obsługują %(daita)s. Dlatego automatycznie używamy funkcji wielokrotnego przeskoku, aby umożliwić działanie %(daita)s z dowolnym serwerem."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Zaciemnianie"
@@ -2754,6 +2829,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Zaciemnianie ukrywa ruch WireGuard w innym protokole. Można go użyć do obchodzenia cenzury i innych typów filtrowania, w których zwykłe połączenie WireGuard byłoby blokowane."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Port"
@@ -2815,10 +2891,6 @@ msgstr "Ta funkcja sprawia, że tunel WireGuard jest odporny na potencjalne atak
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-przez-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Port UDP-przez-TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2916,6 +2988,9 @@ msgstr "Dodaj czas"
 msgid "Adding method..."
 msgstr "Dodawanie metody..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Po zaktualizowaniu aplikacji VPN w systemie Android 16 urządzenia mogą znaleźć się w stanie, w którym aplikacje VPN nie będą już miały dostępu do Internetu."
+
 msgid "Agree and continue"
 msgstr "Zaakceptuj i kontynuuj"
 
@@ -2930,6 +3005,12 @@ msgstr "Opcja „Zawsze włączony VPN” przypisana jest do %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Opcja „Zawsze włączony VPN” przypisana jest do innej aplikacji VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "System Android 16 ma znany nam problem. Uruchom ponownie urządzenie i spróbuj jeszcze raz. Aby dowiedzieć się więcej,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Czy na pewno chcesz wylogować <b>%s</b>?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Należy włączyć co najmniej jedną metodę"
@@ -2963,6 +3044,9 @@ msgstr "Blokowanie Internetu (urządzenie rozłączone)"
 
 msgid "Blocking..."
 msgstr "Blokowanie..."
+
+msgid "Can't connect?"
+msgstr "Nie możesz się połączyć?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Zmiany w ustawieniach związanych z usługą DNS mogą nie zostać wprowadzone natychmiast ze względu na zbuforowane wyniki."
@@ -3000,9 +3084,6 @@ msgstr "Utwórz nową listę"
 msgid "Critical error (your attention is required)"
 msgstr "Błąd krytyczny (wymagana uwaga)"
 
-msgid "Current device"
-msgstr "Bieżące urządzenie"
-
 msgid "Current: %s"
 msgstr "Bieżąca: %s"
 
@@ -3023,9 +3104,6 @@ msgstr "Usunąć metodę?"
 
 msgid "Device IP version"
 msgstr "Wersja protokołu IP urządzenia"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Aby aktywować te ustawienia, wyłącz opcję „%s” poniżej."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Aby aktywować to ustawienie, wyłącz powyżej wszystkie „%s”."
@@ -3105,9 +3183,6 @@ msgstr "Nie udało się ustawić jako bieżącą — przyczyna nieznana"
 msgid "File"
 msgstr "Plik"
 
-msgid "Filters:"
-msgstr "Filtry:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Aby łączyć automatycznie sieć VPN po uruchomieniu urządzenia, aplikacja musi mieć uprawnienia do sieci VPN. Możesz je przyznać, klikając opcję „Połącz” w widoku mapy i wybierając przycisk „OK”, jeśli wyświetlony zostanie monit. Dodatkowo upewnij się, że aplikacja jest zainstalowana w wewnętrznej pamięci masowej, sprawdzając informacje o pamięci masowej w szczegółach aplikacji, w ustawieniach systemowych."
 
@@ -3174,9 +3249,6 @@ msgstr "Zmieniono lokalizacje dla „%s”"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Zapewnia, że urządzenie zawsze działa za pośrednictwem tunelu VPN."
 
-msgid "Manage devices"
-msgstr "Zarządzaj urządzeniami"
-
 msgid "More actions"
 msgstr "Więcej działań"
 
@@ -3204,8 +3276,8 @@ msgstr "Brak dostępnych list niestandardowych"
 msgid "No internet connection"
 msgstr "Brak połączenia z Internetem"
 
-msgid "No locations found"
-msgstr "Nie znaleziono lokalizacji"
+msgid "No matching servers found."
+msgstr "Nie znaleziono pasujących serwerów."
 
 msgid "No recent selection history"
 msgstr "Brak historii ostatnich wyborów"
@@ -3245,6 +3317,12 @@ msgstr "Wprowadź prawidłowy port serwera zdalnego"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Naciśnij przycisk Połącz, aby zażądać uprawnienia VPN"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Ponownie uruchom urządzenie i ponów próbę połączenia. Jeśli to nie zadziała, wyślij wiadomość e-mail na adres %s w języku szwedzkim lub angielskim."
+
+msgid "Please try changing your filters."
+msgstr "Spróbuj zmienić filtry."
 
 msgid "Privacy"
 msgstr "Prywatność"
@@ -3333,9 +3411,6 @@ msgstr "Metoda „Bieżąca” reprezentuje metodę używaną przez aplikację w
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Aplikacja blokuje dostęp do Internetu. Rozłącz się najpierw"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Urządzenie zostanie usunięte z listy i wylogowane."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Lokalny serwer DNS nie będzie działał, dopóki nie włączysz opcji „Udostępnianie sieci lokalnej” w obszarze Ustawienia VPN."
 
@@ -3393,6 +3468,12 @@ msgstr "Zaktualizuj serwer DNS"
 msgid "Update list name"
 msgstr "Zaktualizuj nazwę listy"
 
+msgid "Update server list"
+msgstr "Zaktualizuj listę serwerów"
+
+msgid "Updating server list in the background..."
+msgstr "Aktualizowanie listy serwerów w tle..."
+
 msgid "Use method"
 msgstr "Użyj metody"
 
@@ -3429,9 +3510,6 @@ msgstr "Weryfikowanie zakupu..."
 msgid "Verifying voucher…"
 msgstr "Weryfikowanie kuponu…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Wyświetlaj wszystkie zalogowane urządzenia i zarządzaj nimi. Na jednym koncie możesz mieć do 5 urządzeń naraz. Każde urządzenie otrzymuje nazwę po zalogowaniu, co ułatwia ich rozróżnienie."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Nadal weryfikujemy zakup. Może to zająć trochę czasu. Jeśli weryfikacja powiedzie się, czas zostanie dodany."
 
@@ -3453,11 +3531,17 @@ msgstr "Zaciemnianie WireGuard"
 msgid "WireGuard port"
 msgstr "Port WireGuard"
 
+msgid "Yes, log out device"
+msgstr "Tak, wyloguj urządzenie"
+
 msgid "\"%s\" was created"
 msgstr "Utworzono „%s”"
 
 msgid "\"%s\" was deleted"
 msgstr "Usunięto „%s”"
+
+msgid "click here"
+msgstr "kliknij tutaj"
 
 msgid "here"
 msgstr "tutaj"

--- a/desktop/packages/mullvad-vpn/locales/pl/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/pl/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Polish\n"
 "Language: pl_PL\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/pt/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/pt/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Portuguese\n"
 "Language: pt_PT\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "Mais %(amount)d..."
@@ -168,6 +168,11 @@ msgstr "Ativar mesmo assim"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Ativar apenas direta"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Erro ao obter a lista de dispositivos"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "ERRO AO ESTABELECER LIGAÇÃO SEGURA"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "Definições de UDP sobre TCP"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Utilize a tecla de seta para a direita para focar o botão de definições."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Atualmente indisponível"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Terminar sessão"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Gerir dispositivos"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Introduza uma porta localhost válida."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Introduza uma porta de servidor remoto válida."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Selecione um nome para o método de acesso que ainda não esteja em utilização."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Editar ponte personalizada"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Tem a certeza de que quer terminar a sessão de <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Continuar com a ligação"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Criado: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Dispositivo atual"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Se terminar a sessão, o dispositivo e o nome do dispositivo são removidos. Quando voltar a iniciar sessão, o dispositivo recebe um novo nome."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Gerir dispositivos"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Desligue-se de pelo menos um dos dispositivos removendo-o da lista abaixo. Pode encontrar o nome do dispositivo correspondente nas definições de Conta do dispositivo."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Remover"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Remover <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Excelente!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "O dispositivo será removido da lista e terminará a sessão."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Demasiados dispositivos"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Sim, desligar o dispositivo"
+msgid "Try again"
+msgstr "Tentar novamente"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Veja e faça a gestão de todos os seus dispositivos com sessão iniciada. Pode ter até 5 dispositivos numa conta de cada vez. Cada dispositivo recebe um nome quando tem sessão iniciada para ajudar a distingui-los facilmente."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "A porta %(wireGuard)s selecionada não é suportada. Altere-a em "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Este dispositivo passou a chamar-se <em>%(deviceName)s</em>. Veja mais em \"Gerir dispositivos\" na Conta."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "VERIFICAÇÃO CONCLUÍDA! A INICIAR O INSTALADOR..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "ERRO NA VERIFICAÇÃO"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Bem-vindo, este dispositivo é agora chamado <b>%(deviceName)s</b>. Para mais detalhes consulte o botão de informação na Conta."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Erro"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Não foi possível criar a conta"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Erro ao obter a lista de dispositivos"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "A %(applicationName)s é problemática e não pode ser executada através do túnel VPN."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s não é suportada pelo seu sistema."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Adicionar"
@@ -2148,6 +2197,11 @@ msgstr "Todas as aplicações"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Escolha as aplicações que deseja excluir do túnel VPN."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Clique aqui para saber mais"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Tente novamente ou envie um relatório do problema."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Reiniciar o serviço Mullvad"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Para usar %(splitTunneling)s, mude para uma versão do kernel Linux que suporte cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Liga-se automaticamente a um servidor quando a app inicia."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Desative <b>%(customDnsFeatureName)s</b> abaixo para ativar estas definições."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Desative \"%(customDnsFeatureName)s\" abaixo para ativar estas definições."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Se um observador monitorizar estes pacotes de dados, %(daita)s dificulta significativamente a identificação dos sites que visita ou com quem comunica."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "Versão IP"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Fá-lo ao realizar uma troca de chaves adicional utilizando um algoritmo de segurança quântica e misturando o resultado na encriptação regular do WireGuard. Este passo adicional utiliza aproximadamente 500 kiB de tráfego sempre que um novo túnel é estabelecido."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihop"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "O Multihop está a ser usado para ativar DAITA na localização selecionada"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Nem todos os servidores suportam %(daita)s. Por isso, utilizamos multihop automaticamente para ativar %(daita)s em qualquer servidor."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Ofuscação"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "A ofuscação oculta o tráfego do WireGuard dentro de outro protocolo. Pode ser utilizado para ajudar a contornar a censura e outros tipos de filtragem, onde uma simples ligação WireGuard seria bloqueada."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Porta"
@@ -2803,10 +2879,6 @@ msgstr "Esta funcionalidade torna o túnel do WireGuard resistente a potenciais 
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP sobre TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Porta UDP sobre TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Adicionar tempo"
 msgid "Adding method..."
 msgstr "A adicionar método..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Após atualizar uma aplicação de VPN no Android 16, os dispositivos podem ficar num estado em que as aplicações de VPN deixam de conseguir aceder à internet."
+
 msgid "Agree and continue"
 msgstr "Concordar e continuar"
 
@@ -2918,6 +2993,12 @@ msgstr "VPN sempre ligada atribuída a %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "VPN sempre ligada atribuída a outra VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "O Android 16 tem um problema conhecido. Reinicie o seu dispositivo e tente novamente. Para saber mais,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Tem a certeza de que quer terminar a sessão de <b>%s</b>?"
 
 msgid "At least one method needs to be enabled"
 msgstr "É necessário ativar pelo menos um método"
@@ -2951,6 +3032,9 @@ msgstr "Bloqueio de Internet (dispositivo offline)"
 
 msgid "Blocking..."
 msgstr "A bloquear..."
+
+msgid "Can't connect?"
+msgstr "Não consegue ligar?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "As alterações às definições relacionadas com o DNS podem não fazer efeito imediatamente devido aos resultados em cache."
@@ -2988,9 +3072,6 @@ msgstr "Criar nova lista"
 msgid "Critical error (your attention is required)"
 msgstr "Erro crítico (é necessária a sua atenção)"
 
-msgid "Current device"
-msgstr "Dispositivo atual"
-
 msgid "Current: %s"
 msgstr "Atual: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Eliminar método?"
 
 msgid "Device IP version"
 msgstr "Versão do IP do dispositivo"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Desative \"%s\" abaixo para ativar estas definições."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Desative todos os \"%s\" acima para ativar esta definição."
@@ -3093,9 +3171,6 @@ msgstr "Erro ao definir como atual — motivo desconhecido"
 msgid "File"
 msgstr "Ficheiro"
 
-msgid "Filters:"
-msgstr "Filtros:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Para que a VPN se ligue automaticamente no arranque do dispositivo, a aplicação deve ter permissões de VPN. Pode concedê-las clicando em \"Ligar\" na vista de mapa e selecionando \"OK\" se solicitado. Além disso, confirme se a aplicação está instalada no armazenamento interno, verificando as informações de armazenamento nos detalhes da aplicação, nas definições do sistema."
 
@@ -3162,9 +3237,6 @@ msgstr "As localizações foram alteradas para \"%s\""
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Assegura que o dispositivo está sempre no túnel VPN."
 
-msgid "Manage devices"
-msgstr "Gerir dispositivos"
-
 msgid "More actions"
 msgstr "Mais ações"
 
@@ -3192,8 +3264,8 @@ msgstr "Nenhuma lista personalizada disponível"
 msgid "No internet connection"
 msgstr "Sem ligação à internet"
 
-msgid "No locations found"
-msgstr "Nenhuma localização encontrada"
+msgid "No matching servers found."
+msgstr "Nenhum servidor correspondente encontrado."
 
 msgid "No recent selection history"
 msgstr "Sem histórico de seleção recente"
@@ -3233,6 +3305,12 @@ msgstr "Introduza uma porta de servidor remoto válida"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Prima \"ligar\" para solicitar a permissão de VPN"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Reinicie o seu dispositivo e tente estabelecer a ligação novamente. Se isto não funcionar, escreva um e-mail para %s em sueco ou inglês."
+
+msgid "Please try changing your filters."
+msgstr "Tente alterar os seus filtros."
 
 msgid "Privacy"
 msgstr "Privacidade"
@@ -3321,9 +3399,6 @@ msgstr "O método \"Atual\" representa o método que a aplicação está a utili
 msgid "The app is blocking internet, please disconnect first"
 msgstr "A aplicação está a bloquear a Internet. Desligue primeiro"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "O dispositivo será removido da lista e terminará a sessão."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "O servidor DNS local não funcionará a menos que ative a \"Partilha de rede local\" nas definições de VPN."
 
@@ -3381,6 +3456,12 @@ msgstr "Atualizar servidor DNS"
 msgid "Update list name"
 msgstr "Atualizar nome da lista"
 
+msgid "Update server list"
+msgstr "Atualizar lista de servidores"
+
+msgid "Updating server list in the background..."
+msgstr "A atualizar a lista de servidores em segundo plano..."
+
 msgid "Use method"
 msgstr "Utilizar método"
 
@@ -3417,9 +3498,6 @@ msgstr "A verificar compra..."
 msgid "Verifying voucher…"
 msgstr "A verificar voucher…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Veja e faça a gestão de todos os seus dispositivos com sessão iniciada. Pode ter até 5 dispositivos numa conta de cada vez. Cada dispositivo recebe um nome quando tem sessão iniciada para ajudar a distingui-los facilmente."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Ainda estamos a verificar a sua compra, o que pode demorar algum tempo. O seu tempo será adicionado se a verificação for bem-sucedida."
 
@@ -3441,11 +3519,17 @@ msgstr "Ofuscação WireGuard"
 msgid "WireGuard port"
 msgstr "Porta WireGuard"
 
+msgid "Yes, log out device"
+msgstr "Sim, terminar sessão do dispositivo"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" foi criada"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" foi eliminada"
+
+msgid "click here"
+msgstr "clique aqui"
 
 msgid "here"
 msgstr "aqui"

--- a/desktop/packages/mullvad-vpn/locales/pt/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/pt/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Portuguese\n"
 "Language: pt_PT\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/ru/google_play.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/google_play.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "Mullvad VPN – a service, for a monthly fee, that helps keep your online activity, identity, and location private."
 msgstr "Mullvad VPN — сервис с ежемесячной оплатой, который помогает сохранить в секрете вашу личность, местоположение и действия в сети."

--- a/desktop/packages/mullvad-vpn/locales/ru/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "Еще %(amount)d..."
@@ -180,6 +180,11 @@ msgstr "Всё равно включить"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Включить «Только напрямую»"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Не удалось получить список устройств"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "НЕ УДАЛОСЬ УСТАНОВИТЬ БЕЗОПАСНОЕ ПОДКЛЮЧЕНИЕ"
@@ -448,6 +453,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "Настройки UDP через TCP"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Нажмите клавишу со стрелкой вправо, чтобы перейти к кнопке настроек."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -465,6 +474,11 @@ msgstr "Сейчас недоступно"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Выйти"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Управление устройствами"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -570,6 +584,10 @@ msgstr "Введите действительный порт localhost."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Введите действительный порт удаленного сервера."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Выберите уникальное имя для метода доступа."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1020,14 +1038,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Изменение своего моста"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Действительно выйти из профиля на устройстве <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1039,6 +1049,11 @@ msgstr "Войти"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Создано: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Текущее устройство"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1073,15 +1088,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Если вы выйдете, устройство и его имя удалятся. При повторном входе устройство получит новое имя."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Управление устройствами"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Выйдите из учетной записи хотя бы на одном из устройств, удалив его из списка ниже. Имя устройства указано в настройках учетной записи."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Удалить"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Удалить устройство <em>%(deviceName)s</em>?"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Отлично!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Устройство выйдет из профиля и будет удалено из списка."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1097,10 +1135,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Слишком много устройств"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Выйти из профиля на устройстве"
+msgid "Try again"
+msgstr "Повторить"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Просмотр подключенных устройств и управление ими. К одной учетной записи можно подключить 5 устройств. При входе каждому устройству присваивается имя, чтобы их было легче различать."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1375,6 +1419,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Выбранный порт %(wireGuard)s не поддерживается — измените его в "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Имя этого устройства изменено на <em>%(deviceName)s</em>. Подробности указаны в разделе «Управление устройствами» в учетной записи."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1410,10 +1461,6 @@ msgstr "ПРОВЕРКА ВЫПОЛНЕНА. УСТАНОВЩИК ЗАПУСКА
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "СБОЙ ПРОВЕРКИ"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Добро пожаловать, теперь это устройство называется <b>%(deviceName)s</b>. Для получения более подробной нажмите на кнопку «Информация» в учетной записи."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1541,11 +1588,6 @@ msgstr "Ошибка"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Не удалось создать учетную запись"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Не удалось получить список устройств"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2149,6 +2191,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s является проблемным и не может быть исключено из туннеля VPN."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s не поддерживается вашей системой."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Добавить"
@@ -2160,6 +2209,11 @@ msgstr "Все приложения"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Выберите приложения, которые нужно исключить из туннеля VPN."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Нажмите здесь, чтобы узнать больше"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2207,6 +2261,14 @@ msgstr "Повторите попытку или отправьте сообще
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Перезапустить сервис Mullvad"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "Чтобы использовать %(splitTunneling)s, установите версию ядра Linux с поддержкой cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2522,8 +2584,8 @@ msgstr "Автоматически подключаться к серверу п
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Чтобы активировать эти параметры, отключите опцию <b>%(customDnsFeatureName)s</b> ниже."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Чтобы активировать эти настройки, отключите параметр «%(customDnsFeatureName)s»."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2715,6 +2777,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "В случае, если наблюдатель отслеживает пакеты данных, %(daita)s значительно затрудняет определение того, какие веб-сайты вы посещаете или с кем общаетесь."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "Версия IP"
@@ -2724,12 +2787,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Для этого функция выполняет дополнительный обмен ключами с использованием квантово-устойчивого алгоритма и добавляет результат к обычному шифрованию WireGuard. Эта дополнительная мера использует примерно 500 КиБ трафика при каждом создании нового туннеля."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Многократный переход"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Чтобы включить DAITA для выбранного местоположения, используется многократный переход"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2744,6 +2818,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "%(daita)s поддерживается не на всех серверах. Поэтому, чтобы функция %(daita)s работала с любым сервером, мы автоматически используем многократный переход."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Обфускация"
@@ -2754,6 +2829,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Обфускация скрывает трафик WireGuard внутри другого протокола. Это может использоваться для обхода цензуры и других видов фильтрации, когда обычные соединения WireGuard блокируются."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Порт"
@@ -2815,10 +2891,6 @@ msgstr "Эта функция делает туннель WireGuard устойч
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP через TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "Порт для UDP через TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2916,6 +2988,9 @@ msgstr "Добавить время"
 msgid "Adding method..."
 msgstr "Добавление метода..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "После обновления VPN-приложения на Android 16 VPN-приложения иногда теряют доступ к Интернету."
+
 msgid "Agree and continue"
 msgstr "Согласиться и продолжить"
 
@@ -2930,6 +3005,12 @@ msgstr "Опция «Постоянная VPN» назначена прилож�
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Опция «Постоянная VPN» назначена другой VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "В Android 16 есть известная проблема. Перезагрузите устройство и попробуйте снова. Чтобы узнать больше,"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Действительно выйти из профиля на устройстве <b>%s</b>?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Должен быть включен хотя бы один метод"
@@ -2963,6 +3044,9 @@ msgstr "Блокируется доступ в Интернет (устройс�
 
 msgid "Blocking..."
 msgstr "Блокировка..."
+
+msgid "Can't connect?"
+msgstr "Проблемы с подключением?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Изменения в настройках, связанные с DNS, могут не сразу вступить в силу из-за кешированных результатов."
@@ -3000,9 +3084,6 @@ msgstr "Создание нового списка"
 msgid "Critical error (your attention is required)"
 msgstr "Критическая ошибка (требуется ваше участие)"
 
-msgid "Current device"
-msgstr "Текущее устройство"
-
 msgid "Current: %s"
 msgstr "Текущий: %s"
 
@@ -3023,9 +3104,6 @@ msgstr "Удалить метод?"
 
 msgid "Device IP version"
 msgstr "Версия IP на устройстве"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Чтобы активировать эти параметры, отключите параметр «%s»."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Чтобы активировать этот параметр, отключите все %s выше."
@@ -3105,9 +3183,6 @@ msgstr "Не удалось установить текущий метод: пр
 msgid "File"
 msgstr "Файл"
 
-msgid "Filters:"
-msgstr "Фильтры:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "Чтобы VPN подключался автоматически при запуске устройства, приложению нужны разрешения на использование VPN. Чтобы предоставить их, нажмите «Подключить» на карте и подтвердите выбор кнопкой «ОК». Убедитесь также, что приложение установлено во внутренней памяти устройства — это можно увидеть в сведениях о приложении в системных настройках."
 
@@ -3174,9 +3249,6 @@ msgstr "Местоположения были изменены для «%s»"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Обеспечивает постоянное подключение устройства к туннелю VPN."
 
-msgid "Manage devices"
-msgstr "Управление устройствами"
-
 msgid "More actions"
 msgstr "Дополнительные действия"
 
@@ -3204,8 +3276,8 @@ msgstr "Нет своих списков"
 msgid "No internet connection"
 msgstr "Нет подключения к Интернету"
 
-msgid "No locations found"
-msgstr "Местоположения не найдены"
+msgid "No matching servers found."
+msgstr "Подходящих серверов не найдено."
 
 msgid "No recent selection history"
 msgstr "Нет истории недавнего выбора"
@@ -3245,6 +3317,12 @@ msgstr "Введите действительный порт удаленног�
 
 msgid "Please press connect to request VPN permission"
 msgstr "Чтобы запросить разрешение для VPN, нажмите «Подключить»"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Перезагрузите устройство и снова попробуйте подключиться. Если это не поможет, отправьте письмо на %s на английском или шведском."
+
+msgid "Please try changing your filters."
+msgstr "Попробуйте изменить фильтры."
 
 msgid "Privacy"
 msgstr "Конфиденциальность"
@@ -3333,9 +3411,6 @@ msgstr "«Текущий» метод — это метод, который п�
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Приложение блокирует интернет. Сначала отключитесь."
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Устройство будет удалено из списка. На нем будет выполнен выход из системы."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Локальный DNS-сервер не будет работать, если не включить «Обмен данными в локальной сети» в разделе «Настройки VPN»."
 
@@ -3393,6 +3468,12 @@ msgstr "Обновить DNS-сервер"
 msgid "Update list name"
 msgstr "Обновление названия списка"
 
+msgid "Update server list"
+msgstr "Обновить список серверов"
+
+msgid "Updating server list in the background..."
+msgstr "Фоновое обновление списка серверов..."
+
 msgid "Use method"
 msgstr "Использовать метод"
 
@@ -3429,9 +3510,6 @@ msgstr "Идет проверка оплаты..."
 msgid "Verifying voucher…"
 msgstr "Идет проверка ваучера…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Просмотр подключенных устройств и управление ими. К одной учетной записи можно подключить 5 устройств. При входе каждому устройству присваивается имя, чтобы помочь различать их."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Мы все еще проверяем, прошла ли оплата; нужно немного подождать. После успешного завершения проверки оплаченное время будет добавлено."
 
@@ -3453,11 +3531,17 @@ msgstr "Обфускация WireGuard"
 msgid "WireGuard port"
 msgstr "Порт WireGuard"
 
+msgid "Yes, log out device"
+msgstr "Выйти из профиля на устройстве"
+
 msgid "\"%s\" was created"
 msgstr "Список «%s» создан"
 
 msgid "\"%s\" was deleted"
 msgstr "Список «%s» удален"
+
+msgid "click here"
+msgstr "нажмите здесь"
 
 msgid "here"
 msgstr "здесь"

--- a/desktop/packages/mullvad-vpn/locales/ru/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/ru/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Russian\n"
 "Language: ru_RU\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/sv/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/sv/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Swedish\n"
 "Language: sv_SE\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 12:26\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d till ..."
@@ -168,6 +168,11 @@ msgstr "Aktivera ändå"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "Aktivera Endast direkt"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Det gick inte att hämta lista med enheter"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "DET GICK INTE ATT SÄKRA ANSLUTNINGEN"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP över TCP-inställningar"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Använd höger pil för att fokusera inställningsknappen."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Inte tillgänglig för närvarande"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Logga ut"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Hantera enheter"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Ange en giltig localhost-port."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Ange en giltig fjärrserverport."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Välj ett namn på åtkomstmetoden som inte redan används."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Redigera anpassad brygga"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "Vill du verkligen logga ut <b>%(deviceName)s</b>?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Fortsätt med inloggning"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Skapades: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Aktuell enhet"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Om du loggar ut tas enheten och enhetsnamnet bort. När du loggar in igen får enheten ett nytt namn."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Hantera enheter"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Logga ut på minst en enhet genom att ta bort den från listan nedan. Du hittar motsvarande enhetsnamn i enhetens kontoinställningar."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Ta bort"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "Ta bort <em>%(deviceName)s?</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Super!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Enheten tas bort från listan och loggas ut."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "För många enheter"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Ja, logga ut enheten"
+msgid "Try again"
+msgstr "Försök igen"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Visa och hantera alla dina inloggade enheter. Du kan ha upp till fem enheter åt gången på ett konto. Varje enhet får ett namn när den loggas in så att du enklare kan skilja dem åt."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Den valda %(wireGuard)s-porten stöds inte, ändra den i "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Den här enheten heter nu <em>%(deviceName)s</em>. Du hittar mer information i \"Hantera enheter\" under Konto."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "VERIFIERINGEN HAR SLUTFÖRTS! STARTAR INSTALLATIONSPROGRAMMET ..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "DET GICK INTE ATT VERIFIERA"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Välkommen! Den här enheten heter nu <b>%(deviceName)s</b>. Använd informationsknappen i Konto för mer information."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Fel"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Det gick inte att skapa konto"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Det gick inte att hämta lista med enheter"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s är problematiskt och kan inte exkluderas från VPN-tunneln."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "Ditt system har inte stöd för %(splitTunneling)s."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Lägg till"
@@ -2148,6 +2197,11 @@ msgstr "Alla appar"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "Välj de appar du vill exkludera från VPN-tunneln."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Klicka här för mer information"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Försök igen eller skicka en problemrapport."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Starta om Mullvad-tjänsten"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "För att använda %(splitTunneling)s byter du till en Linux kärnversion som har stöd för cgroup v1."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Anslut automatiskt till en server när appen startas."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Inaktivera <b>%(customDnsFeatureName)s</b> nedan för att aktivera dessa inställningar."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Inaktivera \"%(customDnsFeatureName)s\" nedan för att aktivera dessa inställningar."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Om dessa datapaket övervakas av en observatör, gör %(daita)s det svårare för dem att identifiera vilka webbplatser du besöker eller vem du kommunicerar med."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP-version"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Den gör det genom att göra ett extra nyckelutbyte med en kvantsäker algoritm och kombinera resultatet med WireGuards vanliga kryptering. Det här extra steget använder ungefär 500 KiB i trafik varje gång en ny tunnel upprättas."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Multihopp"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Multihopp används för att aktivera DAITA för din valda plats"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "Det är inte alla våra servrar som är %(daita)s-aktiverade. Därför använder vi multihopp automatiskt för att aktivera %(daita)s med alla servrar."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Obfuskering"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Obfuskering döljer WireGuard-trafik inne i ett annat protokoll. Det kan användas för att kringgå censur och andra filtertyper där en vanlig WireGuard-anslutning skulle blockeras."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Port"
@@ -2803,10 +2879,6 @@ msgstr "Den här funktionen gör WireGuard-tunneln resistent mot potentiella att
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP över TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-över-TCP-port"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Lägg till tid"
 msgid "Adding method..."
 msgstr "Lägger till metod ..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "När en VPN-app har uppdaterats på Android 16 kan enheterna hamna i ett tillstånd där VPN-apparna inte längre har åtkomst till internet."
+
 msgid "Agree and continue"
 msgstr "Godkänn och fortsätt"
 
@@ -2918,6 +2993,12 @@ msgstr "Alltid på-VPN har tilldelats %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Alltid på-VPN har tilldelats en annan VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 har ett känt fel. Starta om din enhet och försök igen. Om du vill veta mer"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "Vill du verkligen logga ut <b>%s</b>?"
 
 msgid "At least one method needs to be enabled"
 msgstr "Minst en metod måste vara aktiverad"
@@ -2951,6 +3032,9 @@ msgstr "Blockerar internet (enheten är offline)"
 
 msgid "Blocking..."
 msgstr "Blockerar ..."
+
+msgid "Can't connect?"
+msgstr "Kan du inte ansluta?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "Ändringar i DNS-relaterade inställningar kanske inte börjar gälla direkt på grund av cachade resultat."
@@ -2988,9 +3072,6 @@ msgstr "Skapa ny lista"
 msgid "Critical error (your attention is required)"
 msgstr "Kritiskt fel (kräver din uppmärksamhet)"
 
-msgid "Current device"
-msgstr "Aktuell enhet"
-
 msgid "Current: %s"
 msgstr "Aktuell: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Radera metod?"
 
 msgid "Device IP version"
 msgstr "Enhetens IP-version"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Inaktivera \"%s\" nedan för att aktivera dessa inställningar."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Inaktivera alla \"%s\" ovan för att aktivera inställningen."
@@ -3093,9 +3171,6 @@ msgstr "Kan inte ställas in som aktuell – Okänd anledning"
 msgid "File"
 msgstr "Fil"
 
-msgid "Filters:"
-msgstr "Filter:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "För att VPN ska anslutas automatiskt när enheten startas måste appen ha VPN-behörighet. Du kan bevilja dessa genom att klicka på \"Anslut\" i kartvisningen och välja \"OK\" om du uppmanas till det. Dessutom ska du säkerställa att appen har installerats på det interna lagringsutrymmet genom att kontrollera lagringsinformationen i appinformationen i systeminställningarna."
 
@@ -3162,9 +3237,6 @@ msgstr "Platserna har ändrats för \"%s\""
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Ser till att enheten alltid är i VPN-tunneln."
 
-msgid "Manage devices"
-msgstr "Hantera enheter"
-
 msgid "More actions"
 msgstr "Fler åtgärder"
 
@@ -3192,8 +3264,8 @@ msgstr "Inga anpassade listor är tillgängliga"
 msgid "No internet connection"
 msgstr "Ingen internetanslutning"
 
-msgid "No locations found"
-msgstr "Inga platser hittades"
+msgid "No matching servers found."
+msgstr "Inga överensstämmande servrar hittades."
 
 msgid "No recent selection history"
 msgstr "Ingen historik av senaste val"
@@ -3233,6 +3305,12 @@ msgstr "Ange en giltig fjärrserverport"
 
 msgid "Please press connect to request VPN permission"
 msgstr "Tryck på anslut för att begära VPN-behörighet"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Starta om enheten och försök att ansluta igen. Om det inte fungerar kan du skicka ett e-postmeddelande till %s på svenska eller engelska."
+
+msgid "Please try changing your filters."
+msgstr "Prova att ändra dina filter."
 
 msgid "Privacy"
 msgstr "Sekretess"
@@ -3321,9 +3399,6 @@ msgstr "\"Aktuell\" metod representerar vilken metod appen använder för att n�
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Appen blockerar internet, koppla först från anslutningen"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Enheten kommer att tas bort från listan och loggas ut."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "Den lokala DNS-servern fungerar inte om du inte aktiverar \"Lokal nätverksdelning\" under VPN-inställningar."
 
@@ -3381,6 +3456,12 @@ msgstr "Uppdatera DNS-server"
 msgid "Update list name"
 msgstr "Uppdatera listnamn"
 
+msgid "Update server list"
+msgstr "Uppdatera serverlistan"
+
+msgid "Updating server list in the background..."
+msgstr "Uppdaterar serverlistan i bakgrunden ..."
+
 msgid "Use method"
 msgstr "Använd metod"
 
@@ -3417,9 +3498,6 @@ msgstr "Verifierar köp ..."
 msgid "Verifying voucher…"
 msgstr "Verifierar kupong …"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Visa och hantera alla dina inloggade enheter. Du kan ha upp till fem enheter åt gången på ett konto. Varje enhet får ett namn när den loggas in så att du enklare kan skilja dem åt."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Vi verifierar fortfarande ditt köp och det kan ta en stund. Din tid läggs till om verifieringen slutförs."
 
@@ -3441,11 +3519,17 @@ msgstr "WireGuard-obfuskering"
 msgid "WireGuard port"
 msgstr "WireGuard-port"
 
+msgid "Yes, log out device"
+msgstr "Ja, logga ut enheten"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" har skapats"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" har tagits bort"
+
+msgid "click here"
+msgstr "klicka här"
 
 msgid "here"
 msgstr "här"

--- a/desktop/packages/mullvad-vpn/locales/sv/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/sv/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Swedish\n"
 "Language: sv_SE\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 12:26\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/th/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/th/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Thai\n"
 "Language: th_TH\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "อีก %(amount)d..."
@@ -162,6 +162,11 @@ msgstr "เปิดใช้งานต่อไป"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "เปิดใช้งานโดยตรงเท่านั้น"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "ไม่สามารถดึงรายการอุปกรณ์มาได้"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "ไม่สามารถเชื่อมต่ออย่างปลอดภัยได้"
@@ -430,6 +435,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "การตั้งค่า UDP-ผ่าน-TCP"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "ใช้ปุ่มลูกศรขวาเพื่อโฟกัสไปที่ปุ่มการตั้งค่า"
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -447,6 +456,11 @@ msgstr "ไม่พร้อมใช้งานในปัจจุบัน
 msgctxt "account-view"
 msgid "Log out"
 msgstr "ลงชื่อออก"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "จัดการอุปกรณ์"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -552,6 +566,10 @@ msgstr "โปรดป้อนพอร์ต localhost ที่ถูกต�
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "โปรดป้อนพอร์ตเซิร์ฟเวอร์ระยะไกลที่ถูกต้อง"
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "โปรดเลือกชื่อสำหรับวิธีการเข้าถึงที่ยังไม่ได้ใช้งาน"
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1002,14 +1020,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "แก้ไข Bridge แบบกำหนดเอง"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบบน <b>%(deviceName)s</b>"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1021,6 +1031,11 @@ msgstr "เข้าสู่ระบบต่อ"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "วันที่สร้าง: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "อุปกรณ์ปัจจุบัน"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1055,15 +1070,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "หากคุณออกจากระบบ อุปกรณ์และชื่ออุปกรณ์จะถูกลบออก และเมื่อคุณลงชื่อเข้าใช้อีกครั้ง อุปกรณ์จะได้รับชื่อใหม่"
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "จัดการอุปกรณ์"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "โปรดลงชื่อออกจากระบบบนอุปกรณ์อย่างน้อยหนึ่งเครื่อง เพื่อนำอุปกรณ์ออกจากรายการด้านล่าง คุณสามารถดูชื่ออุปกรณ์ที่เกี่ยวข้องได้ ภายใต้การตั้งค่าบัญชีของอุปกรณ์"
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "ลบ"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "ลบ <em>%(deviceName)s หรือไม่</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "เยี่ยมยอด!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "อุปกรณ์จะถูกลบออกจากรายการและออกจากระบบ"
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1079,10 +1117,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "มีอุปกรณ์มากเกินไป"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "ใช่ นำอุปกรณ์ออกจากระบบ"
+msgid "Try again"
+msgstr "ลองอีกครั้ง"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "ดูและจัดการอุปกรณ์ทั้งหมดที่คุณลงชื่อเข้าใช้ คุณสามารถมีอุปกรณ์ได้สูงสุด 5 เครื่องในหนึ่งบัญชีในเวลาเดียวกัน แต่ละอุปกรณ์จะได้รับชื่อในขณะที่ลงชื่อเข้าใช้ เพื่อช่วยให้คุณแยกแยะอุปกรณ์แต่ละเครื่องได้อย่างง่ายดาย"
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1357,6 +1401,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "ไม่รองรับพอร์ต %(wireGuard)s ที่เลือก โปรดเปลี่ยนพอร์ตภายใต้ส่วน"
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "อุปกรณ์นี้ได้รับการตั้งชื่อว่า <em>%(deviceName)s</em> แล้ว ดูเพิ่มเติมได้ภายใต้หัวข้อ \"จัดการอุปกรณ์\" ในบัญชี"
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1392,10 +1443,6 @@ msgstr "การตรวจสอบเสร็จสมบูรณ์! ก�
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "การตรวจสอบล้มเหลว"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "ยินดีต้อนรับ ขณะนี้อุปกรณ์นี้จะมีชื่อว่า <b>%(deviceName)s</b> สำหรับข้อมูลเพิ่มเติม โปรดกดปุ่มข้อมูลในบัญชี"
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1523,11 +1570,6 @@ msgstr "ข้อผิดพลาด"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "ไม่สามารถสร้างบัญชีได้"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "ไม่สามารถดึงรายการอุปกรณ์มาได้"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2131,6 +2173,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s ได้ก่อให้เกิดปัญหาขึ้น และไม่สามารถแยกออกจากช่องทาง VPN ได้"
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s ไม่ได้รับการรองรับโดยระบบของคุณ"
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "เพิ่ม"
@@ -2142,6 +2191,11 @@ msgstr "แอปทั้งหมด"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "เลือกแอปที่คุณต้องการแยกออกจากช่องทาง VPN"
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "คลิกที่นี่เพื่อเรียนรู้เพิ่มเติม"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2189,6 +2243,14 @@ msgstr "โปรดลองใหม่อีกครั้ง หรือ�
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "รีสตาร์ตบริการ Mullavad"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "หากต้องการใช้ %(splitTunneling)s โปรดเปลี่ยนเป็นเวอร์ชันเคอร์เนล Linux ที่รองรับ cgroup v1"
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2504,8 +2566,8 @@ msgstr "เชื่อมต่อเซิร์ฟเวอร์โดยอ
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "ปิดใช้งาน <b>%(customDnsFeatureName)s</b> ด้านล่าง เพื่อเปิดใช้การตั้งค่าเหล่านี้"
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "ปิดใช้งาน \"%(customDnsFeatureName)s\" ด้านล่างเพื่อเปิดใช้งานการตั้งค่าเหล่านี้"
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2697,6 +2759,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "หากผู้สังเกตการณ์เฝ้าดูแพ็กเก็ตข้อมูลเหล่านี้ %(daita)s จะทำให้พวกเขาระบุเว็บไซต์ที่คุณกำลังเยี่ยมชม หรือผู้ที่คุณกำลังติดต่อสื่อสารด้วยได้ยากขึ้นอย่างมาก"
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "เวอร์ชัน IP"
@@ -2706,12 +2769,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "ระบบจะดำเนินการสิ่งนี้ผ่านการแลกเปลี่ยนคีย์เพิ่มเติม โดยการใช้อัลกอริทึมแบบควอนตัมที่ปลอดภัย และผสมผลลัพธ์เข้ากับการเข้ารหัสตามปกติของ WireGuard และขั้นตอนพิเศษนี้ใช้การรับส่งข้อมูลประมาณ 500 kiB ในทุกครั้งที่สร้างช่องทางใหม่"
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "มัลติฮอป"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "กำลังใช้ Multihop เพื่อเปิดใช้งาน DAITA สำหรับตำแหน่งที่คุณเลือก"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2726,6 +2800,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "ไม่ใช่ทุกเซิร์ฟเวอร์ของเราที่เปิดใช้งาน %(daita)s ด้วยเหตุนี้เอง เราจึงใช้การมัลติฮอปอัตโนมัติ เพื่อเปิดใช้งาน %(daita)s กับทุกเซิร์ฟเวอร์"
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "การทำให้ข้อมูลยุ่งเหยิง"
@@ -2736,6 +2811,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "การทำให้ข้อมูลยุ่งเหยิงจะซ่อนการรับส่งข้อมูล WireGuard ภายในอีกโพรโทคอลหนึ่ง ซึ่งใช้เพื่อช่วยหลบเลี่ยงการเซ็นเซอร์ และการกรองประเภทอื่นๆ ที่การเชื่อมต่อ WireGuard แบบธรรมดาจะถูกบล็อกได้"
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "พอร์ต"
@@ -2797,10 +2873,6 @@ msgstr "คุณลักษณะนี้จะช่วยให้ช่อ
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-ผ่าน-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "พอร์ต UDP-ผ่าน-TCP"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2898,6 +2970,9 @@ msgstr "เพิ่มเวลา"
 msgid "Adding method..."
 msgstr "กำลังเพิ่มวิธีการ..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "หลังจากอัปเดตแอป VPN บน Android 16 อุปกรณ์อาจอยู่ในสถานะที่แอป VPN ไม่สามารถเข้าถึงอินเทอร์เน็ตได้อีกต่อไป"
+
 msgid "Agree and continue"
 msgstr "ยอมรับและดำเนินการต่อ"
 
@@ -2912,6 +2987,12 @@ msgstr "VPN เปิดอยู่เสมอ ได้รับการม�
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "VPN เปิดอยู่เสมอ ได้รับการมอบหมายไปยัง VPN อื่นแล้ว"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 มีปัญหาที่ทราบแล้ว โปรดรีสตาร์ทอุปกรณ์ของคุณแล้วลองอีกครั้ง หากต้องการเรียนรู้เพิ่มเติม"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบ <b>%s</b>"
 
 msgid "At least one method needs to be enabled"
 msgstr "จำเป็นต้องเปิดใช้อย่างน้อยหนึ่งวิธีการ"
@@ -2945,6 +3026,9 @@ msgstr "กำลังบล็อกอินเทอร์เน็ต (อ�
 
 msgid "Blocking..."
 msgstr "กำลังบล็อก..."
+
+msgid "Can't connect?"
+msgstr "ไม่สามารถเชื่อมต่อได้ใช่ไหม"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "การเปลี่ยนแปลงการตั้งค่าที่เกี่ยวข้องกับ DNS อาจไม่มีผลทันที เนื่องจากผลลัพธ์ที่แคชไว้"
@@ -2982,9 +3066,6 @@ msgstr "สร้างรายการใหม่"
 msgid "Critical error (your attention is required)"
 msgstr "ข้อผิดพลาดร้ายแรง (คุณจำเป็นต้องตรวจสอบ)"
 
-msgid "Current device"
-msgstr "อุปกรณ์ปัจจุบัน"
-
 msgid "Current: %s"
 msgstr "ปัจจุบัน: %s"
 
@@ -3005,9 +3086,6 @@ msgstr "ลบวิธีการหรือไม่"
 
 msgid "Device IP version"
 msgstr "เวอร์ชัน IP ของอุปกรณ์"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "ปิดใช้งาน \"%s\" ด้านล่าง เพื่อเปิดใช้การตั้งค่าเหล่านี้"
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "ปิดใช้งาน \"%s\" ด้านบนทั้งหมด เพื่อเปิดใช้งานการตั้งค่านี้"
@@ -3087,9 +3165,6 @@ msgstr "ไม่สามารถตั้งค่าเป็นปัจจ
 msgid "File"
 msgstr "ไฟล์"
 
-msgid "Filters:"
-msgstr "ตัวกรอง:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "เพื่อให้ VPN เชื่อมต่อโดยอัตโนมัติเมื่ออุปกรณ์เริ่มทำงาน แอปต้องมีสิทธิ์ VPN คุณสามารถให้สิทธิ์เหล่านี้ได้โดยคลิก \"เชื่อมต่อ\" ในมุมมองแผนที่ และเลือก \"ตกลง\" หากได้รับแจ้ง นอกจากนี้ โปรดตรวจสอบให้แน่ใจว่าแอปติดตั้งอยู่ในพื้นที่จัดเก็บข้อมูลภายใน โดยตรวจสอบข้อมูลพื้นที่จัดเก็บข้อมูลในรายละเอียดแอปในการตั้งค่าระบบ"
 
@@ -3156,9 +3231,6 @@ msgstr "ตำแหน่งที่ตั้งสำหรับ \"%s\" ม�
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "ตรวจสอบให้แน่ใจว่า อุปกรณ์อยู่ในช่องทาง VPN เสมอ"
 
-msgid "Manage devices"
-msgstr "จัดการอุปกรณ์"
-
 msgid "More actions"
 msgstr "การดำเนินการเพิ่มเติม"
 
@@ -3186,8 +3258,8 @@ msgstr "ไม่มีรายการแบบกำหนดเองที
 msgid "No internet connection"
 msgstr "ไม่มีการเชื่อมต่ออินเทอร์เน็ต"
 
-msgid "No locations found"
-msgstr "ไม่พบตำแหน่งที่ตั้ง"
+msgid "No matching servers found."
+msgstr "ไม่พบเซิร์ฟเวอร์ที่ตรงกัน"
 
 msgid "No recent selection history"
 msgstr "ไม่มีประวัติการเลือกล่าสุด"
@@ -3227,6 +3299,12 @@ msgstr "โปรดป้อนพอร์ตเซิร์ฟเวอร์
 
 msgid "Please press connect to request VPN permission"
 msgstr "กรุณากดเชื่อมต่อ เพื่อขออนุญาตสิทธิ์ VPN"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "โปรดรีสตาร์ทอุปกรณ์ของคุณและลองเชื่อมต่ออีกครั้ง หากวิธีนี้ไม่ได้ผล โปรดเขียนอีเมลถึง %s เป็นภาษาสวีเดนหรืออังกฤษ"
+
+msgid "Please try changing your filters."
+msgstr "โปรดลองเปลี่ยนตัวกรองของคุณ"
 
 msgid "Privacy"
 msgstr "ความเป็นส่วนตัว"
@@ -3315,9 +3393,6 @@ msgstr "วิธีการ \"ปัจจุบัน\" แสดงถึง
 msgid "The app is blocking internet, please disconnect first"
 msgstr "แอปกำลังปิดกั้นอินเทอร์เน็ต โปรดตัดการเชื่อมต่อก่อน"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "อุปกรณ์จะถูกลบออกจากรายการและออกจากระบบ"
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "เซิร์ฟเวอร์ DNS ท้องถิ่นจะไม่ทำงาน เว้นแต่คุณจะเปิดใช้งาน \"การแชร์ในเครือข่ายท้องถิ่น\" ซึ่งอยู่ในส่วนการตั้งค่า VPN"
 
@@ -3375,6 +3450,12 @@ msgstr "อัปเดตเซิร์ฟเวอร์ DNS"
 msgid "Update list name"
 msgstr "อัปเดตชื่อรายการ"
 
+msgid "Update server list"
+msgstr "อัปเดตรายการเซิร์ฟเวอร์"
+
+msgid "Updating server list in the background..."
+msgstr "กำลังอัปเดตรายชื่อเซิร์ฟเวอร์ในพื้นหลัง..."
+
 msgid "Use method"
 msgstr "ใช้วิธีการ"
 
@@ -3411,9 +3492,6 @@ msgstr "กำลังตรวจสอบยืนยันการซื้
 msgid "Verifying voucher…"
 msgstr "กำลังตรวจสอบยืนยันบัตรกำนัล…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "ดูและจัดการอุปกรณ์ทั้งหมดที่คุณลงชื่อเข้าใช้ คุณสามารถมีอุปกรณ์ได้สูงสุด 5 เครื่องในหนึ่งบัญชีในเวลาเดียวกัน แต่ละอุปกรณ์จะได้รับชื่อในขณะที่ลงชื่อเข้าใช้ เพื่อช่วยให้คุณแยกแยะอุปกรณ์แต่ละเครื่องได้อย่างง่ายดาย"
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "เรากำลังตรวจสอบการสั่งซื้อของคุณ ซึ่งอาจใช้เวลาสักครู่ หากการตรวจสอบเสร็จสมบูรณ์ เราจะเพิ่มเวลาของคุณ"
 
@@ -3435,11 +3513,17 @@ msgstr "การทำให้ข้อมูลยุ่งเหยิงข
 msgid "WireGuard port"
 msgstr "พอร์ต WireGuard"
 
+msgid "Yes, log out device"
+msgstr "ใช่ นำอุปกรณ์ออกจากระบบ"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" ถูกสร้างแล้ว"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" ถูกลบแล้ว"
+
+msgid "click here"
+msgstr "คลิกที่นี่"
 
 msgid "here"
 msgstr "ที่นี่"

--- a/desktop/packages/mullvad-vpn/locales/th/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/th/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Thai\n"
 "Language: th_TH\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/tr/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/tr/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Turkish\n"
 "Language: tr_TR\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "%(amount)d tane daha..."
@@ -168,6 +168,11 @@ msgstr "Yine de etkinleştir"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "\"Yalnızca doğrudan\" seçeneğini etkinleştir"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "Cihaz listesi alınamadı"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "GÜVENLİ BAĞLANTI OLUŞTURULAMADI"
@@ -436,6 +441,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "TCP üzerinden UDP ayarları"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "Ayarlar düğmesine odaklanmak için sağ ok tuşunu kullanın."
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -453,6 +462,11 @@ msgstr "Şu an kullanılamıyor"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "Oturumu kapat"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "Cihazları yönet"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -558,6 +572,10 @@ msgstr "Lütfen geçerli bir localhost portu girin."
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "Lütfen geçerli bir uzak sunucu portu girin."
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "Lütfen erişim yöntemi için henüz kullanımda olmayan bir ad seçin."
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1008,14 +1026,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "Özel köprüyü düzenle"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "<b>%(deviceName)s</b> adlı cihazdan çıkış yapmak istediğinizden emin misiniz?"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1027,6 +1037,11 @@ msgstr "Giriş yapmak için devam et"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "Oluşturma tarihi: %(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "Mevcut cihaz"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1061,15 +1076,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "Oturumu kapatırsanız cihaz ve cihaz adı kaldırılır. Tekrar oturum açtığınızda cihaza yeni bir ad verilir."
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "Cihazları yönet"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "Lütfen aşağıdaki listeden en az bir cihazı kaldırarak çıkış yapın. İlgili cihaz adını cihazın Hesap ayarları altında bulabilirsiniz."
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "Kaldır"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "<em>%(deviceName)s</em> cihazı kaldırılsın mı?"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "Süper!"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "Cihaz listeden kaldırılacak ve oturum kapatılacak."
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1085,10 +1123,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "Cihaz sayısı çok fazla"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "Evet, cihazdan çıkış yap"
+msgid "Try again"
+msgstr "Tekrar dene"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "Oturum açtığınız tüm cihazları görüntüleyin ve yönetin. Bir hesapta aynı anda en fazla 5 cihaz bulunabilir. Kolayca ayırt edebilmeniz için her cihaza giriş sırasında bir ad atanır."
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1363,6 +1407,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "Seçilen %(wireGuard)s portu desteklenmiyor, lütfen portu değiştirin: "
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "Bu cihazın adı artık <em>%(deviceName)s</em>. Daha fazla bilgi için Hesap menüsündeki \"Cihazları yönet\" bölümüne bakın."
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1398,10 +1449,6 @@ msgstr "DOĞRULAMA TAMAMLANDI! YÜKLEYİCİ BAŞLATILIYOR..."
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "DOĞRULAMA BAŞARISIZ"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "Hoş geldiniz, bu cihazın adı artık <b>%(deviceName)s</b>. Daha fazla ayrıntı için Hesap içinden bilgi düğmesine bakın."
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1529,11 +1576,6 @@ msgstr "Hata"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "Hesap oluşturulamadı"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "Cihaz listesi alınamadı"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2137,6 +2179,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s uygulaması hatalı ve VPN tünelinin dışında bırakılamıyor."
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "%(splitTunneling)s sisteminiz tarafından desteklenmiyor."
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "Ekle"
@@ -2148,6 +2197,11 @@ msgstr "Tüm uygulamalar"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "VPN tünelinden hariç tutmak istediğiniz uygulamaları seçin."
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "Daha bilgi için buraya tıklayın"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2195,6 +2249,14 @@ msgstr "Lütfen tekrar deneyin veya bir hata raporu gönderin."
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "Mullvad Hizmetini Yeniden Başlat"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "%(splitTunneling)s özelliğini kullanmak için lütfen cgroup v1'i destekleyen bir Linux çekirdek sürümüne geçin."
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2510,8 +2572,8 @@ msgstr "Uygulama başladığında bir sunucuya otomatik olarak bağlan."
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "Bu ayarları etkinleştirmek için aşağıdaki <b>%(customDnsFeatureName)s</b> seçeneğini devre dışı bırakın."
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "Bu ayarları etkinleştirmek için aşağıdaki \"%(customDnsFeatureName)s\" seçeneğini devre dışı bırakın."
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2703,6 +2765,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "Bir gözlemci bu veri paketlerini izliyorsa, %(daita)s ziyaret ettiğiniz web sitelerini veya iletişim kurduğunuz alıcıları tespit etmesini önemli ölçüde zorlaştırır."
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP sürümü"
@@ -2712,12 +2775,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "Bu işlemi, bir kuantum güvenlik algoritmasıyla ekstra bir anahtar değişimi gerçekleştirdikten sonra sonucu WireGuard'ın normal şifrelemesiyle karıştırarak yapar. Bu ekstra adım, her yeni tünel kurulduğunda yaklaşık 500 kiB trafik kullanır."
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "Çoklu geçiş"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "Seçtiğiniz konumda DAITA'yı etkinleştirmek için Çoklu Geçiş kullanılıyor"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2732,6 +2806,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "%(daita)s, tüm sunucularımızda etkin değildir. Bu nedenle, %(daita)s özelliğini herhangi bir sunucuda etkinleştirmek için otomatik olarak çoklu geçişi kullanırız."
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "Gizleme"
@@ -2742,6 +2817,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "Gizleme, WireGuard trafiğini başka bir protokolün içinde gizler. Normal bir WireGuard bağlantısının engelleneceği sansürü ve diğer filtreleme türlerini aşmaya yardımcı olmak için kullanılabilir."
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "Port"
@@ -2803,10 +2879,6 @@ msgstr "Bu özellik, WireGuard tünelini kuantum bilgisayarlardan gelebilecek po
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "TCP üzerinden UDP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "TCP üzerinden UDP portu"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2904,6 +2976,9 @@ msgstr "Süre ekle"
 msgid "Adding method..."
 msgstr "Yöntem ekleniyor..."
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "Android 16'da bir VPN uygulaması güncellendikten sonra, cihazlar VPN uygulamalarının artık internete erişemediği bir duruma geçebilir."
+
 msgid "Agree and continue"
 msgstr "Kabul et ve devam et"
 
@@ -2918,6 +2993,12 @@ msgstr "Her zaman açık VPN %s uygulamasına atandı"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "Her zaman açık VPN diğer VPN'e atandı"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16'da bilinen bir sorun mevcut. Lütfen cihazınızı yeniden başlatıp tekrar deneyin. Daha fazla bilgi için"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "<b>%s</b> adlı cihazdan çıkış yapmak istediğinizden emin misiniz?"
 
 msgid "At least one method needs to be enabled"
 msgstr "En az bir yöntemin etkinleştirilmesi gerekiyor"
@@ -2951,6 +3032,9 @@ msgstr "İnternet bağlantısı engelleniyor (cihaz çevrimdışı)"
 
 msgid "Blocking..."
 msgstr "Engelleniyor..."
+
+msgid "Can't connect?"
+msgstr "Bağlanamıyor musunuz?"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "DNS ile ilgili ayarlarda yapılan değişiklikler, önbelleğe alınan sonuçlar nedeniyle hemen etkili olmayabilir."
@@ -2988,9 +3072,6 @@ msgstr "Yeni liste oluştur"
 msgid "Critical error (your attention is required)"
 msgstr "Kritik hata (Lütfen dikkatli olun)"
 
-msgid "Current device"
-msgstr "Mevcut cihaz"
-
 msgid "Current: %s"
 msgstr "Geçerli: %s"
 
@@ -3011,9 +3092,6 @@ msgstr "Yöntem silinsin mi?"
 
 msgid "Device IP version"
 msgstr "Cihaz IP sürümü"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "Bu ayarları etkinleştirmek için aşağıdaki \"%s\" seçeneğini devre dışı bırakın."
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "Bu ayarı etkinleştirmek için yukarıdaki \"%s\" seçeneklerinin tümünü devre dışı bırakın."
@@ -3093,9 +3171,6 @@ msgstr "Geçerli olarak ayarlanamadı - Bilinmeyen neden"
 msgid "File"
 msgstr "Dosya"
 
-msgid "Filters:"
-msgstr "Filtreler:"
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "VPN'in cihaz başlatıldığında otomatik olarak bağlanabilmesi için uygulamanın VPN izinlerine sahip olması gerekir. Harita görünümünde “Bağlan”a tıklayıp istendiğinde “Tamam”ı seçerek bu izinleri verebilirsiniz. Ayrıca, sistem ayarlarında yer alan uygulama ayrıntılarındaki depolama bilgilerini kontrol ederek uygulamanın dahili depolamaya yüklendiğinden emin olun."
 
@@ -3162,9 +3237,6 @@ msgstr "\"%s\" için konumlar değiştirildi"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "Cihazın her zaman VPN tünelinde olduğundan emin olun."
 
-msgid "Manage devices"
-msgstr "Cihazları yönet"
-
 msgid "More actions"
 msgstr "Diğer işlemler"
 
@@ -3192,8 +3264,8 @@ msgstr "Özel listeler mevcut değil"
 msgid "No internet connection"
 msgstr "İnternet bağlantısı yok"
 
-msgid "No locations found"
-msgstr "Konum bulunamadı"
+msgid "No matching servers found."
+msgstr "Eşleşen sunucu bulunamadı."
 
 msgid "No recent selection history"
 msgstr "Son seçim geçmişi yok"
@@ -3233,6 +3305,12 @@ msgstr "Lütfen geçerli bir uzak sunucu portu girin"
 
 msgid "Please press connect to request VPN permission"
 msgstr "VPN izni istemek için lütfen bağlantıya dokunun"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "Lütfen cihazınızı yeniden başlatın ve tekrar bağlanmayı deneyin. Bu işe yaramazsa lütfen %s adresine İsveççe veya İngilizce bir e-posta yazın."
+
+msgid "Please try changing your filters."
+msgstr "Lütfen filtrelerinizi değiştirmeyi deneyin."
 
 msgid "Privacy"
 msgstr "Gizlilik"
@@ -3321,9 +3399,6 @@ msgstr "\"Geçerli\" yöntem, uygulamanın API'ye ulaşmak için kullandığı y
 msgid "The app is blocking internet, please disconnect first"
 msgstr "Uygulama internet bağlantısını engelliyor. Lütfen önce bağlantıyı kesin"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "Cihaz listeden kaldırılacak ve oturum kapatılacak."
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "VPN ayarlarındaki \"Yerel Ağ Paylaşımı\" seçeneğini etkinleştirmediğiniz sürece yerel DNS sunucusu etkinleşmez."
 
@@ -3381,6 +3456,12 @@ msgstr "DNS sunucusunu güncelle"
 msgid "Update list name"
 msgstr "Liste adını güncelle"
 
+msgid "Update server list"
+msgstr "Sunucu listesini güncelle"
+
+msgid "Updating server list in the background..."
+msgstr "Sunucu listesi arka planda güncelleniyor..."
+
 msgid "Use method"
 msgstr "Yöntemi kullan"
 
@@ -3417,9 +3498,6 @@ msgstr "Satın alma işlemi doğrulanıyor..."
 msgid "Verifying voucher…"
 msgstr "Kupon doğrulanıyor…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "Oturum açtığınız tüm cihazlarınızı görüntüleyin ve yönetin. Bir hesapta aynı anda en fazla 5 cihaz bulunabilir. Kolayca ayırt edebilmeniz için her cihaza giriş sırasında bir ad atanır."
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "Satın alma işleminiz doğrulanıyor. Bu işlem biraz zaman alabilir. Süreniz, doğrulama işleminin başarılı olması durumunda eklenecektir."
 
@@ -3441,11 +3519,17 @@ msgstr "WireGuard gizlemesi"
 msgid "WireGuard port"
 msgstr "WireGuard portu"
 
+msgid "Yes, log out device"
+msgstr "Evet, cihazdan çıkış yap"
+
 msgid "\"%s\" was created"
 msgstr "\"%s\" oluşturuldu"
 
 msgid "\"%s\" was deleted"
 msgstr "\"%s\" silindi"
+
+msgid "click here"
+msgstr "buraya tıklayın"
 
 msgid "here"
 msgstr "burada"

--- a/desktop/packages/mullvad-vpn/locales/tr/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/tr/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Turkish\n"
 "Language: tr_TR\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/zh-CN/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-CN/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "其他 %(amount)d 个…"
@@ -162,6 +162,11 @@ msgstr "仍然启用"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "启用仅直连"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "无法获取设备列表"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "无法保护连接"
@@ -430,6 +435,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCP 设置"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "使用向右箭头键将焦点移至设置按钮。"
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -447,6 +456,11 @@ msgstr "当前不可用"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "退出"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "管理设备"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -552,6 +566,10 @@ msgstr "请输入有效的 localhost 端口。"
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "请输入有效的远程服务器端口。"
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "请为尚未使用的访问方法选择一个名称。"
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1002,14 +1020,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "编辑自定义网桥"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "确定要退出<b>%(deviceName)s</b>吗？"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1021,6 +1031,11 @@ msgstr "继续登录"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "创建日期：%(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "当前设备"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1055,15 +1070,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "如果您退出登录，设备和设备名称将被移除。当您再次登录时，设备将获得新名称。"
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "管理设备"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "请通过从以下列表中移除的方式退出至少一个帐户。您可以在设备的帐户设置下找到相应设备名称。"
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "移除"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "是否移除 <em>%(deviceName)s</em>？"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "太棒了！"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "该设备将从列表中移除并退出登录。"
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1079,10 +1117,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "设备过多"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "是，退出设备"
+msgid "Try again"
+msgstr "重试"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "查看和管理您所有已登录的设备。一个帐户最多可以同时登录 5 台设备。每台设备登录时都会获得一个名称，以便您能够轻松区分。"
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1357,6 +1401,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "所选 %(wireGuard)s 端口不受支持，请在以下位置更改："
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "此设备现已命名为 <em>%(deviceName)s</em>。请在“帐户”中的“管理设备”下查看更多信息。"
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1392,10 +1443,6 @@ msgstr "验证完成！正在启动安装程序…"
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "验证失败"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "欢迎，此设备现在名为 <b>%(deviceName)s</b>。有关详情，请点击“帐户”中的信息按钮。"
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1523,11 +1570,6 @@ msgstr "错误"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "无法创建帐户"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "无法获取设备列表"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2131,6 +2173,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s 出现问题且无法从 VPN 隧道排除。"
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "您的系统不支持%(splitTunneling)s。"
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "添加"
@@ -2142,6 +2191,11 @@ msgstr "所有应用"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "选择您想要从 VPN 隧道中排除的应用。"
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "点击此处了解详情"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2189,6 +2243,14 @@ msgstr "请重试或发送问题报告。"
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "重新启动 Mullvad 服务"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "要使用%(splitTunneling)s，请更改为支持 cgroup v1 的 Linux 内核版本。"
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2504,8 +2566,8 @@ msgstr "在应用启动时自动连接到服务器。"
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "禁用下方的<b>%(customDnsFeatureName)s</b>以激活这些设置。"
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "禁用下方的“%(customDnsFeatureName)s”以激活这些设置。"
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2697,6 +2759,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "如果某个观察者监视这些数据包，%(daita)s 会大大提高他们识别您所访问的网站或您沟通对象的难度。"
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP 版本"
@@ -2706,12 +2769,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "实现方法是使用量子安全算法执行额外的密钥交换，并将结果混合到 WireGuard 的常规加密中。每次建立新隧道时，这一额外步骤都会使用约 500 kiB 的流量。"
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "多跳"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "正在使用多跳为您的所选位置启用 DAITA"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2726,6 +2800,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "我们的部分服务器未启用 %(daita)s。因此，我们使用多跳自动为任何服务器启用 %(daita)s。"
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "混淆"
@@ -2736,6 +2811,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "混淆会将 WireGuard 流量隐藏在其他协议中。这有助于规避审查和其他类型的过滤，在这些过滤中，普通 WireGuard 连接将被阻止。"
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "端口"
@@ -2797,10 +2873,6 @@ msgstr "借助此功能，WireGuard 隧道能够抵抗可能通过量子计算�
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCP 端口"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2898,6 +2970,9 @@ msgstr "添加时间"
 msgid "Adding method..."
 msgstr "正在添加方法…"
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "在 Android 16 上更新 VPN 应用后，设备可能会出现 VPN 应用无法连接互联网的情况。"
+
 msgid "Agree and continue"
 msgstr "同意并继续"
 
@@ -2912,6 +2987,12 @@ msgstr "“始终开启 VPN”已分配给 %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "“始终开启 VPN”已分配给其他 VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 存在已知问题。请重启您的设备并重试。如需了解详情，"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "确定要退出 <b>%s</b> 吗？"
 
 msgid "At least one method needs to be enabled"
 msgstr "至少需要启用一个方法"
@@ -2945,6 +3026,9 @@ msgstr "正在阻止网络（设备离线）"
 
 msgid "Blocking..."
 msgstr "正在屏蔽…"
+
+msgid "Can't connect?"
+msgstr "无法连接？"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "由于缓存结果，对 DNS 相关设置的更改可能不会立即生效。"
@@ -2982,9 +3066,6 @@ msgstr "创建新列表"
 msgid "Critical error (your attention is required)"
 msgstr "严重错误（需要注意）"
 
-msgid "Current device"
-msgstr "当前设备"
-
 msgid "Current: %s"
 msgstr "当前：%s"
 
@@ -3005,9 +3086,6 @@ msgstr "是否删除方法？"
 
 msgid "Device IP version"
 msgstr "设备 IP 版本"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "禁用下方的“%s”以激活这些设置。"
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "禁用上方的所有“%s”以激活此设置。"
@@ -3087,9 +3165,6 @@ msgstr "无法设置为当前方法 – 未知原因"
 msgid "File"
 msgstr "文件"
 
-msgid "Filters:"
-msgstr "筛选器："
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "为了让 VPN 在设备启动时自动连接，应用必须拥有 VPN 权限。您可以通过点击地图视图中的“连接”并在弹出提示时选择“确定”来授予这些权限。此外，请通过检查系统设置中应用详细信息内的存储信息，确保该应用已安装在内部存储空间中。"
 
@@ -3156,9 +3231,6 @@ msgstr "已更改“%s”的位置"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "确保设备始终位于 VPN 隧道上。"
 
-msgid "Manage devices"
-msgstr "管理设备"
-
 msgid "More actions"
 msgstr "更多操作"
 
@@ -3186,8 +3258,8 @@ msgstr "有可用的自定义列表"
 msgid "No internet connection"
 msgstr "没有互联网连接"
 
-msgid "No locations found"
-msgstr "找不到位置"
+msgid "No matching servers found."
+msgstr "找不到匹配的服务器。"
 
 msgid "No recent selection history"
 msgstr "无最近选择历史记录"
@@ -3227,6 +3299,12 @@ msgstr "请输入有效的远程服务器端口"
 
 msgid "Please press connect to request VPN permission"
 msgstr "请按“连接”以请求 VPN 权限"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "请重新启动您的设备，然后再次尝试连接。如果仍然无法连接，请用瑞典语或英语发送电子邮件至 %s。"
+
+msgid "Please try changing your filters."
+msgstr "请更改您的筛选器。"
 
 msgid "Privacy"
 msgstr "隐私"
@@ -3315,9 +3393,6 @@ msgstr "“当前”方法表示应用用来访问 API 的方法。"
 msgid "The app is blocking internet, please disconnect first"
 msgstr "应用正在阻止互联网，请先断开连接"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "该设备将从列表中移除并退出登录。"
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "除非您在 VPN 设置下启用“本地网络共享”，否则本地 DNS 服务器将不会运行。"
 
@@ -3375,6 +3450,12 @@ msgstr "更新 DNS 服务器"
 msgid "Update list name"
 msgstr "更新列表名称"
 
+msgid "Update server list"
+msgstr "更新服务器列表"
+
+msgid "Updating server list in the background..."
+msgstr "正在后台更新服务器列表…"
+
 msgid "Use method"
 msgstr "使用方法"
 
@@ -3411,9 +3492,6 @@ msgstr "正在验证购买…"
 msgid "Verifying voucher…"
 msgstr "正在验证优惠券…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "查看和管理您所有已登录的设备。一个帐户最多可以同时登录 5 台设备。每台设备登录时都会获得一个名称，以便您能够轻松区分。"
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "我们目前仍在验证您的购买，这可能需要一些时间。如果验证成功，您的时间将被添加。"
 
@@ -3435,11 +3513,17 @@ msgstr "WireGuard 混淆"
 msgid "WireGuard port"
 msgstr "WireGuard 端口"
 
+msgid "Yes, log out device"
+msgstr "是，退出登录设备"
+
 msgid "\"%s\" was created"
 msgstr "“%s”已创建"
 
 msgid "\"%s\" was deleted"
 msgstr "“%s”已被删除"
+
+msgid "click here"
+msgstr "点击此处"
 
 msgid "here"
 msgstr "（点击此处）"

--- a/desktop/packages/mullvad-vpn/locales/zh-CN/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-CN/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Simplified\n"
 "Language: zh_CN\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"

--- a/desktop/packages/mullvad-vpn/locales/zh-TW/messages.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-TW/messages.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 msgid "%(amount)d more..."
 msgstr "其他 %(amount)d 個…"
@@ -162,6 +162,11 @@ msgstr "仍然啟用"
 #. A toggle that refers to the setting "Direct only".
 msgid "Enable direct only"
 msgstr "啟用僅限直接連線"
+
+#. Error message shown trying to login but the app fails
+#. to fetch the list of registered devices.
+msgid "Failed to fetch list of devices"
+msgstr "無法取得裝置清單"
 
 msgid "FAILED TO SECURE CONNECTION"
 msgstr "保護連線失敗"
@@ -430,6 +435,10 @@ msgctxt "accessibility"
 msgid "UDP-over-TCP settings"
 msgstr "UDP-over-TCP 設定"
 
+msgctxt "accessibility"
+msgid "Use the right arrow key to focus the settings button."
+msgstr "使用向右鍵來聚焦設定按鈕。"
+
 #. Title label in navigation bar
 msgctxt "account-view"
 msgid "Account"
@@ -447,6 +456,11 @@ msgstr "目前不可用"
 msgctxt "account-view"
 msgid "Log out"
 msgstr "登出"
+
+#. Link text in the account view to navigate to the manage devices view.
+msgctxt "account-view"
+msgid "Manage devices"
+msgstr "管理裝置"
 
 msgctxt "account-view"
 msgid "OUT OF TIME"
@@ -552,6 +566,10 @@ msgstr "請輸入有效的 localhost 連接埠。"
 msgctxt "api-access-methods-view"
 msgid "Please enter a valid remote server port."
 msgstr "請輸入有效的遠端伺服器連接埠。"
+
+msgctxt "api-access-methods-view"
+msgid "Please select a name for the access method not already in use."
+msgstr "請為尚未使用的存取方式選擇名稱。"
 
 msgctxt "api-access-methods-view"
 msgid "Remote Server"
@@ -1002,14 +1020,6 @@ msgctxt "custom-bridge"
 msgid "Edit custom bridge"
 msgstr "編輯自訂橋接"
 
-#. Text displayed above button which logs out another device.
-#. The text enclosed in "<b></b>" will appear bold.
-#. Available placeholders:
-#. %(deviceName)s - The name of the device to log out.
-msgctxt "device-management"
-msgid "Are you sure you want to log <b>%(deviceName)s</b> out?"
-msgstr "確定要將 <b>%(deviceName)s</b> 登出嗎？"
-
 #. Button for continuing login process.
 msgctxt "device-management"
 msgid "Continue with login"
@@ -1021,6 +1031,11 @@ msgstr "繼續登入"
 msgctxt "device-management"
 msgid "Created: %(createdDate)s"
 msgstr "建立日期：%(createdDate)s"
+
+#. Label indicating that this device is the current device.
+msgctxt "device-management"
+msgid "Current device"
+msgstr "目前裝置"
 
 msgctxt "device-management"
 msgid "Device is inactive"
@@ -1055,15 +1070,38 @@ msgctxt "device-management"
 msgid "If you log out, the device and the device name is removed. When you log back in again, the device will get a new name."
 msgstr "如果您登出，則系統會移除裝置和裝置名稱。當您再次登入時，裝置則會獲得新名稱。"
 
+#. Title label in navigation bar for the manage devices view.
+#. Title text in the manage devices view
+msgctxt "device-management"
+msgid "Manage devices"
+msgstr "管理裝置"
+
 msgctxt "device-management"
 msgid "Please log out of at least one by removing it from the list below. You can find the corresponding device name under the device’s Account settings."
 msgstr "請從底下清單至少移除一個裝置來將其登出。您可以在裝置的「帳戶」設定下找到相應裝置名稱。"
+
+#. Button label for confirming removing a device.
+msgctxt "device-management"
+msgid "Remove"
+msgstr "移除"
+
+#. Text displayed above button which logs out another device.
+#. The text enclosed in "<b></b>" will appear bold.
+#. Available placeholders:
+#. %(deviceName)s - The name of the device to log out.
+msgctxt "device-management"
+msgid "Remove <em>%(deviceName)s?</em>"
+msgstr "是否要移除 <em>%(deviceName)s？</em>"
 
 #. Page title informing user that enough devices has been removed to continue
 #. login process.
 msgctxt "device-management"
 msgid "Super!"
 msgstr "太好了！"
+
+msgctxt "device-management"
+msgid "The device will be removed from the list and logged out."
+msgstr "裝置將從清單中移除並登出。"
 
 msgctxt "device-management"
 msgid "This is the name assigned to the device. Each device logged in on a Mullvad account gets a unique name that helps you identify it when you manage your devices in the app or on the website."
@@ -1079,10 +1117,16 @@ msgctxt "device-management"
 msgid "Too many devices"
 msgstr "裝置過多"
 
-#. Button label for confirming logout of another device.
+#. Button text to retry fetching devices.
 msgctxt "device-management"
-msgid "Yes, log out device"
-msgstr "是，將裝置登出"
+msgid "Try again"
+msgstr "再試一次"
+
+#. Subtitle text in the manage devices view, explaining
+#. devices and what they can do in the manage devices view.
+msgctxt "device-management"
+msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
+msgstr "檢視並管理所有已登入的裝置。一個帳戶最多能同時登入 5 台裝置。每台裝置登入時都會獲得一個名稱，以協助您輕鬆區分。"
 
 msgctxt "device-management"
 msgid "You can have up to 5 devices logged in on one Mullvad account."
@@ -1357,6 +1401,13 @@ msgctxt "in-app-notifications"
 msgid "The selected %(wireGuard)s port is not supported, please change it under "
 msgstr "不支援所選的 %(wireGuard)s 連接埠，請至下列位置變更："
 
+#. Notification text when a new device has been created.
+#. Available placeholders:
+#. - %(deviceName)s: Name of created device.
+msgctxt "in-app-notifications"
+msgid "This device is now named <em>%(deviceName)s</em>. See more under \"Manage devices\" in Account."
+msgstr "現在此裝置的名稱是 <em>%(deviceName)s</em>。如需更多資訊，請參閱「帳戶」中的「管理裝置」。"
+
 #. The in-app banner displayed to the user when the app beta update is
 #. available.
 #. Available placeholders:
@@ -1392,10 +1443,6 @@ msgstr "驗證完成！正在啟動安裝程式…"
 msgctxt "in-app-notifications"
 msgid "VERIFICATION FAILED"
 msgstr "驗證失敗"
-
-msgctxt "in-app-notifications"
-msgid "Welcome, this device is now called <b>%(deviceName)s</b>. For more details see the info button in Account."
-msgstr "歡迎，此裝置現在稱為 <b>%(deviceName)s</b>。如需詳細資訊，請點按「帳戶」中的資訊按鈕。"
 
 #. Status text app is trying to connect to the system service.
 msgctxt "launch-view"
@@ -1523,11 +1570,6 @@ msgstr "錯誤"
 msgctxt "login-view"
 msgid "Failed to create account"
 msgstr "無法建立帳戶"
-
-#. Error message shown above login input when trying to login but the app fails
-#. to fetch the list of registered devices.
-msgid "Failed to fetch list of devices"
-msgstr "無法取得裝置清單"
 
 msgctxt "login-view"
 msgid "Finishing upgrade."
@@ -2131,6 +2173,13 @@ msgctxt "split-tunneling-view"
 msgid "%(applicationName)s is problematic and can’t be excluded from the VPN tunnel."
 msgstr "%(applicationName)s 發生問題且無法從 VPN 通道排除。"
 
+#. Information about split tunneling not being supported on the system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "%(splitTunneling)s is not supported by your system."
+msgstr "您的系統不支援 %(splitTunneling)s。"
+
 msgctxt "split-tunneling-view"
 msgid "Add"
 msgstr "新增"
@@ -2142,6 +2191,11 @@ msgstr "所有應用程式"
 msgctxt "split-tunneling-view"
 msgid "Choose the apps you want to exclude from the VPN tunnel."
 msgstr "選擇要從 VPN 通道中排除的應用程式。"
+
+#. Link for learning more
+msgctxt "split-tunneling-view"
+msgid "Click here to learn more"
+msgstr "按一下此處了解更多資訊"
 
 msgctxt "split-tunneling-view"
 msgid "Click on an app to launch it. Its traffic will bypass the VPN tunnel until you close it."
@@ -2189,6 +2243,14 @@ msgstr "請再試一次或傳送問題回報。"
 msgctxt "split-tunneling-view"
 msgid "Restart Mullvad Service"
 msgstr "重新啟動 Mullvad 服務"
+
+#. Information about split tunneling being unavailable due to
+#. missing support in the user's operating system.
+#. Available placeholders:
+#. %(splitTunneling)s - will be replaced with Split tunneling
+msgctxt "split-tunneling-view"
+msgid "To use %(splitTunneling)s, please change to a Linux kernel version that supports cgroup v1."
+msgstr "若要使用 %(splitTunneling)s，請改為使用支援 cgroup v1 的 Linux 核心版本。"
 
 msgctxt "split-tunneling-view"
 msgid "To use split tunneling please enable “Full disk access” for “Mullvad VPN” in the macOS system settings."
@@ -2504,8 +2566,8 @@ msgstr "啟動應用程式時，自動連線伺服器。"
 #. Available placeholders:
 #. %(customDnsFeatureName)s - The name displayed next to the custom DNS toggle.
 msgctxt "vpn-settings-view"
-msgid "Disable <b>%(customDnsFeatureName)s</b> below to activate these settings."
-msgstr "停用下方的 <b>%(customDnsFeatureName)s</b> 以啟動這些設定。"
+msgid "Disable \"%(customDnsFeatureName)s\" below to activate these settings."
+msgstr "停用下方的「%(customDnsFeatureName)s」以啟動這些設定。"
 
 #. This is displayed when either or both of the block ads/trackers settings are
 #. turned on which makes the custom DNS setting disabled.
@@ -2697,6 +2759,7 @@ msgctxt "wireguard-settings-view"
 msgid "If an observer monitors these data packets, %(daita)s makes it significantly harder for them to identify which websites you are visiting or with whom you are communicating."
 msgstr "如果有觀察者正在監控這些資料封包，%(daita)s 會大大增加他們的難度，讓他們很難辨識您正在瀏覽哪些網站或者在和誰通訊。"
 
+#. The title for the WireGuard IP version selector.
 msgctxt "wireguard-settings-view"
 msgid "IP version"
 msgstr "IP 版本"
@@ -2706,12 +2769,23 @@ msgid "It does this by performing an extra key exchange using a quantum safe alg
 msgstr "實現方法是使用量子安全演算法執行額外的金鑰交換，並將結果混合至 WireGuard 的常規加密。每次建立新通道時，這一額外步驟都會使用約 500 kiB 流量。"
 
 msgctxt "wireguard-settings-view"
+msgid "LWO"
+msgstr "LWO"
+
+#. The title for the WireGuard MTU setting. MTU stands for Maximum
+#. Transmission Unit and controls the maximum size of packets sent over
+#. the VPN tunnel.
+msgctxt "wireguard-settings-view"
 msgid "MTU"
 msgstr "MTU"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop"
 msgstr "多點跳躍"
+
+msgctxt "wireguard-settings-view"
+msgid "Multihop is being used to enable DAITA for your selected location"
+msgstr "正在使用多點跳躍為您所選位置啟用 DAITA"
 
 msgctxt "wireguard-settings-view"
 msgid "Multihop routes your traffic into one WireGuard server and out another, making it harder to trace. This results in increased latency but increases anonymity online."
@@ -2726,6 +2800,7 @@ msgctxt "wireguard-settings-view"
 msgid "Not all our servers are %(daita)s-enabled. Therefore, we use multihop automatically to enable %(daita)s with any server."
 msgstr "我們有些伺服器並未啟用 %(daita)s。因此，我們使用多點跳躍自動來為任意伺服器啟用 %(daita)s 。"
 
+#. The title for the WireGuard obfuscation selector.
 msgctxt "wireguard-settings-view"
 msgid "Obfuscation"
 msgstr "混淆"
@@ -2736,6 +2811,7 @@ msgctxt "wireguard-settings-view"
 msgid "Obfuscation hides the WireGuard traffic inside another protocol. It can be used to help circumvent censorship and other types of filtering, where a plain WireGuard connection would be blocked."
 msgstr "藉由混淆，WireGuard 的流量能隱藏在另一個通訊協定中。這有助於規避審查或其他類型的篩選。在這類篩選中，普通 WireGuard 連線將遭到封鎖。"
 
+#. The title for the WireGuard port selector.
 msgctxt "wireguard-settings-view"
 msgid "Port"
 msgstr "連接埠"
@@ -2797,10 +2873,6 @@ msgstr "借助此功能，WireGuard 通道便能夠抵抗可能從量子電腦�
 msgctxt "wireguard-settings-view"
 msgid "UDP-over-TCP"
 msgstr "UDP-over-TCP"
-
-msgctxt "wireguard-settings-view"
-msgid "UDP-over-TCP port"
-msgstr "UDP-over-TCP 連接埠"
 
 #. Text describing the valid port range for a port selector.
 msgctxt "wireguard-settings-view"
@@ -2898,6 +2970,9 @@ msgstr "增加時間"
 msgid "Adding method..."
 msgstr "正在新增方式…"
 
+msgid "After updating a VPN app on Android 16, devices might end up in a state where VPN apps are no longer able to reach the internet."
+msgstr "在 Android 16 更新 VPN 應用程式後，裝置可能會出現 VPN 應用程式無法連線至網際網路的情況。"
+
 msgid "Agree and continue"
 msgstr "同意並繼續"
 
@@ -2912,6 +2987,12 @@ msgstr "「一律啟用 VPN」已指派給 %s"
 
 msgid "Always-on VPN assigned to other VPN"
 msgstr "「一律啟用 VPN」已指派給其他 VPN"
+
+msgid "Android 16 has a known issue. Please restart your device and try again. To learn more,"
+msgstr "Android 16 存在已知問題。請重新啟動您的裝置並再試一次。如需更多資訊，"
+
+msgid "Are you sure you want to log <b>%s</b> out?"
+msgstr "確定要將 <b>%s</b> 登出嗎？"
 
 msgid "At least one method needs to be enabled"
 msgstr "至少需要啟用一種方式"
@@ -2945,6 +3026,9 @@ msgstr "封鎖網際網路 (裝置離線)"
 
 msgid "Blocking..."
 msgstr "正在封鎖…"
+
+msgid "Can't connect?"
+msgstr "無法連線嗎？"
 
 msgid "Changes to DNS related settings might not go into effect immediately due to cached results."
 msgstr "由於快取的結果，對 DNS 相關設定所做的變更可能不會立即生效。"
@@ -2982,9 +3066,6 @@ msgstr "建立新清單"
 msgid "Critical error (your attention is required)"
 msgstr "嚴重錯誤 (需注意)"
 
-msgid "Current device"
-msgstr "目前裝置"
-
 msgid "Current: %s"
 msgstr "目前：%s"
 
@@ -3005,9 +3086,6 @@ msgstr "要刪除方式嗎？"
 
 msgid "Device IP version"
 msgstr "裝置 IP 版本"
-
-msgid "Disable \"%s\" below to activate these settings."
-msgstr "停用下方的「%s」以啟動這些設定。"
 
 msgid "Disable all \"%s\" above to activate this setting."
 msgstr "停用上方所有「%s」以啟動此設定。"
@@ -3087,9 +3165,6 @@ msgstr "無法設定為目前方式 - 不明原因"
 msgid "File"
 msgstr "檔案"
 
-msgid "Filters:"
-msgstr "篩選器："
-
 msgid "For the VPN to connect automatically on device startup, the app must have VPN permissions. You can grant these by clicking “Connect” in the map view and selecting “OK” if prompted. Additionally, ensure the app is installed on the internal storage by checking the storage information in the app details in system settings."
 msgstr "為讓 VPN 在裝置啟動時自動連線，應用程式需擁有 VPN 權限。您可以在地圖檢視中點擊「連線」，然後在顯示提示時選擇「確定」來授予權限。此外，請在系統設定中檢查應用程式詳細資訊中的儲存資訊，以確保應用程式已安裝於內部儲存空間。"
 
@@ -3156,9 +3231,6 @@ msgstr "已變更「%s」的位置"
 msgid "Makes sure the device is always on the VPN tunnel."
 msgstr "請確認裝置始終位於 VPN 通道上。"
 
-msgid "Manage devices"
-msgstr "管理裝置"
-
 msgid "More actions"
 msgstr "更多操作"
 
@@ -3186,8 +3258,8 @@ msgstr "有可用的自訂清單"
 msgid "No internet connection"
 msgstr "沒有網際網路連線"
 
-msgid "No locations found"
-msgstr "找不到位置"
+msgid "No matching servers found."
+msgstr "找不到相符的伺服器。"
 
 msgid "No recent selection history"
 msgstr "無最近選擇歷史"
@@ -3227,6 +3299,12 @@ msgstr "請輸入有效的遠端伺服器連接埠"
 
 msgid "Please press connect to request VPN permission"
 msgstr "請按「連線」請求 VPN 權限"
+
+msgid "Please restart your device and try connecting again. If this does not work, please write an email to %s in Swedish or English."
+msgstr "請重新啟動您的裝置並嘗試重新連線。若不成功，請以瑞典語或英語撰寫電子郵件並寄至 %s。"
+
+msgid "Please try changing your filters."
+msgstr "請變更您的篩選器試試。"
 
 msgid "Privacy"
 msgstr "隱私權"
@@ -3315,9 +3393,6 @@ msgstr "「目前」方式表示應用程式正用來存取 API 的方式。"
 msgid "The app is blocking internet, please disconnect first"
 msgstr "此應用程式正在封鎖網際網路，請先中斷連線"
 
-msgid "The device will be removed from the list and logged out."
-msgstr "裝置將從清單中移除並登出。"
-
 msgid "The local DNS server will not work unless you enable \"Local Network Sharing\" under VPN settings."
 msgstr "若要使本機 DNS 伺服器運作，需先在 VPN 設定下啟用「本機網路共享」。"
 
@@ -3375,6 +3450,12 @@ msgstr "更新 DNS 伺服器"
 msgid "Update list name"
 msgstr "更新清單名稱"
 
+msgid "Update server list"
+msgstr "更新伺服器清單"
+
+msgid "Updating server list in the background..."
+msgstr "正在背景更新伺服器清單……"
+
 msgid "Use method"
 msgstr "使用方式"
 
@@ -3411,9 +3492,6 @@ msgstr "正在驗證購買…"
 msgid "Verifying voucher…"
 msgstr "正在驗證優惠券…"
 
-msgid "View and manage all your logged in devices. You can have up to 5 devices on one account at a time. Each device gets a name when logged in to help you tell them apart easily."
-msgstr "檢視並管理所有已登入的裝置。一個帳戶最多能同時登入 5 台裝置。每台裝置登入時都會獲得一個名稱，以協助您輕鬆區分。"
-
 msgid "We are still verifying your purchase, this might take some time. Your time will be added if the verification is successful."
 msgstr "我們仍在驗證您的購買，這可能需要一些時間。如果驗證成功，您的時間就會增加。"
 
@@ -3435,11 +3513,17 @@ msgstr "WireGuard 混淆"
 msgid "WireGuard port"
 msgstr "WireGuard 連接埠"
 
+msgid "Yes, log out device"
+msgstr "是，將裝置登出"
+
 msgid "\"%s\" was created"
 msgstr "已建立「%s」"
 
 msgid "\"%s\" was deleted"
 msgstr "「%s」已刪除"
+
+msgid "click here"
+msgstr "按一下此處"
 
 msgid "here"
 msgstr "此處"

--- a/desktop/packages/mullvad-vpn/locales/zh-TW/relay-locations.po
+++ b/desktop/packages/mullvad-vpn/locales/zh-TW/relay-locations.po
@@ -10,7 +10,7 @@ msgstr ""
 "Project-Id-Version: mullvad-app\n"
 "Language-Team: Chinese Traditional\n"
 "Language: zh_TW\n"
-"PO-Revision-Date: 2025-09-30 07:30\n"
+"PO-Revision-Date: 2025-10-20 06:58\n"
 
 #. AU ADL
 msgid "Adelaide"


### PR DESCRIPTION
This PR backports https://github.com/mullvad/mullvadvpn-app/pull/9152 to the `2025.13` release branch. We could hold off on merging this until everything has been ported from `prepare-2025.13` to `main`, but I'll submit this PR early to not forget about it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9162)
<!-- Reviewable:end -->
