### PR TITLE
Do not escape <b> tags to fix issue with them not being parsed correctly

### DIFF
--- a/android/lib/ui/resource/src/main/res/values-ar/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-ar/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">جميع التطبيقات</string>
     <string name="all_locations">جميع المواقع</string>
     <string name="all_providers">جميع موفري الخدمة</string>
-    <string name="always_on_vpn_error_notification_content">يتعذَّر بدء اتصال النفق. يُرجى إيقاف \"تشغيل VPN دائمًا\" لـ &lt;b&gt;%1$s&lt;/b&gt; قبل استخدام Mullvad VPN.</string>
+    <string name="always_on_vpn_error_notification_content">يتعذَّر بدء اتصال النفق. يُرجى إيقاف \"تشغيل VPN دائمًا\" لـ <b>%1$s</b> قبل استخدام Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">تم تعيين \"تشغيل VPN دائمًا\" إلى %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">بعد تحديث تطبيق VPN على نظام التشغيل Android 16، قد تصل الأجهزة إلى حالة تفقد فيها تطبيقات VPN قدرتها على الوصول إلى الإنترنت.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">يُرجى إعادة تشغيل جهازك ومحاولة الاتصال مرة أخرى. إذا لم ينجح ذلك، يُرجى إرسال رسالة بريد إلكتروني إلى %1$s باللغة السويدية أو الإنجليزية.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">هل يتعذَّر الاتصال؟</string>
     <string name="anti_censorship">مكافحة الرقابة</string>
     <string name="anti_censorship_info_first_paragraph">قد تكون هذه الطرق مفيدة في حال تم حظر وصولك إلى Mullvad. عند اختيار \"تلقائي\"، سيحاول التطبيق استخدام جميع الطرق حتى تنجح إحداها.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;يُرجى ملاحظة أن هذه الطرق لا تعمل على تحسين الأداء، وقد تؤدي إلى زيادة استخدام النظام واستنزاف البطارية.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>يُرجى ملاحظة أن هذه الطرق لا تعمل على تحسين الأداء، وقد تؤدي إلى زيادة استخدام النظام واستنزاف البطارية.</b></string>
     <string name="any">أي نوع</string>
     <string name="api_access_description">إدارة طرق مُخصَّصة للوصول إلى Mullvad API وإضافتها.</string>
     <string name="api_access_method_info_first_line">يحتاج التطبيق إلى التواصل مع خادم Mullvad API لتسجيل دخولك، وجلب قوائم الخوادم، وغيرها من العمليات المهمة.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">الطقس</string>
     <string name="appearance">المظهر</string>
     <string name="appearance_description">تغيير عنوان ورمز تطبيق VPN على جهاز Android لديك. لن يؤدي ذلك إلى تغيير الرمز لأي إشعارات متعلقة بـ Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;تنبيه:&lt;/b&gt; سيتم إيقاف التطبيق تلقائيًا ويلزم فتحه يدويًا مرة أخرى بعد اختيار أيقونة وعنوان جديدين. لن يؤثر ذلك على اتصال VPN لديك.</string>
+    <string name="appearance_description_warning"><b>تنبيه:</b> سيتم إيقاف التطبيق تلقائيًا ويلزم فتحه يدويًا مرة أخرى بعد اختيار أيقونة وعنوان جديدين. لن يؤثر ذلك على اتصال VPN لديك.</string>
     <string name="apply">تطبيق</string>
     <string name="applying_changes">يجري تطبيق التغييرات...</string>
     <string name="at_least_on_method_needs_to_enabled">يجب تفعيل طريقة واحدة على الأقل</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">يمكن العثور على إعدادات \"الاتصال التلقائي\" و\"وضع التأمين\" في إعدادات نظام Android. اتَّبع هذا الدليل لتفعيل أحدهما أو كليهما.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. لتفعيل الاتصال التلقائي، انقر على زر التبديل بجوار \"تشغيل VPN دائمًا\".</string>
     <string name="auto_connect_carousel_second_slide_top_text">يُطلق على الاتصال التلقائي اسم \"تشغيل VPN دائمًا\" في إعدادات نظام Android، ويتأكد من اتصالك الدائم بنفق VPN ويتصل تلقائيًا بعد إعادة التشغيل.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. لتفعيل وضع التأمين، انقر على زر التبديل بجوار \"حظر الاتصالات دون VPN\". &lt;br /&gt;&lt;br /&gt;&lt;b&gt;تحذير: يحظر هذا الإعداد التطبيقات المُقسَّمة وميزة مشاركة الشبكة المحلية.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. لتفعيل وضع التأمين، انقر على زر التبديل بجوار \"حظر الاتصالات دون VPN\". <br /><br /><b>تحذير: يحظر هذا الإعداد التطبيقات المُقسَّمة وميزة مشاركة الشبكة المحلية.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">يُسمَّى \"وضع التأمين\" باسم \"حظر الاتصالات دون VPN\" في إعدادات نظام Android. يساعد هذا الوضع في تقليل التسريبات، لكن لديه بعض القيود المعروفة التي يمكنك قراءة المزيد عنها</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">هنا</string>
     <string name="automatic">تلقائي</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">إزالة المنفذ المُخصَّص</string>
     <string name="custom_port_dialog_submit">تعيين المنفذ</string>
     <string name="custom_port_dialog_valid_ranges">النطاقات الصالحة: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;تنبيه:&lt;/b&gt; تدعم بعض الخوادم فقط نطاق المنفذ الكامل.</string>
+    <string name="custom_port_recommended_range_first"><b>تنبيه:</b> تدعم بعض الخوادم فقط نطاق المنفذ الكامل.</string>
     <string name="custom_port_recommended_range_second">النطاق الصالح لجميع الخوادم: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">يتعذَّر حل مشكلة مضيف النفق المُخصَّص. جرِّب تغيير إعداداتك.</string>
     <string name="daita_description_slide_1_first_paragraph">تنبيه: يزيد ذلك من حركة بيانات الشبكة، ويؤثر سلبًا على السرعة وزمن الوصول واستهلاك البطارية. يُرجى توخي الحذر عند استخدام الباقات المحدودة.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">هل تريد إزالة %1$s؟</string>
     <string name="manage_devices_confirm_removal_description_line2">ستتم إزالة الجهاز من القائمة وتسجيل الخروج.</string>
     <string name="manage_devices_description">يمكنك عرض جميع أجهزتك المُسجَّلة وإدارتها. يمكنك ربط ما يصل إلى 5 أجهزة بحسابٍ واحد في الوقت نفسه. يحصل كل جهاز على اسم عند تسجيل الدخول ليسهُل عليك تمييزه.</string>
-    <string name="max_devices_confirm_removal_description">هل تريد بالتأكيد تسجيل خروج &lt;b&gt;%1$s&lt;/b&gt;؟</string>
+    <string name="max_devices_confirm_removal_description">هل تريد بالتأكيد تسجيل خروج <b>%1$s</b>؟</string>
     <string name="max_devices_resolved_description">يمكنك الآن متابعة تسجيل الدخول على هذا الجهاز.</string>
     <string name="max_devices_resolved_title">رائع!</string>
     <string name="max_devices_warning_description">يُرجى تسجيل الخروج من جهاز واحد على الأقل عن طريق إزالته من القائمة أدناه. يمكنك العثور على اسم الجهاز المقابل في إعدادات الحساب على ذلك الجهاز.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">تنقل</string>
     <string name="new_changelog_notification_message">انقر هنا للاطلاع على آخر المستجدات.</string>
     <string name="new_changelog_notification_title">تم تثبيت إصدار جديد</string>
-    <string name="new_device_notification_message">مرحبًا، يُسمَّى هذا الجهاز الآن &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">مرحبًا، يُسمَّى هذا الجهاز الآن <b>%1$s</b>.</string>
     <string name="new_device_notification_title">تم إنشاء جهاز جديد</string>
     <string name="new_list">قائمة جديدة</string>
     <string name="no_custom_lists_available">لا توجد قوائم مُخصَّصة متاحة</string>

--- a/android/lib/ui/resource/src/main/res/values-da/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-da/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Alle applikationer</string>
     <string name="all_locations">Alle placeringer</string>
     <string name="all_providers">Alle udbydere</string>
-    <string name="always_on_vpn_error_notification_content">Kunne ikke starte tunnelforbindelse. Deaktiver Altid-til VPN for &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="always_on_vpn_error_notification_content">Kunne ikke starte tunnelforbindelse. Deaktiver Altid-til VPN for <b>%1$s</b>.</string>
     <string name="always_on_vpn_error_notification_title">Altid-til VPN tildelt %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Når en VPN-app er blevet opdateret på Android 16, kan enheder ende i en tilstand, hvor VPN-apps ikke længere kan få kontakt til internettet.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Genstart din enhed, og prøv at oprette forbindelse igen. Hvis det ikke hjælper, kan du skrive en e-mail til %1$s på svensk eller engelsk.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Kan du ikke oprette forbindelse?</string>
     <string name="anti_censorship">Anti-censur</string>
     <string name="anti_censorship_info_first_paragraph">Disse metoder kan være nyttige i situationer, hvor du blokeres fra at nå Mullvad. Når \"Automatisk\" er valgt, vil appen forsøge alle metoder, indtil en virker.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Bemærk, at disse metoder ikke forbedrer præstationen og kan øge system- og batteriforbruget.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Bemærk, at disse metoder ikke forbedrer præstationen og kan øge system- og batteriforbruget.</b></string>
     <string name="any">Enhver</string>
     <string name="api_access_description">Administrer og tilføj brugerdefinerede metoder for at få adgang til Mullvad API.</string>
     <string name="api_access_method_info_first_line">Appen skal kommunikere med en Mullvad API-server for at kunne logge dig på, hente serverlister og andre kritiske operationer.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Vejr</string>
     <string name="appearance">Udseende</string>
     <string name="appearance_description">Ændr titlen og ikonet for Mullvad VPN-appen på din Android-enhed. Dette ændrer ikke ikonet for Mullvad VPN-relaterede notifikationer.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Bemærk:&lt;/b&gt; Appen lukker automatisk og skal åbnes igen manuelt efter valg af et nyt ikon og en ny titel. Dette påvirker ikke din VPN-forbindelse.</string>
+    <string name="appearance_description_warning"><b>Bemærk:</b> Appen lukker automatisk og skal åbnes igen manuelt efter valg af et nyt ikon og en ny titel. Dette påvirker ikke din VPN-forbindelse.</string>
     <string name="apply">Anvend</string>
     <string name="applying_changes">Anvender ændringer ...</string>
     <string name="at_least_on_method_needs_to_enabled">Mindst én metode skal aktiveres</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Indstillingerne for automatisk forbindelse og Lockdown-tilstand kan findes i Android- systemindstillingerne. Følg denne vejledning for at aktivere en eller begge.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. For at aktivere automatisk forbindelse skal du klikke på knappen ved siden af \"Altid-til VPN\".</string>
     <string name="auto_connect_carousel_second_slide_top_text">Auto-tilslutning kaldes Altid-til VPN i Android-systemindstillingerne, og det sørger for, at du konstant er forbundet til VPN-tunnelen og automatisk forbinder efter genstart.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. For at aktivere Lockdown-tilstand skal du klikke på knappen ved siden af \"Bloker forbindelser uden VPN\".&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Advarsel: Denne indstilling blokerer delte apps og funktionen Lokal netværksdeling.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. For at aktivere Lockdown-tilstand skal du klikke på knappen ved siden af \"Bloker forbindelser uden VPN\".<br /><br /><b>Advarsel: Denne indstilling blokerer delte apps og funktionen Lokal netværksdeling.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Lockdown-tilstanden kaldes \"Bloker forbindelser uden VPN\" i Android-systemindstillingerne. Det hjælper med at minimere lækager, men det har nogle kendte begrænsninger, som du kan læse mere om</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">her</string>
     <string name="automatic">Automatisk</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Fjern brugerdefineret port</string>
     <string name="custom_port_dialog_submit">Indstil port</string>
     <string name="custom_port_dialog_valid_ranges">Gyldige områder: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Bemærk:&lt;/b&gt; Kun nogle servere understøtter hele portintervallet.</string>
+    <string name="custom_port_recommended_range_first"><b>Bemærk:</b> Kun nogle servere understøtter hele portintervallet.</string>
     <string name="custom_port_recommended_range_second">Gyldigt interval for alle servere: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Kunne ikke fortolke værten for den tilpassede tunnel. Prøv at ændre dine indstillinger.</string>
     <string name="daita_description_slide_1_first_paragraph">Bemærk: Dette øger netværkstrafikken og vil også påvirke hastighed, ventetid og batteriforbrug negativt. Brug det varsomt på abonnementer med begrænsninger.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Fjern %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Enheden fjernes fra listen og logges ud.</string>
     <string name="manage_devices_description">Vis og administrer alle dine enheder, der er logget på. Du kan have op til 5 enheder på en konto ad gangen. Hver enhed tildeles et navn, når du logger på, så du let kan se forskel på dem.</string>
-    <string name="max_devices_confirm_removal_description">Er du sikker på, at du vil logge &lt;b&gt;%1$s&lt;/b&gt; af?</string>
+    <string name="max_devices_confirm_removal_description">Er du sikker på, at du vil logge <b>%1$s</b> af?</string>
     <string name="max_devices_resolved_description">Du kan nu fortsætte med at logge ind på denne enhed.</string>
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Log ud af mindst én ved at fjerne den fra listen nedenfor. Du kan finde det tilsvarende enhedsnavn under enhedens kontoindstillinger.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Naviger</string>
     <string name="new_changelog_notification_message">Klik her for at se nyhederne.</string>
     <string name="new_changelog_notification_title">NY VERSION INSTALLERET</string>
-    <string name="new_device_notification_message">Velkommen, denne enhed har nu fået navnet &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Velkommen, denne enhed har nu fået navnet <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NY ENHED OPRETTET</string>
     <string name="new_list">Ny liste</string>
     <string name="no_custom_lists_available">Ingen brugerdefinerede lister tilgængelige</string>

--- a/android/lib/ui/resource/src/main/res/values-de/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-de/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Alle Anwendungen</string>
     <string name="all_locations">Alle Standorte</string>
     <string name="all_providers">Alle Anbieter</string>
-    <string name="always_on_vpn_error_notification_content">Tunnelverbindung kann nicht gestartet werden. Bitte deaktivieren Sie Always-on VPN für &lt;b&gt;%1$s&lt;/b&gt;, bevor Sie Mullvad VPN verwenden.</string>
+    <string name="always_on_vpn_error_notification_content">Tunnelverbindung kann nicht gestartet werden. Bitte deaktivieren Sie Always-on VPN für <b>%1$s</b>, bevor Sie Mullvad VPN verwenden.</string>
     <string name="always_on_vpn_error_notification_title">Always-on VPN ist %1$s zugeordnet</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Nach dem Update einer VPN-App auf Android 16 kann es vorkommen, dass die VPN-Apps auf diesen Geräten nicht länger auf das Internet zugreifen können.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Bitte starten Sie Ihr Gerät neu und versuchen Sie erneut, sich zu verbinden. Wenn dies nicht funktioniert, schreiben Sie bitte eine E-Mail an %1$s auf Schwedisch oder Englisch.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Keine Verbindung möglich?</string>
     <string name="anti_censorship">Anti-Zensur</string>
     <string name="anti_censorship_info_first_paragraph">Diese Methoden können nützlich sein, wenn Sie daran gehindert werden, Mullvad zu erreichen. Wenn „Automatisch“ ausgewählt ist, probiert die App alle Methoden aus, bis eine funktioniert.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Bitte beachten Sie, dass diese Methoden die Leistung nicht verbessern und möglicherweise zu einem höheren Verbrauch von Systemressourcen und Akku führen.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Bitte beachten Sie, dass diese Methoden die Leistung nicht verbessern und möglicherweise zu einem höheren Verbrauch von Systemressourcen und Akku führen.</b></string>
     <string name="any">Beliebige</string>
     <string name="api_access_description">Verwaltung und Hinzufügen benutzerdefinierter Methoden für den Zugriff auf die Mullvad-API.</string>
     <string name="api_access_method_info_first_line">Die App muss mit einem Mullvad API-Server kommunizieren, um Sie anzumelden, Serverlisten abzurufen und andere wichtige Vorgänge durchzuführen.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Wetter</string>
     <string name="appearance">Erscheinungsbild</string>
     <string name="appearance_description">Ändern Sie den Titel und das Symbol der Mullvad VPN-App auf Ihrem Android-Gerät. Dadurch wird das Symbol für Mullvad-VPN-bezogene Benachrichtigungen nicht geändert.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Achtung:&lt;/b&gt; Die Anwendung wird automatisch geschlossen und muss nach der Auswahl eines neuen Symbols und eines neuen Titels manuell erneut geöffnet werden. Dies hat keine Auswirkungen auf Ihre VPN-Verbindung.</string>
+    <string name="appearance_description_warning"><b>Achtung:</b> Die Anwendung wird automatisch geschlossen und muss nach der Auswahl eines neuen Symbols und eines neuen Titels manuell erneut geöffnet werden. Dies hat keine Auswirkungen auf Ihre VPN-Verbindung.</string>
     <string name="apply">Anwenden</string>
     <string name="applying_changes">Änderungen werden angewendet …</string>
     <string name="at_least_on_method_needs_to_enabled">Mindestens eine Methode muss aktiviert sein</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Die Einstellungen für die automatische Verbindung und den Sperrmodus finden Sie in den Android-Systemeinstellungen. Folgen Sie dieser Anleitung, um eine oder beide Einstellungen zu aktivieren.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Um die automatische Verbindung zu aktivieren, klicken Sie auf den Kippschalter neben „Always-on VPN“.</string>
     <string name="auto_connect_carousel_second_slide_top_text">Die automatische Verbindung wird in den Android-Systemeinstellungen als „Always-on VPN“ bezeichnet und sorgt dafür, dass Sie ständig mit dem VPN-Tunnel verbunden sind und sich nach einem Neustart automatisch verbinden.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Um den Sperrmodus zu aktivieren, klicken Sie auf den Kippschalter neben „Verbindungen ohne VPN blockieren“.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warnung: Diese Einstellung blockiert geteilte Apps und die Funktion der lokalen Netzwerkfreigabe.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Um den Sperrmodus zu aktivieren, klicken Sie auf den Kippschalter neben „Verbindungen ohne VPN blockieren“.<br /><br /><b>Warnung: Diese Einstellung blockiert geteilte Apps und die Funktion der lokalen Netzwerkfreigabe.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Der Sperrmodus heißt in den Android-Systemeinstellungen „Verbindungen ohne VPN blockieren“. Dieser trägt dazu bei, Lecks zu minimieren, hat jedoch einige bekannte Einschränkungen. Mehr dazu finden Sie</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">hier</string>
     <string name="automatic">Automatisch</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Eigenen Port entfernen</string>
     <string name="custom_port_dialog_submit">Port festlegen</string>
     <string name="custom_port_dialog_valid_ranges">Gültige Bereiche: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Achtung:&lt;/b&gt; Nicht alle Server unterstützen den gesamten Portbereich.</string>
