### PR TITLE
Fix login test regression

### DIFF
--- a/android/lib/feature/login/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/login/impl/LoginScreen.kt
+++ b/android/lib/feature/login/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/login/impl/LoginScreen.kt
@@ -99,6 +99,7 @@ import net.mullvad.mullvadvpn.lib.ui.designsystem.VariantButton
 import net.mullvad.mullvadvpn.lib.ui.resource.R
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_INPUT_TEST_TAG
+import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_SCREEN_DELETE_ACCOUNT_HISTORY_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_TITLE_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.theme.AppTheme
@@ -356,7 +357,10 @@ private fun ColumnScope.LoginInput(
             )
         },
         trailingIcon = {
-            IconButton(onClick = { showPassword = !showPassword }) {
+            IconButton(
+                modifier = Modifier.testTag(LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG),
+                onClick = { showPassword = !showPassword },
+            ) {
                 Icon(
                     imageVector =
                         if (showPassword) Icons.Outlined.VisibilityOff

--- a/android/lib/ui/tag/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/tag/TestTagConstants.kt
+++ b/android/lib/ui/tag/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/tag/TestTagConstants.kt
@@ -83,6 +83,7 @@ const val PLAY_PAYMENT_INFO_ICON_TEST_TAG = "play_payment_info_icon_test_tag"
 
 const val LOGIN_TITLE_TEST_TAG = "login_title_test_tag"
 const val LOGIN_INPUT_TEST_TAG = "login_input_test_tag"
+const val LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG = "login_reveal_input_button_test_tag"
 const val LOGIN_BUTTON_TEST_TAG = "login_button_test_tag"
 
 // VoucherDialog

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
@@ -3,6 +3,7 @@ package net.mullvad.mullvadvpn.test.common.page
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_BUTTON_TEST_TAG
+import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_SCREEN_DELETE_ACCOUNT_HISTORY_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.TOP_BAR_SETTINGS_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
@@ -33,6 +34,10 @@ class LoginPage internal constructor() : Page() {
 
     fun verifyShowingInvalidAccount() {
         uiDevice.findObjectWithTimeout(invalidAccountNumberSelector, EXTREMELY_LONG_TIMEOUT)
+    }
+
+    fun toggleRevealInput() {
+        uiDevice.findObjectWithTimeout(By.res(LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG)).click()
     }
 
     fun assertHasAccountHistory(accountNumber: String) {

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountHistoryMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/AccountHistoryMockApiTest.kt
@@ -33,6 +33,7 @@ class AccountHistoryMockApiTest : MockApiTest() {
 
         val expectedResult = "1234 1234 1234 1234"
         on<LoginPage> {
+            toggleRevealInput()
             assertHasAccountHistory(expectedResult)
             device.findObjectWithTimeout(By.text(expectedResult)).click()
         }


### PR DESCRIPTION
The test suite looks for the next button after the login textfield, this caused it to find the hide/show input button instead. We now try to find the login button based on a test tag instead.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9904)
<!-- Reviewable:end -->
