### PR TITLE
Revert wireguard-go workaround in connectivity monitor

### DIFF
--- a/talpid-wireguard/src/connectivity/check.rs
+++ b/talpid-wireguard/src/connectivity/check.rs
@@ -182,17 +182,7 @@ impl Check {
                 {
                     return Ok(true);
                 }
-                // Calling get_stats has an unwanted effect of possibly causing segmentation fault,
-                // stacktrace hints towards Garbage Collector failing. The cause has yet not been
-                // determined, it could be because some dangling pointer, bug inside WG-go or
-                // something else. So for now we avoid spamming get_config too much since it lowers
-                // the risk of crash happening.
-                //
-                // The value was previously set to 20 ms, depending on when we called
-                // establish_connectivity, this caused the crash to reliably occur.
-                //
-                // Tracked by DROID-1825 (Investigate GO crash issue with runtime.GC())
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                tokio::time::sleep(Duration::from_millis(20)).await;
             }
         };
 


### PR DESCRIPTION
This PR reverts a workaround for wggo where calling `get_config` too frequently could cause wggo to crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9724)
<!-- Reviewable:end -->
