### PR TITLE
Remove all uses of localizedDescription in logs

### DIFF
--- a/ios/Assets/Localizable.xcstrings
+++ b/ios/Assets/Localizable.xcstrings
@@ -13139,6 +13139,9 @@
         }
       }
     },
+    "Could not restore previous purchases. Try again later or contact support." : {
+
+    },
     "Create" : {
       "localizations" : {
         "da" : {
@@ -40318,6 +40321,9 @@
           }
         }
       }
+    },
+    "Previous purchases were found" : {
+
     },
     "privacy policy" : {
       "localizations" : {

--- a/ios/MullvadLogging/Error+LogFormat.swift
+++ b/ios/MullvadLogging/Error+LogFormat.swift
@@ -6,20 +6,8 @@
 //  Copyright © 2025 Mullvad VPN AB. All rights reserved.
 //
 
-import Foundation
-import MullvadTypes
-
 extension Error {
-    public func logFormatError() -> String {
-        let nsError = self as NSError
-        var message = ""
-
-        let description =
-            (self as? CustomErrorDescriptionProtocol)?
-            .customErrorDescription ?? localizedDescription
-
-        message += "\(description) (domain = \(nsError.domain), code = \(nsError.code))"
-
-        return message
+    public var description: String {
+        (self as NSError).description
     }
 }

--- a/ios/MullvadLogging/LoggerBuilder.swift
+++ b/ios/MullvadLogging/LoggerBuilder.swift
@@ -96,7 +96,7 @@ public final class LoggerBuilder: @unchecked Sendable {
                 let rotationLogger = Logger(label: "LogRotation")
 
                 for error in logRotationErrors {
-                    rotationLogger.error(error: error, message: error.localizedDescription)
+                    rotationLogger.error(error: error, message: error.description)
                 }
             }
         }

--- a/ios/MullvadREST/ApiHandlers/DefaultLocationService.swift
+++ b/ios/MullvadREST/ApiHandlers/DefaultLocationService.swift
@@ -30,7 +30,7 @@ public struct DefaultLocationService {
                 for: URLRequest(url: url, timeoutInterval: REST.defaultAPINetworkTimeout.timeInterval))
             serverLocation = try JSONDecoder().decode(REST.ServerLocation.self, from: data.0)
         } catch {
-            logger.log(level: .error, "Could not fetch server location: \(error.localizedDescription)")
+            logger.log(level: .error, "Could not fetch server location: \(error.description)")
             return nil
         }
 

--- a/ios/MullvadTypes/Error+Chain.swift
+++ b/ios/MullvadTypes/Error+Chain.swift
@@ -24,15 +24,11 @@ extension Error {
 
     public func logFormatError() -> String {
         let nsError = self as NSError
-        var message = ""
-
         let description =
             (self as? CustomErrorDescriptionProtocol)?
-            .customErrorDescription ?? localizedDescription
+            .customErrorDescription ?? nsError.description
 
-        message += "\(description) (domain = \(nsError.domain), code = \(nsError.code))"
-
-        return message
+        return description
     }
 
     private func getUnderlyingError() -> Error? {

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -362,7 +362,6 @@
 		58D2240A294C90210029F5F8 /* IPAddress+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AC115628F848D00037AF9A /* IPAddress+Codable.swift */; };
 		58D2240B294C90210029F5F8 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AC113628F83FD70037AF9A /* Cancellable.swift */; };
 		58D2240C294C90210029F5F8 /* WrappingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E511E028DDB7F100B0BCDE /* WrappingError.swift */; };
-		58D2240D294C90210029F5F8 /* CustomErrorDescriptionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E511E328DDDE8900B0BCDE /* CustomErrorDescriptionProtocol.swift */; };
 		58D2240E294C90210029F5F8 /* Error+Chain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E511EA28DDE18400B0BCDE /* Error+Chain.swift */; };
 		58D2240F294C90210029F5F8 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AEEF642344A36000C9BBD5 /* KeychainError.swift */; };
 		58D22410294C90210029F5F8 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A1AA8623F43901009F7EA6 /* Location.swift */; };
