### PR TITLE
Fix E2E tests always running with GotaTun on manual trigger

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -34,6 +34,7 @@ on:
         type: string
       gotatun:
         type: boolean
+        default: false
         description: "Run tests with GotaTun 🦀"
 
 permissions: {}
@@ -146,12 +147,12 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build app
-        if: ${{ !github.event.inputs.gotatun }}
+        if: ${{ github.event.inputs.gotatun == 'false' }}
         run: |
           export CARGO_TARGET_DIR=target/
           ./build.sh --optimize
       - name: Build app (with GotaTun 🦀)
-        if: ${{ github.event.inputs.gotatun }}
+        if: ${{ github.event.inputs.gotatun == 'true' }}
         run: |
           export CARGO_TARGET_DIR=target/
           ./build.sh --optimize --boringtun
@@ -336,7 +337,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/mullvad-build-env
       - name: Build app
-        if: ${{ !github.event.inputs.gotatun }}
+        if: ${{ github.event.inputs.gotatun == 'false' }}
         shell: bash
         run: |
           ./build.sh
@@ -349,7 +350,7 @@ jobs:
           mv "$original_file" "$new_file"
           popd
       - name: Build app (with GotaTun 🦀)
-        if: ${{ github.event.inputs.gotatun }}
+        if: ${{ github.event.inputs.gotatun == 'true' }}
         shell: bash
         run: |
           ./build.sh --optimize --boringtun
@@ -443,10 +444,10 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/mullvad-build-env
       - name: Build app
-        if: ${{ !github.event.inputs.gotatun }}
+        if: ${{ github.event.inputs.gotatun == 'false' }}
         run: ./build.sh
       - name: Build app (with GotaTun 🦀)
-        if: ${{ github.event.inputs.gotatun }}
+        if: ${{ github.event.inputs.gotatun == 'true' }}
         run: ./build.sh --optimize --boringtun
       - name: Build test executable
         run: ./desktop/packages/mullvad-vpn/scripts/build-test-executable.sh


### PR DESCRIPTION
This PR fixes a regression to the E2E desktop test workflow introduced in https://github.com/mullvad/mullvadvpn-app/pull/8982 where a manual workflow dispatch would cause the app to always be built with GotaTun enabled because GHA is bad: https://github.com/actions/runner/issues/1483.

Test run with this fix and `GotaTun` option left unchecked: https://github.com/mullvad/mullvadvpn-app/actions/runs/19028680988/job/54337464895

Unblocks https://github.com/mullvad/mullvadvpn-app/pull/9227.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9235)
<!-- Reviewable:end -->
