### PR TITLE
Add count of all/available locations to select location header

### DIFF
--- a/ios/Assets/Localizable.xcstrings
+++ b/ios/Assets/Localizable.xcstrings
@@ -45772,6 +45772,16 @@
         }
       }
     },
+    "Showing %lld of %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Showing %1$lld of %2$lld"
+          }
+        }
+      }
+    },
     "Singapore" : {
       "localizations" : {
         "da" : {

--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationContext.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationContext.swift
@@ -3,6 +3,8 @@ struct LocationContext {
     var customLists: [LocationNode]
     var filter: [SelectLocationFilter]
     let selectLocation: (LocationNode) -> Void
+    var totalRelayCount: Int
+    var availableRelayCount: Int
 
     init(
         locations: [LocationNode] = [],
@@ -10,11 +12,15 @@ struct LocationContext {
         filter: [SelectLocationFilter] = [],
         selectedLocation: LocationNode? = nil,
         connectedRelayHostname: String? = nil,
+        totalRelayCount: Int = 0,
+        availableRelayCount: Int = 0,
         selectLocation: @escaping (LocationNode) -> Void = { _ in }
     ) {
         self.locations = locations
         self.customLists = customLists
         self.filter = filter
+        self.totalRelayCount = totalRelayCount
+        self.availableRelayCount = availableRelayCount
         self.selectLocation = selectLocation
     }
 

--- a/ios/MullvadVPN/View controllers/SelectLocation/MockSelectLocationViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/MockSelectLocationViewModel.swift
@@ -12,65 +12,66 @@ class MockSelectLocationViewModel: SelectLocationViewModel {
 
     init() {
         entryContext = LocationContext()
+        let exitLocations: [LocationNode] = [
+            LocationNode(
+                name: "Sweden", code: "se",
+                children: [
+                    LocationNode(
+                        name: "Stockholm",
+                        code: "sth",
+                        children: [
+                            LocationNode(name: sth1, code: sth1),
+                            LocationNode(name: sth2, code: sth2),
+                            LocationNode(name: sth3, code: sth3),
+                        ], showsChildren: true
+                    ),
+                    LocationNode(
+                        name: "Gothenburg", code: "got",
+                        children: [
+                            LocationNode(name: got1, code: got1),
+                            LocationNode(name: got2, code: got2),
+                            LocationNode(name: got3, code: got3),
+                        ], showsChildren: true),
+                ], showsChildren: true),
+            LocationNode(
+                name: "Germany", code: "de",
+                children: [
+                    LocationNode(
+                        name: "Berlin", code: "ber",
+                        children: [
+                            LocationNode(name: ber1, code: ber1),
+                            LocationNode(name: ber2, code: ber2),
+                            LocationNode(name: ber3, code: ber3),
+                        ], showsChildren: true),
+                    LocationNode(
+                        name: "Frankfurt", code: "fra",
+                        children: [
+                            LocationNode(name: fra1, code: fra1),
+                            LocationNode(name: fra2, code: fra2),
+                            LocationNode(name: fra3, code: fra3),
+                        ], showsChildren: true),
+                ], showsChildren: true),
+            LocationNode(
+                name: "France", code: "fr",
+                children: [
+                    LocationNode(
+                        name: "Paris", code: "par",
+                        children: [
+                            LocationNode(name: par1, code: par1),
+                            LocationNode(name: par2, code: par2),
+                            LocationNode(name: par3, code: par3),
+                        ], showsChildren: true),
+                    LocationNode(
+                        name: "Lyon", code: "lyo",
+                        children: [
+                            LocationNode(name: lyo1, code: lyo1),
+                            LocationNode(name: lyo2, code: lyo2),
+                            LocationNode(name: lyo3, code: lyo3),
+                        ], showsChildren: true),
+                ], showsChildren: true),
+        ]
         exitContext = LocationContext(
-            locations: [
-                LocationNode(
-                    name: "Sweden", code: "se",
-                    children: [
-                        LocationNode(
-                            name: "Stockholm",
-                            code: "sth",
-                            children: [
-                                LocationNode(name: sth1, code: sth1),
-                                LocationNode(name: sth2, code: sth2),
-                                LocationNode(name: sth3, code: sth3),
-                            ], showsChildren: true
-                        ),
-                        LocationNode(
-                            name: "Gothenburg", code: "got",
-                            children: [
-                                LocationNode(name: got1, code: got1),
-                                LocationNode(name: got2, code: got2),
-                                LocationNode(name: got3, code: got3),
-                            ], showsChildren: true),
-                    ], showsChildren: true),
-                LocationNode(
-                    name: "Germany", code: "de",
-                    children: [
-                        LocationNode(
-                            name: "Berlin", code: "ber",
-                            children: [
-                                LocationNode(name: ber1, code: ber1),
-                                LocationNode(name: ber2, code: ber2),
-                                LocationNode(name: ber3, code: ber3),
-                            ], showsChildren: true),
-                        LocationNode(
-                            name: "Frankfurt", code: "fra",
-                            children: [
-                                LocationNode(name: fra1, code: fra1),
-                                LocationNode(name: fra2, code: fra2),
-                                LocationNode(name: fra3, code: fra3),
-                            ], showsChildren: true),
-                    ], showsChildren: true),
-                LocationNode(
-                    name: "France", code: "fr",
-                    children: [
-                        LocationNode(
-                            name: "Paris", code: "par",
-                            children: [
-                                LocationNode(name: par1, code: par1),
-                                LocationNode(name: par2, code: par2),
-                                LocationNode(name: par3, code: par3),
-                            ], showsChildren: true),
-                        LocationNode(
-                            name: "Lyon", code: "lyo",
-                            children: [
-                                LocationNode(name: lyo1, code: lyo1),
-                                LocationNode(name: lyo2, code: lyo2),
-                                LocationNode(name: lyo3, code: lyo3),
-                            ], showsChildren: true),
-                    ], showsChildren: true),
-            ],
+            locations: exitLocations,
             customLists: [
                 LocationNode(
                     name: "MyList1", code: "mylist1",

--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
@@ -274,16 +274,29 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
         relaysCandidates = try? relaySelectorWrapper.findCandidates(
             tunnelSettings: tunnelManager.settings
         )
+        if let allRelaysCandidates = try? relaySelectorWrapper.findCandidates(
+            tunnelSettings: .init(
+                tunnelMultihopState: tunnelManager.settings.tunnelMultihopState
+            )
+        ) {
+            entryContext.totalRelayCount = allRelaysCandidates.entryRelays?.count ?? 0
+            exitContext.totalRelayCount = allRelaysCandidates.exitRelays.count
+        } else {
+            entryContext.totalRelayCount = 0
+            exitContext.totalRelayCount = 0
+        }
         if let relaysCandidates {
             exitLocationsDataSource
                 .reload(relaysCandidates.exitRelays.toLocationRelays())
             exitContext.locations = exitLocationsDataSource.nodes
+            exitContext.availableRelayCount = relaysCandidates.exitRelays.count
 
             if let entryRelays = relaysCandidates.entryRelays {
                 entryLocationsDataSource
                     .reload(entryRelays.toLocationRelays())
                 entryContext.locations =
                     entryLocationsDataSource.nodes
+                entryContext.availableRelayCount = entryRelays.count
             }
         } else {
             entryContext.locations = []

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
@@ -78,7 +78,10 @@ struct ExitLocationView<ViewModel: SelectLocationViewModel>: View {
     @ViewBuilder
     func allLocationsSection(isShowingHeader: Bool) -> some View {
         if isShowingHeader {
-            MullvadListSectionHeader(title: "All locations")
+            MullvadListSectionHeader(
+                title: "All locations",
+                subtitle: "Showing \(context.availableRelayCount) of \(context.totalRelayCount)"
+            )
         }
         LocationsListView(
             locations: $context.locations,

--- a/ios/MullvadVPN/Views/MullvadListSectionHeader.swift
+++ b/ios/MullvadVPN/Views/MullvadListSectionHeader.swift
@@ -2,6 +2,12 @@ import SwiftUI
 
 struct MullvadListSectionHeader: View {
     let title: LocalizedStringKey
+    let subtitle: LocalizedStringKey?
+
+    init(title: LocalizedStringKey, subtitle: LocalizedStringKey? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+    }
 
     var body: some View {
         HStack {
@@ -12,6 +18,12 @@ struct MullvadListSectionHeader: View {
             Rectangle()
                 .frame(height: 1)
                 .foregroundStyle(Color.mullvadTextPrimary.opacity(0.2))
+            if let subtitle {
+                Text(subtitle)
+                    .font(.mullvadTiny)
+                    .foregroundStyle(Color.mullvadTextSecondary)
+                    .layoutPriority(1)
+            }
         }
         .frame(minHeight: 44, alignment: .center)
     }


### PR DESCRIPTION
This adds the "Showing xx of yy" subtitle to the trailing side of the header in the location list.

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/b1424985-077d-4187-80d3-8e9ec8190c29" />


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9520)
<!-- Reviewable:end -->