@@ -671,6 +670,7 @@
 		7AFBE3892D089163002335FC /* TunnelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFBE3882D08915D002335FC /* TunnelViewController.swift */; };
 		7AFBE38B2D09AAFF002335FC /* SinglehopPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFBE38A2D09AAFF002335FC /* SinglehopPicker.swift */; };
 		7AFBE38D2D09AB2E002335FC /* MultihopPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFBE38C2D09AB2E002335FC /* MultihopPicker.swift */; };
+		7AFE63352EE31BA800D27DC7 /* CustomErrorDescriptionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFE63342EE31BA800D27DC7 /* CustomErrorDescriptionProtocol.swift */; };
 		850201DB2B503D7700EF8C96 /* RelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850201DA2B503D7700EF8C96 /* RelayTests.swift */; };
 		850201DD2B503D8C00EF8C96 /* SelectLocationPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850201DC2B503D8C00EF8C96 /* SelectLocationPage.swift */; };
 		850201DF2B5040A500EF8C96 /* TunnelControlPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850201DE2B5040A500EF8C96 /* TunnelControlPage.swift */; };
@@ -1939,7 +1939,6 @@
 		58E20770274672CA00DE5D77 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		58E25F802837BBBB002CFB2C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		58E511E028DDB7F100B0BCDE /* WrappingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappingError.swift; sourceTree = "<group>"; };
-		58E511E328DDDE8900B0BCDE /* CustomErrorDescriptionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomErrorDescriptionProtocol.swift; sourceTree = "<group>"; };
 		58E511E528DDDEAC00B0BCDE /* CodingErrors+CustomErrorDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CodingErrors+CustomErrorDescription.swift"; sourceTree = "<group>"; };
 		58E511EA28DDE18400B0BCDE /* Error+Chain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Chain.swift"; sourceTree = "<group>"; };
 		58E973DD24850EB600096F90 /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
@@ -2198,6 +2197,7 @@
 		7AFBE3882D08915D002335FC /* TunnelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelViewController.swift; sourceTree = "<group>"; };
 		7AFBE38A2D09AAFF002335FC /* SinglehopPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglehopPicker.swift; sourceTree = "<group>"; };
 		7AFBE38C2D09AB2E002335FC /* MultihopPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultihopPicker.swift; sourceTree = "<group>"; };
+		7AFE63342EE31BA800D27DC7 /* CustomErrorDescriptionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomErrorDescriptionProtocol.swift; sourceTree = "<group>"; };
 		85006A8E2B73EF67004AD8FB /* MullvadVPNUITestsSmoke.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = MullvadVPNUITestsSmoke.xctestplan; sourceTree = "<group>"; };
 		850201DA2B503D7700EF8C96 /* RelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayTests.swift; sourceTree = "<group>"; };
 		850201DC2B503D8C00EF8C96 /* SelectLocationPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationPage.swift; sourceTree = "<group>"; };
@@ -3014,7 +3014,7 @@
 				584D26BE270C550B004EA533 /* AnyIPAddress.swift */,
 				586A951329013235007BAF2B /* AnyIPEndpoint.swift */,
 				06AC113628F83FD70037AF9A /* Cancellable.swift */,
-				58E511E328DDDE8900B0BCDE /* CustomErrorDescriptionProtocol.swift */,
+				7AFE63342EE31BA800D27DC7 /* CustomErrorDescriptionProtocol.swift */,
 				586168682976F6BD00EF8598 /* DisplayError.swift */,
 				7A307ADA2A8F56DF0017618B /* Duration+Extensions.swift */,
 				58E511EA28DDE18400B0BCDE /* Error+Chain.swift */,
@@ -6737,7 +6737,6 @@
 				A9A8A8EB2A262AB30086D569 /* FileCache.swift in Sources */,
 				A90C48692C36BF3900DCB94C /* TunnelProvider.swift in Sources */,
 				44EC6C5A2E3BB3F60087F54A /* PersistentProxyConfiguration.swift in Sources */,
