### PR TITLE
Remove duplicate `cargo build` invocation in build-rust-library.sh

### DIFF
--- a/ios/build-rust-library.sh
+++ b/ios/build-rust-library.sh
@@ -50,7 +50,6 @@ for arch in $ARCHS; do
     case "$arch" in
         arm64)
             "$HOME"/.cargo/bin/cargo build $LOCKEDFLAG -p "$FFI_TARGET" --lib $RELFLAG --target $TARGET ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
-            "$HOME"/.cargo/bin/cargo build $LOCKEDFLAG -p "$FFI_TARGET" --lib --target $TARGET ${FEATURE_FLAGS:+--features "$FEATURE_FLAGS"}
             ;;
     esac
 done


### PR DESCRIPTION
We have invoked cargo twice since the first version of this script. From the start this was needed because *something* failed otherwise. I don't think we ever figured out what or why. Here I try to challenge this, since a lot of time passed. It would be great if we could get away with not building twice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9427)
<!-- Reviewable:end -->
