### PR TITLE
Fix post quantum settings not being migrated

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -71,6 +71,9 @@ pub enum Error {
     #[error("Unexpected settings format")]
     InvalidSettingsContent,
 
+    #[error("Missing setting {0}")]
+    MissingKey(&'static str),
+
     #[error("Unable to serialize settings to JSON")]
     Serialize(#[source] serde_json::Error),
 

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_auto_to_on-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_auto_to_on-2.snap
@@ -1,11 +1,11 @@
 ---
-source: mullvad-daemon/src/migrations/v11.rs
+source: mullvad-daemon/src/migrations/v12.rs
 expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
 ---
 {
   "tunnel_options": {
     "wireguard": {
-      "quantum_resistant": "auto"
+      "quantum_resistant": "on"
     }
   }
 }

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_auto_to_on.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_auto_to_on.snap
@@ -1,11 +1,11 @@
 ---
-source: mullvad-daemon/src/migrations/v11.rs
+source: mullvad-daemon/src/migrations/v12.rs
 expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
 ---
 {
   "tunnel_options": {
     "wireguard": {
-      "quantum_resistant": "on"
+      "quantum_resistant": "auto"
     }
   }
 }

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_default_to_on-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_default_to_on-2.snap
@@ -1,5 +1,5 @@
 ---
-source: mullvad-daemon/src/migrations/v11.rs
+source: mullvad-daemon/src/migrations/v12.rs
 expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
 ---
 {

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_default_to_on.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v11_to_v12_migration_pq_default_to_on.snap
@@ -1,0 +1,9 @@
+---
+source: mullvad-daemon/src/migrations/v12.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "tunnel_options": {
+    "wireguard": {}
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v12_to_v13_migration.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v12_to_v13_migration.snap
@@ -53,5 +53,10 @@ expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
       }
     }
   },
-  "settings_version": 13
+  "settings_version": 13,
+  "tunnel_options": {
+    "wireguard": {
+      "quantum_resistant": "on"
+    }
+  }
 }

--- a/mullvad-daemon/src/migrations/v11.rs
+++ b/mullvad-daemon/src/migrations/v11.rs
@@ -14,7 +14,6 @@ pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
 
     migrate_block_when_disconnected(settings)?;
     migrate_duplicated_api_access_method_names(settings)?;
-    migrate_quantum_resistance(settings)?;
 
     settings["settings_version"] = serde_json::json!(SettingsVersion::V12);
 
@@ -152,35 +151,6 @@ fn migrate_duplicated_api_access_method_names(settings: &mut serde_json::Value) 
         }
     }
 
-    Ok(())
-}
-/// Map "quantum_resistant": "auto" -> "quantum_resistant": "on".
-fn migrate_quantum_resistance(settings: &mut serde_json::Value) -> Result<()> {
-    use serde_json::Value;
-    // settings.tunnel_options.wireguard
-    fn wg(settings: &mut Value) -> Option<&mut Value> {
-        settings
-            .as_object_mut()?
-            .get_mut("tunnel_options")?
-            .get_mut("wireguard")
-    }
-    let wg = wg(settings).ok_or(Error::InvalidSettingsContent)?;
-    match wg.get_mut("quantum_resistant") {
-        Some(quantum_resistance) => {
-            if quantum_resistance == "auto" {
-                *quantum_resistance = "on".into();
-            }
-        }
-        None => {
-            // Believe it or not, the PQ setting is not guaranteed to exist coming from an earlier
-            // settings version, because it was never added through a settings migration!
-            // I'll go ahead and fix that right here, but going forward we should be more cautious
-            // about *not* adding certain settings via migrations. Not doing so means that we rely on
-            // the implemenation of Settings::default to fill in all the missing details, which might
-            // be ok..
-            wg["quantum_resistant"] = "on".into();
-        }
-    }
     Ok(())
 }
 
@@ -350,34 +320,6 @@ mod test {
             }
         });
         migrate_duplicated_api_access_method_names(&mut old_settings).unwrap();
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
-    }
-
-    /// quantum resistant setting is migrated from auto to on.
-    #[test]
-    fn test_v11_to_v12_migration_pq_auto_to_on() {
-        let mut old_settings = json!({
-            "tunnel_options": {
-              "wireguard": {
-                "quantum_resistant": "auto"
-              }
-            }
-        });
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
-        migrate_quantum_resistance(&mut old_settings).unwrap();
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
-    }
-
-    /// quantum resistant setting is set to on if it does not exist.
-    #[test]
-    fn test_v11_to_v12_migration_pq_default_to_on() {
-        let mut old_settings = json!({
-            "tunnel_options": {
-              "wireguard": { }
-            }
-        });
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
-        migrate_quantum_resistance(&mut old_settings).unwrap();
         insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
     }
 }

