### PR TITLE
Add a timeout to early-boot-blocking.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Change "Go back" keyboard shortcut from `Esc` to `Alt + Left Arrow` or `Alt + [`.
 - Use Wayland by default on Linux if available, otherwise fall back to X11.
+- Add a 60 second timeout to `mullvad-early-boot-blocking.service`. If this service fails badly,
+  we allow the user to boot, at the risk of potentially leaking some traffic before the daemon
+  starts up.
 
 #### macOS
 - Change "Go back" keyboard shortcut from `Esc` to `Cmd + Left Arrow` or `Cmd + [`.

--- a/dist-assets/linux/mullvad-early-boot-blocking.service
+++ b/dist-assets/linux/mullvad-early-boot-blocking.service
@@ -11,6 +11,8 @@ Before=basic.target mullvad-daemon.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/mullvad-daemon --initialize-early-boot-firewall
+# Ensure we can still boot if the service gets stuck for whatever reason.
+TimeoutStartSec=60
 
 [Install]
 WantedBy=mullvad-daemon.service


### PR DESCRIPTION
This lets the user boot their system after 60 seconds if the early boot firewall were to break horribly and stall forever. If the timeout is reached, the service will show as `failed` by systemd.

The downside of this is that the user risks leakage, but this is preferable to not being able to boot.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9777)
<!-- Reviewable:end -->
