### PR TITLE
Disable 'cache-bin' for cache action

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -53,6 +53,9 @@ runs:
         cache-directories: >-
           ${{ inputs.rust-cache-targets == 'true' && env.CARGO_TARGET_DIR || '' }}
         cache-targets: ${{ inputs.rust-cache-targets }}
+        # `cache-bin` causes `~/.cargo/bin/rustup` to be deleted for self-hosted runners
+        # See https://github.com/Swatinem/rust-cache/issues/16
+        cache-bin: false
 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3


### PR DESCRIPTION
Caching `~/.cargo/bin` causes the action to delete `rustup` in self-hosted runners during cleanup. This explains some E2E tests failing: https://github.com/mullvad/mullvadvpn-app/actions/runs/20339487109/job/58435009825

E2E run: https://github.com/mullvad/mullvadvpn-app/actions/runs/20341647968

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9553)
<!-- Reviewable:end -->
