### PR TITLE
Fix parsing of last handshake timestamp from Netlink messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5795,6 +5795,7 @@ dependencies = [
  "widestring",
  "windows-sys 0.61.1",
  "wireguard-go-rs",
+ "zerocopy",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,8 @@ netlink-packet-route = "0.25"
 netlink-proto = "0.12"
 netlink-sys = "0.8.3"
 
+zerocopy = "0.8.27"
+
 # Hickory & DNS
 hickory-proto = "0.24.3"
 hickory-resolver = "0.24.3"

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -60,6 +60,7 @@ rtnetlink = { workspace = true }
 netlink-packet-core = { workspace = true }
 netlink-packet-route = { workspace = true }
 netlink-proto = { workspace = true }
+zerocopy = { workspace = true, features = ["derive"] }
 talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(windows)'.dependencies]

--- a/talpid-wireguard/src/wireguard_kernel/mod.rs
+++ b/talpid-wireguard/src/wireguard_kernel/mod.rs
@@ -25,6 +25,7 @@ use tokio_stream::StreamExt;
 
 mod parsers;
 mod stats;
+mod timespec;
 
 pub mod wg_message;
 use wg_message::{DeviceMessage, DeviceNla};

--- a/talpid-wireguard/src/wireguard_kernel/stats.rs
+++ b/talpid-wireguard/src/wireguard_kernel/stats.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
 use super::wg_message::{DeviceMessage, DeviceNla, PeerNla};
 use crate::stats::{Stats, StatsMap};
 
@@ -19,18 +17,10 @@ impl Stats {
                         match nla {
                             PeerNla::TxBytes(bytes) => tx_bytes = *bytes,
                             PeerNla::RxBytes(bytes) => rx_bytes = *bytes,
-                            PeerNla::LastHandshakeTime(time) => {
-                                last_handshake_time = || -> Option<SystemTime> {
-                                    // handshake_{sec,nsec} are relative to UNIX_EPOCH
-                                    // https://www.wireguard.com/xplatform/
-                                    Some(
-                                        UNIX_EPOCH
-                                            + Duration::new(
-                                                time.tv_sec().try_into().ok()?,
-                                                time.tv_nsec().try_into().ok()?,
-                                            ),
-                                    )
-                                }();
+                            PeerNla::LastHandshakeTime(timestamp) => {
+                                if let Some(timestamp) = timestamp.as_systemtime() {
+                                    last_handshake_time = Some(timestamp)
+                                }
                             }
                             PeerNla::PublicKey(key) => pub_key = Some(*key),
                             _ => continue,

--- a/talpid-wireguard/src/wireguard_kernel/timespec.rs
+++ b/talpid-wireguard/src/wireguard_kernel/timespec.rs
@@ -1,0 +1,36 @@
+use std::time::{Duration, SystemTime};
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+/// `__kernel_timespec` from uapi/linux/time_types.h.
+///
+/// This time type is used for the WireGuard last handshake timestamp.
+/// Source: Linux kernel source code
+/// - drivers/net/wireguard/netlink.c
+/// - include/uapi/linux/time_types.h
+#[derive(Debug, Copy, Clone, PartialEq, Eq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+#[repr(C, packed)]
+pub struct KernelTimespec {
+    /// seconds
+    pub(crate) tv_sec: libc::c_longlong,
+    /// nanoseconds
+    pub(crate) tv_nsec: libc::c_longlong,
+}
+
+impl KernelTimespec {
+    pub fn as_systemtime(&self) -> Option<SystemTime> {
+        let (tv_sec, tv_nsec) = (
+            Duration::from_secs(self.tv_sec.try_into().ok()?),
+            Duration::from_nanos(
+                self
+                .tv_nsec
+                .try_into()
+                // Source: man timespec
+                .expect("tv_nsec is at most 999_999_999"),
+            ),
+        );
+        // handshake_{sec,nsec} are relative to UNIX_EPOCH
+        // https://www.wireguard.com/xplatform/
+        Some(SystemTime::UNIX_EPOCH + tv_sec + tv_nsec)
+    }
+}


### PR DESCRIPTION
This PR tackles the last remaining code that would not compile for a 32 bit target: parsing the last handshake timestamp from kernel WireGuard on Linux. Our parsing of the timestamp was not portable because it assumed non-portable sizes of [`timespec`](https://man7.org/linux/man-pages/man3/timespec.3type.html) fields, and I think that it was incorrect in the first place for multiple reasons:
- the buffer size check was incorrect, since it used the size of `timespec` and not the equivalent of `timespec64` (which is not exposed through libc, but still. [rustix](https://github.com/bytecodealliance/rustix) exposes a more appropriate `timespec` for this case)
- the seconds field was parsed twice, leaving out the nanos part of the timestamp

Parsing the last handshake timestamp is in done in a portable way using [std::time::SystemTime](https://doc.rust-lang.org/std/time/struct.SystemTime.html) as target struct instead of [libc::timespec](https://docs.rs/libc/latest/libc/struct.timespec.html).

I also triggered a test run to make sure I didn't break anything: https://github.com/mullvad/mullvadvpn-app/actions/runs/19082975291

This is me trying to upstream part of my last hackday results in an attempt to make the app easier to port to alternative platforms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9260)
<!-- Reviewable:end -->
