### PR TITLE
Bump mnl to 0.3.1 to fix unsoundness issue

### DIFF
--- a/ci/ios/test-router/raas/Cargo.lock
+++ b/ci/ios/test-router/raas/Cargo.lock
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "mnl"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a5469630da93e1813bb257964c0ccee3b26b6879dd858039ddec35cc8681ed"
+checksum = "528ab362254419b09757228dc96e0d834e75392c52870d759df2274753007065"
 dependencies = [
  "libc",
  "log",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "mnl-sys"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9750685b201e1ecfaaf7aa5d0387829170fa565989cc481b49080aa155f70457"
+checksum = "a0f3c607af12ed53f3cade8ee7adeced5533800abc0b07f5b6bdc7081d1e0d4c"
 dependencies = [
  "libc",
  "pkg-config",

--- a/ci/ios/test-router/raas/Cargo.toml
+++ b/ci/ios/test-router/raas/Cargo.toml
@@ -13,7 +13,7 @@ env_logger = "0.10"
 futures = "0.3"
 ipnetwork = { version = "0.21", features = ["serde"] }
 log = "0.4"
-mnl = { version = "0.2", features = ["mnl-1-0-4"] }
+mnl = { version = "0.3.1", features = ["mnl-1-0-4"] }
 nftnl = { version = "0.9", features = ["nftnl-1-1-0"] }
 once_cell = "1"
 pcap = { version = "1.2.0", features = ["capture-stream"] }

--- a/ci/ios/test-router/raas/src/block_list/mod.rs
+++ b/ci/ios/test-router/raas/src/block_list/mod.rs
@@ -62,7 +62,8 @@ impl BlockList {
         let mut buffer = vec![0; nftnl::nft_nlmsg_maxsize() as usize];
 
         let seq = 0;
-        while let Some(message) = Self::socket_recv(&socket, &mut buffer[..])? {
+        for message in socket.recv(&mut buffer[..])? {
+            let message = message?;
             match mnl::cb_run(message, seq, portid)? {
                 mnl::CbResult::Stop => {
                     break;
@@ -72,15 +73,6 @@ impl BlockList {
         }
 
         Ok(())
-    }
-
-    fn socket_recv<'a>(socket: &mnl::Socket, buf: &'a mut [u8]) -> io::Result<Option<&'a [u8]>> {
-        let ret = socket.recv(buf)?;
-        if ret > 0 {
-            Ok(Some(&buf[..ret]))
-        } else {
-            Ok(None)
-        }
     }
 
     fn nft_forward_rules<'a>(&'a self, chain: &'a Chain<'a>) -> impl Iterator<Item = Rule<'a>> {


### PR DESCRIPTION
This PR bumps `mnl` to 0.3.1 in the `raas` crate, which fixes https://osv.dev/vulnerability/RUSTSEC-2025-0142.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9946)
<!-- Reviewable:end -->
