### PR TITLE
Fix testReconnectingTunnelRefreshesItsStatus

### DIFF
--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
@@ -222,10 +222,12 @@ class TunnelManagerTests: XCTestCase {
         let connectedExpectation = expectation(description: "Connected")
         let reconnectingExpectation = expectation(description: "Reconnecting")
         let tunnelObserver = TunnelBlockObserver(
-            didUpdateTunnelStatus: { _, tunnelStatus in
+            didUpdateTunnelStatus: { manager, tunnelStatus in
                 switch tunnelStatus.state {
                 case .connected: connectedExpectation.fulfill()
-                case .reconnecting: reconnectingExpectation.fulfill()
+                case .reconnecting:
+                    manager.removeObserver(self.tunnelObserver)
+                    reconnectingExpectation.fulfill()
                 default: return
                 }
             }


### PR DESCRIPTION
Since the simulated tunnel connection ends up always transitioning back to the connected state, this test will fail due to fulfilling the connected state expectation multiple times. The fix here is to not let that happen in the first place by removing the listener as soon as we see the expected reconnecting state. An alternative way of fixing this would be to allow the connected fulfillment to be done multiple times too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9807)
<!-- Reviewable:end -->
