### PR TITLE
Bump EmbarkStudios/cargo-deny-action to @v2 in test workspace

### DIFF
--- a/.github/workflows/testframework-rust-supply-chain.yml
+++ b/.github/workflows/testframework-rust-supply-chain.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run cargo deny (test workspace)
-        uses: EmbarkStudios/cargo-deny-action@v1
+        uses: EmbarkStudios/cargo-deny-action@v2
         with:
           manifest-path: ./test/Cargo.toml
           log-level: warn


### PR DESCRIPTION
Bumping the action to the latest (major) version. This makes it consistent with the version we use elsewhere. Hopefully this should also fix the following issue I ran into: https://github.com/mullvad/mullvadvpn-app/actions/runs/20783175995/job/59685488206?pr=9521

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9605)
<!-- Reviewable:end -->
