### PR TITLE
Link against MullvadRustRuntime in MullvadRESTTests

### DIFF
--- a/ios/MullvadRESTTests/MullvadApiTests.swift
+++ b/ios/MullvadRESTTests/MullvadApiTests.swift
@@ -66,13 +66,8 @@ class MullvadApiTests: XCTestCase {
 
         let bodyData = try encoder.encode(expectedEndpoints)
         let body = String(data: bodyData, encoding: .utf8)!
-        let responseCode: UInt = 200
-        let mock = mullvad_api_mock_get(
-            "/app/v1/api-addrs",
-            UInt(responseCode),
-            body
-        )
-        defer { mullvad_api_mock_drop(mock) }
+
+        let mock = MullvadApiMock.get(path: "/app/v1/api-addrs", responseCode: 200, responseData: body)
         let apiProxy = try makeApiProxy(port: mock.port)
 
         let result: Result<[AnyIPEndpoint], Error> = await withCheckedContinuation { continuation in
@@ -95,12 +90,8 @@ class MullvadApiTests: XCTestCase {
 
     func testHTTPError() async throws {
         let expectedResponseCode = 500
-        let mock = mullvad_api_mock_get(
-            "/app/v1/api-addrs",
-            UInt(expectedResponseCode),
-            ""
-        )
-        defer { mullvad_api_mock_drop(mock) }
+        let mock = MullvadApiMock.get(
+            path: "/app/v1/api-addrs", responseCode: UInt(expectedResponseCode), responseData: "")
         let apiProxy = try makeApiProxy(port: mock.port)
 
         let result: Result<[AnyIPEndpoint], Error> = await withCheckedContinuation { continuation in
@@ -124,13 +115,9 @@ class MullvadApiTests: XCTestCase {
     }
 
     func testInvalidBody() async throws {
-        let expectedResponseCode = 200
-        let mock = mullvad_api_mock_get(
-            "/app/v1/api-addrs",
-            UInt(expectedResponseCode),
-            "This is an invalid JSON"
+        let mock = MullvadApiMock.get(
+            path: "/app/v1/api-addrs", responseCode: 200, responseData: "This is an invalid JSON"
         )
-        defer { mullvad_api_mock_drop(mock) }
         let apiProxy = try makeApiProxy(port: mock.port)
 
         let result: Result<[AnyIPEndpoint], Error> = await withCheckedContinuation { continuation in
@@ -156,16 +143,15 @@ class MullvadApiTests: XCTestCase {
     func testCustomErrorCode() async throws {
         let expectedResponseCode = 400
         let expectedErrorCode = 123
-        let mock = mullvad_api_mock_get(
-            "/app/v1/api-addrs",
-            UInt(expectedResponseCode),
-            """
-            {"code": "\(expectedErrorCode)",
-            "error": "A magical error occurred"
-            }
-            """
+        let mock = MullvadApiMock.get(
+            path: "/app/v1/api-addrs", responseCode: UInt(expectedResponseCode),
+            responseData:
+                """
+                {"code": "\(expectedErrorCode)",
+                "error": "A magical error occurred"
+                }
+                """
         )
-        defer { mullvad_api_mock_drop(mock) }
         let apiProxy = try makeApiProxy(port: mock.port)
 
         let result: Result<[AnyIPEndpoint], Error> = await withCheckedContinuation { continuation in
@@ -205,12 +191,8 @@ class MullvadApiTests: XCTestCase {
         // The mock server will only responde to requests with `matchBodyString` as body.
         let matchBodyString = String(data: try encoder.encode(problemReportRequest), encoding: .utf8)!
         let expectedResponseCode: UInt = 204
-        let mock = mullvad_api_mock_post(
-            "/app/v1/problem-report",
-            UInt(expectedResponseCode),
-            matchBodyString
-        )
-        defer { mullvad_api_mock_drop(mock) }
+        let mock = MullvadApiMock.post(
+            path: "/app/v1/problem-report", responseCode: expectedResponseCode, responseData: matchBodyString)
         let apiProxy = try makeApiProxy(port: mock.port)
 
         let result: Result<Void, Error> = await withCheckedContinuation { continuation in

--- a/ios/MullvadRustRuntime/MullvadAPIMock.swift
+++ b/ios/MullvadRustRuntime/MullvadAPIMock.swift
@@ -1,0 +1,36 @@
+//
+//  MullvadAPIMock.swift
+//  MullvadRustRuntime
+//
+//  Created by Marco Nikic on 2025-11-14.
+//  Copyright © 2025 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadRustRuntimeProxy
+
+public class MullvadApiMock {
+    private let mock: SwiftServerMock
+
+    public var port: UInt16 {
+        mock.port
+    }
+
+    private init(_ mock: SwiftServerMock) {
+        self.mock = mock
+    }
+
+    public static func get(path: String, responseCode: UInt, responseData: String) -> MullvadApiMock {
+        let newMock = mullvad_api_mock_get(path, responseCode, responseData)
+        return MullvadApiMock(newMock)
+    }
+
+    public static func post(path: String, responseCode: UInt, responseData: String) -> MullvadApiMock {
+        let newMock = mullvad_api_mock_post(path, responseCode, responseData)
+        return MullvadApiMock(newMock)
+    }
+
+    deinit {
+        mullvad_api_mock_drop(self.mock)
+    }
+}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -866,6 +866,8 @@
 		A9B6AC182ADE8F4300F7802A /* MigrationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6AC172ADE8F4300F7802A /* MigrationManagerTests.swift */; };
 		A9B6AC1A2ADE8FBB00F7802A /* InMemorySettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6AC192ADE8FBB00F7802A /* InMemorySettingsStore.swift */; };
 		A9B6AC1B2ADEA3AD00F7802A /* MemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BDEB9C2A98F69E00F578F2 /* MemoryCache.swift */; };
+		A9B95DED2EC73A3400C7FE9B /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
+		A9B95DEF2EC73BB800C7FE9B /* MullvadAPIMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B95DEE2EC73BB800C7FE9B /* MullvadAPIMock.swift */; };
 		A9BA08312BA32FA9005A7A2D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A92962582B1F4FDB00DFB93B /* PrivacyInfo.xcprivacy */; };
 		A9BA08322BA32FB6005A7A2D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A92962582B1F4FDB00DFB93B /* PrivacyInfo.xcprivacy */; };
 		A9BFAFFF2BD004ED00F2BCA1 /* CustomListsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BFAFFE2BD004ED00F2BCA1 /* CustomListsTests.swift */; };
@@ -2295,6 +2297,7 @@
 		A9AA56772EAF9FDB005807E4 /* ReduceAnonymityWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduceAnonymityWarningView.swift; sourceTree = "<group>"; };
 		A9B6AC172ADE8F4300F7802A /* MigrationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationManagerTests.swift; sourceTree = "<group>"; };
 		A9B6AC192ADE8FBB00F7802A /* InMemorySettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySettingsStore.swift; sourceTree = "<group>"; };
+		A9B95DEE2EC73BB800C7FE9B /* MullvadAPIMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadAPIMock.swift; sourceTree = "<group>"; };
 		A9BFAFFE2BD004ED00F2BCA1 /* CustomListsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomListsTests.swift; sourceTree = "<group>"; };
 		A9BFB0002BD00B7F00F2BCA1 /* CustomListPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomListPage.swift; sourceTree = "<group>"; };
 		A9C308392C19DDA7008715F1 /* MullvadPostQuantum+Stubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MullvadPostQuantum+Stubs.swift"; sourceTree = "<group>"; };
@@ -2622,6 +2625,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9B95DED2EC73A3400C7FE9B /* MullvadRustRuntime.framework in Frameworks */,
 				58FBFBEA291622580020E046 /* MullvadREST.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4516,6 +4520,7 @@
 				A98207F02D91A0AC00654558 /* MullvadShadowsocksBridgeProvider.swift */,
 				A98207F22D9ACE4C00654558 /* MullvadAccessMethodReceiver.swift */,
 				A97687C92DD60F36000D96E8 /* MullvadAddressCacheProvider.swift */,
+				A9B95DEE2EC73BB800C7FE9B /* MullvadAPIMock.swift */,
 			);
 			path = MullvadRustRuntime;
 			sourceTree = "<group>";
@@ -6819,6 +6824,7 @@
 				F0A89CB72D9D923300580C27 /* String+UnsafePointer.swift in Sources */,
 				A97687CA2DD60F36000D96E8 /* MullvadAddressCacheProvider.swift in Sources */,
 				A9D9A4B22C36D12D004088DD /* TunnelObfuscator.swift in Sources */,
+				A9B95DEF2EC73BB800C7FE9B /* MullvadAPIMock.swift in Sources */,
 				A98207F12D91A0AC00654558 /* MullvadShadowsocksBridgeProvider.swift in Sources */,
 				7AB931262D43D22F005FCEBA /* MullvadApiResponse.swift in Sources */,
 				A98207F32D9ACE4C00654558 /* MullvadAccessMethodReceiver.swift in Sources */,


### PR DESCRIPTION
This PR fixes the linker issue we had in our test target where we would consume `mullvad-ios` via a transient dependency (`MullvadRest`) instead of consuming `MullvadRustRuntime` directly to get FFI code from `mullvad-ios`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9333)
<!-- Reviewable:end -->
