### PR TITLE
Update workflow to accommodate relay list handling

### DIFF
--- a/.github/workflows/ios-screenshots-creation.yml
+++ b/.github/workflows/ios-screenshots-creation.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Setup project
         uses: ./.github/actions/ios/setup-project-toolchain
 
+      - name: Copy relay list
+        run: cp MullvadREST/Assets/relays-test-data.json MullvadREST/Assets/relays.json
+        working-directory: ios
+
       - name: Add test account to config
         run: |
           sed -i "" \

--- a/.github/workflows/ios-screenshots-tests.yml
+++ b/.github/workflows/ios-screenshots-tests.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Setup project
         uses: ./.github/actions/ios/setup-project-toolchain
 
+      - name: Copy relay list
+        run: cp MullvadREST/Assets/relays-test-data.json MullvadREST/Assets/relays.json
+        working-directory: ios
+
       - name: Add test account to config
         run: |
           sed -i "" \

--- a/.github/workflows/ios-validate-build-schemas.yml
+++ b/.github/workflows/ios-validate-build-schemas.yml
@@ -19,7 +19,7 @@ permissions: {}
 
 jobs:
   test:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     name: Validate build schemas
     runs-on: macos-15-xlarge
     env:
@@ -31,6 +31,10 @@ jobs:
 
       - name: Setup project
         uses: ./.github/actions/ios/setup-project-toolchain
+
+      - name: Copy relay list
+        run: cp MullvadREST/Assets/relays-test-data.json MullvadREST/Assets/relays.json
+        working-directory: ios
 
       - name: Run build validation for Staging and MockRelease configurations as well as the MullvadVPNUITests target
         run: |


### PR DESCRIPTION
Since we no longer automatically download the relay list during builds, our screenshot tests and mockrelease build tests fail. I've updated the GitHub workflows to copy the relay list from the benchmark list - this limits our dependency on the API during GitHub runs. 

Here's a successful [screenshot test run](https://github.com/mullvad/mullvadvpn-app/actions/runs/21870207362). Funnily enough, all my mockrelease workflow runs get cancelled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9809)
<!-- Reviewable:end -->
