### PR TITLE
Fix `reset-settings` edge case

### DIFF
--- a/mullvad-daemon/src/settings/mod.rs
+++ b/mullvad-daemon/src/settings/mod.rs
@@ -266,9 +266,11 @@ impl SettingsPersister {
                     e.display_chain_with_msg("Unable to save default settings")
                 );
                 log::info!("Will attempt to remove settings file");
-                fs::remove_file(&path)
-                    .map_err(|e| Error::DeleteError(path.display().to_string(), e))
-                    .await
+                match fs::remove_file(&path).await {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(Error::DeleteError(path.display().to_string(), e)),
+                }
             })
             .await?;
 


### PR DESCRIPTION
Spotted in a test. Realistically you shouldn't end up here unless `mullvad reset-settings` fails twice to save `settings.json`. I'm guessing that's what happened there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9722)
<!-- Reviewable:end -->
