### PR TITLE
Fix outdated CLI usage in UI tests

### DIFF
--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/obfuscation.spec.ts
@@ -35,11 +35,8 @@ test('App should have automatic obfuscation', async () => {
 
   await expect(automaticObfuscationOption).toHaveAttribute('aria-selected', 'true');
 
-  const cliObfuscation = execSync('mullvad obfuscation get').toString().split('\n');
+  const cliObfuscation = execSync('mullvad anti-censorship get').toString().split('\n');
   expect(cliObfuscation[0]).toEqual('mode: auto');
-  expect(cliObfuscation[1]).toEqual('udp2tcp settings: any port');
-  expect(cliObfuscation[2]).toEqual('shadowsocks settings: any port');
-  expect(cliObfuscation[3]).toEqual('wireguard-port settings: any port');
 });
 
 test('App should set obfuscation to shadowsocks with custom port', async () => {
@@ -61,7 +58,7 @@ test('App should set obfuscation to shadowsocks with custom port', async () => {
   await routes.antiCensorship.selectShadowsocks();
   await expect(shadowsocksOption).toHaveAttribute('aria-selected', 'true');
 
-  const cliObfuscation = execSync('mullvad obfuscation get').toString().split('\n')[2];
+  const cliObfuscation = execSync('mullvad anti-censorship get').toString().split('\n')[2];
   expect(cliObfuscation).toEqual(`shadowsocks settings: port ${SHADOWSOCKS_PORT}`);
 });
 
@@ -91,6 +88,6 @@ test('App should set obfuscation to UDP-over-TCP with port', async () => {
   await expect(udpOverTcpItem).toHaveAttribute('aria-selected', 'true');
   await expect(udpOverTcpItem).toContainText(`Port: ${UDPOVERTCP_PORT}`);
 
-  const cliObfuscation = execSync('mullvad obfuscation get').toString().split('\n')[1];
+  const cliObfuscation = execSync('mullvad anti-censorship get').toString().split('\n')[1];
   expect(cliObfuscation).toEqual(`udp2tcp settings: port ${UDPOVERTCP_PORT}`);
 });

--- a/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/e2e/installed/state-dependent/tunnel-state.spec.ts
@@ -72,21 +72,21 @@ test.describe('Tunnel state and settings', () => {
     const inIp = routes.main.getInIp();
     await expect(inIp).toHaveText(new RegExp(':[0-9]+'));
 
-    await exec('mullvad obfuscation set mode wireguard-port');
-    await exec('mullvad obfuscation set wireguard-port --port 53');
+    await exec('mullvad anti-censorship set mode wireguard-port');
+    await exec('mullvad anti-censorship set wireguard-port --port 53');
     await expectConnected(page);
     await routes.main.expandConnectionPanel();
 
     await expect(inIp).toHaveText(new RegExp(':53'));
 
-    await exec('mullvad obfuscation set wireguard-port --port 51820');
+    await exec('mullvad anti-censorship set wireguard-port --port 51820');
     await expectConnected(page);
     await routes.main.expandConnectionPanel();
 
     await expect(inIp).toHaveText(new RegExp(':51820'));
 
-    await exec('mullvad obfuscation set wireguard-port --port any');
-    await exec('mullvad obfuscation set mode auto');
+    await exec('mullvad anti-censorship set wireguard-port --port any');
+    await exec('mullvad anti-censorship set mode auto');
   });
 
   test.describe('Wireguard UDP-over-TCP', () => {
@@ -156,9 +156,9 @@ test.describe('Tunnel state and settings', () => {
   });
 
   test('App should connect with Shadowsocks', async () => {
-    await exec('mullvad obfuscation set mode shadowsocks');
+    await exec('mullvad anti-censorship set mode shadowsocks');
     await expectConnected(page);
-    await exec('mullvad obfuscation set mode off');
+    await exec('mullvad anti-censorship set mode off');
     await expectConnected(page);
   });
 


### PR DESCRIPTION
In general, it seems too brittle to a rely on an unstable CLI here, and even more so to make assumptions about the text output being stable. Could we come up with a better approach?

Fix DES-2819

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9720)
<!-- Reviewable:end -->
