### PR TITLE
Remove fedora 41 test runner from set of default runners

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -21,8 +21,8 @@ on:
           windows10 windows11 \
           macos12 macos13 macos14 macos15 macos26`.\n
           Default images:\n
-          `debian13 ubuntu2204 ubuntu2404 ubuntu2504 ubuntu2510 \
-          fedora41 fedora42 fedora43 windows10 windows11 \
+          `ubuntu2204 ubuntu2404 ubuntu2504 ubuntu2510 \
+          debian13 fedora42 fedora43 windows10 windows11 \
           macos13 macos14 macos15 macos26`."
         default: ''
         required: false
@@ -50,7 +50,7 @@ jobs:
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
           all='["debian11","debian12","debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","fedora41","fedora42","fedora43"]'
-          default='["debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","fedora41","fedora42","fedora43"]'
+          default='["debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","fedora42","fedora43"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then


### PR DESCRIPTION
Fedora 41 has been [EOL since 15/12-2025](https://docs.fedoraproject.org/en-US/releases/eol/), and no longer receive updates / security patches. We also suspect that it will be stuck with a kernel bug which has been fixed in Linux kernel 6.18 and backported to older kernels of [all distros that we officially support](https://github.com/mullvad/mullvadvpn-app?tab=readme-ov-file#platformos-support) (Related to https://github.com/mullvad/mullvadvpn-app/issues/9786), making it even harder to support properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9829)
<!-- Reviewable:end -->
