### PR TITLE
Remove reference to OpenVPN in doc comment

### DIFF
--- a/mullvad-types/src/version.rs
+++ b/mullvad-types/src/version.rs
@@ -9,8 +9,8 @@ pub struct AppVersionInfo {
     /// False if Mullvad has stopped supporting the currently running version. This could mean
     /// a number of things. For example:
     /// * API endpoints it uses might not work any more.
-    /// * Software bundled with this version, such as OpenVPN or OpenSSL, has known security
-    ///   issues, so using it is no longer recommended.
+    /// * Software bundled with this version has known security issues, so using it is no longer
+    ///   recommended.
     ///
     /// The user should really upgrade when this is false.
     pub current_version_supported: bool,

--- a/talpid-routing/src/windows/get_best_default_route.rs
+++ b/talpid-routing/src/windows/get_best_default_route.rs
@@ -114,8 +114,7 @@ fn is_route_on_physical_interface(route: &MIB_IPFORWARD_ROW2) -> Result<bool> {
         return Ok(false);
     }
 
-    // OpenVPN uses interface type IF_TYPE_PROP_VIRTUAL,
-    // but tethering etc. may rely on virtual adapters too,
+    // Tethering etc. may rely on virtual adapters,
     // so we have to filter out the TAP adapter specifically.
 
     // SAFETY: We are allowed to initialize MIB_IF_ROW2 with zeroed because it is made up entirely


### PR DESCRIPTION
This PR removes some more references to OpenVPN in a doc comment. Now I can't find any more obvious occurrences of OpenVPN in the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9337)
<!-- Reviewable:end -->
