### PR TITLE
Remove ignore of RUSTSEC-2025-0142 from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,8 +31,6 @@ ignore = [
 
   # Bincode is unmaintained. Version 1.3.3 is considered "complete" and can still be used
   "RUSTSEC-2025-0141",
-  # Segmentation fault and invalid memory read in mnl::cb_run. We don't pass untrusted input
-  "RUSTSEC-2025-0142"
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Follow up to https://github.com/mullvad/mullvadvpn-app/pull/9805 - we no longer have to ignore this CVE since it's been fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9854)
<!-- Reviewable:end -->
