### PR TITLE
Remove duplicate iOS e2e test run on opened PR

### DIFF
--- a/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
+++ b/.github/workflows/ios-end-to-end-tests-merge-to-main.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     types:
       - closed
-      - opened
     branches:
       - main
     paths:


### PR DESCRIPTION
The e2e currently tests run twice when opening a PR. There is a separate workflow responsible for opened PRs (`ios-end-to-end-tests-pr-opened`)
`ios-end-to-end-tests-merge-to-main` should not run on opened PRs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9212)
<!-- Reviewable:end -->
