### PR TITLE
Fix DAITA overhead log

### DIFF
--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -1049,8 +1049,8 @@ async fn log_daita_overhead(tunnel: &TunnelType) {
         let daita = stats.daita.as_ref().unwrap();
         let total_out = stats.tx_bytes / 1024 / 1024;
         let total_in = stats.rx_bytes / 1024 / 1024;
-        let padding_packet_out = stats.tx_bytes / 1024 / 1024;
-        let padding_packet_in = stats.rx_bytes / 1024 / 1024;
+        let padding_packet_out = daita.tx_padding_packet_bytes / 1024 / 1024;
+        let padding_packet_in = daita.rx_padding_packet_bytes / 1024 / 1024;
         let constant_size_padding_out = daita.tx_padding_bytes / 1024 / 1024;
         let constant_size_padding_in = daita.rx_padding_bytes / 1024 / 1024;
 


### PR DESCRIPTION
Regression caused by #9214, whoopsie. The total traffic was logged instead of the overhead from padding packets.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9283)
<!-- Reviewable:end -->
