### PR TITLE
Add direnv which auto loads devshell ❄️

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 *.bak
 android/.idea
 .vscode/
+.direnv/

--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -67,6 +67,20 @@ sudo dnf install dbus-devel
 sudo dnf install rpm-build
 ```
 
+## Using nix devshell
+
+This is supported on Linux (x86_64) as well as macOS (x86_64 and aarch64).
+[Install nix](./android/docs/BuildInstructions.md#Build-using-nix-devshell) if you haven't already.
+
+   ```bash
+   nix develop
+   ```
+
+#### direnv
+
+Provided in the repository root is a [direnv](https://direnv.net/) for automatically sourcing the devshell.
+Allow it by executing `direnv allow .` (in `<repository>`) once.
+
 ### Cross-compiling for ARM64
 
 By default, the app will build for the host platform. It is also possible to cross-compile the app


### PR DESCRIPTION
This PR adds a small convenience for nix users. [direnv](https://direnv.net/) is a common tool for *doing stuff* upon entering a repository, such as sourcing env variables and whatnot. What is loaded when is all dictated by `.envrc` usually located in the repository root. [It integrates with `nix`](https://github.com/direnv/direnv/blob/8eee8fc73848021612a3059d24cabcab2914e8e1/stdlib.sh#L1316-L1332), and will automatically reload the devshell if `flake.nix` changes etc.

Note: activating the direnv is completely opt-in, and is disabled by default. I added instructions on how to enable it to our build instructions on setting up a local development environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9470)
<!-- Reviewable:end -->
