### PR TITLE
Partially fix CVE-2026-26960 

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -921,9 +921,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/rebuild/node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3959,9 +3959,9 @@
       "license": "MIT"
     },
     "node_modules/app-builder-lib/node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4599,9 +4599,9 @@
       }
     },
     "node_modules/cacache/node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -8630,9 +8630,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -12654,9 +12654,9 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-          "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+          "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
           "dev": true,
           "requires": {
             "@isaacs/fs-minipass": "^4.0.0",
@@ -14665,9 +14665,9 @@
           "dev": true
         },
         "tar": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-          "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+          "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
           "dev": true,
           "requires": {
             "@isaacs/fs-minipass": "^4.0.0",
@@ -15117,9 +15117,9 @@
           }
         },
         "tar": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-          "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+          "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
           "dev": true,
           "requires": {
             "@isaacs/fs-minipass": "^4.0.0",
@@ -18036,9 +18036,9 @@
           }
         },
         "tar": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-          "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+          "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
           "dev": true,
           "requires": {
             "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
Updates `tar` package to partially fix CVE-2026-26960

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9869)
<!-- Reviewable:end -->
