### PR TITLE
Enable gotatun by default for macOS app builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,8 +31,12 @@ NOTARIZE="false"
 # If a macOS or Windows build should create an installer artifact working on both
 # x86 and arm64
 UNIVERSAL="false"
-# Use gotatun instead of wireguard-go. The current desktop default is wireguard-go.
+# Use gotatun instead of wireguard-go.
 GOTATUN="false"
+# Enable GotaTun by default on macOS.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    GOTATUN="true"
+fi
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in


### PR DESCRIPTION
This PR makes `build.sh` produce app builds with GotaTun instead of Wireguard-go on macOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9745)
<!-- Reviewable:end -->
