### PR TITLE
Disable routing in tun 0.8 for macOS

### DIFF
--- a/talpid-tunnel/src/tun_provider/unix.rs
+++ b/talpid-tunnel/src/tun_provider/unix.rs
@@ -275,6 +275,11 @@ mod tun08_imp {
             let mut tunnel_device = {
                 #[allow(unused_mut)]
                 let mut builder = TunnelDeviceBuilder::default();
+                #[cfg(target_os = "macos")]
+                builder.config.platform_config(|cfg| {
+                    // Routing is managed by the tunnel state machine
+                    cfg.enable_routing(false);
+                });
                 #[cfg(target_os = "linux")]
                 {
                     if self.config.packet_information {


### PR DESCRIPTION
By default, tun (0.8) adds routes for us on macOS. We do not want this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9598)
<!-- Reviewable:end -->
