### PR TITLE
Don't create IPv6 routes without in-tunnel IPv6 on Android

### DIFF
--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -687,7 +687,13 @@ pub fn get_tunnel_for_userspace(
     // Route everything into the tunnel and have WireGuard act as a firewall when
     // blocking. These will not necessarily be the actual routes used by android. Those will
     // be generated at a later stage e.g. if Local Network Sharing is enabled.
-    tun_config.routes = vec!["0.0.0.0/0".parse().unwrap(), "::/0".parse().unwrap()];
+    // If IPv6 is not enabled in the tunnel we should not route IPv6 traffic as this
+    // leads to leaks.
+    tun_config.routes = if config.ipv6_gateway.is_some() {
+        vec!["0.0.0.0/0".parse().unwrap(), "::/0".parse().unwrap()]
+    } else {
+        vec!["0.0.0.0/0".parse().unwrap()]
+    };
 
     const MAX_PREPARE_TUN_ATTEMPTS: usize = 4;
 


### PR DESCRIPTION
By creating IPv6 routes, and NOT assigning an IPv6 address to the TUN device, IPv6-traffic would leak outside the tunnel.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9360)
<!-- Reviewable:end -->
