### PR TITLE
Skip nondeterministic test

### DIFF
--- a/ios/MullvadRESTTests/DefaultLocationServiceTests.swift
+++ b/ios/MullvadRESTTests/DefaultLocationServiceTests.swift
@@ -15,6 +15,10 @@ class DefaultLocationServiceTests: XCTestCase {
     private let encoder = JSONEncoder()
 
     func testFetchCurrentLocationIdentifier() async throws {
+        let skipReason = """
+                The behavior is currently nondeterministic. Skip until this is fixed.
+            """
+        try XCTSkipIf(true, skipReason)
         let mockData = try encoder.encode(
             REST.ServerLocation(
                 country: "USA",


### PR DESCRIPTION
The tested function is nondeterministic. This will be fixed soon. Until then, skip the test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9557)
<!-- Reviewable:end -->
