### PR TITLE
Do not use return in not a function

### DIFF
--- a/ios/relays-prebuild.sh
+++ b/ios/relays-prebuild.sh
@@ -14,7 +14,7 @@ if [ "$CONFIGURATION" == "Release" ]; then
     echo "No file found at $RELAYS_FILE"
     exit 1
   fi
-  return 0
+  exit 0
 fi
 
 BACKUP_FILE="$CONFIGURATION_TEMP_DIR/relays.json"


### PR DESCRIPTION
Fix the `relays-prebuild` script to use an exit instead of a return statement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9330)
<!-- Reviewable:end -->
