### PR TITLE
Make test workspace Clippy job trigger on changes to linting rules

### DIFF
--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/testframework-clippy.yml
       - 'test/**/*.rs'
+      - 'test/**/Cargo.toml' # Lint rules defined in toml files
       - clippy.toml
       - 'ci/cargo-ci.sh'
   workflow_dispatch:


### PR DESCRIPTION
We did not properly trigger the clippy job in the test workspace when the linting rules in `test/Cargo.toml` changed. This issue was really introduced in #9625

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9665)
<!-- Reviewable:end -->
