### PR TITLE
Disable compiling `libwg` & `maybenot` for Windows from non-Windows hosts

### DIFF
--- a/wireguard-go-rs/build.rs
+++ b/wireguard-go-rs/build.rs
@@ -22,10 +22,11 @@ fn main() -> anyhow::Result<()> {
 
     let out_dir = env::var("OUT_DIR").context("Missing OUT_DIR")?;
     match target_os()? {
-        Os::Windows => build_windows_dynamic_lib(&out_dir)?,
+        Os::Windows if host_os() == Os::Windows => build_windows_dynamic_lib(&out_dir)?,
         Os::Linux => build_linux_static_lib(&out_dir)?,
         Os::Macos => build_macos_static_lib(&out_dir)?,
         Os::Android => build_android_dynamic_lib(&out_dir)?,
+        _ => (),
     }
 
     Ok(())
@@ -132,6 +133,8 @@ fn target_libc() -> anyhow::Result<Libc> {
 }
 
 /// Compile libwg and maybenot and place them in the target dir relative to `OUT_DIR`.
+///
+/// The host has to run Windows.
 fn build_windows_dynamic_lib(out_dir: &str) -> anyhow::Result<()> {
     let target_dir = Path::new(out_dir)
         .ancestors()


### PR DESCRIPTION
This PR lifts out the `Misc` section of https://github.com/mullvad/mullvadvpn-app/pull/9164 into a separate PR, since they are distinct changes. Here's a copy of that misc section:

I could not type check Windows code from my Linux computer due to `wireguard-go-rs` trying to build `maybenot.dll`, which won't work due to a bunch of M$ reasons. So I added a check when compiling `wireguard-go-rs` for Windows: If the host is not Windows, it's a no-op.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9186)
<!-- Reviewable:end -->
