### PR TITLE
Silence encrypted dns proxy errors from deprecated configs

### DIFF
--- a/mullvad-encrypted-dns-proxy/src/config_resolver.rs
+++ b/mullvad-encrypted-dns-proxy/src/config_resolver.rs
@@ -110,6 +110,7 @@ pub async fn resolve_config_with_resolverconfig(
                 log::trace!("IPv6 {addr} parsed into proxy config: {proxy_config:?}");
                 proxy_configs.push(proxy_config);
             }
+            Err(config::Error::XorV1Unsupported) => continue, // ignore deprecated configs
             Err(e) => log::error!("IPv6 {addr} fails to parse to a proxy config: {e}"),
         }
     }


### PR DESCRIPTION
This is not actually an error, and shouldn't pollute the logs.
Note that in the event that the DNS lookup produces _no_ valid proxy configs at all, a different error is logged further up the stack.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9279)
<!-- Reviewable:end -->
