### PR TITLE
Add -allowProvisioningUpdates to CI build

### DIFF
--- a/.github/actions/ios/build-ios-e2e-tests/action.yml
+++ b/.github/actions/ios/build-ios-e2e-tests/action.yml
@@ -91,6 +91,7 @@ runs:
           -testPlan MullvadVPNUITestsAll $TEST_NAME_ARGUMENT \
           -destination "platform=iOS,id=$TEST_DEVICE_UDID" \
           -derivedDataPath derived-data \
+          -allowProvisioningUpdates \
           clean build-for-testing 2>&1
       shell: bash
       working-directory: ios/

--- a/.github/actions/ios/run-ios-e2e-tests/action.yml
+++ b/.github/actions/ios/run-ios-e2e-tests/action.yml
@@ -62,6 +62,7 @@ runs:
           -testPlan MullvadVPNUITestsAll $TEST_NAME_ARGUMENT \
           -resultBundlePath ${{ env.TEST_OUTPUT_DIRECTORY }}/xcode-test-report \
           -derivedDataPath derived-data \
+          -allowProvisioningUpdates \
           -destination "platform=iOS,id=$TEST_DEVICE_UDID" \
           test-without-building 2>&1 | xcbeautify --report junit \
           --report-path ${{ env.TEST_OUTPUT_DIRECTORY }}/junit-test-report

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -51,6 +51,7 @@ jobs:
           -testPlan MullvadVPNUITestsAll \
           -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
           -disableAutomaticPackageResolution \
+          -allowProvisioningUpdates \
           -destination "platform=iOS Simulator,name=iPhone 16" \
           clean build-for-testing 2>&1 | xcbeautify
         working-directory: ios/
@@ -76,6 +77,7 @@ jobs:
             -destination "platform=iOS Simulator,name=iPhone 16" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
             -disableAutomaticPackageResolution \
+            -allowProvisioningUpdates \
             -resultBundlePath xcode-test-report \
             test 2>&1 | xcbeautify
         working-directory: ios/


### PR DESCRIPTION
Automatic signing on CI requires the currently missing flag `-allowProvisioningUpdates`.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9574)
<!-- Reviewable:end -->
