### PR TITLE
App enters offline state before connecting with ian ios 1435

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -111,6 +111,9 @@ final class TunnelManager: StorePaymentObserver, @unchecked Sendable {
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
+
+        self.startNetworkMonitor()
+
     }
 
     // MARK: - Periodic private key rotation
@@ -202,8 +205,6 @@ final class TunnelManager: StorePaymentObserver, @unchecked Sendable {
             }
 
             self.updatePrivateKeyRotationTimer()
-            self.startNetworkMonitor()
-
             completionHandler()
         }
 
@@ -884,13 +885,6 @@ final class TunnelManager: StorePaymentObserver, @unchecked Sendable {
                 guard let self else { return }
 
                 self.logger.debug("VPN connection status changed to \(status).")
-
-                if [.disconnected, .invalid].contains(tunnel.status) {
-                    self.startNetworkMonitor()
-                } else {
-                    self.cancelNetworkMonitor()
-                }
-
                 self.updateTunnelStatus(status)
             }
     }


### PR DESCRIPTION
Currently on `main`, the app will often enter the offline state on first startup with IAN enabled. You can test this by logging out, logging in, and only starting a connection after enabling IAN. The changes I am introducing are looking to aid the situation by rolling up path updates, which should result in the UI not responding to spurious path updates. Further, I am disabling reconnecting from the offline state unless a new path update arrives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9657)
<!-- Reviewable:end -->
