### PR TITLE
Enter the blocked state when offline and fix network path update rollup

### DIFF
--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor.swift
@@ -194,7 +194,11 @@ public actor PacketTunnelActor {
                 .recoverableError()
         {
             await handleRestartConnection(nextRelays: .random, reason: .userInitiated)
+            return
         }
+
+        // if network reachability didn't update, just enter offline state
+        await setErrorStateInternal(with: .offline)
     }
 }
 

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActorReducer.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActorReducer.swift
@@ -84,7 +84,7 @@ extension PacketTunnelActor {
             case let .networkReachability(defaultPath):
                 let newReachability = defaultPath.networkReachability
                 let reachabilityChanged = state.connectionData?.networkReachability != newReachability
-                if reachabilityChanged ?? true {
+                if reachabilityChanged {
                     state.mutateAssociatedData { $0.networkReachability = newReachability }
                     return [.updateTunnelMonitorPath(defaultPath)]
 

--- a/ios/PacketTunnelCore/Actor/State+Extensions.swift
+++ b/ios/PacketTunnelCore/Actor/State+Extensions.swift
@@ -206,7 +206,7 @@ extension BlockedStateReason {
             .multihopEntryEqualsExit, .noRelaysSatisfyingObfuscationSettings,
             .noRelaysSatisfyingDaitaConstraints, .readSettings, .invalidAccount, .accountExpired, .deviceRevoked,
             .unknown, .deviceLoggedOut, .outdatedSchema, .invalidRelayPublicKey,
-            .noRelaysSatisfyingPortConstraints, .tunnelAdapter:
+            .noRelaysSatisfyingPortConstraints, .tunnelAdapter, .offline:
             return false
         }
     }

--- a/ios/PacketTunnelCore/Actor/State.swift
+++ b/ios/PacketTunnelCore/Actor/State.swift
@@ -239,6 +239,9 @@ public enum BlockedStateReason: String, Codable, Equatable, Sendable {
     /// Invalid public key.
     case invalidRelayPublicKey
 
+    /// Device is offline
+    case offline
+
     /// Unidentified reason.
     case unknown
 
@@ -248,7 +251,7 @@ public enum BlockedStateReason: String, Codable, Equatable, Sendable {
         case .deviceLocked, .multihopEntryEqualsExit, .outdatedSchema, .noRelaysSatisfyingConstraints,
             .noRelaysSatisfyingPortConstraints, .noRelaysSatisfyingDaitaConstraints,
             .noRelaysSatisfyingFilterConstraints, .noRelaysSatisfyingObfuscationSettings, .readSettings,
-            .invalidRelayPublicKey:
+            .invalidRelayPublicKey, .offline:
             return true
         case .deviceRevoked, .deviceLoggedOut, .tunnelAdapter, .accountExpired, .invalidAccount, .unknown:
             return false


### PR DESCRIPTION
There's no need for the Packet Tunnel Actor to be notified about path updates if the reachability has not chagned. Further, to really quell the packet tunnel actor from attempting to negotiate an ephemeral peer, I've changed it such that the actor will enter the error state when there's no connectivity. 

Do you think these are worthwhile changes?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9591)
<!-- Reviewable:end -->
