### PR TITLE
Collapse multiple layers of Rust if statements

### DIFF
--- a/mullvad-daemon/src/version/check.rs
+++ b/mullvad-daemon/src/version/check.rs
@@ -146,16 +146,16 @@ impl VersionUpdaterInner {
 
     #[cfg(not(target_os = "android"))]
     fn ignore_cache_if_same_version(&self, mut new_version_info: VersionCache) -> VersionCache {
-        if let Some(current_cache) = self.last_app_version_info.as_ref() {
-            if current_cache.metadata_version == new_version_info.metadata_version {
-                log::trace!("Ignoring version info with same metadata version");
-                // Ignore everything except etag and platform timestamp
-                new_version_info = VersionCache {
-                    last_platform_header_check: new_version_info.last_platform_header_check,
-                    etag: new_version_info.etag,
-                    ..current_cache.clone()
-                };
-            }
+        if let Some(current_cache) = self.last_app_version_info.as_ref()
+            && current_cache.metadata_version == new_version_info.metadata_version
+        {
+            log::trace!("Ignoring version info with same metadata version");
+            // Ignore everything except etag and platform timestamp
+            new_version_info = VersionCache {
+                last_platform_header_check: new_version_info.last_platform_header_check,
+                etag: new_version_info.etag,
+                ..current_cache.clone()
+            };
         }
         new_version_info
     }

--- a/mullvad-ios/src/ephemeral_peer_proxy/peer_exchange.rs
+++ b/mullvad-ios/src/ephemeral_peer_proxy/peer_exchange.rs
@@ -27,11 +27,11 @@ impl ExchangeCancelToken {
 
     /// Blocks until the associated ephemeral peer exchange task is finished.
     pub fn cancel(&self) {
-        if let Ok(mut inner) = self.inner.lock() {
-            if let Some(task) = inner.task.take() {
-                task.abort();
-                let _ = inner.tokio_handle.block_on(task);
-            }
+        if let Ok(mut inner) = self.inner.lock()
+            && let Some(task) = inner.task.take()
+        {
+            task.abort();
+            let _ = inner.tokio_handle.block_on(task);
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -128,15 +128,15 @@ impl ConnectingState {
                     #[cfg(target_os = "android")]
                     {
                         shared_values.prepare_tun_config(false);
-                        if retry_attempt > 0 && retry_attempt % MAX_ATTEMPTS_WITH_SAME_TUN == 0 {
-                            if let Err(error) =
-                                { shared_values.tun_provider.lock().unwrap().open_tun_forced() }
-                            {
-                                log::error!(
-                                    "{}",
-                                    error.display_chain_with_msg("Failed to recreate tun device")
-                                );
-                            }
+                        if retry_attempt > 0
+                            && retry_attempt % MAX_ATTEMPTS_WITH_SAME_TUN == 0
+                            && let Err(error) =
+                                shared_values.tun_provider.lock().unwrap().open_tun_forced()
+                        {
+                            log::error!(
+                                "{}",
+                                error.display_chain_with_msg("Failed to recreate tun device")
+                            );
                         }
                     }
 

--- a/talpid-macos/src/process.rs
+++ b/talpid-macos/src/process.rs
@@ -16,10 +16,10 @@ pub fn pid_of_path(find_path: impl AsRef<Path>) -> Option<pid_t> {
     match list_pids() {
         Ok(pids) => {
             for pid in pids {
-                if let Ok(path) = process_path(pid) {
-                    if path == find_path.as_ref() {
-                        return Some(pid);
-                    }
+                if let Ok(path) = process_path(pid)
+                    && path == find_path.as_ref()
+                {
+                    return Some(pid);
                 }
             }
             None

--- a/talpid-routing/src/unix/macos/default_routes.rs
+++ b/talpid-routing/src/unix/macos/default_routes.rs
@@ -190,10 +190,10 @@ impl DefaultRouteMonitor {
         };
 
         self.current_route.set(family, new_route.clone());
-        if let Some(tx) = self.route_tx.get(family) {
-            if tx.unbounded_send(new_route).is_err() {
-                self.route_tx.remove(family);
-            }
+        if let Some(tx) = self.route_tx.get(family)
+            && tx.unbounded_send(new_route).is_err()
+        {
+            self.route_tx.remove(family);
         }
     }
 }

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -267,20 +267,20 @@ impl PrimaryInterfaceMonitor {
         let index = u16::try_from(index).unwrap();
 
         let mut router_ip = service.router_ip;
-        if let IpAddr::V6(addr) = &mut router_ip {
-            if is_link_local_v6(addr) {
-                // The second pair of octets should be set to the scope id
-                // See getaddr() in route.c:
-                // https://opensource.apple.com/source/network_cmds/network_cmds-396.6/route.tproj/route.c.auto.html
+        if let IpAddr::V6(addr) = &mut router_ip
+            && is_link_local_v6(addr)
+        {
+            // The second pair of octets should be set to the scope id
+            // See getaddr() in route.c:
+            // https://opensource.apple.com/source/network_cmds/network_cmds-396.6/route.tproj/route.c.auto.html
 
-                let second_octet = index.to_be_bytes();
+            let second_octet = index.to_be_bytes();
 
-                let mut octets = addr.octets();
-                octets[2] = second_octet[0];
-                octets[3] = second_octet[1];
+            let mut octets = addr.octets();
+            octets[2] = second_octet[0];
+            octets[3] = second_octet[1];
 
-                *addr = Ipv6Addr::from(octets);
-            }
+            *addr = Ipv6Addr::from(octets);
         }
 
         Some(DefaultRoute {

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -276,18 +276,17 @@ impl RouteManagerImpl {
     async fn get_gateway_link_address(&mut self, gateway_ip: IpAddr) -> Option<Gateway> {
         let gateway_msg = RouteMessage::new_route(Destination::Host(gateway_ip));
 
-        if let Ok(Some(msg)) = self.routing_table.get_route(&gateway_msg).await {
-            if let Some(gateway) = msg
+        if let Ok(Some(msg)) = self.routing_table.get_route(&gateway_msg).await
+            && let Some(gateway) = msg
                 .gateway()
                 .and_then(|gateway| gateway.as_link_addr())
                 .and_then(|addr| addr.addr())
-            {
-                let mac_address = MacAddress::from(gateway);
-                return Some(Gateway {
-                    ip_address: gateway_ip,
-                    mac_address,
-                });
-            }
+        {
+            let mac_address = MacAddress::from(gateway);
+            return Some(Gateway {
+                ip_address: gateway_ip,
+                mac_address,
+            });
         }
         None
     }

--- a/talpid-tunnel/src/tun_provider/android/mod.rs
+++ b/talpid-tunnel/src/tun_provider/android/mod.rs
@@ -112,16 +112,16 @@ impl AndroidTunProvider {
 
         // If we are recreating the same tunnel we return the same file descriptor to avoid calling
         // open_tun in android since it may cause leaks.
-        if let Some((vpn_service_config, raw_fd)) = &self.current_tunnel {
-            if vpn_service_config == &config {
-                return Ok(VpnServiceTun {
-                    tunnel: *raw_fd,
-                    is_new: false,
-                    jvm,
-                    class: self.class.clone(),
-                    object: self.object.clone(),
-                });
-            }
+        if let Some((vpn_service_config, raw_fd)) = &self.current_tunnel
+            && vpn_service_config == &config
+        {
+            return Ok(VpnServiceTun {
+                tunnel: *raw_fd,
+                is_new: false,
+                jvm,
+                class: self.class.clone(),
+                object: self.object.clone(),
+            });
         }
 
         self.open_tun_forced()

--- a/talpid-windows/src/net.rs
+++ b/talpid-windows/src/net.rs
@@ -242,10 +242,11 @@ pub async fn wait_for_interfaces(luid: NET_LUID_LH, ipv4: bool, ipv6: bool) -> i
                 AF_INET6 => found_ipv6 = true,
                 _ => (),
             }
-            if found_ipv4 && found_ipv6 {
-                if let Some(tx) = tx.take() {
-                    let _ = tx.send(());
-                }
+            if found_ipv4
+                && found_ipv6
+                && let Some(tx) = tx.take()
+            {
+                let _ = tx.send(());
             }
         },
         None,


### PR DESCRIPTION
Somewhere between Rust 1.88 (our current version) and 1.91 (the one I'm trying to upgrade us to), Clippy started warning about nested if statements that could be collapsed into one. Since we forbid warnings, we must either collapse them, or ignore the `clippy::collapsible_if`. This PR collapses everything just like Clippy suggests. In general we should use default settings for both Rust and Clippy linting. We should only sidestep the defaults if we have consensus that the defaults are worse than the alternative.

Some benefits of collapsed if-statements include:
* Less indentation overall
* Maybe easier to follow the execution flow as there are fewer blocks and fewer branch statements

The major downside of collapsed if statements is IMO that some conditions can be somewhat hard to read.

Here is an example of such a warning (error in our case): https://github.com/mullvad/mullvadvpn-app/actions/runs/19297913944/job/55184412575#step:5:196

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9316)
<!-- Reviewable:end -->
