### PR TITLE
Add v13 settings migration

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -49,6 +49,7 @@ mod v1;
 mod v10;
 mod v11;
 mod v12;
+mod v13;
 mod v2;
 mod v3;
 mod v4;
@@ -216,6 +217,7 @@ async fn migrate_settings(
     v10::migrate(settings)?;
     v11::migrate(settings)?;
     v12::migrate(settings)?;
+    v13::migrate(settings)?;
 
     Ok(migration_data)
 }

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_auto-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_auto-2.snap
@@ -1,0 +1,17 @@
+---
+source: mullvad-daemon/src/migrations/v13.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto",
+    "wireguard_port": {
+      "port": "any"
+    }
+  },
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {}
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_auto.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_auto.snap
@@ -1,0 +1,16 @@
+---
+source: mullvad-daemon/src/migrations/v13.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "obfuscation_settings": {
+    "selected_obfuscation": "auto"
+  },
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "port": "any"
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_custom-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_custom-2.snap
@@ -1,0 +1,17 @@
+---
+source: mullvad-daemon/src/migrations/v13.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "obfuscation_settings": {
+    "selected_obfuscation": "shadowsocks",
+    "wireguard_port": {
+      "port": "any"
+    }
+  },
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {}
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_custom.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_any_selected_obfuscation_custom.snap
@@ -1,0 +1,16 @@
+---
+source: mullvad-daemon/src/migrations/v13.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "obfuscation_settings": {
+    "selected_obfuscation": "shadowsocks"
+  },
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "port": "any"
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_value-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_value-2.snap
@@ -1,0 +1,18 @@
+---
+source: mullvad-daemon/src/migrations/v13.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "obfuscation_settings": {
+    "wireguard_port": {
+      "port": {
+        "only": 53
+      }
+    }
+  },
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {}
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_value.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v13__test__v13_to_v14_migration_wireguard_port_value.snap
@@ -1,0 +1,16 @@
+---
+source: mullvad-daemon/src/migrations/v13.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "obfuscation_settings": {},
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "port": {
+          "only": 53
+        }
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/v13.rs
+++ b/mullvad-daemon/src/migrations/v13.rs
@@ -1,0 +1,111 @@
+use super::Result;
+use mullvad_types::settings::SettingsVersion;
+use serde_json::json;
+
+const WIREGUARD_PORT_OLD_KEY: &str = "port";
+const WIREGUARD_PORT_NEW_KEY: &str = "wireguard_port";
+
+/// This migration handles:
+/// - Migrates the WireGuard port from WireGuard constraints in relay settings
+///   to obfuscation settings.
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to V14");
+
+    migrate_wireguard_port(settings);
+
+    settings["settings_version"] = serde_json::json!(SettingsVersion::V14);
+
+    Ok(())
+}
+
+fn migrate_wireguard_port(settings: &mut serde_json::Value) -> Option<()> {
+    let wireguard_constraints = settings
+        .get_mut("relay_settings")
+        .and_then(|relay_settings| relay_settings.get_mut("normal"))
+        .and_then(|normal_relay_settings| normal_relay_settings.get_mut("wireguard_constraints"))
+        .and_then(|wireguard_constraints| wireguard_constraints.as_object_mut())?;
+
+    let port = wireguard_constraints.remove(WIREGUARD_PORT_OLD_KEY)?;
+
+    let obfuscation_settings = settings
+        .get_mut("obfuscation_settings")
+        .and_then(|obfuscation_settings| obfuscation_settings.as_object_mut())?;
+    obfuscation_settings.insert(WIREGUARD_PORT_NEW_KEY.to_string(), json!({"port": port}));
+
+    Some(())
+}
+
+fn version_matches(settings: &serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V13 as u64)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use crate::migrations::v13::migrate_wireguard_port;
+
+    #[test]
+    fn test_v13_to_v14_migration_wireguard_port_any_selected_obfuscation_custom() {
+        let mut old_settings = json!({
+            "obfuscation_settings": {
+                "selected_obfuscation": "shadowsocks"
+            },
+            "relay_settings": {
+              "normal": {
+                "wireguard_constraints": {
+                    "port": "any"
+                }
+              }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_wireguard_port(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    #[test]
+    fn test_v13_to_v14_migration_wireguard_port_any_selected_obfuscation_auto() {
+        let mut old_settings = json!({
+            "obfuscation_settings": {
+                "selected_obfuscation": "auto"
+            },
+            "relay_settings": {
+              "normal": {
+                "wireguard_constraints": {
+                    "port": "any"
+                }
+              }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_wireguard_port(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    #[test]
+    fn test_v13_to_v14_migration_wireguard_port_value() {
+        let mut old_settings = json!({
+            "obfuscation_settings": {},
+            "relay_settings": {
+              "normal": {
+                "wireguard_constraints": {
+                    "port": {
+                        "only": 53
+                    }
+                }
+              }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_wireguard_port(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+}

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -20,7 +20,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V13;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V14;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -37,6 +37,7 @@ pub enum SettingsVersion {
     V11 = 11,
     V12 = 12,
     V13 = 13,
+    V14 = 14,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -57,6 +58,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V11 as u32 => Ok(SettingsVersion::V11),
             v if v == SettingsVersion::V12 as u32 => Ok(SettingsVersion::V12),
             v if v == SettingsVersion::V13 as u32 => Ok(SettingsVersion::V13),
+            v if v == SettingsVersion::V14 as u32 => Ok(SettingsVersion::V14),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),


### PR DESCRIPTION
Migrate WireGuard port from relay settings' wireguard constraints to obfuscation settings.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9282)
<!-- Reviewable:end -->
