### PR TITLE
Add changelog entry about gotatun being default on macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### macOS
 - Change "Go back" keyboard shortcut from `Esc` to `Cmd + Left Arrow` or `Cmd + [`.
+- GotaTun is now used as the WireGuard implementation. It replaces wireguard-go.
 
 #### Windows
 - Change "Go back" keyboard shortcut from `Esc` to `Alt + Left Arrow` or `Alt + [`.


### PR DESCRIPTION
Follow up to https://github.com/mullvad/mullvadvpn-app/pull/9745. Seems changelog-worthy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9825)
<!-- Reviewable:end -->
