### PR TITLE
Remove unused import

### DIFF
--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::undocumented_unsafe_blocks)] // Remove me if you dare.
 
-use crate::TunnelError;
-
 use super::{
     Tunnel,
     config::Config,


### PR DESCRIPTION
This PR fixes a clippy lint warning for an unused import.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9194)
<!-- Reviewable:end -->
