### PR TITLE
Fix ios e2e tests

### DIFF
--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -675,6 +675,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
         allowAddVPNConfigurationsIfAsked()
 
         TunnelControlPage(app)
+            .waitForConnectedLabel()
             .verifyConnectingUsingQuantumResistance()
 
         HeaderBar(app)


### PR DESCRIPTION
Fixes `testQuantumResistanceSettings` and `testWireGuardOverTCPAutomatically`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9211)
<!-- Reviewable:end -->
