### PR TITLE
Fix desktop E2E CI for non-release tags

### DIFF
--- a/test/scripts/run/ci.sh
+++ b/test/scripts/run/ci.sh
@@ -25,9 +25,11 @@ TEST_OS=$1
 # shellcheck source=test/scripts/utils/lib.sh
 source "../utils/lib.sh"
 
+git fetch --tags --force
+
 # The `CURRENT_VERSION` variable is set by the workflow file which invokes `mullvad-version`
 # We need to add a suffix with tag information to get the current version string
-TAG=$(git describe --exact-match HEAD 2>/dev/null || echo "")
+TAG=$(git describe --tags 2>/dev/null || echo "")
 if [[ -n "$TAG" && ${CURRENT_VERSION} =~ -dev- ]]; then
     # Remove disallowed version characters from the tag
     CURRENT_VERSION+="+${TAG//[^0-9a-z_-]/}"


### PR DESCRIPTION
E2E run: https://github.com/mullvad/mullvadvpn-app/actions/runs/21209380003

Fix DES-2622

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9681)
<!-- Reviewable:end -->
