### PR TITLE
Fix inconsistent location list rerenders

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/DataSource/LocationNode.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/DataSource/LocationNode.swift
@@ -9,6 +9,7 @@
 import MullvadSettings
 import MullvadTypes
 
+@Observable
 class LocationNode: @unchecked Sendable {
     let name: String
     var code: String


### PR DESCRIPTION
Changes to the location node model currently only show if the corresponding location list item has left the viewport and brought back after the change (by scrolling). E.g. the "connected server" label does not change if the actual server changes if the relay is visible in the list during the change. It only appears if the relay was scrolled out of the viewport and brought back.
The model needs to tell the view about state changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9556)
<!-- Reviewable:end -->
