### PR TITLE
Use GotaTun in test manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,9 +1691,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gotatun"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011b0c02e571262b965413848b5e1e25810a9a1b8cea2ce373ea67e8f2174197"
+checksum = "ee896ae91b1a90a10642d58ced8721560dc399ceeaba66d9cab14ad1db846936"
 dependencies = [
  "aead",
  "base64",
@@ -1724,6 +1724,7 @@ dependencies = [
  "socket2 0.6.3",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util 0.7.18",
  "tun 0.8.7",
  "typed-builder 0.21.2",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ ctrlc = "3.5"
 dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"
-gotatun = { version = "0.5.1" }
+gotatun = { version = "0.6.0", default-features = false, features = ["ring"] }
 hickory-proto = "0.25.2"
 hickory-resolver = "0.25.2"
 hickory-server = { version = "0.25.2", features = ["resolver"] }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -133,6 +133,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-tempfile"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +239,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bitfield-struct"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +260,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "blake3"
@@ -256,6 +294,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +329,26 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "c2rust-bitfields"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcee50917f9de1a018e3f4f9a8f2ff3d030a288cffa4b18d9b391e97c12e4cfb"
+dependencies = [
+ "c2rust-bitfields-derive",
+]
+
+[[package]]
+name = "c2rust-bitfields-derive"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b457277798202ccd365b9c112ebee08ddd57f1033916c8b8ea52f222e5b715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "camellia"
@@ -428,6 +499,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -783,6 +863,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fast-socks5"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +1010,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1124,46 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gotatun"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011b0c02e571262b965413848b5e1e25810a9a1b8cea2ce373ea67e8f2174197"
+dependencies = [
+ "aead",
+ "base64",
+ "bitfield-struct",
+ "blake2",
+ "bytes",
+ "chacha20poly1305",
+ "constant_time_eq",
+ "duplicate",
+ "either",
+ "eyre",
+ "futures",
+ "hex",
+ "hmac",
+ "ip_network",
+ "ip_network_table",
+ "ipnetwork 0.21.1",
+ "libc",
+ "log",
+ "nix 0.31.2",
+ "parking_lot",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_core 0.6.4",
+ "ring",
+ "socket2 0.6.3",
+ "thiserror 1.0.69",
+ "tokio",
+ "tun",
+ "typed-builder",
+ "windows-sys 0.61.2",
+ "x25519-dalek",
+ "zerocopy",
+]
 
 [[package]]
 name = "h2"
@@ -1387,6 +1548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1621,28 @@ dependencies = [
  "core-foundation-sys",
  "mach2",
 ]
+
+[[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
+name = "ip_network_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4099b7cfc5c5e2fe8c5edf3f6f7adf7a714c9cc697534f63a5a5da30397cb2c0"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
 
 [[package]]
 name = "ipconfig"
@@ -1691,6 +1880,16 @@ checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -2061,6 +2260,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2181,6 +2381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,7 +2419,7 @@ dependencies = [
  "errno 0.2.8",
  "futures",
  "libc",
- "libloading",
+ "libloading 0.6.7",
  "pkg-config",
  "regex",
  "tokio",
@@ -2271,6 +2477,17 @@ dependencies = [
  "rand 0.9.4",
  "socket2 0.6.3",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
 ]
 
 [[package]]
@@ -3376,11 +3593,11 @@ dependencies = [
  "env_logger",
  "futures",
  "glob",
+ "gotatun",
  "hyper-util",
  "inventory",
  "ipnetwork 0.21.1",
  "itertools 0.10.5",
- "libc",
  "log",
  "mullvad-api",
  "mullvad-api-constants",
@@ -3878,6 +4095,47 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tun"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87dce40a7bfb165d8eb8e96f7463230f3d91b56aae21e0f1e56db60161962e1a"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "futures",
+ "futures-core",
+ "ipnet",
+ "libc",
+ "log",
+ "nix 0.31.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "windows-sys 0.61.2",
+ "wintun-bindings",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "typenum"
@@ -4546,6 +4804,22 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wintun-bindings"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ae04d34b8569174e849128d2e36538329a27daa79c06ed0375f2c5d6704461"
+dependencies = [
+ "blocking",
+ "c2rust-bitfields",
+ "futures",
+ "libloading 0.9.0",
+ "log",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
+ "winreg",
 ]
 
 [[package]]

--- a/test/deny.toml
+++ b/test/deny.toml
@@ -21,7 +21,10 @@ ignore = [
   # put into removing items from the list.
 
   # test-rpc does not deal with random user input
-  "RUSTSEC-2025-0055"
+  "RUSTSEC-2025-0055",
+
+  # Bincode is unmaintained. Version 1.3.3 is considered "complete" and can still be used
+  "RUSTSEC-2025-0141",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/test/osv-scanner.toml
+++ b/test/osv-scanner.toml
@@ -17,3 +17,13 @@ reason = """
 The `log` feature of `rand` is not enabled.
 tarpc transitively depends on unsound version of `rand`, and upgrade path for tarpc is not straight-forward.
 """
+
+# Bincode is unmaintained. Ignored for six months since the code has no known issues that changes to our
+# code could trigger, it is just unmaintained.
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0141"
+ignoreUntil = 2026-06-07
+reason = """
+Bincode is unmaintained. maybenot depend on it.
+Version 1.3.3 is considered "complete" and can still be used safely.
+"""

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -20,11 +20,11 @@ duplicate = { version = "2.0.0", default-features = false }
 env_logger = { workspace = true }
 futures = { workspace = true }
 glob = "0.3"
+gotatun = { version = "0.5.1", features = ["device", "tun"] }
 hyper-util = { workspace = true }
 inventory = "0.3"
 ipnetwork = "0.21.1"
 itertools = "0.10.5"
-libc = "0.2.14"
 log = { workspace = true }
 mullvad-api = { path = "../../mullvad-api", features = ["api-override"] }
 mullvad-api-constants = { path = "../../mullvad-api/mullvad-api-constants" }

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-async-tempfile = "0.2"
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -54,6 +53,7 @@ tower = { workspace = true }
 uuid = "1.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+async-tempfile = "0.2"
 pnet_datalink = "0.35.0"
 
 [lints]

--- a/test/test-manager/src/container.rs
+++ b/test/test-manager/src/container.rs
@@ -1,12 +1,11 @@
-#![cfg(target_os = "linux")]
-
-use nix::unistd::geteuid;
-use tokio::process::Command;
-
 /// Re-launch self with rootlesskit if we're not root.
 /// Allows for rootless and containerized networking.
 /// The VNC port is published to localhost.
+#[cfg(target_os = "linux")]
 pub async fn relaunch_with_rootlesskit(vnc_port: Option<u16>) {
+    use nix::unistd::geteuid;
+    use tokio::process::Command;
+
     // check if user is root (`man getuid`).
     if geteuid().is_root() {
         return;
@@ -37,6 +36,25 @@ pub async fn relaunch_with_rootlesskit(vnc_port: Option<u16>) {
     }
 
     cmd.args(std::env::args());
+
+    let status = cmd.status().await.unwrap_or_else(|e| {
+        panic!("failed to execute [{cmd:?}]: {e}");
+    });
+
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(target_os = "macos")]
+pub async fn relaunch_with_sudo() {
+    // check if user is root (`man getuid`).
+    if nix::unistd::geteuid().is_root() {
+        return;
+    }
+    let mut cmd = tokio::process::Command::new("sudo");
+    cmd.arg("--preserve-env");
+    cmd.args(std::env::args());
+
+    log::info!("Root privileges required. Re-launching with sudo.");
 
     let status = cmd.status().await.unwrap_or_else(|e| {
         panic!("failed to execute [{cmd:?}]: {e}");

--- a/test/test-manager/src/main.rs
+++ b/test/test-manager/src/main.rs
@@ -279,6 +279,9 @@ async fn inner_main() -> Result<()> {
             #[cfg(target_os = "linux")]
             container::relaunch_with_rootlesskit(vnc).await;
 
+            #[cfg(target_os = "macos")]
+            container::relaunch_with_sudo().await;
+
             let mut config = config.clone();
             config.runtime_opts.keep_changes = keep_changes;
             config.runtime_opts.display = if vnc.is_some() {
@@ -311,6 +314,9 @@ async fn inner_main() -> Result<()> {
         } => {
             #[cfg(target_os = "linux")]
             container::relaunch_with_rootlesskit(vnc).await;
+
+            #[cfg(target_os = "macos")]
+            container::relaunch_with_sudo().await;
 
             let mut config = config.clone();
             config.runtime_opts.display = match (display, vnc.is_some()) {

--- a/test/test-manager/src/vm/network/macos.rs
+++ b/test/test-manager/src/vm/network/macos.rs
@@ -1,27 +1,25 @@
-use anyhow::{Context, Result, anyhow, bail};
-use futures::{FutureExt, TryFutureExt, select};
-use nix::{
-    sys::{
-        signal::{Signal, kill},
-        socket::SockaddrStorage,
-    },
-    unistd::Pid,
+use anyhow::{Context, Result, anyhow};
+use gotatun::{
+    device::{self, DefaultDeviceTransports, Device, Peer},
+    tun::tun_async_device::TunDevice,
 };
-use std::{
-    convert::Infallible,
-    net::{Ipv4Addr, SocketAddrV4},
-};
-use talpid_types::drop_guard::on_drop;
-use tokio::{io::AsyncWriteExt, process::Command, time::sleep};
+use ipnetwork::Ipv4Network;
+use nix::sys::socket::SockaddrStorage;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use tokio::process::Command;
 
 // Private key of the wireguard remote peer on host.
-const CUSTOM_TUN_REMOTE_PRIVKEY: &str = "gLvQuyqazziyf+pUCAFUgTnWIwn6fPE5MOReOqPEGHU=";
+data_encoding_macro::base64_array!(
+    "const CUSTOM_TUN_REMOTE_PRIVKEY" = "gLvQuyqazziyf+pUCAFUgTnWIwn6fPE5MOReOqPEGHU="
+);
 // Public key of the wireguard remote peer on host.
 data_encoding_macro::base64_array!(
     "pub const CUSTOM_TUN_REMOTE_PUBKEY" = "7svBwGBefP7KVmH/yes+pZCfO6uSOYeGieYYa1+kZ0E="
 );
 // Private key of the wireguard local peer on guest.
-const CUSTOM_TUN_LOCAL_PUBKEY: &str = "h6elqt3dfamtS/p9jxJ8bIYs8UW9YHfTFhvx0fabTFo=";
+data_encoding_macro::base64_array!(
+    "const CUSTOM_TUN_LOCAL_PUBKEY" = "h6elqt3dfamtS/p9jxJ8bIYs8UW9YHfTFhvx0fabTFo="
+);
 // Private key of the wireguard local peer on guest.
 data_encoding_macro::base64_array!(
     "pub const CUSTOM_TUN_LOCAL_PRIVKEY" = "mPue6Xt0pdz4NRAhfQSp/SLKo7kV7DW+2zvBq0N9iUI="
@@ -37,21 +35,14 @@ pub const CUSTOM_TUN_GATEWAY: Ipv4Addr = CUSTOM_TUN_REMOTE_TUN_ADDR;
 /// Name of the wireguard interface on the host
 pub const CUSTOM_TUN_INTERFACE_NAME: &str = "utun123";
 
-use std::time::Duration;
-
-/// Timeout for wireguard-go to create an interface
-const INTERFACE_SETUP_TIMEOUT: Duration = Duration::from_secs(5);
-
 /// Set up WireGuard relay and dummy hosts.
-pub async fn setup_test_network() -> Result<()> {
+pub async fn setup_test_network() -> Result<Device<DefaultDeviceTransports>> {
     log::debug!("Setting up test network");
 
     enable_forwarding().await?;
     create_wireguard_interface()
         .await
-        .context("Failed to create WireGuard interface")?;
-
-    Ok(())
+        .context("Failed to create WireGuard interface")
 }
 
 /// Returns the interface name and IP address of the bridge gateway, which is the (first) bridge
@@ -93,70 +84,27 @@ async fn enable_forwarding() -> Result<()> {
     Ok(())
 }
 
-async fn create_wireguard_interface() -> Result<()> {
+async fn create_wireguard_interface() -> Result<Device<DefaultDeviceTransports>> {
     log::debug!("Creating custom WireGuard tunnel");
 
-    // Create a future that spawns wireguard-go, and SIGTERMs it when dropped.
-    let wireguard_go = async move {
-        let mut cmd = Command::new("/usr/bin/sudo");
-        cmd.args(["wireguard-go", "-f", CUSTOM_TUN_INTERFACE_NAME]);
+    let peer = Peer::new(CUSTOM_TUN_LOCAL_PUBKEY.into()).with_allowed_ip(
+        const { Ipv4Network::new_checked(CUSTOM_TUN_LOCAL_TUN_ADDR, 32).unwrap() }.into(),
+    );
 
-        // We don't want to SIGKILL sudo, as that would leave wireguard-go orphaned and running
-        cmd.kill_on_drop(false);
-        let child = cmd.spawn().context("Failed to spawn wireguard-go")?;
+    let tun =
+        TunDevice::from_name(CUSTOM_TUN_INTERFACE_NAME).context("Failed to create utun device")?;
 
-        let pid = child.id().context("wireguard-go exited prematurely")?;
-        let pid = Pid::from_raw(pid as libc::pid_t);
+    let device = device::build()
+        .with_default_udp()
+        .with_ip(tun)
+        .with_private_key(CUSTOM_TUN_REMOTE_PRIVKEY.into())
+        .with_peer(peer)
+        .with_listen_port(CUSTOM_TUN_REMOTE_REAL_PORT)
+        .build()
+        .await
+        .context("Failed to create gotatun device")?;
 
-        let _term_on_drop = on_drop(|| {
-            if let Err(e) = kill(pid, Signal::SIGTERM) {
-                log::warn!("Failed to kill wireguard-go ({pid}): {e}");
-            }
-        });
-
-        let output = child.wait_with_output().await.context("Run wireguard-go")?;
-        if output.status.success() {
-            bail!("wireguard-go exited prematurely")
-        } else {
-            bail!("wireguard-go failed with status {:?}", output.status.code())
-        }
-    };
-
-    // Spawn wireguard-go using a tokio task. The task will hang around until this process exits.
-    let wireguard_go = tokio::spawn(wireguard_go.inspect_err(|e| log::error!("{e}")));
-
-    // Create a future that waits until the tunnel interface appears.
-    let tunnel_check = async move {
-        loop {
-            let mut cmd = Command::new("/sbin/ifconfig");
-            cmd.arg(CUSTOM_TUN_INTERFACE_NAME);
-            let output = cmd
-                .output()
-                .await
-                .context("Check if wireguard tunnel exists")?;
-            if output.status.success() {
-                log::debug!("Created custom WireGuard tunnel interface");
-                return Ok(());
-            }
-            sleep(Duration::from_secs(1)).await;
-        }
-    };
-
-    // Wait until...
-    select! {
-        // ...the utun-interface is created
-        result = tunnel_check.fuse() => result,
-
-        // ...or wireguard-go exits with an error
-        result = wireguard_go.fuse() => result
-            .context("wireguard-go task panicked")?
-            .map(|never: Infallible| match never {}), // this task never exits with Ok
-
-        // ...or we hit the timeout
-        _timeout = sleep(INTERFACE_SETUP_TIMEOUT).fuse() => {
-            bail!("WireGuard interface setup timed out");
-        }
-    }
+    Ok(device)
 }
 
 pub async fn configure_tunnel() -> Result<()> {
@@ -170,43 +118,6 @@ pub async fn configure_tunnel() -> Result<()> {
     if output.status.success() {
         log::debug!("Tunnel {CUSTOM_TUN_INTERFACE_NAME} already configured");
         return Ok(());
-    }
-
-    // Set wireguard config
-    let mut tempfile = async_tempfile::TempFile::new()
-        .await
-        .context("Failed to create temporary wireguard config")?;
-
-    tempfile
-        .write_all(
-            format!(
-                "
-
-[Interface]
-PrivateKey = {CUSTOM_TUN_REMOTE_PRIVKEY}
-ListenPort = {CUSTOM_TUN_REMOTE_REAL_PORT}
-
-[Peer]
-PublicKey = {CUSTOM_TUN_LOCAL_PUBKEY}
-AllowedIPs = {CUSTOM_TUN_LOCAL_TUN_ADDR}
-
-"
-            )
-            .as_bytes(),
-        )
-        .await
-        .context("Failed to write wireguard config")?;
-
-    let mut cmd = Command::new("/usr/bin/sudo");
-    cmd.args([
-        "wg",
-        "setconf",
-        CUSTOM_TUN_INTERFACE_NAME,
-        tempfile.file_path().to_str().unwrap(),
-    ]);
-    let output = cmd.output().await.context("Run wg")?;
-    if !output.status.success() {
-        return Err(anyhow!("wg failed: {}", output.status.code().unwrap()));
     }
 
     // Set tunnel IP address

--- a/test/test-manager/src/vm/tart.rs
+++ b/test/test-manager/src/vm/tart.rs
@@ -1,5 +1,6 @@
 use crate::config::{self, Config, VmConfig};
 use anyhow::{Context, Result, anyhow};
+use gotatun::device::{DefaultDeviceTransports, Device};
 use regex::Regex;
 use std::{net::IpAddr, process::Stdio, time::Duration};
 use tokio::process::{Child, Command};
@@ -17,6 +18,9 @@ pub struct TartInstance {
     pub ip_addr: IpAddr,
     child: Child,
     machine_copy: Option<MachineCopy>,
+
+    /// WireGuard device. If this value is dropped, the device is shut down.
+    _wg: Device<DefaultDeviceTransports>,
 }
 
 #[async_trait::async_trait]
@@ -38,7 +42,7 @@ impl VmInstance for TartInstance {
 }
 
 pub async fn run(config: &Config, vm_config: &VmConfig) -> Result<TartInstance> {
-    super::network::macos::setup_test_network()
+    let wg = super::network::macos::setup_test_network()
         .await
         .context("Failed to set up networking")?;
 
@@ -132,6 +136,7 @@ pub async fn run(config: &Config, vm_config: &VmConfig) -> Result<TartInstance> 
         pty_path,
         ip_addr,
         machine_copy: Some(machine_copy),
+        _wg: wg,
     })
 }
 

--- a/test/test-manager/src/vm/tart.rs
+++ b/test/test-manager/src/vm/tart.rs
@@ -213,6 +213,15 @@ impl MachineCopy {
     fn destroy_inner(&mut self) -> Result<()> {
         let output = tart()
             .into_std()
+            .args(["stop", &self.name])
+            .status()
+            .context("Failed to run 'tart stop'")?;
+        if !output.success() {
+            return Err(anyhow!("'tart stop' failed: {output}"));
+        }
+
+        let output = tart()
+            .into_std()
             .args(["delete", &self.name])
             .status()
             .context("Failed to run 'tart delete'")?;


### PR DESCRIPTION

- Run GotaTun in the test-manager process.
- Remove the complicated code for monitoring wireguard-go process.
- Remove wireguard-go dependency from the test-manager. We'll no longer need to install it to our testing VMs beforehand.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9892)
<!-- Reviewable:end -->
