### PR TITLE
Toggle window by clicking the tray icon instead of just showing it on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Line wrap the file at 100 chars.                                              Th
 #### macOS
 - Use arch-specific installers to deliver updates. This makes updates around 50% smaller.
 
+#### Linux
+- Clicking on the tray icon will toggle the window instead of just showing it
+
 ### Fixed
 - Align ciphers for custom shadowsocks API access methods between clients and `mullvad-daemon`. Any
   existing, invalid access method is removed with a settings migration.

--- a/desktop/packages/mullvad-vpn/src/main/user-interface.ts
+++ b/desktop/packages/mullvad-vpn/src/main/user-interface.ts
@@ -605,7 +605,7 @@ export default class UserInterface implements WindowControllerDelegate {
         });
         break;
       case 'linux':
-        this.tray?.on('click', () => this.windowController.show());
+        this.tray?.on('click', () => this.windowController.toggle());
         break;
     }
   }


### PR DESCRIPTION
### What is changed?
Clicking the tray icon on Linux now toggles the window instead of showing it
### Why is this wanted?
Sometimes one just wants to open the app to quickly check the connection status/country and then close it again to free up desktop space. With this PR this process is easier. Also it looks like it already works like this on Windows. Implements #9094
### How to test the change?
Open the app and click the tray icon multiple times to see it toggle
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [x] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [x] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [x] Automatic tests are added for the change, if relevant. All new features must have tests.
* [x] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9544)
<!-- Reviewable:end -->