+    <string name="custom_port_recommended_range_first"><b>Achtung:</b> Nicht alle Server unterstützen den gesamten Portbereich.</string>
     <string name="custom_port_recommended_range_second">Gültiger Bereich für alle Server: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Der Host des benutzerdefinierten Tunnels konnte nicht aufgelöst werden. Versuchen Sie, Ihre Einstellungen zu ändern.</string>
     <string name="daita_description_slide_1_first_paragraph">Achtung! Dies erhöht den Netzwerkverkehr und wirkt sich auch negativ auf die Geschwindigkeit, die Latenz und den Akkuverbrauch aus. Bei begrenzten Tarifen ist Vorsicht geboten.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">%1$s entfernen?</string>
     <string name="manage_devices_confirm_removal_description_line2">Das Gerät wird aus der Liste entfernt und abgemeldet.</string>
     <string name="manage_devices_description">Lassen Sie all Ihre angemeldeten Geräte anzeigen und verwalten Sie sie. Sie können bis zu fünf Geräte gleichzeitig bei einem Konto haben. Jedes Gerät bekommt beim Anmelden einen Namen, damit Sie sie leicht unterscheiden können.</string>
-    <string name="max_devices_confirm_removal_description">Möchten Sie &lt;b&gt;%1$s&lt;/b&gt; wirklich abmelden?</string>
+    <string name="max_devices_confirm_removal_description">Möchten Sie <b>%1$s</b> wirklich abmelden?</string>
     <string name="max_devices_resolved_description">Sie können jetzt mit der Anmeldung auf diesem Gerät fortfahren.</string>
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Bitte melden Sie sich von mindestens einem Gerät ab, indem Sie es aus der Liste unten entfernen. Sie finden den entsprechenden Gerätenamen unter den Kontoeinstellungen des Geräts.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Navigieren</string>
     <string name="new_changelog_notification_message">Klicken Sie hier, um die Änderungen zu sehen.</string>
     <string name="new_changelog_notification_title">NEUE VERSION INSTALLIERT</string>
-    <string name="new_device_notification_message">Willkommen, dieses Gerät heißt jetzt &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Willkommen, dieses Gerät heißt jetzt <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NEUES GERÄT ERSTELLT</string>
     <string name="new_list">Neue Liste</string>
     <string name="no_custom_lists_available">Keine eigenen Listen verfügbar</string>

--- a/android/lib/ui/resource/src/main/res/values-es/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-es/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Todas las aplicaciones</string>
     <string name="all_locations">Todas las ubicaciones</string>
     <string name="all_providers">Todos los proveedores</string>
-    <string name="always_on_vpn_error_notification_content">No se puede iniciar la conexión de túnel. Deshabilite la VPN siempre activa en &lt;b&gt;%1$s&lt;/b&gt; antes de utilizar la VPN de Mullvad.</string>
+    <string name="always_on_vpn_error_notification_content">No se puede iniciar la conexión de túnel. Deshabilite la VPN siempre activa en <b>%1$s</b> antes de utilizar la VPN de Mullvad.</string>
     <string name="always_on_vpn_error_notification_title">La VPN siempre activa se ha asignado a %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Tras actualizar una aplicación VPN en Android 16, los dispositivos podrían terminar en un estado en el que las aplicaciones VPN ya no puedan conectarse a Internet.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Reinicie su dispositivo e intente conectarse de nuevo. Si esto no funciona, escriba un correo electrónico a %1$s en sueco o inglés.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">¿No se puede conectar?</string>
     <string name="anti_censorship">Anticensura</string>
     <string name="anti_censorship_info_first_paragraph">Estos métodos podrían utilizarse en situaciones en las que tiene bloqueado el acceso a Mullvad. Cuando se selecciona «Automático», la aplicación intentará todos los métodos hasta que funcione alguno.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Tenga en cuenta que estos métodos no mejoran el rendimiento, y podrían aumentar el uso del sistema y el consumo de batería.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Tenga en cuenta que estos métodos no mejoran el rendimiento, y podrían aumentar el uso del sistema y el consumo de batería.</b></string>
     <string name="any">Cualquiera</string>
     <string name="api_access_description">Gestione y añada métodos personalizados para acceder a la API de Mullvad.</string>
     <string name="api_access_method_info_first_line">La aplicación necesita comunicarse con un servidor API de Mullvad para iniciar su sesión, obtener las listas de servidores y otras operaciones críticas.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Tiempo</string>
     <string name="appearance">Aspecto</string>
     <string name="appearance_description">Cambie el título y el icono de la aplicación Mullvad VPN en su dispositivo Android. Esto no cambiará el icono en ninguna notificación relacionada con Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Atención:&lt;/b&gt; La aplicación se cerrará automáticamente y deberá abrirse de nuevo manualmente tras seleccionar un nuevo icono y un nuevo título. Esto no afectará a su conexión VPN.</string>
+    <string name="appearance_description_warning"><b>Atención:</b> La aplicación se cerrará automáticamente y deberá abrirse de nuevo manualmente tras seleccionar un nuevo icono y un nuevo título. Esto no afectará a su conexión VPN.</string>
     <string name="apply">Aplicar</string>
     <string name="applying_changes">Aplicando cambios...</string>
     <string name="at_least_on_method_needs_to_enabled">Se debe habilitar al menos un método</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">La configuración del modo de bloqueo y de la conexión automática puede encontrarse en la configuración del sistema Android, siga esta guía para habilitar uno o ambos.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Para activar la conexión automática, haga clic en el botón situado junto a «VPN siempre activa».</string>
     <string name="auto_connect_carousel_second_slide_top_text">La conexión automática se llama VPN siempre activa en la configuración del sistema Android y asegura estar conectado constantemente al túnel de la VPN y conectarse automáticamente después de cada reinicio.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Para habilitar el modo de bloqueo, haga clic en el botón situado junto a «Bloquear conexiones sin VPN».&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Advertencia: Este ajuste bloquea las aplicaciones divididas y la opción Uso compartido de la red local.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Para habilitar el modo de bloqueo, haga clic en el botón situado junto a «Bloquear conexiones sin VPN».<br /><br /><b>Advertencia: Este ajuste bloquea las aplicaciones divididas y la opción Uso compartido de la red local.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">El modo de bloqueo se llama «Bloquear conexiones sin VPN» en la configuración del sistema Android. Ayuda a minimizar las filtraciones, sin embargo, posee algunas limitaciones conocidas sobre las que puede leer más información</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">aquí</string>
     <string name="automatic">Automático</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Quitar puerto personalizado</string>
     <string name="custom_port_dialog_submit">Establecer puerto</string>
     <string name="custom_port_dialog_valid_ranges">Intervalos válidos: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Atención:&lt;/b&gt; Solo algunos servidores admiten el rango completo de puertos.</string>
+    <string name="custom_port_recommended_range_first"><b>Atención:</b> Solo algunos servidores admiten el rango completo de puertos.</string>
     <string name="custom_port_recommended_range_second">Rango válido para todos los servidores: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">No se puede resolver el host del túnel personalizado. Pruebe a cambiar la configuración.</string>
     <string name="daita_description_slide_1_first_paragraph">Atención: Esto aumenta el tráfico de la red y también afectará negativamente a la velocidad, la latencia y el uso de la batería. Úselo con precaución en planes limitados.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">¿Quitar %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">El dispositivo se quitará de la lista y se cerrará la sesión en él.</string>
     <string name="manage_devices_description">Vea y gestione todos los dispositivos con sesión iniciada. Puede tener hasta 5 dispositivos en una cuenta a la vez. Cada dispositivo recibe un nombre al iniciar sesión para ayudarle a distinguirlo fácilmente.</string>
-    <string name="max_devices_confirm_removal_description">¿Seguro que quiere cerrar la sesión de &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="max_devices_confirm_removal_description">¿Seguro que quiere cerrar la sesión de <b>%1$s</b>?</string>
     <string name="max_devices_resolved_description">Ya puede iniciar sesión en este dispositivo.</string>
     <string name="max_devices_resolved_title">¡Genial!</string>
     <string name="max_devices_warning_description">Cierre la sesión como mínimo en un dispositivo (para hacerlo, quítelo de la lista siguiente). Consulte el nombre del dispositivo en la configuración de la cuenta del dispositivo.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Navegar</string>
     <string name="new_changelog_notification_message">Haga clic aquí para ver las novedades.</string>
     <string name="new_changelog_notification_title">NUEVA VERSIÓN INSTALADA</string>
-    <string name="new_device_notification_message">¡Le damos la bienvenida! Este dispositivo ahora se llama &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">¡Le damos la bienvenida! Este dispositivo ahora se llama <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NUEVO DISPOSITIVO CREADO</string>
     <string name="new_list">Nueva lista</string>
     <string name="no_custom_lists_available">No hay listas personalizadas disponibles</string>

--- a/android/lib/ui/resource/src/main/res/values-fa/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-fa/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">تمام اپلیکیشن‌ها</string>
     <string name="all_locations">تمام مکان‌ها</string>
     <string name="all_providers">تمام ارائه‌دهندگان</string>
-    <string name="always_on_vpn_error_notification_content">نمی‌توان اتصال تونل را آغاز کرد. لطفاً پیش از استفاده از Mullvad VPN، گزینهٔ «VPN همیشه‌فعال» را برای &lt;b&gt;%1$s&lt;/b&gt; غیرفعال کنید.</string>
+    <string name="always_on_vpn_error_notification_content">نمی‌توان اتصال تونل را آغاز کرد. لطفاً پیش از استفاده از Mullvad VPN، گزینهٔ «VPN همیشه‌فعال» را برای <b>%1$s</b> غیرفعال کنید.</string>
     <string name="always_on_vpn_error_notification_title">VPN همیشه‌فعال به %1$s اختصاص داده شد</string>
     <string name="android_16_upgrade_warning_dialog_first_message">پس از به‌روزرسانی یک اپلیکیشن VPN در اندروید 16، ممکن است دستگاه‌ها به حالتی برسند که اپلیکیشن‌های VPN دیگر نتوانند به اینترنت دسترسی پیدا کنند.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">لطفاً دستگاه‌تان را دوباره راه‌اندازی کنید و دوباره تلاش کنید وصل شوید. اگر مشکل برطرف نشد، لطفاً یک ایمیل به %1$s به زبان سوئدی یا انگلیسی بنویسید.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">اتصال برقرار نمی‌شود؟</string>
     <string name="anti_censorship">ضد سانسور</string>
     <string name="anti_censorship_info_first_paragraph">این روش‌ها ممکن است زمانی مفید باشند که دسترسی شما به Mullvad مسدود شده باشد. وقتی «خودکار» انتخاب شود، اپلیکیشن همهٔ روش‌ها را امتحان می‌کند تا یکی از آن‌ها کار کند.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;لطفاً توجه داشته باشید که این روش‌ها کارایی را بهبود نمی‌بخشند و ممکن است مصرف سیستم و باتری را افزایش دهند.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>لطفاً توجه داشته باشید که این روش‌ها کارایی را بهبود نمی‌بخشند و ممکن است مصرف سیستم و باتری را افزایش دهند.</b></string>
     <string name="any">هر کدام</string>
     <string name="api_access_description">مدیریت و افزودن روش‌های سفارشی برای دسترسی به ‏Mullvad API.</string>
     <string name="api_access_method_info_first_line">اپلیکیشن برای ورود شما، دریافت فهرست سرورها و انجام دیگر عملیات ضروری، باید با یک سرور Mullvad API ارتباط برقرار کند.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">آب و هوا</string>
     <string name="appearance">ظاهر</string>
     <string name="appearance_description">عنوان و آیکون اپلیکیشن Mullvad VPN را روی دستگاه اندرویدی خود تغییر دهید. این کار، آیکون هیچ‌یک از اعلان‌های مرتبط با Mullvad VPN را تغییر نخواهد داد.</string>
-    <string name="appearance_description_warning">&lt;b&gt;توجه:&lt;/b&gt; اپلیکیشن به‌صورت خودکار بسته می‌شود و پس از انتخاب آیکون و عنوان جدید، باید دوباره به‌صورت دستی باز شود. این موضوع بر اتصال VPN شما تأثیری نخواهد داشت.</string>
+    <string name="appearance_description_warning"><b>توجه:</b> اپلیکیشن به‌صورت خودکار بسته می‌شود و پس از انتخاب آیکون و عنوان جدید، باید دوباره به‌صورت دستی باز شود. این موضوع بر اتصال VPN شما تأثیری نخواهد داشت.</string>
     <string name="apply">اعمال</string>
     <string name="applying_changes">اعمال تغییرات...</string>
     <string name="at_least_on_method_needs_to_enabled">حداقل یک روش باید فعال باشد</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">تنظیمات اتصال خودکار و حالت قفل در تنظیمات سیستمی اندروید قرار دارند. برای فعال‌کردن یکی یا هر دو، این راهنما را دنبال کنید.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. برای فعال کردن «اتصال خودکار»، روی دکمهٔ تغییر وضعیت کنار «VPN همیشه‌فعال» کلیک کنید.</string>
     <string name="auto_connect_carousel_second_slide_top_text">در تنظیمات سیستم اندروید، «اتصال خودکار» با نام «VPN همیشه‌فعال» شناخته می‌شود و باعث می‌شود دستگاه شما همیشه به تونل VPN وصل بماند و پس از راه‌اندازی مجدد نیز به‌طور خودکار دوباره متصل شود.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. برای فعال کردن حالت قفل، روی کلید کنار «مسدود کردن اتصال‌ها بدون VPN» کلیک کنید.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;هشدار: این تنظیم اپلیکیشن‌های تفکیک‌شده و قابلیت اشتراک‌گذاری شبکهٔ محلی را مسدود می‌کند.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. برای فعال کردن حالت قفل، روی کلید کنار «مسدود کردن اتصال‌ها بدون VPN» کلیک کنید.<br /><br /><b>هشدار: این تنظیم اپلیکیشن‌های تفکیک‌شده و قابلیت اشتراک‌گذاری شبکهٔ محلی را مسدود می‌کند.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">حالت قفل در تنظیمات سیستمی اندروید با نام «مسدود کردن اتصال‌ها بدون VPN» نمایش داده می‌شود. این حالت به کاهش نشت ارتباطات کمک می‌کند، اما محدودیت‌های شناخته‌شده‌ای دارد که می‌توانید بیشتر دربارهٔ آن بخوانید</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">اینجا</string>
     <string name="automatic">خودکار</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">حذف پورت سفارشی</string>
     <string name="custom_port_dialog_submit">تنظیم پورت</string>
     <string name="custom_port_dialog_valid_ranges">دامنه‌های معتبر: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;توجه:&lt;/b&gt; تنها بعضی سرورها از محدوده کامل پورت پشتیبانی می‌کنند.</string>
+    <string name="custom_port_recommended_range_first"><b>توجه:</b> تنها بعضی سرورها از محدوده کامل پورت پشتیبانی می‌کنند.</string>
     <string name="custom_port_recommended_range_second">محدوده معتبر برای همه سرورها: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">قادر به شناسایی میزبان تونل سفارشی نیست. لطفاً تنظیمات خود را تغییر دهید و دوباره تلاش کنید.</string>
     <string name="daita_description_slide_1_first_paragraph">توجه: این کار باعث افزایش ترافیک شبکه می‌شود و همچنین سرعت، تأخیر و مصرف باتری را تحت تأثیر منفی قرار می‌دهد. در طرح‌های اینترنتی محدود با احتیاط استفاده کنید.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">%1$s حذف شود؟</string>
     <string name="manage_devices_confirm_removal_description_line2">دستگاه از فهرست حذف شده و خارج خواهد شد.</string>
     <string name="manage_devices_description">تمام دستگاه‌های وارد شده به حساب خود را مشاهده و مدیریت کنید. شما می‌توانید هم‌زمان حداکثر 5 دستگاه در یک حساب داشته باشید. هر دستگاه هنگام ورود یک نام دریافت می‌کند تا بتوانید به‌راحتی آن‌ها را از هم تشخیص دهید.</string>
-    <string name="max_devices_confirm_removal_description">آیا مطمئنید که می‌خواهید &lt;b&gt;%1$s&lt;/b&gt; را خارج کنید؟</string>
+    <string name="max_devices_confirm_removal_description">آیا مطمئنید که می‌خواهید <b>%1$s</b> را خارج کنید؟</string>
     <string name="max_devices_resolved_description">اکنون می‌توانید ورود به این دستگاه را ادامه دهید.</string>
     <string name="max_devices_resolved_title">عالی!</string>
     <string name="max_devices_warning_description">لطفاً حداقل یکی از دستگاه‌ها را با حذف آن از فهرست زیر خارج کنید. نام دستگاه مربوطه را می‌توانید در تنظیمات حساب همان دستگاه پیدا کنید.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">پیمایش</string>
     <string name="new_changelog_notification_message">برای مشاهدهٔ تغییرات جدید، اینجا کلیک کنید.</string>
     <string name="new_changelog_notification_title">نسخهٔ جدید نصب شد</string>
-    <string name="new_device_notification_message">خوش آمدید، این دستگاه اکنون &lt;b&gt;%1$s&lt;/b&gt; نام دارد.</string>
+    <string name="new_device_notification_message">خوش آمدید، این دستگاه اکنون <b>%1$s</b> نام دارد.</string>
     <string name="new_device_notification_title">دستگاه جدید ایجاد شد</string>
     <string name="new_list">فهرست جدید</string>
     <string name="no_custom_lists_available">هیچ فهرست سفارشی موجود نیست</string>

--- a/android/lib/ui/resource/src/main/res/values-fi/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-fi/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Kaikki sovellukset</string>
     <string name="all_locations">Kaikki sijainnit</string>
     <string name="all_providers">Kaikki palveluntarjoajat</string>
-    <string name="always_on_vpn_error_notification_content">Tunneliyhteyden käynnistäminen ei onnistu. Poista aina päällä oleva VPN käytöstä sovellukselle &lt;b&gt;%1$s&lt;/b&gt; ennen Mullvad VPN:n käyttämistä.</string>
+    <string name="always_on_vpn_error_notification_content">Tunneliyhteyden käynnistäminen ei onnistu. Poista aina päällä oleva VPN käytöstä sovellukselle <b>%1$s</b> ennen Mullvad VPN:n käyttämistä.</string>
     <string name="always_on_vpn_error_notification_title">%1$s on määritetty aina päällä olevan VPN:n asetukseksi</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Kun VPN-sovellus päivitetään Android 16:ssa, laitteen saattavat päätyä tilaan, jossa VPN-sovellukset eivät voi enää muodostaa yhteyttä internetiin.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Käynnistä laitteesi uudelleen ja yritä muodostaa yhteys uudelleen. Jos tämä ei toimi, lähetä sähköpostiviesti osoitteeseen %1$s ruotsiksi tai englanniksi.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Eikö yhteyden muodostaminen onnistu?</string>
     <string name="anti_censorship">Sensuurinesto</string>
     <string name="anti_censorship_info_first_paragraph">Nämä tavat voivat olla hyödyllisiä tilanteissa, joissa sinua on estetty pääsemästä Mullvadiin. Kun \"automaattinen\" valitaan, sovellus kokeilee kaikkia tapoja, kunnes jokin niistä toimii.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Huomioithan, että nämä tavat eivät paranna suorituskykyä ja voivat lisätä järjestelmän käyttöastetta ja akun käyttöä.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Huomioithan, että nämä tavat eivät paranna suorituskykyä ja voivat lisätä järjestelmän käyttöastetta ja akun käyttöä.</b></string>
     <string name="any">Mikä tahansa</string>
     <string name="api_access_description">Hallitse ja lisää mukautettuja menetelmiä Mullvadin ohjelmointirajapinnan käyttämiseksi.</string>
     <string name="api_access_method_info_first_line">Sovelluksen on kommunikoitava Mullvadin ohjelmointirajapinnan palvelimen kanssa, jotta sinut voidaan kirjata sisään, palvelinluetteloiden hakemiseksi sekä muiden tärkeiden toimintojen suorittamiseksi.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Sää</string>
     <string name="appearance">Ulkoasu</string>
     <string name="appearance_description">Vaihda Mullvad VPN -sovelluksen otsikko ja kuvake Android-laitteellasi. Mullvad VPN:ään liittyvien ilmoitusten kuvake ei muutu.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Huomio:&lt;/b&gt; Sovellus sulkeutuu automaattisesti uuden kuvakkeen ja otsikon valitsemisen jälkeen, ja se täytyy avata uudelleen manuaalisesti. Tämä ei vaikuta VPN-yhteyteesi.</string>
