### PR TITLE
Bump opinionated-commit-message action to latest commit for more verbs

### DIFF
--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -36,4 +36,4 @@ jobs:
           # All commit message verbs we have used in this repository up until 2025-12-10 are upstreamed
           # to the action's allowed verb list. Consider if you can easily reword your commit message.
           # Otherwise add your new *imperative verb* here. We then try to upstream all new verbs periodically.
-          additional-verbs: ''
+          additional-verbs: 'clone'


### PR DESCRIPTION
I noticed our `additional-verbs` was growing. And that people quite often add new verbs. So I took the list and upstreamed the new ones: https://github.com/mristin/opinionated-commit-message/pull/145. However, I missed `clone` since it was added too recently.

Given this PR where I add *all* our historically used verbs to the allow list: https://github.com/mristin/opinionated-commit-message/pull/131. I do no longer think the default list is "a bit short" as the comment suggested. So I updated our comment about the `additional-verbs` argument. I do think the verb list must be fairly complete by now. I still think we are allowed to add more verbs as we stumble upon them. But it cannot be too hard to also rewrite most commit messages to more "common" verbs in most cases.

This PR removes `impl` as an allowed verb. This "verb" is also not in upstream. It's an abbreviation an not a full word so it does not make sense to upstream it as it would open up a can of worms. I think we can simply write "implement" in our commit messages instead, or is that too much of a limitation?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9512)
<!-- Reviewable:end -->
