### PR TITLE
Change how we expose proptest generators in public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3217,7 +3217,6 @@ dependencies = [
  "log",
  "mockito",
  "mullvad-api-constants",
- "mullvad-update",
  "mullvad-version",
  "proptest",
  "rand 0.8.5",

--- a/installer-downloader/src/controller.rs
+++ b/installer-downloader/src/controller.rs
@@ -12,7 +12,7 @@ use mullvad_update::{
     api::{HttpVersionInfoProvider, MetaRepositoryPlatform},
     app::{self, AppCache, AppDownloader, DownloadedInstaller, HttpAppDownloader},
     local::METADATA_FILENAME,
-    version::{Metadata, SUPPORTED_VERSION, VersionInfo, VersionParameters},
+    version::{Metadata, VersionInfo, VersionParameters, rollout::SUPPORTED_VERSION},
     version_provider::VersionInfoProvider,
 };
 use rand::seq::IndexedRandom;

--- a/mullvad-api/src/version.rs
+++ b/mullvad-api/src/version.rs
@@ -6,7 +6,7 @@ use http::header;
 #[cfg(not(target_os = "android"))]
 use mullvad_update::{
     format::response::SignedResponse,
-    version::{Rollout, VersionInfo, VersionParameters, is_version_supported},
+    version::{VersionInfo, VersionParameters, is_version_supported, rollout::Rollout},
 };
 use std::future::Future;
 use std::str::FromStr;

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -78,7 +78,7 @@ use mullvad_types::{
     relay_list::BridgeList,
 };
 #[cfg(not(target_os = "android"))]
-use mullvad_update::version::Rollout;
+use mullvad_update::version::rollout::Rollout;
 use relay_list::{RelayListUpdater, RelayListUpdaterHandle};
 use settings::SettingsPersister;
 use std::collections::BTreeSet;

--- a/mullvad-daemon/src/version/check.rs
+++ b/mullvad-daemon/src/version/check.rs
@@ -7,7 +7,7 @@ use mullvad_api::{
     availability::ApiAvailability, rest::MullvadRestHandle, version::AppVersionProxy,
 };
 #[cfg(not(target_os = "android"))]
-use mullvad_update::version::Rollout;
+use mullvad_update::version::rollout::Rollout;
 #[cfg(not(target_os = "android"))]
 use mullvad_update::version::{Metadata, VersionInfo};
 use mullvad_version::Version;

--- a/mullvad-daemon/src/version/router.rs
+++ b/mullvad-daemon/src/version/router.rs
@@ -10,7 +10,7 @@ use mullvad_types::version::SuggestedUpgrade;
 #[cfg(in_app_upgrade)]
 use mullvad_update::app::{AppDownloader, AppDownloaderParameters, HttpAppDownloader};
 #[cfg(not(target_os = "android"))]
-use mullvad_update::version::{Rollout, VersionInfo};
+use mullvad_update::version::{VersionInfo, rollout::Rollout};
 use talpid_core::mpsc::Sender;
 #[cfg(in_app_upgrade)]
 use talpid_types::ErrorExt;

--- a/mullvad-update/Cargo.toml
+++ b/mullvad-update/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 default = []
 sign = ["rand08", "clap"]
 client = ["reqwest", "tokio", "thiserror"]
-arbitrary = ["proptest"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -43,13 +42,13 @@ clap = { workspace = true, optional = true }
 # (as of ed25519-dalek 2.2.0)
 rand08 = { package = "rand", version = "0.8.5", optional = true }
 rand = { workspace = true }
+# If a consumer enable the `proptest` feature, then we expose proptest generators in the public API
 proptest = { workspace = true, optional = true }
 
 thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
-# The self-referential dependency is required for enabling the proptest generators in tests.
-mullvad-update = { path = ".", features = ["arbitrary"] }
+proptest = { workspace = true }
 async-tempfile = "0.6"
 insta = { workspace = true }
 mockito = "1.6.1"

--- a/mullvad-update/mullvad-release/src/main.rs
+++ b/mullvad-update/mullvad-release/src/main.rs
@@ -16,7 +16,7 @@ use io_util::create_dir_and_write;
 use platform::Platform;
 
 use mullvad_update::api::HttpVersionInfoProvider;
-use mullvad_update::version::{Rollout, SUPPORTED_VERSION};
+use mullvad_update::version::rollout::{Rollout, SUPPORTED_VERSION};
 
 use crate::io_util::wait_for_confirm;
 

--- a/mullvad-update/mullvad-release/src/platform.rs
+++ b/mullvad-update/mullvad-release/src/platform.rs
@@ -7,7 +7,7 @@ use mullvad_update::format::installer::Installer;
 use mullvad_update::format::key;
 use mullvad_update::format::release::Release;
 use mullvad_update::format::response::{Response, SignedResponse};
-use mullvad_update::version::Rollout;
+use mullvad_update::version::rollout::Rollout;
 use mullvad_update::version::{MIN_VERIFY_METADATA_VERSION, VersionInfo, VersionParameters};
 use std::{cmp::Ordering, fmt, path::PathBuf, str::FromStr};
 use strum::IntoEnumIterator;

--- a/mullvad-update/src/format/mod.rs
+++ b/mullvad-update/src/format/mod.rs
@@ -25,7 +25,7 @@ pub use architecture::Architecture;
 #[cfg(test)]
 mod test {
     use crate::format::release::Release;
-    use crate::version::Rollout;
+    use crate::version::rollout::Rollout;
 
     #[test]
     fn test_default_rollout_serialize() {

--- a/mullvad-update/src/format/release.rs
+++ b/mullvad-update/src/format/release.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::installer::Installer;
-use crate::version::{Rollout, is_complete_rollout};
+use crate::version::rollout::{Rollout, is_complete_rollout};
 
 /// App release
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/mullvad-update/src/version/mod.rs
+++ b/mullvad-update/src/version/mod.rs
@@ -5,11 +5,10 @@
 //! The main input here is [VersionParameters], and the main output is [VersionInfo].
 mod info;
 mod parameters;
-mod rollout;
+pub mod rollout;
 
 pub use info::{MIN_VERIFY_METADATA_VERSION, Metadata, VersionInfo, is_version_supported};
 pub use parameters::VersionParameters;
-pub use rollout::{IGNORE, Rollout, SUPPORTED_VERSION, is_complete_rollout};
 
 pub use crate::format::Architecture;
 pub use crate::format::installer::Installer;

--- a/mullvad-update/src/version/rollout.rs
+++ b/mullvad-update/src/version/rollout.rs
@@ -133,17 +133,18 @@ impl Serialize for Rollout {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(any(test, feature = "proptest"))]
 /// Generators for [Rollout].
-pub mod arbitrary {
+pub mod proptest {
     use super::*;
-
-    use proptest::prelude::*;
+    use ::proptest::{
+        prop_oneof,
+        strategy::{Just, Strategy},
+    };
 
     /// Generate *any* arbitrary [Rollout] values.
     ///
     /// This generator assume that [VALID_ROLLOUT] represent all valid rollouts.
-    #[allow(dead_code)]
     pub fn arb_any_rollout() -> impl Strategy<Value = Rollout> {
         VALID_ROLLOUT.prop_map(Rollout)
     }
@@ -151,7 +152,6 @@ pub mod arbitrary {
     /// Generate an arbitrary [Rollout] values.
     ///
     /// This generator is heavily biased towards edge cases such as zero rollout, full rollout etc.
-    #[allow(dead_code)]
     pub fn arb_rollout() -> impl Strategy<Value = Rollout> {
         let any = arb_any_rollout();
         let edge_cases = prop_oneof![
@@ -169,11 +169,11 @@ pub mod arbitrary {
 
 #[cfg(test)]
 mod test {
-    use super::arbitrary::*;
+    use super::proptest::arb_rollout;
     use super::*;
 
+    use ::proptest::proptest;
     use insta::{assert_snapshot, assert_yaml_snapshot};
-    use proptest::prelude::*;
 
     proptest! {
          /// Assert that all rollout values from 0 up to 1 are valid rollouts.


### PR DESCRIPTION
In #9518 we found some problems regarding exposing arbitrary proptest generators in the public API. I played around with trying to silence the warnings and potentially also reworking a bit how we expose these publicly.

To start at the very end. Just a few minutes ago I realized that the main problem about why rustc complains about the arbitrary generators being dead code when not built for tests, is that we don't even publicly export the `arbitrary` module. So it's not part of the public API and is thus flagged as unused. Just publicly exposing the module could solve the root problem. However, I still think the changes I made here makes sense. But I submit it as a draft PR to discuss it more in depth AFK with you, @MarkusPettersson98.

Bullet form summary of changes:
* Remove explicit `arbitrary` feature. Let users use the implicit `proptest` feature created by the optional dependency
* Make the library include the proptest generators if feature is enabled *or* it is being built for testing. This allows the in-crate tests to use the generators without specifying the own crate as a dev-dependency.
* Rename the module from `arbitrary` to `proptest`. This is not very important at all, I just felt it better explains what it's for. If there is precedence for naming these something else I'm open to change this of course.
* Publicly expose the entire `rollout` module under `version`, instead of selectively exposing certain items from that module. I think this better shows what types are strictly related to rollouts, compared to versions in general. And it allows for exposing the `proptest` module nicer.
* The `#[allow(dead_code)]` attributes are now longer needed! (becomes compatible with `clippy::allow_attributes`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9695)
<!-- Reviewable:end -->
