### PR TITLE
Fix tunnel manager tests

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -55,7 +55,7 @@ final class TunnelManager: StorePaymentObserver, @unchecked Sendable {
     private let internalQueue = DispatchQueue(label: "TunnelManager.internalQueue")
 
     private var statusObserver: TunnelStatusBlockObserver?
-    private var lastMapConnectionStatusOperation: Operation?
+    private weak var lastMapConnectionStatusOperation: Operation?
     private let observerList = ObserverList<TunnelObserver>()
     private var networkMonitor: NWPathMonitor?
     private let relaySelector: RelaySelectorProtocol


### PR DESCRIPTION
The TunnelManager is leaking and can potentially trigger fulfillments multiple times.
This PR fixes the leaking of the TunnelManager

Making the `lastMapConnectionStatusOperation` weak in the `TunnelManager` is safe since the Queue will keep a strong reference until the task is finished.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9534)
<!-- Reviewable:end -->
