### PR TITLE
Fix test failures when API is unavailable

### DIFF
--- a/ios/MullvadVPNUITests/AccountTests.swift
+++ b/ios/MullvadVPNUITests/AccountTests.swift
@@ -238,7 +238,6 @@ class AccountTests: LoggedOutUITestCase {
 
         AccountPage(app)
             .tapLogOutButton()
-            .waitForLogoutSpinnerToDisappear()
 
         LoginPage(app)
 

--- a/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
+++ b/ios/MullvadVPNUITests/Base/BaseUITestCase.swift
@@ -331,7 +331,6 @@ class BaseUITestCase: XCTestCase {
                     .tapAccountButton()
                 AccountPage(app)
                     .tapLogOutButton()
-                    .waitForLogoutSpinnerToDisappear()
             } else {
                 // Workaround for revoked device view not showing account button
                 RevokedDevicePage(app)

--- a/ios/MullvadVPNUITests/ConnectivityTests.swift
+++ b/ios/MullvadVPNUITests/ConnectivityTests.swift
@@ -131,7 +131,6 @@ class ConnectivityTests: LoggedOutUITestCase {
 
         AccountPage(app)
             .tapLogOutButton()
-            .waitForLogoutSpinnerToDisappear()
 
         LoginPage(app)
 
@@ -218,7 +217,6 @@ class ConnectivityTests: LoggedOutUITestCase {
         // Log out will take long because API cannot be reached
         AccountPage(app)
             .tapLogOutButton()
-            .waitForLogoutSpinnerToDisappear()
 
         // Verify API cannot be reached by doing a login attempt which should fail
         LoginPage(app)

--- a/ios/MullvadVPNUITests/Pages/AccountPage.swift
+++ b/ios/MullvadVPNUITests/Pages/AccountPage.swift
@@ -66,12 +66,6 @@ class AccountPage: PaymentPage {
 
         return self
     }
-
-    func waitForLogoutSpinnerToDisappear() {
-        let spinnerDisappeared = app.otherElements[.logOutSpinnerAlertView]
-            .notExistsAfterWait(timeout: .extremelyLong)
-        XCTAssertTrue(spinnerDisappeared, "Log out spinner disappeared")
-    }
 }
 
 private extension Date {

--- a/ios/MullvadVPNUITests/Pages/Page.swift
+++ b/ios/MullvadVPNUITests/Pages/Page.swift
@@ -23,7 +23,7 @@ class Page {
     func waitForPageToBeShown() {
         if let pageElement {
             XCTAssertTrue(
-                pageElement.existsAfterWait(),
+                pageElement.existsAfterWait(timeout: .extremelyLong),
                 "Page is shown"
             )
         }


### PR DESCRIPTION
This PR fixes the test failures when API is unavailable. the original idea is waiting for the login view instead of waiting for disappearing the spinner view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9790)
<!-- Reviewable:end -->