+    <string name="appearance_description_warning"><b>Huomio:</b> Sovellus sulkeutuu automaattisesti uuden kuvakkeen ja otsikon valitsemisen jälkeen, ja se täytyy avata uudelleen manuaalisesti. Tämä ei vaikuta VPN-yhteyteesi.</string>
     <string name="apply">Ota käyttöön</string>
     <string name="applying_changes">Muutoksia otetaan käyttöön...</string>
     <string name="at_least_on_method_needs_to_enabled">Vähintään yhden menetelmän on oltava käytössä</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Automaattisen yhdistämisen ja lukitustilan asetukset löytyvät Androidin järjestelmäasetuksista. Voit ottaa jommankumman tai molemmat käyttöön tämän oppaan ohjeilla.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Ota automaattinen yhteyden muodostus käyttöön napsauttamalla \"Aina päällä oleva VPN\" -kohdan vieressä olevaa valintapainiketta.</string>
     <string name="auto_connect_carousel_second_slide_top_text">Automaattista yhdistämistä kutsutaan aina päällä olevaksi VPN-yhteydeksi Androidin järjestelmäasetuksissa. Se varmistaa, että olet jatkuvasti yhteydessä VPN-tunneliin, sekä muodostaa yhteyden automaattisesti aina uudelleenkäynnistyksen jälkeen.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Ota lukitustila käyttöön napsauttamalla kohdan \"Estä yhteydet ilman VPN:ää\" vieressä olevaa kytkintä.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Varoitus: Tämä asetus estää jaetut sovellukset ja paikallisen verkon jakamisominaisuuden.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Ota lukitustila käyttöön napsauttamalla kohdan \"Estä yhteydet ilman VPN:ää\" vieressä olevaa kytkintä.<br /><br /><b>Varoitus: Tämä asetus estää jaetut sovellukset ja paikallisen verkon jakamisominaisuuden.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Lukitustila löytyy Android-järjestelmäasetuksista nimellä \"Estä yhteydet ilman VPN:ää\". Lukitustila auttaa minimoimaan vuodot, mutta siihen liittyy myös muutamia tunnettuja rajoituksia. Voit lukea niistä lisää</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">täältä</string>
     <string name="automatic">Automaattinen</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Poista mukautettu portti</string>
     <string name="custom_port_dialog_submit">Määritä portti</string>
     <string name="custom_port_dialog_valid_ranges">Kelvolliset portit: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Huomio:&lt;/b&gt; vain tietyt palvelimet tukevat koko porttiväliä.</string>
+    <string name="custom_port_recommended_range_first"><b>Huomio:</b> vain tietyt palvelimet tukevat koko porttiväliä.</string>
     <string name="custom_port_recommended_range_second">Kelvollinen väli kaikille palvelimille: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Muokatun tunnelin isännän selvittäminen ei onnistu. Kokeile muuttaa asetuksiasi.</string>
     <string name="daita_description_slide_1_first_paragraph">Huomio: Toiminto kasvattaa verkkoliikennettä ja vaikuttaa sen vuoksi negatiivisesti sekä nopeuteen, viiveeseen että akun kulumiseen. Käytä harkiten, kun datasopimuksesi on rajoitettu.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Poistetaanko %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Laite poistetaan luettelosta ja kirjataan ulos.</string>
     <string name="manage_devices_description">Tarkastele ja hallitse kaikkia kirjautuneita laitteitasi. Sinulla voi olla enintään viisi laitetta yhdellä tilillä samaan aikaan. Jokainen laite saa nimen, kun se kirjataan sisään, jotta erotat ne helposti.</string>
-    <string name="max_devices_confirm_removal_description">Haluatko varmasti kirjata laitteen &lt;b&gt;%1$s&lt;/b&gt; ulos?</string>
+    <string name="max_devices_confirm_removal_description">Haluatko varmasti kirjata laitteen <b>%1$s</b> ulos?</string>
     <string name="max_devices_resolved_description">Voit nyt jatkaa kirjautumista tällä laitteella.</string>
     <string name="max_devices_resolved_title">Mahtavaa!</string>
     <string name="max_devices_warning_description">Kirjaudu ulos vähintään yhdestä luettelon laitteesta poistamalla se. Löydät vastaavan laitteen nimen laitteen tiliasetuksista.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Siirry</string>
     <string name="new_changelog_notification_message">Katso uudet ominaisuudet napsauttamalla tästä.</string>
     <string name="new_changelog_notification_title">UUSI VERSIO ASENNETTIIN</string>
-    <string name="new_device_notification_message">Tervetuloa! Tämän laitteen nimi on nyt &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Tervetuloa! Tämän laitteen nimi on nyt <b>%1$s</b>.</string>
     <string name="new_device_notification_title">UUSI LAITE LUOTIIN</string>
     <string name="new_list">Uusi luettelo</string>
     <string name="no_custom_lists_available">Mukautettuja luetteloita ei löytynyt</string>

--- a/android/lib/ui/resource/src/main/res/values-fr/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-fr/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Toutes les applications</string>
     <string name="all_locations">Toutes les localisations</string>
     <string name="all_providers">Tous les fournisseurs</string>
-    <string name="always_on_vpn_error_notification_content">Impossible de démarrer la connexion au tunnel. Veuillez désactiver « Toujours exiger un VPN « pour &lt;b&gt;%1$s&lt;/b&gt; avant d\'utiliser Mullvad VPN.</string>
+    <string name="always_on_vpn_error_notification_content">Impossible de démarrer la connexion au tunnel. Veuillez désactiver « Toujours exiger un VPN « pour <b>%1$s</b> avant d\'utiliser Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">« Toujours exiger un VPN » est assigné à %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Après la mise à jour d\'une application de VPN sur Android 16, les appareils peuvent se retrouver dans un état où ces applications de VPN ne sont plus en mesure d\'accéder à Internet.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Veuillez redémarrer votre appareil et réessayer de vous connecter. Si cela ne fonctionne pas, veuillez envoyer un e-mail à %1$s en suédois ou en anglais.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Connexion impossible ?</string>
     <string name="anti_censorship">Anti-censure</string>
     <string name="anti_censorship_info_first_paragraph">Ces méthodes peuvent servir dans les situations où il vous est empêché d\'atteindre Mullvad. Quand « Automatique » est sélectionné, l\'application essaiera toutes les méthodes jusqu\'à ce que l\'une d\'entre elles fonctionne.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Veuillez noter que ces méthodes n\'améliorent pas les performances et pourraient augmenter l\'utilisation du système et la consommation de batterie.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Veuillez noter que ces méthodes n\'améliorent pas les performances et pourraient augmenter l\'utilisation du système et la consommation de batterie.</b></string>
     <string name="any">N\'importe lequel</string>
     <string name="api_access_description">Gérez et ajoutez des modes d\'accès personnalisés à l\'API Mullvad.</string>
     <string name="api_access_method_info_first_line">L\'application doit communiquer avec un serveur d\'API Mullvad pour vous connecter, récupérer des listes de serveurs et effectuer d\'autres opérations critiques.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Météo</string>
     <string name="appearance">Apparence</string>
     <string name="appearance_description">Modifiez le titre et l\'icône de l\'application Mullvad VPN sur votre appareil Android. Cela ne modifiera pas l\'icône pour les notifications liées à Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Attention :&lt;/b&gt; l\'application se fermera automatiquement et devra être rouverte manuellement après avoir sélectionné une nouvelle icône et un nouveau titre. Cela n\'affectera pas votre connexion VPN.</string>
+    <string name="appearance_description_warning"><b>Attention :</b> l\'application se fermera automatiquement et devra être rouverte manuellement après avoir sélectionné une nouvelle icône et un nouveau titre. Cela n\'affectera pas votre connexion VPN.</string>
     <string name="apply">Appliquer</string>
     <string name="applying_changes">Application des modifications...</string>
     <string name="at_least_on_method_needs_to_enabled">Au moins une méthode doit être activée</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Les paramètres de la connexion automatique et du mode Verrouillage se trouvent dans les paramètres du système Android, suivez ce guide pour activer l\'un, l\'autre ou les deux.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Pour activer la connexion automatique, cliquez sur l\'interrupteur situé à côté de « Toujours exiger un VPN ».</string>
     <string name="auto_connect_carousel_second_slide_top_text">La connexion automatique est appelée VPN toujours actif dans les paramètres du système Android et elle s\'assure que vous êtes constamment connecté au tunnel VPN et se connecte automatiquement après le redémarrage.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Pour activer le mode Verrouillage, cliquez sur l\'interrupteur situé à côté de « Bloquer les connexions sans VPN ».&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Avertissement : ce paramètre bloque les applications fractionnées et la fonctionnalité de partage du réseau local.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Pour activer le mode Verrouillage, cliquez sur l\'interrupteur situé à côté de « Bloquer les connexions sans VPN ».<br /><br /><b>Avertissement : ce paramètre bloque les applications fractionnées et la fonctionnalité de partage du réseau local.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Le mode Verrouillage est appelé « Bloquer les connexions sans VPN » dans les paramètres système d\'Android. Il permet de minimiser les fuites, mais présente des limites connues sur lesquelles vous pouvez en savoir plus</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">ici</string>
     <string name="automatic">Automatique</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Supprimer le port personnalisé</string>
     <string name="custom_port_dialog_submit">Définir le port</string>
     <string name="custom_port_dialog_valid_ranges">Plages valides : %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Attention :&lt;/b&gt; seuls certains serveurs prennent en charge la plage de ports entière.</string>
+    <string name="custom_port_recommended_range_first"><b>Attention :</b> seuls certains serveurs prennent en charge la plage de ports entière.</string>
     <string name="custom_port_recommended_range_second">Plage valide pour tous les serveurs : %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Échec de la résolution de l\'hôte du tunnel personnalisé. Essayez de modifier vos paramètres.</string>
     <string name="daita_description_slide_1_first_paragraph">Attention : cette option augmente le trafic sur le réseau et peut avoir un impact négatif sur la vitesse, la latence et l\'utilisation de la batterie. À utiliser avec précaution pour les forfaits limités.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Supprimer %1$s ?</string>
     <string name="manage_devices_confirm_removal_description_line2">L\'appareil sera supprimé de la liste et déconnecté.</string>
     <string name="manage_devices_description">Affichez et gérez tous vos appareils connectés. Vous pouvez avoir jusqu\'à 5 appareils sur un même compte. Chaque appareil reçoit un nom lorsqu\'il est connecté, ce qui vous permet de le distinguer facilement.</string>
-    <string name="max_devices_confirm_removal_description">Voulez-vous vraiment déconnecter &lt;b&gt;%1$s&lt;/b&gt; ?</string>
+    <string name="max_devices_confirm_removal_description">Voulez-vous vraiment déconnecter <b>%1$s</b> ?</string>
     <string name="max_devices_resolved_description">Vous pouvez maintenant continuer la connexion sur cet appareil.</string>
     <string name="max_devices_resolved_title">Super !</string>
     <string name="max_devices_warning_description">Merci de vous déconnecter d\'au moins un appareil en le supprimant de la liste ci-dessous. Vous trouverez le nom de l\'appareil correspondant dans les paramètres du compte de l\'appareil.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Navigation</string>
     <string name="new_changelog_notification_message">Cliquez ici pour voir les nouveautés.</string>
     <string name="new_changelog_notification_title">NOUVELLE VERSION INSTALLÉE</string>
-    <string name="new_device_notification_message">Bienvenue, cet appareil est maintenant appelé &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Bienvenue, cet appareil est maintenant appelé <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NOUVEL APPAREIL CRÉÉ</string>
     <string name="new_list">Nouvelle liste</string>
     <string name="no_custom_lists_available">Aucune liste personnalisée disponible</string>

--- a/android/lib/ui/resource/src/main/res/values-it/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-it/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Tutte le applicazioni</string>
     <string name="all_locations">Tutti i luoghi</string>
     <string name="all_providers">Tutti i fornitori</string>
-    <string name="always_on_vpn_error_notification_content">Impossibile avviare la connessione tunnel. Disabilita VPN sempre attiva per &lt;b&gt;%1$s&lt;/b&gt; prima di utilizzare Mullvad VPN.</string>
+    <string name="always_on_vpn_error_notification_content">Impossibile avviare la connessione tunnel. Disabilita VPN sempre attiva per <b>%1$s</b> prima di utilizzare Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">VPN sempre attiva assegnata a %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Dopo aver aggiornato un\'app VPN su Android 16, i dispositivi potrebbero trovarsi in uno stato in cui le app VPN non sono più in grado di accedere a Internet.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Riavvia il dispositivo e riprova a connetterti. Se non funziona, scrivi un\'e-mail a %1$s in svedese o in inglese.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Impossibile connetterti?</string>
     <string name="anti_censorship">Anticensura</string>
     <string name="anti_censorship_info_first_paragraph">Questi metodi potrebbero essere utili in situazioni in cui non riesci a raggiungere Mullvad. Selezionando \"Automatico\", l\'app tenterà tutti i metodi finché uno non funziona.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Tieni presente che questi metodi non migliorano le prestazioni e potrebbero aumentare l\'utilizzo di risorse del sistema e il consumo della batteria.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Tieni presente che questi metodi non migliorano le prestazioni e potrebbero aumentare l\'utilizzo di risorse del sistema e il consumo della batteria.</b></string>
     <string name="any">Qualsiasi</string>
     <string name="api_access_description">Gestisci e aggiungi metodi personalizzati per accedere all\'API Mullvad.</string>
     <string name="api_access_method_info_first_line">L\'app deve comunicare con un server API Mullvad per accedere, recuperare elenchi di server e altre operazioni critiche.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Meteo</string>
     <string name="appearance">Aspetto</string>
     <string name="appearance_description">Cambia il titolo e l\'icona dell\'app Mullvad VPN sul tuo dispositivo Android. Questa operazione non modificherà l\'icona delle notifiche relative a Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Attenzione:&lt;/b&gt; l\'app si chiuderà automaticamente e dovrà essere riaperta manualmente dopo aver selezionato una nuova icona e un nuovo titolo. Ciò non influirà sulla connessione VPN.</string>
+    <string name="appearance_description_warning"><b>Attenzione:</b> l\'app si chiuderà automaticamente e dovrà essere riaperta manualmente dopo aver selezionato una nuova icona e un nuovo titolo. Ciò non influirà sulla connessione VPN.</string>
     <string name="apply">Applica</string>
     <string name="applying_changes">Applicazione modifiche...</string>
     <string name="at_least_on_method_needs_to_enabled">È necessario abilitare almeno un metodo</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Le impostazioni della modalità di Connessione automatica e di Blocco si trovano nelle impostazioni del sistema Android. Segui questa guida per abilitare una o entrambe.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Per abilitare la connessione automatica, clicca sull\'interruttore accanto a \"VPN sempre attiva\".</string>
     <string name="auto_connect_carousel_second_slide_top_text">La connessione automatica è denominata VPN sempre attiva nelle impostazioni del sistema Android e garantisce di essere costantemente connessi al tunnel VPN e di connettersi automaticamente dopo il riavvio.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Per abilitare la Modalità Blocco, clicca sull\'interruttore accanto a \"Blocca connessioni senza VPN\".&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Avviso: questa impostazione blocca le app divise e la funzionalità di condivisione della rete locale.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Per abilitare la Modalità Blocco, clicca sull\'interruttore accanto a \"Blocca connessioni senza VPN\".<br /><br /><b>Avviso: questa impostazione blocca le app divise e la funzionalità di condivisione della rete locale.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">La Modalità Blocco si chiama \"Blocca connessioni senza VPN\" nelle impostazioni del sistema Android. Aiuta a ridurre al minimo le perdite, tuttavia presenta alcune limitazioni su cui consigliamo di approfondire</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">qui</string>
     <string name="automatic">Automatico</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Rimuovi porta personalizzata</string>
     <string name="custom_port_dialog_submit">Imposta porta</string>
     <string name="custom_port_dialog_valid_ranges">Intervalli validi: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Attenzione:&lt;/b&gt; solo alcuni server supportano l\'intervallo di porte completo.</string>
+    <string name="custom_port_recommended_range_first"><b>Attenzione:</b> solo alcuni server supportano l\'intervallo di porte completo.</string>
     <string name="custom_port_recommended_range_second">Intervallo valido per tutti i server: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Impossibile risolvere l\'host del tunnel personalizzato. Prova a modificare le impostazioni.</string>
     <string name="daita_description_slide_1_first_paragraph">Attenzione: questo aumenta il traffico di rete e avrà anche effetti negativi su velocità, latenza e consumo della batteria. Da usare con cautela su un piano dati limitato.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Rimuovere %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Il dispositivo verrà rimosso dall\'elenco e disconnesso.</string>
     <string name="manage_devices_description">Visualizza e gestisci tutti i dispositivi da cui effettui l\'accesso. Puoi avere contemporaneamente fino a 5 dispositivi su un account. Ogni dispositivo riceve un nome quando si effettua l\'accesso per aiutarti a distinguerli facilmente.</string>
-    <string name="max_devices_confirm_removal_description">Vuoi davvero disconnettere &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="max_devices_confirm_removal_description">Vuoi davvero disconnettere <b>%1$s</b>?</string>
     <string name="max_devices_resolved_description">Ora puoi continuare ad accedere su questo dispositivo.</string>
     <string name="max_devices_resolved_title">Fantastico!</string>
     <string name="max_devices_warning_description">Disconnettiti da almeno un dispositivo rimuovendolo dall\'elenco seguente. Puoi trovare il nome del dispositivo corrispondente nelle impostazioni dell\'account del dispositivo.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Naviga</string>
     <string name="new_changelog_notification_message">Clicca qui per vedere le novità.</string>
     <string name="new_changelog_notification_title">NUOVA VERSIONE INSTALLATA</string>
-    <string name="new_device_notification_message">Ti diamo il benvenuto, questo dispositivo ora si chiama &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Ti diamo il benvenuto, questo dispositivo ora si chiama <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NUOVO DISPOSITIVO CREATO</string>
     <string name="new_list">Nuovo elenco</string>
     <string name="no_custom_lists_available">Nessun elenco personalizzato disponibile</string>

--- a/android/lib/ui/resource/src/main/res/values-ja/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-ja/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">すべてのアプリケーション</string>
     <string name="all_locations">すべての場所</string>
     <string name="all_providers">すべてのプロバイダ</string>
