### PR TITLE
Make the "showing x of y" subtitle only visible if x<y

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/LocationContext.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/LocationContext.swift
@@ -29,4 +29,6 @@ struct LocationContext {
             .flatMap { [$0] + $0.flattened }
             .first { $0.isSelected }
     }
+
+    var relaysAreFiltered: Bool { availableRelayCount < totalRelayCount }
 }

--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/ExitLocationView.swift
@@ -80,7 +80,8 @@ struct ExitLocationView<ViewModel: SelectLocationViewModel>: View {
         if isShowingHeader {
             MullvadListSectionHeader(
                 title: "All locations",
-                subtitle: "Showing \(context.availableRelayCount) of \(context.totalRelayCount)"
+                subtitle: context.relaysAreFiltered
+                    ? ("Showing \(context.availableRelayCount) of \(context.totalRelayCount)") : nil
             )
         }
         LocationsListView(


### PR DESCRIPTION
This is an addendum to IOS-1370, making the "Showing __ of __" subtitle in the locations view visible only if some relays are filtered out.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9567)
<!-- Reviewable:end -->
