### PR TITLE
Bump precompiled header memory allocation limit

### DIFF
--- a/build-windows-modules.sh
+++ b/build-windows-modules.sh
@@ -88,7 +88,12 @@ function build_solution_config {
     fi
 
     set -x
-    cmd.exe "/c msbuild.exe $MAX_CPU_COUNT_ARG $(to_win_path "$sln") /p:Configuration=$config /p:Platform=$platform"
+    # Note: We've seen issues in CI (Windows ARM) indicating that the amount of memory that VS is allowed to reserve
+    # for pre-compiled headers is too small. '/Zm' allow us to tweak this value. /Zm100 is the default, and the value
+    # represents a multiplier expressed in percents. That is, /Zm400 equates to 4x the amount of memory VS is allowed
+    # to reserve compared to the default value. This parameter may be subject to tweaking if the issue persists.
+    # /Zm200 was not enough from our empirical testing, so /Zm400 was semi-arbitrarily chosen for now.
+    cmd.exe "/c msbuild.exe $MAX_CPU_COUNT_ARG $(to_win_path "$sln") /p:Configuration=$config /p:Platform=$platform /p:AdditionalOptions=/Zm400"
     set +x
 }
 


### PR DESCRIPTION
Another follow-up to https://github.com/mullvad/mullvadvpn-app/pull/8672. The GitHub hosted runners do have 16GB ram, which should be plenty to compile our Windows modules. This change allow VS to reserve more memory for pre-compiled headers, which the error messages suggest is a problem atm. :crossed_fingers:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9357)
<!-- Reviewable:end -->
