### PR TITLE
Fix standalone build glob path

### DIFF
--- a/desktop/packages/mullvad-vpn/tsconfig.standalone.json
+++ b/desktop/packages/mullvad-vpn/tsconfig.standalone.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
-    "test/e2e/*.ts",
+    "test/e2e/**/*.ts",
     "playwright.config.ts",
     "standalone-tests.ts"
   ]


### PR DESCRIPTION
- Fix glob path used in TS config for `standalone` build
  - The previous glob path failed to recursively resolve all files in the `test/e2e` folder.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9675)
<!-- Reviewable:end -->
