### PR TITLE
Fix panic in relay selector due to unresolvable PQ constraint

### DIFF
--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -300,7 +300,7 @@ impl<'a> TryFrom<NormalSelectorConfig<'a>> for RelayQuery {
                 obfuscation: ObfuscationQuery::from(obfuscation_settings),
                 daita: Constraint::Only(daita),
                 daita_use_multihop_if_necessary: Constraint::Only(daita_use_multihop_if_necessary),
-                quantum_resistant,
+                quantum_resistant: Constraint::Only(quantum_resistant),
             }
         }
 

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -206,7 +206,7 @@ pub struct WireguardRelayQuery {
     pub obfuscation: ObfuscationQuery,
     pub daita: Constraint<bool>,
     pub daita_use_multihop_if_necessary: Constraint<bool>,
-    pub quantum_resistant: QuantumResistantState,
+    pub quantum_resistant: Constraint<QuantumResistantState>,
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -305,7 +305,7 @@ impl WireguardRelayQuery {
             obfuscation: ObfuscationQuery::Auto,
             daita: Constraint::Any,
             daita_use_multihop_if_necessary: Constraint::Any,
-            quantum_resistant: QuantumResistantState::default(),
+            quantum_resistant: Constraint::Any,
         }
     }
 
@@ -573,7 +573,7 @@ pub mod builder {
         pub fn quantum_resistant(
             mut self,
         ) -> RelayQueryBuilder<Wireguard<Multihop, Obfuscation, Daita, bool>> {
-            self.query.wireguard_constraints.quantum_resistant = QuantumResistantState::On;
+            self.query.wireguard_constraints.quantum_resistant = QuantumResistantState::On.into();
             // Update the type state
             RelayQueryBuilder {
                 query: self.query,


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/mullvad/mullvadvpn-app/pull/9160 preventing the relay selector from resolving relay constraints if the user's PQ setting was incompatible with the default value (`On`). This PR separates the app default (`On`) from the assumed default in the "relay selector query language" (Which should be `Any`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9243)
<!-- Reviewable:end -->
