### PR TITLE
Add a "Secure development" section to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ the current state of the latest code in git, not necessarily any existing releas
 
 [DAITA]: https://mullvad.net/en/blog/introducing-defense-against-ai-guided-traffic-analysis-daita
 
-## Security and anonymity
+## User security, privacy and anonymity
 
 This app is a privacy preserving VPN client. As such it goes to great lengths to stop traffic
 leaks. And basically all settings default to the more secure/private option. The user has to
@@ -79,6 +79,35 @@ explicitly allow more loose rules if desired. See the [dedicated security docume
 on what the app blocks and allows, as well as how it does it.
 
 [dedicated security document]: docs/security.md
+
+## Secure development
+
+Since the security of the users of the app is a top priority, by extension the security
+of the development and release process also becomes a top priority. This is something we work
+actively on.
+
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9411/badge)](https://www.bestpractices.dev/projects/9411)
+
+### Git signatures
+
+All merge commits to the main branch must be PGP (gpg) signed in git. This signs off the entire
+feature branch. The individual commits in the feature branch do not need to be signed,
+unless they change one or more of the files deemed extra important.
+
+The list of files requiring signatures to every commit that change them is defined in the
+[`verify-locked-down-signatures`](.github/workflows/verify-locked-down-signatures.yml)
+workflow.
+
+### Audits, pentests and external security reviews
+
+This app is audited by external security experts and penetration testers every second year.
+We also carry out feature specific audits for certain security critical features and changes.
+
+The results of these audits are always made public in their unredacted original form, for
+full transparency towards the users. See the [audits readme](./audits/README.md) for this.
+
+Moreover, we welcome any individual to review the security of this app and submit any found
+issue to us. See [SECURITY.md](SECURITY.md) for more.
 
 ## Checking out the code
 
@@ -98,8 +127,9 @@ git submodule update --init wireguard-go-rs/libwg/wireguard-go
 ```
 Further details on why this is necessary can be found in the [wireguard-go-rs crate](./wireguard-go-rs/README.md).
 
-We sign every commit on the `main` branch as well as our release tags. If you would like to verify
-your checkout, you can find our developer keys on [Mullvad's Open Source page].
+We sign every merge commit to the `main` branch as well as our release tags.
+If you would like to verify your checkout, you can find our developer keys on
+[Mullvad's Open Source page].
 
 ### Binaries submodule
 
@@ -432,11 +462,6 @@ Instructions for how to handle locales and translations are found
 For instructions specific to the Android app, see [here](./android/README.md).
 
 For instructions specific to the iOS app, see [here](./ios/translation/README.md).
-
-## Audits, pentests and external security reviews
-
-Mullvad has used external pentesting companies to carry out security audits of this VPN app. Read
-more about them in the [audits readme](./audits/README.md).
 
 # License
 


### PR DESCRIPTION
Starts explaining how we work with secure development. **Far** from done, but it's a start. This now includes the section about external audits, which was moved up to be placed here.

I realized we did not document our requirement to sign all merge commits in git very well. You can find it spread out here and there, but no place dedicated to it.

I also wanted a place to put our OpenSSF badge. This is not to brag publicly in any way. I see it more as a commitment to ourselves to keep up to date with recognized best practices, and to make it visible to us and others if we were to fall below the passing threshold of this standard.

I have been monitoring [our OpenSSF score](https://securityscorecards.dev/viewer/?uri=github.com/mullvad/mullvadvpn-app) for years. I think we are doing a good job overall! We do not have the highest possible score. But most areas where they knock off points are things we do not gain any actual value or security by following their best practices in. For example, we lose a lot of points on minor details of our Github actions workflow setup. But since our workflows do not have access to anything secret or confidential, nor does it produce any artifacts used for anything important, the security of those workflows is not critical.

Over time I would like to have a dedicated secure development document with more details on requirements. Either in `docs/` in this repo, or in our [coding guidelines](https://github.com/mullvad/coding-guidelines/) maybe. But until then, I think this PR takes us in the right direction.

Other things a public secure development document could explain:
* Github rulesets for protecting branches and tags
* Rules around dependency management, lockfiles etc.
* Threat models
* ... Lots more

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9810)
<!-- Reviewable:end -->
