### PR TITLE
Remove superflous build workspace step from GHA

### DIFF
--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -104,6 +104,8 @@ jobs:
 
   build-windows:
     strategy:
+      # Even if onw of the Windows jobs fail, the other should not be cancelled.
+      fail-fast: false
       matrix:
         config:
           - os: windows-latest


### PR DESCRIPTION
Dug into the [`daemon.yml`](https://github.com/mullvad/mullvadvpn-app/blob/main/.github/workflows/daemon.yml) workflow a bit, and noticed that we ran `cargo build` & `cargo test` in subsequent steps. This seems excessive, as `cargo test` will build *and* run the test, so might as well cut the prior `cargo build` step since it just performs redundant work. Build artifacts does not automatically carry over from a prior step to the next, so running `cargo build` in a prior, separate step actually carries quite a lot of penalty to the total CI time.

This also seems to fix a resource error that started to pop up recently, where the runner would run out of disk space: https://github.com/mullvad/mullvadvpn-app/actions/runs/19887394280/job/56997616403

### Numbers
Here are some preliminary results. `main` is based on the CI run for 38993835f2202cd972b4431851a734812cc4e618

| OS  / CI time		| [This patch ](https://github.com/mullvad/mullvadvpn-app/actions/runs/19920993029)	|  [`main`](https://github.com/mullvad/mullvadvpn-app/actions/runs/19921306692) 	|
| --------------------- | ------------- | ------------- |
| Windows (x86) 	| 12m33s	| -  		|
| Windows (ARM) 	| - 		| -  		|
| Linux (Stable)	| 3m 38s	| 4m50s		|
| Linux (Beta)		| 3m 39s	| 4m59s		|
| Linux (Nightly)	| 3m 47s	| 4m45s (failed)|
| macOS 		| 3m 57s	| 5m48s		|



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9471)
<!-- Reviewable:end -->
