### PR TITLE
Remove unused dependencies found with cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,6 @@ dependencies = [
  "cacao",
  "chrono",
  "fern",
- "hex",
  "insta",
  "log",
  "mullvad-paths",
@@ -2304,7 +2303,6 @@ dependencies = [
  "native-windows-gui",
  "objc_id",
  "rand 0.9.2",
- "reqwest",
  "serde",
  "talpid-platform-metadata",
  "tokio",
@@ -2974,7 +2972,6 @@ dependencies = [
  "futures",
  "hickory-resolver",
  "insta",
- "ipnetwork",
  "libc",
  "log",
  "log-panics",
@@ -2997,7 +2994,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-signal",
- "socket2 0.5.8",
  "talpid-core",
  "talpid-dbus",
  "talpid-dns",
@@ -3025,7 +3021,6 @@ dependencies = [
  "hickory-resolver",
  "log",
  "rustls",
- "rustls-pki-types",
  "serde",
  "tokio",
  "webpki-roots 1.0.4",
@@ -3054,7 +3049,6 @@ dependencies = [
 name = "mullvad-ios"
 version = "0.0.0"
 dependencies = [
- "async-trait",
  "cbindgen",
  "futures",
  "hyper",
@@ -3066,7 +3060,6 @@ dependencies = [
  "mullvad-encrypted-dns-proxy",
  "mullvad-types",
  "oslog",
- "serde_json",
  "talpid-future",
  "talpid-tunnel-config-client",
  "talpid-types",
@@ -3086,9 +3079,7 @@ dependencies = [
  "mullvad-api",
  "mullvad-daemon",
  "mullvad-problem-report",
- "mullvad-types",
  "talpid-platform-metadata",
- "talpid-tunnel",
  "talpid-types",
  "thiserror 2.0.17",
  "tokio",
@@ -3169,10 +3160,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "cbindgen",
- "libloading 0.9.0",
  "mullvad-paths",
  "talpid-platform-metadata",
- "talpid-types",
  "widestring",
  "windows-sys 0.61.2",
 ]
@@ -3214,7 +3203,6 @@ name = "mullvad-relay-selector"
 version = "0.0.0"
 dependencies = [
  "chrono",
- "intersection-derive",
  "ipnetwork",
  "itertools 0.14.0",
  "log",
@@ -3240,7 +3228,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
  "strum",
  "tokio",
  "toml 0.8.19",
@@ -5218,7 +5205,6 @@ dependencies = [
  "talpid-platform-metadata",
  "talpid-routing",
  "talpid-tunnel",
- "talpid-tunnel-config-client",
  "talpid-types",
  "talpid-windows",
  "talpid-wireguard",
@@ -5372,7 +5358,6 @@ dependencies = [
  "log",
  "ml-kem",
  "nix 0.30.1",
- "oslog",
  "pqcrypto-hqc",
  "pqcrypto-traits",
  "prost",
@@ -5436,7 +5421,6 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.2",
- "rand_chacha 0.3.1",
  "rtnetlink",
  "socket2 0.5.8",
  "surge-ping",
@@ -5456,7 +5440,6 @@ dependencies = [
  "windows-sys 0.61.2",
  "wireguard-go-rs",
  "zerocopy",
- "zeroize",
 ]
 
 [[package]]
@@ -6001,7 +5984,6 @@ dependencies = [
  "nix 0.30.1",
  "rand 0.8.5",
  "shadowsocks",
- "socket2 0.5.8",
  "talpid-types",
  "thiserror 2.0.17",
  "tokio",

--- a/ci/ios/test-router/raas/Cargo.lock
+++ b/ci/ios/test-router/raas/Cargo.lock
@@ -448,12 +448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,15 +565,6 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "object"
@@ -763,14 +748,11 @@ dependencies = [
  "pcap-file-tokio",
  "pnet_packet",
  "serde",
- "serde_json",
  "thiserror",
  "tokio",
  "tokio-util",
  "tower 0.4.13",
  "tower-http",
- "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -891,15 +873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,16 +967,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1122,19 +1085,7 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -1144,32 +1095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1186,12 +1111,6 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"

--- a/ci/ios/test-router/raas/Cargo.toml
+++ b/ci/ios/test-router/raas/Cargo.toml
@@ -23,10 +23,7 @@ tower-http = { version = "0.5", features = [ "trace" ] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 futures = "0.3"
-tracing = "0.1.35"
-tracing-subscriber = "0.3.14"
 serde = { version = "1.0.138", features = ["derive"] }
-serde_json = "1.0"
 uuid = { version = "1", features = [ "serde" ] }
 anyhow = "1"
 ipnetwork = { version = "0.21", features = [ "serde" ]}

--- a/installer-downloader/Cargo.toml
+++ b/installer-downloader/Cargo.toml
@@ -22,10 +22,8 @@ anyhow = { workspace = true }
 async-trait = "0.1"
 chrono = { workspace = true, features = ["clock"] }
 fern = { workspace = true }
-hex = "0.4"
 log = { workspace = true }
 rand = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
 

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -31,8 +31,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features =  ["fs", "io-util", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"]}
-socket2 = { workspace = true }
-ipnetwork = { workspace = true }
 rand = { workspace = true }
 
 mullvad-relay-selector = { path = "../mullvad-relay-selector" }

--- a/mullvad-encrypted-dns-proxy/Cargo.toml
+++ b/mullvad-encrypted-dns-proxy/Cargo.toml
@@ -17,7 +17,6 @@ hickory-resolver = { workspace = true, features = [ "https-ring", "tls-ring" ]}
 serde = { workspace = true, features = ["derive"] }
 webpki-roots.workspace = true
 rustls.workspace = true
-rustls-pki-types.workspace = true
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/mullvad-ios/Cargo.toml
+++ b/mullvad-ios/Cargo.toml
@@ -31,9 +31,7 @@ talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-api = { path = "../mullvad-api", default-features = false }
 mullvad-types = { path = "../mullvad-types" }
-serde_json = { workspace = true }
 mockito = "1.6.1"
-async-trait = "0.1"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cbindgen = { version = "0.28.0", default-features = false }

--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -29,7 +29,5 @@ log-panics = "2"
 mullvad-api = { path = "../mullvad-api" }
 mullvad-daemon = { path = "../mullvad-daemon" }
 mullvad-problem-report = { path = "../mullvad-problem-report" }
-mullvad-types = { path = "../mullvad-types" }
-talpid-tunnel = { path = "../talpid-tunnel" }
 talpid-types = { path = "../talpid-types" }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }

--- a/mullvad-nsis/Cargo.toml
+++ b/mullvad-nsis/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["staticlib"]
 [target.i686-pc-windows-msvc.dependencies]
 anyhow.workspace = true
 mullvad-paths = { path = "../mullvad-paths" }
-talpid-types = { path = "../talpid-types" }
 talpid-platform-metadata = { path = "../talpid-platform-metadata" }
 windows-sys = { workspace = true, features = [
     "Wdk_Foundation",
@@ -31,7 +30,6 @@ windows-sys = { workspace = true, features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
 ] }
-libloading = { version = "0.9.0" }
 widestring.workspace = true
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/mullvad-relay-selector/Cargo.toml
+++ b/mullvad-relay-selector/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = { workspace = true }
 talpid-types = { path = "../talpid-types" }
 vec1 = { workspace = true }
 mullvad-types = { path = "../mullvad-types" }
-intersection-derive = { path = "../mullvad-types/intersection-derive"}
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/mullvad-update/mullvad-release/Cargo.toml
+++ b/mullvad-update/mullvad-release/Cargo.toml
@@ -18,7 +18,6 @@ hex = { version = "0.4" }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
-sha2 = { workspace = true }
 strum = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 toml = "0.8"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -25,7 +25,6 @@ rand = { workspace = true }
 talpid-dns = { path = "../talpid-dns" }
 talpid-routing = { path = "../talpid-routing" }
 talpid-tunnel = { path = "../talpid-tunnel" }
-talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 talpid-types = { path = "../talpid-types" }
 talpid-wireguard = { path = "../talpid-wireguard" }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -38,8 +38,5 @@ tonic-build = { workspace = true, default-features = false, features = [
     "prost",
 ] }
 
-[target.'cfg(target_os = "ios")'.dependencies]
-oslog = "0.2"
-
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -27,7 +27,6 @@ talpid-routing = { path = "../talpid-routing" }
 talpid-types = { path = "../talpid-types" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }
 talpid-tunnel = { path = "../talpid-tunnel" }
-zeroize = "1"
 chrono = { workspace = true, features = ["clock"], optional = true }
 tokio = { workspace = true, features = ["process", "rt-multi-thread", "fs"] }
 tunnel-obfuscation = { path = "../tunnel-obfuscation" }
@@ -62,7 +61,6 @@ talpid-dbus = { path = "../talpid-dbus" }
 bitflags = "1.2"
 talpid-windows = { path = "../talpid-windows" }
 widestring = { workspace = true }
-rand_chacha = "0.3.1"
 chrono = { workspace = true, features = ["clock"] }
 
 # TODO: Figure out which features are needed and which are not

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -746,18 +746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,19 +758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "3.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
-dependencies = [
- "num-bigint",
- "num-traits",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1566,12 +1541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ioctl-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c429fffa658f288669529fc26565f728489a2e39bc7b24a428aaaf51355182e"
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,7 +2008,6 @@ dependencies = [
  "hickory-resolver",
  "log",
  "rustls",
- "rustls-pki-types",
  "serde",
  "tokio",
  "webpki-roots 1.0.4",
@@ -2094,7 +2062,6 @@ name = "mullvad-relay-selector"
 version = "0.0.0"
 dependencies = [
  "chrono",
- "intersection-derive",
  "ipnetwork",
  "itertools 0.14.0",
  "log",
@@ -2229,30 +2196,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -3615,17 +3562,14 @@ dependencies = [
  "socks-server",
  "ssh2",
  "talpid-types",
- "tarpc",
  "test-rpc",
  "test_macro",
  "thiserror 2.0.3",
  "tokio",
- "tokio-serde",
  "tokio-serial",
  "tokio-util",
  "tonic",
  "tower",
- "tun",
  "uuid",
 ]
 
@@ -3633,7 +3577,6 @@ dependencies = [
 name = "test-rpc"
 version = "0.0.0"
 dependencies = [
- "async-trait",
  "bytes",
  "colored",
  "futures",
@@ -3649,7 +3592,6 @@ dependencies = [
  "thiserror 2.0.3",
  "tokio",
  "tokio-rustls",
- "tokio-serde",
  "tokio-util",
 ]
 
@@ -3669,7 +3611,6 @@ dependencies = [
  "plist",
  "rand 0.9.1",
  "rs-release",
- "serde",
  "serde_json",
  "socket2 0.5.8",
  "surge-ping",
@@ -3680,7 +3621,6 @@ dependencies = [
  "test-rpc",
  "thiserror 2.0.3",
  "tokio",
- "tokio-serde",
  "tokio-serial",
  "tokio-util",
  "windows-service",
@@ -3865,12 +3805,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
  "bytes",
- "educe",
  "futures-core",
  "futures-sink",
  "pin-project",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4158,17 +4095,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tun"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc25e23adc6cac7dd895ce2780f255902290fc39b00e1ae3c33e89f3d20fa66"
-dependencies = [
- "ioctl-sys",
- "libc",
- "thiserror 1.0.59",
-]
 
 [[package]]
 name = "typenum"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -55,7 +55,6 @@ tokio-serial = "5.4.1"
 # Serde and related crates
 serde = "1.0"
 serde_json = "1.0"
-tokio-serde = { version = "0.8.0", features = ["json"] }
 
 # Tonic and related crates
 tonic = "0.13.1"

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = { version = "1", features = ["backtrace"] }
 futures = { workspace = true }
 regex = "1"
 chrono = { workspace = true }
-tarpc = { workspace = true }
 tokio = { workspace = true }
 tokio-serial = { workspace = true }
 thiserror = { workspace = true }
@@ -36,7 +35,6 @@ glob = "0.3"
 
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio-serde = { workspace = true }
 log = { workspace = true }
 
 pcap = { version = "1.3", features = ["capture-stream"] }
@@ -68,7 +66,6 @@ socket2 = { workspace = true }
 duplicate = { version = "2.0.0", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-tun = "0.5.1"
 nix.workspace = true
 
 [dependencies.tokio-util]

--- a/test/test-rpc/Cargo.toml
+++ b/test/test-rpc/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 futures = { workspace = true }
 tokio = { workspace = true }
-tokio-serde = { workspace = true }
 tarpc = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -21,7 +20,6 @@ bytes = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 colored = { workspace = true }
-async-trait = { workspace = true }
 
 hyper = { version = "1.4.1", features = ["client", "http2"] }
 hyper-rustls = { version = "0.27.3", features = ["logging", "webpki-roots", "http1", "ring"], default-features = false}

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -20,9 +20,7 @@ thiserror = { workspace = true }
 log = { workspace = true }
 parity-tokio-ipc = "0.9"
 bytes = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
-tokio-serde = { workspace = true }
 surge-ping = { workspace = true }
 rand = { workspace = true }
 

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -22,7 +22,6 @@ shadowsocks = { workspace = true }
 mullvad-masque-proxy = { path = "../mullvad-masque-proxy" }
 talpid-types = { path = "../talpid-types" }
 rand = { version = "0.8.5", features = ["small_rng"] }
-socket2 = { workspace = true, features = ["all"] }
 
 [target.'cfg(target_os="linux")'.dependencies]
 nix = { workspace = true, features = ["socket"]}


### PR DESCRIPTION
We already have a CI job that tries to detect unused dependencies. But the analysis is not perfect. `cargo machete` is another tool that also tries to find unused dependencies. It is also not perfect according to themselves. But I think it found some unused stuff in our code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9617)
<!-- Reviewable:end -->
