### PR TITLE
Hide `talpid_core::ffi` in Windows firewall module

### DIFF
--- a/talpid-core/src/firewall/windows/ffi.rs
+++ b/talpid-core/src/firewall/windows/ffi.rs
@@ -1,3 +1,5 @@
+//! Misc FFI utilities.
+
 /// Creates a new result type that returns the given result variant on error.
 #[macro_export]
 macro_rules! ffi_error {

--- a/talpid-core/src/firewall/windows/mod.rs
+++ b/talpid-core/src/firewall/windows/mod.rs
@@ -14,6 +14,8 @@ use crate::dns::ResolvedDnsConfig;
 
 mod hyperv;
 mod winfw;
+#[macro_use]
+mod ffi;
 
 const HYPERV_LEAK_WARNING_MSG: &str = "Hyper-V (e.g. WSL machines) may leak in blocked states.";
 

--- a/talpid-core/src/firewall/windows/winfw/sys.rs
+++ b/talpid-core/src/firewall/windows/winfw/sys.rs
@@ -5,6 +5,7 @@ use talpid_windows::string::multibyte_to_wide;
 use windows_sys::Win32::Globalization::CP_ACP;
 
 use super::{Error, WideCString};
+use crate::ffi_error;
 
 pub const LOGGING_CONTEXT: &CStr = c"WinFw";
 

--- a/talpid-core/src/lib.rs
+++ b/talpid-core/src/lib.rs
@@ -3,11 +3,6 @@
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 
-/// Misc FFI utilities.
-#[cfg(windows)]
-#[macro_use]
-mod ffi;
-
 /// Window API wrappers and utilities
 #[cfg(target_os = "windows")]
 pub mod window;


### PR DESCRIPTION
This PR hides an implementation detail of `talpid-core` in the firewall submodule. There's no reason that it should live in `lib.rs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9351)
<!-- Reviewable:end -->
