### PR TITLE
Ignore RUSTSEC-2025-0142 for two months

### DIFF
--- a/ci/ios/test-router/raas/osv-scanner.toml
+++ b/ci/ios/test-router/raas/osv-scanner.toml
@@ -1,0 +1,10 @@
+# See repository root `osv-scanner.toml` for instructions and rules for this file.
+
+# Segmentation fault and invalid memory read in mnl::cb_run.
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0142"
+ignoreUntil = 2026-03-09
+reason = """
+We do not pass untrusted input to cb_run
+"""
+

--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,10 @@ ignore = [
     # put into removing items from the list.
 
     # Bincode is unmaintained. Version 1.3.3 is considered "complete" and can still be used
-    "RUSTSEC-2025-0141"
+    "RUSTSEC-2025-0141",
+
+    # Segmentation fault and invalid memory read in mnl::cb_run. We don't pass untrusted input
+    "RUSTSEC-2025-0142"
 ]
 
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -78,3 +78,11 @@ reason = """
 Bincode is unmaintained. maybenot depend on it.
 Version 1.3.3 is considered "complete" and can still be used safely.
 """
+
+# Segmentation fault and invalid memory read in mnl::cb_run.
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0142"
+ignoreUntil = 2026-03-09
+reason = """
+We do not pass untrusted input to cb_run
+"""


### PR DESCRIPTION
Short ignore time since we should fix our own crate and upgrade.
This is not dangerous since we never pass untrusted input to `mnl::cb_run`

https://rustsec.org/advisories/RUSTSEC-2025-0142

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9627)
<!-- Reviewable:end -->
