### PR TITLE
Remove unused shadowsocks dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,6 @@ fern = { version = "0.6", default-features = false }
 
 # Shadowsocks
 shadowsocks = "1.23.2"
-shadowsocks-service = "1.23.2"
 
 itertools = "0.14"
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -75,10 +75,6 @@ thiserror = "2.0"
 log = "0.4"
 colored = "2.0.0"
 
-# Proxy protocols
-shadowsocks = "1.23.2"
-shadowsocks-service = "1.23.2"
-
 windows-sys = "0.52.0"
 chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4.2.7", features = ["cargo", "derive"] }


### PR DESCRIPTION
Follow up to #9617. I now ran `cargo neat` and realized we had one global workspace dependency that no crate actually used!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9621)
<!-- Reviewable:end -->
