### PR TITLE
Make a bunch more clippy lints warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,11 +77,14 @@ single_use_lifetimes = "warn"
 
 
 [workspace.lints.clippy]
-borrow_as_ptr = "warn"
+as_ptr_cast_mut = "warn"
 as_underscore = "warn"
+borrow_as_ptr = "warn"
 implicit_clone = "warn"
 undocumented_unsafe_blocks = "warn"
+unicode_not_nfc = "warn"
 unused_async = "deny"
+wildcard_dependencies = "deny"
 
 [workspace.dependencies]
 dirs = "6.0.0"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -33,10 +33,14 @@ unused_macro_rules = "warn"
 single_use_lifetimes = "warn"
 
 [workspace.lints.clippy]
+as_ptr_cast_mut = "warn"
+as_underscore = "warn"
 borrow_as_ptr = "warn"
 implicit_clone = "warn"
-as_underscore = "warn"
+undocumented_unsafe_blocks = "warn"
+unicode_not_nfc = "warn"
 unused_async = "deny"
+wildcard_dependencies = "deny"
 
 [workspace.dependencies]
 dirs = "6.0.0"


### PR DESCRIPTION
At the Rust forum meeting yesterday we discussed enabling even more clippy lints, to make our automatic checks stricter. After #9383 I had a git stash of more lints I wanted to enable, so I resurrected that stash and went through it. I want to create a PR where we can discuss a bunch of unrelated lints in one go.

Some of these trigger warnings in the `test` workspace. I left them as commented out for now. We can decide to not enforce those in the test workspace. Given that the different code bases are used for very different things and by different people (developers vs customers) we can enforce different rules.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9517)
<!-- Reviewable:end -->