--- a/mullvad-daemon/src/migrations/v12.rs
+++ b/mullvad-daemon/src/migrations/v12.rs
@@ -1,12 +1,14 @@
-use super::Result;
+use super::{Error, Result};
 use mullvad_types::settings::SettingsVersion;
 
-/// This version introduces 2 new fields to the [mullvad_constraints::WireguardConstraints] struct:
-/// pub entry_providers: Constraint<Providers>,
-/// pub entry_ownership: Constraint<Ownership>,
-/// When set, these filters apply to the entry relay when multihop is used.
-/// A migration is needed to transfer the current providers and ownership to these new fields
-/// so that the user's current filters don't change.
+/// This migration handles:
+/// - Removing the Automatic option from the quantum resistance setting. The default is now "On".
+/// - Introduces 2 new fields to the [mullvad_constraints::WireguardConstraints] struct:
+///   pub entry_providers: Constraint<Providers>,
+///   pub entry_ownership: Constraint<Ownership>,
+///   When set, these filters apply to the entry relay when multihop is used.
+///   A migration is needed to transfer the current providers and ownership to these new fields
+///   so that the user's current filters don't change.
 pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
     if !version_matches(settings) {
         return Ok(());
@@ -14,6 +16,7 @@ pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
 
     log::info!("Migrating settings format to V13");
 
+    migrate_quantum_resistance(settings)?;
     migrate_filters_to_new_entry_only_filters(settings);
 
     settings["settings_version"] = serde_json::json!(SettingsVersion::V13);
@@ -41,9 +44,43 @@ fn migrate_filters_to_new_entry_only_filters(settings: &mut serde_json::Value) -
     Some(())
 }
 
+/// Map "quantum_resistant": "auto" -> "quantum_resistant": "on".
+fn migrate_quantum_resistance(settings: &mut serde_json::Value) -> Result<()> {
+    use serde_json::Value;
+    // settings.tunnel_options.wireguard
+    fn wg(settings: &mut Value) -> Result<&mut Value> {
+        settings
+            .as_object_mut()
+            .ok_or(Error::InvalidSettingsContent)?
+            .get_mut("tunnel_options")
+            .ok_or(Error::MissingKey("'tunnel_options' missing"))?
+            .get_mut("wireguard")
+            .ok_or(Error::MissingKey("'wireguard' missing"))
+    }
+    let wg = wg(settings)?;
+    match wg.get_mut("quantum_resistant") {
+        Some(quantum_resistance) => {
+            if quantum_resistance == "auto" {
+                *quantum_resistance = "on".into();
+            }
+        }
+        None => {
+            // Believe it or not, the PQ setting is not guaranteed to exist coming from an earlier
+            // settings version, because it was never added through a settings migration!
+            // I'll go ahead and fix that right here, but going forward we should be more cautious
+            // about *not* adding certain settings via migrations. Not doing so means that we rely on
+            // the implemenation of Settings::default to fill in all the missing details, which might
+            // be ok..
+            wg["quantum_resistant"] = "on".into();
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
-    use super::{migrate, version_matches};
+    use super::*;
+    use serde_json::json;
 
     const V12_SETTINGS: &str = r#"
 {
@@ -86,17 +123,51 @@ mod test {
       }
     }
   },
+  "tunnel_options": {
+    "wireguard": {
+      "quantum_resistant": "auto"
+    }
+  },
   "settings_version": 12
 }
 "#;
 
     #[test]
-    fn test_v12_to_v13_migration() {
+    fn test_v12_to_v13_migration() -> Result<()> {
         let mut old_settings = serde_json::from_str(V12_SETTINGS).unwrap();
 
         assert!(version_matches(&old_settings));
 
-        migrate(&mut old_settings).unwrap();
+        migrate(&mut old_settings)?;
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        Ok(())
+    }
+
+    /// quantum resistant setting is migrated from auto to on.
+    #[test]
+    fn test_v11_to_v12_migration_pq_auto_to_on() {
+        let mut old_settings = json!({
+            "tunnel_options": {
+              "wireguard": {
+                "quantum_resistant": "auto"
+              }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_quantum_resistance(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    /// quantum resistant setting is set to on if it does not exist.
+    #[test]
+    fn test_v11_to_v12_migration_pq_default_to_on() {
+        let mut old_settings = json!({
+            "tunnel_options": {
+              "wireguard": { }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_quantum_resistance(&mut old_settings).unwrap();
         insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
     }
 }


### PR DESCRIPTION
The migration ended up in a closed migration after `remove-openvpn` was rebased on `main`:(

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9205)
<!-- Reviewable:end -->