-    <string name="always_on_vpn_error_notification_content">トンネル接続を開始できません。Mullvad VPNを使用する前に&lt;b&gt;%1$s&lt;/b&gt;のAlways-on VPNを無効にしてください。</string>
+    <string name="always_on_vpn_error_notification_content">トンネル接続を開始できません。Mullvad VPNを使用する前に<b>%1$s</b>のAlways-on VPNを無効にしてください。</string>
     <string name="always_on_vpn_error_notification_title">Always-on VPNは%1$sに割り当てられました</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Android 16でVPNアプリを更新すると、デバイス上のVPNアプリがインターネットにアクセス不可能な状態になる可能性があります。</string>
     <string name="android_16_upgrade_warning_dialog_second_message">デバイスを再起動して再接続してください。それでも問題が解決しない場合は、%1$sにスウェーデン語か英語のメールでお問い合わせください。</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">接続できませんか？</string>
     <string name="anti_censorship">検閲回避</string>
     <string name="anti_censorship_info_first_paragraph">これらの方式は、Mullvadへの接続がブロックされている状況で役立つ可能性があります。「自動」を選択すると、アプリは有効な方法が見つかるまですべての方式を試します。</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;これらの方式はパフォーマンスを向上させるものではなく、システム使用率やバッテリー消費量を増加させる可能性がありますのでご注意ください。&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>これらの方式はパフォーマンスを向上させるものではなく、システム使用率やバッテリー消費量を増加させる可能性がありますのでご注意ください。</b></string>
     <string name="any">すべて</string>
     <string name="api_access_description">Mullvad APIへのカスタムのアクセス方法を管理・追加します。</string>
     <string name="api_access_method_info_first_line">アプリはユーザーのログイン、サーバーリストの取得、およびその他の重要な操作を行うためにMullvad APIサーバーと通信する必要があります。</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">天気</string>
     <string name="appearance">外観</string>
     <string name="appearance_description">Androidデバイス上で、Mullvad VPNアプリのタイトルとアイコンを変更します。この変更は、Mullvad VPNに関連する通知のアイコンには適用されません。</string>
-    <string name="appearance_description_warning">&lt;b&gt;注意：&lt;/b&gt;新しいアイコンとタイトルを選択すると、アプリは自動的に終了します。その後、手動で再起動する必要があります。なお、この操作によってVPN接続が切断されることはありません。</string>
+    <string name="appearance_description_warning"><b>注意：</b>新しいアイコンとタイトルを選択すると、アプリは自動的に終了します。その後、手動で再起動する必要があります。なお、この操作によってVPN接続が切断されることはありません。</string>
     <string name="apply">適用</string>
     <string name="applying_changes">変更内容を適用しています…</string>
     <string name="at_least_on_method_needs_to_enabled">方法は少なくとも 1 つは有効化する必要があります</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">自動接続とロックダウンモードの設定はAndroidシステム設定にあります。どちらか、または両方をこのガイドに従って有効にしてください。</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. 自動接続を有効にするには、[Always-on VPN] の横のトグルボタンをクリックします。</string>
     <string name="auto_connect_carousel_second_slide_top_text">自動接続はAndroidシステム設定で「Always-on VPN」と呼ばれており、確実に一貫してVPNトンネルに接続し、再起動の後に自動接続を行う機能です。</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. ロックダウンモードを有効にするには、[VPN 以外の接続のブロック] の横にあるトグルボタンをクリックします。&lt;br /&gt;&lt;br /&gt;&lt;b&gt;警告: この設定では、分割アプリとローカルネットワーク共有の機能がブロックされます。&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. ロックダウンモードを有効にするには、[VPN 以外の接続のブロック] の横にあるトグルボタンをクリックします。<br /><br /><b>警告: この設定では、分割アプリとローカルネットワーク共有の機能がブロックされます。</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">このロックダウンモードは、Androidのシステム設定では [VPN以外の接続のブロック] と呼ばれています。情報漏洩の可能性を低減することが可能ですが、既知の制限がいくつかあります。制限については、</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">こちらをご覧ください。</string>
     <string name="automatic">自動</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">カスタムポートを削除</string>
     <string name="custom_port_dialog_submit">ポートを設定</string>
     <string name="custom_port_dialog_valid_ranges">有効な範囲: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;注意:&lt;/b&gt; 全ポート範囲をサポートしているのは一部のサーバーのみです。</string>
+    <string name="custom_port_recommended_range_first"><b>注意:</b> 全ポート範囲をサポートしているのは一部のサーバーのみです。</string>
     <string name="custom_port_recommended_range_second">全サーバーの有効範囲: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">カスタムトンネルのホストを解決できません。設定を変更してみてください。</string>
     <string name="daita_description_slide_1_first_paragraph">注意: これによりネットワークトラフィックが増加し、速度、遅延、およびバッテリー使用率に悪影響を及ぼします。上限付きプランでは注意して使用してください。</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">%1$sを削除しますか？</string>
     <string name="manage_devices_confirm_removal_description_line2">リストからデバイスが削除され、ログアウトされます。</string>
     <string name="manage_devices_description">ログイン中のすべてのデバイスを表示・管理します。1つのアカウントで最大5台のデバイスを同時に利用できます。各デバイスは識別しやすくするため、ログイン時に名前が付けられます。</string>
-    <string name="max_devices_confirm_removal_description">本当に&lt;b&gt;%1$s&lt;/b&gt;をログアウトしますか？</string>
+    <string name="max_devices_confirm_removal_description">本当に<b>%1$s</b>をログアウトしますか？</string>
     <string name="max_devices_resolved_description">このデバイスでログインを続けられるようになりました。</string>
     <string name="max_devices_resolved_title">素晴らしい！</string>
     <string name="max_devices_warning_description">以下のリストから少なくとも1つを削除してログアウトしてください。対応するデバイス名はデバイスのアカウント設定で確認できます。</string>
@@ -299,7 +299,7 @@
     <string name="navigate">移動</string>
     <string name="new_changelog_notification_message">新機能を確認するにはここをクリックしてください。</string>
     <string name="new_changelog_notification_title">新バージョンがインストールされました</string>
-    <string name="new_device_notification_message">ようこそ。このデバイス名は&lt;b&gt;%1$s&lt;/b&gt;です。</string>
+    <string name="new_device_notification_message">ようこそ。このデバイス名は<b>%1$s</b>です。</string>
     <string name="new_device_notification_title">新しいデバイスが作成されました</string>
     <string name="new_list">新規リスト</string>
     <string name="no_custom_lists_available">利用可能なカスタムリストはありません</string>

--- a/android/lib/ui/resource/src/main/res/values-ko/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-ko/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">모든 애플리케이션</string>
     <string name="all_locations">모든 위치</string>
     <string name="all_providers">모든 제공업체</string>
-    <string name="always_on_vpn_error_notification_content">터널 연결을 시작할 수 없습니다. Mullvad VPN을 사용하기 전에 &lt;b&gt;%1$s&lt;/b&gt;에 대한 상시 접속 VPN을 비활성화하세요.</string>
+    <string name="always_on_vpn_error_notification_content">터널 연결을 시작할 수 없습니다. Mullvad VPN을 사용하기 전에 <b>%1$s</b>에 대한 상시 접속 VPN을 비활성화하세요.</string>
     <string name="always_on_vpn_error_notification_title">상시 접속 VPN이 %1$s에 할당됨</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Android 16에서 VPN 앱을 업데이트하면 VPN 앱이 더 이상 인터넷에 연결되지 않는 상태가 될 수 있습니다.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">장치를 재시작하고 다시 연결해 주세요. 그래도 해결되지 않는다면 %1$s에 스웨덴어 또는 영어로 이메일을 보내주세요.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">연결이 되지 않나요?</string>
     <string name="anti_censorship">검열 방지</string>
     <string name="anti_censorship_info_first_paragraph">이 방법들은 Mullvad 사용이 차단된 경우에 유용합니다. \"자동\"을 선택하면 통하는 방법이 있을 때까지 모든 방법을 시도합니다.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;다음 방법은 성능을 향상하는 것이 아니며 시스템 사용률 및 배터리 소모량이 증가할 수 있습니다.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>다음 방법은 성능을 향상하는 것이 아니며 시스템 사용률 및 배터리 소모량이 증가할 수 있습니다.</b></string>
     <string name="any">모두</string>
     <string name="api_access_description">Mullvad API에 액세스하기 위한 사용자 지정 방법을 관리하고 추가합니다.</string>
     <string name="api_access_method_info_first_line">이 앱은 로그인, 서버 목록 가져오기 및 기타 중요한 작업을 위해 Mullvad API 서버와 통신해야 합니다.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">날씨</string>
     <string name="appearance">외관 설정</string>
     <string name="appearance_description">Android 장치에서 Mullvad VPN의 타이틀과 아이콘을 변경하세요. Mullvad VPN과 관련된 알림의 아이콘은 변경되지 않습니다.</string>
-    <string name="appearance_description_warning">&lt;b&gt;주의:&lt;/b&gt; 새 아이콘과 타이틀을 선택하면 앱이 자동으로 종료되며 수동으로 다시 실행해야 합니다. VPN 연결에는 영향을 미치지 않습니다.</string>
+    <string name="appearance_description_warning"><b>주의:</b> 새 아이콘과 타이틀을 선택하면 앱이 자동으로 종료되며 수동으로 다시 실행해야 합니다. VPN 연결에는 영향을 미치지 않습니다.</string>
     <string name="apply">적용</string>
     <string name="applying_changes">변경 사항 적용 중...</string>
     <string name="at_least_on_method_needs_to_enabled">1개 이상의 방법이 활성화되어 있어야 합니다</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">자동 연결 및 잠금 모드 설정은 Android 시스템 설정에서 찾을 수 있습니다. 이 가이드에 따라 하나 또는 둘 다를 활성화하세요.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. 자동 연결을 활성화하려면 \"상시 접속 VPN\" 옆에 있는 토글을 클릭합니다.</string>
     <string name="auto_connect_carousel_second_slide_top_text">자동 연결은 Android 시스템 설정에서 상시 접속 VPN이라고 하며 VPN 터널에 지속적으로 연결되고 다시 시작한 후 자동 연결되게 해줍니다.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. 잠금 모드를 활성화하려면 \"VPN 없이 연결 차단\" 옆에 있는 토글을 클릭합니다.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;경고: 이 설정은 분할 앱과 로컬 네트워크 공유 기능을 차단합니다.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. 잠금 모드를 활성화하려면 \"VPN 없이 연결 차단\" 옆에 있는 토글을 클릭합니다.<br /><br /><b>경고: 이 설정은 분할 앱과 로컬 네트워크 공유 기능을 차단합니다.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">잠금 모드는 Android 시스템 설정에서 \"VPN 없이 연결 차단\"이라고 합니다. 유출을 최소화하는 데 도움이 되지만, 몇 가지 알려진 제한 사항이 있습니다. 다음에서 자세한 내용을 확인하세요.</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">여기</string>
     <string name="automatic">자동</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">사용자 지정 포트 제거</string>
     <string name="custom_port_dialog_submit">포트 설정</string>
     <string name="custom_port_dialog_valid_ranges">유효한 범위: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;주의:&lt;/b&gt; 일부 서버에서만 전체 포트 범위를 지원합니다.</string>
+    <string name="custom_port_recommended_range_first"><b>주의:</b> 일부 서버에서만 전체 포트 범위를 지원합니다.</string>
     <string name="custom_port_recommended_range_second">모든 서버의 유효 범위: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">사용자 지정 터널의 호스트를 확인할 수 없습니다. 설정을 변경해 보세요.</string>
     <string name="daita_description_slide_1_first_paragraph">주의: 이 기능은 네트워크 트래픽을 증가시키며 속도, 대기 시간, 배터리 사용에도 부정적인 영향을 미칩니다. 제한된 데이터 플랜 사용 시에는 유의하시기 바랍니다.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">%1$s을(를) 제거하시겠습니까?</string>
     <string name="manage_devices_confirm_removal_description_line2">장치가 목록에서 제거되고 로그아웃됩니다.</string>
     <string name="manage_devices_description">로그인된 모든 장치를 보고 관리하세요. 한 계정에서 최대 5대의 장치를 동시에 보유할 수 있습니다. 사용자가 쉽게 구분할 수 있도록 로그인 시 각 장치에 이름이 부여됩니다.</string>
-    <string name="max_devices_confirm_removal_description">&lt;b&gt;%1$s&lt;/b&gt;에서 로그아웃하시겠습니까?</string>
+    <string name="max_devices_confirm_removal_description"><b>%1$s</b>에서 로그아웃하시겠습니까?</string>
     <string name="max_devices_resolved_description">이제 이 장치에 계속 로그인할 수 있습니다.</string>
     <string name="max_devices_resolved_title">좋습니다!</string>
     <string name="max_devices_warning_description">하나 이상의 항목을 아래 목록에서 제거하여 로그아웃하세요. 장치의 계정 설정에서 해당 장치 이름을 찾을 수 있습니다.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">이동</string>
     <string name="new_changelog_notification_message">업데이트 내역을 확인하려면 여기를 클릭하세요.</string>
     <string name="new_changelog_notification_title">새 버전 설치 완료</string>
-    <string name="new_device_notification_message">환영합니다. 이 장치의 호칭은 이제 &lt;b&gt;%1$s&lt;/b&gt;입니다.</string>
+    <string name="new_device_notification_message">환영합니다. 이 장치의 호칭은 이제 <b>%1$s</b>입니다.</string>
     <string name="new_device_notification_title">새 장치가 생성됨</string>
     <string name="new_list">새 목록</string>
     <string name="no_custom_lists_available">이용 가능한 사용자 지정 목록 없음</string>

--- a/android/lib/ui/resource/src/main/res/values-my/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-my/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">အပလီကေးရှင်း အားလုံး</string>
     <string name="all_locations">တည်နေရာအာလုံး</string>
     <string name="all_providers">ပံ့ပိုးသူအားလုံး</string>
-    <string name="always_on_vpn_error_notification_content">Tunnel ချိတ်ဆက်မှုကို စတင်၍ မရနိုင်ပါ။ Mullvad VPN ကို မသုံးမီ &lt;b&gt;%1$s&lt;/b&gt; အတွက် VPN အမြဲဖွင့်ထားမှုကို ပိတ်ပေးပါ။</string>
+    <string name="always_on_vpn_error_notification_content">Tunnel ချိတ်ဆက်မှုကို စတင်၍ မရနိုင်ပါ။ Mullvad VPN ကို မသုံးမီ <b>%1$s</b> အတွက် VPN အမြဲဖွင့်ထားမှုကို ပိတ်ပေးပါ။</string>
     <string name="always_on_vpn_error_notification_title">အမြဲဖွင့် VPN ကို %1$s သို့ သတ်မှတ်ထားပါသည်</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Android 16 တွင် VPN အက်ပ်ကို အပ်ဒိတ်လုပ်ပြီးနောက် စက်များတွင် VPN အက်ပ်များက အင်တာနက်ချိတ်မပေးနိုင်တော့သည့် အခြေအနေမျိုး ကြုံရတတ်သည်။</string>
     <string name="android_16_upgrade_warning_dialog_second_message">စက်ကို ရီစတက်ချပြီး ထပ်မံချိတ်ဆက်ကြည့်ပါ။ ချိတ်၍မရသေးလျှင် %1$s သို့ ဆွီဒင် သို့မဟုတ် အင်္ဂလိပ်ဘာသာစကားဖြင့် အီးမေးလ်ပို့ပါ။</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">ချိတ်မရဘူးလား။</string>
     <string name="anti_censorship">ဆင်ဆာဖြတ်တောက်မှု ကျော်လွှားရေး</string>
     <string name="anti_censorship_info_first_paragraph">Mullvad နှင့် ချိတ်ဆက်၍ မရအောင် ပိတ်ပင်ခံရသည့် အခြေအနေများတွင် ဤနည်းလမ်းများက အသုံးဝင်နိုင်ပါသည်။ “အော်တိုမက်တစ်” ကို ရွေးချယ်ထားချိန်တွင် အက်ပ်က အလုပ်ဖြစ်သည့် နည်းလမ်းတစ်ခုခုကို မတွေ့မချင်း နည်းလမ်းအားလုံးကို ကြိုးပမ်းသွားပါမည်။</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;ဤနည်းလမ်းများသည် စွမ်းဆောင်ရည်ကို မတိုးတက်စေဘဲ စနစ်ကို ပိုသုံးစွဲ၍ ဘက်ထရီ အားပိုကုန်စေနိုင်ကြောင်း သတိပြုပါ။&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>ဤနည်းလမ်းများသည် စွမ်းဆောင်ရည်ကို မတိုးတက်စေဘဲ စနစ်ကို ပိုသုံးစွဲ၍ ဘက်ထရီ အားပိုကုန်စေနိုင်ကြောင်း သတိပြုပါ။</b></string>
     <string name="any">တစ်ခုခု</string>
     <string name="api_access_description">Mullvad API ကို ရယူသုံးစွဲရန် စိတ်ကြိုက် နည်းလမ်းများကို ပေါင်းထည့်၍ စီမံပါ။</string>
     <string name="api_access_method_info_first_line">Mullvad API ဆာဗာသို့ သင်ဝင်ရောက်ရန်၊ ဆာဗာစာရင်းများ ရယူရန်နှင့် အလွန်အရေးပါသည့် အခြားလုပ်ဆောင်မှုများအတွက် ဤအက်ပ်သည် ၎င်းနှင့်ဆက်သွယ်ရန် လိုအပ်ပါသည်။</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Weather</string>
     <string name="appearance">ပုံသဏ္ဌာန်</string>
     <string name="appearance_description">Android စက်ရှိ Mullvad VPN အက်ပ်၏ ခေါင်းစဉ်နှင့် အိုင်ကွန်ကို ပြောင်းပါ။ ဤသို့ ပြောင်းခြင်းသည် Mullvad VPN ဆက်စပ်သော အသိပေးချက်မှန်သမျှအတွက် အိုင်ကွန်ကို မပြောင်းစေပါ။</string>
-    <string name="appearance_description_warning">&lt;b&gt;သတိပြုရန်-&lt;/b&gt; အိုင်ကွန်နှင့် ခေါင်းစဉ်အသစ်ကို ရွေးပြီးသည်နှင့် အက်ပ်က အော်တို ပိတ်သွားမည်ဖြစ်ပြီး ကိုယ်တိုင် ပြန်ဖွင့်ရန် လိုအပ်ပါသည်။ ဤလုပ်ဆောင်မှုသည် VPN ချိတ်ဆက်မှုကို မထိခိုက်ပါ။</string>
+    <string name="appearance_description_warning"><b>သတိပြုရန်-</b> အိုင်ကွန်နှင့် ခေါင်းစဉ်အသစ်ကို ရွေးပြီးသည်နှင့် အက်ပ်က အော်တို ပိတ်သွားမည်ဖြစ်ပြီး ကိုယ်တိုင် ပြန်ဖွင့်ရန် လိုအပ်ပါသည်။ ဤလုပ်ဆောင်မှုသည် VPN ချိတ်ဆက်မှုကို မထိခိုက်ပါ။</string>
     <string name="apply">သုံးရန်</string>
     <string name="applying_changes">ပြောင်းလဲမှုများ လုပ်ဆောင်နေဆဲ...</string>
     <string name="at_least_on_method_needs_to_enabled">အနည်းဆုံး နည်းလမ်းတစ်ခုကို ဖွင့်ရမည်</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">အော်တို ချိတ်ဆက်မှုနှင့် လော့ခ်ဒေါင်းစနစ် ဆက်တင်များကို Android စနစ် ဆက်တင်များတွင် ရှာတွေ့နိုင်ပြီး တစ်ခု သို့မဟုတ် နှစ်ခုလုံးကို ဖွင့်ရန် ဤလမ်းညွှန်ချက်ကို လိုက်နာပါ။</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. အော်တို ချိတ်ဆက်မှုကို ဖွင့်ရန် \"အမြဲဖွင့် VPN\" ဘေးရှိ ဖွင့်/ပိတ် ခလုတ်ကို နှိပ်ပါ။</string>
     <string name="auto_connect_carousel_second_slide_top_text">Android စနစ် ဆက်တင်တွင် အော်တိုချိတ်ဆက်မှုကို အမြဲဖွင့် VPN ဟုခေါ်ပြီး VPN Tunnel ကို အမြဲချိတ်ဆက်ထားကြောင်း သေချာစေပြီး အစမှ ပြန်ဖွင့်ပြီးနောက် အော်တို ချိတ်ဆက်ပါသည်။</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. လော့ခ်ဒေါင်းစနစ်ကို ဖွင့်ရန် \"VPN မသုံးဘဲ ချိတ်ဆက်မှုများကို ပိတ်ဆို့ရန်\"ဘေးရှိ ဖွင့်/ပိတ်ခလုတ်ကို နှိပ်ပါ။.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;သတိပေးချက်- ဤဆက်တင်သည် Split အက်ပ်များနှင့် လိုကယ် ကွန်ရက် ဝေမျှမှု လုပ်ဆောင်ချက်ကို တားမြစ်ပါသည်။&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. လော့ခ်ဒေါင်းစနစ်ကို ဖွင့်ရန် \"VPN မသုံးဘဲ ချိတ်ဆက်မှုများကို ပိတ်ဆို့ရန်\"ဘေးရှိ ဖွင့်/ပိတ်ခလုတ်ကို နှိပ်ပါ။.<br /><br /><b>သတိပေးချက်- ဤဆက်တင်သည် Split အက်ပ်များနှင့် လိုကယ် ကွန်ရက် ဝေမျှမှု လုပ်ဆောင်ချက်ကို တားမြစ်ပါသည်။</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">လော့ခ်ဒေါင်းစနစ်ကို Android စနစ်ဆက်တင်များတွင် \"VPN မသုံးဘဲ ချိတ်ဆက်မှုများကို ပိတ်ဆို့ရန်\"ဟု ခေါ်ဆိုပါသည်။ ၎င်းသည် ပေါက်ကြားမှုများကို လျှော့ချနိုင်အောင် ကူညီပေးနိုင်သော်လည်း အများသိ အကန့်အသတ်များရှိပြီး ၎င်းတို့အကြောင်းကို ဖော်ပြပါတွင် ဖတ်ရှုနိုင်သည်</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">ဤနေရာတွင် ပိုမိုဖတ်ရှုနိုင်ပါသည်</string>
     <string name="automatic">အလိုအလျောက်</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">စိတ်ကြိုက် ပေါ့တ်ကို ဖယ်ရှားရန်</string>
     <string name="custom_port_dialog_submit">ပေါ့တ် သတ်မှတ်ရန်</string>
     <string name="custom_port_dialog_valid_ranges">အကျုံးဝင်သည့် အပိုင်းအခြား- %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;သတိပြုရန်-&lt;/b&gt; ဆာဗာအချို့သာ ပေါ့တ်အပိုင်းအခြား အပြည့် ပံ့ပိုးပေးပါသည်။</string>
