### PR TITLE
modified to support mullvad browser packages for multiple architectures

### DIFF
--- a/ci/mullvad-browser/download-mullvad-browser.sh
+++ b/ci/mullvad-browser/download-mullvad-browser.sh
@@ -2,7 +2,22 @@
 
 set -eu
 
-BROWSER_RELEASES=("stable" "alpha")
+# We'll need to add "stable_aarch64.rpm" and "stable_arm64.deb" later.
+BROWSER_RELEASES=( \
+    "stable_x86_64.rpm" \
+    "stable_amd64.deb" \
+    "alpha_x86_64.rpm" \
+    "alpha_amd64.deb" \
+    "alpha_aarch64.rpm" \
+    "alpha_arm64.deb" )
+
+# NOTE: Currently this script will distribute the Stable and Alpha
+# browser packages to both the "stable" and "beta" sections of the
+# repositories. This is intentional and is also mentioned on the
+# browser download page.
+# If this needs to change in the future then the code near the end
+# ( for repository in "${REPOSITORIES[@]}"; do ... ) will need to
+# be updated to separate the packages by release.
 REPOSITORIES=("stable" "beta")
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -23,44 +38,37 @@ function usage() {
 
 
 function main() {
-    local package_filename_base=$1
-    local extension=$2
-    PACKAGE_FILENAME="$package_filename_base.$extension"
+    local package_filename=$1
 
-    PACKAGE_URL=https://cdn.mullvad.net/browser/$PACKAGE_FILENAME
+    PACKAGE_URL=https://cdn.mullvad.net/browser/$package_filename
     SIGNATURE_URL=$PACKAGE_URL.asc
 
-    echo "[#] Downloading $PACKAGE_FILENAME"
+    echo "[#] Downloading $package_filename"
     if ! wget --quiet "$PACKAGE_URL"; then
         echo "[!] Failed to download $PACKAGE_URL"
         exit 1
     fi
 
-    echo "[#] Downloading $PACKAGE_FILENAME.asc"
+    echo "[#] Downloading $package_filename.asc"
     if ! wget --quiet "$SIGNATURE_URL"; then
         echo "[!] Failed to download $SIGNATURE_URL"
-        rm "$PACKAGE_FILENAME"
+        rm "$package_filename"
         exit 1
     fi
 
-    echo "[#] Verifying $PACKAGE_FILENAME signature"
-    if ! gpg --verify "$PACKAGE_FILENAME".asc "$PACKAGE_FILENAME"; then
+    echo "[#] Verifying $package_filename signature"
+    if ! gpg --verify "$package_filename".asc "$package_filename"; then
         echo "[!] Failed to verify signature"
-        rm "$PACKAGE_FILENAME" "$PACKAGE_FILENAME.asc"
+        rm "$package_filename" "$package_filename.asc"
         exit 1
     fi
-    rm "$PACKAGE_FILENAME.asc"
-
-    # Hack to get the architecture into the filename
-    local filename_with_arch="${package_filename_base}_x86_64.$extension"
-    mv "$PACKAGE_FILENAME" "$filename_with_arch"
-    PACKAGE_FILENAME="$filename_with_arch"
+    rm "$package_filename.asc"
 
     # Check if the deb package has changed since last time
     # Handle the bootstrap problem by checking if the "output file" even exists and just moving on if it doesn't
-    if [[ -f "$WORKDIR/$PACKAGE_FILENAME" ]] && cmp "$PACKAGE_FILENAME" "$WORKDIR/$PACKAGE_FILENAME"; then
-        echo "[#] $PACKAGE_FILENAME has not changed"
-        rm "$PACKAGE_FILENAME"
+    if [[ -f "$WORKDIR/$package_filename" ]] && cmp "$package_filename" "$WORKDIR/$package_filename"; then
+        echo "[#] $package_filename has not changed"
+        rm "$package_filename"
         return
     fi
 
@@ -94,8 +102,7 @@ trap 'delete_tmp_dir' EXIT
 
 echo "[#] Configured releases are: ${BROWSER_RELEASES[*]}"
 for release in "${BROWSER_RELEASES[@]}"; do
-    main "mullvad-browser-$release" "deb"
-    main "mullvad-browser-$release" "rpm"
+    main "mullvad-browser-$release"
 done
 
 if [[ -z "$(ls -A "$TMP_DIR")" ]]; then


### PR DESCRIPTION

Fixes for managing multiple package architectures in ci/mullvad-browser/download-mullvad-browser.sh 

The script now expects the input data on the CDN to look like this:

```
15.0.7/
16.0a3/
mullvad-browser-alpha_aarch64.rpm -> 16.0a3/mullvad-browser-alpha-16.0a3-1.aarch64.rpm
mullvad-browser-alpha_aarch64.rpm.asc -> 16.0a3/mullvad-browser-alpha-16.0a3-1.aarch64.rpm.asc
mullvad-browser-alpha_amd64.deb -> 16.0a3/mullvad-browser-alpha_16.0a3-1_amd64.deb
mullvad-browser-alpha_amd64.deb.asc -> 16.0a3/mullvad-browser-alpha_16.0a3-1_amd64.deb.asc
mullvad-browser-alpha_arm64.deb -> 16.0a3/mullvad-browser-alpha_16.0a3-1_arm64.deb
mullvad-browser-alpha_arm64.deb.asc -> 16.0a3/mullvad-browser-alpha_16.0a3-1_arm64.deb.asc
mullvad-browser-alpha_x86_64.rpm -> 16.0a3/mullvad-browser-alpha-16.0a3-1.x86_64.rpm
mullvad-browser-alpha_x86_64.rpm.asc -> 16.0a3/mullvad-browser-alpha-16.0a3-1.x86_64.rpm.asc
mullvad-browser-stable_amd64.deb -> 15.0.7/mullvad-browser_15.0.7-1_amd64.deb
mullvad-browser-stable_amd64.deb.asc -> 15.0.7/mullvad-browser_15.0.7-1_amd64.deb.asc
mullvad-browser-stable_x86_64.rpm -> 15.0.7/mullvad-browser-15.0.7-1.x86_64.rpm
mullvad-browser-stable_x86_64.rpm.asc -> 15.0.7/mullvad-browser-15.0.7-1.x86_64.rpm.asc
update_responses/
```

The corresponding update in browser-upload that will create the file structure above also needs to be merged for this to work.


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9916)
<!-- Reviewable:end -->
