### PR TITLE
Ensure we always zeroize psk buffer

### DIFF
--- a/talpid-tunnel-config-client/src/lib.rs
+++ b/talpid-tunnel-config-client/src/lib.rs
@@ -187,12 +187,12 @@ pub async fn request_ephemeral_peer_with(
 
         // Store the PSK data on the heap. So it can be passed around and then zeroized on drop
         // without being stored in a bunch of places on the stack.
-        let mut psk_data = Box::new([0u8; 32]);
+        let mut psk = PresharedKey::from(Box::default());
 
         // Decapsulate ML-KEM and mix into PSK
         {
             let mut shared_secret = ml_kem_keypair.decapsulate(ml_kem_ciphertext)?;
-            xor_assign(&mut psk_data, &shared_secret);
+            xor_assign(psk.as_bytes_mut(), &shared_secret);
 
             // The shared secret is sadly stored in an array on the stack. So we can't get any
             // guarantees that it's not copied around on the stack. The best we can do here
@@ -203,7 +203,7 @@ pub async fn request_ephemeral_peer_with(
         // Decapsulate HQC and mix into PSK
         {
             let mut shared_secret = hqc_keypair.decapsulate(hqc_ciphertext)?;
-            xor_assign(&mut psk_data, &shared_secret);
+            xor_assign(psk.as_bytes_mut(), &shared_secret);
 
             // The shared secret is sadly stored in an array on the stack. So we can't get any
             // guarantees that it's not copied around on the stack. The best we can do here
@@ -212,7 +212,7 @@ pub async fn request_ephemeral_peer_with(
             shared_secret.zeroize();
         }
 
-        Some(PresharedKey::from(psk_data))
+        Some(psk)
     } else {
         None
     };

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -303,6 +303,13 @@ impl PresharedKey {
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
+
+    /// Mutably access the PSK as bytes. Try to move or dereference this data as little
+    /// as possible, since copying it to more memory locations potentially leaves the secret in
+    /// more memory locations.
+    pub fn as_bytes_mut(&mut self) -> &mut [u8; 32] {
+        &mut self.0
+    }
 }
 
 impl From<Box<[u8; 32]>> for PresharedKey {


### PR DESCRIPTION
This fixes an issue where the buffer isn't zeroed if `hqc_keypair.decapslate()?` returns an error.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9947)
<!-- Reviewable:end -->
