### PR TITLE
Update name in references to lockdown mode setting in security.md

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -150,7 +150,7 @@ This is the default state that the `mullvad-daemon` starts in when the device bo
 [connecting] state immediately.
 
 The disconnected state behaves very differently depending on the value of the
-"always require VPN" setting. If this setting is enabled, the disconnected state behaves
+"Lockdown mode" setting. If this setting is enabled, the disconnected state behaves
 like and has the same security properties as, the [error] state. If the setting is
 disabled (the default), then it is the only state where the app does not enforce any firewall
 rules. It then behaves the same as if the `mullvad-daemon` was not even running. It lets
@@ -264,10 +264,10 @@ then they can't leave at all.
 Essentially, one can say that the app's "kill switch" is the fact that the [connecting],
 [disconnecting] and [error] states prevent leaks via firewall rules.
 
-### Always require VPN
+### Lockdown mode
 
-The "always require VPN" setting in the app is regularly misunderstood as the kill switch.
-This is not the case. The "always require VPN" setting only changes whether or not the
+The "Lockdown mode" setting in the app is regularly misunderstood as the kill switch.
+This is not the case. The "Lockdown mode" setting only changes whether or not the
 [disconnected] state should allow traffic to flow freely or to block it. The
 disconnected state is not active during intermittent network issues or server changes, when
 a kill switch would normally be operating.
@@ -309,7 +309,7 @@ Locally running malicious programs are outside of the app's threat model.
 The `mullvad-daemon` transition to the [disconnected] state before exiting. To
 limit leaks during computer shutdown, it will maintain the blocking firewall
 rules upon exit in the following scenarios:
-- _Always require VPN_ is enabled
+- _Lockdown mode_ is enabled
 - A user didn't explicitly request for the `mullvad-daemon` to be shut down and
   either or both of the following are true
     - The daemon is currently in one of the blocking states ([connected],
@@ -325,7 +325,7 @@ On Windows, persistent firewall filters may be added when the service exits, in 
 decides to continue to enforce a blocking policy. These filters block any traffic occurring before
 the service has started back up again during boot, including before the BFE service has started.
 
-As with "Always require VPN", enabling "Auto-connect" in the service will cause it to
+As with "Lockdown mode", enabling "Auto-connect" in the service will cause it to
 enforce the blocking policy before being stopped.
 
 ### Linux


### PR DESCRIPTION
The Lockdown mode settings was previously called "Always require VPN". The name was changed in 2022 in https://github.com/mullvad/mullvadvpn-app/pull/3759, but `security.md` was not updated. This PR updates `security.md` with the correct name.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9264)
<!-- Reviewable:end -->
