### PR TITLE
Fix IP override e2e test setup not using pre-determinted WG port

### DIFF
--- a/test/test-manager/src/tests/relay_ip_overrides.rs
+++ b/test/test-manager/src/tests/relay_ip_overrides.rs
@@ -36,7 +36,7 @@ pub async fn test_wireguard_ip_override(
     // make sure udp2tcp is turned off for this test
     mullvad_client
         .set_obfuscation_settings(ObfuscationSettings {
-            selected_obfuscation: SelectedObfuscation::Off,
+            selected_obfuscation: SelectedObfuscation::Port,
             ..Default::default()
         })
         .await


### PR DESCRIPTION
This test will try to connect to a UDP proxy (the server with hidden IP address) running on a predetermined port, but since the `WireGuard port` anti-censorship method was not selected, the port selection would not be respected.

This is only an issue with this particular test. I've tested the server IP override feature on the latest 2025.14-beta2 on a production relay, and Wireshark reports the overridden in-IP correctly.

E2E test run: https://github.com/mullvad/mullvadvpn-app/actions/runs/19851303345

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9448)
<!-- Reviewable:end -->
