### PR TITLE
Add `Swatinem/rust-cache@v2`

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -13,18 +13,16 @@ inputs:
     description: "Token for setup-protoc (defaults to GITHUB_TOKEN)"
     default: "${{ github.token }}"
     required: false
+  rust-cache-targets:
+    description: >-
+      Determines whether workspace `target` directories are cached. If `false`,
+      only the cargo registry will be cached. If `true`, the `target` directories
+      will be cached as well.
+    default: "false"
+    required: false
 runs:
   using: "composite"
   steps:
-    - name: Cache cargo cache and index
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-${{ inputs.rust-toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Override Rust toolchain
       if: ${{ inputs.rust-toolchain != 'stable' }}
       shell: bash
@@ -40,6 +38,21 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: rustup target add i686-pc-windows-msvc
+
+    - name: Set CARGO_TARGET_DIR env
+      shell: bash
+      run: |
+        if [[ -n "$CARGO_TARGET_DIR" ]]; then
+          echo "CARGO_TARGET_DIR=$CARGO_TARGET_DIR" >> $GITHUB_ENV
+        fi
+
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        add-job-id-key: "false" # Preserve cache across jobs
+        cache-directories: >-
+          ${{ inputs.rust-cache-targets == 'true' && env.CARGO_TARGET_DIR || '' }}
+        cache-targets: ${{ inputs.rust-cache-targets }}
 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
@@ -115,5 +128,5 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version-file: desktop/package.json
-        cache: 'npm'
+        cache: "npm"
         cache-dependency-path: desktop/package-lock.json

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: ./.github/actions/mullvad-build-env
         with:
           rustup-components: clippy
+          rust-cache-targets: ${{ runner.os == 'Windows' }}
 
       - name: Clippy check
         shell: bash

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -3,28 +3,28 @@ name: Daemon+CLI - Build and test
 on:
   pull_request:
     paths:
-      - '**'
-      - '!**/**.md'
-      - '!.github/workflows/**'
-      - '.github/workflows/daemon.yml'
-      - '!.github/CODEOWNERS'
-      - '!android/**'
-      - '!audits/**'
-      - '!build.sh'
-      - '!ci/**'
-      - 'ci/cargo-ci.sh'
-      - '!clippy.toml'
-      - '!deny.toml'
-      - '!docs/**'
-      - '!graphics/**'
-      - '!desktop/**'
-      - '!ios/**'
-      - '!scripts/**'
-      - '!.*ignore'
-      - '!prepare-release.sh'
-      - '!rustfmt.toml'
-      - '!.yamllint'
-      - '!**/osv-scanner.toml'
+      - "**"
+      - "!**/**.md"
+      - "!.github/workflows/**"
+      - ".github/workflows/daemon.yml"
+      - "!.github/CODEOWNERS"
+      - "!android/**"
+      - "!audits/**"
+      - "!build.sh"
+      - "!ci/**"
+      - "ci/cargo-ci.sh"
+      - "!clippy.toml"
+      - "!deny.toml"
+      - "!docs/**"
+      - "!graphics/**"
+      - "!desktop/**"
+      - "!ios/**"
+      - "!scripts/**"
+      - "!.*ignore"
+      - "!prepare-release.sh"
+      - "!rustfmt.toml"
+      - "!.yamllint"
+      - "!**/osv-scanner.toml"
 
   workflow_dispatch:
     inputs:
@@ -44,7 +44,8 @@ jobs:
 
       - name: Use custom container image if specified
         if: ${{ github.event.inputs.override_container_image != '' }}
-        run: echo "inner_container_image=${{ github.event.inputs.override_container_image }}"
+        run:
+          echo "inner_container_image=${{ github.event.inputs.override_container_image }}"
           >> $GITHUB_ENV
 
       - name: Use default container image and resolve digest
@@ -88,6 +89,12 @@ jobs:
         if: ${{ matrix.rust != 'stable' }}
         run: rustup override set ${{ matrix.rust }}
 
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          add-job-id-key: "false" # Preserve cache across jobs
+          cache-targets: "false" # Only cache cargo registry
+
       - name: Test crates
         run: ci/cargo-ci.sh test --workspace
 
@@ -123,6 +130,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/mullvad-build-env
+        with:
+          rust-cache-targets: "true"
 
       - name: Build Windows modules (x86_64)
         if: ${{ matrix.config.arch == 'x64' }}


### PR DESCRIPTION
This PR enables `Swatinem/rust-cache@v2` for `mullvad-build-env/action.yml` which is used by the following actions:
- `Daemon+CLI - Build and test`
- `Rust - Run Clippy to check lints`
- `DES Testframework - Clippy`
- `Desktop - End-to-end tests` (though i disabled caching the `target/` directory as it would require some more configuration).

The job ID is not used as a cache key, so we should benefit from this across multiple runs. The `Cargo.lock/Cargo.toml` files *are*  included in the key, to prevent conflicts across branches.

We only cache the target folder for Windows, and the below table shows the reasoning for that. If target folder caching is enabled for all platforms, we get roughly the following action duration depending on cache hits:

| OS  / CI time		| [With cache hit](https://github.com/mullvad/mullvadvpn-app/actions/runs/19920993029)	| [Partial cache miss](https://github.com/mullvad/mullvadvpn-app/actions/runs/20058576030/usage?pr=9481)|  [No cache](https://github.com/mullvad/mullvadvpn-app/actions/runs/20033097697/job/57456799138?pr=9481) |[Reference](https://github.com/mullvad/mullvadvpn-app/actions/runs/20031619690/usage) 	|
| --------------------- | ------------- | ---- |----|------------- |
| Windows (x86) 	| 8m 8s	| 10m 5s  | 12m 17s  | 12m 12 s |
| Windows (ARM) 	| 12m 8s | 12m 56s  |  14m 3s  | 12m 12s |
| Linux (Stable)	| 2m 36s |  7m 40s   | 7m 10s   | 3m 43s |
| Linux (Beta)		| 2m 50s | 7m 34s  | 7m 33s  | 3m 47s |
| Linux (Nightly)	| 2m 46s |  8m 3s  | 7m 40s  | 3m 50s |
| macOS 		| 2m 17s	| 4m 18s  | 7m 11s   | 3m 44s|

The results can vary wildly from run to run, so take them with a large grain of salt. What we should expect to see is that the full cache hit is faster than on main, the partial cache his is slightly slower or equal to main and the full cache miss is much slower.

Note that when the `Cargo.toml` file is updated, it doesn't invalidate the cache of the cargo registry so dependencies don't have to be downloaded, but they do need to be recompiled. This is the "Partial cache miss" column. If, however, the a cache is removed, then the registry is also wiped. This would make the corresponding platforms have to redownload crates, which makes it significantly slower than on main.

The PR also removes the custom target dir on Windows to simplify the configuration for the cache action.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9481)
<!-- Reviewable:end -->
