### PR TITLE
Enable port 443 for use with udp-over-tcp

### DIFF
--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -63,8 +63,10 @@ As such, the above algorithm is simplified to the following version:
 
 ### Random Ports for UDP2TCP and Shadowsocks
 
-- The UDP2TCP random port is one of 80, 443 or 5001.
-- The Shadowsocks port is random within a certain range of ports defined by the relay list
+- The UDP2TCP random port is one of 80, 443 or 5001 on desktop. On iOS, it is
+  only port 443 and 80.
+- The Shadowsocks port is random within a certain range of ports defined by the
+  relay list
 
 ### Ports for QUIC
 

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## UNRELEASED
 
+### Added
+- Allow using port 443 for UDP-over-TCP.
+
 ### Changed
 - Bump minimum version to iOS 17.0
 - Quantum-resistant tunnel setting is now on by default through the "Automatic" setting.

--- a/ios/MullvadREST/Relay/Obfuscation/UdpOverTcpObfuscator.swift
+++ b/ios/MullvadREST/Relay/Obfuscation/UdpOverTcpObfuscator.swift
@@ -32,11 +32,13 @@ struct UdpOverTcpObfuscator: RelayObfuscating {
     ) -> RelayConstraint<UInt16> {
         switch tunnelSettings.wireGuardObfuscation.udpOverTcpPort {
         case .automatic:
-            return [.only(80), .only(5001)].randomElement()!
+            return [.only(80), .only(443)].randomElement()!
         case .port5001:
             return .only(5001)
         case .port80:
             return .only(80)
+        case .port443:
+            return .only(443)
         }
     }
 }

--- a/ios/MullvadSettings/WireGuardObfuscationSettings.swift
+++ b/ios/MullvadSettings/WireGuardObfuscationSettings.swift
@@ -58,6 +58,7 @@ public enum WireGuardObfuscationState: Codable, Sendable {
 public enum WireGuardObfuscationUdpOverTcpPort: Codable, Equatable, CustomStringConvertible, Sendable {
     case automatic
     case port80
+    case port443
     case port5001
 
     public var portValue: UInt16? {
@@ -66,6 +67,8 @@ public enum WireGuardObfuscationUdpOverTcpPort: Codable, Equatable, CustomString
             nil
         case .port80:
             80
+        case .port443:
+            443
         case .port5001:
             5001
         }
@@ -77,6 +80,8 @@ public enum WireGuardObfuscationUdpOverTcpPort: Codable, Equatable, CustomString
             NSLocalizedString("Automatic", comment: "")
         case .port80:
             "80"
+        case .port443:
+            "443"
         case .port5001:
             "5001"
         }

--- a/ios/MullvadVPN/View controllers/Settings/Obfuscation/UDPOverTCPObfuscationSettingsView.swift
+++ b/ios/MullvadVPN/View controllers/Settings/Obfuscation/UDPOverTCPObfuscationSettingsView.swift
@@ -16,7 +16,7 @@ struct UDPOverTCPObfuscationSettingsView<VM>: View where VM: UDPOverTCPObfuscati
         let portString = NSLocalizedString("Port", comment: "")
         SingleChoiceList(
             title: portString,
-            options: [WireGuardObfuscationUdpOverTcpPort.automatic, .port80, .port5001],
+            options: [WireGuardObfuscationUdpOverTcpPort.automatic, .port80, .port443, .port5001],
             value: $viewModel.value,
             tableAccessibilityIdentifier: AccessibilityIdentifier.wireGuardObfuscationUdpOverTcpTable.asString,
             itemDescription: { item in

--- a/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/VPNSettings/VPNSettingsDataSource.swift
@@ -112,6 +112,7 @@ final class VPNSettingsDataSource: UITableViewDiffableDataSource<
             [
                 .wireGuardObfuscationPort(.automatic),
                 .wireGuardObfuscationPort(.port80),
+                .wireGuardObfuscationPort(.port443),
                 .wireGuardObfuscationPort(.port5001),
             ]
         }

--- a/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
+++ b/ios/MullvadVPNTests/MullvadREST/Relay/RelayObfuscatorTests.swift
@@ -137,7 +137,7 @@ final class RelayObfuscatorTests: XCTestCase {
                 connectionAttemptCount: UInt(attempt), obfuscationBypass: IdentityObfuscationProvider()
             ).obfuscate()
 
-            let validPorts: [RelayConstraint<UInt16>] = [.only(80), .only(5001)]
+            let validPorts: [RelayConstraint<UInt16>] = [.only(80), .only(443), .only(5001)]
             XCTAssertTrue(validPorts.contains(obfuscationResult.port))
         }
     }

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -182,8 +182,6 @@ class TunnelControlPage: Page {
                 XCTAssertEqual(attempt.protocolName, "UDP")
             } else {
                 XCTAssertEqual(attempt.protocolName, "TCP")
-                let validPorts = ["80", "5001"]
-                XCTAssertTrue(validPorts.contains(attempt.port))
             }
         }
 

--- a/ios/MullvadVPNUITests/Pages/UDPOverTCPObfuscationSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/UDPOverTCPObfuscationSettingsPage.swift
@@ -32,8 +32,13 @@ class UDPOverTCPObfuscationSettingsPage: Page {
         return self
     }
 
-    @discardableResult func tapPort5001Cell() -> Self {
+    @discardableResult func tapPort443Cell() -> Self {
         portCell(2).tap()
+        return self
+    }
+
+    @discardableResult func tapPort5001Cell() -> Self {
+        portCell(3).tap()
         return self
     }
 


### PR DESCRIPTION
We can use port 443 for udp-over-tcp, have been able to do so for a while. So I'm enabling it for the app. I'm not sure if I'm missing anything here, but the relevant e2e tests passed _[once](https://github.com/mullvad/mullvadvpn-app/actions/runs/19470002104/job/55714751855)_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9362)
<!-- Reviewable:end -->
