### PR TITLE
Trim whitespace from rust logs

### DIFF
--- a/ios/MullvadRustRuntime/RustLogging.swift
+++ b/ios/MullvadRustRuntime/RustLogging.swift
@@ -34,7 +34,11 @@ private func rustLogCallback(level: UInt8, messagePtr: UnsafePointer<CChar>?) {
             .debug
         }
 
-    rustLogger.log(level: level, "\(message)")
+    rustLogger
+        .log(
+            level: level,
+            "\(message.trimmingCharacters(in: .whitespacesAndNewlines))"
+        )
 }
 
 /// Initializes the Rust logging system to forward logs to Swift's Logger.


### PR DESCRIPTION
We're not trimming the whitespace from the Rust log message, so now here's a fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9725)
<!-- Reviewable:end -->
