### PR TITLE
Add `cargo deny` to devshell

### DIFF
--- a/nix/desktop-devshell.nix
+++ b/nix/desktop-devshell.nix
@@ -1,7 +1,10 @@
 { pkgs, desktop-toolchain }:
 pkgs.devshell.mkShell {
   name = "mullvad-desktop-devshell";
-  packages = desktop-toolchain.packages ++ [ pkgs.cargo-insta ];
+  packages = desktop-toolchain.packages ++ [
+    pkgs.cargo-insta
+    pkgs.cargo-deny
+  ];
 
   env = import ./desktop-env.nix {
     inherit pkgs;


### PR DESCRIPTION
This PR adds [cargo deny](https://github.com/EmbarkStudios/cargo-deny) to the desktop devshell, which is handy to debug issues when they show up in CI.

Note that we use stable nixpkgs (25.05) which packages `cargo-deny 0.18.2`. This will fail to parse our GPL3 license check atm. This has been resolved in a later version, and switching to unstable nixpkgs shipping `cargo-deny 0.18.5` works just fine. We will probably bump nixpkgs from 25.05 -> 25.11 as soon as it is released.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9356)
<!-- Reviewable:end -->