+    <string name="custom_port_recommended_range_first"><b>သတိပြုရန်-</b> ဆာဗာအချို့သာ ပေါ့တ်အပိုင်းအခြား အပြည့် ပံ့ပိုးပေးပါသည်။</string>
     <string name="custom_port_recommended_range_second">ဆာဗာအားလုံးအတွက် အကျုံးဝင်သော အပိုင်းအခြား- %1$s</string>
     <string name="custom_tunnel_host_resolution_error">စိတ်ကြိုက်ပြုလုပ်ထားသည့် Tunnel ၏ Host ကို ဖြေရှင်း၍ မရနိုင်ပါ။ သင့်ဆက်တင်ကို ပြောင်းကြည့်ပါ။</string>
     <string name="daita_description_slide_1_first_paragraph">သတိပြုပါ- ဤသည်က ကွန်ရက် ကူးလူးမှုကို မြင့်တက်စေပြီး အမြန်နှုန်း၊ တုံ့ပြန်မှုနှောင့်နှေးခြင်း (Latency) နှင့် ဘက်ထရီ သုံးစွဲမှုကိုလည်း ထိခိုက်စေပါလိမ့်မည်။ အကန့်အသတ်ရှိသော ပလန်များကို သတိဖြင့် သုံးစွဲပါ။</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">%1$s ကို ဖယ်ရှားမလား။</string>
     <string name="manage_devices_confirm_removal_description_line2">စက်ကို စာရင်းမှ ဖယ်ရှားပြီး စနစ်မှ ထွက်သွားလိမ့်မည်။</string>
     <string name="manage_devices_description">သင်ဝင်ရောက်ထားသည့် စက်အားလုံးကို ကြည့်ရှုစီမံပါ။ အကောင့်တစ်ခုလျှင် စက် ၅ လုံးအထိ တစ်ပြိုင်နက်ဝင်ထားနိုင်သည်။ ဝင်ရောက်သည့်အခါတိုင်း ခွဲခြားရလွယ်ကူစေရန် စက်တစ်လုံးချင်းကို အမည်ပေးထားသည်။</string>
-    <string name="max_devices_confirm_removal_description">&lt;b&gt;%1$s&lt;/b&gt; မှ ထွက်လိုသည်မှာ သေချာပါသလား။</string>
+    <string name="max_devices_confirm_removal_description"><b>%1$s</b> မှ ထွက်လိုသည်မှာ သေချာပါသလား။</string>
     <string name="max_devices_resolved_description">သင်သည် ယခု ဤစက်တွင် ဆက်လက် ဝင်ရောက်နိုင်သည်။</string>
     <string name="max_devices_resolved_title">အလွန်ကောင်း။</string>
     <string name="max_devices_warning_description">အောက်ပါစာရင်းမှ အနည်းဆုံး တစ်ခုကို ဖယ်ရှားခြင်းဖြင့် ၎င်းမှ ထွက်ပါ။ စက်၏ အကောင့်ဆက်တင်အောက်တွင် သက်ဆိုင်သော စက်အမည်ကို သင် ရှာနိုင်သည်။</string>
@@ -299,7 +299,7 @@
     <string name="navigate">သွားရန်</string>
     <string name="new_changelog_notification_message">အသစ်ထူးသော အကြောင်းအရာကို ကြည့်ရန် ဤနေရာကို နှိပ်ပါ</string>
     <string name="new_changelog_notification_title">ဗားရှင်းအသစ်ကို ထည့်သွင်းထားသည်</string>
-    <string name="new_device_notification_message">ကြိုဆိုပါတယ်၊ ဤစက်ကို ယခု &lt;b&gt;%1$s&lt;/b&gt; ဟု ခေါ်ပါသည်။</string>
+    <string name="new_device_notification_message">ကြိုဆိုပါတယ်၊ ဤစက်ကို ယခု <b>%1$s</b> ဟု ခေါ်ပါသည်။</string>
     <string name="new_device_notification_title">စက်အသစ် ဖန်တီးထားသည်</string>
     <string name="new_list">စာရင်းသစ်</string>
     <string name="no_custom_lists_available">စိတ်ကြိုက် စာရင်းများကို မရရှိနိုင်ပါ</string>

--- a/android/lib/ui/resource/src/main/res/values-nb/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-nb/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Alle applikasjoner</string>
     <string name="all_locations">Alle steder</string>
     <string name="all_providers">Alle leverandører</string>
-    <string name="always_on_vpn_error_notification_content">Kunne ikke starte tunneltilkobling. Deaktiver VPN som alltid er på, for &lt;b&gt;%1$s&lt;/b&gt; før du bruker Mullvad VPN.</string>
+    <string name="always_on_vpn_error_notification_content">Kunne ikke starte tunneltilkobling. Deaktiver VPN som alltid er på, for <b>%1$s</b> før du bruker Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">VPN som alltid er på, er tilordnet %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Etter å ha oppdatert en VPN-app på Android 16, kan enhetene havne i en tilstand der VPN-appene ikke lenger får tilgang til internett.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Start enheten på nytt og prøv å koble til igjen. Hvis dette ikke fungerer, kan du skrive en e-post til %1$s på svensk eller engelsk.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Kan du ikke koble til?</string>
     <string name="anti_censorship">Antisensur</string>
     <string name="anti_censorship_info_first_paragraph">Disse metodene kan være nyttige i situasjoner der du er blokkert fra å nå Mullvad. Når «Automatisk» er valgt, vil appen prøve alle metodene helt til en av dem fungerer.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Vær oppmerksom på at disse metodene ikke forbedrer ytelsen og kan øke systemutnyttelsen og batteriforbruket.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Vær oppmerksom på at disse metodene ikke forbedrer ytelsen og kan øke systemutnyttelsen og batteriforbruket.</b></string>
     <string name="any">Hvilken som helst</string>
     <string name="api_access_description">Administrer og legg til tilpassede metoder for tilgang til Mullvad API.</string>
     <string name="api_access_method_info_first_line">Appen må kunne kommunisere med en Mullvad API-server for å logge deg inn, hente serverlister og utføre andre kritiske operasjoner.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Vær</string>
     <string name="appearance">Utseende</string>
     <string name="appearance_description">Endre tittelen og ikonet for Mullvad VPN-appen på Android-enheten din. Dette vil ikke endre ikonet for varsler knyttet til Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Merk:&lt;/b&gt; Appen lukkes automatisk og må åpnes manuelt igjen etter at du har valgt et nytt ikon og en ny tittel. Dette vil ikke ha innvirkning VPN-tilkoblingen din.</string>
+    <string name="appearance_description_warning"><b>Merk:</b> Appen lukkes automatisk og må åpnes manuelt igjen etter at du har valgt et nytt ikon og en ny tittel. Dette vil ikke ha innvirkning VPN-tilkoblingen din.</string>
     <string name="apply">Angi</string>
     <string name="applying_changes">Tar i bruk endringer …</string>
     <string name="at_least_on_method_needs_to_enabled">Minst én metode må være aktivert</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Du finner innstillingene for automatisk tilkobling og låsemodus i Androids systeminnstillinger. Følg denne veiledningen for å aktivere én eller begge.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. For å aktivere «Automatisk tilkobling» klikker du på bryteren ved siden av «VPN alltid på».</string>
     <string name="auto_connect_carousel_second_slide_top_text">Automatisk tilkobling heter «Alltid-på-VPN» i Androids systeminnstillinger og sørger for at du alltid er tilkoblet VPN-tunnelen og automatisk tilkobling etter omstart.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Klikk på bryteren ved siden av «Blokker tilkoblinger uten VPN» for å aktivere låsemodusen.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Advarsel: Denne innstillingen blokkerer delte apper og funksjonen «Deling over lokalt nettverk».&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Klikk på bryteren ved siden av «Blokker tilkoblinger uten VPN» for å aktivere låsemodusen.<br /><br /><b>Advarsel: Denne innstillingen blokkerer delte apper og funksjonen «Deling over lokalt nettverk».</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Låsemodusen kalles «Blokker tilkoblinger uten VPN» i systeminnstillingene for Android. Den bidrar til å minimere lekkasjer, men den har noen kjente begrensninger som du kan lese mer om</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">her</string>
     <string name="automatic">Automatisk</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Fjern tilpasset port</string>
     <string name="custom_port_dialog_submit">Konfigurer port</string>
     <string name="custom_port_dialog_valid_ranges">Gyldige verdiområder: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Merk:&lt;/b&gt; Det er bare enkelte servere som støtter alle porter.</string>
+    <string name="custom_port_recommended_range_first"><b>Merk:</b> Det er bare enkelte servere som støtter alle porter.</string>
     <string name="custom_port_recommended_range_second">Gyldig intervall for alle servere: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Kunne ikke løse vert for egendefinert tunnel. Forsøk å endre innstillingene dine.</string>
     <string name="daita_description_slide_1_first_paragraph">OBS: Dette vil øke nettverkstrafikken og også ha negativ innvirkning på hastighet, ventetid og batteriforbruk. Bruk med varsomhet hvis du har abonnement med begrenset data.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Fjerne %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Enheten blir fjernet fra listen og logget ut.</string>
     <string name="manage_devices_description">Se og administrer alle innloggede enheter. Du kan ha opptil fem enheter på én konto om gangen. Hver enhet får et navn når du logger inn, slik at du enkelt kan skille dem fra hverandre.</string>
-    <string name="max_devices_confirm_removal_description">Vil du virkelig logge &lt;b&gt;%1$s&lt;/b&gt; av?</string>
+    <string name="max_devices_confirm_removal_description">Vil du virkelig logge <b>%1$s</b> av?</string>
     <string name="max_devices_resolved_description">Du kan nå fortsette med å logge på denne enheten.</string>
     <string name="max_devices_resolved_title">Supert!</string>
     <string name="max_devices_warning_description">Logg ut av minst én ved å fjerne den fra listen nedenfor. Du finner det tilsvarende enhetsnavnet under enhetens kontoinnstillinger.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Navigér</string>
     <string name="new_changelog_notification_message">Klikk her for å se hva som er nytt.</string>
     <string name="new_changelog_notification_title">NY VERSJON INSTALLERT</string>
-    <string name="new_device_notification_message">Velkommen. Denne enheten har fått navnet &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Velkommen. Denne enheten har fått navnet <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NY ENHET OPPRETTET</string>
     <string name="new_list">Ny liste</string>
     <string name="no_custom_lists_available">Ingen tilgjengelige egendefinerte lister</string>

--- a/android/lib/ui/resource/src/main/res/values-nl/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-nl/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Alle toepassingen</string>
     <string name="all_locations">Alle locaties</string>
     <string name="all_providers">Alle aanbieders</string>
-    <string name="always_on_vpn_error_notification_content">Kan de tunnelverbinding niet starten. Schakel Altijd-aan VPN uit voor &lt;b&gt;%1$s&lt;/b&gt; voordat u Mullvad VPN gebruikt.</string>
+    <string name="always_on_vpn_error_notification_content">Kan de tunnelverbinding niet starten. Schakel Altijd-aan VPN uit voor <b>%1$s</b> voordat u Mullvad VPN gebruikt.</string>
     <string name="always_on_vpn_error_notification_title">Altijd-aan VPN toegewezen aan %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Na het bijwerken van een VPN-app in Android 16 kan het apparaat in een toestand raken waarin de VPN-apps het internet niet meer kunnen bereiken.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Start uw apparaat opnieuw op en probeer het opnieuw. Als dat niet werkt, kun u een e-mail schrijven naar %1$s (in het Zweeds of in het Engels).</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Krijgt u geen verbinding?</string>
     <string name="anti_censorship">Anti-censuur</string>
     <string name="anti_censorship_info_first_paragraph">Deze methoden kunnen nuttig zijn in situaties waarin de toegang tot Mullvad is geblokkeerd. Als \"Automatisch\" is geselecteerd, probeert de app alle methoden totdat er een werkt.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Houd er rekening mee dat deze methoden niet de prestaties verbeteren en mogelijk zorgen voor een hogere belasting van systeembronnen en meer energieverbruik.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Houd er rekening mee dat deze methoden niet de prestaties verbeteren en mogelijk zorgen voor een hogere belasting van systeembronnen en meer energieverbruik.</b></string>
     <string name="any">Elke</string>
     <string name="api_access_description">Beheer en voeg aangepaste methoden toe om toegang te krijgen tot de Mullvad-API.</string>
     <string name="api_access_method_info_first_line">De app moet communiceren met een Mullvad-API-server om u aan te melden, serverlijsten op te halen en andere belangrijke handelingen uit te voeren.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Weer</string>
     <string name="appearance">Uiterlijk</string>
     <string name="appearance_description">Wijzig de titel en het pictogram van de Mullvad VPN-app op uw Android-apparaat. Dit wijzigt het pictogram voor Mullvad VPN-gerelateerde meldingen niet.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Let op:&lt;/b&gt; de app wordt automatisch gesloten en moet handmatig opnieuw worden geopend na het selecteren van een nieuw pictogram en een nieuwe titel. Dit heeft geen invloed op uw VPN-verbinding.</string>
+    <string name="appearance_description_warning"><b>Let op:</b> de app wordt automatisch gesloten en moet handmatig opnieuw worden geopend na het selecteren van een nieuw pictogram en een nieuwe titel. Dit heeft geen invloed op uw VPN-verbinding.</string>
     <string name="apply">Toevoegen</string>
     <string name="applying_changes">Wijzigingen toepassen...</string>
     <string name="at_least_on_method_needs_to_enabled">Er moet minimaal één methode ingeschakeld zijn</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">De instellingen Automatisch verbinden en Lockdownmodus zijn te vinden in de Android-systeeminstellingen, volg deze gids om een of beide in te schakelen.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Klik om Automatisch verbinden in te schakelen op de schakelaar naast \"Altijd-aan VPN\".</string>
     <string name="auto_connect_carousel_second_slide_top_text">Automatisch verbinden heet Altijd-aan VPN in de Android-systeeminstellingen en zorgt ervoor dat u altijd verbonden bent met de VPN-tunnel en automatisch verbinding maakt na een herstart.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Klik om de Lockdownmodus in te schakelen op de schakelaar naast \"Verbindingen zonder VPN blokkeren\".&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Waarschuwing: deze instelling blokkeert gesplitste apps en de functie Delen via lokaal netwerk.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Klik om de Lockdownmodus in te schakelen op de schakelaar naast \"Verbindingen zonder VPN blokkeren\".<br /><br /><b>Waarschuwing: deze instelling blokkeert gesplitste apps en de functie Delen via lokaal netwerk.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">De Lockdownmodus heet \"Verbindingen zonder VPN blokkeren\" in de Android-systeeminstellingen. Deze helpt om lekken te minimaliseren, maar heeft enkele bekende beperkingen. Meer daarover leest u</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">hier</string>
     <string name="automatic">Automatisch</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Aangepaste poort verwijderen</string>
     <string name="custom_port_dialog_submit">Poort instellen</string>
     <string name="custom_port_dialog_valid_ranges">Geldige bereiken: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Let op:&lt;/b&gt; alleen sommige servers ondersteunen het volledige poortbereik.</string>
+    <string name="custom_port_recommended_range_first"><b>Let op:</b> alleen sommige servers ondersteunen het volledige poortbereik.</string>
     <string name="custom_port_recommended_range_second">Geldig bereik voor alle servers: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Kan host van aangepaste tunnel niet omzetten. Probeer uw instellingen te wijzigen.</string>
     <string name="daita_description_slide_1_first_paragraph">Let op: dit verhoogt het netwerkverkeer en heeft een negatieve invloed op de snelheid, de latentie en het batterijverbruik. Gebruik dit voorzichtig bij beperkte abonnementen.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">%1$s verwijderen?</string>
     <string name="manage_devices_confirm_removal_description_line2">Het apparaat wordt verwijderd uit de lijst en afgemeld.</string>
     <string name="manage_devices_description">Bekijk en beheer al uw aangemelde apparaten. Eén account kan maximaal 5 apparaten tegelijkertijd bevatten. Elk apparaat krijgt bij aanmelding een naam, zodat u ze eenvoudig uit elkaar kunt houden.</string>
-    <string name="max_devices_confirm_removal_description">Weet u zeker dat u &lt;b&gt;%1$s&lt;/b&gt; wilt afmelden?</string>
+    <string name="max_devices_confirm_removal_description">Weet u zeker dat u <b>%1$s</b> wilt afmelden?</string>
     <string name="max_devices_resolved_description">U kunt nu doorgaan met het aanmelden bij dit apparaat.</string>
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Meld u bij minstens één apparaat af door het te verwijderen uit de onderstaande lijst. U kunt de bijbehorende apparaatnaam vinden in de accountinstellingen van het apparaat.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Navigeren</string>
     <string name="new_changelog_notification_message">Klik hier om te zien wat er nieuw is.</string>
     <string name="new_changelog_notification_title">NIEUWE VERSIE GEÏNSTALLEERD</string>
-    <string name="new_device_notification_message">Welkom. De naam van dit apparaat is nu &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Welkom. De naam van dit apparaat is nu <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NIEUW APPARAAT GEMAAKT</string>
     <string name="new_list">Nieuwe lijst</string>
     <string name="no_custom_lists_available">Geen aangepaste lijsten beschikbaar</string>

