### PR TITLE
Silence CVE-2025-47913 for a year

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -162,3 +162,9 @@ reason = "wireguard-go does not use archive/tar"
 id = "CVE-2025-61724" # GO-2025-4015
 ignoreUntil = 2026-10-30
 reason = "wireguard-go does not use net/textproto"
+
+# Potential denial of service in golang.org/x/crypto/ssh/agent
+[[IgnoredVulns]]
+id = "CVE-2025-47913" # GO-2025-4116
+ignoreUntil = 2026-11-14
+reason = "wireguard-go does not use x/crypto/ssh/agent"


### PR DESCRIPTION
This PR puts CVE-2025-47913 on the `osv-scanner` ignore list for **1 year**.  `wireguard-go` does not use the library described in the CVE, so this is a nothingburger in our case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9331)
<!-- Reviewable:end -->
