### PR TITLE
 Ignore GO-2026-434{0,1,2} CVEs for a year

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -193,3 +193,10 @@ reason = "wireguard-go does not use crypto/tls"
 id = "GO-2026-4341"
 ignoreUntil = 2027-01-29
 reason = "wireguard-go does not use net/url"
+
+# Excessive CPU consumption when building archive index in archive/zip
+# https://osv.dev/GO-2026-4342
+[[IgnoredVulns]]
+id = "GO-2026-4342"
+ignoreUntil = 2027-01-29
+reason = "wireguard-go does not use archive/zip"


### PR DESCRIPTION
Another week, even more go cves 🔥 (😮‍💨😮‍💨😮‍💨).

I chose to put this on the ignore list for 1 year since wireguard-go does not use the vulnerable parts of the standard library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9727)
<!-- Reviewable:end -->
