### PR TITLE
Handle pagination of github api responses in code owner CI

### DIFF
--- a/.github/workflows/code-owner-approval.yml
+++ b/.github/workflows/code-owner-approval.yml
@@ -54,18 +54,18 @@ jobs:
 
             // Returns an array of file paths changed in the PR
             async function getChangedFiles() {
-              const changedFiles = await github.rest.pulls.listFiles({
+              const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.issue.number
               });
 
-              return changedFiles.data.map(file => file.filename);
+              return changedFiles.map(file => file.filename);
             }
 
             // Returns a list of usernames who approved the PR (based on their latest review)
             async function getApprovers() {
-              const reviews = await github.rest.pulls.listReviews({
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.issue.number
@@ -73,7 +73,7 @@ jobs:
 
               const latestReviews = new Map();
 
-              for (const review of reviews.data) {
+              for (const review of reviews) {
                 const currentLatest = latestReviews.get(review.user.id);
 
                 // Keep the most recent review (higher ID = more recent)


### PR DESCRIPTION
We saw seemingly random failures in the code ownership CI job from time to time. A prime example is https://github.com/mullvad/mullvadvpn-app/actions/runs/22849944506/job/66275730006 from the PR https://github.com/mullvad/mullvadvpn-app/pull/9938

From the output we can see that the code owner CI only considers 30 files. That is because the github API it uses to obtain changed files is paginated :facepalm:. This PR fixes that

Here is a test run on this branch where I pushed random changes to >30 files just to see if the job picked it up: https://github.com/mullvad/mullvadvpn-app/actions/runs/22893987191/job/66423407285?pr=9950

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9950)
<!-- Reviewable:end -->
