### PR TITLE
Fix ios screenshot tests by swapping order

### DIFF
--- a/ios/MullvadVPNUITests/Screenshots/ScreenshotTests.swift
+++ b/ios/MullvadVPNUITests/Screenshots/ScreenshotTests.swift
@@ -22,7 +22,7 @@ class ScreenshotTests: LoggedInWithTimeUITestCase {
         try await super.setUp()
     }
 
-    func testTakeScreenshotOfQuantumSecuredConnection() async throws {
+    func testTakeScreenshotOfAQuantumSecuredConnection() async throws {
         // We can't close banners in the screenshot tests due to how the NotificationController view
         // is overridden, so we need to restart the app once to make sure the "new device" notification
         // isn't visible.

--- a/ios/TestPlans/MullvadVPNScreenshots.xctestplan
+++ b/ios/TestPlans/MullvadVPNScreenshots.xctestplan
@@ -19,10 +19,10 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "ScreenshotTests\/testTakeScreenshotOfAQuantumSecuredConnection()",
         "ScreenshotTests\/testTakeScreenshotOfAccount()",
         "ScreenshotTests\/testTakeScreenshotOfCustomListSelected()",
         "ScreenshotTests\/testTakeScreenshotOfDNSSettings()",
-        "ScreenshotTests\/testTakeScreenshotOfQuantumSecuredConnection()",
         "ScreenshotTests\/testTakeScreenshotOfRelayFilter()",
         "ScreenshotTests\/testTakeScreenshotOfVPNSettings()"
       ],


### PR DESCRIPTION
In the new select location view, locations can only be clicked when they are inside the viewport. 
The screenshot tests don't clean up after themself so they depend on the previous test.
The screenshot tests run in alphabetic order.
In the current order, "Sweden" is outside the viewport when `testTakeScreenshotOfQuantumSecuredConnection` runs because of the previous tests created custom list.
So lets run it first by changing it's name 😎

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9453)
<!-- Reviewable:end -->
