### PR TITLE
Compile out not supported VM types per platform in test-manager

### DIFF
--- a/test/test-manager/src/config/vm.rs
+++ b/test/test-manager/src/config/vm.rs
@@ -121,8 +121,10 @@ impl VmConfig {
 #[derive(clap::ValueEnum, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum VmType {
+    #[cfg(target_os = "linux")]
     /// QEMU VM
     Qemu,
+    #[cfg(target_os = "macos")]
     /// Tart VM
     Tart,
 }

--- a/test/test-manager/src/vm/mod.rs
+++ b/test/test-manager/src/vm/mod.rs
@@ -6,6 +6,7 @@ use crate::config::{Config, ConfigFile, VmConfig, VmType};
 mod logging;
 pub mod network;
 pub mod provision;
+#[cfg(target_os = "linux")]
 mod qemu;
 mod ssh;
 #[cfg(target_os = "macos")]
@@ -40,19 +41,19 @@ pub async fn run(config: &Config, name: &str) -> Result<Box<dyn VmInstance>> {
     log::info!("Starting VM \"{name}\"");
 
     let instance = match vm_conf.vm_type {
+        #[cfg(target_os = "linux")]
         VmType::Qemu => Box::new(
             qemu::run(config, vm_conf)
                 .await
                 .context("Failed to run QEMU VM")?,
         ) as Box<_>,
+
         #[cfg(target_os = "macos")]
         VmType::Tart => Box::new(
             tart::run(config, vm_conf)
                 .await
                 .context("Failed to run Tart VM")?,
         ) as Box<_>,
-        #[cfg(not(target_os = "macos"))]
-        VmType::Tart => return Err(anyhow::anyhow!("Failed to run Tart VM on a non-macOS host")),
     };
 
     log::debug!("Started instance of \"{name}\" vm");

--- a/test/test-manager/src/vm/network/mod.rs
+++ b/test/test-manager/src/vm/network/mod.rs
@@ -1,7 +1,7 @@
-// #[cfg(target_os = "linux")]
-pub mod linux;
 use std::net::Ipv4Addr;
 
+#[cfg(target_os = "linux")]
+pub mod linux;
 #[cfg(target_os = "linux")]
 pub use linux as platform;
 


### PR DESCRIPTION
In my can-of-worms attempt to forbid `#[allow(...)]` attributes (#9518) I hit a problem with unused code in the `test-manager`. Turns out we do compile qemu on all platforms, but we only compile tart on macos. Do we actually use qemu on non-Linux targets? This PR tries to compile out much more code for invalid targets, to hit problems with unused code etc less.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9521)
<!-- Reviewable:end -->
