### PR TITLE
Always attempt to return stored value

### DIFF
--- a/ios/MullvadSettings/AppStorage.swift
+++ b/ios/MullvadSettings/AppStorage.swift
@@ -20,7 +20,7 @@ public struct AppStorage<Value: Codable> {
                 let data = container.data(forKey: key),
                 let value = try? JSONDecoder().decode(Value.self, from: data)
             else {
-                return defaultValue
+                return container.value(forKey: key) as? Value ?? defaultValue
             }
             return value
         }


### PR DESCRIPTION
Me and @mojganii found the culprit - the new `AppConfiguration` serialization does not work for primitive values stored by previous versions, so it always ends up reading the default one and storing it again. I've added a small fix that resolves this. 

However, we should consider if composite values (like the notificaiton settings) should be stored with a different property wrapper, such that we have 2 code paths - one for primitives and one for composites. And in the composites case, if we expect a composite (i.e. have to use `container.data` instead of `container.value`), we should throw instead of attempting to call the other accessor method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9821)
<!-- Reviewable:end -->
