### PR TITLE
Lower log level for GotaTun

### DIFF
--- a/mullvad-logging/src/lib.rs
+++ b/mullvad-logging/src/lib.rs
@@ -37,7 +37,7 @@ pub const SILENCED_CRATES: &[&str] = &[
 ];
 
 /// Crates that are silenced one level below the configured level
-pub const SLIGHTLY_SILENCED_CRATES: &[&str] = &["nftnl", "udp_over_tcp"];
+pub const SLIGHTLY_SILENCED_CRATES: &[&str] = &["nftnl", "udp_over_tcp", "gotatun"];
 
 /// Returns the effective log level for a given target (crate/module name).
 ///


### PR DESCRIPTION
Stops logging every handshake (except when trace logging is enabled).

Fix DES-2824

Related: https://github.com/mullvad/gotatun/pull/99

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9929)
<!-- Reviewable:end -->
