### PR TITLE
Remove unused OSV-scanner ignores

### DIFF
--- a/android/gradle/osv-scanner.toml
+++ b/android/gradle/osv-scanner.toml
@@ -13,12 +13,6 @@ id = "CVE-2024-29025" # GHSA-5jpm-x58v-624v
 ignoreUntil = 2026-02-01
 reason = "We do not use netty for http communication."
 
-# netty: Vulnerable to HTTP/2 Rapid Reset Attack
-[[IgnoredVulns]]
-id = "CVE-2023-44487" # GHSA-xpw8-rcwv-8f8p
-ignoreUntil = 2026-02-01
-reason = "No impact on this app since it uses UDS rather than HTTP2."
-
 # Same as the vuln above, but it seems like osv scanner does not always make the connection.
 [[IgnoredVulns]]
 id = "GHSA-xpw8-rcwv-8f8p"
@@ -48,12 +42,6 @@ reason = "Apache commons compress is used by lint and not the app directly."
 id = "CVE-2020-13956" # GHSA-7r82-7xv7-xcpj
 ignoreUntil = 2026-02-01
 reason = "Apache http client is used by lint and not the app directly."
-
-# kotlin: Improper Locking
-[[IgnoredVulns]]
-id = "CVE-2022-24329" # GHSA-2qp4-g3q3-f92w
-ignoreUntil = 2026-02-01
-reason = "This CVE only affect Multiplatform Gradle Projects, which this project is not."
 
 # netty: Denial of Service attack on windows app
 [[IgnoredVulns]]

--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -1,32 +1,8 @@
 # See repository root `osv-scanner.toml` for instructions and rules for this file.
 
-# PostCSS line return parsing error
-[[IgnoredVulns]]
-id = "CVE-2023-44270" # GHSA-7fh5-64p2-3v2j
-ignoreUntil = 2025-06-05
-reason = "This project does not use PostCSS to parse untrusted CSS"
-
-# braces: Uncontrolled resource consumption
-[[IgnoredVulns]]
-id = "CVE-2024-4068" # GHSA-grv7-fg5c-xmjg
-ignoreUntil = 2025-06-05
-reason = "This package is only used to match paths from either us or trusted libraries"
-
-# micromatch (dev): Regular Expression Denial of Service (ReDoS) in micromatch
-[[IgnoredVulns]]
-id = "CVE-2024-4067" # GHSA-952p-6rrq-rcjv
-ignoreUntil = 2025-05-23
-reason = "This is just a dev dependency, and we don't have untrusted input to micromatch there"
-
 # node-gettext: Prototype Pullution via the addTranslations function
 [[IgnoredVulns]]
 id = "CVE-2024-21528" # GHSA-g974-hxvm-x689
 ignoreUntil = 2026-04-16 # The vulnerability is ignored for 6 months as the affected library is not receiving updates and we can not patch the vulnerability without migrating to another library, which is no minor feat.
 reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"
-
-# electron: Electron has ASAR Integrity Bypass via resource modification
-[[IgnoredVulns]]
-id = "CVE-2025-55305" # GHSA-vmqv-hx8q-j7mg
-ignoreUntil = 2025-12-04
-reason = "The embeddedAsarIntegrityValidation and onlyLoadAppFromAsar fuses aren't enabled"
 

--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -23,12 +23,6 @@ id = "CVE-2024-45338" # GO-2024-3333
 ignoreUntil = 2026-09-12
 reason = "wireguard-go does not use the affected code"
 
-# Denial of service in HTML Parse function in go/net/html
-[[IgnoredVulns]]
-id = "GHSA-w32m-9786-jp63" # GO-2024-3333
-ignoreUntil = 2026-09-12
-reason = "wireguard-go does not use the affected code"
-
 # Sensitive headers incorrectly sent after cross-domain redirect in net/http
 [[IgnoredVulns]]
 id = "CVE-2024-45336" # GO-2025-3420
@@ -82,12 +76,6 @@ reason = "wireguard-go does not use OpenFile on Windows"
 id = "CVE-2025-4673" # GO-2025-3751
 ignoreUntil = 2026-09-12
 reason = "wireguard-go does not use Proxy-Authorization or Proxy-Authenticate headers"
-
-# Usage of ExtKeyUsageAny disables policy validation in crypto/x509
-[[IgnoredVulns]]
-id = "CVE-2025-22874" # GO-2025-3749
-ignoreUntil = 2026-09-12
-reason = "wireguard-go does not use crypto/x509"
 
 # Incorrect results returned from Rows.Scan in database/sql
 [[IgnoredVulns]]


### PR DESCRIPTION
OSV scanner reports that these ignores are no longer needed:

```
android/gradle/osv-scanner.toml has unused ignores:
 - CVE-2023-44487
 - CVE-2022-24329
desktop/osv-scanner.toml has unused ignores:
 - CVE-2023-44270
 - CVE-2024-4068
 - CVE-2024-4067
 - CVE-2025-55305
wireguard-go-rs/libwg/osv-scanner.toml has unused ignores:
 - GHSA-w32m-9786-jp63
 - CVE-2025-22874
 ```
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9687)
<!-- Reviewable:end -->
