### PR TITLE
Fix osv-scanner config by removing extra whitespace

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -171,12 +171,12 @@ reason = "wireguard-go does not use x/crypto/ssh/agent"
 
 # golang.org/x/crypto/ssh allows an attacker to cause unbounded memory consumption
 [[IgnoredVulns]]
-id = "CVE-2025-58181 " # GO-2025-4134
+id = "CVE-2025-58181" # GO-2025-4134
 ignoreUntil = 2026-11-21
 reason = "wireguard-go does not use x/crypto/ssh"
 
 # golang.org/x/crypto/ssh/agent vulnerable to panic if message is malformed due to out of bounds read
 [[IgnoredVulns]]
-id = "CVE-2025-47914 " # GO-2025-4135
+id = "CVE-2025-47914" # GO-2025-4135
 ignoreUntil = 2026-11-21
 reason = "wireguard-go does not use x/crypto/ssh/agent"


### PR DESCRIPTION
https://github.com/mullvad/mullvadvpn-app/pull/9390 ignored some new CVEs, but snuck in some extra whitspace in the ID field. `osv-scanner` is not robust enough to handle this (fair enough), so we'll have to trim the IDs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9396)
<!-- Reviewable:end -->
