### PR TITLE
Add `tombi` config file

### DIFF
--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,9 @@
+[files]
+exclude = [
+  "android/rust-android-gradle-plugin/**",
+  "wireguard-go-rs/libwg/wireguard-go/**",
+  "dist-assets/binaries/**",
+  "ios/wireguard-apple/**",
+  "windows/libwfp/**",
+  "windows/windows-libraries/**",
+]


### PR DESCRIPTION
Exclude submodules by default. Without this config option, linting from the root would output warnings:
```bash
$ tombi lint .
Warning: `package.authors` is deprecated
    at ./android/rust-android-gradle-plugin/plugin/src/test/resources/rust/Cargo.toml:4:11
Warning: `package.authors` is deprecated
    at ./android/rust-android-gradle-plugin/samples/rust/Cargo.toml:4:11
79 files linted successfully
```

And running `tombi format` would format *all* toml files, including in submodules

```bash
$ tombi format .
3 files formatted
76 files did not need formatting

$ git diff
diff --git a/android/rust-android-gradle-plugin b/android/rust-android-gradle-plugin
--- a/android/rust-android-gradle-plugin
+++ b/android/rust-android-gradle-plugin
@@ -1 +1 @@
-Subproject commit 505aa265d754f915e81a4becb83c8171cf77fbca
+Subproject commit 505aa265d754f915e81a4becb83c8171cf77fbca-dirty
diff --git a/wireguard-go-rs/libwg/wireguard-go b/wireguard-go-rs/libwg/wireguard-go
--- a/wireguard-go-rs/libwg/wireguard-go
+++ b/wireguard-go-rs/libwg/wireguard-go
@@ -1 +1 @@
-Subproject commit 0b750ea8445a378b6f314fa6135c889e9d171b19
+Subproject commit 0b750ea8445a378b6f314fa6135c889e9d171b19-dirty
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9710)
<!-- Reviewable:end -->