--- a/android/lib/ui/resource/src/main/res/values-pl/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-pl/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Wszystkie aplikacje</string>
     <string name="all_locations">Wszystkie lokalizacje</string>
     <string name="all_providers">Wszyscy dostawcy</string>
-    <string name="always_on_vpn_error_notification_content">Nie można uruchomić połączenia tunelowego. Przed rozpoczęciem użytkowania usługi Mullvad VPN wyłącz opcję „Zawsze włączony VPN” w &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="always_on_vpn_error_notification_content">Nie można uruchomić połączenia tunelowego. Przed rozpoczęciem użytkowania usługi Mullvad VPN wyłącz opcję „Zawsze włączony VPN” w <b>%1$s</b>.</string>
     <string name="always_on_vpn_error_notification_title">Opcja „Zawsze włączony VPN” przypisana jest do %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Po zaktualizowaniu aplikacji VPN w systemie Android 16 urządzenia mogą znaleźć się w stanie, w którym aplikacje VPN nie będą już miały dostępu do Internetu.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Ponownie uruchom urządzenie i ponów próbę połączenia. Jeśli to nie zadziała, wyślij wiadomość e-mail na adres %1$s w języku szwedzkim lub angielskim.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Nie możesz się połączyć?</string>
     <string name="anti_censorship">Przeciwdziałanie cenzurze</string>
     <string name="anti_censorship_info_first_paragraph">Metody te mogą być przydatne w sytuacjach, gdy masz zablokowany dostęp do Mullvad. Po wybraniu opcji „Automatycznie” aplikacja będzie próbować wszystkich metod, dopóki jedna z nich nie zadziała.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Pamiętaj, że metody te nie poprawiają wydajności i mogą zwiększyć obciążenie systemu oraz zużycie baterii.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Pamiętaj, że metody te nie poprawiają wydajności i mogą zwiększyć obciążenie systemu oraz zużycie baterii.</b></string>
     <string name="any">Dowolny</string>
     <string name="api_access_description">Zarządzaj i dodawaj niestandardowe metody dostępu do interfejsu API Mullvad.</string>
     <string name="api_access_method_info_first_line">Aplikacja musi komunikować się z serwerem API Mullvad, aby można było się zalogować, pobrać listy serwerów i wykonywać inne krytyczne operacje.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Pogoda</string>
     <string name="appearance">Wygląd</string>
     <string name="appearance_description">Zmień tytuł i ikonę aplikacji Mullvad VPN na urządzeniu z systemem Android. Nie spowoduje to zmiany ikony żadnych powiadomień związanych z Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Uwaga:&lt;/b&gt; aplikacja zostanie zamknięta automatycznie i trzeba będzie ręcznie otworzyć ją ponownie po wybraniu nowej ikony i tytułu. Nie wpłynie to na połączenie VPN.</string>
+    <string name="appearance_description_warning"><b>Uwaga:</b> aplikacja zostanie zamknięta automatycznie i trzeba będzie ręcznie otworzyć ją ponownie po wybraniu nowej ikony i tytułu. Nie wpłynie to na połączenie VPN.</string>
     <string name="apply">Zastosuj</string>
     <string name="applying_changes">Stosowanie zmian...</string>
     <string name="at_least_on_method_needs_to_enabled">Należy włączyć co najmniej jedną metodę</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Ustawienia trybu automatycznego łączenia i trybu Lockdown można znaleźć w ustawieniach systemu Android. Aby włączyć jeden lub oba tryby, postępuj zgodnie z niniejszym poradnikiem.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Aby włączyć automatyczne łączenie, kliknij przełącznik obok opcji Zawsze włączony VPN.</string>
     <string name="auto_connect_carousel_second_slide_top_text">Automatyczne łączenie w ustawieniach systemu Android nazywa się „Zawsze włączony VPN” i zapewnia stałe połączenie z tunelem VPN oraz automatyczne łączenie po ponownym uruchomieniu.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Aby włączyć tryb Lockdown, kliknij przełącznik obok opcji Blokuj połączenia bez VPN.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Ostrzeżenie: to ustawienie blokuje aplikacje dzielące i funkcję udostępniania sieci lokalnej.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Aby włączyć tryb Lockdown, kliknij przełącznik obok opcji Blokuj połączenia bez VPN.<br /><br /><b>Ostrzeżenie: to ustawienie blokuje aplikacje dzielące i funkcję udostępniania sieci lokalnej.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Tryb Lockdown w ustawieniach systemu Android nazywa się Blokuj połączenia bez pośrednictwa sieci VPN. Pomaga zminimalizować wycieki, jednak ma pewne znane ograniczenia, o których można przeczytać więcej</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">tutaj</string>
     <string name="automatic">Automatycznie</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Usuń port niestandardowy</string>
     <string name="custom_port_dialog_submit">Ustaw port</string>
     <string name="custom_port_dialog_valid_ranges">Prawidłowe zakresy: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Uwaga:&lt;/b&gt; tylko niektóre serwery obsługują pełen zakres portów.</string>
+    <string name="custom_port_recommended_range_first"><b>Uwaga:</b> tylko niektóre serwery obsługują pełen zakres portów.</string>
     <string name="custom_port_recommended_range_second">Prawidłowy zakres dla wszystkich serwerów: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Nie można rozpoznać hosta tunelu niestandardowego. Spróbuj zmienić ustawienia.</string>
     <string name="daita_description_slide_1_first_paragraph">Uwaga: zwiększa to ruch sieciowy, a także negatywnie wpływa na szybkość, opóźnienia i zużycie baterii. Używaj ostrożnie w przypadku planów z ograniczeniami.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Usunąć %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Urządzenie zostanie usunięte z listy i wylogowane.</string>
     <string name="manage_devices_description">Wyświetlaj wszystkie zalogowane urządzenia i zarządzaj nimi. Na jednym koncie możesz mieć do 5 urządzeń naraz. Każde zalogowane urządzenie otrzymuje nazwę, co ułatwia ich rozróżnienie.</string>
-    <string name="max_devices_confirm_removal_description">Czy na pewno chcesz wylogować &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="max_devices_confirm_removal_description">Czy na pewno chcesz wylogować <b>%1$s</b>?</string>
     <string name="max_devices_resolved_description">Teraz można kontynuować logowanie się na tym urządzeniu.</string>
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Wyloguj się z co najmniej jednego urządzenia, usuwając je z poniższej listy. Odpowiednią nazwę urządzenia można znaleźć w ustawieniach konta urządzenia.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Nawiguj</string>
     <string name="new_changelog_notification_message">Kliknij tutaj, aby zobaczyć, co nowego.</string>
     <string name="new_changelog_notification_title">ZAINSTALOWANO NOWĄ WERSJĘ</string>
-    <string name="new_device_notification_message">To urządzenie ma teraz nazwę &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">To urządzenie ma teraz nazwę <b>%1$s</b>.</string>
     <string name="new_device_notification_title">UTWORZONO NOWE URZĄDZENIE</string>
     <string name="new_list">Nowa lista</string>
     <string name="no_custom_lists_available">Brak dostępnych list niestandardowych</string>

--- a/android/lib/ui/resource/src/main/res/values-pt/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-pt/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Todas as aplicações</string>
     <string name="all_locations">Todas as localizações</string>
     <string name="all_providers">Todos os fornecedores</string>
-    <string name="always_on_vpn_error_notification_content">Não foi possível iniciar a ligação de túnel. Desative a VPN sempre ligada para &lt;b&gt;%1$s&lt;/b&gt; antes de utilizar a Mullvad VPN.</string>
+    <string name="always_on_vpn_error_notification_content">Não foi possível iniciar a ligação de túnel. Desative a VPN sempre ligada para <b>%1$s</b> antes de utilizar a Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">VPN sempre ligada atribuída a %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Após atualizar uma aplicação de VPN no Android 16, os dispositivos podem ficar num estado em que as aplicações de VPN deixam de conseguir aceder à internet.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Reinicie o seu dispositivo e tente estabelecer a ligação novamente. Se isto não funcionar, escreva um e-mail para %1$s em sueco ou inglês.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Não consegue ligar?</string>
     <string name="anti_censorship">Anti-censura</string>
     <string name="anti_censorship_info_first_paragraph">Estes métodos podem ser úteis em situações em que esteja impedido de aceder à Mullvad. Quando está selecionado \"Automático\", a aplicação tentará todos os métodos até que um funcione.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Tenha em atenção que estes métodos não melhoram o desempenho e podem aumentar a utilização do sistema e o consumo da bateria.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Tenha em atenção que estes métodos não melhoram o desempenho e podem aumentar a utilização do sistema e o consumo da bateria.</b></string>
     <string name="any">Qualquer</string>
     <string name="api_access_description">Gerir e adicionar métodos personalizados para aceder à Mullvad API.</string>
     <string name="api_access_method_info_first_line">A app precisa de comunicar com um servidor da Mullvad API para iniciar a sua sessão, obter listas de servidores e outras operações críticas.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Meteorologia</string>
     <string name="appearance">Aparência</string>
     <string name="appearance_description">Altere o título e o ícone da aplicação Mullvad VPN no seu dispositivo Android. Isto não irá alterar o ícone de nenhuma notificação relacionada com a Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Atenção:&lt;/b&gt; a aplicação será encerrada automaticamente e terá de ser aberta manualmente novamente após selecionar um novo ícone e título. Isto não afetará a sua ligação VPN.</string>
+    <string name="appearance_description_warning"><b>Atenção:</b> a aplicação será encerrada automaticamente e terá de ser aberta manualmente novamente após selecionar um novo ícone e título. Isto não afetará a sua ligação VPN.</string>
     <string name="apply">Aplicar</string>
     <string name="applying_changes">A aplicar alterações...</string>
     <string name="at_least_on_method_needs_to_enabled">É necessário ativar pelo menos um método</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">As definições da ligação automática e do modo de bloqueio podem ser encontradas nas definições do sistema Android. Siga este guia para ativar uma ou ambas as funcionalidades.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Para ativar a ligação automática, clique no botão de alternar junto a \"VPN sempre ligada\".</string>
     <string name="auto_connect_carousel_second_slide_top_text">A ligação automática é designada por VPN sempre ligada nas definições do sistema Android e assegura que está constantemente ligado ao túnel VPN e ligar-se-á automaticamente após o reinício.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Para ativar o modo de bloqueio, clique no botão de alternância junto a \"Bloquear ligações sem VPN\".&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Aviso: esta definição bloqueia as aplicações divididas e a funcionalidade de Partilha de Rede Local.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Para ativar o modo de bloqueio, clique no botão de alternância junto a \"Bloquear ligações sem VPN\".<br /><br /><b>Aviso: esta definição bloqueia as aplicações divididas e a funcionalidade de Partilha de Rede Local.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">O modo de bloqueio é designado por \"Bloquear ligações sem VPN\" nas definições do sistema Android. Ajuda a minimizar fugas, mas tem algumas limitações conhecidas sobre as quais pode ler mais</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">aqui</string>
     <string name="automatic">Automático</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Remover porta personalizada</string>
     <string name="custom_port_dialog_submit">Definir porta</string>
     <string name="custom_port_dialog_valid_ranges">Intervalos válidos: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Atenção:&lt;/b&gt; só alguns servidores suportam o intervalo completo de portas.</string>
+    <string name="custom_port_recommended_range_first"><b>Atenção:</b> só alguns servidores suportam o intervalo completo de portas.</string>
     <string name="custom_port_recommended_range_second">Intervalo válido para todos os servidores: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Não foi possível resolver o anfitrião do túnel personalizado. Experimente alterar as suas definições.</string>
     <string name="daita_description_slide_1_first_paragraph">Atenção: Isto aumenta o tráfego de rede e também afeta negativamente a velocidade, a latência e a utilização da bateria. Utilize com precaução em planos limitados.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Remover %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">O dispositivo será removido da lista e terminará a sessão.</string>
     <string name="manage_devices_description">Veja e faça a gestão de todos os seus dispositivos com sessão iniciada. Pode ter até 5 dispositivos numa conta de cada vez. Cada dispositivo recebe um nome quando tem sessão iniciada para ajudar a distingui-los facilmente.</string>
-    <string name="max_devices_confirm_removal_description">Tem a certeza de que quer terminar a sessão de &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="max_devices_confirm_removal_description">Tem a certeza de que quer terminar a sessão de <b>%1$s</b>?</string>
     <string name="max_devices_resolved_description">Agora pode continuar a ligação neste dispositivo.</string>
     <string name="max_devices_resolved_title">Excelente!</string>
     <string name="max_devices_warning_description">Desligue-se de pelo menos um dos dispositivos removendo-o da lista abaixo. Pode encontrar o nome do dispositivo correspondente nas definições de Conta do dispositivo.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Navegar</string>
     <string name="new_changelog_notification_message">Clique aqui para ver as novidades.</string>
     <string name="new_changelog_notification_title">NOVA VERSÃO INSTALADA</string>
-    <string name="new_device_notification_message">As boas-vindas, este dispositivo tem agora o nome &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">As boas-vindas, este dispositivo tem agora o nome <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NOVO DISPOSITIVO CRIADO</string>
     <string name="new_list">Nova lista</string>
     <string name="no_custom_lists_available">Nenhuma lista personalizada disponível</string>

--- a/android/lib/ui/resource/src/main/res/values-ru/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-ru/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Все приложения</string>
     <string name="all_locations">Все местоположения</string>
     <string name="all_providers">Все провайдеры</string>
-    <string name="always_on_vpn_error_notification_content">Не удалось запустить туннельное подключение. Перед использованием Mullvad VPN отключите опцию «Постоянная VPN» для приложения &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="always_on_vpn_error_notification_content">Не удалось запустить туннельное подключение. Перед использованием Mullvad VPN отключите опцию «Постоянная VPN» для приложения <b>%1$s</b>.</string>
     <string name="always_on_vpn_error_notification_title">Опция «Постоянная VPN» назначена приложению «%1$s»</string>
     <string name="android_16_upgrade_warning_dialog_first_message">После обновления VPN-приложения на Android 16 VPN-приложения иногда теряют доступ к Интернету.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Перезагрузите устройство и снова попробуйте подключиться. Если это не поможет, отправьте письмо на %1$s на английском или шведском.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Проблемы с подключением?</string>
     <string name="anti_censorship">Обход цензуры</string>
     <string name="anti_censorship_info_first_paragraph">Эти методы могут помочь, если вам заблокировали доступ в Mullvad. Когда выбран вариант «Автоматически», приложение будет перебирать все методы, пока не найдет подходящий.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Обратите внимание: эти методы не улучшают производительность, а наоборот, могут увеличить энергопотребление и нагрузку на систему.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Обратите внимание: эти методы не улучшают производительность, а наоборот, могут увеличить энергопотребление и нагрузку на систему.</b></string>
     <string name="any">Все</string>
     <string name="api_access_description">Добавление пользовательских методов для доступа к API Mullvad и управление ими.</string>
     <string name="api_access_method_info_first_line">Приложение должно взаимодействовать с сервером API Mullvad для входа в учетную запись, получения списков серверов и других важных операций.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Погода</string>
     <string name="appearance">Внешний вид</string>
     <string name="appearance_description">Измените название и значок приложения Mullvad VPN на устройстве Android. Это не повлияет на значок уведомлений, связанных с Mullvad VPN.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Внимание:&lt;/b&gt; после выбора нового значка и названия приложение автоматически закроется и его потребуется открыть вручную. Это не повлияет на ваше VPN-соединение.</string>
+    <string name="appearance_description_warning"><b>Внимание:</b> после выбора нового значка и названия приложение автоматически закроется и его потребуется открыть вручную. Это не повлияет на ваше VPN-соединение.</string>
     <string name="apply">Применить</string>
     <string name="applying_changes">Применяем изменения...</string>
     <string name="at_least_on_method_needs_to_enabled">Должен быть включен хотя бы один метод</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Настройки автоподключения и режима блокировки можно найти в системных настройках Android. Чтобы включить их, следуйте этой инструкции.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Чтобы включить автоподключение, нажмите на переключатель возле пункта «Постоянная VPN».</string>
     <string name="auto_connect_carousel_second_slide_top_text">В системных настройках Android автоподключение называется «Постоянная VPN». Эта опция обеспечивает постоянное подключение к туннелю VPN и автоподключение после перезапуска.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Чтобы включить режим блокировки, нажмите на переключатель рядом с пунктом «Блокировать соединения без VPN».&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Предупреждение: этот параметр блокирует приложения из списка раздельного туннелирования и функцию «Обмен данными в локальной сети».&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Чтобы включить режим блокировки, нажмите на переключатель рядом с пунктом «Блокировать соединения без VPN».<br /><br /><b>Предупреждение: этот параметр блокирует приложения из списка раздельного туннелирования и функцию «Обмен данными в локальной сети».</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">В системных настройках Android режим блокировки называется «Блокировать соединения без VPN». Он помогает минимизировать утечки, однако имеет ряд известных ограничений, прочитать подробнее о которых можно</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">здесь</string>
     <string name="automatic">Автоматически</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Удалить пользовательский порт</string>
     <string name="custom_port_dialog_submit">Установить порт</string>
     <string name="custom_port_dialog_valid_ranges">Допустимые диапазоны: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Внимание:&lt;/b&gt; не все серверы поддерживают полный диапазон портов.</string>
+    <string name="custom_port_recommended_range_first"><b>Внимание:</b> не все серверы поддерживают полный диапазон портов.</string>
     <string name="custom_port_recommended_range_second">Допустимый диапазон для всех серверов: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Не удалось преобразовать имя узла пользовательского туннеля. Попробуйте изменить настройки.</string>
     <string name="daita_description_slide_1_first_paragraph">Внимание! Включение этой функции приведет к увеличению сетевого трафика. Также снизится скорость, увеличится задержка и усилится расход заряда аккумулятора. Будьте внимательны при использовании функции на ограниченных по трафику планах.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Удалить устройство «%1$s»?</string>
     <string name="manage_devices_confirm_removal_description_line2">Устройство выйдет из профиля и будет удалено из списка.</string>
     <string name="manage_devices_description">Просмотр подключенных устройств и управление ими. К одной учетной записи можно подключить 5 устройств. При входе каждому устройству присваивается имя, чтобы их было легче различать.</string>
-    <string name="max_devices_confirm_removal_description">Действительно выйти из профиля на устройстве &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="max_devices_confirm_removal_description">Действительно выйти из профиля на устройстве <b>%1$s</b>?</string>
     <string name="max_devices_resolved_description">Теперь можно войти в учетную запись на этом устройстве.</string>
     <string name="max_devices_resolved_title">Отлично!</string>
     <string name="max_devices_warning_description">Выйдите из учетной записи хотя бы на одном из устройств, удалив его из списка ниже. Имя устройства указано в настройках учетной записи.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Перейти</string>
     <string name="new_changelog_notification_message">Нажмите здесь и узнайте, что нового.</string>
     <string name="new_changelog_notification_title">УСТАНОВЛЕНА НОВАЯ ВЕРСИЯ</string>
-    <string name="new_device_notification_message">Добро пожаловать! Это устройство теперь называется &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Добро пожаловать! Это устройство теперь называется <b>%1$s</b>.</string>
     <string name="new_device_notification_title">СОЗДАНО НОВОЕ УСТРОЙСТВО</string>
     <string name="new_list">Новый список</string>
     <string name="no_custom_lists_available">Нет своих списков</string>

--- a/android/lib/ui/resource/src/main/res/values-sv/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-sv/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Alla applikationer</string>
     <string name="all_locations">Alla platser</string>
     <string name="all_providers">Alla leverantörer</string>
