### PR TITLE
Log whenever user taps to change tunnel state

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -124,9 +124,11 @@ class TunnelViewController: UIViewController, RootContainment {
         connectionView.action = { [weak self] action in
             switch action {
             case .connect:
+                self?.logger.debug("User tapped connect button")
                 self?.interactor.startTunnel()
 
             case .cancel:
+                self?.logger.debug("User tapped cancel button")
                 if case .waitingForConnectivity(.noConnection) = self?.interactor.tunnelStatus.state {
                     self?.shouldShowCancelTunnelAlert?()
                 } else {
@@ -134,9 +136,11 @@ class TunnelViewController: UIViewController, RootContainment {
                 }
 
             case .disconnect:
+                self?.logger.debug("User tapped disconnect button")
                 self?.interactor.stopTunnel()
 
             case .reconnect:
+                self?.logger.debug("User tapped reconnect button")
                 self?.interactor.reconnectTunnel(selectNewRelay: true)
 
             case .selectLocation:


### PR DESCRIPTION
Adding logging to the connection view action handler to have positive proof in the logs as to when the users click to connect/disconnect/reconnect or cancel the tunnel connection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9568)
<!-- Reviewable:end -->
