### PR TITLE
Log Kermit logs to disk and attach to problem report

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -190,6 +190,7 @@ android {
                 events("passed", "skipped", "failed", "standardOut", "standardError")
                 showCauses = true
                 showExceptions = true
+                showStandardStreams = true
             }
         }
     }

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -138,6 +138,7 @@ val uiModule = module {
             context = androidContext(),
             apiEndpointOverride = getOrNull(),
             apiEndpointFromIntentHolder = get(),
+            kermitFileLogDirName = KERMIT_FILE_LOG_DIR_NAME,
             accountRepository = get(),
         )
     }
@@ -353,3 +354,4 @@ val uiModule = module {
 const val SELF_PACKAGE_NAME = "SELF_PACKAGE_NAME"
 const val APP_PREFERENCES_NAME = "${BuildConfig.APPLICATION_ID}.app_preferences"
 const val BOOT_COMPLETED_RECEIVER_COMPONENT_NAME = "BOOT_COMPLETED_RECEIVER_COMPONENT_NAME"
+const val KERMIT_FILE_LOG_DIR_NAME = "android_app_logs"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/FileLogWriter.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/util/FileLogWriter.kt
@@ -1,0 +1,203 @@
+package net.mullvad.mullvadvpn.util
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import java.io.BufferedWriter
+import java.io.IOException
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.io.path.createFile
+import kotlin.io.path.deleteExisting
+import kotlin.io.path.exists
+import kotlin.io.path.fileSize
+import kotlin.io.path.getLastModifiedTime
+import kotlin.io.path.listDirectoryEntries
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * THREAD SAFETY: This class must be thread-safe because any thread can call the Kermit logger
+ * (which is itself thread-safe). This is done by only accessing mutable state via a Mutex.
+ */
+class FileLogWriter(
+    private val logDir: Path,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val maxFileCount: Int = MAX_FILE_COUNT,
+    private val maxTotalSizeBytes: Long = MAX_TOTAL_SIZE_BYTES,
+    private val truncateKeepPercentage: Double = TRUNCATE_KEEP_PERCENTAGE,
+    private val checkSizeLimitAfter: Int = SIZE_CHECK_AFTER,
+) : LogWriter() {
+
+    private var log: FileAndWriter
+
+    private var currentDateComponents: DateComponents
+
+    private var sizeCheckCounter: Int
+
+    private val mutex = Mutex()
+
+    init {
+        // The synchronized here is to guarantee field visibility for all threads.
+        synchronized(this) {
+            Files.createDirectories(logDir)
+            currentDateComponents = DateComponents.utcNow()
+            log = FileAndWriter.create(logDir.logFile(currentDateComponents))
+            sizeCheckCounter = 0
+            checkRemoveOldLog()
+            // If the app exited while truncating we may have temporary files we should delete
+            logDir.listDirectoryEntries("*.tmp").forEach { it.deleteExisting() }
+        }
+    }
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+
+        scope.launch(dispatcher) {
+            val logTimeStamp = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(ZonedDateTime.now())
+
+            mutex.withLock {
+                try {
+                    checkLogRotation()
+                    log.writer.appendLine("$logTimeStamp ${severity.name.first()}: $message")
+                    throwable?.let { log.writer.appendLine(it.stackTraceToString()) }
+                    log.writer.flush()
+                } catch (e: IOException) {
+                    android.util.Log.e("mullvad", "Error writing to log file", e)
+                }
+            }
+        }
+    }
+
+    private fun checkLogRotation() {
+
+        fun rotateLog(now: DateComponents) {
+            log.writer.close()
+            log = FileAndWriter.create(logDir.logFile(now))
+            currentDateComponents = now
+            checkRemoveOldLog()
+        }
+
+        fun rotateLogSizeLimitIfNeeded() {
+            val allLogs = logDir.listDirectoryEntries()
+            val totalSizeBytes = allLogs.sumOf { path -> path.fileSize() }
+            if (totalSizeBytes <= maxTotalSizeBytes) return
+
+            // The number of bytes we should truncate.
+            var needToTruncate =
+                totalSizeBytes - (maxTotalSizeBytes * truncateKeepPercentage).toLong()
+
+            val oldestFirst = allLogs.sortedBy { it.getLastModifiedTime() }
+
+            for (oldest in oldestFirst) {
+                if (needToTruncate <= 0) break
+
+                val size = oldest.fileSize()
+                if (size <= needToTruncate) {
+                    // Size of the the oldest log is less than what we need to truncate so
+                    // we can just delete the file. Note that this can never be the current log.
+                    oldest.deleteExisting()
+                    needToTruncate -= size
+                } else {
+                    // Size of the oldest log is greater than what we need to truncate so we
+                    // have to truncate the file.
+                    val tmpFile = logDir.resolve("${oldest.fileName}.tmp")
+                    if (!tmpFile.exists()) tmpFile.createFile()
+
+                    val isCurrentLog = oldest == log.logFilePath
+                    if (isCurrentLog) log.writer.close()
+
+                    copyNBytesFromEnd(oldest, tmpFile, needToTruncate)
+                    Files.move(tmpFile, oldest, StandardCopyOption.REPLACE_EXISTING)
+
+                    if (isCurrentLog) log = FileAndWriter.create(log.logFilePath)
+                    needToTruncate = 0
+                }
+            }
+        }
+
+        val now = DateComponents.utcNow()
+        if (now != currentDateComponents) {
+            // The day has changed, so we need to rotate the log file
+            rotateLog(now)
+        }
+
+        sizeCheckCounter += 1
+        if (sizeCheckCounter >= checkSizeLimitAfter) {
+            sizeCheckCounter = 0
+            rotateLogSizeLimitIfNeeded()
+        }
+    }
+
+    private fun checkRemoveOldLog() {
+        val allLogs = logDir.listDirectoryEntries()
+        if (allLogs.size > maxFileCount) {
+            val oldest = allLogs.minBy { it.getLastModifiedTime() }
+            oldest.deleteExisting()
+        }
+    }
+
+    private fun Path.logFile(components: DateComponents): Path {
+        val year = components.year
+        val month = components.month.toString().padStart(2, '0')
+        val day = components.day.toString().padStart(2, '0')
+        return resolve("app_log_$year-$month-$day.log")
+    }
+
+    private fun copyNBytesFromEnd(source: Path, dest: Path, n: Long) {
+        FileChannel.open(source, StandardOpenOption.READ).use { inChannel ->
+            FileChannel.open(
+                    dest,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                )
+                .use { outChannel ->
+                    val start = inChannel.size() - n
+                    inChannel.transferTo(start, n, outChannel)
+                }
+        }
+    }
+
+    companion object {
+        private const val MAX_FILE_COUNT = 7
+        private const val MAX_TOTAL_SIZE_BYTES = 1024L * 1024L * 2L // 2 MB
+        private const val TRUNCATE_KEEP_PERCENTAGE = 0.8
+
+        // As an optimization only check if the log size exceeds the limit after this many log
+        // writes
+        private const val SIZE_CHECK_AFTER = 100
+    }
+}
+
+private data class FileAndWriter(val logFilePath: Path, val writer: BufferedWriter) {
+    companion object {
+        fun create(logFile: Path): FileAndWriter {
+            if (!logFile.exists()) logFile.createFile()
+
+            return FileAndWriter(
+                logFile,
+                Files.newBufferedWriter(logFile, StandardOpenOption.APPEND),
+            )
+        }
+    }
+}
+
+private data class DateComponents(val year: Int, val month: Int, val day: Int) {
+    companion object {
+        fun utcNow(): DateComponents {
+            val now = OffsetDateTime.now(ZoneOffset.UTC)
+            return DateComponents(now.year, now.monthValue, now.dayOfMonth)
+        }
+    }
+}

