### PR TITLE
Ignore CVEs GO-2026-{4601,4602,4603}

### DIFF
--- a/wireguard-go-rs/libwg/osv-scanner.toml
+++ b/wireguard-go-rs/libwg/osv-scanner.toml
@@ -229,3 +229,24 @@ reason = "wireguard-go does not use html.Parse"
 id = "GO-2026-4337"
 ignoreUntil = 2027-02-06
 reason = "wireguard(-go) does not use tls"
+
+# Incorrect parsing of IPv6 host literals in net/url
+# https://osv.dev/vulnerability/GO-2026-4601
+[[IgnoredVulns]]
+id = "GO-2026-4601"
+ignoreUntil = 2027-03-09
+reason = "wireguard-go does not use net/url"
+
+# FileInfo can escape from a Root in os
+# https://osv.dev/vulnerability/GO-2026-4602
+[[IgnoredVulns]]
+id = "GO-2026-4602"
+ignoreUntil = 2027-03-09
+reason = "wireguard-go does not call ReadDir or Readdir"
+
+# URLs in meta content attribute actions are not escaped in html/template
+# https://osv.dev/vulnerability/GO-2026-4603
+[[IgnoredVulns]]
+id = "GO-2026-4603"
+ignoreUntil = 2027-03-09
+reason = "wireguard-go does not use html/template"


### PR DESCRIPTION
You know the deal at this point. wireguard-go does not use any of these vulnerable libs/functions, so upgrading the go version is overkill. It will soon be ripped out anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9945)
<!-- Reviewable:end -->
