### PR TITLE
Edit GitHub release as part of release script

### DIFF
--- a/desktop/scripts/release/4-make-release
+++ b/desktop/scripts/release/4-make-release
@@ -1,17 +1,25 @@
 #!/usr/bin/env bash
 
 # This script downloads the build artifacts along with the signatures, verifies the signatures and
-# creates a GitHub draft release. This should be run after `3-verify-build`.
+# creates a GitHub release. This should be run after `3-verify-build`. To create a draft release,
+# add the --draft flag.
 
 set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
+function usage {
+    echo "Usage: $0 [--draft] [-h|--help]"
+    echo "  --draft Creates the GitHub release as a draft"
+    exit 0
+}
+
 DRAFT="false"
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --draft) DRAFT="true";;
+        -h|--help) usage ;;
     esac
     shift
 done


### PR DESCRIPTION
This PR:
* Opens the GitHub release body in an editor to be finalized before publishing
* Makes publishing non-draft releases the default
* Makes it possible to publish draft releases by supplying `--draft` to `4-make-release`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9201)
<!-- Reviewable:end -->
