### PR TITLE
Fix filename check in test_problem_report_collect

### DIFF
--- a/test/test-manager/src/tests/install.rs
+++ b/test/test-manager/src/tests/install.rs
@@ -419,15 +419,17 @@ pub async fn test_problem_report_collect(
 
     let found_filenames = log_paths
         .iter()
-        .filter_map(|path| path.file_name().and_then(|name| name.to_str()))
+        // Take the part of `path` that follows its last `/` or `\` (i.e., its filename).
+        // Since this path is for the guest runner, we cannot use `file_name` here.
+        // It likely won't even exist on the host, and the host OS may differ.
+        .filter_map(|path| path.to_str().and_then(|s| s.rsplit(['\\', '/']).next()))
         .collect::<Vec<_>>();
 
     // Files that should be present if we have installed the daemon and started the UI
     // at least once.
-    let mut required_filenames = vec!["daemon.log", "frontend-renderer.log", "frontend-main.log"];
-
     // NOTE: Not looking for *.old.log files because they may not be present
     // NOTE: Not looking for early-boot-fw.log because we may not have rebooted
+    let mut required_filenames = vec!["daemon.log", "frontend-renderer.log", "frontend-main.log"];
 
     if TEST_CONFIG.os == Os::Windows {
         required_filenames.push("install.log");


### PR DESCRIPTION
See comment. `Path::file_name` isn't a good idea here because it's not running on the machine that owns the file.

E2E run: https://github.com/mullvad/mullvadvpn-app/actions/runs/20819013958

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9618)
<!-- Reviewable:end -->
