### PR TITLE
Ignore even more go CVEs

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -222,3 +222,10 @@ reason = "wireguard-go does not use golang.org/x/net/html"
 id = "GO-2026-4441"
 ignoreUntil = 2027-02-06
 reason = "wireguard-go does not use html.Parse"
+
+# Unexpected session resumption in crypto/tls
+# https://osv.dev/vulnerability/GO-2026-4337
+[[IgnoredVulns]]
+id = "GO-2026-4337"
+ignoreUntil = 2027-02-06
+reason = "wireguard(-go) does not use tls"


### PR DESCRIPTION
Another day, 3 new go CVEs ...

I chose to put this on the ignore list for 1 year since wireguard-go does not use any of the affected libraries directly nor indirectly.

GotaTun save us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9775)
<!-- Reviewable:end -->