-    <string name="always_on_vpn_error_notification_content">Det går inte att starta tunnelanslutning. Inaktivera Alltid på-VPN för &lt;b&gt;%1$s&lt;/b&gt; innan du använder Mullvad VPN.</string>
+    <string name="always_on_vpn_error_notification_content">Det går inte att starta tunnelanslutning. Inaktivera Alltid på-VPN för <b>%1$s</b> innan du använder Mullvad VPN.</string>
     <string name="always_on_vpn_error_notification_title">Alltid på-VPN har tilldelats %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">När en VPN-app har uppdaterats på Android 16 kan enheterna hamna i ett tillstånd där VPN-apparna inte längre har åtkomst till internet.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Starta om enheten och försök att ansluta igen. Om det inte fungerar kan du skicka ett e-postmeddelande till %1$s på svenska eller engelska.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Kan du inte ansluta?</string>
     <string name="anti_censorship">Anti-censur</string>
     <string name="anti_censorship_info_first_paragraph">Dessa metoder kan vara användbara i situationer där du blockeras från att nå Mullvad. När \"Automatiskt\" är valt försöker appen med alla metoder tills en fungerar.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Observera att dessa metoder inte förbättrar prestandan och kan komma att öka systemanvändningen och batteriförbrukningen.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Observera att dessa metoder inte förbättrar prestandan och kan komma att öka systemanvändningen och batteriförbrukningen.</b></string>
     <string name="any">Valfri</string>
     <string name="api_access_description">Hantera och lägg till anpassade metoder för att komma åt Mullvad API.</string>
     <string name="api_access_method_info_first_line">Appen måste kommunicera med en Mullvad API-server för att logga in dig, hämta serverlistor och andra viktiga åtgärder.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Väder</string>
     <string name="appearance">Utseende</string>
     <string name="appearance_description">Ändra titeln och ikonen för Mullvad VPN-appen på Android-enheten. Detta ändrar inte ikonen för Mullvad VPN-relaterade aviseringar.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Obs!&lt;/b&gt; Appen stängs automatiskt och måste öppnas igen manuellt efter att du väljer en ny ikon och titel. Detta påverkar inte din VPN-anslutning.</string>
+    <string name="appearance_description_warning"><b>Obs!</b> Appen stängs automatiskt och måste öppnas igen manuellt efter att du väljer en ny ikon och titel. Detta påverkar inte din VPN-anslutning.</string>
     <string name="apply">Använd</string>
     <string name="applying_changes">Tillämpar ändringar …</string>
     <string name="at_least_on_method_needs_to_enabled">Minst en metod måste vara aktiverad</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Inställningar för Anslut automatiskt och Låsningsläge finns i Androids systeminställningar. Följ guiden för att aktivera en av dem eller båda.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Om du vill aktivera Anslut automatiskt klickar du på växlingsknappen bredvid \"Alltid på-VPN\".</string>
     <string name="auto_connect_carousel_second_slide_top_text">Anslut automatiskt kallas Alltid på-VPN i Androids systeminställningar och ser till att du är ansluten till VPN-tunneln oavbrutet och ansluter automatiskt efter omstart.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Om du vill aktivera Låsningsläge klickar du på växlingsknappen bredvid \"Blockera anslutningar utan VPN\".&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Varning! Den här inställningen blockerar delade appar och funktionen Lokal nätverksdelning.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Om du vill aktivera Låsningsläge klickar du på växlingsknappen bredvid \"Blockera anslutningar utan VPN\".<br /><br /><b>Varning! Den här inställningen blockerar delade appar och funktionen Lokal nätverksdelning.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Låsningsläget kallas \"Blockera anslutningar utan VPN\" i systeminställningarna på Android. Det minimerar läckor men det finns några kända begränsningar som du kan läsa mer om</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">här</string>
     <string name="automatic">Automatisk</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Ta bort anpassad port</string>
     <string name="custom_port_dialog_submit">Ställ in port</string>
     <string name="custom_port_dialog_valid_ranges">Giltiga intervall: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Obs!&lt;/b&gt; Enbart några servrar har stöd för hela portintervallet.</string>
+    <string name="custom_port_recommended_range_first"><b>Obs!</b> Enbart några servrar har stöd för hela portintervallet.</string>
     <string name="custom_port_recommended_range_second">Giltigt intervall för alla servrar: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Det går inte att lösa värd för anpassad tunnel. Försök att ändra inställningarna.</string>
     <string name="daita_description_slide_1_first_paragraph">Obs! Detta ökar nätverkstrafiken men påverkar också hastighet, fördröjning och batterianvändning negativt. Var försiktig om du har ett abonnemang med begränsad datamängd.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">Ta bort %1$s?</string>
     <string name="manage_devices_confirm_removal_description_line2">Enheten tas bort från listan och loggas ut.</string>
     <string name="manage_devices_description">Visa och hantera alla dina inloggade enheter. Du kan ha upp till fem enheter åt gången på ett konto. Varje enhet får ett namn när den loggas in så att du enklare kan skilja dem åt.</string>
-    <string name="max_devices_confirm_removal_description">Vill du verkligen logga ut &lt;b&gt;%1$s&lt;/b&gt;?</string>
+    <string name="max_devices_confirm_removal_description">Vill du verkligen logga ut <b>%1$s</b>?</string>
     <string name="max_devices_resolved_description">Du kan nu fortsätta med att logga in på den här enheten.</string>
     <string name="max_devices_resolved_title">Super!</string>
     <string name="max_devices_warning_description">Logga ut på minst en enhet genom att ta bort den från listan nedan. Du hittar motsvarande enhetsnamn i enhetens kontoinställningar.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Navigera</string>
     <string name="new_changelog_notification_message">Klicka här för att se nyheterna.</string>
     <string name="new_changelog_notification_title">NY VERSION INSTALLERAD</string>
-    <string name="new_device_notification_message">Välkommen. Den här enheten har fått namnet &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Välkommen. Den här enheten har fått namnet <b>%1$s</b>.</string>
     <string name="new_device_notification_title">NY ENHET HAR SKAPATS</string>
     <string name="new_list">Ny lista</string>
     <string name="no_custom_lists_available">Inga anpassade listor är tillgängliga</string>

--- a/android/lib/ui/resource/src/main/res/values-th/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-th/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">แอปพลิเคชันทั้งหมด</string>
     <string name="all_locations">ตำแหน่งที่ตั้งทั้งหมด</string>
     <string name="all_providers">ผู้ให้บริการทั้งหมด</string>
-    <string name="always_on_vpn_error_notification_content">ไม่สามารถเริ่มการเชื่อมต่ออุโมงค์ได้ โปรดปิดใช้งาน Always-on VPN เป็นเวลา &lt;b&gt;%1$s&lt;/b&gt; ก่อนที่จะใช้งาน Mullvad VPN</string>
+    <string name="always_on_vpn_error_notification_content">ไม่สามารถเริ่มการเชื่อมต่ออุโมงค์ได้ โปรดปิดใช้งาน Always-on VPN เป็นเวลา <b>%1$s</b> ก่อนที่จะใช้งาน Mullvad VPN</string>
     <string name="always_on_vpn_error_notification_title">VPN เปิดอยู่เสมอ ได้รับการมอบหมายไปยัง %1$s แล้ว</string>
     <string name="android_16_upgrade_warning_dialog_first_message">หลังจากอัปเดตแอป VPN บน Android 16 อุปกรณ์อาจอยู่ในสถานะที่แอป VPN ไม่สามารถเข้าถึงอินเทอร์เน็ตได้อีกต่อไป</string>
     <string name="android_16_upgrade_warning_dialog_second_message">โปรดรีสตาร์ทอุปกรณ์ของคุณและลองเชื่อมต่ออีกครั้ง หากวิธีนี้ไม่ได้ผล โปรดเขียนอีเมลถึง %1$s เป็นภาษาสวีเดนหรืออังกฤษ</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">ไม่สามารถเชื่อมต่อได้ใช่ไหม</string>
     <string name="anti_censorship">การป้องกันการเซ็นเซอร์</string>
     <string name="anti_censorship_info_first_paragraph">วิธีการเหล่านี้อาจมีประโยชน์ในสถานการณ์ที่คุณถูกบล็อกไม่ให้เข้าถึง Mullvad เมื่อเลือก \"อัตโนมัติ\" แอปจะพยายามใช้ทุกวิธีจนกว่าจะมีวิธีใดวิธีหนึ่งที่ใช้งานได้</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;โปรดทราบว่าวิธีการเหล่านี้ไม่ได้ช่วยปรับปรุงประสิทธิภาพ แต่อาจเพิ่มการใช้งานระบบและการใช้แบตเตอรี่&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>โปรดทราบว่าวิธีการเหล่านี้ไม่ได้ช่วยปรับปรุงประสิทธิภาพ แต่อาจเพิ่มการใช้งานระบบและการใช้แบตเตอรี่</b></string>
     <string name="any">อะไรก็ได้</string>
     <string name="api_access_description">จัดการและเพิ่มวิธีแบบกำหนดเอง เพื่อเข้าถึง Mullvad API</string>
     <string name="api_access_method_info_first_line">แอปจำเป็นต้องสื่อสารกับเซิร์ฟเวอร์ Mullvad API เพื่อนำคุณเข้าสู่ระบบ ดึงข้อมูลรายการเซิร์ฟเวอร์ และการดำเนินการที่สำคัญอื่นๆ</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">สภาพอากาศ</string>
     <string name="appearance">รูปลักษณ์</string>
     <string name="appearance_description">เปลี่ยนชื่อและไอคอนของแอป Mullvad VPN บนอุปกรณ์ Android ของคุณ การดำเนินการนี้จะไม่เปลี่ยนไอคอนสำหรับการแจ้งเตือนที่เกี่ยวข้องกับ Mullvad VPN</string>
-    <string name="appearance_description_warning">&lt;b&gt;ข้อควรระวัง:&lt;/b&gt; แอปจะปิดโดยอัตโนมัติและต้องเปิดใหม่ด้วยตนเองหลังจากเลือกไอคอนและชื่อใหม่ การดำเนินการนี้จะไม่ส่งผลต่อการเชื่อมต่อ VPN ของคุณ</string>
+    <string name="appearance_description_warning"><b>ข้อควรระวัง:</b> แอปจะปิดโดยอัตโนมัติและต้องเปิดใหม่ด้วยตนเองหลังจากเลือกไอคอนและชื่อใหม่ การดำเนินการนี้จะไม่ส่งผลต่อการเชื่อมต่อ VPN ของคุณ</string>
     <string name="apply">ใช้</string>
     <string name="applying_changes">กำลังปรับใช้การเปลี่ยนแปลง...</string>
     <string name="at_least_on_method_needs_to_enabled">จำเป็นต้องเปิดใช้อย่างน้อยหนึ่งวิธีการ</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">การตั้งค่าการเชื่อมต่ออัตโนมัติและโหมดล็อกดาวน์ อยู่ในการตั้งค่าระบบ Android โปรดทำตามคำแนะนำนี้ เพื่อเปิดใช้งานโหมดใดโหมดหนึ่ง หรือทั้งสองโหมด</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. ในการเปิดใช้การเชื่อมต่ออัตโนมัติ ให้คลิกปุ่มเปิด/ปิดที่อยู่ถัดจาก \"VPN เปิดอยู่เสมอ\"</string>
     <string name="auto_connect_carousel_second_slide_top_text">การเชื่อมต่ออัตโนมัติเรียกว่า Always-on VPN ในการตั้งค่าระบบ Android ซึ่งจะช่วยให้คุณมั่นใจได้ว่า คุณเชื่อมต่อกับช่องทาง VPN อย่างต่อเนื่อง และมีการเชื่อมต่ออัตโนมัติหลังจากรีสตาร์ต</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. ในการเปิดโหมดล็อกดาวน์ ให้คลิกปุ่มเปิด/ปิดที่อยู่ถัดจาก \"ปิดกั้นการเชื่อมต่อที่ไม่ใช้ VPN\"&lt;br /&gt;&lt;br /&gt;&lt;b&gt;คำเตือน: การตั้งค่านี้จะบล็อกแอปที่มีการแยก และคุณลักษณะการแชร์เครือข่ายท้องถิ่น&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. ในการเปิดโหมดล็อกดาวน์ ให้คลิกปุ่มเปิด/ปิดที่อยู่ถัดจาก \"ปิดกั้นการเชื่อมต่อที่ไม่ใช้ VPN\"<br /><br /><b>คำเตือน: การตั้งค่านี้จะบล็อกแอปที่มีการแยก และคุณลักษณะการแชร์เครือข่ายท้องถิ่น</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">โหมดล็อกดาวน์ถูกเรียกว่า \"ปิดกั้นการเชื่อมต่อที่ไม่ใช้ VPN\" ในการตั้งค่าระบบ Android ซึ่งจะช่วยลดการรั่วไหล แต่ก็มีข้อจำกัดบางประการ ซึ่งคุณสามารถอ่านข้อมูลเพิ่มเติมเกี่ยวกับเรื่องดังกล่าวได้</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">ที่นี่</string>
     <string name="automatic">อัตโนมัติ</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">นำพอร์ตแบบกำหนดเองออก</string>
     <string name="custom_port_dialog_submit">ตั้งค่าพอร์ต</string>
     <string name="custom_port_dialog_valid_ranges">ช่วงที่ใช้ได้: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;ข้อควรระวัง:&lt;/b&gt; มีเพียงบางเซิร์ฟเวอร์เท่านั้นที่รองรับช่วงพอร์ตได้ทั้งหมด</string>
+    <string name="custom_port_recommended_range_first"><b>ข้อควรระวัง:</b> มีเพียงบางเซิร์ฟเวอร์เท่านั้นที่รองรับช่วงพอร์ตได้ทั้งหมด</string>
     <string name="custom_port_recommended_range_second">ช่วงที่ใช้ได้สำหรับทุกเซิร์ฟเวอร์: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">ไม่พบโฮสต์ของช่องทางแบบกำหนดเอง กรุณาลองเปลี่ยนการตั้งค่าของคุณ</string>
     <string name="daita_description_slide_1_first_paragraph">โปรดทราบ: การดำเนินการนี้จะเพิ่มการรับส่งข้อมูลทางเครือข่าย และส่งผลเสียต่อความเร็ว ความหน่วงแฝง และการใช้งานแบตเตอรี่ โปรดใช้ด้วยความระมัดระวังในขณะที่ใช้แผนบริการแบบจำกัด</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">ลบ %1$s หรือไม่</string>
     <string name="manage_devices_confirm_removal_description_line2">อุปกรณ์จะถูกลบออกจากรายการและออกจากระบบ</string>
     <string name="manage_devices_description">ดูและจัดการอุปกรณ์ทั้งหมดที่คุณลงชื่อเข้าใช้ คุณสามารถมีอุปกรณ์ได้สูงสุด 5 เครื่องในหนึ่งบัญชีในเวลาเดียวกัน แต่ละอุปกรณ์จะได้รับชื่อในขณะที่ลงชื่อเข้าใช้ เพื่อช่วยให้คุณแยกแยะอุปกรณ์แต่ละเครื่องได้อย่างง่ายดาย</string>
-    <string name="max_devices_confirm_removal_description">คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบ &lt;b&gt;%1$s&lt;/b&gt;</string>
+    <string name="max_devices_confirm_removal_description">คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบ <b>%1$s</b></string>
     <string name="max_devices_resolved_description">คุณสามารถดำเนินการเข้าสู่ระบบต่อบนอุปกรณ์เครื่องนี้ได้แล้ว</string>
     <string name="max_devices_resolved_title">เยี่ยมยอด!</string>
     <string name="max_devices_warning_description">โปรดลงชื่อออกจากระบบบนอุปกรณ์อย่างน้อยหนึ่งเครื่อง เพื่อนำอุปกรณ์ออกจากรายการด้านล่าง คุณสามารถดูชื่ออุปกรณ์ที่เกี่ยวข้องได้ ภายใต้การตั้งค่าบัญชีของอุปกรณ์</string>
@@ -299,7 +299,7 @@
     <string name="navigate">นำทาง</string>
     <string name="new_changelog_notification_message">คลิกที่นี่ เพื่อดูว่ามีอะไรใหม่</string>
     <string name="new_changelog_notification_title">ติดตั้งเวอร์ชันใหม่แล้ว</string>
-    <string name="new_device_notification_message">ยินดีต้อนรับ อุปกรณ์นี้มีชื่อว่า &lt;b&gt;%1$s&lt;/b&gt; แล้ว</string>
+    <string name="new_device_notification_message">ยินดีต้อนรับ อุปกรณ์นี้มีชื่อว่า <b>%1$s</b> แล้ว</string>
     <string name="new_device_notification_title">สร้างอุปกรณ์ใหม่แล้ว</string>
     <string name="new_list">รายการใหม่</string>
     <string name="no_custom_lists_available">ไม่มีรายการแบบกำหนดเองที่พร้อมใช้งาน</string>

--- a/android/lib/ui/resource/src/main/res/values-tr/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-tr/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">Tüm uygulamalar</string>
     <string name="all_locations">Tüm konumlar</string>
     <string name="all_providers">Tüm hizmet sağlayıcılar</string>
-    <string name="always_on_vpn_error_notification_content">Tünel bağlantısı başlatılamıyor. Mullvad VPN\'i kullanmadan önce lütfen Her zaman açık VPN\'i &lt;b&gt;%1$s&lt;/b&gt; için devre dışı bırakın.</string>
+    <string name="always_on_vpn_error_notification_content">Tünel bağlantısı başlatılamıyor. Mullvad VPN\'i kullanmadan önce lütfen Her zaman açık VPN\'i <b>%1$s</b> için devre dışı bırakın.</string>
     <string name="always_on_vpn_error_notification_title">Her zaman açık VPN %1$s uygulamasına atandı</string>
     <string name="android_16_upgrade_warning_dialog_first_message">Android 16\'da bir VPN uygulaması güncellendikten sonra, cihazlar VPN uygulamalarının artık internete erişemediği bir duruma geçebilir.</string>
     <string name="android_16_upgrade_warning_dialog_second_message">Lütfen cihazınızı yeniden başlatın ve tekrar bağlanmayı deneyin. Bu işe yaramazsa lütfen %1$s adresine İsveççe veya İngilizce bir e-posta yazın.</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">Bağlanamıyor musunuz?</string>
     <string name="anti_censorship">Sansürü önleme</string>
     <string name="anti_censorship_info_first_paragraph">Bu yöntemler, Mullvad erişiminin engellendiği durumlarda faydalı olabilir. \"Otomatik\" seçeneği ayarlandığında uygulama yöntemlerden biri çalışana kadar tüm yöntemleri dener.</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;Bu yöntemlerin performansı iyileştirmediğini ve sistem kullanımı ile pil tüketimini artırabileceğini lütfen göz önünde bulundurun.&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>Bu yöntemlerin performansı iyileştirmediğini ve sistem kullanımı ile pil tüketimini artırabileceğini lütfen göz önünde bulundurun.</b></string>
     <string name="any">Tümü</string>
     <string name="api_access_description">Mullvad API\'sine erişim için özel yöntemler ekleyip yönetin.</string>
     <string name="api_access_method_info_first_line">Uygulamanın oturumunuzu açmak, sunucu listelerini almak ve diğer kritik işlemleri yapmak için bir Mullvad API sunucusuyla iletişim kurması gerekir.</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">Hava durumu</string>
     <string name="appearance">Görünüm</string>
     <string name="appearance_description">Android cihazınızdaki Mullvad VPN uygulamasının başlığını ve simgesini değiştirin. Bu işlem, Mullvad VPN ile ilgili bildirimlerin simgesini değiştirmeyecektir.</string>
