### PR TITLE
Make testCreateAccount work when the app is not a fresh install

### DIFF
--- a/ios/MullvadVPNUITests/AccountTests.swift
+++ b/ios/MullvadVPNUITests/AccountTests.swift
@@ -18,6 +18,7 @@ class AccountTests: LoggedOutUITestCase {
     func testCreateAccount() throws {
         LoginPage(app)
             .tapCreateAccountButton()
+            .tryConfirmAccountCreation()
 
         // Verify welcome page is shown and get account number from it
         let accountNumber = WelcomePage(app).getAccountNumber()

--- a/ios/MullvadVPNUITests/Pages/LoginPage.swift
+++ b/ios/MullvadVPNUITests/Pages/LoginPage.swift
@@ -52,6 +52,13 @@ class LoginPage: Page {
         return self
     }
 
+    @discardableResult public func tryConfirmAccountCreation() -> Self {
+        if app.buttons[AccessibilityIdentifier.createAccountConfirmationButton].existsAfterWait(timeout: .short) {
+            return confirmAccountCreation()
+        }
+        return self
+    }
+
     @discardableResult public func verifyFailIconShown() -> Self {
         let predicate = NSPredicate(format: "identifier == 'statusImageView' AND value == 'fail'")
         let elementQuery = app.images.containing(predicate)


### PR DESCRIPTION
This is a small PR to make sure that `testCreateAccount` always works whether a previous run ended in a success or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9422)
<!-- Reviewable:end -->
