### PR TITLE
Add top level `permissions: {}` to CI workflows missing it

### DIFF
--- a/.github/workflows/code-owner-approval.yml
+++ b/.github/workflows/code-owner-approval.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check-code-owner-approvals:
     runs-on: ubuntu-latest

--- a/.github/workflows/daemon-nix.yml
+++ b/.github/workflows/daemon-nix.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
According to the principle of least privilege no CI workflow should be able to do more than they need. We usually specify `permissions: {}` at the global level of all workflows to lock down permissions and then selectively unlock only the ones we need. But this was missed on two workflows (as reported by OpenSSF scorecard: https://securityscorecards.dev/viewer/?uri=github.com/mullvad/mullvadvpn-app).

Related to #6499

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9658)
<!-- Reviewable:end -->
