### PR TITLE
Use Duration::from_hours/mins instead of lots of math in from_secs

### DIFF
--- a/ci/ios/test-router/raas/src/capture/cleanup.rs
+++ b/ci/ios/test-router/raas/src/capture/cleanup.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use tokio::{fs, time::Duration};
 use uuid::Uuid;
 
-const ONE_DAY_AGO: Duration = Duration::from_secs(24 * 60 * 60); // 86400 seconds in a day
+const ONE_DAY: Duration = Duration::from_hours(24);
 
 pub async fn delete_old_captures() -> std::io::Result<()> {
     delete_old_captures_inner(&super::Capture::capture_dir_path()).await
@@ -49,7 +49,7 @@ async fn should_delete_capture_file(path: &Path) -> bool {
             if let Ok(modified_time) = metadata.modified() {
                 // Calculate the elapsed time since the file was modified
                 if let Ok(duration) = modified_time.elapsed() {
-                    return duration > ONE_DAY_AGO;
+                    return duration > ONE_DAY;
                 }
             }
         }

--- a/ci/ios/test-router/raas/src/main.rs
+++ b/ci/ios/test-router/raas/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
 
     tokio::spawn(async {
         loop {
-            tokio::time::sleep(Duration::from_secs(60 * 60 * 24)).await;
+            tokio::time::sleep(Duration::from_hours(24)).await;
 
             if let Err(err) = capture::delete_old_captures().await {
                 log::error!("Failed to delete old captures: {err}");

--- a/mullvad-api/src/availability.rs
+++ b/mullvad-api/src/availability.rs
@@ -7,7 +7,7 @@ use tokio::sync::broadcast;
 
 /// Pause background requests if [ApiAvailabilityHandle::reset_inactivity_timer] hasn't been
 /// called for this long.
-const INACTIVITY_TIME: Duration = Duration::from_secs(3 * 24 * 60 * 60);
+const INACTIVITY_TIME: Duration = Duration::from_hours(3 * 24);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/mullvad-daemon/src/api_address_updater.rs
+++ b/mullvad-daemon/src/api_address_updater.rs
@@ -5,9 +5,9 @@ use mullvad_api::ApiEndpoint;
 use mullvad_api::{AddressCache, ApiProxy, rest::MullvadRestHandle};
 use std::time::Duration;
 
-const API_IP_CHECK_INITIAL: Duration = Duration::from_secs(15 * 60);
-const API_IP_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
-const API_IP_CHECK_ERROR_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const API_IP_CHECK_INITIAL: Duration = Duration::from_mins(15);
+const API_IP_CHECK_INTERVAL: Duration = Duration::from_hours(24);
+const API_IP_CHECK_ERROR_INTERVAL: Duration = Duration::from_mins(15);
 
 pub async fn run_api_address_fetcher(
     address_cache: AddressCache,

--- a/mullvad-daemon/src/device/service.rs
+++ b/mullvad-daemon/src/device/service.rs
@@ -22,8 +22,7 @@ use talpid_future::retry::{ConstantInterval, ExponentialBackoff, Jittered, retry
 const RETRY_ACTION_STRATEGY: ConstantInterval = ConstantInterval::new(Duration::ZERO, Some(3));
 /// Retry strategy used for background tasks
 const RETRY_BACKOFF_STRATEGY: Jittered<ExponentialBackoff> = Jittered::jitter(
-    ExponentialBackoff::new(Duration::from_secs(4), 5)
-        .max_delay(Some(Duration::from_secs(24 * 60 * 60))),
+    ExponentialBackoff::new(Duration::from_secs(4), 5).max_delay(Some(Duration::from_hours(24))),
 );
 
 #[derive(Clone)]
@@ -206,7 +205,7 @@ impl DeviceService {
         let api_handle = self.api_availability.clone();
         let pubkey = private_key.public_key();
 
-        let rotate_retry_strategy = std::iter::repeat(Duration::from_secs(24 * 60 * 60));
+        let rotate_retry_strategy = std::iter::repeat(Duration::from_hours(24));
 
         let addresses = retry_future(
             move || {

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -117,7 +117,7 @@ pub mod service {
 }
 
 /// Delay between generating a new WireGuard key and reconnecting
-const WG_RECONNECT_DELAY: Duration = Duration::from_secs(4 * 60);
+const WG_RECONNECT_DELAY: Duration = Duration::from_mins(4);
 
 pub type ResponseTx<T, E> = oneshot::Sender<Result<T, E>>;
 

--- a/mullvad-daemon/src/relay_list/mod.rs
+++ b/mullvad-daemon/src/relay_list/mod.rs
@@ -20,13 +20,12 @@ use talpid_types::ErrorExt;
 /// How often the updater should wake up to check the cache of the in-memory cache of relays.
 /// This check is very cheap. The only reason to not have it very often is because if downloading
 /// constantly fails it will try very often and fill the logs etc.
-const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(60 * 15);
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_mins(15);
 /// How old the cached relays need to be to trigger an update
-const UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const UPDATE_INTERVAL: Duration = Duration::from_hours(1);
 
 const DOWNLOAD_RETRY_STRATEGY: Jittered<ExponentialBackoff> = Jittered::jitter(
-    ExponentialBackoff::new(Duration::from_secs(16), 8)
-        .max_delay(Some(Duration::from_secs(2 * 60 * 60))),
+    ExponentialBackoff::new(Duration::from_secs(16), 8).max_delay(Some(Duration::from_hours(2))),
 );
 
 /// Where the relay list is cached on disk.

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -40,8 +40,8 @@ use windows_sys::Win32::{
 
 static SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
-const SERVICE_RECOVERY_LAST_RESTART_DELAY: Duration = Duration::from_secs(60 * 10);
-const SERVICE_FAILURE_RESET_PERIOD: Duration = Duration::from_secs(60 * 15);
+const SERVICE_RECOVERY_LAST_RESTART_DELAY: Duration = Duration::from_mins(10);
+const SERVICE_FAILURE_RESET_PERIOD: Duration = Duration::from_mins(15);
 
 static SERVICE_ACCESS: LazyLock<ServiceAccess> = LazyLock::new(|| {
     ServiceAccess::QUERY_CONFIG

--- a/mullvad-daemon/src/version/check.rs
+++ b/mullvad-daemon/src/version/check.rs
@@ -41,14 +41,14 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15);
 const FIRST_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 /// How long to wait between version checks, regardless of whether they succeed
 #[cfg(not(target_os = "android"))]
-const UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const UPDATE_INTERVAL: Duration = Duration::from_hours(1);
 /// How long to wait between version checks, regardless of whether they succeed
 // On Android, be more conservative since we use old endpoint. Retry at most once per 6 hours.
 #[cfg(target_os = "android")]
-const UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60 * 6);
+const UPDATE_INTERVAL: Duration = Duration::from_hours(6);
 /// Wait this long before sending platform metadata in check
 /// `M-Platform-Version` should only be sent once per 24h to make statistics predictable.
-const PLATFORM_HEADER_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
+const PLATFORM_HEADER_INTERVAL: Duration = Duration::from_hours(24);
 /// Retry strategy for `GetVersionInfo`.
 const IMMEDIATE_RETRY_STRATEGY: ConstantInterval = ConstantInterval::new(Duration::ZERO, Some(3));
 

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -6,8 +6,8 @@ use talpid_types::net::wireguard;
 
 use crate::Intersection;
 
-pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_secs(1 * 24 * 60 * 60);
-pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_hours(24);
+pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_hours(30 * 24);
 pub const DEFAULT_ROTATION_INTERVAL: Duration = MAX_ROTATION_INTERVAL;
 
 #[derive(Serialize, Deserialize, Default, Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
With Rust 1.91 `Duration::from_hours` and `from_mins` stabilized. This allows us to create `Duration` instances with less multiplication, leading to easier to read code.

In the future, maybe [`Duration::from_days`](https://doc.rust-lang.org/nightly/std/time/struct.Duration.html#method.from_days) is stabilized, allowing simplifying some durations slightly further.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9450)
<!-- Reviewable:end -->
