### PR TITLE
Stop cloning extra submodules in macOS workflows

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -46,11 +46,10 @@ runs:
       with:
         repo-token: ${{ inputs.protoc-token }}
 
-    - name: Checkout submodules
+    - name: Checkout Wireguard-GO submodule
       shell: bash
       run: |
         git config --global --add safe.directory '*'
-        git submodule update --init --depth=1 windows
         git submodule update --init wireguard-go-rs/libwg/wireguard-go
 
     - name: Checkout Mullvad binaries submodule
@@ -60,6 +59,14 @@ runs:
       run: |
         git config --global --add safe.directory '*'
         git submodule update --init --depth=1 dist-assets/binaries
+
+    - name: Checkout Windows libraries submodule
+      # These libraries are only required if building for Windows.
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        git config --global --add safe.directory '*'
+        git submodule update --init --depth=1 windows
 
     - name: Calculate Windows libraries cache hash
       if: runner.os == 'Windows'


### PR DESCRIPTION
Since the binaries submodule does not contain any macOS binaries since https://github.com/mullvad/mullvadvpn-app/pull/9336, we can avoid cloning the binaries for Linux and Windows in macOS workflows!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9340)
<!-- Reviewable:end -->
