### PR TITLE
Set the app in a blocking state if invalid ipv6 config

### DIFF
--- a/android/app/src/test/kotlin/net/mullvad/talpid/TalpidVpnServiceInvalidIpv6ConfigTest.kt
+++ b/android/app/src/test/kotlin/net/mullvad/talpid/TalpidVpnServiceInvalidIpv6ConfigTest.kt
@@ -43,7 +43,11 @@ class TalpidVpnServiceInvalidIpv6ConfigTest {
         every { anyConstructed<VpnService.Builder>().setBlocking(any()) } returns builderMockk
         every { anyConstructed<VpnService.Builder>().addAddress(any<InetAddress>(), any()) } returns
             builderMockk
+        every { anyConstructed<VpnService.Builder>().addAddress(any<String>(), any()) } returns
+            builderMockk
         every { anyConstructed<VpnService.Builder>().addRoute(any<InetAddress>(), any()) } returns
+            builderMockk
+        every { anyConstructed<VpnService.Builder>().addRoute(any<String>(), any()) } returns
             builderMockk
         every { anyConstructed<VpnService.Builder>().addDnsServer(any<InetAddress>()) } returns
             builderMockk

--- a/android/lib/grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/grpc/mapper/ToDomain.kt
+++ b/android/lib/grpc/src/main/kotlin/net/mullvad/mullvadvpn/lib/grpc/mapper/ToDomain.kt
@@ -135,10 +135,26 @@ private fun ManagementInterface.TunnelState.Error.toDomain(): TunnelState.Error 
         }
 
     val invalidDnsServers =
