### PR TITLE
Refactor AddressCache to have pluggable backing for persistence

### DIFF
--- a/mullvad-api/src/lib.rs
+++ b/mullvad-api/src/lib.rs
@@ -33,7 +33,7 @@ mod relay_list;
 
 pub mod ffi;
 
-pub use address_cache::AddressCache;
+pub use address_cache::{AddressCache, FileAddressCacheBacking};
 pub use device::DevicesProxy;
 pub use hyper::StatusCode;
 pub use relay_list::RelayListProxy;


### PR DESCRIPTION
This PR refactors the mullvad-api `AddressCache`, moving file reading/writing to an `AddressCacheBacking` trait, and implementing the default file-based ones in one named `FileAddressCacheBacking`.  The purpose of this is to allow the creation of an iOS-specific `AddressCacheBacking` that uses iOS Keychain facilities provided through the FFI for storage, allowing the API's address caching logic to be used on iOS as well.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9474)
<!-- Reviewable:end -->
