### PR TITLE
Ignore GO-2025-4155 CVE for a year

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -180,3 +180,9 @@ reason = "wireguard-go does not use x/crypto/ssh"
 id = "CVE-2025-47914" # GO-2025-4135
 ignoreUntil = 2026-11-21
 reason = "wireguard-go does not use x/crypto/ssh/agent"
+
+# Excessive resource consumption when printing error string for host certificate validation in crypto/x509
+[[IgnoredVulns]]
+id = "CVE-2025-61729" # GO-2025-4155
+ignoreUntil = 2026-12-03
+reason = "wireguard-go does not use crypto/x509"


### PR DESCRIPTION
Another week, another go cve :fire: (:face_exhaling:)

A new cve was filed against the `crypto/x509` module, which wireguard-go does not use (CVE-2025-61729). Therefore, I chose to put this on the ignore list for *1 year*.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9455)
<!-- Reviewable:end -->
