### PR TITLE
Replace unmaintained `parity-parity-ipc` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,17 +1592,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
@@ -3125,11 +3114,11 @@ dependencies = [
  "mullvad-paths",
  "mullvad-types",
  "nix 0.30.1",
- "parity-tokio-ipc",
  "prost",
  "prost-types",
  "talpid-types",
  "thiserror 2.0.9",
+ "tipsy",
  "tokio",
  "tonic",
  "tonic-build",
@@ -3795,20 +3784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-tokio-ipc"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
-dependencies = [
- "futures",
- "libc",
- "log",
- "rand 0.7.3",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,19 +4354,6 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -4413,16 +4375,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -4439,15 +4391,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -4476,15 +4419,6 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.2",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5649,6 +5583,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tipsy"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91456c51834a52defbaf5f9797f8791df0e2814aec790956669485dc8eab621c"
+dependencies = [
+ "dirs",
+ "futures-util",
+ "libc",
+ "tokio",
+ "tracing",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6221,12 +6169,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ unused_async = "deny"
 dirs = "6.0.0"
 tokio = { version = "1.44" }
 tokio-util = "0.7"
-parity-tokio-ipc = "0.9"
+tipsy = "0.6.5"
 futures = "0.3.15"
 vec1 = "1.12"
 sha2 = "0.10"

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -23,7 +23,7 @@ use mullvad_types::{
 };
 use std::collections::BTreeSet;
 use std::{
-    path::Path,
+    path::PathBuf,
     str::FromStr,
     sync::{Arc, Mutex},
     time::Duration,
@@ -1291,7 +1291,7 @@ pub struct ManagementInterfaceServer {
 impl ManagementInterfaceServer {
     pub fn start(
         daemon_tx: DaemonCommandSender,
-        rpc_socket_path: impl AsRef<Path>,
+        rpc_socket_path: PathBuf,
         app_upgrade_broadcast: tokio::sync::broadcast::Sender<version::AppUpgradeEvent>,
     ) -> Result<ManagementInterfaceServer, Error> {
         let subscriptions = Arc::<Mutex<Vec<EventsListenerSender>>>::default();
@@ -1311,13 +1311,13 @@ impl ManagementInterfaceServer {
             async move {
                 StreamExt::into_future(server_abort_rx).await;
             },
-            &rpc_socket_path,
+            rpc_socket_path.clone(),
         )
         .map_err(Error::SetupError)?;
 
         log::info!(
             "Management interface listening on {}",
-            rpc_socket_path.as_ref().display()
+            rpc_socket_path.display()
         );
 
         let broadcast = ManagementInterfaceEventBroadcaster { subscriptions };

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -26,7 +26,7 @@ prost-types = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features =  ["rt"] }
 vec1 = { workspace = true }
-parity-tokio-ipc = { workspace = true }
+tipsy = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["user", "fs"] }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -2066,11 +2066,11 @@ dependencies = [
  "mullvad-paths",
  "mullvad-types",
  "nix 0.30.1",
- "parity-tokio-ipc",
  "prost",
  "prost-types",
  "talpid-types",
  "thiserror 2.0.3",
+ "tipsy",
  "tokio",
  "tonic",
  "tonic-build",
@@ -3803,6 +3803,20 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tipsy"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91456c51834a52defbaf5f9797f8791df0e2814aec790956669485dc8eab621c"
+dependencies = [
+ "dirs",
+ "futures-util",
+ "libc",
+ "tokio",
+ "tracing",
+ "windows-sys 0.61.1",
+]
 
 [[package]]
 name = "tokio"


### PR DESCRIPTION
This PR replaces [parity-tokio-ipc](https://github.com/paritytech/parity-tokio-ipc) with a maintained fork called [tipsy](https://github.com/aschey/tipsy). The main benefit is that we can shed some old dependencies, mainly `rand 0.7` and friends.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9505)
<!-- Reviewable:end -->
