### PR TITLE
Clear out-of-time notification on login/revoke screens

### DIFF
--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/MullvadApplication.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/MullvadApplication.kt
@@ -59,17 +59,11 @@ class MullvadApplication : Application() {
                 when (action) {
                     NotificationAction.CancelExisting -> {
                         accountExpiryNotificationProvider.cancelNotification()
-                        scheduleNotificationAlarmUseCase(
-                            context = this@MullvadApplication,
-                            accountExpiry = null,
-                        )
+                        scheduleNotificationAlarmUseCase(accountExpiry = null)
                     }
 
                     is NotificationAction.ScheduleAlarm ->
-                        scheduleNotificationAlarmUseCase(
-                            context = this@MullvadApplication,
-                            accountExpiry = action.alarmTime,
-                        )
+                        scheduleNotificationAlarmUseCase(accountExpiry = action.alarmTime)
                 }
             }
         }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/AppModule.kt
@@ -64,7 +64,7 @@ val appModule = module {
     single { ConnectionProxy(get(), get(), get()) }
     single { LocaleRepository(get()) }
     single { RelayLocationTranslationRepository(get(), get(), MainScope()) }
-    single { ScheduleNotificationAlarmUseCase(get()) }
+    single { ScheduleNotificationAlarmUseCase(androidContext(), get()) }
     single { AccountExpiryNotificationActionUseCase(get(), get()) }
 
     single { NotificationChannel.TunnelUpdates } bind NotificationChannel::class

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -255,11 +255,11 @@ val uiModule = module {
     }
     viewModel { DeviceListViewModel(get(), get()) }
     viewModel { ManageDevicesViewModel(get(), get()) }
-    viewModel { DeviceRevokedViewModel(get(), get()) }
+    viewModel { DeviceRevokedViewModel(get(), get(), get(), get()) }
     viewModel { MtuDialogViewModel(get(), get()) }
     viewModel { DnsDialogViewModel(get(), get(), get(), get()) }
     viewModel { WireguardCustomPortDialogViewModel(get()) }
-    viewModel { LoginViewModel(get(), get(), get()) }
+    viewModel { LoginViewModel(get(), get(), get(), get(), get()) }
     viewModel { PrivacyDisclaimerViewModel(get(), IS_PLAY_BUILD) }
     viewModel {
         SelectLocationViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get())

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/receiver/NotificationAlarmReceiver.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/receiver/NotificationAlarmReceiver.kt
@@ -33,7 +33,7 @@ class NotificationAlarmReceiver : BroadcastReceiver(), KoinComponent {
         goAsync {
             // Only schedule the next alarm if we still have time left on the account.
             if (context != null && expiry > ZonedDateTime.now()) {
-                scheduleNotificationAlarmUseCase(context = context, accountExpiry = expiry)
+                scheduleNotificationAlarmUseCase(accountExpiry = expiry, customContext = context)
             }
         }
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/receiver/ScheduleNotificationBootCompletedReceiver.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/receiver/ScheduleNotificationBootCompletedReceiver.kt
@@ -27,6 +27,6 @@ class ScheduleNotificationBootCompletedReceiver : BroadcastReceiver(), KoinCompo
 
     private suspend fun scheduleAccountExpiryNotification(context: Context) {
         val expiry = userPreferencesRepository.accountExpiry() ?: return
-        scheduleNotificationAlarmUseCase(context, expiry)
+        scheduleNotificationAlarmUseCase(expiry, customContext = context)
     }
 }


### PR DESCRIPTION
There are cases when a user may get to the login or device revoked screens without their previously scheduled account expiry notification being cancelled.

This can happen if for some reason the dameon has not sent the logged out/revoked event, for example if the account is logged out via the website while the app is not running.

This PR cancels the notification when the user gets to the login or device revoked screens.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9168)
<!-- Reviewable:end -->
