### PR TITLE
Proxy requests to the API when connecting

### DIFF
--- a/ios/MullvadVPN/TransportMonitor/APITransportMonitor.swift
+++ b/ios/MullvadVPN/TransportMonitor/APITransportMonitor.swift
@@ -41,12 +41,16 @@ final class APITransportMonitor: APITransportProviderProtocol {
     private func shouldRouteThroughTunnel(tunnel: any TunnelProtocol) -> Bool {
         switch tunnel.status {
         case .connected:
-            // Use tunnel if the tunnel is connected but the tunnel manager reports an error
-            if case .error = tunnelManager.tunnelStatus.state {
+            switch tunnelManager.tunnelStatus.state {
+            // Use tunnel if the tunnel is connected but the tunnel manager
+            // reports an error or the tunnel is still connecting
+            case .error, .connecting, .negotiatingEphemeralPeer:
                 return true
-            }
             // Also use tunnel if configuration is loaded and device is revoked
-            return tunnelManager.isConfigurationLoaded && tunnelManager.deviceState == .revoked
+            default:
+                return tunnelManager.isConfigurationLoaded && tunnelManager.deviceState == .revoked
+
+            }
 
         case .connecting, .reasserting:
             // Use tunnel while it's in a transitional connecting state


### PR DESCRIPTION
When connecting, the frontend app won't be able to reach the API unless it is proxying its requests outside of the tunnel. I don't believe we need to merge these changes necessarily, but these changes are still valid to talk about. These changes do imply leaking more requests to our API outside of the tunnel - we only do this to remedy the cases where a tunnel cannot be established. 

Yet this will not help users who suffer from login/logout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9581)
<!-- Reviewable:end -->
