### PR TITLE
Move gradle repositories to gradle settings

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -21,11 +21,6 @@ plugins {
 }
 
 buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
     dependencies {
         //noinspection UseTomlInstead
         // Dependency class paths are required for Gradle metadata verification to work properly,
@@ -109,11 +104,6 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
 
 allprojects {
     apply(plugin = rootProject.libs.plugins.ktfmt.get().pluginId)
-
-    repositories {
-        google()
-        mavenCentral()
-    }
 
     // Should be the same as ktfmt config in buildSrc/build.gradle.kts
     configure<com.ncorti.ktfmt.gradle.KtfmtExtension> {

--- a/android/buildSrc/build.gradle.kts
+++ b/android/buildSrc/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     alias(libs.plugins.detekt) apply true
 }
 
-repositories { maven("https://plugins.gradle.org/m2/") }
-
 kotlin { jvmToolchain(17) }
 
 // Should be the same as ktfmt config in project root build.gradle.kts

--- a/android/buildSrc/settings.gradle.kts
+++ b/android/buildSrc/settings.gradle.kts
@@ -2,4 +2,5 @@ rootProject.name = "buildSrc"
 
 dependencyResolutionManagement {
     versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
+    repositories { gradlePluginPortal() }
 }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -2,7 +2,20 @@ pluginManagement {
     repositories {
         google()
         mavenCentral()
-        gradlePluginPortal()
+        gradlePluginPortal() {
+            content {
+                // Exclude gRPC artifacts - they're only available in Maven Central
+                excludeGroup("io.grpc")
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This PR moves the gradle repository configuration to `settings.gradle.kts` which is how modern gradle projects are configured.

Fixes: DROID-1888
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9218)
<!-- Reviewable:end -->
