### PR TITLE
Update Linux repo upload script to use new user and port

### DIFF
--- a/ci/linux-repository-builder/build-linux-repositories.sh
+++ b/ci/linux-repository-builder/build-linux-repositories.sh
@@ -66,6 +66,9 @@ case "$environment" in
         ;;
 esac
 
+echo "Running against environment: $environment"
+echo "repository upload domain: $repository_server_upload_domain"
+
 inbox_dir="$LINUX_REPOSITORY_INBOX_DIR_BASE/$environment"
 
 if [[ ! -d "$inbox_dir" ]]; then
@@ -136,14 +139,14 @@ function rsync_repo {
     local local_repo_dir=$1
     local remote_repo_dir=$2
 
-    echo "Syncing to $repository_server_upload_domain:$remote_repo_dir"
+    echo "Syncing to repository-upload@$repository_server_upload_domain:$remote_repo_dir"
     # We have an issue where the rsync can fail due to the remote dir being locked (only one rsync at a time allowed)
     # We suspect this is because of too fast subsequent invocations of rsync to the same target dir. With a hacky sleep
     # we hope to avoid this issue for now.
     sleep 10
-    rsync -av --delete --mkpath --rsh='ssh -p 1122' \
+    rsync -av --delete --mkpath --rsh='ssh -p 1322' \
         "$local_repo_dir"/ \
-        build@"$repository_server_upload_domain":"$remote_repo_dir"
+        repository-upload@"$repository_server_upload_domain":"$remote_repo_dir"
 }
 
 function invalidate_bunny_cdn_cache {


### PR DESCRIPTION
The CDN servers are being upgraded to have a separate upload account for the Linux repositories. This user is available on another sshd instance on the port 1322.

The servers are at the same time restricted to only allow this SSH KEX:
```
KexAlgorithms sntrup761x25519-sha512@openssh.com
```
However, that config is not part of this repo. I'll try to update docs elsewhere to include that the build server must have this config line added locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9327)
<!-- Reviewable:end -->
