### PR TITLE
Ignore GO-2026-4403 CVE for a year 

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -200,3 +200,10 @@ reason = "wireguard-go does not use net/url"
 id = "GO-2026-4342"
 ignoreUntil = 2027-01-29
 reason = "wireguard-go does not use archive/zip"
+
+# Improper access to parent directory of root in os
+# https://osv.dev/GO-2026-4403
+[[IgnoredVulns]]
+id = "GO-2026-4403"
+ignoreUntil = 2027-02-05
+reason = "wireguard-go does not use os.checkPathEscapesInternal, os.doInRoot nor os.splitPathInRoot"


### PR DESCRIPTION
I chose to put this week's go CVE on the ignore list for 1 year since wireguard-go does not use the vulnerable parts of the standard library. These are the affected functions:

* `os.checkPathEscapesInternal`
* `os.doInRoot`
* `os.splitPathInRoot`

https://osv.dev/vulnerability/GO-2026-4403

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9764)
<!-- Reviewable:end -->
