### PR TITLE
Extend ignore of tar for 3 weeks

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -9,11 +9,17 @@ reason = "There is no fix yet and we don't send untrusted input to the first arg
 # tar: node-tar is Vulnerable to Arbitrary File Overwrite and Symlink Poisoning via Insufficient Path Sanitization
 [[IgnoredVulns]]
 id = "CVE-2026-23745"  # GHSA-8qq5-rm4j-mr97
-ignoreUntil = 2026-02-02
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to Github's package repository are compromised an attack is not possible."
+ignoreUntil = 2026-02-24
+reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
 
 # tar: Race Condition in node-tar Path Reservations via Unicode Ligature Collisions on macOS APFS
 [[IgnoredVulns]]
 id = "CVE-2026-23950"  # GHSA-r6q2-hw4h-h46w
-ignoreUntil = 2026-02-02
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to Github's package repository are compromised an attack is not possible."
+ignoreUntil = 2026-02-24
+reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
+
+# tar: node-tar Vulnerable to Arbitrary File Creation/Overwrite via Hardlink Path Traversal
+[[IgnoredVulns]]
+id = "CVE-2026-24842"  # GHSA-34x7-hfp2-rc4v
+ignoreUntil = 2026-02-24
+reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."


### PR DESCRIPTION
Currently we have no way to update the tar package to a patched version due to the grpc-tools npm package, which is used by the management-interface package to generate gRPC JS bindings.

However, a fix is being worked on to remove the tar dependency from our dependency chain by reworking how we generate the gRPC JS bindings.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9752)
<!-- Reviewable:end -->
