### PR TITLE
Fix too short timeouts in ios UI tests

### DIFF
--- a/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
+++ b/ios/MullvadVPNUITests/Pages/DeviceManagementPage.swift
@@ -25,7 +25,7 @@ class DeviceManagementPage: Page {
     @discardableResult func waitForNoLoading() -> Self {
         XCTAssertTrue(
             app.otherElements[.deviceRemovalProgressView]
-                .notExistsAfterWait(timeout: .long)
+                .notExistsAfterWait(timeout: .longerThanMullvadAPITimeout)
         )
 
         return self

--- a/ios/MullvadVPNUITests/Pages/LoginPage.swift
+++ b/ios/MullvadVPNUITests/Pages/LoginPage.swift
@@ -62,13 +62,15 @@ class LoginPage: Page {
     @discardableResult public func verifyFailIconShown() -> Self {
         let predicate = NSPredicate(format: "identifier == 'statusImageView' AND value == 'fail'")
         let elementQuery = app.images.containing(predicate)
-        let elementExists = elementQuery.firstMatch.existsAfterWait(timeout: .veryLong)
+        let elementExists = elementQuery.firstMatch.existsAfterWait(
+            timeout: .longerThanMullvadAPITimeout
+        )
         XCTAssertTrue(elementExists, "Fail icon shown")
         return self
     }
 
     /// Checks whether success icon is being shown
     func getSuccessIconShown() -> Bool {
-        app.images[.statusImageView].existsAfterWait(timeout: .long)
+        app.images[.statusImageView].existsAfterWait(timeout: .longerThanMullvadAPITimeout)
     }
 }

--- a/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
+++ b/ios/MullvadVPNUITests/XCUIElement+Extensions.swift
@@ -138,6 +138,9 @@ extension XCUIElement {
         case `default` = 5
         case long = 15
         case veryLong = 20
+        // API calls with `RetryStrategy.default` have a maximum timeout of 36 seconds
+        // 10 sec * 3 tries + 2 sec + 2 sec ^ 2 = 36
+        case longerThanMullvadAPITimeout = 37
         case extremelyLong = 180
     }
 


### PR DESCRIPTION
When making API calls in the UI tests (e.g. login) the test needs to wait longer than the API timeout to make sure the test does not fail too early when it could have succeeded.
We have seen in several different test runs that login takes more than 30 seconds and the test fails because of a too short timeout:
https://github.com/mullvad/mullvadvpn-app/actions/runs/20286756363
https://github.com/mullvad/mullvadvpn-app/actions/runs/20224259235

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9541)
<!-- Reviewable:end -->
