### PR TITLE
Stop running testframework build on CODEOWNERS change

### DIFF
--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -7,7 +7,8 @@ on:
       - '**'
       - '!**/**.md'
       - '!.github/workflows/**'
-      - '.github/workflows/daemon.yml'
+      - '.github/workflows/testframework.yml'
+      - "!.github/CODEOWNERS"
       - '!android/**'
       - '!audits/**'
       - '!build.sh'


### PR DESCRIPTION
I noticed the entire testframework workflow was triggered in a PR that only changed the CODEOWNERS. I fixed that and then noticed that it was also invalidly triggered on changes to `daemon.yml` and not itself (`testframework.yml`). So I fixed that also.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9502)
<!-- Reviewable:end -->
