### PR TITLE
Update vite to 7.1.11

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -10811,9 +10811,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
-      "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11432,7 +11432,7 @@
         "playwright": "^1.55.0",
         "postject": "^1.0.0-alpha.6",
         "sinon": "^14.0.1",
-        "vite": "7.1.7",
+        "vite": "7.1.11",
         "vite-plugin-electron": "^0.29.0",
         "xvfb-maybe": "^0.2.1"
       },
@@ -17627,7 +17627,7 @@
         "sinon": "^14.0.1",
         "sprintf-js": "^1.1.2",
         "styled-components": "^6.1.19",
-        "vite": "7.1.7",
+        "vite": "7.1.11",
         "vite-plugin-electron": "^0.29.0",
         "windows-utils": "0.0.0",
         "xvfb-maybe": "^0.2.1"
@@ -19702,9 +19702,9 @@
       }
     },
     "vite": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
-      "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "peer": true,
       "requires": {

--- a/desktop/packages/mullvad-vpn/package.json
+++ b/desktop/packages/mullvad-vpn/package.json
@@ -64,7 +64,7 @@
     "playwright": "^1.55.0",
     "postject": "^1.0.0-alpha.6",
     "sinon": "^14.0.1",
-    "vite": "7.1.7",
+    "vite": "7.1.11",
     "vite-plugin-electron": "^0.29.0",
     "xvfb-maybe": "^0.2.1"
   },


### PR DESCRIPTION
Patches the following vulnerability:
https://osv.dev/vulnerability/GHSA-93m4-6634-74q7

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9175)
<!-- Reviewable:end -->
