### PR TITLE
Patch `RUSTSEC-2025-0126`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "nftnl"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be089a98a3f53ef44cd2359d074b421d6ab7f42b117d586c5adb36bdeb82b01b"
+checksum = "e65c1365321c197bc2c7b3c858d87ad9db235632622278f19a2eff0de704b968"
 dependencies = [
  "bitflags 2.9.0",
  "log",

--- a/ci/ios/test-router/raas/Cargo.lock
+++ b/ci/ios/test-router/raas/Cargo.lock
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "nftnl"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a7491dd91b71643f65546389f25506da70723d1f1ec8c8d6d20444d1c23f27"
+checksum = "e65c1365321c197bc2c7b3c858d87ad9db235632622278f19a2eff0de704b968"
 dependencies = [
  "bitflags 2.9.0",
  "log",

--- a/ci/ios/test-router/raas/Cargo.toml
+++ b/ci/ios/test-router/raas/Cargo.toml
@@ -7,7 +7,7 @@ description = "RaaS stands for Router as a Service"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nftnl = { version = "0.7", features = ["nftnl-1-1-0"] }
+nftnl = { version = "0.9", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2", features = ["mnl-1-0-4"] }
 once_cell = "1"
 log = "0.4"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -35,7 +35,7 @@ jnix = { version = "0.5.1", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true, features = ["mount"] }
-nftnl = { version = "0.8.0", features = ["nftnl-1-1-0"] }
+nftnl = { version = "0.9.0", features = ["nftnl-1-1-0"] }
 mnl = { version = "0.2.3", features = ["mnl-1-0-4"] }
 talpid-dbus = { path = "../talpid-dbus" }
 


### PR DESCRIPTION
Bump `nftnl` to 0.9.0 which includes a fix for https://osv.dev/vulnerability/GHSA-2fjw-whxm-9v4q.

`nftnl-rs` changelog: https://github.com/mullvad/nftnl-rs/blob/v0.9.0/CHANGELOG.md#090---2025-11-26

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9417)
<!-- Reviewable:end -->
