### PR TITLE
Remove bridging and fix networkd config

### DIFF
--- a/ci/ios/test-router/router-config.nix
+++ b/ci/ios/test-router/router-config.nix
@@ -47,17 +47,10 @@ in
 
   system.stateVersion = "24.11";
 
-  systemd.network.netdevs."1-lanBridge" = {
-    netdevConfig = {
-      Kind = "bridge";
-      Name = "lan";
-    };
-  };
-
   systemd.network.links = {
-    "1-lanIface" = ifNotNull lanMac {
+    "1-lanIface" = {
       matchConfig.PermanentMACAddress = args.lanMac;
-      linkConfig.Name = "lanEth";
+      linkConfig.Name = "lan";
     };
 
     "1-wanIface" = {
@@ -69,6 +62,7 @@ in
   networking = {
     firewall.enable = false;
   };
+
   hardware.bluetooth.enable = false;
 
   boot.kernel.sysctl = {
@@ -125,7 +119,7 @@ in
 
   systemd.network.enable = true;
 
-  systemd.network.networks.wan = {
+  systemd.network.networks."1-wan" = {
     name = "wan";
     DHCP = "yes";
 
@@ -157,13 +151,11 @@ in
   #  org.freedesktop.network1.DHCPServer \
   #  Leases
 
-  systemd.network.networks."lanEth" = ifNotNull lanMac {
-    matchConfig.Name = "lanEth";
-    networkConfig.Bridge = "lan";
-    linkConfig.RequiredForOnline = "enslaved";
-  };
-
-  systemd.network.networks.lan = {
+  # if the network name is not prefixed by a number lower than 99, then the
+  # default ethernet dhcp network config will apply and this configuration will
+  # be ignored.systemd That is the reason why this network is called "1-lan"
+  # instead of "lan".
+  systemd.network.networks."1-lan" = {
     name = "lan";
     address = [ "192.168.105.1/24" ];
 


### PR DESCRIPTION
After applying the config fro #9509, we came to realize it is slightly broken - the LAN interface wasn't configured properly. To rectify this, I removed the rudimentary bridge config, yet it was still broken. Due to rudimentary ambitions of running the WiFi network for the test router off of the built-in WiFi chipset, there was a bridge interface created that was now useless. This complicated matters a bit, so I removed it. But the underlying issue is that the LAN interface was being configured by the wrong networkd network configuration file since there exists something along the lines of `99-ethernet-default-dhcp.network` which supersedes the nicely named `lan.network` configuration. Thus, the ultimate fix is to name our network config files `1-lan` and `1-wan`.

These changes also add git to the environment of the router to make fixing this next time way easier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9516)
<!-- Reviewable:end -->
