### PR TITLE
Support blocking Ipv6 in E2E tests

### DIFF
--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
@@ -130,8 +130,7 @@ class ConnectionTest : EndToEndTest() {
             }
 
             // Block UDP traffic to the relay
-            val firewallRule = DropRule.blockUDPTrafficRule(relayIpAddress!!)
-            firewallClient.createRule(firewallRule)
+            createFirewallRules { DropRule.blockUDPTrafficRule(relayIpAddress!!) }
 
             on<ConnectPage> {
                 clickConnect()
@@ -168,8 +167,7 @@ class ConnectionTest : EndToEndTest() {
             }
 
             // Block UDP traffic to the relay
-            val firewallRule = DropRule.blockUDPTrafficRule(relayIpAddress!!)
-            firewallClient.createRule(firewallRule)
+            createFirewallRules { DropRule.blockUDPTrafficRule(relayIpAddress!!) }
 
             on<ConnectPage> { setObfuscationStory(ObfuscationOption.Off) }
 
@@ -210,8 +208,7 @@ class ConnectionTest : EndToEndTest() {
         }
 
         // Block UDP traffic to the relay
-        val firewallRule = DropRule.blockUDPTrafficRule(relayIpAddress!!)
-        firewallClient.createRule(firewallRule)
+        createFirewallRules { DropRule.blockUDPTrafficRule(relayIpAddress!!) }
 
         // Enable UDP-over-TCP
         on<ConnectPage> { setObfuscationStory(ObfuscationOption.Udp2Tcp) }
@@ -251,8 +248,7 @@ class ConnectionTest : EndToEndTest() {
         }
 
         // Block UDP traffic to the relay
-        val firewallRule = DropRule.blockWireGuardTrafficRule(relayIpAddress!!)
-        firewallClient.createRule(firewallRule)
+        createFirewallRules { DropRule.blockWireGuardTrafficRule(relayIpAddress!!) }
 
         // Enable QUIC
         on<ConnectPage> { setObfuscationStory(ObfuscationOption.Quic) }
@@ -293,8 +289,7 @@ class ConnectionTest : EndToEndTest() {
         }
 
         // Block UDP traffic to the relay
-        val firewallRule = DropRule.blockWireGuardTrafficRule(relayIpAddress!!)
-        firewallClient.createRule(firewallRule)
+        createFirewallRules { DropRule.blockWireGuardTrafficRule(relayIpAddress!!) }
 
         // Enable LWO
         on<ConnectPage> { setObfuscationStory(ObfuscationOption.Lwo) }
@@ -315,8 +310,7 @@ class ConnectionTest : EndToEndTest() {
             app.applySettings(localNetworkSharing = true, obfuscationMode = ObfuscationMode.Off)
 
             // Block all WireGuard traffic
-            val firewallRule = DropRule.blockWireGuardTrafficRule(ANY_IP_ADDRESS)
-            firewallClient.createRule(firewallRule)
+            createFirewallRules { DropRule.blockWireGuardTrafficRule(ANY_IPV4_ADDRESS) }
 
             on<ConnectPage> { clickConnect() }
 
@@ -349,8 +343,7 @@ class ConnectionTest : EndToEndTest() {
         on<ConnectPage>()
 
         // Block everything except the default relay IP. After this the API is no longer reachable.
-        val firewallRule = DropRule.blockAllTrafficExceptToDestinationRule(testRelayIp)
-        firewallClient.createRule(firewallRule)
+        createFirewallRules { DropRule.blockAllTrafficExceptToDestinationRule(testRelayIp) }
 
         // Restarting the activity will re-create the daemon which will try to reach the API.
         targetActivity.finishAffinity()
@@ -443,9 +436,12 @@ class ConnectionTest : EndToEndTest() {
         assertEquals(result.mullvadExitIpHostname, defaultRelay.relay)
     }
 
+    private suspend fun createFirewallRules(block: () -> List<DropRule>) =
+        block().forEach { firewallClient.createRule(it) }
+
     companion object {
         const val VERY_FORGIVING_WIREGUARD_OFF_CONNECTION_TIMEOUT = 60000L
         const val UNSUCCESSFUL_CONNECTION_TIMEOUT = 30000L
-        const val ANY_IP_ADDRESS = "0.0.0.0/0"
+        const val ANY_IPV4_ADDRESS = "0.0.0.0/0"
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/Networking.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/misc/Networking.kt
@@ -1,23 +1,30 @@
 package net.mullvad.mullvadvpn.test.e2e.misc
 
 import java.net.Inet4Address
+import java.net.Inet6Address
 import java.net.NetworkInterface
-import org.junit.Assert.fail
+
+data class IpAddrs(val ipv4: String, val ipv6: List<String>)
 
 object Networking {
-    fun getDeviceIpv4Address(): String {
-        NetworkInterface.getNetworkInterfaces()!!.toList().map { networkInterface ->
-            val address =
+    fun getDeviceIpAddrs(): IpAddrs {
+        NetworkInterface.getNetworkInterfaces()!!.toList().forEach { networkInterface ->
+            val v4 =
                 networkInterface.inetAddresses.toList().find {
                     !it.isLoopbackAddress && it is Inet4Address
                 }
 
-            if (address != null && address.hostAddress != null) {
-                return address.hostAddress!!
+            val v6 =
+                networkInterface.inetAddresses
+                    .toList()
+                    .filter { !it.isLoopbackAddress && it is Inet6Address }
+                    .map { it.hostAddress!! }
+
+            if (v4 != null && v4.hostAddress != null) {
+                return IpAddrs(v4.hostAddress!!, v6)
             }
         }
 
-        fail("Failed to get test device IP address")
-        return ""
+        error("Failed to get test device IP address")
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/router/firewall/DropRule.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/router/firewall/DropRule.kt
@@ -19,26 +19,46 @@ data class DropRule(
     @SerialName("block_all_except_dst") val blockAllExceptDestination: Boolean = false,
 ) {
     companion object {
-        fun blockUDPTrafficRule(to: String): DropRule {
-            val testDeviceIpAddress = Networking.getDeviceIpv4Address()
-            return DropRule(
-                source = testDeviceIpAddress,
-                destination = to,
-                protocols = listOf(NetworkingProtocol.UDP),
-            )
-        }
 
-        fun blockWireGuardTrafficRule(to: String): DropRule =
-            blockUDPTrafficRule(to).copy(protocols = listOf(NetworkingProtocol.WireGuard))
+        fun blockUDPTrafficRule(toIpv4: String): List<DropRule> =
+            blockTrafficToRule(protocols = listOf(NetworkingProtocol.UDP), toIpv4 = toIpv4)
 
-        fun blockAllTrafficExceptToDestinationRule(to: String): DropRule {
-            val testDeviceIpAddress = Networking.getDeviceIpv4Address()
-            return DropRule(
-                source = testDeviceIpAddress,
-                destination = to,
+        fun blockWireGuardTrafficRule(toIpv4: String): List<DropRule> =
+            blockTrafficToRule(protocols = listOf(NetworkingProtocol.WireGuard), toIpv4 = toIpv4)
+
+        fun blockAllTrafficExceptToDestinationRule(toIpv4: String): List<DropRule> =
+            blockTrafficToRule(
                 protocols = emptyList(),
+                toIpv4 = toIpv4,
                 blockAllExceptDestination = true,
             )
+
+        private fun blockTrafficToRule(
+            protocols: List<NetworkingProtocol>,
+            toIpv4: String,
+            blockAllExceptDestination: Boolean = false,
+        ): List<DropRule> {
+            val (sourceIpv4, sourceIpv6) = Networking.getDeviceIpAddrs()
+
+            val ipv4Rule =
+                DropRule(
+                    source = sourceIpv4,
+                    destination = toIpv4,
+                    protocols = protocols,
+                    blockAllExceptDestination = blockAllExceptDestination,
+                )
+
+            val ipv6Rules =
+                sourceIpv6.map {
+                    DropRule(
+                        source = it.split('%')[0], // remove link-local suffix
+                        destination = toIpv4,
+                        protocols = protocols,
+                        blockAllExceptDestination = blockAllExceptDestination,
+                    )
+                }
+
+            return ipv6Rules + ipv4Rule
         }
     }
 }

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/router/packetCapture/PacketCapture.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/router/packetCapture/PacketCapture.kt
@@ -19,7 +19,6 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import java.util.UUID
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import net.mullvad.mullvadvpn.test.e2e.constant.getRaasHost
 import net.mullvad.mullvadvpn.test.e2e.misc.Networking
@@ -107,7 +106,7 @@ class PacketCaptureClient(private val httpClient: HttpClient = defaultHttpClient
     }
 
     suspend fun sendGetCapturedPacketsRequest(session: PacketCaptureSession): HttpResponse {
-        val testDeviceIpAddress = Networking.getDeviceIpv4Address()
+        val testDeviceIpAddress = Networking.getDeviceIpAddrs().ipv4
         return httpClient.put("parse-capture/${session.value}") {
             contentType(ContentType.Application.Json)
             accept(ContentType.Application.Json)


### PR DESCRIPTION
If the device uses ipv6 to talk to RAAS we need to block the ipv6 source address as well.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9523)
<!-- Reviewable:end -->
