### PR TITLE
Split `mullvad_update::format` into multiple modules

### DIFF
--- a/installer-downloader/src/controller.rs
+++ b/installer-downloader/src/controller.rs
@@ -12,6 +12,7 @@ use mullvad_update::{
     api::{HttpVersionInfoProvider, MetaRepositoryPlatform},
     app::{self, AppCache, AppDownloader, DownloadedInstaller, HttpAppDownloader},
     local::METADATA_FILENAME,
+    version::rollout::SUPPORTED_VERSION,
     version::{Version, VersionInfo, VersionParameters},
     version_provider::VersionInfoProvider,
 };
@@ -214,7 +215,7 @@ where
         let version_params = VersionParameters {
             architecture,
             // For the downloader, the rollout version is always preferred
-            rollout: mullvad_update::version::SUPPORTED_VERSION,
+            rollout: SUPPORTED_VERSION,
             allow_empty: false,
             // The downloader allows any version
             lowest_metadata_version: mullvad_update::version::MIN_VERIFY_METADATA_VERSION,

--- a/installer-downloader/tests/mock.rs
+++ b/installer-downloader/tests/mock.rs
@@ -10,7 +10,7 @@ use mullvad_update::app::{
     AppCache, AppDownloader, DownloadError, DownloadedInstaller, VerifiedInstaller,
 };
 use mullvad_update::fetch::ProgressUpdater;
-use mullvad_update::format::{Response, SignedResponse};
+use mullvad_update::format::response::{Response, SignedResponse};
 use mullvad_update::version::{Version, VersionInfo, VersionParameters};
 use mullvad_update::version_provider::VersionInfoProvider;
 use std::io;

--- a/mullvad-api/src/version.rs
+++ b/mullvad-api/src/version.rs
@@ -4,7 +4,11 @@ use std::sync::Arc;
 
 use http::StatusCode;
 use http::header;
-use mullvad_update::version::{Rollout, VersionInfo, VersionParameters, is_version_supported};
+use mullvad_update::format::response::SignedResponse;
+use mullvad_update::version::VersionInfo;
+use mullvad_update::version::VersionParameters;
+use mullvad_update::version::is_version_supported;
+use mullvad_update::version::rollout::Rollout;
 
 type AppVersion = String;
 
@@ -140,11 +144,8 @@ impl AppVersionProxy {
 
             let bytes = response.body_with_max_size(Self::SIZE_LIMIT).await?;
 
-            let response = mullvad_update::format::SignedResponse::deserialize_and_verify(
-                &bytes,
-                lowest_metadata_version,
-            )
-            .map_err(|err| rest::Error::FetchVersions(Arc::new(err)))?;
+            let response = SignedResponse::deserialize_and_verify(&bytes, lowest_metadata_version)
+                .map_err(|err| rest::Error::FetchVersions(Arc::new(err)))?;
 
             let params = VersionParameters {
                 architecture,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -71,8 +71,10 @@ use mullvad_types::{
     version::AppVersionInfo,
     wireguard::{PublicKey, QuantumResistantState, RotationInterval},
 };
+#[cfg(target_os = "android")]
+use mullvad_update::version::rollout::SUPPORTED_VERSION;
 #[cfg(not(target_os = "android"))]
-use mullvad_update::version::generate_rollout_seed;
+use mullvad_update::version::rollout::{Rollout, generate_rollout_seed};
 use relay_list::{RELAYS_FILENAME, RelayListUpdater, RelayListUpdaterHandle};
 use settings::SettingsPersister;
 use std::collections::BTreeSet;
@@ -963,10 +965,10 @@ impl Daemon {
             let version = mullvad_version::VERSION
                 .parse()
                 .expect("App version to be parsable");
-            mullvad_update::version::Rollout::threshold(seed, version)
+            Rollout::threshold(seed, version)
         };
         #[cfg(target_os = "android")]
-        let rollout = mullvad_update::version::SUPPORTED_VERSION;
+        let rollout = SUPPORTED_VERSION;
         let version_handle = version::router::spawn_version_router(
             api_handle.clone(),
             api_handle.availability.clone(),
@@ -3232,7 +3234,7 @@ impl Daemon {
         let version = mullvad_version::VERSION
             .parse::<mullvad_version::Version>()
             .expect("Failed to parse version");
-        let threshold = mullvad_update::version::Rollout::threshold(seed, version);
+        let threshold = Rollout::threshold(seed, version);
         // a tiny bit hacky way to map Rollout -> f32, but it works.
         threshold
             .to_string()

--- a/mullvad-daemon/src/version/check.rs
+++ b/mullvad-daemon/src/version/check.rs
@@ -6,7 +6,7 @@ use futures::{
 use mullvad_api::{
     availability::ApiAvailability, rest::MullvadRestHandle, version::AppVersionProxy,
 };
-use mullvad_update::version::{Rollout, VersionInfo};
+use mullvad_update::version::{VersionInfo, rollout::Rollout};
 use mullvad_version::Version;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/mullvad-daemon/src/version/router.rs
+++ b/mullvad-daemon/src/version/router.rs
@@ -7,7 +7,8 @@ use mullvad_api::{availability::ApiAvailability, rest::MullvadRestHandle};
 use mullvad_types::version::{AppVersionInfo, SuggestedUpgrade};
 #[cfg(in_app_upgrade)]
 use mullvad_update::app::{AppDownloader, AppDownloaderParameters, HttpAppDownloader};
-use mullvad_update::version::{Rollout, VersionInfo};
+use mullvad_update::version::VersionInfo;
+use mullvad_update::version::rollout::Rollout;
 use talpid_core::mpsc::Sender;
 #[cfg(in_app_upgrade)]
 use talpid_types::ErrorExt;

--- a/mullvad-update/mullvad-release/src/artifacts.rs
+++ b/mullvad-update/mullvad-release/src/artifacts.rs
@@ -4,18 +4,20 @@ use anyhow::Context;
 use std::path::Path;
 use tokio::{fs, io::BufReader};
 
-use mullvad_update::{format, hash};
+use mullvad_update::format::Architecture;
+use mullvad_update::format::installer::Installer;
+use mullvad_update::hash;
 
 /// Generate `format::Installer` for a given `artifact`.
 ///
 /// The presence of the files relative to `base_urls` is not verified.
 /// See [crate::config::Config::base_urls] for the assumptions made.
 pub async fn generate_installer_details(
-    architecture: format::Architecture,
+    architecture: Architecture,
     version: &mullvad_version::Version,
     base_urls: &[String],
     artifact: &Path,
-) -> anyhow::Result<format::Installer> {
+) -> anyhow::Result<Installer> {
     let file = fs::File::open(artifact)
         .await
         .with_context(|| format!("Failed to open file at {}", artifact.display()))?;
@@ -39,7 +41,7 @@ pub async fn generate_installer_details(
         .context("Unexpected filename")?;
     let urls = derive_urls(base_urls, version, filename);
 
-    Ok(format::Installer {
+    Ok(Installer {
         architecture,
         urls,
         size: file_size.try_into().context("Invalid file size")?,

--- a/mullvad-update/mullvad-release/src/platform.rs
+++ b/mullvad-update/mullvad-release/src/platform.rs
@@ -1,12 +1,15 @@
 //! Types for handling per-platform metadata
 
 use anyhow::{Context, anyhow, bail};
-use mullvad_update::{
-    api::{HttpVersionInfoProvider, MetaRepositoryPlatform},
-    format::{self, key},
-    version::{
-        MIN_VERIFY_METADATA_VERSION, Rollout, VersionArchitecture, VersionInfo, VersionParameters,
-    },
+use mullvad_update::api::{HttpVersionInfoProvider, MetaRepositoryPlatform};
+use mullvad_update::format::Architecture;
+use mullvad_update::format::installer::Installer;
+use mullvad_update::format::key;
+use mullvad_update::format::release::Release;
+use mullvad_update::format::response::{Response, SignedResponse};
+use mullvad_update::version::rollout::Rollout;
+use mullvad_update::version::{
+    MIN_VERIFY_METADATA_VERSION, VersionArchitecture, VersionInfo, VersionParameters,
 };
 use std::{cmp::Ordering, fmt, path::PathBuf, str::FromStr};
 use strum::IntoEnumIterator;
@@ -176,7 +179,7 @@ impl Platform {
 
         // Read unsigned JSON data
         let data = fs::read(work_path).await?;
-        let mut response = format::SignedResponse::deserialize_insecure(&data)?;
+        let mut response = SignedResponse::deserialize_insecure(&data)?;
 
         // Update the expiration date
         response.signed.metadata_expiry = chrono::Utc::now()
@@ -196,7 +199,7 @@ impl Platform {
         response.signed.metadata_version = new_version;
 
         // Sign it
-        let signed_response = format::SignedResponse::sign(secret, response.signed)?;
+        let signed_response = SignedResponse::sign(secret, response.signed)?;
 
         // Update signed data
         let signed_bytes = serde_json::to_string_pretty(&signed_response)
@@ -243,7 +246,7 @@ impl Platform {
         }
 
         // Make release
-        let new_release = format::Release {
+        let new_release = Release {
             changelog: changes.to_owned(),
             version: version.clone(),
             installers,
@@ -268,13 +271,13 @@ impl Platform {
         &self,
         version: &mullvad_version::Version,
         base_urls: &[String],
-    ) -> anyhow::Result<Vec<format::Installer>> {
+    ) -> anyhow::Result<Vec<Installer>> {
         let mut installers = vec![];
         let artifacts = self.artifact_filenames(version);
         for artifact in artifacts.arm64_artifacts {
             installers.push(
                 artifacts::generate_installer_details(
-                    format::Architecture::Arm64,
+                    Architecture::Arm64,
                     version,
                     base_urls,
                     &artifact,
@@ -285,7 +288,7 @@ impl Platform {
         for artifact in artifacts.x86_artifacts {
             installers.push(
                 artifacts::generate_installer_details(
-                    format::Architecture::X86,
+                    Architecture::X86,
                     version,
                     base_urls,
                     &artifact,
@@ -421,29 +424,29 @@ impl Platform {
 
     /// Reads the metadata for `platform` in the work directory.
     /// If the file doesn't exist, this returns a new, empty response.
-    async fn read_work(&self) -> anyhow::Result<format::SignedResponse> {
+    async fn read_work(&self) -> anyhow::Result<SignedResponse> {
         let work_path = self.work_path();
         let bytes = match fs::read(&work_path).await {
             Ok(bytes) => bytes,
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 // Return empty response
-                return Ok(format::SignedResponse {
+                return Ok(SignedResponse {
                     signatures: vec![],
-                    signed: format::Response::default(),
+                    signed: Response::default(),
                 });
             }
             Err(error) => bail!("Failed to read {}: {error}", work_path.display()),
         };
         // Note: We don't need to verify the signature here
-        format::SignedResponse::deserialize_insecure(&bytes)
+        SignedResponse::deserialize_insecure(&bytes)
     }
 
     /// Read and verify the metadata for `platform` in the signed directory.
-    async fn read_signed(&self) -> anyhow::Result<format::SignedResponse> {
+    async fn read_signed(&self) -> anyhow::Result<SignedResponse> {
         let signed_path = self.signed_path();
         let bytes = fs::read(signed_path).await.context("Failed to read file")?;
 
-        format::SignedResponse::deserialize_and_verify(
+        SignedResponse::deserialize_and_verify(
             &bytes,
             mullvad_update::version::MIN_VERIFY_METADATA_VERSION,
         )
@@ -464,7 +467,7 @@ impl From<Platform> for MetaRepositoryPlatform {
 /// Print release info:
 /// Version: 2025.3 (arm, x86) (50%)
 /// <Changelog>
-fn print_release_info(release: &format::Release) {
+fn print_release_info(release: &Release) {
     let mut architectures: Vec<_> = release
         .installers
         .iter()

--- a/mullvad-update/src/bin/mullvad-version-metadata.rs
+++ b/mullvad-update/src/bin/mullvad-version-metadata.rs
@@ -5,7 +5,8 @@ use clap::Parser;
 use std::io::Read;
 use tokio::{fs, io};
 
-use mullvad_update::format::{self, key};
+use mullvad_update::format::key;
+use mullvad_update::format::response::{Response, SignedResponse};
 
 #[allow(dead_code)]
 const DEFAULT_EXPIRY_MONTHS: u32 = 6;
@@ -51,11 +52,11 @@ async fn sign(file: String, secret: key::SecretKey) -> anyhow::Result<()> {
     };
 
     // Deserialize version data
-    let response: format::Response =
+    let response: Response =
         serde_json::from_slice(&data).context("Failed to deserialize version metadata")?;
 
     // Sign it
-    let signed_response = format::SignedResponse::sign(secret, response)?;
+    let signed_response = SignedResponse::sign(secret, response)?;
 
     // Print it
     println!(

--- a/mullvad-update/src/client/api.rs
+++ b/mullvad-update/src/client/api.rs
@@ -9,7 +9,7 @@ use tokio::fs;
 use vec1::Vec1;
 
 use crate::defaults;
-use crate::format;
+use crate::format::response::SignedResponse;
 use crate::version::{VersionInfo, VersionParameters};
 
 use super::version_provider::VersionInfoProvider;
@@ -100,7 +100,7 @@ impl HttpVersionInfoProvider {
     pub async fn get_versions_for_platform(
         platform: MetaRepositoryPlatform,
         lowest_metadata_version: usize,
-    ) -> anyhow::Result<format::SignedResponse> {
+    ) -> anyhow::Result<SignedResponse> {
         HttpVersionInfoProvider::from(platform)
             .get_versions(lowest_metadata_version)
             .await
@@ -110,12 +110,9 @@ impl HttpVersionInfoProvider {
     ///
     /// By default, `pinned_certificate` will be set to the LE root certificate, and
     /// and the keys in `trusted-metadata-signing-keys` will be used for verification.
-    async fn get_versions(
-        &self,
-        lowest_metadata_version: usize,
-    ) -> anyhow::Result<format::SignedResponse> {
+    async fn get_versions(&self, lowest_metadata_version: usize) -> anyhow::Result<SignedResponse> {
         self.get_versions_inner(|raw_json| {
-            format::SignedResponse::deserialize_and_verify(raw_json, lowest_metadata_version)
+            SignedResponse::deserialize_and_verify(raw_json, lowest_metadata_version)
         })
         .await
     }
@@ -125,10 +122,10 @@ impl HttpVersionInfoProvider {
     async fn get_versions_with_keys(
         &self,
         lowest_metadata_version: usize,
-        verifying_keys: &Vec1<format::key::VerifyingKey>,
-    ) -> anyhow::Result<format::SignedResponse> {
+        verifying_keys: &Vec1<crate::format::key::VerifyingKey>,
+    ) -> anyhow::Result<SignedResponse> {
         self.get_versions_inner(|raw_json| {
-            format::SignedResponse::deserialize_and_verify_at_time(
+            SignedResponse::deserialize_and_verify_at_time(
                 verifying_keys,
                 raw_json,
                 chrono::DateTime::UNIX_EPOCH,
@@ -140,8 +137,8 @@ impl HttpVersionInfoProvider {
 
     async fn get_versions_inner(
         &self,
-        deserialize_fn: impl FnOnce(&[u8]) -> anyhow::Result<format::SignedResponse>,
-    ) -> anyhow::Result<format::SignedResponse> {
+        deserialize_fn: impl FnOnce(&[u8]) -> anyhow::Result<SignedResponse>,
+    ) -> anyhow::Result<SignedResponse> {
         let raw_json = Self::get(&self.url, self.pinned_certificate.clone(), self.resolve).await?;
         let signed_response = deserialize_fn(&raw_json)?;
         if let Some(path) = &self.dump_to_path {
@@ -231,12 +228,11 @@ impl HttpVersionInfoProvider {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+
     use async_tempfile::TempDir;
     use insta::assert_yaml_snapshot;
     use vec1::vec1;
-
-    use super::*;
-    use crate::format::SignedResponse;
 
     // These tests rely on `insta` for snapshot testing. If they fail due to snapshot assertions,
     // then most likely the snapshots need to be updated. The most convenient way to review

--- a/mullvad-update/src/client/local.rs
+++ b/mullvad-update/src/client/local.rs
@@ -6,7 +6,8 @@ use anyhow::{Context, bail};
 use std::{path::PathBuf, vec};
 use tokio::fs;
 
-use crate::{format::SignedResponse, version::VersionParameters};
+use crate::format::response::SignedResponse;
+use crate::version::VersionParameters;
 
 use super::app::{AppCache, InstallerFile};
 
@@ -28,7 +29,7 @@ impl AppCache for AppCacheDir {
         }
     }
 
-    async fn get_metadata(&self) -> anyhow::Result<crate::format::SignedResponse> {
+    async fn get_metadata(&self) -> anyhow::Result<SignedResponse> {
         let metadata_file = self.directory.join(METADATA_FILENAME);
         let raw_json = fs::read(metadata_file)
             .await

--- a/mullvad-update/src/format/architecture.rs
+++ b/mullvad-update/src/format/architecture.rs
@@ -1,0 +1,24 @@
+//! Installer architecture
+
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "strum", derive(strum::EnumIter))]
+pub enum Architecture {
+    /// x86-64 architecture
+    X86,
+    /// ARM64 architecture
+    Arm64,
+}
+
+impl Display for Architecture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Architecture::X86 => f.write_str("x86"),
+            Architecture::Arm64 => f.write_str("arm64"),
+        }
+    }
+}

--- a/mullvad-update/src/format/deserializer.rs
+++ b/mullvad-update/src/format/deserializer.rs
@@ -3,9 +3,8 @@
 use anyhow::Context;
 use vec1::Vec1;
 
-use super::Response;
 use super::key::*;
-use super::{PartialSignedResponse, ResponseSignature, SignedResponse};
+use super::response::{PartialSignedResponse, Response, ResponseSignature, SignedResponse};
 
 impl SignedResponse {
     /// Deserialize some bytes to JSON, and verify them, including signature and expiry.

--- a/mullvad-update/src/format/installer.rs
+++ b/mullvad-update/src/format/installer.rs
@@ -1,0 +1,19 @@
+//! App installer
+
+use serde::{Deserialize, Serialize};
+
+use super::architecture::Architecture;
+
+/// App installer
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct Installer {
+    /// Installer architecture
+    pub architecture: Architecture,
+    /// Mirrors that host the artifact
+    pub urls: Vec<String>,
+    /// Size of the installer, in bytes
+    pub size: usize,
+    /// Hash of the installer, hexadecimal string
+    pub sha256: String,
+}

--- a/mullvad-update/src/format/release.rs
+++ b/mullvad-update/src/format/release.rs
@@ -1,0 +1,33 @@
+//! App release
+
+use serde::{Deserialize, Serialize};
+
+use super::installer::Installer;
+use crate::version::rollout::{Rollout, is_complete_rollout};
+
+/// App release
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Release {
+    /// Mullvad app version
+    pub version: mullvad_version::Version,
+    /// Changelog entries
+    pub changelog: String,
+    /// Installer details for different architectures
+    pub installers: Vec<Installer>,
+    /// Fraction of users that should receive the new version
+    #[serde(default = "Rollout::complete")]
+    #[serde(skip_serializing_if = "is_complete_rollout")]
+    pub rollout: Rollout,
+}
+
+impl PartialEq for Release {
+    fn eq(&self, other: &Self) -> bool {
+        self.version.eq(&other.version)
+    }
+}
+
+impl PartialOrd for Release {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.version.partial_cmp(&other.version)
+    }
+}

--- a/mullvad-update/src/format/response.rs
+++ b/mullvad-update/src/format/response.rs
@@ -1,0 +1,62 @@
+//! Payload from the Mullvad metadata API.
+
+use serde::{Deserialize, Serialize};
+
+use super::key;
+use super::release::Release;
+
+/// JSON response including signature and signed content
+/// This type does not implement [serde::Deserialize] to prevent accidental deserialization without
+/// signature verification.
+#[derive(Debug, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct SignedResponse {
+    /// Signatures of the canonicalized JSON of `signed`
+    pub signatures: Vec<ResponseSignature>,
+    /// Content signed by `signature`
+    pub signed: Response,
+}
+
+impl SignedResponse {
+    pub fn get_releases(self) -> Vec<Release> {
+        self.signed.releases
+    }
+}
+
+/// Signed JSON response, not including the signature
+#[derive(Default, Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct Response {
+    /// Version counter
+    pub metadata_version: usize,
+    /// When the signature expires
+    pub metadata_expiry: chrono::DateTime<chrono::Utc>,
+    /// Available app releases
+    pub releases: Vec<Release>,
+}
+
+/// JSON response signature
+#[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(tag = "keytype")]
+#[serde(rename_all = "lowercase")]
+pub enum ResponseSignature {
+    Ed25519 {
+        keyid: key::VerifyingKey,
+        sig: key::Signature,
+    },
+    #[serde(untagged)]
+    Other { keyid: String, sig: String },
+}
+
+/// Helper type that leaves the signed data untouched
+/// Note that deserializing doesn't verify anything
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub(super) struct PartialSignedResponse {
+    /// Signatures of the canonicalized JSON of `signed`
+    pub signatures: Vec<ResponseSignature>,
+    /// Content signed by `signature`
+    pub signed: serde_json::Value,
+}

--- a/mullvad-update/src/version/rollout.rs
+++ b/mullvad-update/src/version/rollout.rs
@@ -52,6 +52,17 @@ impl Rollout {
         let threshold = rng.random_range(SUPPORTED_VERSION.0..=FULLY_ROLLED_OUT.0);
         Self::try_from(threshold).expect("threshold is within the Rollout domain")
     }
+
+    /// A full rollout includes all users
+    pub const fn complete() -> Self {
+        FULLY_ROLLED_OUT
+    }
+}
+
+pub fn is_complete_rollout(b: impl std::borrow::Borrow<Rollout>) -> bool {
+    // TODO: do we actually need this? if so, should we bake it into Rollout::eq?
+    //(b.borrow() - complete_rollout()).abs() < f32::EPSILON
+    b.borrow() == &FULLY_ROLLED_OUT
 }
 
 impl TryFrom<f32> for Rollout {


### PR DESCRIPTION
This will be useful when we start to add `proptest` generators for ~each datatype.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9320)
<!-- Reviewable:end -->
