### PR TITLE
Add date and branch name to test report

### DIFF
--- a/.github/actions/ios/run-ios-e2e-tests/action.yml
+++ b/.github/actions/ios/run-ios-e2e-tests/action.yml
@@ -72,11 +72,21 @@ runs:
         TEST_NAME: ${{ inputs.test_name }}
         TEST_DEVICE_UDID: ${{ inputs.test_device_udid }}
 
+    - name: Set artifact name with branch and timestamp
+      run: |
+        BRANCH_NAME="${{ github.ref_name }}"
+        # Sanitize branch name by replacing slashes and other special characters
+        BRANCH_NAME_SANITIZED=$(printf "$BRANCH_NAME" | sed 's/[\/:]/_/g')
+        TIMESTAMP=$(date +%Y-%m-%d-%H-%M-%S)
+        ARTIFACT_NAME="${{ env.TEST_NAME_SANITIZED }}-${BRANCH_NAME_SANITIZED}-${TIMESTAMP}-test-results"
+        echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+      shell: bash
+
     - name: Store test report artifact
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.TEST_NAME_SANITIZED }}-test-results
+        name: ${{ env.ARTIFACT_NAME }}
         path: |
           ${{ env.TEST_OUTPUT_DIRECTORY }}/junit-test-report/junit.xml
           ${{ env.TEST_OUTPUT_DIRECTORY }}/xcode-test-report.xcresult


### PR DESCRIPTION
I'm really tired of the following output of `ls *.zip`
```
/home/emilsp/Downloads/MullvadVPNUITests_RelayTests-test-results(1).zip
/home/emilsp/Downloads/MullvadVPNUITests_RelayTests-test-results(2).zip
/home/emilsp/Downloads/MullvadVPNUITests_RelayTests-test-results(3).zip
/home/emilsp/Downloads/MullvadVPNUITests_RelayTests-test-results(4).zip
/home/emilsp/Downloads/MullvadVPNUITests_RelayTests-test-results.zip
```

Thus I am adding the current branch and timestamp to the filename. I'm pinging you @faern because you might have opinions about including the branch name. I'm OK with removing that too, but I think it'd be a great practical improvement in our day to day lives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9624)
<!-- Reviewable:end -->
