### PR TITLE
Fix failing test due to time zone change

### DIFF
--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/AccountExpiryInAppNotificationUseCaseTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/AccountExpiryInAppNotificationUseCaseTest.kt
@@ -75,7 +75,7 @@ class AccountExpiryInAppNotificationUseCaseTest {
     fun `account that expires after the threshold should not emit a notification`() = runTest {
         accountExpiryInAppNotificationUseCase().test {
             assertNull(awaitItem())
-            setExpiry(notificationThreshold.plusDays(1))
+            setExpiry(notificationThreshold.plusHours(24))
             expectNoEvents()
         }
     }
@@ -124,7 +124,7 @@ class AccountExpiryInAppNotificationUseCaseTest {
 
             // Make sure we reset the list of notifications emitted when new time is added
             setExpiry(
-                ZonedDateTime.now().plus(ACCOUNT_EXPIRY_CLOSE_TO_EXPIRY_THRESHOLD).plusDays(1)
+                ZonedDateTime.now().plus(ACCOUNT_EXPIRY_CLOSE_TO_EXPIRY_THRESHOLD).plusHours(24)
             )
             assertNull(expectMostRecentItem())
         }

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/OutOfTimeUseCaseTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/usecase/OutOfTimeUseCaseTest.kt
@@ -88,7 +88,7 @@ class OutOfTimeUseCaseTest {
     fun `tunnel is connected should emit false`() =
         scope.runTest {
             // Arrange
-            val expiredAccountExpiry = AccountData.mock(ZonedDateTime.now().plusDays(1))
+            val expiredAccountExpiry = AccountData.mock(ZonedDateTime.now().plusHours(24))
             val tunnelStateChanges =
                 listOf(
                     TunnelState.Disconnected(),
@@ -129,7 +129,7 @@ class OutOfTimeUseCaseTest {
     fun `account expiry that has not expired should emit false`() =
         scope.runTest {
             // Arrange
-            val notExpiredAccountExpiry = AccountData.mock(ZonedDateTime.now().plusDays(1))
+            val notExpiredAccountExpiry = AccountData.mock(ZonedDateTime.now().plusHours(24))
 
             // Act, Assert
             outOfTimeUseCase.isOutOfTime.test {
@@ -167,7 +167,7 @@ class OutOfTimeUseCaseTest {
         scope.runTest {
             // Arrange
             val initialAccountExpiry = AccountData.mock(ZonedDateTime.now().plusSeconds(100))
-            val updatedExpiry = AccountData.mock(initialAccountExpiry.expiryDate.plusDays(30))
+            val updatedExpiry = AccountData.mock(initialAccountExpiry.expiryDate.plusHours(30 * 24))
 
             // Act, Assert
             outOfTimeUseCase.isOutOfTime.test {
@@ -195,7 +195,7 @@ class OutOfTimeUseCaseTest {
         scope.runTest {
             // Arrange
             val initialAccountExpiry = AccountData.mock(ZonedDateTime.now().plusSeconds(100))
-            val updatedExpiry = AccountData.mock(initialAccountExpiry.expiryDate.plusDays(30))
+            val updatedExpiry = AccountData.mock(initialAccountExpiry.expiryDate.plusHours(30 * 24))
             // Act, Assert
             outOfTimeUseCase.isOutOfTime.test {
                 // Initial event

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/LoginViewModelTest.kt
@@ -158,7 +158,7 @@ class LoginViewModelTest {
             val sideEffects = loginViewModel.uiSideEffect.testIn(backgroundScope)
             coEvery { mockedAccountRepository.login(any()) } returns Unit.right()
             coEvery { mockedAccountRepository.accountData } returns
-                MutableStateFlow(AccountData.mock(ZonedDateTime.now().plusDays(3)))
+                MutableStateFlow(AccountData.mock(ZonedDateTime.now().plusHours(3 * 24)))
 
             // Act, Assert
             uiStates.skipDefaultItem()

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/viewmodel/WelcomeViewModelTest.kt
@@ -150,7 +150,7 @@ class WelcomeViewModelTest {
     @Test
     fun `when user has added time then uiSideEffect should emit OpenConnectScreen`() = runTest {
         // Arrange
-        accountExpiryStateFlow.emit(AccountData.mock(ZonedDateTime.now().plusDays(1)))
+        accountExpiryStateFlow.emit(AccountData.mock(ZonedDateTime.now().plusHours(24)))
 
         // Act, Assert
         viewModel.uiSideEffect.test {

--- a/android/service/src/test/kotlin/net/mullvad/mullvadvpn/service/notifications/accountexpiry/AccountExpiryNotificationTriggerTest.kt
+++ b/android/service/src/test/kotlin/net/mullvad/mullvadvpn/service/notifications/accountexpiry/AccountExpiryNotificationTriggerTest.kt
@@ -11,11 +11,11 @@ class AccountExpiryNotificationTriggerTest {
     fun `long account expiry should trigger 3 days before expiry`() {
         val now = ZonedDateTime.now()
 
-        val threeMonthsExpiry = now.plusDays(90)
+        val threeMonthsExpiry = now.plusHours(90 * 24)
         val trigger1 = accountExpiryNotificationTriggerAt(now, threeMonthsExpiry)
         assertEquals(87, Duration.between(now, trigger1).toDays())
 
-        val fourAndHalfDaysExpiry = now.plusDays(4).plusHours(12)
+        val fourAndHalfDaysExpiry = now.plusHours(4 * 24 + 12)
         val trigger2 = accountExpiryNotificationTriggerAt(now, fourAndHalfDaysExpiry)
         assertEquals(Duration.ofDays(1).plusHours(12), Duration.between(now, trigger2))
     }

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountExpiryMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountExpiryMockApiTest.kt
@@ -75,7 +75,7 @@ class AccountExpiryMockApiTest : MockApiTest() {
         on<ConnectPage>()
 
         // Set account time as expired
-        val newAccountExpiry = ZonedDateTime.now().plusDays(3).plusSeconds(5)
+        val newAccountExpiry = ZonedDateTime.now().plusHours(3 * 24).plusSeconds(5)
         apiDispatcher.accountExpiry = newAccountExpiry
 
         on<ConnectPage> { clickAccount() }

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
@@ -21,7 +21,7 @@ class LoginMockApiTest : MockApiTest() {
         val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
             expectedAccountNumber = null
-            accountExpiry = ZonedDateTime.now().plusDays(1)
+            accountExpiry = ZonedDateTime.now().plusHours(24)
         }
 
         // Act login with invalid credentials
@@ -42,7 +42,7 @@ class LoginMockApiTest : MockApiTest() {
         val validAccountNumber = "1234123412341234"
         apiDispatcher.apply {
             expectedAccountNumber = validAccountNumber
-            accountExpiry = ZonedDateTime.now().plusDays(1)
+            accountExpiry = ZonedDateTime.now().plusHours(24)
             devices = DEFAULT_DEVICE_LIST.toMutableMap()
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
         }

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiDispatcher.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/MockApiDispatcher.kt
@@ -83,7 +83,7 @@ class MockApiDispatcher : Dispatcher() {
                 .setBody(
                     accessTokenJsonResponse(
                             accessToken = DUMMY_ACCESS_TOKEN,
-                            expiry = ZonedDateTime.now().plusDays(1),
+                            expiry = ZonedDateTime.now().plusHours(24),
                         )
                         .toString()
                 )


### PR DESCRIPTION
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9181)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized time calculations in test and mock API files to use consistent hour-based expressions across account expiry and login workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->