### PR TITLE
Fix truncated text in certain display sizes

### DIFF
--- a/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/Views/SettingsInfoView.swift
@@ -67,6 +67,7 @@ struct SettingsInfoView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                     bodyText(page)
+                        .fixedSize(horizontal: false, vertical: true)
                         .font(.subheadline)
                         .opacity(0.6)
                 }


### PR DESCRIPTION
This PR fixes the multihop text being truncated in certain display sizes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9172)
<!-- Reviewable:end -->
