### PR TITLE
Use a newer version of visual studio in CI

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -75,9 +75,9 @@ runs:
 
     - name: Install msbuild
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
       with:
-        vs-version: 16
+        vs-version: latest
 
     - name: Install latest zig
       if: runner.os == 'Windows'


### PR DESCRIPTION
Follow-up to https://github.com/mullvad/mullvadvpn-app/pull/8672, since that did not solve the Windows ARM CI problems: https://github.com/mullvad/mullvadvpn-app/actions/runs/19290019513/job/55158370658?pr=9308. This PR updates our CI to use a newer version of Visual Studio. The benefits here are two-fold as I see it:

* Windows ARM is a moving target, so I expect Microsoft to continuously fix problems with Windows ARM and Visual Studio
* We notice breaking changes to Visual Studio quicker

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9345)
<!-- Reviewable:end -->
