### PR TITLE
Remove some unused #[allow] attributes, and replace some with #[expect]

### DIFF
--- a/mullvad-daemon/src/leak_checker/mod.rs
+++ b/mullvad-daemon/src/leak_checker/mod.rs
@@ -153,7 +153,7 @@ impl Task {
 }
 
 #[cfg(target_os = "android")]
-#[allow(clippy::unused_async)]
+#[expect(clippy::unused_async)]
 async fn check_for_leaks(
     _route_manager: &RouteManagerHandle,
     _destination: Endpoint,

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -3442,7 +3442,7 @@ impl Daemon {
         Self::oneshot_send(tx, (), "on_toggle_relay response");
     }
 
-    #[cfg_attr(not(in_app_upgrade), allow(clippy::unused_async))]
+    #[cfg_attr(not(in_app_upgrade), expect(clippy::unused_async))]
     async fn on_app_upgrade(&self, tx: ResponseTx<(), version::Error>) {
         #[cfg(in_app_upgrade)]
         {
@@ -3456,7 +3456,7 @@ impl Daemon {
         };
     }
 
-    #[cfg_attr(not(in_app_upgrade), allow(clippy::unused_async))]
+    #[cfg_attr(not(in_app_upgrade), expect(clippy::unused_async))]
     async fn on_app_upgrade_abort(&self, tx: ResponseTx<(), version::Error>) {
         #[cfg(in_app_upgrade)]
         {
@@ -3473,7 +3473,7 @@ impl Daemon {
         };
     }
 
-    #[cfg_attr(not(in_app_upgrade), allow(clippy::unused_async))]
+    #[cfg_attr(not(in_app_upgrade), expect(clippy::unused_async))]
     async fn on_get_app_upgrade_cache_dir(&self, tx: ResponseTx<PathBuf, version::Error>) {
         #[cfg(in_app_upgrade)]
         {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1261,7 +1261,7 @@ impl ManagementService for ManagementServiceImpl {
     }
 }
 
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 impl ManagementServiceImpl {
     /// Sends a command to the daemon and maps the error to an RPC error.
     fn send_command_to_daemon(&self, command: DaemonCommand) -> Result<(), Status> {

--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -115,7 +115,7 @@ fn handle_custom_list_error(
 pub struct SettingsPersister {
     settings: Settings,
     path: PathBuf,
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     on_change_listeners: Vec<Box<dyn Fn(&Settings) + Send + Sync>>,
 }
 

--- a/mullvad-daemon/src/version/check.rs
+++ b/mullvad-daemon/src/version/check.rs
@@ -127,7 +127,7 @@ impl VersionUpdater {
 impl VersionUpdaterInner {
     /// Update [Self::last_app_version_info] and write it to disk cache, and notify the `update`
     /// callback.
-    #[allow(unused_mut)]
+    #[cfg_attr(target_os = "android", expect(unused_mut))]
     async fn update_version_info(
         &mut self,
         update: &impl Fn(VersionCache) -> BoxFuture<'static, Result<(), Error>>,

--- a/mullvad-daemon/src/version/router.rs
+++ b/mullvad-daemon/src/version/router.rs
@@ -203,7 +203,7 @@ impl State {
     }
 }
 
-#[cfg_attr(not(in_app_upgrade), allow(unused_variables))]
+#[cfg_attr(not(in_app_upgrade), expect(unused_variables))]
 pub(crate) fn spawn_version_router(
     api_handle: MullvadRestHandle,
     availability_handle: ApiAvailability,
@@ -551,7 +551,7 @@ where
 
 /// Wait for the update to finish. In case no update is in progress (or the platform does not
 /// support in-app upgrades), then the future will never resolve as to not escape the select statement.
-#[allow(clippy::unused_async, unused_variables)]
+#[cfg_attr(not(in_app_upgrade), expect(unused_variables))]
 async fn wait_for_update(state: &mut State) -> Option<AppVersionInfo> {
     #[cfg(in_app_upgrade)]
     match state {

--- a/mullvad-leak-checker/src/traceroute/unix/mod.rs
+++ b/mullvad-leak-checker/src/traceroute/unix/mod.rs
@@ -66,7 +66,7 @@ pub trait AsyncIcmpSocket: Sized {
     async fn send_to(&self, packet: &[u8], destination: impl Into<IpAddr>) -> io::Result<usize>;
 
     /// Receive an ICMP packet.
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), allow(dead_code))]
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), expect(dead_code))]
     async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, IpAddr)>;
 
     /// Try to read ICMP/TimeExceeded error packets to see if probe packets leaked.

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -88,7 +88,7 @@ impl TryFrom<types::daemon_event::Event> for DaemonEvent {
 #[cfg(not(target_os = "android"))]
 impl MullvadProxyClient {
     pub async fn new() -> Result<Self> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         super::new_rpc_client().await.map(Self)
     }
 

--- a/mullvad-management-interface/src/types/conversions/states.rs
+++ b/mullvad-management-interface/src/types/conversions/states.rs
@@ -443,7 +443,7 @@ impl TryFrom<proto::TunnelState> for mullvad_types::states::TunnelState {
     }
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
+#[cfg_attr(not(target_os = "windows"), expect(unused_variables))]
 fn try_firewall_policy_error_from_i32(
     policy_error: i32,
     lock_pid: u32,

--- a/mullvad-management-interface/src/types/mod.rs
+++ b/mullvad-management-interface/src/types/mod.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 mod proto {
     tonic::include_proto!("mullvad_daemon.management_interface");
 }

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -188,7 +188,7 @@ struct NormalSelectorConfig<'a> {
 /// The return type of [`RelaySelector::get_relay`].
 // There won't ever be many instances of GetRelay floating around, so the 'large' difference in
 // size between its variants is negligible.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum GetRelay {
     Mullvad {

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -400,7 +400,7 @@ impl Intersection for BridgeQuery {
     }
 }
 
-#[allow(unused)]
+#[expect(unused)]
 pub mod builder {
     //! Strongly typed Builder pattern for of relay constraints though the use of the Typestate
     //! pattern.

--- a/mullvad-types/src/access_method.rs
+++ b/mullvad-types/src/access_method.rs
@@ -239,7 +239,7 @@ pub struct AccessMethodSetting {
 pub struct Id(uuid::Uuid);
 
 impl Id {
-    #[allow(clippy::new_without_default)]
+    #[expect(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(uuid::Uuid::new_v4())
     }

--- a/mullvad-types/src/constraints/constraint.rs
+++ b/mullvad-types/src/constraints/constraint.rs
@@ -135,7 +135,7 @@ impl<T: PartialEq> Constraint<T> {
 }
 
 // Using the default attribute fails on Android
-#[allow(clippy::derivable_impls)]
+#[expect(clippy::derivable_impls)]
 impl<T> Default for Constraint<T> {
     fn default() -> Self {
         Constraint::Any

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -237,7 +237,7 @@ pub struct TunnelOptions {
     pub rotation_interval: Option<RotationInterval>,
 }
 
-#[allow(clippy::derivable_impls)]
+#[expect(clippy::derivable_impls)]
 impl Default for TunnelOptions {
     fn default() -> Self {
         TunnelOptions {

--- a/mullvad-update/src/bin/mullvad-version-metadata.rs
+++ b/mullvad-update/src/bin/mullvad-version-metadata.rs
@@ -8,7 +8,7 @@ use tokio::{fs, io};
 use mullvad_update::format::key;
 use mullvad_update::format::response::{Response, SignedResponse};
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 const DEFAULT_EXPIRY_MONTHS: u32 = 6;
 
 /// A tool that generates signed Mullvad version metadata.

--- a/mullvad-update/src/version/rollout.rs
+++ b/mullvad-update/src/version/rollout.rs
@@ -87,7 +87,7 @@ impl TryFrom<f32> for Rollout {
 
 impl Eq for Rollout {}
 
-#[allow(clippy::derive_ord_xor_partial_ord)] // we impl Ord in terms of PartalOrd, so it's fine
+#[expect(clippy::derive_ord_xor_partial_ord)] // we impl Ord in terms of PartalOrd, so it's fine
 impl Ord for Rollout {
     fn cmp(&self, other: &Self) -> Ordering {
         debug_assert!(self.0.is_finite());

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -645,7 +645,7 @@ impl ConnectingState {
     }
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
+#[cfg_attr(not(target_os = "windows"), expect(unused_variables))]
 fn should_retry(error: &tunnel_monitor::Error, retry_attempt: u32) -> bool {
     #[cfg(target_os = "windows")]
     if error.get_tunnel_device_error().is_some() {

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -132,7 +132,10 @@ pub struct LinuxNetworkingIdentifiers {
 }
 
 /// Spawn the tunnel state machine thread, returning a channel for sending tunnel commands.
-#[allow(clippy::too_many_arguments)]
+#[cfg_attr(
+    any(target_os = "android", target_os = "windows", target_os = "linux"),
+    expect(clippy::too_many_arguments)
+)]
 pub async fn spawn(
     initial_settings: InitialTunnelState,
     tunnel_parameters_generator: impl TunnelParametersGenerator,

--- a/talpid-net/src/unix.rs
+++ b/talpid-net/src/unix.rs
@@ -91,7 +91,7 @@ impl IfReq {
         // https://docs.rs/libc/latest/x86_64-unknown-linux-musl/libc/fn.ioctl.html
         // https://docs.rs/libc/latest/x86_64-unknown-linux-musl/libc/type.c_ulong.html
         // https://docs.rs/libc/latest/x86_64-unknown-linux-musl/libc/constant.SIOCSIFMTU.html
-        #[allow(clippy::useless_conversion)]
+        #[expect(clippy::useless_conversion)]
         let request = SIOCSIFMTU.try_into().unwrap();
         // SAFETY: SIOCSIFMTU expects an ifreq with an MTU and interface set. The interface is set
         // by [Self::new].
@@ -113,7 +113,7 @@ impl IfReq {
         // https://docs.rs/libc/latest/x86_64-unknown-linux-musl/libc/fn.ioctl.html
         // https://docs.rs/libc/latest/x86_64-unknown-linux-musl/libc/type.c_ulong.html
         // https://docs.rs/libc/latest/x86_64-unknown-linux-musl/libc/constant.SIOCGIFMTU.html
-        #[allow(clippy::useless_conversion)]
+        #[expect(clippy::useless_conversion)]
         let request = SIOCGIFMTU.try_into().unwrap();
         // SAFETY: SIOCGIFMTU expects an ifreq with an interface set, which is guaranteed by
         // [Self::new].

--- a/talpid-routing/src/unix/linux.rs
+++ b/talpid-routing/src/unix/linux.rs
@@ -102,7 +102,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can happen in the Linux routing integration
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
 pub enum Error {
     #[error("Failed to open a netlink connection")]
     Connect(#[source] io::Error),

--- a/talpid-routing/src/unix/mod.rs
+++ b/talpid-routing/src/unix/mod.rs
@@ -22,17 +22,17 @@ use std::collections::HashSet;
 #[cfg(target_os = "linux")]
 use std::net::IpAddr;
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 #[cfg(target_os = "macos")]
 #[path = "macos/mod.rs"]
 pub mod imp;
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 #[cfg(target_os = "linux")]
 #[path = "linux.rs"]
 mod imp;
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 #[cfg(target_os = "android")]
 #[path = "android.rs"]
 mod imp;

--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -21,7 +21,7 @@ mod socket;
 #[cfg(not(target_os = "ios"))]
 mod socket_sniffer;
 
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[expect(clippy::derive_partial_eq_without_eq)]
 mod proto {
     tonic::include_proto!("ephemeralpeer");
 }

--- a/talpid-tunnel/src/tun_provider/unix.rs
+++ b/talpid-tunnel/src/tun_provider/unix.rs
@@ -273,7 +273,6 @@ mod tun08_imp {
         /// Open a tunnel using the current tunnel config.
         pub fn open_tun(&mut self) -> Result<UnixTun, Error> {
             let mut tunnel_device = {
-                #[allow(unused_mut)]
                 let mut builder = TunnelDeviceBuilder::default();
                 #[cfg(target_os = "macos")]
                 builder.config.platform_config(|cfg| {
@@ -366,7 +365,7 @@ mod tun08_imp {
         #[cfg(target_os = "linux")]
         pub fn enable_packet_information(&mut self) -> &mut Self {
             self.config.platform_config(|config| {
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 // NOTE: This function does seemingly have an effect on Linux, despite what the deprecation
                 // warning says.
                 config.packet_information(true);

--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -219,7 +219,7 @@ impl WgConfigBuffer {
 }
 
 /// Returns a CString with the appropriate config for WireGuard-go
-#[allow(single_use_lifetimes)]
+#[expect(single_use_lifetimes)]
 pub fn userspace_format<'a>(
     private_key: &PrivateKey,
     peers: impl Iterator<Item = &'a PeerConfig>,

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -858,7 +858,7 @@ impl WireguardMonitor {
     }
 
     /// Returns routes to the peer endpoints (through the physical interface).
-    #[cfg_attr(target_os = "linux", allow(unused_variables))]
+    #[cfg_attr(target_os = "linux", expect(unused_variables))]
     #[cfg(not(target_os = "android"))]
     fn get_endpoint_routes(
         endpoints: &[std::net::IpAddr],
@@ -877,7 +877,7 @@ impl WireguardMonitor {
         })
     }
 
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
+    #[cfg_attr(not(target_os = "windows"), expect(unused_variables))]
     #[cfg(not(target_os = "android"))]
     fn get_tunnel_nodes(
         iface_name: &str,
@@ -1071,7 +1071,6 @@ enum CloseMsg {
     ObfuscatorFailed(Error),
 }
 
-#[allow(unused)]
 #[async_trait::async_trait]
 pub(crate) trait Tunnel: Send + Sync {
     fn get_interface_name(&self) -> String;
@@ -1173,7 +1172,6 @@ pub enum TunnelError {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(dead_code)]
 fn will_nm_manage_dns() -> bool {
     use talpid_dbus::network_manager::NetworkManager;
 

--- a/test/test-manager/src/main.rs
+++ b/test/test-manager/src/main.rs
@@ -29,7 +29,6 @@ struct Args {
 }
 
 #[derive(clap::Subcommand, Debug)]
-#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Manage configuration for tests and VMs
     #[clap(subcommand)]
@@ -145,7 +144,7 @@ enum Commands {
 }
 
 #[derive(clap::Subcommand, Debug)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum ConfigArg {
     /// Print the current config
     Get,
@@ -157,7 +156,7 @@ enum ConfigArg {
 }
 
 #[derive(clap::Subcommand, Debug)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum VmConfig {
     /// Create or edit a VM config
     Set {

--- a/test/test-manager/src/tests/config.rs
+++ b/test/test-manager/src/tests/config.rs
@@ -33,7 +33,7 @@ pub struct TestConfig {
 }
 
 impl TestConfig {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     // TODO: This argument list is very long, we should strive to shorten it if possible.
     pub const fn new(
         account_number: String,

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -836,7 +836,7 @@ pub fn into_constraint(relay: &Relay) -> Constraint<LocationConstraint> {
 /// To customize [`Pinger`] before the pinging and network monitoring starts,
 /// see [`PingerBuilder`]. Call [`start`](Pinger::start) to start pinging, and
 /// [`stop`](Pinger::stop) to get the leak test results.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct Pinger {
     // These values can be configured with [`PingerBuilder`].
     destination: SocketAddr,
@@ -884,7 +884,7 @@ impl Pinger {
         // Create some network activity for the network monitor to sniff.
         let ping_rpc = rpc.clone();
         let mut interval = tokio::time::interval(builder.interval.period());
-        #[allow(clippy::async_yields_async)]
+        #[expect(clippy::async_yields_async)]
         let ping_task = AbortOnDrop::new(tokio::spawn(async move {
             loop {
                 send_guest_probes_without_monitor(ping_rpc.clone(), None, builder.destination)
@@ -933,7 +933,7 @@ pub struct PingerBuilder {
     interval: tokio::time::Interval,
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 impl PingerBuilder {
     /// Create a default [`PingerBuilder`].
     ///

--- a/test/test-manager/src/vm/network/linux.rs
+++ b/test/test-manager/src/vm/network/linux.rs
@@ -46,17 +46,14 @@ data_encoding_macro::base64_array!(
 );
 
 /// Port of the wireguard remote peer as defined in `setup-network.sh`.
-#[allow(dead_code)]
 pub const CUSTOM_TUN_REMOTE_REAL_PORT: u16 = 51820;
 /// Tunnel address of the wireguard local peer as defined in `setup-network.sh`.
 pub const CUSTOM_TUN_LOCAL_TUN_ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 15, 2);
 /// Tunnel address of the wireguard remote peer as defined in `setup-network.sh`.
 pub const CUSTOM_TUN_REMOTE_TUN_ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 15, 1);
 /// Gateway (and default DNS resolver) of the wireguard tunnel.
-#[allow(dead_code)]
 pub const CUSTOM_TUN_GATEWAY: Ipv4Addr = CUSTOM_TUN_REMOTE_TUN_ADDR;
 /// Gateway of the non-tunnel interface.
-#[allow(dead_code)]
 pub(super) const NON_TUN_GATEWAY: Ipv4Addr = Ipv4Addr::new(172, 29, 1, 1);
 /// Name of the wireguard interface on the host
 pub const CUSTOM_TUN_INTERFACE_NAME: &str = "wg-relay0";

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -44,7 +44,7 @@ struct SpawnedProcess {
     stdout: Option<ChildStdout>,
     stdin: Option<ChildStdin>,
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     abort_handle: OnDrop,
 }
 
@@ -598,7 +598,7 @@ impl Service for TestServer {
         sys::get_os_version()
     }
 
-    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+    #[cfg_attr(not(target_os = "macos"), expect(unused_variables))]
     async fn ifconfig_alias_add(
         self,
         _: context::Context,
@@ -615,7 +615,7 @@ impl Service for TestServer {
             .map_err(test_rpc::Error::Other)
     }
 
-    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+    #[cfg_attr(not(target_os = "macos"), expect(unused_variables))]
     async fn ifconfig_alias_remove(
         self,
         _: context::Context,

--- a/test/test-runner/src/package.rs
+++ b/test/test-runner/src/package.rs
@@ -267,7 +267,7 @@ async fn install_nsis_exe(path: &Path) -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-#[allow(unused)]
+#[expect(unused)]
 enum Distribution {
     Debian,
     Ubuntu,


### PR DESCRIPTION
This is a smaller subset of #9518. And it does not make `clippy::allow_attributes` into a warning. This allows the PR to much quicker get a lot of the code merged, making the original PR focused on solving the trickier cases, as well as actually enabling the lint.

This battles bit-rot, as the original PR has some of it over the Christmas holidays, and I'm not sure when I can fix the trickier cases. But having most of this is still a bonus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9612)
<!-- Reviewable:end -->
