### PR TITLE
Use default log level in mullvad-setup

### DIFF
--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, process, str::FromStr, sync::LazyLock, time::Duration};
 use talpid_core::firewall::{self, Firewall};
 use talpid_future::retry::{ConstantInterval, retry_future};
 use talpid_types::ErrorExt;
-use tracing_subscriber::{EnvFilter, filter::LevelFilter};
+use tracing_subscriber::EnvFilter;
 
 #[cfg(target_os = "windows")]
 mod service;
@@ -118,7 +118,7 @@ enum Cli {
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive(LevelFilter::INFO.into()))
+        .with_env_filter(EnvFilter::from_default_env())
         .init();
 
     let result = match Cli::parse() {


### PR DESCRIPTION
Since 2025.14, we have changed the logging to use `tracing`. With this, `mullvad-setup` was changed to log message with log level `INFO`. This is a deviation from the standard, which is to only log errors: https://docs.rs/env_filter/1.0.0/src/env_filter/filter.rs.html#138-149.

This PR changes back to the previous behavior. `mullvad-setup` is intended to be called from scripts, so logs for the happy path will most likely look out of place. Error logs are still useful, though.

```
# Current
$ mullvad-setup reset-firewall
2026-02-24T07:35:59.186214Z  INFO talpid_core::firewall: Resetting firewall policy
0
# Expected
$ mullvad-setup reset-firewall && echo $?
0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9885)
<!-- Reviewable:end -->
