### PR TITLE
Set line ending style to LF in *.h files in `.gitattributes`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,9 @@ indent_size = 2
 end_of_line = lf
 indent_style = tab
 
+[*.{h}]
+end_of_line = lf
+
 [*.{yml,yaml}]
 indent_style = space
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,7 @@
 # Use LF for Rust because rustfmt works best like that
 *.rs text eol=lf
 
+*.h text eol=lf
+
 wireguard/libwg/go.mod text eol=lf
 wireguard/libwg/go.sum text eol=lf


### PR DESCRIPTION
We have had some trouble with git on windows complaining that line endings in `mullvad-nsis/include/mullvad-nsis.h` changes after a rebuild. This is an attempt at silencing that by telling git that this file has and should keep LF line endings.

The warning we got was:
```
warning: in the working copy of 'mullvad-nsis/include/mullvad-nsis.h', LF will be replaced by CRLF the next time Git touches it
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9176)
<!-- Reviewable:end -->
