### PR TITLE
Remove PQ migration logic from 12->13 migration

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -71,9 +71,6 @@ pub enum Error {
     #[error("Unexpected settings format")]
     InvalidSettingsContent,
 
-    #[error("Missing setting {0}")]
-    MissingKey(&'static str),
-
     #[error("Unable to serialize settings to JSON")]
     Serialize(#[source] serde_json::Error),
 

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v12_to_v13_migration.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v12__test__v12_to_v13_migration.snap
@@ -56,7 +56,7 @@ expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
   "settings_version": 13,
   "tunnel_options": {
     "wireguard": {
-      "quantum_resistant": "on"
+      "quantum_resistant": "auto"
     }
   }
 }

--- a/mullvad-daemon/src/migrations/v12.rs
+++ b/mullvad-daemon/src/migrations/v12.rs
@@ -1,8 +1,9 @@
-use super::{Error, Result};
+use super::Result;
 use mullvad_types::settings::SettingsVersion;
 
+/// NOTE: This migration has been closed.
+///
 /// This migration handles:
-/// - Removing the Automatic option from the quantum resistance setting. The default is now "On".
 /// - Introduces 2 new fields to the [mullvad_constraints::WireguardConstraints] struct:
 ///   pub entry_providers: Constraint<Providers>,
 ///   pub entry_ownership: Constraint<Ownership>,
@@ -16,7 +17,6 @@ pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
 
     log::info!("Migrating settings format to V13");
 
-    migrate_quantum_resistance(settings)?;
     migrate_filters_to_new_entry_only_filters(settings);
 
     settings["settings_version"] = serde_json::json!(SettingsVersion::V13);
@@ -44,43 +44,9 @@ fn migrate_filters_to_new_entry_only_filters(settings: &mut serde_json::Value) -
     Some(())
 }
 
-/// Map "quantum_resistant": "auto" -> "quantum_resistant": "on".
-fn migrate_quantum_resistance(settings: &mut serde_json::Value) -> Result<()> {
-    use serde_json::Value;
-    // settings.tunnel_options.wireguard
-    fn wg(settings: &mut Value) -> Result<&mut Value> {
-        settings
-            .as_object_mut()
-            .ok_or(Error::InvalidSettingsContent)?
-            .get_mut("tunnel_options")
-            .ok_or(Error::MissingKey("'tunnel_options' missing"))?
-            .get_mut("wireguard")
-            .ok_or(Error::MissingKey("'wireguard' missing"))
-    }
-    let wg = wg(settings)?;
-    match wg.get_mut("quantum_resistant") {
-        Some(quantum_resistance) => {
-            if quantum_resistance == "auto" {
-                *quantum_resistance = "on".into();
-            }
-        }
-        None => {
-            // Believe it or not, the PQ setting is not guaranteed to exist coming from an earlier
-            // settings version, because it was never added through a settings migration!
-            // I'll go ahead and fix that right here, but going forward we should be more cautious
-            // about *not* adding certain settings via migrations. Not doing so means that we rely on
-            // the implemenation of Settings::default to fill in all the missing details, which might
-            // be ok..
-            wg["quantum_resistant"] = "on".into();
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde_json::json;
 
     const V12_SETTINGS: &str = r#"
 {
@@ -141,33 +107,5 @@ mod test {
         migrate(&mut old_settings)?;
         insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
         Ok(())
-    }
-
-    /// quantum resistant setting is migrated from auto to on.
-    #[test]
-    fn test_v11_to_v12_migration_pq_auto_to_on() {
-        let mut old_settings = json!({
-            "tunnel_options": {
-              "wireguard": {
-                "quantum_resistant": "auto"
-              }
-            }
-        });
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
-        migrate_quantum_resistance(&mut old_settings).unwrap();
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
-    }
-
-    /// quantum resistant setting is set to on if it does not exist.
-    #[test]
-    fn test_v11_to_v12_migration_pq_default_to_on() {
-        let mut old_settings = json!({
-            "tunnel_options": {
-              "wireguard": { }
-            }
-        });
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
-        migrate_quantum_resistance(&mut old_settings).unwrap();
-        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
     }
 }


### PR DESCRIPTION
Title. This will be submitted as a new migration. Marking the current latest migration as closed because Android already cut a release with it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9384)
<!-- Reviewable:end -->
