### PR TITLE
Ignore new GO-2025-413x cves `(libwg/wireguard-go)`

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -169,6 +169,12 @@ id = "CVE-2025-47913" # GO-2025-4116
 ignoreUntil = 2026-11-14
 reason = "wireguard-go does not use x/crypto/ssh/agent"
 
+# golang.org/x/crypto/ssh allows an attacker to cause unbounded memory consumption
+[[IgnoredVulns]]
+id = "CVE-2025-58181 " # GO-2025-4134
+ignoreUntil = 2026-11-21
+reason = "wireguard-go does not use x/crypto/ssh"
+
 # golang.org/x/crypto/ssh/agent vulnerable to panic if message is malformed due to out of bounds read
 [[IgnoredVulns]]
 id = "CVE-2025-47914 " # GO-2025-4135


### PR DESCRIPTION
A bunch of new CVEs against the Go stdlib just dropped. Again. 🔥

groups.google.com/g/golang-announce/c/w-oX3UxNcZA

I iterated them, and it turns out that neither libwg nor wireguard-go are affected by any of these CVEs. As such, I added them to the osv-scanner ignore list for 1 year.

Edit: [gotatun](https://github.com/mullvad/gotatun) save us :pray:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9390)
<!-- Reviewable:end -->
