### PR TITLE
Adress new GO-2025-40xx cves (`libwg`/`wireguard-go`)

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -156,3 +156,9 @@ reason = "'This affects programs which validate arbitrary certificate chains.' w
 id = "CVE-2025-58183" # GO-2025-4014
 ignoreUntil = 2026-10-30
 reason = "wireguard-go does not use archive/tar"
+
+# Excessive CPU consumption in Reader.ReadResponse (net/textproto)
+[[IgnoredVulns]]
+id = "CVE-2025-61724" # GO-2025-4015
+ignoreUntil = 2026-10-30
+reason = "wireguard-go does not use net/textproto"


### PR DESCRIPTION
A bunch of new CVEs against the Go stdlib just dropped :fire:

https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI?pli=1

I iterated them, and it turns out that neither `libwg` nor `wireguard-go` are affected by any of these CVEs. As such, I added them to the `osv-scanner` ignore list for **1 year**.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9220)
<!-- Reviewable:end -->
 