### PR TITLE
Move "Time left" label fix to unreleased section in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Fixed
+- Fix "Time left" label in main view not updating when time passes.
 
 
 ## [2025.14-beta2] - 2025-11-26
@@ -32,9 +34,6 @@ Line wrap the file at 100 chars.                                              Th
 - Fix issues where the in-app updates view is not in sync with the daemon after system is suspended
   or daemon is restarted.
 
-
-### Fixed
-- Fix "Time left" label in main view not updating when time passes.
 
 ## [2025.14-beta1] - 2025-11-11
 ### Changed


### PR DESCRIPTION
Fix https://github.com/mullvad/mullvadvpn-app/pull/9421 adding the changelog entry under the wrong header. The fix is yet unreleased.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9438)
<!-- Reviewable:end -->
