### PR TITLE
Add `cargo-insta` to desktop devshell

### DIFF
--- a/nix/desktop-devshell.nix
+++ b/nix/desktop-devshell.nix
@@ -5,7 +5,7 @@
 }:
 pkgs.devshell.mkShell {
   name = "mullvad-desktop-devshell";
-  packages = desktop-toolchain.packages;
+  packages = desktop-toolchain.packages ++ [ pkgs.cargo-insta ];
 
   env = import ./desktop-env.nix {
     inherit pkgs;


### PR DESCRIPTION
This PR adds the [cargo-insta](https://github.com/mitsuhiko/insta) cli to the desktop devshell. :camera_flash: :snowflake:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9348)
<!-- Reviewable:end -->
