### PR TITLE
WIP Add router mode

### DIFF
--- a/mullvad-types/Cargo.toml
+++ b/mullvad-types/Cargo.toml
@@ -21,5 +21,8 @@ thiserror = { workspace = true }
 uuid = { version = "1.4.1", features = ["serde", "v4"] }
 vec1 = { workspace = true }
 
+[features]
+router = []
+
 [lints]
 workspace = true

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -281,7 +281,8 @@ impl Default for Settings {
             },
             custom_lists: CustomListsSettings::default(),
             api_access_methods: access_method::Settings::default(),
-            allow_lan: false,
+            // Always allow LAN sharing in router mode (not otherwise).
+            allow_lan: cfg!(feature = "router"),
             #[cfg(not(target_os = "android"))]
             lockdown_mode: false,
             auto_connect: false,

--- a/talpid-core/src/offline/mod.rs
+++ b/talpid-core/src/offline/mod.rs
@@ -24,9 +24,10 @@ mod imp;
 
 /// Disables offline monitor
 static FORCE_DISABLE_OFFLINE_MONITOR: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("TALPID_DISABLE_OFFLINE_MONITOR")
-        .map(|v| v != "0")
-        .unwrap_or(false)
+    // HACK: It is fair to assume that a router has a stable connection and won't drop out very
+    // often. An offline monitor might induce unwarranted reconnects, which would be very annoying.
+    // TODO: Find a way to conditionally disable the offline monitor.
+    true
 });
 
 pub struct MonitorHandle(Option<imp::MonitorHandle>);


### PR DESCRIPTION
This PR adds basic support for deploying `mullvad-daemon` on routers.

## Changes
- LAN sharing is always enabled - The router has to be able to talk to devices on its networks.
## Removes
- Offline monitor - The assumption here is that the router has a stable connection and does not roam.
## Adds
- Forwarding rules - The router has to be able to NAT traffic from devices on its networks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9918)
<!-- Reviewable:end -->
