### PR TITLE
Ignore GO-2025-4175 CVE for a year

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -186,3 +186,9 @@ reason = "wireguard-go does not use x/crypto/ssh/agent"
 id = "CVE-2025-61729" # GO-2025-4155
 ignoreUntil = 2026-12-03
 reason = "wireguard-go does not use crypto/x509"
+
+# Improper application of excluded DNS name constraints when verifying wildcard names in crypto/x509
+[[IgnoredVulns]]
+id = "CVE-2025-61727" # GO-2025-4175
+ignoreUntil = 2026-12-04
+reason = "wireguard-go does not use crypto/x509"


### PR DESCRIPTION
Another week, another go cve 🔥 (😮‍💨😮‍💨😮‍💨).

Since https://github.com/mullvad/mullvadvpn-app/pull/9455, a new cve was filed against the crypto/x509 module which wireguard-go still does not use (CVE-2025-61727). Therefore, I chose to put this on the ignore list for 1 year.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9472)
<!-- Reviewable:end -->