--- a/android/app/src/test/kotlin/net/mullvad/mullvadvpn/utils/FileLogWriterTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/mullvadvpn/utils/FileLogWriterTest.kt
@@ -1,0 +1,202 @@
+package net.mullvad.mullvadvpn.utils
+
+import co.touchlab.kermit.Severity
+import java.nio.file.Path
+import kotlin.io.path.createFile
+import kotlin.io.path.fileSize
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readLines
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import net.mullvad.mullvadvpn.lib.common.test.TestCoroutineRule
+import net.mullvad.mullvadvpn.util.FileLogWriter
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+
+@ExtendWith(TestCoroutineRule::class)
+class FileLogWriterTest {
+    @Test
+    fun `the log file should be created with the correct file name format`(@TempDir tempDir: Path) =
+        runTest {
+            FileLogWriter(tempDir, scope = this)
+            val logFile = tempDir.listDirectoryEntries().first()
+            val fileName = logFile.fileName.toString()
+            val nameRegex = Regex("app_log_\\d{4}-\\d{2}-\\d{2}.log")
+            assertTrue(nameRegex.matches(fileName), "file name was: $fileName")
+        }
+
+    @Test
+    fun `a log file with the current date should be written to`(@TempDir tempDir: Path) = runTest {
+        val log1 = tempDir.resolve("app_log_2025-10-26.txt").createFile()
+
+        val writer = FileLogWriter(tempDir, scope = this, dispatcher = Dispatchers.Main)
+
+        writer.log(Severity.Debug, "test", "test")
+
+        val new = tempDir.listDirectoryEntries().toSet() - setOf(log1)
+
+        assertEquals(0, log1.fileSize())
+        assertEquals(1, new.size)
+        assertTrue(new.first().fileSize() > 0)
+    }
+
+    @Test
+    fun `the oldest log should be deleted when the max log file count is reached`(
+        @TempDir tempDir: Path
+    ) = runTest {
+        val log1 = tempDir.resolve("app_log_2025-10-26.txt").createFile()
+        // Sleep is needed to ensure the files have different last modified timestamps
+        Thread.sleep(10)
+        tempDir.resolve("app_log_2025-10-27.txt").createFile()
+        Thread.sleep(10)
+        tempDir.resolve("app_log_2025-10-28.txt").createFile()
+
+        FileLogWriter(tempDir, maxFileCount = 3, scope = this, dispatcher = Dispatchers.Main)
+
+        val logFiles = tempDir.listDirectoryEntries()
+
+        assertEquals(3, logFiles.size)
+        assertFalse(logFiles.contains(log1))
+    }
+
+    @Test
+    fun `temporary files should be deleted when the file writer is created`(
+        @TempDir tempDir: Path
+    ) = runTest {
+        tempDir.resolve("app_log_2025-10-26.txt").createFile()
+        val tmp = tempDir.resolve("app_log_2025-10-26.txt.tmp").createFile()
+
+        FileLogWriter(tempDir, scope = this, dispatcher = Dispatchers.Main)
+
+        val logFiles = tempDir.listDirectoryEntries()
+
+        assertEquals(2, logFiles.size)
+        assertFalse(logFiles.contains(tmp))
+    }
+
+    @Test
+    fun `a single log file larger than the max size should be truncated`(@TempDir tempDir: Path) =
+        runTest {
+            val maxBytes = 1024L * 10
+            val writer =
+                FileLogWriter(
+                    tempDir,
+                    maxTotalSizeBytes = maxBytes,
+                    truncateKeepPercentage = 0.5,
+                    checkSizeLimitAfter = 20,
+                    scope = this,
+                    dispatcher = Dispatchers.Main,
+                )
+            val logFile = tempDir.listDirectoryEntries().first()
+
+            // Write so we are about 60% full
+            val writeTo = (maxBytes * 0.6).toInt()
+            var writes = 0
+            while (logFile.fileSize() < writeTo) {
+                writer.log(Severity.Debug, "x", "x")
+                writes += 1
+            }
+
+            // Write another 60% of the way to the max size to push over the limit
+            repeat(writes) { writer.log(Severity.Debug, "z", "z") }
+
+            // Check that the file was truncated
+            assertTrue(
+                logFile.fileSize() < maxBytes,
+                "expected new size ${logFile.fileSize()} to be less than $maxBytes",
+            )
+            assertTrue(logFile.fileSize() > 0)
+
+            // Check that the file was truncated from the start, not the end, so that the most
+            // recent logs are present in the new file
+            val lines = logFile.readLines()
+            val (z, x) = lines.partition { it.contains("z") }
+            assertTrue(z.size > x.size)
+        }
+
+    @Test
+    fun `multiple log files that are larger than the max size should truncate the oldest log if big enough`(
+        @TempDir tempDir: Path
+    ) = runTest {
+        val maxBytes = 1024L * 10
+        val log1 =
+            tempDir.resolve("app_log_2025-10-26.txt").createFile().also {
+                it.writeText("a".repeat((maxBytes * 0.4).toInt()))
+            }
+        val log1OrigSize = log1.fileSize()
+        Thread.sleep(10)
+        val log2 =
+            tempDir.resolve("app_log_2025-10-27.txt").createFile().also {
+                it.writeText("b".repeat((maxBytes * 0.4).toInt()))
+            }
+
+        val writer =
+            FileLogWriter(
+                tempDir,
+                maxTotalSizeBytes = maxBytes,
+                checkSizeLimitAfter = 20,
+                scope = this,
+                dispatcher = Dispatchers.Main,
+            )
+        val logFile = tempDir.listDirectoryEntries().find { it != log1 && it != log2 }!!
+
+        // Exceed the size limit.
+        // The oldest log's size is greater than the amount we need to truncate.
+        val writeTo = (maxBytes * 0.3).toInt()
+        while (logFile.fileSize() < writeTo) {
+            writer.log(Severity.Debug, "x", "x")
+        }
+
+        val logFiles = tempDir.listDirectoryEntries()
+
+        assertEquals(3, logFiles.size)
+        assertTrue(log1OrigSize > log1.fileSize())
+    }
+
+    @Test
+    fun `multiple log files that are larger than the max size should remove the oldest log if small enough`(
+        @TempDir tempDir: Path
+    ) = runTest {
+        val maxBytes = 1024L * 10
+        val log1 =
+            tempDir.resolve("app_log_2025-10-26.txt").createFile().also {
+                it.writeText("a".repeat((maxBytes * 0.1).toInt()))
+            }
+        Thread.sleep(10)
+        val log2 =
+            tempDir.resolve("app_log_2025-10-27.txt").createFile().also {
+                it.writeText("b".repeat((maxBytes * 0.7).toInt()))
+            }
+        val log2OrigSize = log2.fileSize()
+
+        val writer =
+            FileLogWriter(
+                tempDir,
+                maxTotalSizeBytes = maxBytes,
+                checkSizeLimitAfter = 20,
+                scope = this,
+                dispatcher = Dispatchers.Main,
+            )
+        val logFile = tempDir.listDirectoryEntries().find { it != log1 && it != log2 }!!
+
+        // Exceed the size limit.
+        // The oldest log's size is smaller than the amount we need to truncate.
+        val writeTo = (maxBytes * 0.3).toInt()
+        while (logFile.fileSize() < writeTo) {
+            writer.log(Severity.Debug, "x", "x")
+        }
+
+        val logFiles = tempDir.listDirectoryEntries()
+
+        assertEquals(2, logFiles.size)
+        assertTrue(logFiles.contains(log2))
+        assertFalse(logFiles.contains(log1))
+        // Also check that the second oldest log was truncated.
+        assertTrue(log2OrigSize > log2.fileSize())
+    }
+}

