### PR TITLE
Improve wait times for UI tests

### DIFF
--- a/ios/MullvadVPNUITests/Pages/AccountPage.swift
+++ b/ios/MullvadVPNUITests/Pages/AccountPage.swift
@@ -78,7 +78,7 @@ class AccountPage: Page {
 
     func waitForLogoutSpinnerToDisappear() {
         let spinnerDisappeared = app.otherElements[.logOutSpinnerAlertView]
-            .waitForNonExistence(timeout: BaseUITestCase.extremelyLongTimeout)
+            .notExistsAfterWait(timeout: .extremelyLong)
         XCTAssertTrue(spinnerDisappeared, "Log out spinner disappeared")
     }
 }

--- a/ios/MullvadVPNUITests/Pages/AddAccessMethodPage.swift
+++ b/ios/MullvadVPNUITests/Pages/AddAccessMethodPage.swift
@@ -65,7 +65,7 @@ class AddAccessMethodPage: Page {
     @discardableResult func waitForAPIUnreachableLabel() -> Self {
         XCTAssertTrue(
             app.staticTexts[AccessibilityIdentifier.addAccessMethodTestStatusUnreachableLabel]
-                .waitForExistence(timeout: BaseUITestCase.longTimeout)
+                .existsAfterWait(timeout: .long)
         )
         return self
     }

--- a/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
+++ b/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
@@ -25,7 +25,7 @@ class DeviceManagementPage: Page {
     @discardableResult func waitForNoLoading() -> Self {
         XCTAssertTrue(
             app.otherElements[.deviceRemovalProgressView]
-                .waitForNonExistence(timeout: BaseUITestCase.longTimeout)
+                .notExistsAfterWait(timeout: .long)
         )
 
         return self
@@ -35,7 +35,7 @@ class DeviceManagementPage: Page {
         XCTAssertTrue(
             app
                 .collectionViews[AccessibilityIdentifier.deviceManagementView]
-                .waitForExistence(timeout: BaseUITestCase.longTimeout)
+                .existsAfterWait(timeout: .long)
         )
 
         return self
@@ -58,7 +58,7 @@ class DeviceManagementPage: Page {
     @discardableResult public func verifyCurrentDeviceExists() -> Self {
         XCTAssertTrue(
             app.staticTexts["Current device"]
-                .waitForExistence(timeout: BaseUITestCase.defaultTimeout)
+                .existsAfterWait()
         )
 
         return self

--- a/ios/MullvadVPNUITests/Pages/EditAccessMethodPage.swift
+++ b/ios/MullvadVPNUITests/Pages/EditAccessMethodPage.swift
@@ -38,11 +38,11 @@ class EditAccessMethodPage: Page {
     @discardableResult func verifyTestStatus(_ status: TestStatus) -> Self {
         switch status {
         case .reachable:
-            XCTAssertTrue(app.staticTexts["API reachable"].waitForExistence(timeout: BaseUITestCase.longTimeout))
+            XCTAssertTrue(app.staticTexts["API reachable"].existsAfterWait(timeout: .long))
         case .unreachable:
-            XCTAssertTrue(app.staticTexts["API unreachable"].waitForExistence(timeout: BaseUITestCase.longTimeout))
+            XCTAssertTrue(app.staticTexts["API unreachable"].existsAfterWait(timeout: .long))
         case .testing:
-            XCTAssertTrue(app.staticTexts["Testing..."].waitForExistence(timeout: BaseUITestCase.longTimeout))
+            XCTAssertTrue(app.staticTexts["Testing..."].existsAfterWait(timeout: .long))
         }
 
         return self

--- a/ios/MullvadVPNUITests/Pages/HeaderBar.swift
+++ b/ios/MullvadVPNUITests/Pages/HeaderBar.swift
@@ -33,7 +33,8 @@ class HeaderBar: Page {
     @discardableResult public func verifyDeviceLabelShown() -> Self {
         XCTAssertTrue(
             app.staticTexts[AccessibilityIdentifier.headerDeviceNameLabel]
-                .waitForExistence(timeout: BaseUITestCase.defaultTimeout), "Device name displayed in header"
+                .existsAfterWait(),
+            "Device name displayed in header"
         )
 
         return self

--- a/ios/MullvadVPNUITests/Pages/LoginPage.swift
+++ b/ios/MullvadVPNUITests/Pages/LoginPage.swift
@@ -24,7 +24,7 @@ class LoginPage: Page {
 
     @discardableResult public func waitForAccountNumberSubmitButton() -> Self {
         let submitButtonExist = app.buttons[AccessibilityIdentifier.loginTextFieldButton]
-            .waitForExistence(timeout: BaseUITestCase.defaultTimeout)
+            .existsAfterWait()
         XCTAssertTrue(submitButtonExist, "Account number submit button shown")
         return self
     }
@@ -55,33 +55,13 @@ class LoginPage: Page {
     @discardableResult public func verifyFailIconShown() -> Self {
         let predicate = NSPredicate(format: "identifier == 'statusImageView' AND value == 'fail'")
         let elementQuery = app.images.containing(predicate)
-        let elementExists = elementQuery.firstMatch.waitForExistence(timeout: BaseUITestCase.veryLongTimeout)
+        let elementExists = elementQuery.firstMatch.existsAfterWait(timeout: .veryLong)
         XCTAssertTrue(elementExists, "Fail icon shown")
         return self
     }
 
     /// Checks whether success icon is being shown
     func getSuccessIconShown() -> Bool {
-        // Success icon is only shown very briefly, since another view is presented after success icon is shown.
-        // Therefore we need to poll faster than waitForElement function.
-        let successIconDisplayedExpectation = XCTestExpectation(description: "Success icon shown")
-        nonisolated(unsafe) var isShown = false
-        let timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [self] _ in
-            DispatchQueue.main.async {
-                let statusImageView = self.app.images[.statusImageView]
-
-                if statusImageView.exists {
-                    if statusImageView.value as? String == "success" {
-                        isShown = true
-                        successIconDisplayedExpectation.fulfill()
-                    }
-                }
-            }
-        }
-
-        _ = XCTWaiter.wait(for: [successIconDisplayedExpectation], timeout: BaseUITestCase.longTimeout)
-        timer.invalidate()
-
-        return isShown
+        app.images[.statusImageView].existsAfterWait(timeout: .long)
     }
 }

--- a/ios/MullvadVPNUITests/Pages/Page.swift
+++ b/ios/MullvadVPNUITests/Pages/Page.swift
@@ -23,7 +23,7 @@ class Page {
     func waitForPageToBeShown() {
         if let pageElement {
             XCTAssertTrue(
-                pageElement.waitForExistence(timeout: BaseUITestCase.defaultTimeout),
+                pageElement.existsAfterWait(),
                 "Page is shown"
             )
         }

--- a/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
+++ b/ios/MullvadVPNUITests/Pages/SelectLocationPage.swift
@@ -27,6 +27,7 @@ class SelectLocationPage: Page {
         let cell = app.buttons[AccessibilityIdentifier.locationListItem(name)]
         let expandButton = cell.buttons[AccessibilityIdentifier.expandButton]
         expandButton.tap()
+
         return self
     }
 

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -114,7 +114,7 @@ class TunnelControlPage: Page {
 
     @discardableResult func waitForConnectedLabel() -> Self {
         let labelFound = app.staticTexts[.connectionStatusConnectedLabel]
-            .waitForExistence(timeout: BaseUITestCase.extremelyLongTimeout)
+            .existsAfterWait(timeout: .extremelyLong)
         XCTAssertTrue(labelFound, "Secure connection label presented")
 
         return self
@@ -122,9 +122,7 @@ class TunnelControlPage: Page {
 
     @discardableResult func tapRelayStatusExpandCollapseButton() -> Self {
         let button = app.buttons[AccessibilityIdentifier.relayStatusCollapseButton]
-
-        _ = button.waitForExistence(timeout: BaseUITestCase.defaultTimeout)
-        button.tap()
+        button.tapWhenHittable()
 
         return self
     }

--- a/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
+++ b/ios/MullvadVPNUITests/Pages/VPNSettingsPage.swift
@@ -32,8 +32,7 @@ class VPNSettingsPage: Page {
         let expandButton = matchingCells.buttons[.expandButton]
         let lastCell = tableView.cells.allElementsBoundByIndex.last!
         tableView.scrollDownToElement(element: lastCell)
-        _ = expandButton.waitForExistence(timeout: BaseUITestCase.defaultTimeout)
-        return expandButton
+        return expandButton.wait()
     }
 
     private func cellPortSelectorButton(_ cellAccessiblityIdentifier: AccessibilityIdentifier) -> XCUIElement {

--- a/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
+++ b/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
@@ -9,14 +9,6 @@
 import XCTest
 
 extension XCUIElement {
-    func waitForNonExistence(timeout: TimeInterval) -> Bool {
-        let predicate = NSPredicate(format: "exists == FALSE")
-        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
-
-        _ = XCTWaiter().wait(for: [expectation], timeout: timeout)
-        return !exists
-    }
-
     func scrollDownToElement(element: XCUIElement, maxScrolls: UInt = 5) {
         var count = 0
         while !element.isVisible && count < maxScrolls {
@@ -36,5 +28,192 @@ extension XCUIElement {
     var isVisible: Bool {
         guard self.exists && !self.frame.isEmpty else { return false }
         return XCUIApplication().windows.element(boundBy: 0).frame.contains(self.frame)
+    }
+
+    /// Waits for element to exist and returns true if it does so within the specified time frame.
+    /// - Parameters:
+    ///     - timeout: Waiting time. Defaults to `Timeout.default`.
+    ///     - description: String describing the reason for waiting.
+    func existsAfterWait(
+        timeout: Timeout = .default,
+        description: String? = nil
+    ) -> Bool {
+        wait(
+            for: .exists,
+            timeout: timeout,
+            failOnUnmetCondition: false,
+            description: description
+        ).exists
+    }
+
+    /// Waits for element to not exist and returns true if it doesn't within the specified time frame.
+    /// - Parameters:
+    ///     - timeout: Waiting time. Defaults to `Timeout.default`.
+    ///     - description: String describing the reason for waiting.
+    func notExistsAfterWait(
+        timeout: Timeout = .default,
+        description: String? = nil
+    ) -> Bool {
+        !wait(
+            for: .notExists,
+            timeout: timeout,
+            failOnUnmetCondition: false,
+            description: description
+        ).exists
+    }
+
+    /// Waits for element to meet a certain condition within the specified time frame.
+    /// - Parameters:
+    ///     - condition: The condition to wait for. Defaults to `Condition.exists`.
+    ///     - timeout: Waiting time. Defaults to `Timeout.default`.
+    ///     - failOnUnmetCondition: If true, fails the test if the condition is not met.
+    ///     - description: String describing the reason for waiting.
+    /// - Note: It's preferred to use `existsAfterWait()`, `notExistsAfterWait()` or `tapWhenHittable()`
+    /// to handle those respective specific scenarios.
+    @discardableResult
+    func wait(
+        for condition: Condition = .exists,
+        timeout: Timeout = .default,
+        failOnUnmetCondition: Bool = true,
+        description: String? = nil
+    ) -> Self {
+        let conditionMet = XCUIElement.wait(
+            for: {
+                switch condition {
+                case .exists:
+                    self.exists
+                case .notExists:
+                    !self.exists
+                case .hittable:
+                    self.isHittable
+                }
+            },
+            timeout: timeout,
+            description: description
+        )
+
+        if !conditionMet && failOnUnmetCondition {
+            XCTFail(description ?? "Element failed to meet condition '\(condition)'")
+        }
+
+        return self
+    }
+
+    /// Waits for element to be hittable and, if successful, taps it.
+    /// - Parameters:
+    ///     - timeout: Waiting time. Defaults to `Timeout.default`.
+    ///     - failOnUnmetCondition: If true, fails the test if the condition is not met.
+    ///     - description: String describing the reason for waiting.
+    @discardableResult
+    func tapWhenHittable(
+        timeout: Timeout = .default,
+        failOnUnmetCondition: Bool = true,
+        description: String? = nil
+    ) -> Self {
+        if wait(
+            for: .hittable,
+            timeout: timeout,
+            failOnUnmetCondition: failOnUnmetCondition,
+            description: description
+        ).isHittable {
+            tap()
+        } else if failOnUnmetCondition {
+            XCTFail(description ?? "Failed to tap element after timeout")
+        }
+
+        return self
+    }
+}
+
+// Borrowed and adapted from https://eng.wealthfront.com/2025/03/17/how-we-sped-up-ios-end-to-end-tests-by-over-50-with-40-lines-of-code/.
+extension XCUIElement {
+    enum Condition {
+        case exists
+        case notExists
+        case hittable
+    }
+
+    enum Timeout: TimeInterval {
+        case short = 1
+        case `default` = 5
+        case long = 15
+        case veryLong = 20
+        case extremelyLong = 180
+    }
+
+    private struct PredicatePollerDefaults {
+        static let pollInterval: TimeInterval = 0.2
+        static let maxIterations: Int = 100
+    }
+
+    // This function actively polls the hierarchy on a set interval. This speeds up the waiting process
+    // siginificantly by returning much sooner than the default system `waitForExistence()` function.
+    @discardableResult
+    private static func wait(
+        for condition: @escaping () -> Bool,
+        timeout: Timeout = .default,
+        failureMessage: String = "Condition not met",
+        description: String? = nil
+    ) -> Bool {
+        if condition() {
+            return true
+        }
+
+        let timeoutDate = Date().addingTimeInterval(timeout.rawValue)
+        let expectation = XCTestExpectation(description: description ?? "Waiting for condition to be met")
+        var iterationCount = 0
+
+        while Date() < timeoutDate {
+            iterationCount += 1
+            if iterationCount > PredicatePollerDefaults.maxIterations {
+                return false
+            }
+
+            if condition() {
+                expectation.fulfill()
+                return true
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(PredicatePollerDefaults.pollInterval))
+        }
+
+        return false
+    }
+}
+
+extension XCUIElement {
+    @available(*, deprecated, message: "Use wait(for:timeout:failOnUnmetCondition:description)")
+    func waitForExistence(timeout: TimeInterval) -> Bool {
+        existsAfterWait(timeout: Timeout(rawValue: timeout) ?? .default)
+    }
+
+    @available(*, deprecated, message: "Use wait(for:timeout:failOnUnmetCondition:description)")
+    func waitForNonExistence(timeout: TimeInterval) -> Bool {
+        notExistsAfterWait(timeout: Timeout(rawValue: timeout) ?? .default)
+    }
+
+    @available(*, deprecated, message: "Use wait(for:timeout:failOnUnmetCondition:description)")
+    func wait<V>(for keyPath: KeyPath<XCUIElement, V>, toEqual expectedValue: V, timeout: TimeInterval) -> Bool
+    where V: Equatable {
+        let timeout = Timeout(rawValue: timeout) ?? .default
+
+        do {
+            return switch keyPath {
+            case \.exists:
+                if try XCTUnwrap(expectedValue as? Bool) == true {
+                    existsAfterWait(timeout: timeout)
+                } else {
+                    notExistsAfterWait(timeout: timeout)
+                }
+            case \.isHittable:
+                wait(for: .hittable, timeout: timeout).isHittable
+            default:
+                throw NSError()
+            }
+        } catch {
+            XCTFail("Could not map KeyPath to Condition")
+        }
+
+        return false
     }
 }


### PR DESCRIPTION
**Why this needs to be done**

We want to try the approach described in the [wealthfront blog](https://eng.wealthfront.com/2025/03/17/how-we-sped-up-ios-end-to-end-tests-by-over-50-with-40-lines-of-code/) to speed up our UITests runtime execution

**How do we implement this feature?**

See [wealthfront blog](https://eng.wealthfront.com/2025/03/17/how-we-sped-up-ios-end-to-end-tests-by-over-50-with-40-lines-of-code/) 

**Acceptance criteria**

- Run tests with and without the new approach and document the outcome.
- The new approach should be faster than the old.
- General testing stability should not be degraded.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9372)
<!-- Reviewable:end -->