-    <string name="appearance_description_warning">&lt;b&gt;Dikkat:&lt;/b&gt; Uygulama otomatik olarak kapanacağı için yeni bir simge ve başlık seçildikten sonra manuel olarak tekrar açılması gerekecektir. Bu durum VPN bağlantınızı etkilemez.</string>
+    <string name="appearance_description_warning"><b>Dikkat:</b> Uygulama otomatik olarak kapanacağı için yeni bir simge ve başlık seçildikten sonra manuel olarak tekrar açılması gerekecektir. Bu durum VPN bağlantınızı etkilemez.</string>
     <string name="apply">Uygula</string>
     <string name="applying_changes">Değişiklikler uygulanıyor...</string>
     <string name="at_least_on_method_needs_to_enabled">En az bir yöntemin etkinleştirilmesi gerekiyor</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">Otomatik Bağlantı ve Kilitleme modu ayarları Android sistem ayarlarında yer alır. Bu ayarlardan birini veya her ikisini de etkinleştirmek için bu kılavuza göz atın.</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. Otomatik bağlantıyı etkinleştirmek için \"VPN her zaman açık\" seçeneğinin yanındaki düğmeye tıklayın.</string>
     <string name="auto_connect_carousel_second_slide_top_text">Otomatik bağlantı, Android sistem ayarlarında VPN her zaman açık olarak gösterilir ve VPN tüneline sürekli bağlı olmanızı ve yeniden başlatma sonrası otomatik olarak bağlanmanızı sağlar.</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. Kilitleme modunu etkinleştirmek için \"VPN üzerinden olmayan bağlantıları engelle\" seçeneğinin yanındaki düğmeye tıklayın.&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Uyarı: Bu ayar, bölünmüş uygulamaları ve Yerel Ağ Paylaşımı özelliğini engeller.&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. Kilitleme modunu etkinleştirmek için \"VPN üzerinden olmayan bağlantıları engelle\" seçeneğinin yanındaki düğmeye tıklayın.<br /><br /><b>Uyarı: Bu ayar, bölünmüş uygulamaları ve Yerel Ağ Paylaşımı özelliğini engeller.</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">Android sistem ayarlarında \"Kilitleme modu VPN üzerinden olmayan bağlantıları engelle\" olarak adlandırılmıştır. Bu özellik, sızıntıları en aza indirmeye yardımcı olsa da ayrıntılar konusunda bilgi edinmeniz gereken bazı bilinen sınırlamaları vardır</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">burada</string>
     <string name="automatic">Otomatik</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">Özel portu kaldır</string>
     <string name="custom_port_dialog_submit">Portu ayarla</string>
     <string name="custom_port_dialog_valid_ranges">Geçerli aralıklar: %1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;Dikkat:&lt;/b&gt; Sadece bazı sunucular tam bağlantı noktası aralığını destekler.</string>
+    <string name="custom_port_recommended_range_first"><b>Dikkat:</b> Sadece bazı sunucular tam bağlantı noktası aralığını destekler.</string>
     <string name="custom_port_recommended_range_second">Tüm sunucular için geçerli aralık: %1$s</string>
     <string name="custom_tunnel_host_resolution_error">Özel tünel ana bilgisayarı çözülemedi. Ayarlarınızı değiştirmeyi deneyin.</string>
     <string name="daita_description_slide_1_first_paragraph">Dikkat: Bu, ağ trafiğini artırır ve hızı, gecikmeyi ve pil kullanımını da olumsuz bir şekilde etkiler. Sınırlı planlarda dikkatli kullanın.</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">%1$s kaldırılsın mı?</string>
     <string name="manage_devices_confirm_removal_description_line2">Cihaz listeden kaldırılacak ve oturum kapatılacak.</string>
     <string name="manage_devices_description">Oturum açtığınız tüm cihazları görüntüleyin ve yönetin. Bir hesapta aynı anda en fazla 5 cihaz bulunabilir. Kolayca ayırt edebilmeniz için her cihaza giriş sırasında bir ad atanır.</string>
-    <string name="max_devices_confirm_removal_description">&lt;b&gt;%1$s&lt;/b&gt; adlı cihazdan çıkış yapmak istediğinizden emin misiniz?</string>
+    <string name="max_devices_confirm_removal_description"><b>%1$s</b> adlı cihazdan çıkış yapmak istediğinizden emin misiniz?</string>
     <string name="max_devices_resolved_description">Artık bu cihazda oturum açmaya devam edebilirsiniz.</string>
     <string name="max_devices_resolved_title">Süper!</string>
     <string name="max_devices_warning_description">Lütfen aşağıdaki listeden en az bir cihazı kaldırarak çıkış yapın. İlgili cihaz adını cihazın Hesap ayarları altında bulabilirsiniz.</string>
@@ -299,7 +299,7 @@
     <string name="navigate">Git</string>
     <string name="new_changelog_notification_message">Yenilikleri incelemek için buraya tıklayın.</string>
     <string name="new_changelog_notification_title">YENİ SÜRÜM YÜKLENDİ</string>
-    <string name="new_device_notification_message">Hoş geldiniz, bu cihazın yeni adı artık &lt;b&gt;%1$s&lt;/b&gt;.</string>
+    <string name="new_device_notification_message">Hoş geldiniz, bu cihazın yeni adı artık <b>%1$s</b>.</string>
     <string name="new_device_notification_title">YENİ CİHAZ OLUŞTURULDU</string>
     <string name="new_list">Yeni liste</string>
     <string name="no_custom_lists_available">Özel listeler mevcut değil</string>

--- a/android/lib/ui/resource/src/main/res/values-zh-rCN/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-zh-rCN/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">所有应用程序</string>
     <string name="all_locations">所有位置</string>
     <string name="all_providers">所有提供商</string>
-    <string name="always_on_vpn_error_notification_content">无法启动隧道连接。在使用 Mullvad VPN 之前，请为 &lt;b&gt;%1$s&lt;/b&gt; 停用“始终开启 VPN”。</string>
+    <string name="always_on_vpn_error_notification_content">无法启动隧道连接。在使用 Mullvad VPN 之前，请为 <b>%1$s</b> 停用“始终开启 VPN”。</string>
     <string name="always_on_vpn_error_notification_title">“始终开启 VPN”已分配给 %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">在 Android 16 上更新 VPN 应用后，设备可能会出现 VPN 应用无法连接互联网的情况。</string>
     <string name="android_16_upgrade_warning_dialog_second_message">请重新启动您的设备，然后再次尝试连接。如果仍然无法连接，请用瑞典语或英语发送电子邮件至 %1$s。</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">无法连接？</string>
     <string name="anti_censorship">反审查</string>
     <string name="anti_censorship_info_first_paragraph">这些方法在您无法连接到 Mullvad 时可能会有所帮助。选择“自动”时，应用将尝试所有方法，直到其中一种方法生效。</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;请注意，这些方法并不能提高性能，反而可能会增加系统资源占用率和电量消耗。&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>请注意，这些方法并不能提高性能，反而可能会增加系统资源占用率和电量消耗。</b></string>
     <string name="any">任何</string>
     <string name="api_access_description">管理和添加访问 Mulvad API 的自定义方法。</string>
     <string name="api_access_method_info_first_line">该应用需要与 Mulvad API 服务器通信，以便您登录、获取服务器列表和执行其他关键操作。</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">天气</string>
     <string name="appearance">外观</string>
     <string name="appearance_description">更改 Android 设备上 Mullvad VPN 应用的标题和图标。这不会更改任何 Mullvad VPN 相关通知的图标。</string>
-    <string name="appearance_description_warning">&lt;b&gt;注意&lt;/b&gt;：应用将自动关闭，在选择新的图标和标题后，需要手动再次打开。这不会影响您的 VPN 连接。</string>
+    <string name="appearance_description_warning"><b>注意</b>：应用将自动关闭，在选择新的图标和标题后，需要手动再次打开。这不会影响您的 VPN 连接。</string>
     <string name="apply">应用</string>
     <string name="applying_changes">正在应用更改…</string>
     <string name="at_least_on_method_needs_to_enabled">至少需要启用一个方法</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">自动连接和锁定模式设置可以在 Android 系统设置中找到，请按照本指南启用其中一项或两项。</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. 要启用自动连接，请点击“始终开启 VPN”旁边的开关。</string>
     <string name="auto_connect_carousel_second_slide_top_text">自动连接在 Android 系统设置中称为“始终开启 VPN”，此功能可确保您始终连接到 VPN 隧道并在重新启动后自动连接。</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. 要启用锁定模式，请点击“屏蔽未使用 VPN 的所有连接”旁边的开关。&lt;br /&gt;&lt;br /&gt;&lt;b&gt;警告：此设置会屏蔽分割应用和“本地网络共享”功能。&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. 要启用锁定模式，请点击“屏蔽未使用 VPN 的所有连接”旁边的开关。<br /><br /><b>警告：此设置会屏蔽分割应用和“本地网络共享”功能。</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">在 Android 系统设置中，锁定模式被称为“屏蔽未使用 VPN 的所有连接”。该模式可以最大限度地减少泄露，但是也有一些已知的限制，要了解详情，请点击</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">（点击此处）</string>
     <string name="automatic">自动</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">移除自定义端口</string>
     <string name="custom_port_dialog_submit">设置端口</string>
     <string name="custom_port_dialog_valid_ranges">有效范围：%1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;注意&lt;/b&gt;：只有部分服务器支持完整的端口范围。</string>
+    <string name="custom_port_recommended_range_first"><b>注意</b>：只有部分服务器支持完整的端口范围。</string>
     <string name="custom_port_recommended_range_second">所有服务器的有效范围：%1$s</string>
     <string name="custom_tunnel_host_resolution_error">无法解析自定义隧道的主机。请尝试更改您的设置。</string>
     <string name="daita_description_slide_1_first_paragraph">注意：这会增加网络流量，还会对速度、延迟和电池使用产生负面影响。如果套餐流量有限，请谨慎使用。</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">是否移除“%1$s”？</string>
     <string name="manage_devices_confirm_removal_description_line2">该设备将从列表中移除并退出登录。</string>
     <string name="manage_devices_description">查看和管理您所有已登录的设备。一个帐户最多可以同时登录 5 台设备。每台设备登录时都会获得一个名称，以便您能够轻松区分。</string>
-    <string name="max_devices_confirm_removal_description">确定要退出 &lt;b&gt;%1$s&lt;/b&gt; 吗？</string>
+    <string name="max_devices_confirm_removal_description">确定要退出 <b>%1$s</b> 吗？</string>
     <string name="max_devices_resolved_description">您现在可以继续在此设备上登录。</string>
     <string name="max_devices_resolved_title">太棒了！</string>
     <string name="max_devices_warning_description">请通过从以下列表中移除的方式退出至少一个帐户。您可以在设备的帐户设置下找到相应设备名称。</string>
@@ -299,7 +299,7 @@
     <string name="navigate">导航</string>
     <string name="new_changelog_notification_message">点击此处查看最新变化。</string>
     <string name="new_changelog_notification_title">已安装新版本</string>
-    <string name="new_device_notification_message">欢迎，此设备现已命名为 &lt;b&gt;%1$s&lt;/b&gt;。</string>
+    <string name="new_device_notification_message">欢迎，此设备现已命名为 <b>%1$s</b>。</string>
     <string name="new_device_notification_title">已创建新设备</string>
     <string name="new_list">新建列表</string>
     <string name="no_custom_lists_available">有可用的自定义列表</string>

--- a/android/lib/ui/resource/src/main/res/values-zh-rTW/strings.xml
+++ b/android/lib/ui/resource/src/main/res/values-zh-rTW/strings.xml
@@ -22,7 +22,7 @@
     <string name="all_applications">所有應用程式</string>
     <string name="all_locations">所有位置</string>
     <string name="all_providers">所有供應商</string>
-    <string name="always_on_vpn_error_notification_content">無法啟動通道連線。在使用 Mullvad VPN 之前，請先為 &lt;b&gt;%1$s&lt;/b&gt; 停用「始終啟用 VPN」。</string>
+    <string name="always_on_vpn_error_notification_content">無法啟動通道連線。在使用 Mullvad VPN 之前，請先為 <b>%1$s</b> 停用「始終啟用 VPN」。</string>
     <string name="always_on_vpn_error_notification_title">「一律啟用 VPN」已指派給 %1$s</string>
     <string name="android_16_upgrade_warning_dialog_first_message">在 Android 16 更新 VPN 應用程式後，裝置可能會出現 VPN 應用程式無法連線至網際網路的情況。</string>
     <string name="android_16_upgrade_warning_dialog_second_message">請重新啟動您的裝置並嘗試重新連線。若不成功，請以瑞典語或英語撰寫電子郵件並寄至 %1$s。</string>
@@ -30,7 +30,7 @@
     <string name="android_16_upgrade_warning_title">無法連線嗎？</string>
     <string name="anti_censorship">反審查</string>
     <string name="anti_censorship_info_first_paragraph">當您無法連上 Mullvad 時，這些方式可能會派上用場。選擇「自動」時，應用程式會嘗試所有方式，直到其中一種成功為止。</string>
-    <string name="anti_censorship_info_second_paragraph">&lt;b&gt;請注意，這些方式不會提升效能，還可能消耗更多系統資源與電力。&lt;/b&gt;</string>
+    <string name="anti_censorship_info_second_paragraph"><b>請注意，這些方式不會提升效能，還可能消耗更多系統資源與電力。</b></string>
     <string name="any">任何</string>
     <string name="api_access_description">管理並新增自訂方式以存取 Mullvad API。</string>
     <string name="api_access_method_info_first_line">該應用程式需要與 Mulvad API 伺服器通訊，以便您登入、取得伺服器清單並執行其他重要作業。</string>
@@ -48,7 +48,7 @@
     <string name="app_name_weather">天氣</string>
     <string name="appearance">外觀</string>
     <string name="appearance_description">變更您 Android 裝置上 Mullvad VPN 應用程式的圖示與標題。這不會變更 Mullvad VPN 相關通知所使用的圖示。</string>
-    <string name="appearance_description_warning">&lt;b&gt;請注意：&lt;/b&gt;應用程式將自動關閉，在選擇新的圖示與標題後，需手動重新開啟。這不會影響您的 VPN 連線。</string>
+    <string name="appearance_description_warning"><b>請注意：</b>應用程式將自動關閉，在選擇新的圖示與標題後，需手動重新開啟。這不會影響您的 VPN 連線。</string>
     <string name="apply">套用</string>
     <string name="applying_changes">正在套用變更…</string>
     <string name="at_least_on_method_needs_to_enabled">至少需要啟用一種方式</string>
@@ -60,7 +60,7 @@
     <string name="auto_connect_carousel_first_slide_top_text">自動連線和鎖定模式設定皆可在 Android 系統設定中找到，請按照本指南的指示，啟用其中一項或兩項設定。</string>
     <string name="auto_connect_carousel_second_slide_bottom_text">2. 若要啟用自動連線，請按一下「一律啟用 VPN」旁邊的開關。</string>
     <string name="auto_connect_carousel_second_slide_top_text">自動連線在 Android 系統設定中稱為「始終啟用 VPN」，此功能可確保您始終與 VPN 通道連線，並且會在重新啟動後自動連線。</string>
-    <string name="auto_connect_carousel_third_slide_bottom_text">3. 若要啟用鎖定模式，請按一下「在沒有 VPN 的情況下封鎖連線」旁邊的開關。&lt;br /&gt;&lt;br /&gt;&lt;b&gt;警告：此設定會封鎖分割應用程式和「本機網路共享」功能。&lt;/b&gt;</string>
+    <string name="auto_connect_carousel_third_slide_bottom_text">3. 若要啟用鎖定模式，請按一下「在沒有 VPN 的情況下封鎖連線」旁邊的開關。<br /><br /><b>警告：此設定會封鎖分割應用程式和「本機網路共享」功能。</b></string>
     <string name="auto_connect_carousel_third_slide_top_text">在 Android 系統設定中，鎖定模式稱為「在沒有 VPN 的情況下封鎖連線」。這有助於讓洩漏的情形降至最低。然而，也有一些已知的侷限性。如需進一步的相關資訊，請按一下</string>
     <string name="auto_connect_carousel_third_slide_top_text_website_link">此處</string>
     <string name="automatic">自動</string>
@@ -127,7 +127,7 @@
     <string name="custom_port_dialog_remove">移除自訂連接埠</string>
     <string name="custom_port_dialog_submit">設定連接埠</string>
     <string name="custom_port_dialog_valid_ranges">有效範圍：%1$s</string>
-    <string name="custom_port_recommended_range_first">&lt;b&gt;請注意：&lt;/b&gt;並非所有伺服器都支援完整連接埠範圍。</string>
+    <string name="custom_port_recommended_range_first"><b>請注意：</b>並非所有伺服器都支援完整連接埠範圍。</string>
     <string name="custom_port_recommended_range_second">所有伺服器的有效範圍：%1$s</string>
     <string name="custom_tunnel_host_resolution_error">無法解析自訂通道的主機。請嘗試變更您的設定。</string>
     <string name="daita_description_slide_1_first_paragraph">請注意：這會增加網路流量，並對速度、延遲與電池耗電產生負面影響。若方案流量有限，請謹慎使用。</string>
@@ -278,7 +278,7 @@
     <string name="manage_devices_confirm_removal_description_line1">是否移除 %1$s？</string>
     <string name="manage_devices_confirm_removal_description_line2">裝置將從清單中移除並登出。</string>
     <string name="manage_devices_description">檢視並管理所有已登入的裝置。一個帳戶最多能同時登入 5 台裝置。每台裝置登入時都會獲得一個名稱，以協助您輕鬆區分。</string>
-    <string name="max_devices_confirm_removal_description">確定要將 &lt;b&gt;%1$s&lt;/b&gt; 登出嗎？</string>
+    <string name="max_devices_confirm_removal_description">確定要將 <b>%1$s</b> 登出嗎？</string>
     <string name="max_devices_resolved_description">現在，您可以繼續在此裝置上登入。</string>
     <string name="max_devices_resolved_title">太好了！</string>
     <string name="max_devices_warning_description">請從底下清單至少移除一個裝置來將其登出。您可以在裝置的「帳戶」設定下找到相應裝置名稱。</string>
@@ -299,7 +299,7 @@
     <string name="navigate">導覽</string>
     <string name="new_changelog_notification_message">按一下此處查看最新動態。</string>
     <string name="new_changelog_notification_title">已安裝新版本</string>
-    <string name="new_device_notification_message">歡迎，此裝置現在名為 &lt;b&gt;%1$s&lt;/b&gt;。</string>
+    <string name="new_device_notification_message">歡迎，此裝置現在名為 <b>%1$s</b>。</string>
     <string name="new_device_notification_title">已建立新裝置</string>
     <string name="new_list">新清單</string>
     <string name="no_custom_lists_available">有可用的自訂清單</string>

--- a/android/translations-converter/src/android/string_value.rs
+++ b/android/translations-converter/src/android/string_value.rs
@@ -17,8 +17,11 @@ impl StringValue {
     /// they don't have any. Indices are assigned sequentially starting from the previously
     /// specified index plus one, or starting from one if there aren't any previously specified
     /// indices.
+    ///
+    /// NOTE: Due to how we parse <b> tags in the code we do not escape all characters.
     pub fn from_unescaped(string: &str, arg_ordering: Option<&Vec<u8>>) -> Self {
-        let value_with_parameters = htmlize::escape_text(string)
+        let value_with_parameters = string
+            .replace('&', r"&amp;")
             .replace('\\', r"\\")
             .replace('\"', "\\\"")
             .replace('\'', r"\'");


### PR DESCRIPTION
This is due to us using an annoted string parse instead of using a proper html parse.
u
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9915)
<!-- Reviewable:end -->
