### PR TITLE
Add gRPC service for relay selector

### DIFF
--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -20,6 +20,7 @@ mod macos;
 pub mod management_interface;
 mod migrations;
 mod relay_list;
+mod relay_selector;
 #[cfg(not(target_os = "android"))]
 pub mod rpc_uniqueness_check;
 pub mod runtime;
@@ -714,6 +715,39 @@ impl Daemon {
         #[cfg(target_os = "macos")]
         macos::bump_filehandle_limit();
 
+        let migration_data = migrations::migrate_all(&config.cache_dir, &config.settings_dir)
+            .await
+            .unwrap_or_else(|error| {
+                log::error!(
+                    "{}",
+                    error.display_chain_with_msg("Failed to migrate settings or cache")
+                );
+                None
+            });
+
+        let mut settings = SettingsPersister::load(&config.settings_dir).await;
+
+        // Initialize relay selector asap, since it's a pre-requisite for accepting incoming gRPC
+        // connections.
+        let initial_relay_list = parse_relays_from_file(&config.cache_dir, &config.resource_dir)
+            .inspect_err(|err| log::error!("{err}"))
+            .ok();
+        let relay_selector = {
+            let (initial_relay_list, initial_bridge_list) = initial_relay_list
+                .clone()
+                .map(CachedRelayList::into_internal_repr)
+                .unwrap_or_default();
+            // TODO: This should preferably be done once, by the relay list updater.
+            let initial_relay_list =
+                initial_relay_list.apply_overrides(settings.relay_overrides.clone());
+            let initial_selector_config = SelectorConfig::from_settings(&settings);
+            RelaySelector::new(
+                initial_selector_config,
+                initial_relay_list.clone(),
+                initial_bridge_list.clone(),
+            )
+        };
+
         let command_sender = daemon_command_channel.sender();
         let app_upgrade_broadcast = tokio::sync::broadcast::channel(32).0;
         let management_interface = ManagementInterfaceServer::start(
@@ -721,6 +755,7 @@ impl Daemon {
             config.rpc_socket_path,
             app_upgrade_broadcast.clone(),
             config.log_handle,
+            relay_selector.clone(),
         )
         .map_err(Error::ManagementInterfaceError)?;
 
@@ -750,42 +785,11 @@ impl Daemon {
         let api_availability = api_runtime.availability_handle();
         api_availability.suspend();
 
-        let migration_data = migrations::migrate_all(&config.cache_dir, &config.settings_dir)
-            .await
-            .unwrap_or_else(|error| {
-                log::error!(
-                    "{}",
-                    error.display_chain_with_msg("Failed to migrate settings or cache")
-                );
-                None
-            });
-
         let settings_event_listener = management_interface.notifier().clone();
-        let mut settings = SettingsPersister::load(&config.settings_dir).await;
-
         settings.register_change_listener(move |settings| {
             // Notify management interface server of changes to the settings
             settings_event_listener.notify_settings(settings.to_owned());
         });
-
-        let initial_relay_list = parse_relays_from_file(&config.cache_dir, &config.resource_dir)
-            .inspect_err(|err| log::error!("{err}"))
-            .ok();
-        let relay_selector = {
-            let (initial_relay_list, initial_bridge_list) = initial_relay_list
-                .clone()
-                .map(CachedRelayList::into_internal_repr)
-                .unwrap_or_default();
-            // TODO: This should preferably be done once, by the relay list updater.
-            let initial_relay_list =
-                initial_relay_list.apply_overrides(settings.relay_overrides.clone());
-            let initial_selector_config = SelectorConfig::from_settings(&settings);
-            RelaySelector::new(
-                initial_selector_config,
-                initial_relay_list.clone(),
-                initial_bridge_list.clone(),
-            )
-        };
 
         let encrypted_dns_proxy_cache = EncryptedDnsProxyState::default();
         let method_resolver = DaemonAccessMethodResolver::new(

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1,4 +1,7 @@
-use crate::{DaemonCommand, DaemonCommandSender, account_history, device};
+use crate::{
+    DaemonCommand, DaemonCommandSender, account_history, device,
+    relay_selector::RelaySelectorServiceImpl,
+};
 use futures::{
     StreamExt,
     channel::{mpsc, oneshot},
@@ -1345,6 +1348,7 @@ impl ManagementInterfaceServer {
         rpc_socket_path: PathBuf,
         app_upgrade_broadcast: AppUpgradeBroadcast,
         log_reload_handle: crate::logging::LogHandle,
+        relay_selector: mullvad_relay_selector::RelaySelector,
     ) -> Result<ManagementInterfaceServer, Error> {
         let subscriptions = Arc::<Mutex<Vec<EventsListenerSender>>>::default();
 
@@ -1353,14 +1357,18 @@ impl ManagementInterfaceServer {
         // received and started processing the shutdown signal.
         let (server_abort_tx, server_abort_rx) = mpsc::channel(0);
 
-        let server = ManagementServiceImpl {
+        let management_service = ManagementServiceImpl {
             daemon_tx,
             subscriptions: subscriptions.clone(),
             app_upgrade_broadcast,
             log_reload_handle,
         };
+
+        let relay_selector_service = RelaySelectorServiceImpl::new(relay_selector);
+
         let rpc_server_join_handle = mullvad_management_interface::spawn_rpc_server(
-            server,
+            management_service,
+            relay_selector_service,
             async move {
                 StreamExt::into_future(server_abort_rx).await;
             },

--- a/mullvad-daemon/src/relay_selector.rs
+++ b/mullvad-daemon/src/relay_selector.rs
@@ -1,0 +1,29 @@
+//! Relay selector gRPC service.
+
+use mullvad_management_interface::types::relay_selector as proto;
+use mullvad_management_interface::{RelaySelectorService, Request, Response, Status};
+use mullvad_relay_selector::RelaySelector;
+use mullvad_types::relay_selector::Predicate;
+
+/// The relay selector exposed as a gRPC service. See `relay_selector.proto` for API.
+pub struct RelaySelectorServiceImpl(RelaySelector);
+
+impl RelaySelectorServiceImpl {
+    pub fn new(relay_selector: RelaySelector) -> Self {
+        RelaySelectorServiceImpl(relay_selector)
+    }
+}
+
+#[mullvad_management_interface::async_trait]
+impl RelaySelectorService for RelaySelectorServiceImpl {
+    async fn partition_relays(
+        &self,
+        predicate: Request<proto::Predicate>,
+    ) -> Result<Response<proto::RelayPartitions>, Status> {
+        let predicate = predicate.into_inner();
+        let predicate = Predicate::try_from(predicate)?;
+        let partitions = self.0.partition_relays(predicate);
+        let partitions = proto::RelayPartitions::from(partitions);
+        Ok(Response::new(partitions))
+    }
+}

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -402,6 +402,7 @@ enum Ownership {
 }
 
 message LocationConstraint {
+  // When a LocationConstraint is constructed, the inner `type` value MUST NOT be null.
   oneof type {
     string custom_list = 1;
     GeographicLocationConstraint location = 2;

--- a/mullvad-management-interface/proto/relay_selector.proto
+++ b/mullvad-management-interface/proto/relay_selector.proto
@@ -1,13 +1,12 @@
-// Relay Selector service.
-//
-// This API is used to query which relays are selectable for a set of filters,
-// and to provide information about about how to unblock discarded relays.
-
 syntax = "proto3";
 package mullvad_daemon.relay_selector;
 
 import "management_interface.proto";
 
+// Relay Selector service.
+//
+// This API is used to query which relays are selectable for a set of filters,
+// and to provide information about about how to unblock discarded relays.
 service RelaySelectorService {
   // Partition the available relays by a predicate. The predicate can be
   // derived from the current settings or a set of future settings changes
@@ -32,10 +31,10 @@ message Predicate {
     EntryConstraints singlehop = 1;
     // Get matching relays with automatic multihop when necessary.
     //
-    // If the entry-specific constraints are not met for a given relay but an alternative
-    // entry node can be selected that matches the constraints, the relay will still be
-    // returned as a viable exit node. Connecting to the relay will result in a implicit
-    // multihop connection.
+    // If the entry-specific constraints are not met for a given relay but an
+    // alternative entry node can be selected that matches the constraints, the
+    // relay will still be returned as a viable exit node. Connecting to the
+    // relay will result in a implicit multihop connection.
     EntryConstraints autohop = 2;
     // Get matching entry relays for multihop.
     MultiHopConstraints entry = 3;
@@ -61,6 +60,10 @@ message EntryConstraints {
 // This is a subset of `EntryConstraints`.
 message ExitConstraints {
   management_interface.LocationConstraint location = 1;
+  // Only show exit locations operated by these providers.
+  //
+  // Constructing this parameter with 0 providers means that no filtering is
+  // done based on the provider. I.e. relays from all providers are shown.
   repeated Provider providers = 2;
   management_interface.Ownership ownership = 3;
 }
@@ -109,7 +112,6 @@ message IncompatibleConstraints {
   // The relay does not reside in the given location.
   bool location = 2;
   // The relay is not hosted by the given provider.
-  // TODO: Return which provider it needs? Can be looked up in the full relay list
   bool providers = 3;
   // The relay ownership does not match.
   bool ownership = 4;

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -1,5 +1,4 @@
 //! Client that returns and takes mullvad types as arguments instead of prost-generated types
-
 use crate::types;
 #[cfg(not(target_os = "android"))]
 use futures::{Stream, StreamExt};
@@ -93,7 +92,7 @@ impl TryFrom<types::daemon_event::Event> for DaemonEvent {
 impl MullvadProxyClient {
     pub async fn new() -> Result<Self> {
         #[expect(deprecated)]
-        super::new_rpc_client().await.map(Self)
+        crate::new_management_service_client().await.map(Self)
     }
 
     pub fn from_rpc_client(client: crate::ManagementServiceClient) -> Self {
@@ -726,5 +725,25 @@ impl TryFrom<types::LeakInfo> for LeakInfo {
             interface: leak.interface,
             reachable_nodes,
         })
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+pub struct RelaySelectorClient(crate::RelaySelectorServiceClient);
+
+#[cfg(not(target_os = "android"))]
+impl RelaySelectorClient {
+    pub async fn new() -> Result<Self> {
+        let channel = crate::grpc_transport_channel().await?;
+        let client = crate::RelaySelectorServiceClient::new(channel);
+        Ok(Self(client))
+    }
+
+    pub async fn partition_relays(
+        &mut self,
+        predicate: crate::types::relay_selector::Predicate,
+    ) -> Result<crate::types::relay_selector::RelayPartitions> {
+        let result = self.0.partition_relays(predicate).await?.into_inner();
+        Ok(result)
     }
 }

--- a/mullvad-management-interface/src/lib.rs
+++ b/mullvad-management-interface/src/lib.rs
@@ -24,6 +24,8 @@ pub type ManagementServiceClient =
     types::management_service_client::ManagementServiceClient<Channel>;
 pub use types::management_service_server::{ManagementService, ManagementServiceServer};
 
+pub use types::{RelaySelectorService, RelaySelectorServiceClient, RelaySelectorServiceServer};
+
 #[cfg(unix)]
 use std::sync::LazyLock;
 #[cfg(unix)]
@@ -132,20 +134,27 @@ impl From<tonic::Status> for Error {
 
 #[cfg(not(target_os = "android"))]
 #[deprecated(note = "Prefer MullvadProxyClient")]
-pub async fn new_rpc_client() -> Result<ManagementServiceClient, Error> {
+pub async fn new_management_service_client() -> Result<ManagementServiceClient, Error> {
+    grpc_transport_channel()
+        .await
+        .map(ManagementServiceClient::new)
+}
+
+/// Create a [Channel] for communication between any of the available gRPC clients (e.g.
+/// [ManagementServiceClient]) and the management interface gRPC service.
+#[cfg(not(target_os = "android"))]
+pub(crate) async fn grpc_transport_channel() -> Result<Channel, Error> {
     use futures::TryFutureExt;
 
     let ipc_path = mullvad_paths::get_rpc_socket_path();
 
     // The URI will be ignored
-    let channel = Endpoint::from_static("lttp://[::]:50051")
+    Endpoint::from_static("lttp://[::]:50051")
         .connect_with_connector(service_fn(move |_: Uri| {
             IpcEndpoint::connect(ipc_path.clone()).map_ok(hyper_util::rt::tokio::TokioIo::new)
         }))
         .await
-        .map_err(Error::GrpcTransportError)?;
-
-    Ok(ManagementServiceClient::new(channel))
+        .map_err(Error::GrpcTransportError)
 }
 
 #[cfg(not(target_os = "android"))]
@@ -153,45 +162,58 @@ pub use client::MullvadProxyClient;
 
 pub type ServerJoinHandle = tokio::task::JoinHandle<()>;
 
-pub fn spawn_rpc_server<T: ManagementService, F: Future<Output = ()> + Send + 'static>(
-    service: T,
-    abort_rx: F,
+pub fn spawn_rpc_server(
+    management_service: impl ManagementService,
+    relay_selector_service: impl RelaySelectorService,
+    abort_rx: impl Future<Output = ()> + Send + 'static,
     rpc_socket_path: PathBuf,
 ) -> std::result::Result<ServerJoinHandle, Error> {
-    use futures::stream::TryStreamExt;
-    use tipsy::SecurityAttributes;
+    use futures::TryStreamExt;
 
-    let endpoint = IpcEndpoint::new(rpc_socket_path.clone(), tipsy::OnConflict::Error)
+    let endpoint = create_endpoint(rpc_socket_path)?;
+
+    let incoming = endpoint
+        .clone()
+        .incoming()
         .map_err(Error::StartServerError)?
-        .security_attributes(
-            SecurityAttributes::allow_everyone_create()
-                .map_err(Error::SecurityAttributes)?
-                .mode(0o766)
-                .map_err(Error::SecurityAttributes)?,
-        );
-    let incoming = endpoint.incoming().map_err(Error::StartServerError)?;
+        .map_ok(StreamBox);
 
     #[cfg(unix)]
-    if let Some(group_name) = &*MULLVAD_MANAGEMENT_SOCKET_GROUP {
+    if let Some(group_name) = MULLVAD_MANAGEMENT_SOCKET_GROUP.as_ref() {
+        let endpoint_path = endpoint.path();
         let group = nix::unistd::Group::from_name(group_name)
             .map_err(Error::ObtainGidError)?
             .ok_or(Error::NoGidError)?;
-        nix::unistd::chown(&rpc_socket_path, None, Some(group.gid)).map_err(Error::SetGidError)?;
-        fs::set_permissions(rpc_socket_path, PermissionsExt::from_mode(0o760))
+        nix::unistd::chown(endpoint_path, None, Some(group.gid)).map_err(Error::SetGidError)?;
+        fs::set_permissions(endpoint_path, PermissionsExt::from_mode(0o760))
             .map_err(Error::PermissionsError)?;
     }
 
-    Ok(tokio::spawn(async move {
-        if let Err(execution_error) = Server::builder()
-            .add_service(ManagementServiceServer::new(service))
-            .serve_with_incoming_shutdown(incoming.map_ok(StreamBox), abort_rx)
-            .await
-            .map_err(Error::GrpcTransportError)
-        {
+    let grpc_server = Server::builder()
+        .add_service(ManagementServiceServer::new(management_service))
+        .add_service(RelaySelectorServiceServer::new(relay_selector_service))
+        .serve_with_incoming_shutdown(incoming, abort_rx);
+
+    let server_task = tokio::spawn(async move {
+        if let Err(execution_error) = grpc_server.await.map_err(Error::GrpcTransportError) {
             log::error!("Management server panic: {execution_error}");
         }
         log::trace!("gRPC server is shutting down");
-    }))
+    });
+
+    Ok(server_task)
+}
+
+fn create_endpoint(rpc_socket_path: PathBuf) -> Result<IpcEndpoint, Error> {
+    let endpoint = IpcEndpoint::new(rpc_socket_path, tipsy::OnConflict::Error)
+        .map_err(Error::StartServerError)?;
+    let endpoint = endpoint.security_attributes(
+        tipsy::SecurityAttributes::allow_everyone_create()
+            .map_err(Error::SecurityAttributes)?
+            .mode(0o766)
+            .map_err(Error::SecurityAttributes)?,
+    );
+    Ok(endpoint)
 }
 
 #[derive(Debug)]

--- a/mullvad-management-interface/src/types/conversions/mod.rs
+++ b/mullvad-management-interface/src/types/conversions/mod.rs
@@ -11,6 +11,7 @@ mod logging;
 mod net;
 pub mod relay_constraints;
 mod relay_list;
+mod relay_selector;
 mod settings;
 #[cfg(target_os = "windows")]
 mod split_tunnel;
@@ -22,6 +23,12 @@ mod wireguard;
 pub enum FromProtobufTypeError {
     #[error("Invalid argument for type conversion: {0}")]
     InvalidArgument(&'static str),
+}
+
+/// Shorthand for `FromProtobufTypeError::InvalidArgument`.
+#[inline(always)]
+pub(crate) fn invalid_argument(msg: &'static str) -> FromProtobufTypeError {
+    FromProtobufTypeError::InvalidArgument(msg)
 }
 
 fn bytes_to_pubkey(

--- a/mullvad-management-interface/src/types/conversions/relay_constraints.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_constraints.rs
@@ -1,4 +1,4 @@
-use crate::types::{FromProtobufTypeError, proto};
+use crate::types::{FromProtobufTypeError, invalid_argument, proto};
 use mullvad_types::{
     constraints::Constraint,
     custom_list::Id,
@@ -21,18 +21,17 @@ impl TryFrom<&proto::WireguardConstraints>
         use mullvad_types::relay_constraints as mullvad_constraints;
         use talpid_types::net;
 
-        let ip_version = match constraints.ip_version {
-            Some(version) => Some(net::IpVersion::from(
-                proto::IpVersion::try_from(version).map_err(|_| {
-                    FromProtobufTypeError::InvalidArgument("invalid IP protocol version")
-                })?,
-            )),
-            None => None,
-        };
+        let ip_version = constraints
+            .ip_version
+            .map(proto::IpVersion::try_from)
+            .transpose()
+            .map_err(|_| invalid_argument("invalid IP protocol version"))?
+            .map(net::IpVersion::from);
+
         let allowed_ips = AllowedIps::parse(&constraints.allowed_ips)
             .map_err(|e| {
                 log::error!("Failed to parse allowed IPs: {}", e);
-                FromProtobufTypeError::InvalidArgument("invalid allowed IPs")
+                invalid_argument("invalid allowed IPs")
             })?
             .to_constraint();
 
@@ -44,13 +43,10 @@ impl TryFrom<&proto::WireguardConstraints>
                 .entry_location
                 .clone()
                 .and_then(|loc| {
-                    Constraint::<mullvad_types::relay_constraints::LocationConstraint>::try_from(
-                        loc,
-                    )
-                    .ok()
+                    mullvad_types::relay_constraints::LocationConstraint::try_from(loc).ok()
                 })
-                .unwrap_or(Constraint::Any),
-            entry_providers: try_providers_constraint_from_proto(&constraints.entry_providers)?,
+                .into(),
+            entry_providers: providers_constraint_from_proto(&constraints.entry_providers),
             entry_ownership: try_ownership_constraint_from_i32(constraints.entry_ownership)?,
         })
     }
@@ -89,9 +85,11 @@ impl TryFrom<proto::RelaySettings> for mullvad_types::relay_constraints::RelaySe
             proto::relay_settings::Endpoint::Normal(settings) => {
                 let location = settings
                     .location
-                    .and_then(|loc| Constraint::<mullvad_types::relay_constraints::LocationConstraint>::try_from(loc).ok())
-                    .unwrap_or(Constraint::Any);
-                let providers = try_providers_constraint_from_proto(&settings.providers)?;
+                    .and_then(|loc| {
+                        mullvad_types::relay_constraints::LocationConstraint::try_from(loc).ok()
+                    })
+                    .into();
+                let providers = providers_constraint_from_proto(&settings.providers);
                 let ownership = try_ownership_constraint_from_i32(settings.ownership)?;
 
                 let mut wireguard_constraints =
@@ -277,26 +275,28 @@ impl From<mullvad_types::relay_constraints::LocationConstraint> for proto::Locat
     }
 }
 
-impl TryFrom<proto::LocationConstraint>
-    for Constraint<mullvad_types::relay_constraints::LocationConstraint>
-{
+impl TryFrom<proto::LocationConstraint> for mullvad_types::relay_constraints::LocationConstraint {
     type Error = FromProtobufTypeError;
 
     fn try_from(location: proto::LocationConstraint) -> Result<Self, Self::Error> {
         use mullvad_types::relay_constraints::LocationConstraint;
-        match location.r#type {
-            Some(proto::location_constraint::Type::Location(location)) => Ok(Constraint::Only(
+        let Some(typ) = location.r#type else {
+            return Err(invalid_argument(
+                "Type of location constraint was not provided",
+            ));
+        };
+        match typ {
+            proto::location_constraint::Type::Location(location) => Ok(
                 LocationConstraint::Location(GeographicLocationConstraint::try_from(location)?),
-            )),
-            Some(proto::location_constraint::Type::CustomList(list_id)) => {
+            ),
+            proto::location_constraint::Type::CustomList(list_id) => {
                 let location = LocationConstraint::CustomList {
                     list_id: Id::from_str(&list_id).map_err(|_| {
                         FromProtobufTypeError::InvalidArgument("Id could not be parsed to a uuid")
                     })?,
                 };
-                Ok(Constraint::Only(location))
+                Ok(location)
             }
-            None => Ok(Constraint::Any),
         }
     }
 }
@@ -492,17 +492,22 @@ impl TryFrom<proto::RelayOverride> for mullvad_types::relay_constraints::RelayOv
     }
 }
 
-pub fn try_providers_constraint_from_proto(
-    providers: &[String],
-) -> Result<Constraint<mullvad_types::relay_constraints::Providers>, FromProtobufTypeError> {
+impl From<proto::relay_selector::Provider> for mullvad_types::relay_constraints::Provider {
+    fn from(provider: proto::relay_selector::Provider) -> Self {
+        provider.name
+    }
+}
+
+pub fn providers_constraint_from_proto(
+    providers: &[impl Into<String> + Clone],
+) -> Constraint<mullvad_types::relay_constraints::Providers> {
     if !providers.is_empty() {
-        Ok(Constraint::Only(
-            mullvad_types::relay_constraints::Providers::new(providers.iter().cloned()).map_err(
-                |_| FromProtobufTypeError::InvalidArgument("must specify at least one provider"),
-            )?,
-        ))
+        Constraint::Only(
+            mullvad_types::relay_constraints::Providers::new(providers.iter().cloned())
+                .expect("Providers has been checked to not be empty"),
+        )
     } else {
-        Ok(Constraint::Any)
+        Constraint::Any
     }
 }
 

--- a/mullvad-management-interface/src/types/conversions/relay_selector.rs
+++ b/mullvad-management-interface/src/types/conversions/relay_selector.rs
@@ -1,0 +1,171 @@
+use mullvad_types::{
+    constraints::Constraint,
+    relay_list::Relay,
+    relay_selector::{
+        EntryConstraints, ExitConstraints, MultihopConstraints, Predicate, Reason, RelayPartitions,
+    },
+};
+
+use crate::types::{
+    FromProtobufTypeError, IpVersion, invalid_argument,
+    relay_constraints::try_ownership_constraint_from_i32,
+};
+use crate::types::{relay_constraints::providers_constraint_from_proto, relay_selector as proto};
+
+impl TryFrom<proto::Predicate> for Predicate {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(predicate: proto::Predicate) -> Result<Self, Self::Error> {
+        let Some(context) = predicate.context else {
+            return Err(invalid_argument("context must be provided"));
+        };
+        match context {
+            proto::predicate::Context::Singlehop(constraints) => {
+                EntryConstraints::try_from(constraints).map(Self::Singlehop)
+            }
+            proto::predicate::Context::Autohop(constraints) => {
+                EntryConstraints::try_from(constraints).map(Self::Autohop)
+            }
+            proto::predicate::Context::Entry(proto::MultiHopConstraints {
+                entry: Some(entry),
+                exit: Some(exit),
+            }) => {
+                let entry = EntryConstraints::try_from(entry)?;
+                let exit = ExitConstraints::try_from(exit)?;
+                let constraints = MultihopConstraints { entry, exit };
+                Ok(Self::Entry(constraints))
+            }
+            proto::predicate::Context::Exit(proto::MultiHopConstraints {
+                entry: Some(entry),
+                exit: Some(exit),
+            }) => {
+                let entry = EntryConstraints::try_from(entry)?;
+                let exit = ExitConstraints::try_from(exit)?;
+                let constraints = MultihopConstraints { entry, exit };
+                Ok(Self::Exit(constraints))
+            }
+            proto::predicate::Context::Entry(_) | proto::predicate::Context::Exit(_) => {
+                Err(invalid_argument("entry + exit must be provided"))
+            }
+        }
+    }
+}
+
+impl TryFrom<proto::EntryConstraints> for EntryConstraints {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(
+        proto::EntryConstraints {
+            general_constraints,
+            obfuscation_settings,
+            daita_settings,
+            ip_version,
+        }: proto::EntryConstraints,
+    ) -> Result<Self, Self::Error> {
+        let general = general_constraints
+            .map(ExitConstraints::try_from)
+            .transpose()?
+            .unwrap_or_default();
+
+        // NOTE: Provider and Ownership filters are mirrored from the provided exit constraints.
+        // This is somewhat of hack to make the relay selector logic easier to implement.
+        // TODO: When split filters have been implemented, grab these filters from the provided
+        // entry constraints.
+        let providers = general.providers.clone();
+        let ownership = general.ownership;
+
+        let ip_version: Constraint<_> = IpVersion::try_from(ip_version)
+            .map_err(|_| invalid_argument("invalid IP protocol version"))
+            .map(talpid_types::net::IpVersion::from)?
+            .into();
+
+        let obfuscation_settings: Constraint<_> = obfuscation_settings
+            .map(mullvad_types::relay_constraints::ObfuscationSettings::try_from)
+            .transpose()?
+            .into();
+
+        let daita: Constraint<_> = daita_settings
+            .map(mullvad_types::wireguard::DaitaSettings::from)
+            .into();
+
+        Ok(EntryConstraints {
+            general,
+            obfuscation_settings,
+            daita,
+            ip_version,
+            providers,
+            ownership,
+        })
+    }
+}
+
+impl TryFrom<proto::ExitConstraints> for ExitConstraints {
+    type Error = FromProtobufTypeError;
+
+    fn try_from(
+        proto::ExitConstraints {
+            location,
+            providers,
+            ownership,
+        }: proto::ExitConstraints,
+    ) -> Result<Self, Self::Error> {
+        let location: Constraint<_> = location
+            .map(mullvad_types::relay_constraints::LocationConstraint::try_from)
+            .transpose()?
+            .into();
+        let providers = providers_constraint_from_proto(&providers);
+        let ownership = try_ownership_constraint_from_i32(ownership)?;
+
+        Ok(ExitConstraints {
+            location,
+            providers,
+            ownership,
+        })
+    }
+}
+
+impl From<RelayPartitions> for proto::RelayPartitions {
+    fn from(RelayPartitions { matches, discards }: RelayPartitions) -> Self {
+        let matches = matches
+            .into_iter()
+            .map(|relay| relay.inner)
+            .map(proto::Relay::from)
+            .collect();
+        let discards = discards
+            .into_iter()
+            .map(|(relay, why)| (relay.inner, why))
+            .map(|(relay, why)| proto::DiscardedRelay {
+                relay: Some(proto::Relay::from(relay)),
+                why: Some(proto::IncompatibleConstraints::from(why)),
+            })
+            .collect();
+        Self { matches, discards }
+    }
+}
+
+impl From<Relay> for proto::Relay {
+    fn from(Relay { hostname, .. }: Relay) -> Self {
+        Self { hostname }
+    }
+}
+
+impl From<Vec<Reason>> for proto::IncompatibleConstraints {
+    fn from(reasons: Vec<Reason>) -> Self {
+        use Reason::*;
+        let mut incompatible = Self::default();
+        for reason in reasons {
+            match reason {
+                Inactive => incompatible.inactive = true,
+                Ownership => incompatible.ownership = true,
+                Location => incompatible.location = true,
+                Providers => incompatible.providers = true,
+                IpVersion => incompatible.ip_version = true,
+                Daita => incompatible.daita = true,
+                Obfuscation => incompatible.obfuscation = true,
+                Port => incompatible.port = true,
+                Conflict => incompatible.conflict_with_other_hop = true,
+            };
+        }
+        incompatible
+    }
+}

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -27,6 +27,7 @@ use mullvad_types::{
         ObfuscationSettings, RelayConstraints, RelaySettings, WireguardConstraints,
     },
     relay_list::{Bridge, BridgeList, Relay, RelayList, WireguardRelay},
+    relay_selector::{Predicate, RelayPartitions},
     settings::Settings,
     wireguard::QuantumResistantState,
 };
@@ -809,6 +810,10 @@ impl RelaySelector {
         let endpoint = detailer::bridge_endpoint(&bridge_list.bridge_endpoint, &bridge)
             .ok_or(Error::NoBridge)?;
         Ok((endpoint, bridge))
+    }
+
+    pub fn partition_relays(&self, _: Predicate) -> RelayPartitions {
+        todo!("Implement this algorithm.")
     }
 }
 

--- a/mullvad-types/src/lib.rs
+++ b/mullvad-types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod features;
 pub mod location;
 pub mod relay_constraints;
 pub mod relay_list;
+pub mod relay_selector;
 pub mod settings;
 pub mod states;
 pub mod version;

--- a/mullvad-types/src/relay_constraints.rs
+++ b/mullvad-types/src/relay_constraints.rs
@@ -287,16 +287,17 @@ pub struct Providers {
 pub struct NoProviders(());
 
 impl Providers {
+    /// Create a new `Providers` from an iterator.
+    /// Returns an error if the iterator is empty.
     pub fn new(
         providers: impl IntoIterator<Item = impl Into<Provider>>,
     ) -> Result<Providers, NoProviders> {
-        let providers = Providers {
-            providers: providers.into_iter().map(Into::into).collect(),
-        };
-        if providers.providers.is_empty() {
-            return Err(NoProviders(()));
+        let providers: HashSet<_> = providers.into_iter().map(Into::into).collect();
+        if !providers.is_empty() {
+            Ok(Providers { providers })
+        } else {
+            Err(NoProviders(()))
         }
-        Ok(providers)
     }
 
     pub fn into_vec(self) -> Vec<Provider> {

--- a/mullvad-types/src/relay_selector/mod.rs
+++ b/mullvad-types/src/relay_selector/mod.rs
@@ -1,0 +1,77 @@
+//! Types of `mullvad-relay-selector`.
+//!
+//! Most types in this module are equivalent to the ones in `mullvad-management-interface\proto\management_interface.proto`.
+//! See the proto file for more documentation.
+
+use talpid_types::net::IpVersion;
+
+use crate::{
+    constraints::Constraint,
+    relay_constraints::{LocationConstraint, ObfuscationSettings, Ownership, Providers},
+    relay_list::WireguardRelay,
+    wireguard::DaitaSettings,
+};
+
+/// Specify the constraints that should be applied when selecting relays,
+/// along with a context that may affect the selection behavior.
+#[derive(Debug, Clone)]
+pub enum Predicate {
+    Singlehop(EntryConstraints),
+    Autohop(EntryConstraints),
+    // Multihop-only
+    Entry(MultihopConstraints),
+    Exit(MultihopConstraints),
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct EntryConstraints {
+    pub general: ExitConstraints,
+    // Entry-specific constraints.
+    pub obfuscation_settings: Constraint<ObfuscationSettings>,
+    pub daita: Constraint<DaitaSettings>,
+    pub ip_version: Constraint<IpVersion>,
+    pub providers: Constraint<Providers>,
+    pub ownership: Constraint<Ownership>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ExitConstraints {
+    pub location: Constraint<LocationConstraint>,
+    pub providers: Constraint<Providers>,
+    pub ownership: Constraint<Ownership>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MultihopConstraints {
+    pub entry: EntryConstraints,
+    pub exit: ExitConstraints,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct RelayPartitions {
+    pub matches: Vec<WireguardRelay>,
+    pub discards: Vec<(WireguardRelay, Vec<Reason>)>,
+}
+
+/// All possible reasons why a relay was filtered out for a particular query.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Reason {
+    /// This relay is already used for the other hop (entry/exit).
+    Conflict,
+    /// The relay does not run DAITA.
+    Daita,
+    /// The relay is currently offline.
+    Inactive,
+    /// The relay cannot be connected to with the requested ip version.
+    IpVersion,
+    /// The relay does not reside in the given location.
+    Location,
+    /// The requested obfuscation method is not available.
+    Obfuscation,
+    /// The relay ownership does not match.
+    Ownership,
+    /// The relay cannot be connected to via the requested port.
+    Port,
+    /// The relay is not hosted by the given provider.
+    Providers,
+}


### PR DESCRIPTION
This PR scaffolds https://github.com/mullvad/mullvadvpn-app/pull/9863. It creates a new gRPC service exposing the new relay selector API defined in `relay_selector.proto` created in https://github.com/mullvad/mullvadvpn-app/pull/9793. 

Note that the `PartitionRelays` algorithm is actually being implemented in https://github.com/mullvad/mullvadvpn-app/pull/9863. We decided to split that PR up into smaller chunks to merge the code which is already considered "done" to reduce the risk of merge conflicts arising. Do not call `PartitionRelays` at the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9967)
<!-- Reviewable:end -->
