### PR TITLE
Conditionally build stagemole and e2e apks

### DIFF
--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -148,14 +148,19 @@ jobs:
           ./building/container-run.sh android android/gradlew -p android --console plain --stacktrace --no-daemon
           clean
 
+      - name: Prepare build tasks
+        id: build-tasks
+        run: |
+          tasks=":app:assembleOssProdDebug assembleOssProdAndroidTest :test:mockapi:assemble"
+          if [[ "${{ needs.prepare.outputs.E2E_TEST_REPEAT }}" != '0' ]]; then
+            tasks+=" :app:assemblePlayStagemoleDebug :test:e2e:assemble"
+          fi
+          echo "tasks=$tasks" >> $GITHUB_OUTPUT
+
       - name: Build apks
         run: >
           ./building/container-run.sh android android/gradlew -p android --console plain --stacktrace --no-daemon
-          :app:assembleOssProdDebug
-          :app:assemblePlayStagemoleDebug
-          assembleOssProdAndroidTest
-          :test:mockapi:assemble
-          :test:e2e:assemble
+          "${{ steps.build-tasks.outputs.tasks }}"
 
       - name: Upload apks
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Just testing this really quick and it seems that the build time for just a normal PR job decreases with ~10 seconds, but if you do a full build due to some overhead it increases build time by ~15 seconds.

Due to not needing to upload the stagemole apk and the e2e orchestrator apk it also saves some time when uploading and uploads 100 MB less.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9712)
<!-- Reviewable:end -->
