### PR TITLE
Remove Optional display for account-token when included

### DIFF
--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
@@ -48,8 +48,10 @@ final class ProblemReportInteractor: @unchecked Sendable {
     ) {
         let logString = self.consolidatedLog.string
         let accountToken =
-            if isUserLoggedIn() && includeAccountTokenInLogs {
-                "\naccount-token: \(String(describing: tunnelManager.deviceState.accountData?.identifier))"
+            if isUserLoggedIn() && includeAccountTokenInLogs,
+                let token = tunnelManager.deviceState.accountData?.identifier
+            {
+                "\naccount-token: \(token)"
             } else { "" }
 
         if logString.isEmpty {

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController+ViewManagement.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportViewController+ViewManagement.swift
@@ -78,6 +78,11 @@ extension ProblemReportViewController {
             userPrivacyLabel.pinEdgesToSuperviewMargins(PinnableEdges([.top(0), .trailing(0), .bottom(10)]))
         }
 
+        let constraint = verticalStackView.heightAnchor.constraint(greaterThanOrEqualToConstant: 44)
+        NSLayoutConstraint.activate(
+            [constraint]
+        )
+
         self.reduceAnonymityWarningView = reduceAnonymityWarningView
 
         return verticalStackView


### PR DESCRIPTION
This PR fixes the following:
- The account token is not shown as an optional anymore when included in logs
- The minimum size of the checkbox container view is set to 44 to avoid certain layouts not looking good

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9335)
<!-- Reviewable:end -->
