### PR TITLE
Prevent panic on Android when when initializing tracing multiple times

### DIFF
--- a/mullvad-jni/src/lib.rs
+++ b/mullvad-jni/src/lib.rs
@@ -19,7 +19,7 @@ use mullvad_daemon::{
     runtime::new_multi_thread,
     version,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::OnceLock};
 use std::{
     ffi::CString,
     io,
@@ -93,9 +93,19 @@ pub extern "system" fn Java_net_mullvad_mullvadvpn_service_MullvadDaemon_initial
 
     let env = JnixEnv::from(env);
     let files_dir = pathbuf_from_java(&env, files_directory);
-    let log_handle = start_logging(&files_dir)
-        .map_err(Error::InitializeLogging)
-        .unwrap();
+
+    // In some cases, this function may be called multiple times for the same daemon process.
+    // Since the tracing dispatcher can only be initialized once, we use a OnceLock to
+    // reuse the existing log handle
+    static LOG_HANDLE: OnceLock<LogHandle> = OnceLock::new();
+    let log_handle = LOG_HANDLE
+        .get_or_init(|| {
+            start_logging(&files_dir)
+                .map_err(Error::InitializeLogging)
+                .unwrap()
+        })
+        .clone();
+
     version::log_version();
 
     log::info!("Pre-loading classes!");


### PR DESCRIPTION
Fix a panic on Android when `Java_net_mullvad_mullvadvpn_service_MullvadDaemon_initialize` is called multiple times for the same daemon process.

This caused the global tracing dispatcher to be initialized twice for the running daemon, resulting in a panic.

```
[2mpanic[0m[2m:[0m thread '<unnamed>' panicked at 'failed to set global default subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")': /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-subscriber-0.3.22/src/util.rs:94
Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 20847 (lvad.mullvadvpn), pid 20847 (lvad.mullvadvpn)
```
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9664)
<!-- Reviewable:end -->
