### PR TITLE
Use correct registrar name for Google's DNS

### DIFF
--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -697,7 +697,7 @@ class RelayTests: LoggedInWithTimeUITestCase {
 
     func testCustomDNS() throws {
         let dnsServerIPAddress = "8.8.8.8"
-        let dnsServerProviderName = "GOOGLE"
+        let dnsServerProviderName = "Google LLC"
 
         TunnelControlPage(app)
             .tapConnectButton()


### PR DESCRIPTION
Our tests are broken because Google the provider name they're advertising on it's DNS servers. This is an easy fix.
https://github.com/mullvad/mullvadvpn-app/actions/runs/21845957252

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9798)
<!-- Reviewable:end -->
