### PR TITLE
Update keccak away from yanked 0.1.5 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]


### PR DESCRIPTION
[keccak](https://docs.rs/crate/keccak/latest) 0.1.5 is yanked, but 0.1.6 is available. Here is the changelog for that crate: https://github.com/RustCrypto/sponges/blob/master/keccak/CHANGELOG.md#016-2026-02-13

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9855)
<!-- Reviewable:end -->
