### PR TITLE
Upgrade osv-scanner to 2.3.2 in CI workflow

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -10,13 +10,14 @@ permissions: {}
 jobs:
   scan-pr:
     permissions:
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
       # Require writing security events to upload SARIF file to security tab
       security-events: write
       # Only need to read contents
       contents: read
-      actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.2 + submodule patch
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@2a387edfbe02a11d856b89172f6e978100177eb4" # v2.3.2
     with:
       checkout-submodules: true

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -11,13 +11,14 @@ permissions: {}
 jobs:
   scan-scheduled:
     permissions:
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
       # Require writing security events to upload SARIF file to security tab
       security-events: write
       # Only need to read contents
       contents: read
-      actions: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@ab8175fc65a74d8c0308f623b1c617a39bdc34fe"  # v1.9.2 + submodule patch
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@2a387edfbe02a11d856b89172f6e978100177eb4" # v2.3.2
     with:
       checkout-submodules: false


### PR DESCRIPTION
We have used osv-scanner 1.9.2 for a long time now. They have released plenty of new releases since we started using it. This PR bumps to the latest version.

I'm not aware of any specific new feature or bug fix that we want or need. This PR is just because it's good to stay up to date, and in the hopes that the job is either faster, or more accurate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9685)
<!-- Reviewable:end -->