-				58D2240D294C90210029F5F8 /* CustomErrorDescriptionProtocol.swift in Sources */,
 				A98207EF2D9192A300654558 /* ShadowsocksBridgeProviding.swift in Sources */,
 				58D2240E294C90210029F5F8 /* Error+Chain.swift in Sources */,
 				586168692976F6BD00EF8598 /* DisplayError.swift in Sources */,
@@ -6745,6 +6744,7 @@
 				A959E2422D75F3D200F95DDB /* AccessMethodKind.swift in Sources */,
 				58D22410294C90210029F5F8 /* Location.swift in Sources */,
 				7AA5C37A2E9FDA6C00B35530 /* URLSessionProtocol.swift in Sources */,
+				7AFE63352EE31BA800D27DC7 /* CustomErrorDescriptionProtocol.swift in Sources */,
 				A98207EB2D9190F100654558 /* ShadowsocksConfiguration.swift in Sources */,
 				58D22411294C90210029F5F8 /* MullvadEndpoint.swift in Sources */,
 				58D22412294C90210029F5F8 /* RelayConstraint.swift in Sources */,

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodValidationError.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/Models/AccessMethodValidationError.swift
@@ -15,7 +15,7 @@ struct AccessMethodValidationError: LocalizedError, Equatable {
     let fieldErrors: [AccessMethodFieldValidationError]
 
     var errorDescription: String? {
-        fieldErrors.map({ $0.localizedDescription }).joinedParagraphs(lineBreaks: 1)
+        fieldErrors.map({ $0.errorDescription }).joinedParagraphs(lineBreaks: 1)
     }
 }
 
@@ -63,7 +63,7 @@ struct AccessMethodFieldValidationError: LocalizedError, Equatable {
     /// Validation field context.
     let context: Context
 
-    var errorDescription: String? {
+    var errorDescription: String {
         switch kind {
         case .emptyValue:
             String(format: NSLocalizedString("%@ cannot be empty.", comment: ""), field.rawValue)

--- a/ios/MullvadVPN/Notifications/NotificationManager.swift
+++ b/ios/MullvadVPN/Notifications/NotificationManager.swift
@@ -202,7 +202,7 @@ final class NotificationManager: NotificationProviderDelegate {
                             self.logger.error(
                                 """
                                 Failed to add notification request with identifier \
-                                \(request.identifier). Error: \(error.localizedDescription)
+                                \(request.identifier). Error: \(error.description)
                                 """
                             )
                         }

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -415,12 +415,12 @@ extension PacketTunnelProvider {
         case let .failure(error):
             switch error {
             case is DeviceCheckError:
-                providerLogger.error("\(error.localizedDescription) Forcing a log out")
+                providerLogger.error("\(error.description) Forcing a log out")
                 actor.setErrorState(reason: .deviceLoggedOut)
             default:
                 providerLogger
                     .error(
-                        "Device check encountered a network error: \(error.localizedDescription)"
+                        "Device check encountered a network error: \(error.description)"
                     )
             }
 


### PR DESCRIPTION
**Why this needs to be done**

Logs sent by people using a non english locale makes it harder for us to figure out what went wrong with their devices.

A user using a Russian locale, or chinese locale would have us read error messages in those languages which is not helpful.

**How do we implement this feature ?**

Whenever we send something to the logs, we should just use description(or debugDescription as long as it doesn't involve sensitive data) not localizedDescription

**Acceptance criteria**

The app sends logs in English.

**How should this be tested ?**

- Set your phone locale in a different language, like Russian, Japanese of Farsi
- Take actions that will result in an error (use the app with airplane mode, turn on the VPN and restart the phone etc…)
- Trigger log collection
- Verify that the errors are in english when they are sent to support via the ProblemReportInteractor 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9482)
<!-- Reviewable:end -->
