### PR TITLE
Workaround xcode26 bugs ios 1412

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -48,7 +48,7 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
         return persistentTunnels
     }
 
-    func loadPersistentTunnels(completion: @escaping (Error?) -> Void) {
+    func loadPersistentTunnels(completion: @escaping @Sendable (Error?) -> Void) {
         TunnelProviderManagerType.loadAllFromPreferences { managers, error in
             self.lock.lock()
             defer {

--- a/ios/MullvadVPN/TunnelManager/VPNConnectionProtocol.swift
+++ b/ios/MullvadVPN/TunnelManager/VPNConnectionProtocol.swift
@@ -20,11 +20,11 @@ protocol VPNTunnelProviderManagerProtocol: Equatable {
 
     init()
 
-    func loadFromPreferences(completionHandler: @escaping (Error?) -> Void)
-    func saveToPreferences(completionHandler: ((Error?) -> Void)?)
-    func removeFromPreferences(completionHandler: ((Error?) -> Void)?)
+    func loadFromPreferences(completionHandler: @escaping @Sendable (Error?) -> Void)
+    func saveToPreferences(completionHandler: (@Sendable (Error?) -> Void)?)
+    func removeFromPreferences(completionHandler: (@Sendable (Error?) -> Void)?)
 
-    static func loadAllFromPreferences(completionHandler: @escaping ([SelfType]?, Error?) -> Void)
+    static func loadAllFromPreferences(completionHandler: @escaping @Sendable ([SelfType]?, Error?) -> Void)
 }
 
 protocol VPNConnectionProtocol: NSObject {

--- a/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewModel.swift
+++ b/ios/MullvadVPN/View controllers/AccountDeletion/AccountDeletionViewModel.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import SwiftUICore
+import SwiftUI
 
 protocol AccountDeletionBackEnd {
     var accountNumber: String? { get }


### PR DESCRIPTION
**Why this needs to be done**

We want to use Xcode26, but it is buggy ([IOS-1411](https://linear.app/mullvad/issue/IOS-1411/report-networkextension-incompatibility-with-swift-6-concurrency)). We can work around this by using the old callback interface for the PacketTunnelProvider.

**How do we do this?**

We can use the callback based interface for startTunnel, the issue stems from the fact that the map containing settings contains NSObjects, which are not sendable. We could parse the map into a better type, but I believe this will cascade changes down to WireGuardKit, and we don't need that.

**Acceptance criteria**

First iteration:
- App compiles and runs without crashes when built with Xcode 26
- App compiles and runs without crashes when built with Xcode 16.4
- CI pipeline compiles and runs without crashes when built with Xcode 16.4
- Run full test suite (unit, UI, E2E) on 16.4

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9572)
<!-- Reviewable:end -->
