### PR TITLE
Add support for Wayland under GNOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Line wrap the file at 100 chars.                                              Th
 ## [Unreleased]
 ### Added
 - Add port 443 to list of valid UDP2TCP ports.
+- Support GNOME as a Wayland compositor.
 
 
 ## [2025.14-beta1] - 2025-11-11

--- a/dist-assets/linux/mullvad-gui-launcher.sh
+++ b/dist-assets/linux/mullvad-gui-launcher.sh
@@ -8,7 +8,7 @@ else
     SANDBOX_FLAG=""
 fi
 
-SUPPORTED_COMPOSITORS="sway river Hyprland niri"
+SUPPORTED_COMPOSITORS="sway river Hyprland niri GNOME"
 if [ "${XDG_SESSION_TYPE:-""}"  = "wayland" ] && \
     echo " $SUPPORTED_COMPOSITORS " | \
     grep -qi -e " ${XDG_CURRENT_DESKTOP:-""} " -e " ${XDG_SESSION_DESKTOP:-""} "


### PR DESCRIPTION
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change
-->

Currently, the Linux desktop app is [hard-coded to only support four compositors under Wayland](https://github.com/mullvad/mullvadvpn-app/blob/main/dist-assets/linux/mullvad-gui-launcher.sh#L11): `sway river Hyprland niri`. 

There was some discussion about removing the `XDG_CURRENT_DESKTOP` check entirely last May (#6284), but I think the devs prefer to only support compositors they know function well under Wayland.

For what it's worth, with the appropriate runtime arguments `mullvad-gui` works fine for me on GNOME 49, while under `xwayland` it doesn't respect my display scaling settings. Also GNOME 49+ do not support X11 sessions.

This PR adds support for GNOME as a Wayland compositor. I'd be happy to help stress test more rigorously if there's a procedure for that.

Related:
- #8409 
- #8953 
- #4772

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9404)
<!-- Reviewable:end -->
