### PR TITLE
Update obfuscation E2E test to handle new output format from CLI

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
@@ -36,9 +36,10 @@ test('App should have automatic obfuscation', async () => {
   await expect(automaticObfuscationOption).toHaveAttribute('aria-selected', 'true');
 
   const cliObfuscation = execSync('mullvad obfuscation get').toString().split('\n');
-  expect(cliObfuscation[0]).toEqual('Obfuscation mode: auto');
+  expect(cliObfuscation[0]).toEqual('mode: auto');
   expect(cliObfuscation[1]).toEqual('udp2tcp settings: any port');
-  expect(cliObfuscation[2]).toEqual('Shadowsocks settings: any port');
+  expect(cliObfuscation[2]).toEqual('shadowsocks settings: any port');
+  expect(cliObfuscation[3]).toEqual('wireguard-port settings: any port');
 });
 
 test('App should set obfuscation to shadowsocks with custom port', async () => {
@@ -61,7 +62,7 @@ test('App should set obfuscation to shadowsocks with custom port', async () => {
   await expect(shadowsocksOption).toHaveAttribute('aria-selected', 'true');
 
   const cliObfuscation = execSync('mullvad obfuscation get').toString().split('\n')[2];
-  expect(cliObfuscation).toEqual(`Shadowsocks settings: port ${SHADOWSOCKS_PORT}`);
+  expect(cliObfuscation).toEqual(`shadowsocks settings: port ${SHADOWSOCKS_PORT}`);
 });
 
 test('App should still have shadowsocks custom port', async () => {


### PR DESCRIPTION
Fix the failing E2E test after https://github.com/mullvad/mullvadvpn-app/pull/9295 was merged and the output format of the CLI was changed for the `obfuscation` command.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9528)
<!-- Reviewable:end -->
