### PR TITLE
Update `setup-go` to a newer version to fix go downloads in CI

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -107,7 +107,7 @@ runs:
         sudo apt-get install libdbus-1-dev
 
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 1.21.3
 


### PR DESCRIPTION
This PR the same issue as described in https://github.com/actions/setup-go/issues/664.

Smoke test: https://github.com/mullvad/mullvadvpn-app/actions/runs/19901703163/job/57047083512

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9467)
<!-- Reviewable:end -->