--- a/mullvad-jni/src/problem_report.rs
+++ b/mullvad-jni/src/problem_report.rs
@@ -16,15 +16,24 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_dataproxy_MullvadProblemRepor
     env: JNIEnv<'_>,
     _: JObject<'_>,
     logDirectory: JString<'_>,
+    extraAppLogsDirectory: JString<'_>,
     outputPath: JString<'_>,
 ) -> jboolean {
     let env = JnixEnv::from(env);
     let log_dir_string = String::from_java(&env, logDirectory);
     let log_dir = Path::new(&log_dir_string);
+    let extra_logs_dir_string = String::from_java(&env, extraAppLogsDirectory);
+    let extra_logs_dir = Path::new(&extra_logs_dir_string);
     let output_path_string = String::from_java(&env, outputPath);
     let output_path = Path::new(&output_path_string);
 
-    match mullvad_problem_report::collect_report::<&str>(&[], output_path, Vec::new(), log_dir) {
+    match mullvad_problem_report::collect_report::<&str>(
+        &[],
+        output_path,
+        Vec::new(),
+        log_dir,
+        extra_logs_dir,
+    ) {
         Ok(()) => JNI_TRUE,
         Err(error) => {
             log::error!(


### PR DESCRIPTION
The FileLogWriter class logs all Kermit logs from the app to a log file saved in the data/app_logs directory.

It will create one log file per day and supports log rotation based on the number of days stored or the total size of all the log files in data/app_logs.

These logs are appended to the end of the problem report.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9277)
<!-- Reviewable:end -->