-        errorState.let {
-            if (it.hasInvalidDnsServersError()) {
+        errorState.let { error ->
+            if (error.hasInvalidDnsServersError()) {
                 ErrorStateCause.InvalidDnsServers(
-                    it.invalidDnsServersError.ipAddrsList.toList().map { InetAddress.getByName(it) }
+                    addresses =
+                        error.invalidDnsServersError.ipAddrsList.toList().map {
+                            InetAddress.getByName(it)
+                        }
+                )
+            } else {
+                null
+            }
+        }
+
+    val invalidIpv6Config =
+        errorState.let { error ->
+            if (error.hasInvalidIpv6ConfigError()) {
+                ErrorStateCause.InvalidIpv6Config(
+                    addresses = error.invalidIpv6ConfigError.addrsList,
+                    routes = error.invalidIpv6ConfigError.routesList,
+                    dnsServers = error.invalidIpv6ConfigError.dnsList,
                 )
             } else {
                 null
@@ -150,6 +166,7 @@ private fun ManagementInterface.TunnelState.Error.toDomain(): TunnelState.Error 
             errorState.toDomain(
                 otherAlwaysOnApp = otherAlwaysOnAppError,
                 invalidDnsServers = invalidDnsServers,
+                invalidIpv6Config = invalidIpv6Config,
             )
     )
 }
@@ -246,9 +263,11 @@ internal fun ManagementInterface.AfterDisconnect.toDomain(): ActionAfterDisconne
             throw IllegalArgumentException("Unrecognized action after disconnect")
     }
 
+@Suppress("CyclomaticComplexMethod")
 internal fun ManagementInterface.ErrorState.toDomain(
     otherAlwaysOnApp: ErrorStateCause.OtherAlwaysOnApp?,
     invalidDnsServers: ErrorStateCause.InvalidDnsServers?,
+    invalidIpv6Config: ErrorStateCause.InvalidIpv6Config?,
 ): ErrorState =
     ErrorState(
         cause =
@@ -276,6 +295,7 @@ internal fun ManagementInterface.ErrorState.toDomain(
                 ManagementInterface.ErrorState.Cause.OTHER_LEGACY_ALWAYS_ON_VPN ->
                     ErrorStateCause.OtherLegacyAlwaysOnApp
                 ManagementInterface.ErrorState.Cause.INVALID_DNS_SERVERS -> invalidDnsServers!!
+                ManagementInterface.ErrorState.Cause.INVALID_IPV6_CONFIG -> invalidIpv6Config!!
             },
         isBlocking = !hasBlockingError(),
     )

--- a/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/ErrorStateCause.kt
+++ b/android/lib/model/src/main/kotlin/net/mullvad/mullvadvpn/lib/model/ErrorStateCause.kt
@@ -32,6 +32,12 @@ sealed class ErrorStateCause {
     data object OtherLegacyAlwaysOnApp : ErrorStateCause()
 
     data class NoRelaysMatchSelectedPort(val port: Port) : ErrorStateCause()
+
+    data class InvalidIpv6Config(
+        val addresses: List<String>,
+        val routes: List<String>,
+        val dnsServers: List<String>,
+    ) : ErrorStateCause()
 }
 
 sealed interface AuthFailedError {

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/TalpidVpnService.kt
@@ -1,16 +1,20 @@
 package net.mullvad.talpid
 
 import android.net.ConnectivityManager
-import android.net.VpnService
 import android.os.ParcelFileDescriptor
 import androidx.annotation.CallSuper
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
 import arrow.core.Either
+import arrow.core.Nel
+import arrow.core.left
 import arrow.core.mapOrAccumulate
+import arrow.core.maxBy
 import arrow.core.merge
+import arrow.core.raise.ExperimentalRaiseAccumulateApi
+import arrow.core.raise.accumulate
 import arrow.core.raise.either
-import arrow.core.raise.ensure
+import arrow.core.right
 import co.touchlab.kermit.Logger
 import java.net.Inet4Address
 import java.net.Inet6Address
@@ -25,10 +29,12 @@ import net.mullvad.talpid.model.CreateTunResult.InvalidDnsServers
 import net.mullvad.talpid.model.CreateTunResult.NotPrepared
 import net.mullvad.talpid.model.CreateTunResult.OtherAlwaysOnApp
 import net.mullvad.talpid.model.CreateTunResult.OtherLegacyAlwaysOnVpn
+import net.mullvad.talpid.model.InetNetwork
 import net.mullvad.talpid.model.TunConfig
 import net.mullvad.talpid.util.TalpidSdkUtils.setMeteredIfSupported
 import net.mullvad.talpid.util.UnderlyingConnectivityStatusResolver
 
+@Suppress("TooManyFunctions")
 open class TalpidVpnService : LifecycleVpnService() {
     private var activeTunStatus by
         observable<CreateTunResult?>(null) { _, oldTunStatus, _ ->
@@ -36,6 +42,7 @@ open class TalpidVpnService : LifecycleVpnService() {
                 when (oldTunStatus) {
                     is CreateTunResult.Success -> oldTunStatus.tunFd
                     is InvalidDnsServers -> oldTunStatus.tunFd
+                    is CreateTunResult.InvalidIpv6Config -> oldTunStatus.tunFd
                     else -> null
                 }
 
@@ -63,6 +70,7 @@ open class TalpidVpnService : LifecycleVpnService() {
         synchronized(this) { createTun(config).merge().also { activeTunStatus = it } }
 
     // Used by JNI
+    @Suppress("Unused")
     fun closeTun(): Unit =
         synchronized(this) {
             connectivityListener.invalidateNetworkStateCache()
@@ -70,7 +78,7 @@ open class TalpidVpnService : LifecycleVpnService() {
         }
 
     // Used by JNI
-    fun bypass(socket: Int): Boolean = protect(socket)
+    @Suppress("Unused") fun bypass(socket: Int): Boolean = protect(socket)
 
     private fun createTun(
         config: TunConfig
@@ -78,45 +86,7 @@ open class TalpidVpnService : LifecycleVpnService() {
         prepareVpnSafe().mapLeft { it.toCreateTunError() }.bind()
 
         val builder = Builder()
-        builder.setMtu(config.mtu)
-        builder.setBlocking(false)
-        builder.setMeteredIfSupported(false)
-
-        ensure(config.validIpv6Routes()) {
-            Logger.e("Bad Ipv6 config provided!")
-            Logger.e("IPv6 address: ${config.hasIpv6Address}")
-            Logger.e("IPv6 route: ${config.hasIpv6Route}")
-            Logger.e("IPv6 DnsServer: ${config.hasIpv6DnsServer}")
-            CreateTunResult.InvalidIpv6Config
-        }
-
-        config.addresses.forEach { builder.addAddress(it, it.prefixLength()) }
-        config.routes.forEach { builder.addRoute(it.address, it.prefixLength.toInt()) }
-        config.excludedPackages.forEach { app -> builder.addDisallowedApplication(app) }
-
-        // We don't care if adding DNS servers fails at this point, since we can still create a
-        // tunnel to consume traffic and then notify daemon to later enter blocked state.
-        val dnsConfigureResult =
-            config.dnsServers.mapOrAccumulate {
-                builder.addDnsServerSafe(it).bind()
-                Unit
-            }
-
-        // Never create a tunnel where all DNS servers are invalid or if none was ever set, since
-        // apps then may leak DNS requests.
-        // https://issuetracker.google.com/issues/337961996
-        val shouldAddFallbackDns =
-            dnsConfigureResult.fold(
-                { invalidDnsServers -> invalidDnsServers.size == config.dnsServers.size },
-                { addedDnsServers -> addedDnsServers.isEmpty() },
-            )
-        if (shouldAddFallbackDns) {
-            Logger.w(
-                "All DNS servers invalid or non set, using fallback DNS server to " +
-                    "minimize leaks, dnsServers.isEmpty(): ${config.dnsServers.isEmpty()}"
-            )
-            builder.addDnsServer(FALLBACK_DUMMY_DNS_SERVER)
-        }
+        val configureResult = builder.configureWith(config)
 
         connectivityListener.invalidateNetworkStateCache()
         val vpnInterfaceFd =
@@ -128,9 +98,35 @@ open class TalpidVpnService : LifecycleVpnService() {
 
         val tunFd = vpnInterfaceFd.detachFd()
 
-        dnsConfigureResult.mapLeft { InvalidDnsServers(it, tunFd) }.bind()
-
+        configureResult
+            .mapLeft { errors -> errors.maxBy { it.priority }.toCreateTunError(tunFd) }
+            .bind()
         CreateTunResult.Success(tunFd)
+    }
+
+    @OptIn(ExperimentalRaiseAccumulateApi::class)
+    private fun Builder.configureWith(config: TunConfig): Either<Nel<ConfigError>, Unit> = either {
+        setMtu(config.mtu)
+        setBlocking(false)
+        setMeteredIfSupported(false)
+
+        config.excludedPackages.forEach { app -> addDisallowedApplication(app) }
+
+        accumulate {
+            accumulating { addAddressesAndRoutesSafe(config).bind() }
+            accumulating { addDnsServersSafe(config).bind() }
+        }
+    }
+
+    // Blocking fallback for when we receive an invalid IPv6 config
+    private fun Builder.invalidIpv6Setup() {
+        addAddress(BLOCKING_ADDRESS_IPV4, IPV4_PREFIX_LENGTH)
+        addAddress(BLOCKING_ADDRESS_IPV6, IPV6_PREFIX_LENGTH)
+        addRoute(ROUTE_ALL_IPV4, 0)
+        addRoute(ROUTE_ALL_IPV6, 0)
+        // IPv6 have a minimum mtu of 1280, the daemon can send a lower mtu if IPv6 is disabled
+        // Due to this we need to set a dummy mtu or the establish might fail
+        setMtu(BLOCKING_MTU)
     }
 
     // To avoid leaks a config should either fully contain IPv6 or have no IPv6 configuration. A
@@ -156,9 +152,48 @@ open class TalpidVpnService : LifecycleVpnService() {
             is PrepareError.OtherAlwaysOnApp -> OtherAlwaysOnApp(appName)
         }
 
-    private fun Builder.addDnsServerSafe(
-        dnsServer: InetAddress
-    ): Either<InetAddress, VpnService.Builder> =
+    private fun ConfigError.toCreateTunError(tunFd: Int) =
+        when (this) {
+            is ConfigError.InvalidIpv6 ->
+                CreateTunResult.InvalidIpv6Config(
+                    addresses = addresses,
+                    routes = routes,
+                    dnsServers = dnsServers,
+                    tunFd = tunFd,
+                )
+            is ConfigError.InvalidDns -> InvalidDnsServers(addresses = addresses, tunFd = tunFd)
+        }
+
+    private fun Builder.addDnsServersSafe(
+        config: TunConfig
+    ): Either<ConfigError.InvalidDns, Builder> {
+        // We don't care if adding DNS servers fails at this point, since we can still create a
+        // tunnel to consume traffic and then notify daemon to later enter blocked state.
+        val dnsConfigureResult =
+            config.dnsServers.mapOrAccumulate {
+                addDnsServerSafe(it).bind()
+                Unit
+            }
+
+        // Never create a tunnel where all DNS servers are invalid or if none was ever set, since
+        // apps then may leak DNS requests.
+        // https://issuetracker.google.com/issues/337961996
+        val shouldAddFallbackDns =
+            dnsConfigureResult.fold(
+                { invalidDnsServers -> invalidDnsServers.size == config.dnsServers.size },
+                { addedDnsServers -> addedDnsServers.isEmpty() },
+            )
+        if (shouldAddFallbackDns) {
+            Logger.w(
+                "All DNS servers invalid or non set, using fallback DNS server to " +
+                    "minimize leaks, dnsServers.isEmpty(): ${config.dnsServers.isEmpty()}"
+            )
+            addDnsServer(FALLBACK_DUMMY_DNS_SERVER)
+        }
+        return dnsConfigureResult.mapLeft { ConfigError.InvalidDns(addresses = it) }.map { this }
+    }
+
+    private fun Builder.addDnsServerSafe(dnsServer: InetAddress): Either<InetAddress, Builder> =
         Either.catch { addDnsServer(dnsServer) }
             .mapLeft {
                 when (it) {
@@ -166,6 +201,27 @@ open class TalpidVpnService : LifecycleVpnService() {
                     else -> throw it
                 }
             }
+
+    private fun Builder.addAddressesAndRoutesSafe(
+        config: TunConfig
+    ): Either<ConfigError.InvalidIpv6, Builder> =
+        if (config.validIpv6Routes()) {
+            config.addresses.forEach { addAddress(it, it.prefixLength()) }
+            config.routes.forEach { addRoute(it.address, it.prefixLength.toInt()) }
+            right()
+        } else {
+            Logger.e("Bad Ipv6 config provided!")
+            Logger.e("IPv6 address: ${config.hasIpv6Address}")
+            Logger.e("IPv6 route: ${config.hasIpv6Route}")
+            Logger.e("IPv6 DnsServer: ${config.hasIpv6DnsServer}")
+            invalidIpv6Setup()
+            ConfigError.InvalidIpv6(
+                    addresses = config.addresses,
+                    routes = config.routes,
+                    dnsServers = config.dnsServers,
+                )
+                .left()
+        }
 
     private fun InetAddress.prefixLength(): Int =
         when (this) {
@@ -176,8 +232,29 @@ open class TalpidVpnService : LifecycleVpnService() {
 
     companion object {
         const val FALLBACK_DUMMY_DNS_SERVER = "192.0.2.1"
+        const val BLOCKING_ADDRESS_IPV4 = "10.0.0.1"
+        const val BLOCKING_ADDRESS_IPV6 = "fd00::1"
+        const val ROUTE_ALL_IPV4 = "0.0.0.0"
+        const val ROUTE_ALL_IPV6 = "::"
+        const val BLOCKING_MTU = 1280
 
         private const val IPV4_PREFIX_LENGTH = 32
         private const val IPV6_PREFIX_LENGTH = 128
+    }
+}
+
+private sealed interface ConfigError {
+    val priority: Int
+
+    data class InvalidDns(val addresses: List<InetAddress>) : ConfigError {
+        override val priority: Int = 1
+    }
+
+    data class InvalidIpv6(
+        val addresses: List<InetAddress>,
+        val routes: List<InetNetwork>,
+        val dnsServers: List<InetAddress>,
+    ) : ConfigError {
+        override val priority: Int = 2
     }
 }

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/CreateTunResult.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/CreateTunResult.kt
@@ -31,12 +31,29 @@ sealed interface CreateTunResult {
     }
 
     data class InvalidDnsServers(val addresses: ArrayList<InetAddress>, val tunFd: Int) : Error {
-        constructor(address: List<InetAddress>, tunFd: Int) : this(ArrayList(address), tunFd)
+        constructor(addresses: List<InetAddress>, tunFd: Int) : this(ArrayList(addresses), tunFd)
 
         override val isOpen = true
     }
 
-    data object InvalidIpv6Config : Error {
-        override val isOpen = false
+    data class InvalidIpv6Config(
+        val addresses: ArrayList<InetAddress>,
+        val routes: ArrayList<InetNetwork>,
+        val dnsServers: ArrayList<InetAddress>,
+        val tunFd: Int,
+    ) : Error {
+        constructor(
+            addresses: List<InetAddress>,
+            routes: List<InetNetwork>,
+            dnsServers: List<InetAddress>,
+            tunFd: Int,
+        ) : this(
+            addresses = ArrayList(addresses),
+            routes = ArrayList(routes),
+            dnsServers = ArrayList(dnsServers),
+            tunFd = tunFd,
+        )
+
+        override val isOpen = true
     }
 }

--- a/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/TunConfig.kt
+++ b/android/lib/talpid/src/main/kotlin/net/mullvad/talpid/model/TunConfig.kt
@@ -17,5 +17,5 @@ data class TunConfig(
         get() = dnsServers.any { it is Inet6Address }
 
     val hasIpv6Route: Boolean
-        get() = routes.any { it.address is Inet6Address }
+        get() = routes.any { it.isIpv6 }
 }

--- a/android/lib/ui/component/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/component/NotificationData.kt
+++ b/android/lib/ui/component/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/component/NotificationData.kt
@@ -279,6 +279,7 @@ private fun ErrorStateCause.errorMessageId(): String =
             )
         is ErrorStateCause.NoRelaysMatchSelectedPort ->
             stringResource(R.string.wireguard_port_is_not_supported)
+        is ErrorStateCause.InvalidIpv6Config -> stringResource(R.string.invalid_ipv6_config)
     }
 
 private fun AuthFailedError.errorMessageId(): Int =

--- a/android/lib/ui/resource/src/main/res/values/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values/strings.xml
@@ -495,4 +495,5 @@
     <string name="less_than_a_day_left">Less than a day left on this account</string>
     <string name="you_can_add_more_time_play">You can add more time via the account view to continue using the VPN.</string>
     <string name="you_can_add_more_time_oss">You can add more time via the account view or website to continue using the VPN.</string>
+    <string name="invalid_ipv6_config">Invalid IPv6 config, please try to change the VPN settings.</string>
 </resources>

--- a/desktop/packages/mullvad-vpn/locales/messages.pot
+++ b/desktop/packages/mullvad-vpn/locales/messages.pot
@@ -3102,6 +3102,9 @@ msgstr ""
 msgid "Include my account token for faster help with payment or account related issues"
 msgstr ""
 
+msgid "Invalid IPv6 config, please try to change the VPN settings."
+msgstr ""
+
 msgid "Invalid or missing value \"%1$s\""
 msgstr ""
 

--- a/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
@@ -272,6 +272,7 @@ function convertFromTunnelStateError(state: grpcTypes.ErrorState.AsObject): Erro
     case grpcTypes.ErrorState.Cause.NOT_PREPARED:
     case grpcTypes.ErrorState.Cause.OTHER_ALWAYS_ON_APP:
     case grpcTypes.ErrorState.Cause.OTHER_LEGACY_ALWAYS_ON_VPN:
+    case grpcTypes.ErrorState.Cause.INVALID_IPV6_CONFIG:
       throw new Error('Unsupported error state cause: ' + state.cause);
   }
 }

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -222,6 +222,8 @@ message ErrorState {
     OTHER_LEGACY_ALWAYS_ON_VPN = 10;
     // Android only
     INVALID_DNS_SERVERS = 11;
+    // Android only
+    INVALID_IPV6_CONFIG = 14;
     SPLIT_TUNNEL_ERROR = 12;
     NEED_FULL_DISK_PERMISSIONS = 13;
   }
@@ -259,6 +261,12 @@ message ErrorState {
 
   message InvalidDnsServersError { repeated string ip_addrs = 1; }
 
+  message InvalidIpv6Config {
+    repeated string addrs = 1;
+    repeated string routes = 2;
+    repeated string dns = 3;
+  }
+
   Cause cause = 1;
   FirewallPolicyError blocking_error = 2;
 
@@ -275,6 +283,8 @@ message ErrorState {
   OtherAlwaysOnAppError other_always_on_app_error = 8;
   // Android only
   InvalidDnsServersError invalid_dns_servers_error = 9;
+  // Android only
+  InvalidIpv6Config invalid_ipv6_config_error = 10;
 }
 
 message TunnelState {

--- a/mullvad-management-interface/src/types/conversions/states.rs
+++ b/mullvad-management-interface/src/types/conversions/states.rs
@@ -126,6 +126,10 @@ impl From<mullvad_types::states::TunnelState> for proto::TunnelState {
                             talpid_tunnel::ErrorStateCause::InvalidDnsServers(_) => {
                                 i32::from(Cause::InvalidDnsServers)
                             }
+                            #[cfg(target_os = "android")]
+                            talpid_tunnel::ErrorStateCause::InvalidIPv6Config { .. } => {
+                                i32::from(Cause::InvalidIpv6Config)
+                            }
                             #[cfg(any(
                                 target_os = "windows",
                                 target_os = "macos",
@@ -162,6 +166,24 @@ impl From<mullvad_types::states::TunnelState> for proto::TunnelState {
                             {
                                 Some(proto::error_state::InvalidDnsServersError {
                                     ip_addrs: ip_addrs.iter().map(|ip| ip.to_string()).collect(),
+                                })
+                            } else {
+                                None
+                            },
+                        #[cfg(not(target_os = "android"))]
+                        invalid_ipv6_config_error: None,
+                        #[cfg(target_os = "android")]
+                        invalid_ipv6_config_error:
+                            if let talpid_tunnel::ErrorStateCause::InvalidIPv6Config {
+                                addresses,
+                                routes,
+                                dns_servers,
+                            } = error_state.cause()
+                            {
+                                Some(proto::error_state::InvalidIpv6Config {
+                                    addrs: addresses.iter().map(|ip| ip.to_string()).collect(),
+                                    routes: routes.iter().map(|route| route.to_string()).collect(),
+                                    dns: dns_servers.iter().map(|dns| dns.to_string()).collect(),
                                 })
                             } else {
                                 None

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -727,7 +727,7 @@ impl SharedTunnelStateValues {
 
         let config = tun_provider.config_mut();
         if blocking {
-            config.dns_servers = Some(vec![]);
+            config.set_blocking_config();
         } else {
             let addrs: Vec<_> = self.dns_config.resolve(&[]).addresses().collect();
             config.dns_servers = if addrs.is_empty() { None } else { Some(addrs) };

--- a/talpid-core/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/talpid-core/src/tunnel_state_machine/tunnel_monitor.rs
@@ -63,6 +63,21 @@ impl From<Error> for ErrorStateCause {
                     tun_provider::Error::InvalidDnsServers(addresses),
                 ),
             )) => ErrorStateCause::InvalidDnsServers(addresses),
+
+            #[cfg(target_os = "android")]
+            Error::TunnelMonitoring(talpid_wireguard::Error::TunnelError(
+                talpid_wireguard::TunnelError::SetupTunnelDevice(
+                    tun_provider::Error::InvalidIpv6Config {
+                        addresses,
+                        routes,
+                        dns_servers,
+                    },
+                ),
+            )) => ErrorStateCause::InvalidIPv6Config {
+                addresses,
+                routes,
+                dns_servers,
+            },
             #[cfg(target_os = "windows")]
             error => match error.get_tunnel_device_error() {
                 Some(error) => ErrorStateCause::CreateTunnelDevice {

--- a/talpid-tunnel/src/tun_provider/mod.rs
+++ b/talpid-tunnel/src/tun_provider/mod.rs
@@ -98,6 +98,22 @@ impl TunConfig {
             .map(IpNetwork::from)
             .collect()
     }
+
+    /// Applies the blocking config to the current tunnel config
+    ///
+    /// This is so that if the android system rejects the tun config due to some improper values
+    /// we will apply a set of safe values that work so that we can properly route all
+    /// traffic in the tunnel and block it.
+    #[cfg(target_os = "android")]
+    pub fn set_blocking_config(&mut self) {
+        let blocking_config = blocking_config();
+        self.mtu = blocking_config.mtu;
+        self.addresses = blocking_config.addresses;
+        self.ipv4_gateway = blocking_config.ipv4_gateway;
+        self.ipv6_gateway = blocking_config.ipv6_gateway;
+        self.routes = blocking_config.routes;
+        self.dns_servers = blocking_config.dns_servers;
+    }
 }
 
 /// Return a tunnel configuration that routes all traffic inside the tunnel.
@@ -121,6 +137,9 @@ pub fn blocking_config(
         ipv6_gateway: None,
         routes: DEFAULT_ROUTES.to_vec(),
         allow_lan: false,
+        #[cfg(target_os = "android")]
+        dns_servers: Some(vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))]),
+        #[cfg(not(target_os = "android"))]
         dns_servers: None,
         excluded_packages: vec![],
         #[cfg(target_os = "windows")]

--- a/talpid-types/src/tunnel.rs
+++ b/talpid-types/src/tunnel.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "android")]
+use crate::android::InetNetwork;
 use crate::net::{IpVersion, TunnelEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -87,6 +89,13 @@ pub enum ErrorStateCause {
     /// Android has rejected one or more DNS server addresses.
     #[cfg(target_os = "android")]
     InvalidDnsServers(Vec<IpAddr>),
+    /// Android has rejected due to invalid IPV6 config.
+    #[cfg(target_os = "android")]
+    InvalidIPv6Config {
+        addresses: Vec<IpAddr>,
+        routes: Vec<InetNetwork>,
+        dns_servers: Vec<IpAddr>,
+    },
     /// Failed to create tunnel device.
     #[cfg(target_os = "windows")]
     CreateTunnelDevice { os_error: Option<i32> },
@@ -194,6 +203,32 @@ impl fmt::Display for ErrorStateCause {
                     f,
                     "Invalid DNS server addresses used in tunnel configuration: {}",
                     addresses
+                        .iter()
+                        .map(IpAddr::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+            #[cfg(target_os = "android")]
+            InvalidIPv6Config {
+                addresses,
+                routes,
+                dns_servers,
+            } => {
+                return write!(
+                    f,
+                    "Invalid ipv6 tunnel configuration. addresses: {} routes: {} dns_servers: {}",
+                    addresses
+                        .iter()
+                        .map(IpAddr::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    routes
+                        .iter()
+                        .map(InetNetwork::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    dns_servers
                         .iter()
                         .map(IpAddr::to_string)
                         .collect::<Vec<_>>()


### PR DESCRIPTION
NOTE! Due to how the android implementation of tunnel state machine is set up if the blocking config also is invalid it will throw a critical error and not be in a blocking state.

We could change this, but that would add behavior related specifically to this error.

Easiest way to test:
`git revert fde04b51be6b541f890abb1bbc0dabc3e995607a`
This will revoke the fix for IPv6.
After that the error will trigger if you turn off "In-tunnel IPv6"

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9730)
<!-- Reviewable:end -->
