### PR TITLE
Add `mullvad debug rollout` command

### DIFF
--- a/mullvad-cli/src/cmds/debug.rs
+++ b/mullvad-cli/src/cmds/debug.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use mullvad_management_interface::MullvadProxyClient;
 use mullvad_types::{
     constraints::Constraint,
@@ -12,6 +12,9 @@ pub enum DebugCommands {
     /// Relay
     #[clap(subcommand)]
     Relay(RelayDebugCommands),
+    /// Handy commands for interacting with the app release rollout system.
+    #[clap(subcommand)]
+    Rollout(RolloutDebugCommands),
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -22,6 +25,18 @@ pub enum RelayDebugCommands {
     /// (Re)Activate this _category of relays_ - a category can be one of the following: a relay, a
     /// city, a country or a tunnel protocol (`openvpn` or `wireguard`).
     Enable { relay: String },
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum RolloutDebugCommands {
+    /// Print your rollout threshold.
+    Get,
+    /// Generate a new rollout threshold (overwrites the current threshold value)
+    Reroll,
+    /// Set your rollout threshold seed to a known value.
+    ///
+    /// The seed is used to generate a rollout threshold.
+    Seed { value: u32 },
 }
 
 impl DebugCommands {
@@ -64,6 +79,35 @@ impl DebugCommands {
                 let mut rpc = MullvadProxyClient::new().await?;
                 rpc.enable_relay(relay.clone()).await?;
                 println!("{relay} is now marked as active");
+                Ok(())
+            }
+            DebugCommands::Rollout(rollout_cmd) => rollout_cmd.handle().await,
+        }
+    }
+}
+
+impl RolloutDebugCommands {
+    pub async fn handle(self) -> Result<()> {
+        let mut rpc = MullvadProxyClient::new().await?;
+        match self {
+            RolloutDebugCommands::Get => {
+                let Ok(threshold) = rpc.get_rollout_threshold().await else {
+                    bail!("Failed to get rollout");
+                };
+                println!("{threshold}");
+                Ok(())
+            }
+            RolloutDebugCommands::Reroll => {
+                let Ok(threshold) = rpc.generate_new_rollout_threshold().await else {
+                    bail!("Failed to get rollout");
+                };
+                println!("{threshold}");
+                Ok(())
+            }
+            RolloutDebugCommands::Seed { value: seed } => {
+                if rpc.set_new_rollout_threshold_seed(seed).await.is_err() {
+                    bail!("Failed to update rollout seed");
+                }
                 Ok(())
             }
         }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -430,6 +430,20 @@ pub enum DaemonCommand {
         relay: String,
         tx: oneshot::Sender<()>,
     },
+    /// Calculate and return the rollout threshold for this client.
+    #[cfg(not(target_os = "android"))]
+    GetRolloutThreshold(oneshot::Sender<f32>),
+    /// Generate a new rollout threshold seed and update settings. Returns the new rollout
+    /// threshold.
+    #[cfg(not(target_os = "android"))]
+    GenerateNewRolloutSeed(oneshot::Sender<f32>),
+    /// Set the rollout threshold seed to the provided value and update settings.
+    #[cfg(not(target_os = "android"))]
+    SetRolloutThresholdSeed {
+        seed: u32,
+        tx: oneshot::Sender<()>,
+    },
+
     // App upgrade
     /// Prompt the daemon to start an app version upgrade.
     ///
@@ -1558,6 +1572,19 @@ impl Daemon {
             GetFeatureIndicators(tx) => self.on_get_feature_indicators(tx),
             DisableRelay { relay, tx } => self.on_toggle_relay(relay, false, tx),
             EnableRelay { relay, tx } => self.on_toggle_relay(relay, true, tx),
+            #[cfg(not(target_os = "android"))]
+            GetRolloutThreshold(tx) => self.on_get_rollout_threshold(tx).await,
+            #[cfg(not(target_os = "android"))]
+            GenerateNewRolloutSeed(tx) => {
+                let seed = self.generate_and_set().await;
+                let threshold = Self::calculate_rollout_threshold(seed);
+                let _ = tx.send(threshold);
+            }
+            #[cfg(not(target_os = "android"))]
+            SetRolloutThresholdSeed { seed, tx } => {
+                self.set_rollout_threshold_seed(seed).await;
+                let _ = tx.send(());
+            }
             AppUpgrade(tx) => self.on_app_upgrade(tx).await,
             AppUpgradeAbort(tx) => self.on_app_upgrade_abort(tx).await,
             GetAppUpgradeCacheDir(tx) => self.on_get_app_upgrade_cache_dir(tx).await,
@@ -3260,6 +3287,48 @@ impl Daemon {
         });
 
         self.reconnect_tunnel();
+    }
+
+    #[cfg(not(target_os = "android"))]
+    async fn on_get_rollout_threshold(&mut self, reply: oneshot::Sender<f32>) {
+        let seed = match self.settings.rollout_threshold_seed {
+            Some(seed) => seed,
+            None => self.generate_and_set().await,
+        };
+        let _ = reply.send(Self::calculate_rollout_threshold(seed));
+    }
+
+    #[cfg(not(target_os = "android"))]
+    fn calculate_rollout_threshold(seed: u32) -> f32 {
+        let version = mullvad_version::VERSION
+            .parse::<mullvad_version::Version>()
+            .expect("Failed to parse version");
+        let threshold = mullvad_update::version::Rollout::threshold(seed, version);
+        // a tiny bit hacky way to map Rollout -> f32, but it works.
+        threshold
+            .to_string()
+            .parse()
+            .expect("threshold is a valid Rollout is a valid f32")
+    }
+
+    // Regenrate a new seed and store it to settings.
+    #[cfg(not(target_os = "android"))]
+    async fn generate_and_set(&mut self) -> u32 {
+        let seed = generate_rollout_seed();
+        self.set_rollout_threshold_seed(seed).await;
+        seed
+    }
+
+    // Store the given seed to settings.
+    #[cfg(not(target_os = "android"))]
+    async fn set_rollout_threshold_seed(&mut self, seed: u32) {
+        if let Err(err) = self
+            .settings
+            .update(|settings| settings.rollout_threshold_seed = Some(seed))
+            .await
+        {
+            log::warn!("Failed to save settings when updating rollout seed: {err}");
+        }
     }
 
     fn oneshot_send<T>(tx: oneshot::Sender<T>, t: T, msg: &'static str) {

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -136,6 +136,10 @@ service ManagementService {
   rpc DisableRelay(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
   rpc EnableRelay(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
 
+  rpc GetRolloutThreshold(google.protobuf.Empty) returns (Rollout) {}
+  rpc RegenerateRolloutThreshold(google.protobuf.Empty) returns (Rollout) {}
+  rpc SetRolloutThresholdSeed(Seed) returns (google.protobuf.Empty) {}
+
   // App upgrade
   rpc AppUpgrade(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc AppUpgradeAbort(google.protobuf.Empty) returns (google.protobuf.Empty) {}
@@ -171,6 +175,9 @@ message AppUpgradeError {
   }
   Error error = 1;
 }
+
+message Seed { uint32 seed = 1; }
+message Rollout { float threshold = 1; }
 
 message UUID { string value = 1; }
 

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -635,6 +635,25 @@ impl MullvadProxyClient {
         Ok(())
     }
 
+    pub async fn get_rollout_threshold(&mut self) -> Result<f32> {
+        let rollout = self.0.get_rollout_threshold(()).await?;
+        let threshold = rollout.into_inner().threshold;
+        Ok(threshold)
+    }
+
+    pub async fn generate_new_rollout_threshold(&mut self) -> Result<f32> {
+        let rollout = self.0.regenerate_rollout_threshold(()).await?;
+        let threshold = rollout.into_inner().threshold;
+        Ok(threshold)
+    }
+
+    pub async fn set_new_rollout_threshold_seed(&mut self, seed: u32) -> Result<()> {
+        self.0
+            .set_rollout_threshold_seed(types::Seed { seed })
+            .await?;
+        Ok(())
+    }
+
     pub async fn set_wireguard_allowed_ips(&mut self, allowed_ips: AllowedIps) -> Result<()> {
         self.0
             .set_wireguard_allowed_ips(types::AllowedIpsList {


### PR DESCRIPTION
This PR adds a new debug command for interacting with the desktop app rollout machinery :robot: 
It defines the `get`, `reroll` and `seed` subcommands for quickly inspecting & modifying the rollout threshold. This is pretty handy when debugging new app releases ( :rocket: )

```bash
$ mullvad debug rollout
Handy commands for interacting with the app release rollout system

Usage: mullvad debug rollout <COMMAND>

Commands:
  get     Print your rollout threshold
  reroll  Generate a new rollout threshold (this change is permanent)
  seed    Set your rollout threshold seed to a known value
  help    Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

# Example output
$ mullvad debug rollout get && \
  mullvad debug rollout seed 1337 && mullvad debug rollout get && \
  mullvad debug rollout reroll
0.24747834
0.66151506
0.4807337
```

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9219)
<!-- Reviewable:end -->
