### PR TITLE
Add `#[track_caller]` to `Constraint::unwrap` for better panic messages

### DIFF
--- a/mullvad-types/src/constraints/constraint.rs
+++ b/mullvad-types/src/constraints/constraint.rs
@@ -51,6 +51,7 @@ impl<T: Default> Constraint<T> {
 }
 
 impl<T> Constraint<T> {
+    #[track_caller]
     pub fn unwrap(self) -> T {
         match self {
             Constraint::Any => panic!("called `Constraint::unwrap()` on an `Any` value"),


### PR DESCRIPTION
Title. Thanks @tobias-jarvelov for unwapping an `Any` value and uncovering that the current message is useless for debugging purposes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9236)
<!-- Reviewable:end -->
