### PR TITLE
Remove failing Windows version test

### DIFF
--- a/talpid-platform-metadata/src/windows.rs
+++ b/talpid-platform-metadata/src/windows.rs
@@ -40,7 +40,7 @@ pub fn version() -> String {
         (Ok((major, build)), _) | (_, Ok((major, build))) => {
             format!("Windows {major} Build {build}")
         }
-        (Err(_), Err(_)) => format!("Windows N/A Build N/A"),
+        (Err(_), Err(_)) => "Windows N/A Build N/A".to_string(),
     }
 }
 
@@ -241,17 +241,5 @@ mod test {
     #[test]
     fn test_windows_version() {
         WindowsVersion::new().unwrap();
-    }
-
-    #[test]
-    fn test_ntoskrnl_version() {
-        let winver = WindowsVersion::new().unwrap();
-        let nt_winver = WindowsVersion::from_ntoskrnl().unwrap();
-
-        assert_eq!(winver.major, nt_winver.major);
-        assert_eq!(winver.minor, nt_winver.minor);
-        assert_eq!(winver.build, nt_winver.build);
-
-        // NOTE: We do not know the product type for `nt_winver`
     }
 }


### PR DESCRIPTION
The test `test_ntoskrnl_version` started failing in a recent Windows update, indicating that the version returned by `ntdll` and `ntoskrnl` differ. We can't do much about that, so the test needs to be removed to prevent CI from failing.

To my knowledge, we don't rely on these two methods resolving to the same version in any critical way, though I opt to print both versions in the problem report if they differ.


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9307)
<!-- Reviewable:end -->
