### PR TITLE
Add user-configurable IP/subnet split tunneling on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+#### Windows
+- Add user-configurable IP/subnet exclusions that bypass the VPN firewall. Allows services
+  like Tailscale (100.64.0.0/10) to work alongside Mullvad VPN.
+
 ### Changed
 - Location setting no longer defaults to Sweden, instead it uses you current location if it
   has available relays, and falls back to Sweden otherwise.

--- a/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
+++ b/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
@@ -476,6 +476,18 @@ export class DaemonRpc extends GrpcClient {
     await this.callBool(this.client.setSplitTunnelState, enabled);
   }
 
+  public async addSplitTunnelIpNetwork(network: string): Promise<void> {
+    await this.callString(this.client.addSplitTunnelIpNetwork, network);
+  }
+
+  public async removeSplitTunnelIpNetwork(network: string): Promise<void> {
+    await this.callString(this.client.removeSplitTunnelIpNetwork, network);
+  }
+
+  public async clearSplitTunnelIpNetworks(): Promise<void> {
+    await this.callEmpty(this.client.clearSplitTunnelIpNetworks);
+  }
+
   public async splitTunnelIsSupported(): Promise<boolean> {
     try {
       const isSupported = await this.callEmpty<BoolValue>(this.client.splitTunnelIsSupported);

--- a/desktop/packages/mullvad-vpn/src/main/default-settings.ts
+++ b/desktop/packages/mullvad-vpn/src/main/default-settings.ts
@@ -28,6 +28,7 @@ export function getDefaultSettings(): ISettings {
     splitTunnel: {
       enableExclusions: true,
       appsList: [],
+      ipExclusionsList: [],
     },
     relaySettings: {
       normal: getDefaultRelaySettingsNormal(),

--- a/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
@@ -435,7 +435,7 @@ export function convertFromSettings(settings: grpcTypes.Settings): ISettings | u
   const settingsObject = settings.toObject();
   const relaySettings = convertFromRelaySettings(settings.getRelaySettings())!;
   const tunnelOptions = convertFromTunnelOptions(settingsObject.tunnelOptions!);
-  const splitTunnel = settingsObject.splitTunnel ?? { enableExclusions: false, appsList: [] };
+  const splitTunnel = settingsObject.splitTunnel ?? { enableExclusions: false, appsList: [], ipExclusionsList: [] };
   const obfuscationSettings = convertFromObfuscationSettings(settingsObject.obfuscationSettings);
   const customLists = convertFromCustomListSettings(settings.getCustomLists());
   const apiAccessMethods = convertFromApiAccessMethodSettings(settings.getApiAccessMethods()!);

--- a/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-type-convertions.ts
@@ -435,7 +435,11 @@ export function convertFromSettings(settings: grpcTypes.Settings): ISettings | u
   const settingsObject = settings.toObject();
   const relaySettings = convertFromRelaySettings(settings.getRelaySettings())!;
   const tunnelOptions = convertFromTunnelOptions(settingsObject.tunnelOptions!);
-  const splitTunnel = settingsObject.splitTunnel ?? { enableExclusions: false, appsList: [], ipExclusionsList: [] };
+  const splitTunnel = settingsObject.splitTunnel ?? {
+    enableExclusions: false,
+    appsList: [],
+    ipExclusionsList: [],
+  };
   const obfuscationSettings = convertFromObfuscationSettings(settingsObject.obfuscationSettings);
   const customLists = convertFromCustomListSettings(settings.getCustomLists());
   const apiAccessMethods = convertFromApiAccessMethodSettings(settings.getApiAccessMethods()!);

--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -918,6 +918,15 @@ class ApplicationMain
     IpcMainEventChannel.splitTunneling.handleGetSupported(() => {
       return this.daemonRpc.splitTunnelIsSupported();
     });
+    IpcMainEventChannel.splitTunneling.handleAddIpNetwork((network) => {
+      return this.daemonRpc.addSplitTunnelIpNetwork(network);
+    });
+    IpcMainEventChannel.splitTunneling.handleRemoveIpNetwork((network) => {
+      return this.daemonRpc.removeSplitTunnelIpNetwork(network);
+    });
+    IpcMainEventChannel.splitTunneling.handleClearIpNetworks(() => {
+      return this.daemonRpc.clearSplitTunnelIpNetworks();
+    });
     IpcMainEventChannel.macOsSplitTunneling.handleNeedFullDiskPermissions(async () => {
       const fullDiskState = await this.daemonRpc.needFullDiskPermissions();
       this.needFullDiskAccess = fullDiskState;

--- a/desktop/packages/mullvad-vpn/src/renderer/app.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/app.tsx
@@ -436,6 +436,12 @@ export default class AppRenderer {
     IpcRendererEventChannel.splitTunneling.addApplication(application);
   public forgetManuallyAddedSplitTunnelingApplication = (application: ISplitTunnelingApplication) =>
     IpcRendererEventChannel.splitTunneling.forgetManuallyAddedApplication(application);
+  public addSplitTunnelIpNetwork = (network: string) =>
+    IpcRendererEventChannel.splitTunneling.addIpNetwork(network);
+  public removeSplitTunnelIpNetwork = (network: string) =>
+    IpcRendererEventChannel.splitTunneling.removeIpNetwork(network);
+  public clearSplitTunnelIpNetworks = () =>
+    IpcRendererEventChannel.splitTunneling.clearIpNetworks();
   public needFullDiskPermissions = () =>
     IpcRendererEventChannel.macOsSplitTunneling.needFullDiskPermissions();
   public setObfuscationSettings = (obfuscationSettings: ObfuscationSettings) =>
@@ -848,6 +854,7 @@ export default class AppRenderer {
     reduxSettings.updateWireguardDaita(newSettings.tunnelOptions.daita);
     reduxSettings.updateDnsOptions(newSettings.tunnelOptions.dns);
     reduxSettings.updateSplitTunnelingState(newSettings.splitTunnel.enableExclusions);
+    reduxSettings.setSplitTunnelingIpExclusions(newSettings.splitTunnel.ipExclusionsList);
     reduxSettings.updateObfuscationSettings(newSettings.obfuscationSettings);
     reduxSettings.updateCustomLists(newSettings.customLists);
     reduxSettings.updateApiAccessMethods(newSettings.apiAccessMethods);

--- a/desktop/packages/mullvad-vpn/src/renderer/components/AppRouter.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/AppRouter.tsx
@@ -36,6 +36,7 @@ import {
   SettingsTextImportView,
   SettingsView,
   ShadowsocksSettingsView,
+  SplitTunnelingIpView,
   SplitTunnelingView,
   SupportView,
   TooManyDevicesView,
@@ -82,6 +83,7 @@ export default function AppRouter() {
           <Route exact path={RoutePath.udpOverTcp} component={UdpOverTcpSettingsView} />
           <Route exact path={RoutePath.shadowsocks} component={ShadowsocksSettingsView} />
           <Route exact path={RoutePath.splitTunneling} component={SplitTunnelingView} />
+          <Route exact path={RoutePath.splitTunnelingIp} component={SplitTunnelingIpView} />
           <Route exact path={RoutePath.apiAccessMethods} component={ApiAccessView} />
           <Route exact path={RoutePath.settingsImport} component={SettingsImportView} />
           <Route exact path={RoutePath.settingsTextImport} component={SettingsTextImportView} />

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/index.ts
@@ -22,6 +22,7 @@ export * from './settings-text-import';
 export * from './select-language';
 export * from './shadowsocks-settings';
 export * from './split-tunneling';
+export * from './split-tunneling-ip';
 export * from './support';
 export * from './too-many-devices';
 export * from './udp-over-tcp-settings';

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/SettingsView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/SettingsView.tsx
@@ -13,6 +13,7 @@ import {
   DebugListItem,
   MultihopListItem,
   QuitButton,
+  SplitTunnelingIpListItem,
   SplitTunnelingListItem,
   SupportListItem,
   UserInterfaceSettingsListItem,
@@ -51,7 +52,12 @@ export function SettingsView() {
                         <VpnSettingsListItem />
                         <UserInterfaceSettingsListItem />
                       </FlexColumn>
-                      {showSplitTunneling && <SplitTunnelingListItem position="solo" />}
+                      {showSplitTunneling && (
+                        <FlexColumn>
+                          <SplitTunnelingListItem />
+                          {window.env.platform === 'win32' && <SplitTunnelingIpListItem />}
+                        </FlexColumn>
+                      )}
                     </>
                   ) : (
                     <UserInterfaceSettingsListItem position="solo" />

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/index.ts
@@ -5,6 +5,7 @@ export * from './debug-list-item';
 export * from './multihop-list-item';
 export * from './quit-button';
 export * from './split-tunneling-list-item';
+export * from './split-tunneling-ip-list-item';
 export * from './support-list-item';
 export * from './user-interface-settings-list-item';
 export * from './vpn-settings-list-item';

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/split-tunneling-ip-list-item/SplitTunnelingIpListItem.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/split-tunneling-ip-list-item/SplitTunnelingIpListItem.tsx
@@ -1,0 +1,17 @@
+import { strings } from '../../../../../../shared/constants';
+import { RoutePath } from '../../../../../../shared/routes';
+import { ListItemProps } from '../../../../../lib/components/list-item';
+import { SettingsNavigationListItem } from '../../../../settings-navigation-list-item';
+
+export type SplitTunnelingIpListItemProps = Omit<ListItemProps, 'children'>;
+
+export function SplitTunnelingIpListItem(props: SplitTunnelingIpListItemProps) {
+  return (
+    <SettingsNavigationListItem to={RoutePath.splitTunnelingIp} {...props}>
+      <SettingsNavigationListItem.Label>{strings.splitTunnelingIp}</SettingsNavigationListItem.Label>
+      <SettingsNavigationListItem.ActionGroup>
+        <SettingsNavigationListItem.Icon icon="chevron-right" />
+      </SettingsNavigationListItem.ActionGroup>
+    </SettingsNavigationListItem>
+  );
+}

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/split-tunneling-ip-list-item/SplitTunnelingIpListItem.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/split-tunneling-ip-list-item/SplitTunnelingIpListItem.tsx
@@ -8,7 +8,9 @@ export type SplitTunnelingIpListItemProps = Omit<ListItemProps, 'children'>;
 export function SplitTunnelingIpListItem(props: SplitTunnelingIpListItemProps) {
   return (
     <SettingsNavigationListItem to={RoutePath.splitTunnelingIp} {...props}>
-      <SettingsNavigationListItem.Label>{strings.splitTunnelingIp}</SettingsNavigationListItem.Label>
+      <SettingsNavigationListItem.Label>
+        {strings.splitTunnelingIp}
+      </SettingsNavigationListItem.Label>
       <SettingsNavigationListItem.ActionGroup>
         <SettingsNavigationListItem.Icon icon="chevron-right" />
       </SettingsNavigationListItem.ActionGroup>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/split-tunneling-ip-list-item/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/settings/components/split-tunneling-ip-list-item/index.ts
@@ -1,0 +1,1 @@
+export * from './SplitTunnelingIpListItem';

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
@@ -184,7 +184,7 @@ export function SplitTunnelingIpView() {
                 <HeaderSubTitle>
                   {messages.pgettext(
                     'split-tunneling-ip-view',
-                    'Exclude traffic to specific IP addresses or subnets from the VPN tunnel.',
+                    'Exclude traffic to specific IP addresses or subnets from the VPN tunnel (e.g. 100.64.0.0/10).',
                   )}
                 </HeaderSubTitle>
               </SettingsHeader>
@@ -196,7 +196,7 @@ export function SplitTunnelingIpView() {
                   onKeyDown={onKeyDown}
                   placeholder={messages.pgettext(
                     'split-tunneling-ip-view',
-                    'Enter IP or CIDR (e.g. 100.64.0.0/10)',
+                    'Add IP or subnet...',
                   )}
                 />
                 <StyledAddIcon

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
@@ -1,0 +1,259 @@
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import { strings } from '../../../../shared/constants';
+import { messages } from '../../../../shared/gettext';
+import { useAppContext } from '../../../context';
+import { Flex, Icon, IconButton } from '../../../lib/components';
+import { AnimatedList } from '../../../lib/components/animated-list';
+import { View } from '../../../lib/components/view';
+import { colors, spacings } from '../../../lib/foundations';
+import { usePop } from '../../../history/hooks';
+import { useSelector } from '../../../redux/store';
+import { AppNavigationHeader } from '../../';
+import * as Cell from '../../cell';
+import { normalText } from '../../common-styles';
+import { BackAction } from '../../keyboard-navigation';
+import { NavigationScrollbars } from '../../NavigationScrollbars';
+import { NavigationContainer } from '../../NavigationContainer';
+import SettingsHeader, { HeaderSubTitle, HeaderTitle } from '../../SettingsHeader';
+
+const StyledSearchContainer = styled.div({
+  position: 'relative',
+  display: 'flex',
+  marginLeft: spacings.medium,
+  marginRight: spacings.medium,
+  marginBottom: spacings.medium,
+});
+
+const StyledSearchInput = styled.input.attrs({ type: 'text' })({
+  ...normalText,
+  flex: 1,
+  border: 'none',
+  borderRadius: '4px',
+  padding: '9px 38px 9px 12px',
+  margin: 0,
+  lineHeight: '24px',
+  color: colors.whiteAlpha60,
+  backgroundColor: colors.whiteOnDarkBlue10,
+  outline: 'none',
+  '&&::placeholder': {
+    color: colors.whiteOnDarkBlue60,
+  },
+  '&&:focus': {
+    color: colors.whiteAlpha60,
+    backgroundColor: colors.whiteOnDarkBlue10,
+  },
+});
+
+const StyledAddIcon = styled(Icon)({
+  position: 'absolute',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  right: '9px',
+  backgroundColor: colors.whiteOnDarkBlue60,
+  cursor: 'pointer',
+  '&&:hover': {
+    backgroundColor: colors.whiteOnDarkBlue40,
+  },
+});
+
+const StyledRowContainer = styled(Cell.Container)({
+  backgroundColor: colors.blue40,
+});
+
+export function SplitTunnelingIpView() {
+  const pop = usePop();
+  const ipExclusions = useSelector((state) => state.settings.splitTunnelingIpExclusions);
+  const { addSplitTunnelIpNetwork, removeSplitTunnelIpNetwork } = useAppContext();
+  const [inputValue, setInputValue] = useState('');
+  const [removedIps, setRemovedIps] = useState<string[]>([]);
+
+  if (window.env.platform !== 'win32') {
+    return null;
+  }
+
+  const validateCidr = (value: string): boolean => {
+    const ipv4Cidr = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/;
+    const ipv6Cidr = /^[0-9a-fA-F:.]+(\/\d{1,3})?$/;
+    return ipv4Cidr.test(value) || ipv6Cidr.test(value);
+  };
+
+  const normalizeNetwork = (value: string): string => {
+    if (!value.includes('/')) {
+      return value.includes(':') ? `${value}/128` : `${value}/32`;
+    }
+    return value;
+  };
+
+  const isValidInput = (): boolean => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return false;
+    if (!validateCidr(trimmed)) return false;
+    const network = normalizeNetwork(trimmed);
+    if (ipExclusions.includes(network)) return false;
+    return true;
+  };
+
+  const onAdd = async () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    if (!validateCidr(trimmed)) return;
+
+    const network = normalizeNetwork(trimmed);
+    if (ipExclusions.includes(network)) return;
+
+    try {
+      await addSplitTunnelIpNetwork(network);
+      setInputValue('');
+      setRemovedIps((prev) => prev.filter((ip) => ip !== network));
+    } catch {
+      // silently fail
+    }
+  };
+
+  const onRemoveFromIncluded = useCallback(
+    (network: string) => {
+      void removeSplitTunnelIpNetwork(network);
+      setRemovedIps((prev) => (prev.includes(network) ? prev : [...prev, network]));
+    },
+    [removeSplitTunnelIpNetwork],
+  );
+
+  const onRestoreFromExcluded = useCallback(
+    async (network: string) => {
+      try {
+        await addSplitTunnelIpNetwork(network);
+        setRemovedIps((prev) => prev.filter((ip) => ip !== network));
+      } catch {
+        // silently fail
+      }
+    },
+    [addSplitTunnelIpNetwork],
+  );
+
+  const onPermanentlyRemove = useCallback((network: string) => {
+    setRemovedIps((prev) => prev.filter((ip) => ip !== network));
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      void onAdd();
+    }
+  };
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  const includedTitle = (
+    <Cell.SectionTitle>
+      {
+        // TRANSLATORS: Section title for IP networks included in split tunneling.
+        messages.pgettext('split-tunneling-ip-view', 'Included IPs')
+      }
+    </Cell.SectionTitle>
+  );
+  const excludedTitle = (
+    <Cell.SectionTitle>
+      {
+        // TRANSLATORS: Section title for IP networks removed from split tunneling.
+        messages.pgettext('split-tunneling-ip-view', 'Excluded IPs')
+      }
+    </Cell.SectionTitle>
+  );
+
+  const actualRemovedIps = removedIps.filter((ip) => !ipExclusions.includes(ip));
+  const canAdd = isValidInput();
+
+  return (
+    <View backgroundColor="darkBlue">
+      <BackAction action={pop}>
+        <NavigationContainer>
+          <AppNavigationHeader
+            title={
+              // TRANSLATORS: Title label in navigation bar
+              strings.splitTunnelingIp
+            }
+          />
+
+          <NavigationScrollbars fillContainer>
+            <View.Content>
+              <SettingsHeader>
+                <HeaderTitle>{strings.splitTunnelingIp}</HeaderTitle>
+                <HeaderSubTitle>
+                  {messages.pgettext(
+                    'split-tunneling-ip-view',
+                    'Exclude traffic to specific IP addresses or subnets from the VPN tunnel.',
+                  )}
+                </HeaderSubTitle>
+              </SettingsHeader>
+
+              <StyledSearchContainer>
+                <StyledSearchInput
+                  value={inputValue}
+                  onInput={onInputChange}
+                  onKeyDown={onKeyDown}
+                  placeholder={messages.pgettext(
+                    'split-tunneling-ip-view',
+                    'Enter IP or CIDR (e.g. 100.64.0.0/10)',
+                  )}
+                />
+                <StyledAddIcon
+                  icon={canAdd ? 'add-circle' : 'alert-circle'}
+                  onClick={() => canAdd && void onAdd()}
+                />
+              </StyledSearchContainer>
+
+              <Flex flexDirection="column" gap="medium">
+                <Cell.Section sectionTitle={includedTitle}>
+                  <AnimatedList>
+                    {ipExclusions.map((network) => (
+                      <AnimatedList.Item key={network}>
+                        <StyledRowContainer>
+                          <Cell.Label>{network}</Cell.Label>
+                          <IconButton
+                            variant="secondary"
+                            onClick={() => onRemoveFromIncluded(network)}
+                            aria-label={`Remove ${network}`}>
+                            <IconButton.Icon icon="remove-circle" />
+                          </IconButton>
+                        </StyledRowContainer>
+                      </AnimatedList.Item>
+                    ))}
+                  </AnimatedList>
+                </Cell.Section>
+
+                <Cell.Section sectionTitle={excludedTitle}>
+                  <AnimatedList>
+                    {actualRemovedIps.map((network) => (
+                      <AnimatedList.Item key={network}>
+                        <StyledRowContainer>
+                          <Cell.Label>{network}</Cell.Label>
+                          <Flex gap="small">
+                            <IconButton
+                              variant="secondary"
+                              onClick={() => void onRestoreFromExcluded(network)}
+                              aria-label={`Restore ${network}`}>
+                              <IconButton.Icon icon="add-circle" />
+                            </IconButton>
+                            <IconButton
+                              variant="secondary"
+                              onClick={() => onPermanentlyRemove(network)}
+                              aria-label={`Permanently remove ${network}`}>
+                              <IconButton.Icon icon="remove-circle" />
+                            </IconButton>
+                          </Flex>
+                        </StyledRowContainer>
+                      </AnimatedList.Item>
+                    ))}
+                  </AnimatedList>
+                </Cell.Section>
+              </Flex>
+            </View.Content>
+          </NavigationScrollbars>
+        </NavigationContainer>
+      </BackAction>
+    </View>
+  );
+}

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
@@ -41,8 +41,8 @@ const StyledSearchInput = styled.input.attrs({ type: 'text' })({
     color: colors.whiteOnDarkBlue60,
   },
   '&&:focus': {
-    color: colors.whiteAlpha60,
-    backgroundColor: colors.whiteOnDarkBlue10,
+    color: colors.blue,
+    backgroundColor: colors.white,
   },
 });
 

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/SplitTunnelingIpView.tsx
@@ -4,18 +4,18 @@ import styled from 'styled-components';
 import { strings } from '../../../../shared/constants';
 import { messages } from '../../../../shared/gettext';
 import { useAppContext } from '../../../context';
+import { usePop } from '../../../history/hooks';
 import { Flex, Icon, IconButton } from '../../../lib/components';
 import { AnimatedList } from '../../../lib/components/animated-list';
 import { View } from '../../../lib/components/view';
 import { colors, spacings } from '../../../lib/foundations';
-import { usePop } from '../../../history/hooks';
 import { useSelector } from '../../../redux/store';
 import { AppNavigationHeader } from '../../';
 import * as Cell from '../../cell';
 import { normalText } from '../../common-styles';
 import { BackAction } from '../../keyboard-navigation';
-import { NavigationScrollbars } from '../../NavigationScrollbars';
 import { NavigationContainer } from '../../NavigationContainer';
+import { NavigationScrollbars } from '../../NavigationScrollbars';
 import SettingsHeader, { HeaderSubTitle, HeaderTitle } from '../../SettingsHeader';
 
 const StyledSearchContainer = styled.div({
@@ -62,6 +62,66 @@ const StyledRowContainer = styled(Cell.Container)({
   backgroundColor: colors.blue40,
 });
 
+function validateCidr(value: string): boolean {
+  const ipv4Cidr = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/;
+  const ipv6Cidr = /^[0-9a-fA-F:.]+(\/\d{1,3})?$/;
+  return ipv4Cidr.test(value) || ipv6Cidr.test(value);
+}
+
+function normalizeNetwork(value: string): string {
+  if (!value.includes('/')) {
+    return value.includes(':') ? `${value}/128` : `${value}/32`;
+  }
+  return value;
+}
+
+interface IncludedIpRowProps {
+  network: string;
+  onRemove: (network: string) => void;
+}
+
+function IncludedIpRow({ network, onRemove }: IncludedIpRowProps) {
+  const handleRemove = useCallback(() => onRemove(network), [network, onRemove]);
+  return (
+    <StyledRowContainer>
+      <Cell.Label>{network}</Cell.Label>
+      <IconButton variant="secondary" onClick={handleRemove} aria-label={`Remove ${network}`}>
+        <IconButton.Icon icon="remove-circle" />
+      </IconButton>
+    </StyledRowContainer>
+  );
+}
+
+interface ExcludedIpRowProps {
+  network: string;
+  onRestore: (network: string) => void;
+  onPermanentlyRemove: (network: string) => void;
+}
+
+function ExcludedIpRow({ network, onRestore, onPermanentlyRemove }: ExcludedIpRowProps) {
+  const handleRestore = useCallback(() => onRestore(network), [network, onRestore]);
+  const handleRemove = useCallback(
+    () => onPermanentlyRemove(network),
+    [network, onPermanentlyRemove],
+  );
+  return (
+    <StyledRowContainer>
+      <Cell.Label>{network}</Cell.Label>
+      <Flex gap="small">
+        <IconButton variant="secondary" onClick={handleRestore} aria-label={`Restore ${network}`}>
+          <IconButton.Icon icon="add-circle" />
+        </IconButton>
+        <IconButton
+          variant="secondary"
+          onClick={handleRemove}
+          aria-label={`Permanently remove ${network}`}>
+          <IconButton.Icon icon="remove-circle" />
+        </IconButton>
+      </Flex>
+    </StyledRowContainer>
+  );
+}
+
 export function SplitTunnelingIpView() {
   const pop = usePop();
   const ipExclusions = useSelector((state) => state.settings.splitTunnelingIpExclusions);
@@ -69,33 +129,28 @@ export function SplitTunnelingIpView() {
   const [inputValue, setInputValue] = useState('');
   const [removedIps, setRemovedIps] = useState<string[]>([]);
 
-  if (window.env.platform !== 'win32') {
-    return null;
-  }
+  const onRemoveFromIncluded = useCallback(
+    (network: string) => {
+      void removeSplitTunnelIpNetwork(network);
+      setRemovedIps((prev) => (prev.includes(network) ? prev : [...prev, network]));
+    },
+    [removeSplitTunnelIpNetwork],
+  );
 
-  const validateCidr = (value: string): boolean => {
-    const ipv4Cidr = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/;
-    const ipv6Cidr = /^[0-9a-fA-F:.]+(\/\d{1,3})?$/;
-    return ipv4Cidr.test(value) || ipv6Cidr.test(value);
-  };
+  const onRestoreFromExcluded = useCallback(
+    (network: string) => {
+      void addSplitTunnelIpNetwork(network).then(() => {
+        setRemovedIps((prev) => prev.filter((ip) => ip !== network));
+      });
+    },
+    [addSplitTunnelIpNetwork],
+  );
 
-  const normalizeNetwork = (value: string): string => {
-    if (!value.includes('/')) {
-      return value.includes(':') ? `${value}/128` : `${value}/32`;
-    }
-    return value;
-  };
+  const onPermanentlyRemove = useCallback((network: string) => {
+    setRemovedIps((prev) => prev.filter((ip) => ip !== network));
+  }, []);
 
-  const isValidInput = (): boolean => {
-    const trimmed = inputValue.trim();
-    if (!trimmed) return false;
-    if (!validateCidr(trimmed)) return false;
-    const network = normalizeNetwork(trimmed);
-    if (ipExclusions.includes(network)) return false;
-    return true;
-  };
-
-  const onAdd = async () => {
+  const onAdd = useCallback(async () => {
     const trimmed = inputValue.trim();
     if (!trimmed) return;
     if (!validateCidr(trimmed)) return;
@@ -110,40 +165,36 @@ export function SplitTunnelingIpView() {
     } catch {
       // silently fail
     }
-  };
+  }, [inputValue, ipExclusions, addSplitTunnelIpNetwork]);
 
-  const onRemoveFromIncluded = useCallback(
-    (network: string) => {
-      void removeSplitTunnelIpNetwork(network);
-      setRemovedIps((prev) => (prev.includes(network) ? prev : [...prev, network]));
-    },
-    [removeSplitTunnelIpNetwork],
-  );
+  const handleAddClick = useCallback(() => {
+    void onAdd();
+  }, [onAdd]);
 
-  const onRestoreFromExcluded = useCallback(
-    async (network: string) => {
-      try {
-        await addSplitTunnelIpNetwork(network);
-        setRemovedIps((prev) => prev.filter((ip) => ip !== network));
-      } catch {
-        // silently fail
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        void onAdd();
       }
     },
-    [addSplitTunnelIpNetwork],
+    [onAdd],
   );
 
-  const onPermanentlyRemove = useCallback((network: string) => {
-    setRemovedIps((prev) => prev.filter((ip) => ip !== network));
+  const onInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
   }, []);
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      void onAdd();
-    }
-  };
+  if (window.env.platform !== 'win32') {
+    return null;
+  }
 
-  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
+  const isValidInput = (): boolean => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return false;
+    if (!validateCidr(trimmed)) return false;
+    const network = normalizeNetwork(trimmed);
+    if (ipExclusions.includes(network)) return false;
+    return true;
   };
 
   const includedTitle = (
@@ -194,14 +245,11 @@ export function SplitTunnelingIpView() {
                   value={inputValue}
                   onInput={onInputChange}
                   onKeyDown={onKeyDown}
-                  placeholder={messages.pgettext(
-                    'split-tunneling-ip-view',
-                    'Add IP or subnet...',
-                  )}
+                  placeholder={messages.pgettext('split-tunneling-ip-view', 'Add IP or subnet...')}
                 />
                 <StyledAddIcon
                   icon={canAdd ? 'add-circle' : 'alert-circle'}
-                  onClick={() => canAdd && void onAdd()}
+                  onClick={handleAddClick}
                 />
               </StyledSearchContainer>
 
@@ -210,15 +258,7 @@ export function SplitTunnelingIpView() {
                   <AnimatedList>
                     {ipExclusions.map((network) => (
                       <AnimatedList.Item key={network}>
-                        <StyledRowContainer>
-                          <Cell.Label>{network}</Cell.Label>
-                          <IconButton
-                            variant="secondary"
-                            onClick={() => onRemoveFromIncluded(network)}
-                            aria-label={`Remove ${network}`}>
-                            <IconButton.Icon icon="remove-circle" />
-                          </IconButton>
-                        </StyledRowContainer>
+                        <IncludedIpRow network={network} onRemove={onRemoveFromIncluded} />
                       </AnimatedList.Item>
                     ))}
                   </AnimatedList>
@@ -228,23 +268,11 @@ export function SplitTunnelingIpView() {
                   <AnimatedList>
                     {actualRemovedIps.map((network) => (
                       <AnimatedList.Item key={network}>
-                        <StyledRowContainer>
-                          <Cell.Label>{network}</Cell.Label>
-                          <Flex gap="small">
-                            <IconButton
-                              variant="secondary"
-                              onClick={() => void onRestoreFromExcluded(network)}
-                              aria-label={`Restore ${network}`}>
-                              <IconButton.Icon icon="add-circle" />
-                            </IconButton>
-                            <IconButton
-                              variant="secondary"
-                              onClick={() => onPermanentlyRemove(network)}
-                              aria-label={`Permanently remove ${network}`}>
-                              <IconButton.Icon icon="remove-circle" />
-                            </IconButton>
-                          </Flex>
-                        </StyledRowContainer>
+                        <ExcludedIpRow
+                          network={network}
+                          onRestore={onRestoreFromExcluded}
+                          onPermanentlyRemove={onPermanentlyRemove}
+                        />
                       </AnimatedList.Item>
                     ))}
                   </AnimatedList>

--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/index.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/split-tunneling-ip/index.ts
@@ -1,0 +1,1 @@
+export * from './SplitTunnelingIpView';

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/settings/actions.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/settings/actions.ts
@@ -92,6 +92,11 @@ export interface ISetSplitTunnelingSupportedAction {
   supported: boolean;
 }
 
+export interface ISetSplitTunnelingIpExclusionsAction {
+  type: 'SET_SPLIT_TUNNELING_IP_EXCLUSIONS';
+  ipExclusions: string[];
+}
+
 export interface ISetObfuscationSettings {
   type: 'SET_OBFUSCATION_SETTINGS';
   obfuscationSettings: ObfuscationSettings;
@@ -134,6 +139,7 @@ export type SettingsAction =
   | IUpdateSplitTunnelingStateAction
   | ISetSplitTunnelingApplicationsAction
   | ISetSplitTunnelingSupportedAction
+  | ISetSplitTunnelingIpExclusionsAction
   | ISetObfuscationSettings
   | ISetCustomLists
   | ISetApiAccessMethods
@@ -260,6 +266,13 @@ function setSplitTunnelingSupported(supported: boolean): ISetSplitTunnelingSuppo
   };
 }
 
+function setSplitTunnelingIpExclusions(ipExclusions: string[]): ISetSplitTunnelingIpExclusionsAction {
+  return {
+    type: 'SET_SPLIT_TUNNELING_IP_EXCLUSIONS',
+    ipExclusions,
+  };
+}
+
 function updateObfuscationSettings(
   obfuscationSettings: ObfuscationSettings,
 ): ISetObfuscationSettings {
@@ -314,6 +327,7 @@ export default {
   updateSplitTunnelingState,
   setSplitTunnelingApplications,
   setSplitTunnelingSupported,
+  setSplitTunnelingIpExclusions,
   updateObfuscationSettings,
   updateCustomLists,
   updateApiAccessMethods,

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/settings/actions.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/settings/actions.ts
@@ -266,7 +266,9 @@ function setSplitTunnelingSupported(supported: boolean): ISetSplitTunnelingSuppo
   };
 }
 
-function setSplitTunnelingIpExclusions(ipExclusions: string[]): ISetSplitTunnelingIpExclusionsAction {
+function setSplitTunnelingIpExclusions(
+  ipExclusions: string[],
+): ISetSplitTunnelingIpExclusionsAction {
   return {
     type: 'SET_SPLIT_TUNNELING_IP_EXCLUSIONS',
     ipExclusions,

--- a/desktop/packages/mullvad-vpn/src/renderer/redux/settings/reducers.ts
+++ b/desktop/packages/mullvad-vpn/src/renderer/redux/settings/reducers.ts
@@ -88,6 +88,7 @@ export interface ISettingsReduxState {
   dns: IDnsOptions;
   splitTunneling: boolean;
   splitTunnelingApplications: ISplitTunnelingApplication[];
+  splitTunnelingIpExclusions: string[];
   splitTunnelingSupported: boolean;
   obfuscationSettings: ObfuscationSettings;
   customLists: CustomLists;
@@ -143,6 +144,7 @@ const initialState: ISettingsReduxState = {
   },
   splitTunneling: false,
   splitTunnelingApplications: [],
+  splitTunnelingIpExclusions: [],
   splitTunnelingSupported: false,
   obfuscationSettings: {
     selectedObfuscation: ObfuscationType.auto,
@@ -269,6 +271,12 @@ export default function (
       return {
         ...state,
         splitTunnelingSupported: action.supported,
+      };
+
+    case 'SET_SPLIT_TUNNELING_IP_EXCLUSIONS':
+      return {
+        ...state,
+        splitTunnelingIpExclusions: action.ipExclusions,
       };
 
     case 'SET_OBFUSCATION_SETTINGS':

--- a/desktop/packages/mullvad-vpn/src/shared/constants/strings.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/constants/strings.ts
@@ -2,6 +2,7 @@ export const strings = {
   wireguard: 'WireGuard',
   openvpn: 'OpenVPN',
   splitTunneling: 'Split tunneling',
+  splitTunnelingIp: 'Split tunneling (IP)',
   daita: 'DAITA',
   daitaFull: 'Defence against AI-guided Traffic Analysis',
   supportEmail: 'support@mullvadvpn.net',

--- a/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/daemon-rpc-types.ts
@@ -472,6 +472,7 @@ export interface ISettings {
 export type SplitTunnelSettings = {
   enableExclusions: boolean;
   appsList: string[];
+  ipExclusionsList: string[];
 };
 
 export type WireGuardPortObfuscationSettings = {

--- a/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/ipc-schema.ts
@@ -269,5 +269,8 @@ export const ipcSchema = {
     forgetManuallyAddedApplication: invoke<ISplitTunnelingApplication, void>(),
     getSupported: invoke<void, boolean>(),
     isSupported: notifyRenderer<boolean>(),
+    addIpNetwork: invoke<string, void>(),
+    removeIpNetwork: invoke<string, void>(),
+    clearIpNetworks: invoke<void, void>(),
   },
 };

--- a/desktop/packages/mullvad-vpn/src/shared/localization-contexts.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/localization-contexts.ts
@@ -27,6 +27,7 @@ export type LocalizationContexts =
   | 'wireguard-settings-view'
   | 'wireguard-settings-nav'
   | 'split-tunneling-view'
+  | 'split-tunneling-ip-view'
   | 'split-tunneling-nav'
   | 'api-access-methods-view'
   | 'settings-import'

--- a/desktop/packages/mullvad-vpn/src/shared/routes.ts
+++ b/desktop/packages/mullvad-vpn/src/shared/routes.ts
@@ -19,6 +19,7 @@ export enum RoutePath {
   udpOverTcp = '/settings/advanced/wireguard/udp-over-tcp',
   shadowsocks = '/settings/advanced/shadowsocks',
   splitTunneling = '/settings/split-tunneling',
+  splitTunnelingIp = '/settings/split-tunneling-ip',
   apiAccessMethods = '/settings/api-access-methods',
   settingsImport = '/settings/settings-import',
   settingsTextImport = '/settings/settings-import/text-import',

--- a/mullvad-cli/Cargo.toml
+++ b/mullvad-cli/Cargo.toml
@@ -37,6 +37,9 @@ tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
 clap_complete = { version = "4.4.8" }
 nix = { workspace = true, features = ["signal"] }
 
+[target.'cfg(windows)'.dependencies]
+ipnetwork = { workspace = true }
+
 [target.'cfg(windows)'.build-dependencies]
 mullvad-version = { path = "../mullvad-version" }
 winres = "0.1"

--- a/mullvad-cli/src/cmds/split_tunnel/windows.rs
+++ b/mullvad-cli/src/cmds/split_tunnel/windows.rs
@@ -27,12 +27,34 @@ pub enum SplitTunnel {
     /// Manage applications to exclude from the tunnel
     #[clap(subcommand)]
     App(App),
+
+    /// Manage IP/subnet exclusions from the VPN firewall
+    #[clap(subcommand)]
+    Ip(Ip),
 }
 
 #[derive(Subcommand, Debug)]
 pub enum App {
     Add { path: PathBuf },
     Remove { path: PathBuf },
+    Clear,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Ip {
+    /// Add an IP network (CIDR notation, e.g. 100.64.0.0/10) to bypass the VPN firewall
+    Add {
+        /// IP network in CIDR notation (e.g. 100.64.0.0/10 or 192.168.1.0/24)
+        network: String,
+    },
+    /// Remove an IP network from the exclusion list
+    Remove {
+        /// IP network in CIDR notation (must match exactly what was added)
+        network: String,
+    },
+    /// List all excluded IP networks
+    List,
+    /// Remove all excluded IP networks
     Clear,
 }
 
@@ -49,7 +71,12 @@ impl SplitTunnel {
 
                 println!("Excluded applications:");
                 for path in &settings.apps {
-                    println!("{}", path.display());
+                    println!("  {}", path.display());
+                }
+
+                println!("Excluded IP networks:");
+                for network in &settings.ip_exclusions {
+                    println!("  {network}");
                 }
 
                 if list_processes {
@@ -76,6 +103,7 @@ impl SplitTunnel {
                 Ok(())
             }
             SplitTunnel::App(subcmd) => Self::app(subcmd).await,
+            SplitTunnel::Ip(subcmd) => Self::ip(subcmd).await,
         }
     }
 
@@ -103,6 +131,55 @@ impl SplitTunnel {
                     .clear_split_tunnel_apps()
                     .await?;
                 println!("Stopped excluding all apps");
+                Ok(())
+            }
+        }
+    }
+
+    async fn ip(subcmd: Ip) -> Result<()> {
+        match subcmd {
+            Ip::Add { network } => {
+                // Validate CIDR notation before sending
+                network
+                    .parse::<ipnetwork::IpNetwork>()
+                    .map_err(|e| anyhow::anyhow!("Invalid CIDR notation '{network}': {e}"))?;
+                MullvadProxyClient::new()
+                    .await?
+                    .add_split_tunnel_ip_network(network.clone())
+                    .await?;
+                println!("Added {network} to excluded IP networks");
+                Ok(())
+            }
+            Ip::Remove { network } => {
+                network
+                    .parse::<ipnetwork::IpNetwork>()
+                    .map_err(|e| anyhow::anyhow!("Invalid CIDR notation '{network}': {e}"))?;
+                MullvadProxyClient::new()
+                    .await?
+                    .remove_split_tunnel_ip_network(network.clone())
+                    .await?;
+                println!("Removed {network} from excluded IP networks");
+                Ok(())
+            }
+            Ip::List => {
+                let mut rpc = MullvadProxyClient::new().await?;
+                let settings = rpc.get_settings().await?.split_tunnel;
+                if settings.ip_exclusions.is_empty() {
+                    println!("No excluded IP networks");
+                } else {
+                    println!("Excluded IP networks:");
+                    for network in &settings.ip_exclusions {
+                        println!("  {network}");
+                    }
+                }
+                Ok(())
+            }
+            Ip::Clear => {
+                MullvadProxyClient::new()
+                    .await?
+                    .clear_split_tunnel_ip_networks()
+                    .await?;
+                println!("Cleared all excluded IP networks");
                 Ok(())
             }
         }

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -91,6 +91,7 @@ simple-signal = "1.1"
 [target.'cfg(windows)'.dependencies]
 ctrlc = "3.0"
 dirs = { workspace = true }
+ipnetwork = { workspace = true }
 talpid-windows = { path = "../talpid-windows" }
 winapi = { version = "0.3", features = ["excpt", "winerror", "winnt"] }
 windows-service = "0.6.0"

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -395,6 +395,15 @@ pub enum DaemonCommand {
     /// Returns all processes currently being excluded from the tunnel
     #[cfg(target_os = "windows")]
     GetSplitTunnelProcesses(ResponseTx<Vec<ExcludedProcess>, split_tunnel::Error>),
+    /// Add an IP network (CIDR) whose traffic should bypass the VPN firewall
+    #[cfg(target_os = "windows")]
+    AddSplitTunnelIpNetwork(ResponseTx<(), Error>, ipnetwork::IpNetwork),
+    /// Remove an IP network (CIDR) from the split tunnel firewall exclusion list
+    #[cfg(target_os = "windows")]
+    RemoveSplitTunnelIpNetwork(ResponseTx<(), Error>, ipnetwork::IpNetwork),
+    /// Clear all IP networks from the split tunnel firewall exclusion list
+    #[cfg(target_os = "windows")]
+    ClearSplitTunnelIpNetworks(ResponseTx<(), Error>),
     /// Notify the split tunnel monitor that a volume was mounted or dismounted
     #[cfg(target_os = "windows")]
     CheckVolumes(ResponseTx<(), Error>),
@@ -923,6 +932,8 @@ impl Daemon {
                 reset_firewall: *target_state != TargetState::Secured,
                 #[cfg(any(target_os = "windows", target_os = "android", target_os = "macos"))]
                 exclude_paths,
+                #[cfg(target_os = "windows")]
+                excluded_subnets: settings.split_tunnel.ip_exclusions.clone(),
             },
             parameters_generator.clone(),
             config.log_dir,
@@ -1582,6 +1593,18 @@ impl Daemon {
             SetSplitTunnelState(tx, enabled) => self.on_set_split_tunnel_state(tx, enabled),
             #[cfg(target_os = "windows")]
             GetSplitTunnelProcesses(tx) => self.on_get_split_tunnel_processes(tx),
+            #[cfg(target_os = "windows")]
+            AddSplitTunnelIpNetwork(tx, network) => {
+                self.on_add_split_tunnel_ip_network(tx, network).await
+            }
+            #[cfg(target_os = "windows")]
+            RemoveSplitTunnelIpNetwork(tx, network) => {
+                self.on_remove_split_tunnel_ip_network(tx, network).await
+            }
+            #[cfg(target_os = "windows")]
+            ClearSplitTunnelIpNetworks(tx) => {
+                self.on_clear_split_tunnel_ip_networks(tx).await
+            }
             #[cfg(target_os = "windows")]
             CheckVolumes(tx) => self.on_check_volumes(tx),
             SetObfuscationSettings(tx, settings) => {
@@ -2458,6 +2481,78 @@ impl Daemon {
     fn on_check_volumes(&mut self, tx: ResponseTx<(), Error>) {
         if self.volume_update_tx.unbounded_send(()).is_ok() {
             let _ = tx.send(Ok(()));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn on_add_split_tunnel_ip_network(
+        &mut self,
+        tx: ResponseTx<(), Error>,
+        network: ipnetwork::IpNetwork,
+    ) {
+        let mut new_list = self.settings.to_settings().split_tunnel.ip_exclusions.clone();
+        if new_list.contains(&network) {
+            Self::oneshot_send(tx, Ok(()), "add_split_tunnel_ip_network response");
+            return;
+        }
+        new_list.push(network);
+        self.set_split_tunnel_ip_exclusions(tx, new_list).await;
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn on_remove_split_tunnel_ip_network(
+        &mut self,
+        tx: ResponseTx<(), Error>,
+        network: ipnetwork::IpNetwork,
+    ) {
+        let mut new_list = self.settings.to_settings().split_tunnel.ip_exclusions.clone();
+        new_list.retain(|n| *n != network);
+        self.set_split_tunnel_ip_exclusions(tx, new_list).await;
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn on_clear_split_tunnel_ip_networks(&mut self, tx: ResponseTx<(), Error>) {
+        self.set_split_tunnel_ip_exclusions(tx, vec![]).await;
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn set_split_tunnel_ip_exclusions(
+        &mut self,
+        tx: ResponseTx<(), Error>,
+        new_exclusions: Vec<ipnetwork::IpNetwork>,
+    ) {
+        let exclusions_for_command = new_exclusions.clone();
+        match self
+            .settings
+            .update(move |settings| {
+                settings.split_tunnel.ip_exclusions = new_exclusions;
+            })
+            .await
+        {
+            Ok(settings_changed) => {
+                if settings_changed {
+                    self.send_tunnel_command(TunnelCommand::SetExcludedSubnets(
+                        exclusions_for_command,
+                        oneshot_map(tx, |tx, ()| {
+                            Self::oneshot_send(
+                                tx,
+                                Ok(()),
+                                "set_split_tunnel_ip_exclusions response",
+                            );
+                        }),
+                    ));
+                } else {
+                    Self::oneshot_send(tx, Ok(()), "set_split_tunnel_ip_exclusions response");
+                }
+            }
+            Err(e) => {
+                log::error!("{}", e.display_chain_with_msg("Unable to save settings"));
+                Self::oneshot_send(
+                    tx,
+                    Err(Error::SettingsError(e)),
+                    "set_split_tunnel_ip_exclusions response",
+                );
+            }
         }
     }
 

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -1602,9 +1602,7 @@ impl Daemon {
                 self.on_remove_split_tunnel_ip_network(tx, network).await
             }
             #[cfg(target_os = "windows")]
-            ClearSplitTunnelIpNetworks(tx) => {
-                self.on_clear_split_tunnel_ip_networks(tx).await
-            }
+            ClearSplitTunnelIpNetworks(tx) => self.on_clear_split_tunnel_ip_networks(tx).await,
             #[cfg(target_os = "windows")]
             CheckVolumes(tx) => self.on_check_volumes(tx),
             SetObfuscationSettings(tx, settings) => {
@@ -2490,7 +2488,12 @@ impl Daemon {
         tx: ResponseTx<(), Error>,
         network: ipnetwork::IpNetwork,
     ) {
-        let mut new_list = self.settings.to_settings().split_tunnel.ip_exclusions.clone();
+        let mut new_list = self
+            .settings
+            .to_settings()
+            .split_tunnel
+            .ip_exclusions
+            .clone();
         if new_list.contains(&network) {
             Self::oneshot_send(tx, Ok(()), "add_split_tunnel_ip_network response");
             return;
@@ -2505,7 +2508,12 @@ impl Daemon {
         tx: ResponseTx<(), Error>,
         network: ipnetwork::IpNetwork,
     ) {
-        let mut new_list = self.settings.to_settings().split_tunnel.ip_exclusions.clone();
+        let mut new_list = self
+            .settings
+            .to_settings()
+            .split_tunnel
+            .ip_exclusions
+            .clone();
         new_list.retain(|n| *n != network);
         self.set_split_tunnel_ip_exclusions(tx, new_list).await;
     }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1035,6 +1035,62 @@ impl ManagementService for ManagementServiceImpl {
         Ok(Response::new(()))
     }
 
+    #[cfg(windows)]
+    async fn add_split_tunnel_ip_network(&self, request: Request<String>) -> ServiceResult<()> {
+        log::debug!("add_split_tunnel_ip_network");
+        let network: ipnetwork::IpNetwork = request
+            .into_inner()
+            .parse()
+            .map_err(|e| Status::invalid_argument(format!("Invalid CIDR: {e}")))?;
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::AddSplitTunnelIpNetwork(tx, network))?;
+        self.wait_for_result(rx)
+            .await?
+            .map_err(map_daemon_error)
+            .map(Response::new)
+    }
+
+    #[cfg(not(windows))]
+    async fn add_split_tunnel_ip_network(&self, _: Request<String>) -> ServiceResult<()> {
+        Ok(Response::new(()))
+    }
+
+    #[cfg(windows)]
+    async fn remove_split_tunnel_ip_network(&self, request: Request<String>) -> ServiceResult<()> {
+        log::debug!("remove_split_tunnel_ip_network");
+        let network: ipnetwork::IpNetwork = request
+            .into_inner()
+            .parse()
+            .map_err(|e| Status::invalid_argument(format!("Invalid CIDR: {e}")))?;
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::RemoveSplitTunnelIpNetwork(tx, network))?;
+        self.wait_for_result(rx)
+            .await?
+            .map_err(map_daemon_error)
+            .map(Response::new)
+    }
+
+    #[cfg(not(windows))]
+    async fn remove_split_tunnel_ip_network(&self, _: Request<String>) -> ServiceResult<()> {
+        Ok(Response::new(()))
+    }
+
+    #[cfg(windows)]
+    async fn clear_split_tunnel_ip_networks(&self, _: Request<()>) -> ServiceResult<()> {
+        log::debug!("clear_split_tunnel_ip_networks");
+        let (tx, rx) = oneshot::channel();
+        self.send_command_to_daemon(DaemonCommand::ClearSplitTunnelIpNetworks(tx))?;
+        self.wait_for_result(rx)
+            .await?
+            .map_err(map_daemon_error)
+            .map(Response::new)
+    }
+
+    #[cfg(not(windows))]
+    async fn clear_split_tunnel_ip_networks(&self, _: Request<()>) -> ServiceResult<()> {
+        Ok(Response::new(()))
+    }
+
     async fn apply_json_settings(&self, blob: Request<String>) -> ServiceResult<()> {
         log::debug!("apply_json_settings");
         let (tx, rx) = oneshot::channel();

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -51,6 +51,7 @@ mod v11;
 mod v12;
 mod v13;
 mod v14;
+mod v15;
 mod v2;
 mod v3;
 mod v4;
@@ -220,6 +221,7 @@ async fn migrate_settings(
     v12::migrate(settings)?;
     v13::migrate(settings)?;
     v14::migrate(settings)?;
+    v15::migrate(settings)?;
 
     Ok(migration_data)
 }

--- a/mullvad-daemon/src/migrations/v15.rs
+++ b/mullvad-daemon/src/migrations/v15.rs
@@ -27,10 +27,7 @@ fn add_ip_exclusions(settings: &mut serde_json::Value) -> Option<()> {
         .and_then(|st| st.as_object_mut())?;
 
     if !split_tunnel.contains_key("ip_exclusions") {
-        split_tunnel.insert(
-            "ip_exclusions".to_string(),
-            serde_json::json!([]),
-        );
+        split_tunnel.insert("ip_exclusions".to_string(), serde_json::json!([]));
     }
 
     Some(())

--- a/mullvad-daemon/src/migrations/v15.rs
+++ b/mullvad-daemon/src/migrations/v15.rs
@@ -1,0 +1,103 @@
+use super::Result;
+use mullvad_types::settings::SettingsVersion;
+
+/// NOTE: This migration has been closed.
+///
+/// This migration handles:
+/// - Adding the `ip_exclusions` field to `split_tunnel` settings.
+///   This field holds a list of IP networks (CIDR notation) whose traffic
+///   should bypass the VPN firewall.
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to V16");
+
+    add_ip_exclusions(settings);
+
+    settings["settings_version"] = serde_json::json!(SettingsVersion::V16);
+
+    Ok(())
+}
+
+fn add_ip_exclusions(settings: &mut serde_json::Value) -> Option<()> {
+    let split_tunnel = settings
+        .get_mut("split_tunnel")
+        .and_then(|st| st.as_object_mut())?;
+
+    if !split_tunnel.contains_key("ip_exclusions") {
+        split_tunnel.insert(
+            "ip_exclusions".to_string(),
+            serde_json::json!([]),
+        );
+    }
+
+    Some(())
+}
+
+fn version_matches(settings: &serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V15 as u64)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_v15_to_v16_migration_adds_ip_exclusions() {
+        let mut old_settings = json!({
+            "settings_version": 15,
+            "split_tunnel": {
+                "enable_exclusions": false,
+                "apps": []
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    #[test]
+    fn test_v15_to_v16_migration_preserves_existing_ip_exclusions() {
+        let mut old_settings = json!({
+            "settings_version": 15,
+            "split_tunnel": {
+                "enable_exclusions": true,
+                "apps": [],
+                "ip_exclusions": ["100.64.0.0/10"]
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    #[test]
+    fn test_v15_to_v16_migration_no_split_tunnel() {
+        let mut old_settings = json!({
+            "settings_version": 15
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    #[test]
+    fn test_v15_to_v16_migration_skips_wrong_version() {
+        let mut old_settings = json!({
+            "settings_version": 14,
+            "split_tunnel": {
+                "enable_exclusions": false,
+                "apps": []
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+}

--- a/mullvad-management-interface/proto/management_interface.proto
+++ b/mullvad-management-interface/proto/management_interface.proto
@@ -114,6 +114,11 @@ service ManagementService {
   rpc ClearSplitTunnelApps(google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc GetExcludedProcesses(google.protobuf.Empty) returns (ExcludedProcessList) {}
 
+  // Split tunnel IP/subnet exclusions (Windows)
+  rpc AddSplitTunnelIpNetwork(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
+  rpc RemoveSplitTunnelIpNetwork(google.protobuf.StringValue) returns (google.protobuf.Empty) {}
+  rpc ClearSplitTunnelIpNetworks(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+
   // Play payment (Android)
   rpc InitPlayPurchase(google.protobuf.Empty) returns (PlayPurchasePaymentToken) {}
   rpc VerifyPlayPurchase(PlayPurchase) returns (google.protobuf.Empty) {}
@@ -546,6 +551,8 @@ message Recent {
 message SplitTunnelSettings {
   bool enable_exclusions = 1;
   repeated string apps = 2;
+  // IP networks (CIDR notation) whose traffic should bypass the VPN firewall.
+  repeated string ip_exclusions = 3;
 }
 
 message RelaySettings {

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -601,6 +601,29 @@ impl MullvadProxyClient {
             .collect::<Vec<_>>())
     }
 
+    /// Add an IP network (CIDR) to the split tunnel exclusion list.
+    /// Traffic to this network will bypass the VPN firewall.
+    pub async fn add_split_tunnel_ip_network(&mut self, network: String) -> Result<()> {
+        self.0
+            .add_split_tunnel_ip_network(network)
+            .await?;
+        Ok(())
+    }
+
+    /// Remove an IP network (CIDR) from the split tunnel exclusion list.
+    pub async fn remove_split_tunnel_ip_network(&mut self, network: String) -> Result<()> {
+        self.0
+            .remove_split_tunnel_ip_network(network)
+            .await?;
+        Ok(())
+    }
+
+    /// Remove all IP networks from the split tunnel exclusion list.
+    pub async fn clear_split_tunnel_ip_networks(&mut self) -> Result<()> {
+        self.0.clear_split_tunnel_ip_networks(()).await?;
+        Ok(())
+    }
+
     // check_volumes
 
     pub async fn apply_json_settings(&mut self, blob: String) -> Result<()> {

--- a/mullvad-management-interface/src/client.rs
+++ b/mullvad-management-interface/src/client.rs
@@ -604,17 +604,13 @@ impl MullvadProxyClient {
     /// Add an IP network (CIDR) to the split tunnel exclusion list.
     /// Traffic to this network will bypass the VPN firewall.
     pub async fn add_split_tunnel_ip_network(&mut self, network: String) -> Result<()> {
-        self.0
-            .add_split_tunnel_ip_network(network)
-            .await?;
+        self.0.add_split_tunnel_ip_network(network).await?;
         Ok(())
     }
 
     /// Remove an IP network (CIDR) from the split tunnel exclusion list.
     pub async fn remove_split_tunnel_ip_network(&mut self, network: String) -> Result<()> {
-        self.0
-            .remove_split_tunnel_ip_network(network)
-            .await?;
+        self.0.remove_split_tunnel_ip_network(network).await?;
         Ok(())
     }
 

--- a/mullvad-management-interface/src/types/conversions/settings.rs
+++ b/mullvad-management-interface/src/types/conversions/settings.rs
@@ -22,6 +22,12 @@ impl From<&mullvad_types::settings::Settings> for proto::Settings {
             Some(proto::SplitTunnelSettings {
                 enable_exclusions: settings.split_tunnel.enable_exclusions,
                 apps,
+                ip_exclusions: settings
+                    .split_tunnel
+                    .ip_exclusions
+                    .iter()
+                    .map(|net| net.to_string())
+                    .collect(),
             })
         };
         #[cfg(target_os = "linux")]
@@ -196,6 +202,17 @@ impl From<proto::SplitTunnelSettings> for mullvad_types::settings::SplitTunnelSe
         SplitTunnelSettings {
             enable_exclusions: value.enable_exclusions,
             apps: value.apps.into_iter().map(SplitApp::from).collect(),
+            ip_exclusions: value
+                .ip_exclusions
+                .into_iter()
+                .filter_map(|s| match s.parse() {
+                    Ok(net) => Some(net),
+                    Err(e) => {
+                        log::error!("Failed to parse IP network from proto: {s}: {e}");
+                        None
+                    }
+                })
+                .collect(),
         }
     }
 }

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     wireguard,
 };
+use ipnetwork::IpNetwork;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(any(windows, target_os = "android", target_os = "macos"))]
 use std::collections::HashSet;
@@ -20,7 +21,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V15;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V16;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -39,6 +40,7 @@ pub enum SettingsVersion {
     V13 = 13,
     V14 = 14,
     V15 = 15,
+    V16 = 16,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -61,6 +63,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V13 as u32 => Ok(SettingsVersion::V13),
             v if v == SettingsVersion::V14 as u32 => Ok(SettingsVersion::V14),
             v if v == SettingsVersion::V15 as u32 => Ok(SettingsVersion::V15),
+            v if v == SettingsVersion::V16 as u32 => Ok(SettingsVersion::V16),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),
@@ -188,6 +191,11 @@ pub struct SplitTunnelSettings {
     pub enable_exclusions: bool,
     /// Set of applications to exclude from the tunnel.
     pub apps: HashSet<SplitApp>,
+    /// IP networks (CIDR) whose traffic should bypass the VPN firewall.
+    /// Unlike app exclusions which use the kernel driver, these create WFP
+    /// firewall permit rules so any app can reach these subnets.
+    #[serde(default)]
+    pub ip_exclusions: Vec<IpNetwork>,
 }
 
 /// An application whose traffic should be excluded from any active tunnel.

--- a/talpid-core/src/firewall/mod.rs
+++ b/talpid-core/src/firewall/mod.rs
@@ -100,6 +100,9 @@ pub enum FirewallPolicy {
         /// Interface to redirect (VPN tunnel) traffic to
         #[cfg(target_os = "macos")]
         redirect_interface: Option<String>,
+        /// IP networks (CIDR) whose traffic should bypass the VPN firewall.
+        #[cfg(target_os = "windows")]
+        excluded_subnets: Vec<IpNetwork>,
     },
 
     /// Allow traffic only to server and over tunnel interface
@@ -119,6 +122,9 @@ pub enum FirewallPolicy {
         /// Interface to redirect (VPN tunnel) traffic to
         #[cfg(target_os = "macos")]
         redirect_interface: Option<String>,
+        /// IP networks (CIDR) whose traffic should bypass the VPN firewall.
+        #[cfg(target_os = "windows")]
+        excluded_subnets: Vec<IpNetwork>,
     },
 
     /// Block all network traffic in and out from the computer.
@@ -127,6 +133,9 @@ pub enum FirewallPolicy {
         allow_lan: bool,
         /// Host that should be reachable while in the blocked state.
         allowed_endpoint: Option<AllowedEndpoint>,
+        /// IP networks (CIDR) whose traffic should bypass the VPN firewall.
+        #[cfg(target_os = "windows")]
+        excluded_subnets: Vec<IpNetwork>,
     },
 }
 

--- a/talpid-core/src/firewall/windows/mod.rs
+++ b/talpid-core/src/firewall/windows/mod.rs
@@ -134,16 +134,29 @@ impl Firewall {
                 allow_lan,
                 allowed_endpoint,
                 allowed_tunnel_traffic,
+                excluded_subnets,
             } => {
-                let cfg = &WinFwSettings::new(allow_lan);
-                self.set_connecting_state(
+                let subnet_wstrs: Vec<WideCString> = excluded_subnets
+                    .iter()
+                    .map(|net| WideCString::from_str_truncate(net.to_string()))
+                    .collect();
+                let subnet_ptrs: Vec<*const u16> =
+                    subnet_wstrs.iter().map(|s| s.as_ptr()).collect();
+                let cfg = &WinFwSettings::new(
+                    allow_lan,
+                    subnet_ptrs.len(),
+                    subnet_ptrs.as_ptr(),
+                );
+                let result = self.set_connecting_state(
                     &peer_endpoints,
                     exit_endpoint_ip,
                     cfg,
                     tunnel.as_ref(),
                     allowed_endpoint,
                     &allowed_tunnel_traffic,
-                )
+                );
+                drop(subnet_wstrs);
+                result
             }
             FirewallPolicy::Connected {
                 peer_endpoints,
@@ -151,25 +164,51 @@ impl Firewall {
                 tunnel,
                 allow_lan,
                 dns_config,
+                excluded_subnets,
             } => {
-                let cfg = &WinFwSettings::new(allow_lan);
-                self.set_connected_state(
+                let subnet_wstrs: Vec<WideCString> = excluded_subnets
+                    .iter()
+                    .map(|net| WideCString::from_str_truncate(net.to_string()))
+                    .collect();
+                let subnet_ptrs: Vec<*const u16> =
+                    subnet_wstrs.iter().map(|s| s.as_ptr()).collect();
+                let cfg = &WinFwSettings::new(
+                    allow_lan,
+                    subnet_ptrs.len(),
+                    subnet_ptrs.as_ptr(),
+                );
+                let result = self.set_connected_state(
                     &peer_endpoints,
                     exit_endpoint_ip,
                     cfg,
                     &tunnel,
                     &dns_config,
-                )
+                );
+                drop(subnet_wstrs);
+                result
             }
             FirewallPolicy::Blocked {
                 allow_lan,
                 allowed_endpoint,
+                excluded_subnets,
             } => {
-                let cfg = &WinFwSettings::new(allow_lan);
-                self.set_blocked_state(
+                let subnet_wstrs: Vec<WideCString> = excluded_subnets
+                    .iter()
+                    .map(|net| WideCString::from_str_truncate(net.to_string()))
+                    .collect();
+                let subnet_ptrs: Vec<*const u16> =
+                    subnet_wstrs.iter().map(|s| s.as_ptr()).collect();
+                let cfg = &WinFwSettings::new(
+                    allow_lan,
+                    subnet_ptrs.len(),
+                    subnet_ptrs.as_ptr(),
+                );
+                let result = self.set_blocked_state(
                     cfg,
                     allowed_endpoint.map(WinFwAllowedEndpointContainer::from),
-                )
+                );
+                drop(subnet_wstrs);
+                result
             }
         };
 

--- a/talpid-core/src/firewall/windows/mod.rs
+++ b/talpid-core/src/firewall/windows/mod.rs
@@ -142,11 +142,7 @@ impl Firewall {
                     .collect();
                 let subnet_ptrs: Vec<*const u16> =
                     subnet_wstrs.iter().map(|s| s.as_ptr()).collect();
-                let cfg = &WinFwSettings::new(
-                    allow_lan,
-                    subnet_ptrs.len(),
-                    subnet_ptrs.as_ptr(),
-                );
+                let cfg = &WinFwSettings::new(allow_lan, subnet_ptrs.len(), subnet_ptrs.as_ptr());
                 let result = self.set_connecting_state(
                     &peer_endpoints,
                     exit_endpoint_ip,
@@ -172,11 +168,7 @@ impl Firewall {
                     .collect();
                 let subnet_ptrs: Vec<*const u16> =
                     subnet_wstrs.iter().map(|s| s.as_ptr()).collect();
-                let cfg = &WinFwSettings::new(
-                    allow_lan,
-                    subnet_ptrs.len(),
-                    subnet_ptrs.as_ptr(),
-                );
+                let cfg = &WinFwSettings::new(allow_lan, subnet_ptrs.len(), subnet_ptrs.as_ptr());
                 let result = self.set_connected_state(
                     &peer_endpoints,
                     exit_endpoint_ip,
@@ -198,11 +190,7 @@ impl Firewall {
                     .collect();
                 let subnet_ptrs: Vec<*const u16> =
                     subnet_wstrs.iter().map(|s| s.as_ptr()).collect();
-                let cfg = &WinFwSettings::new(
-                    allow_lan,
-                    subnet_ptrs.len(),
-                    subnet_ptrs.as_ptr(),
-                );
+                let cfg = &WinFwSettings::new(allow_lan, subnet_ptrs.len(), subnet_ptrs.as_ptr());
                 let result = self.set_blocked_state(
                     cfg,
                     allowed_endpoint.map(WinFwAllowedEndpointContainer::from),

--- a/talpid-core/src/firewall/windows/winfw/mod.rs
+++ b/talpid-core/src/firewall/windows/winfw/mod.rs
@@ -32,7 +32,7 @@ pub(super) fn initialize_blocked(
     allowed_endpoint: AllowedEndpoint,
     allow_lan: bool,
 ) -> Result<(), Error> {
-    let cfg = WinFwSettings::new(allow_lan);
+    let cfg = WinFwSettings::new(allow_lan, 0, std::ptr::null());
     let allowed_endpoint = WinFwAllowedEndpointContainer::from(allowed_endpoint);
     // SAFETY: This function is always safe to call.
     let init = unsafe {

--- a/talpid-core/src/firewall/windows/winfw/sys.rs
+++ b/talpid-core/src/firewall/windows/winfw/sys.rs
@@ -13,13 +13,23 @@ pub const LOGGING_CONTEXT: &CStr = c"WinFw";
 pub struct WinFwSettings {
     permitDhcp: bool,
     permitLan: bool,
+    /// Number of IP/subnet exclusions.
+    numExcludedSubnets: usize,
+    /// Pointer to array of wide-string subnet representations (CIDR notation).
+    excludedSubnets: *const *const libc::wchar_t,
 }
 
 impl WinFwSettings {
-    pub fn new(permit_lan: bool) -> WinFwSettings {
+    pub fn new(
+        permit_lan: bool,
+        num_excluded_subnets: usize,
+        excluded_subnets_ptr: *const *const libc::wchar_t,
+    ) -> WinFwSettings {
         WinFwSettings {
             permitDhcp: true,
             permitLan: permit_lan,
+            numExcludedSubnets: num_excluded_subnets,
+            excludedSubnets: excluded_subnets_ptr,
         }
     }
 }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -138,6 +138,8 @@ impl ConnectedState {
             dns_config: Self::resolve_dns(&self.metadata, shared_values),
             #[cfg(target_os = "macos")]
             redirect_interface,
+            #[cfg(target_os = "windows")]
+            excluded_subnets: shared_values.excluded_subnets.clone(),
         }
     }
 
@@ -391,6 +393,24 @@ impl ConnectedState {
                     }
                 }
                 SameState(self)
+            }
+            #[cfg(target_os = "windows")]
+            Some(TunnelCommand::SetExcludedSubnets(subnets, complete_tx)) => {
+                let consequence = if shared_values.set_excluded_subnets(subnets) {
+                    match self.set_firewall_policy(shared_values) {
+                        Ok(()) => SameState(self),
+                        Err(error) => self.disconnect(
+                            shared_values,
+                            AfterDisconnect::Block(ErrorStateCause::SetFirewallPolicyError(
+                                error,
+                            )),
+                        ),
+                    }
+                } else {
+                    SameState(self)
+                };
+                let _ = complete_tx.send(());
+                consequence
             }
         }
     }

--- a/talpid-core/src/tunnel_state_machine/connected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connected_state.rs
@@ -401,9 +401,7 @@ impl ConnectedState {
                         Ok(()) => SameState(self),
                         Err(error) => self.disconnect(
                             shared_values,
-                            AfterDisconnect::Block(ErrorStateCause::SetFirewallPolicyError(
-                                error,
-                            )),
+                            AfterDisconnect::Block(ErrorStateCause::SetFirewallPolicyError(error)),
                         ),
                     }
                 } else {

--- a/talpid-core/src/tunnel_state_machine/connecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/connecting_state.rs
@@ -203,6 +203,8 @@ impl ConnectingState {
             allowed_tunnel_traffic,
             #[cfg(target_os = "macos")]
             redirect_interface,
+            #[cfg(target_os = "windows")]
+            excluded_subnets: shared_values.excluded_subnets.clone(),
         };
         shared_values
             .firewall
@@ -540,6 +542,16 @@ impl ConnectingState {
                     }
                 }
                 SameState(self)
+            }
+            #[cfg(target_os = "windows")]
+            Some(TunnelCommand::SetExcludedSubnets(subnets, complete_tx)) => {
+                let consequence = if shared_values.set_excluded_subnets(subnets) {
+                    self.reset_firewall(shared_values)
+                } else {
+                    SameState(self)
+                };
+                let _ = complete_tx.send(());
+                consequence
             }
         }
     }

--- a/talpid-core/src/tunnel_state_machine/disconnected_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnected_state.rs
@@ -86,6 +86,8 @@ impl DisconnectedState {
             let policy = FirewallPolicy::Blocked {
                 allow_lan: shared_values.allow_lan,
                 allowed_endpoint: Some(shared_values.allowed_endpoint.clone()),
+                #[cfg(target_os = "windows")]
+                excluded_subnets: shared_values.excluded_subnets.clone(),
             };
 
             shared_values.firewall.apply_policy(policy).map_err(|e| {
@@ -252,6 +254,14 @@ impl TunnelState for DisconnectedState {
             #[cfg(target_os = "macos")]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 let _ = result_tx.send(shared_values.set_exclude_paths(paths).map(|_| ()));
+                SameState(self)
+            }
+            #[cfg(target_os = "windows")]
+            Some(TunnelCommand::SetExcludedSubnets(subnets, complete_tx)) => {
+                if shared_values.set_excluded_subnets(subnets) {
+                    Self::set_firewall_policy(shared_values, false);
+                }
+                let _ = complete_tx.send(());
                 SameState(self)
             }
             None => {

--- a/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
+++ b/talpid-core/src/tunnel_state_machine/disconnecting_state.rs
@@ -109,6 +109,11 @@ impl DisconnectingState {
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 let _ = result_tx.send(shared_values.set_exclude_paths(paths).map(|_| ()));
             }
+            #[cfg(target_os = "windows")]
+            Some(TunnelCommand::SetExcludedSubnets(subnets, complete_tx)) => {
+                let _ = shared_values.set_excluded_subnets(subnets);
+                let _ = complete_tx.send(());
+            }
         };
 
         EventConsequence::SameState(self)

--- a/talpid-core/src/tunnel_state_machine/error_state.rs
+++ b/talpid-core/src/tunnel_state_machine/error_state.rs
@@ -80,6 +80,8 @@ impl ErrorState {
         let policy = FirewallPolicy::Blocked {
             allow_lan: shared_values.allow_lan,
             allowed_endpoint: Some(shared_values.allowed_endpoint.clone()),
+            #[cfg(target_os = "windows")]
+            excluded_subnets: shared_values.excluded_subnets.clone(),
         };
 
         #[cfg(target_os = "linux")]
@@ -251,6 +253,14 @@ impl TunnelState for ErrorState {
             #[cfg(target_os = "macos")]
             Some(TunnelCommand::SetExcludedApps(result_tx, paths)) => {
                 let _ = result_tx.send(shared_values.set_exclude_paths(paths).map(|_| ()));
+                SameState(self)
+            }
+            #[cfg(target_os = "windows")]
+            Some(TunnelCommand::SetExcludedSubnets(subnets, complete_tx)) => {
+                if shared_values.set_excluded_subnets(subnets) {
+                    let _ = Self::set_firewall_policy(shared_values);
+                }
+                let _ = complete_tx.send(());
                 SameState(self)
             }
         }

--- a/talpid-core/src/tunnel_state_machine/mod.rs
+++ b/talpid-core/src/tunnel_state_machine/mod.rs
@@ -112,6 +112,9 @@ pub struct InitialTunnelState {
     /// Apps to exclude from the tunnel.
     #[cfg(target_os = "android")]
     pub exclude_paths: Vec<String>,
+    /// IP networks (CIDR) whose traffic should bypass the VPN firewall.
+    #[cfg(target_os = "windows")]
+    pub excluded_subnets: Vec<ipnetwork::IpNetwork>,
 }
 
 /// Identifiers for various network resources that should be unique to a given instance of a tunnel
@@ -240,6 +243,9 @@ pub enum TunnelCommand {
         oneshot::Sender<Result<(), split_tunnel::Error>>,
         Vec<String>,
     ),
+    /// Set IP networks whose traffic should bypass the VPN firewall.
+    #[cfg(target_os = "windows")]
+    SetExcludedSubnets(Vec<ipnetwork::IpNetwork>, oneshot::Sender<()>),
 }
 
 type TunnelCommandReceiver = stream::Fuse<mpsc::UnboundedReceiver<TunnelCommand>>;
@@ -481,6 +487,8 @@ impl TunnelStateMachine {
             connectivity_check_was_enabled: None,
             #[cfg(target_os = "macos")]
             filtering_resolver,
+            #[cfg(target_os = "windows")]
+            excluded_subnets: args.settings.excluded_subnets,
         };
 
         tokio::task::spawn_blocking(move || {
@@ -587,6 +595,10 @@ struct SharedTunnelStateValues {
     /// Filtering resolver handle
     #[cfg(target_os = "macos")]
     filtering_resolver: crate::resolver::ResolverHandle,
+
+    /// IP networks (CIDR) whose traffic should bypass the VPN firewall.
+    #[cfg(target_os = "windows")]
+    excluded_subnets: Vec<ipnetwork::IpNetwork>,
 }
 
 impl SharedTunnelStateValues {
@@ -651,6 +663,17 @@ impl SharedTunnelStateValues {
     pub fn set_allow_lan(&mut self, allow_lan: bool) -> bool {
         if self.allow_lan != allow_lan {
             self.allow_lan = allow_lan;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Update the excluded subnets. Returns true if the value changed.
+    #[cfg(target_os = "windows")]
+    pub fn set_excluded_subnets(&mut self, subnets: Vec<ipnetwork::IpNetwork>) -> bool {
+        if self.excluded_subnets != subnets {
+            self.excluded_subnets = subnets;
             true
         } else {
             false

--- a/windows/winfw/src/winfw/fwcontext.cpp
+++ b/windows/winfw/src/winfw/fwcontext.cpp
@@ -14,6 +14,7 @@
 #include "rules/baseline/permitvpntunnel.h"
 #include "rules/baseline/permitvpntunnelservice.h"
 #include "rules/baseline/permitdns.h"
+#include "rules/baseline/permitsplittunnelsubnets.h"
 #include "rules/dns/blockall.h"
 #include "rules/dns/permitloopback.h"
 #include "rules/dns/permittunnel.h"
@@ -62,6 +63,47 @@ void AppendSettingsRules
 		ruleset.emplace_back(std::make_unique<baseline::PermitLan>());
 		ruleset.emplace_back(std::make_unique<baseline::PermitLanService>());
 		ruleset.emplace_back(baseline::PermitDhcpServer::WithExtent(baseline::PermitDhcpServer::Extent::IPv4Only));
+	}
+
+	//
+	// Split tunnel subnet exclusions
+	//
+	if (settings.numExcludedSubnets > 0 && settings.excludedSubnets != nullptr)
+	{
+		std::vector<wfp::IpNetwork> ipv4Subnets;
+		std::vector<wfp::IpNetwork> ipv6Subnets;
+
+		for (size_t i = 0; i < settings.numExcludedSubnets; i++)
+		{
+			const std::wstring cidr(settings.excludedSubnets[i]);
+
+			// Split CIDR into address and prefix length
+			const auto slashPos = cidr.find(L'/');
+			if (slashPos == std::wstring::npos)
+			{
+				continue;
+			}
+
+			const auto ipStr = cidr.substr(0, slashPos);
+			const auto prefixLen = static_cast<uint8_t>(std::stoi(cidr.substr(slashPos + 1)));
+
+			// Determine address family by checking for ':'
+			if (ipStr.find(L':') != std::wstring::npos)
+			{
+				ipv6Subnets.emplace_back(wfp::IpAddress(ipStr.c_str()), prefixLen);
+			}
+			else
+			{
+				ipv4Subnets.emplace_back(wfp::IpAddress(ipStr.c_str()), prefixLen);
+			}
+		}
+
+		if (!ipv4Subnets.empty() || !ipv6Subnets.empty())
+		{
+			ruleset.emplace_back(std::make_unique<baseline::PermitSplitTunnelSubnets>(
+				ipv4Subnets, ipv6Subnets
+			));
+		}
 	}
 
 	//

--- a/windows/winfw/src/winfw/mullvadguids.cpp
+++ b/windows/winfw/src/winfw/mullvadguids.cpp
@@ -734,6 +734,62 @@ const GUID &MullvadGuids::Filter_Baseline_PermitNdp_Inbound_Redirect()
 }
 
 //static
+const GUID &MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Outbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x3a7e1f2c,
+		0xd514,
+		0x4b8a,
+		{ 0x91, 0xe3, 0x7c, 0xf8, 0xa2, 0x5b, 0x6d, 0x01 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Inbound_Ipv4()
+{
+	static const GUID g =
+	{
+		0x3a7e1f2c,
+		0xd514,
+		0x4b8a,
+		{ 0x91, 0xe3, 0x7c, 0xf8, 0xa2, 0x5b, 0x6d, 0x02 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Outbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0x3a7e1f2c,
+		0xd514,
+		0x4b8a,
+		{ 0x91, 0xe3, 0x7c, 0xf8, 0xa2, 0x5b, 0x6d, 0x03 }
+	};
+
+	return g;
+}
+
+//static
+const GUID &MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Inbound_Ipv6()
+{
+	static const GUID g =
+	{
+		0x3a7e1f2c,
+		0xd514,
+		0x4b8a,
+		{ 0x91, 0xe3, 0x7c, 0xf8, 0xa2, 0x5b, 0x6d, 0x04 }
+	};
+
+	return g;
+}
+
+//static
 const GUID &MullvadGuids::Filter_Baseline_PermitDns_Outbound_Ipv4()
 {
 	static const GUID g =

--- a/windows/winfw/src/winfw/mullvadguids.h
+++ b/windows/winfw/src/winfw/mullvadguids.h
@@ -68,6 +68,11 @@ public:
 	static const GUID &Filter_Baseline_PermitNdp_Inbound_Neighbor_Advertisement();
 	static const GUID &Filter_Baseline_PermitNdp_Inbound_Redirect();
 
+	static const GUID &Filter_Baseline_PermitSplitTunnelSubnets_Outbound_Ipv4();
+	static const GUID &Filter_Baseline_PermitSplitTunnelSubnets_Inbound_Ipv4();
+	static const GUID &Filter_Baseline_PermitSplitTunnelSubnets_Outbound_Ipv6();
+	static const GUID &Filter_Baseline_PermitSplitTunnelSubnets_Inbound_Ipv6();
+
 	static const GUID &Filter_Baseline_PermitDns_Outbound_Ipv4();
 	static const GUID &Filter_Baseline_PermitDns_Outbound_Ipv6();
 

--- a/windows/winfw/src/winfw/rules/baseline/permitsplittunnelsubnets.cpp
+++ b/windows/winfw/src/winfw/rules/baseline/permitsplittunnelsubnets.cpp
@@ -1,0 +1,139 @@
+#include "stdafx.h"
+#include "permitsplittunnelsubnets.h"
+#include <winfw/mullvadguids.h>
+#include <libwfp/filterbuilder.h>
+#include <libwfp/conditionbuilder.h>
+#include <libwfp/conditions/conditionip.h>
+
+using namespace wfp::conditions;
+
+namespace rules::baseline
+{
+
+PermitSplitTunnelSubnets::PermitSplitTunnelSubnets(
+	const std::vector<wfp::IpNetwork> &ipv4Subnets,
+	const std::vector<wfp::IpNetwork> &ipv6Subnets
+)
+	: m_ipv4Subnets(ipv4Subnets)
+	, m_ipv6Subnets(ipv6Subnets)
+{
+}
+
+bool PermitSplitTunnelSubnets::apply(IObjectInstaller &objectInstaller)
+{
+	if (!m_ipv4Subnets.empty())
+	{
+		if (!applyIpv4Outbound(objectInstaller) || !applyIpv4Inbound(objectInstaller))
+		{
+			return false;
+		}
+	}
+
+	if (!m_ipv6Subnets.empty())
+	{
+		if (!applyIpv6Outbound(objectInstaller) || !applyIpv6Inbound(objectInstaller))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool PermitSplitTunnelSubnets::applyIpv4Outbound(IObjectInstaller &objectInstaller) const
+{
+	wfp::FilterBuilder filterBuilder;
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Outbound_Ipv4())
+		.name(L"Permit outbound to split tunnel subnets (IPv4)")
+		.description(L"This filter permits outbound traffic to user-specified IP networks for split tunneling")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V4)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Medium)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V4);
+
+	for (const auto &network : m_ipv4Subnets)
+	{
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+bool PermitSplitTunnelSubnets::applyIpv4Inbound(IObjectInstaller &objectInstaller) const
+{
+	wfp::FilterBuilder filterBuilder;
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Inbound_Ipv4())
+		.name(L"Permit inbound from split tunnel subnets (IPv4)")
+		.description(L"This filter permits inbound traffic from user-specified IP networks for split tunneling")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Medium)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4);
+
+	for (const auto &network : m_ipv4Subnets)
+	{
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+bool PermitSplitTunnelSubnets::applyIpv6Outbound(IObjectInstaller &objectInstaller) const
+{
+	wfp::FilterBuilder filterBuilder;
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Outbound_Ipv6())
+		.name(L"Permit outbound to split tunnel subnets (IPv6)")
+		.description(L"This filter permits outbound traffic to user-specified IP networks for split tunneling")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_CONNECT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Medium)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_CONNECT_V6);
+
+	for (const auto &network : m_ipv6Subnets)
+	{
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+bool PermitSplitTunnelSubnets::applyIpv6Inbound(IObjectInstaller &objectInstaller) const
+{
+	wfp::FilterBuilder filterBuilder;
+
+	filterBuilder
+		.key(MullvadGuids::Filter_Baseline_PermitSplitTunnelSubnets_Inbound_Ipv6())
+		.name(L"Permit inbound from split tunnel subnets (IPv6)")
+		.description(L"This filter permits inbound traffic from user-specified IP networks for split tunneling")
+		.provider(MullvadGuids::Provider())
+		.layer(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6)
+		.sublayer(MullvadGuids::SublayerBaseline())
+		.weight(wfp::FilterBuilder::WeightClass::Medium)
+		.permit();
+
+	wfp::ConditionBuilder conditionBuilder(FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6);
+
+	for (const auto &network : m_ipv6Subnets)
+	{
+		conditionBuilder.add_condition(ConditionIp::Remote(network));
+	}
+
+	return objectInstaller.addFilter(filterBuilder, conditionBuilder);
+}
+
+}

--- a/windows/winfw/src/winfw/rules/baseline/permitsplittunnelsubnets.h
+++ b/windows/winfw/src/winfw/rules/baseline/permitsplittunnelsubnets.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <winfw/rules/ifirewallrule.h>
+#include <libwfp/ipnetwork.h>
+#include <vector>
+
+namespace rules::baseline
+{
+
+//
+// Permits outbound and inbound traffic to/from user-specified IP networks.
+// This is used for split tunneling by IP/subnet, allowing user-specified networks
+// to bypass the VPN firewall.
+//
+class PermitSplitTunnelSubnets : public IFirewallRule
+{
+public:
+
+	PermitSplitTunnelSubnets(
+		const std::vector<wfp::IpNetwork> &ipv4Subnets,
+		const std::vector<wfp::IpNetwork> &ipv6Subnets
+	);
+
+	~PermitSplitTunnelSubnets() = default;
+
+	bool apply(IObjectInstaller &objectInstaller) override;
+
+private:
+
+	bool applyIpv4Outbound(IObjectInstaller &objectInstaller) const;
+	bool applyIpv4Inbound(IObjectInstaller &objectInstaller) const;
+	bool applyIpv6Outbound(IObjectInstaller &objectInstaller) const;
+	bool applyIpv6Inbound(IObjectInstaller &objectInstaller) const;
+
+	std::vector<wfp::IpNetwork> m_ipv4Subnets;
+	std::vector<wfp::IpNetwork> m_ipv6Subnets;
+};
+
+}

--- a/windows/winfw/src/winfw/winfw.h
+++ b/windows/winfw/src/winfw/winfw.h
@@ -26,6 +26,13 @@ typedef struct tag_WinFwSettings
 
 	// Permit all traffic to and from private address ranges.
 	bool permitLan;
+
+	// Number of IP/subnet exclusions for split tunneling.
+	size_t numExcludedSubnets;
+
+	// Array of wide-string subnet representations in CIDR notation (e.g., L"100.64.0.0/10").
+	// Traffic to these subnets bypasses the VPN firewall.
+	const wchar_t * const *excludedSubnets;
 }
 WinFwSettings;
 

--- a/windows/winfw/src/winfw/winfw.vcxproj
+++ b/windows/winfw/src/winfw/winfw.vcxproj
@@ -37,6 +37,7 @@
     <ClCompile Include="rules\baseline\permitdns.cpp" />
     <ClCompile Include="rules\baseline\permitlan.cpp" />
     <ClCompile Include="rules\baseline\permitlanservice.cpp" />
+    <ClCompile Include="rules\baseline\permitsplittunnelsubnets.cpp" />
     <ClCompile Include="rules\baseline\permitloopback.cpp" />
     <ClCompile Include="rules\baseline\permitndp.cpp" />
     <ClCompile Include="rules\baseline\permitvpntunnel.cpp" />
@@ -73,6 +74,7 @@
     <ClInclude Include="rules\baseline\permitdns.h" />
     <ClInclude Include="rules\baseline\permitlan.h" />
     <ClInclude Include="rules\baseline\permitlanservice.h" />
+    <ClInclude Include="rules\baseline\permitsplittunnelsubnets.h" />
     <ClInclude Include="rules\baseline\permitloopback.h" />
     <ClInclude Include="rules\baseline\permitndp.h" />
     <ClInclude Include="rules\baseline\permitvpntunnel.h" />


### PR DESCRIPTION
## What

Add the ability for users to specify IP addresses and CIDR subnets to
bypass the VPN firewall (created by mullvad) on Windows by letting traffic 
from programs such as Tailscale pass-through (which currently doesn't work
for the app based Split Tunneling). This addition would allow services like
Tailscale to work alongside Mullvad since Tailscale communicates over a subnet.

(lots of people requesting this feature, can also make a PR for linux as well)


## Why

Why? Simply because multiple users (like me) and other in a reddit post I made
about a personal change would be really glad to see this implemented
(https://www.reddit.com/r/mullvadvpn/comments/1rmeyxj/would_anyone_else_use_this_worth_openning_a_pr_to/)
As of right now the only ways to get this to work is to disable mullvad entirely, but
my addition to the app would allow people to use both tailscale (which is already encrypted) with mullvad.

I'd also like to highlight there were other instances of people requesting this feature, and
I believe only one person who tried to open a PR as well.

(shown below)

This was suggested by @faern in #6089:
> "Maybe we should consider adding a feature where the user can enter a
> list of networks that they want unblocked?"

Related: #5921, #2071, #4557, #6219, #9537

## How

Feature is opt-in (no on/off switch like Split Tunneling) but you can add your own
IP/Subnets manually, using a very similar GUI as what's already there with Split Tunneling.

Added a new field called "ip_exclusions" in the "SplitTunnelSettings" that stores a list
of user-specified IP networks to exclude from the VPN tunnel, with there being persistence
between sessions via settings migration v15.

Added a WFP firewall rule called PermitSplitTunnelSubnets, built to follow the same pattern
already being used with PermitLan rule. It creates both outbound & inbound filters so traffic
can flow in both directions without being superseded or interrupted by mullvad.

When a user adds or removes a subnet, the change flows through the already existing AllowLan
pipeline: with the setting being saved, daemon sending a TunnelCommand, which updates the
SharedTunnelStateValues, thus triggering the firewall to reapply its rules with the updated
subnet list from the users ip_exclusion settings.

In the Split Tunneling (IP) section the gRPC interface pipeline has three commands.
AddSplitTunnelIpNetwork - add a subnet/IP
RemoveSplitTunnelIpNetwork - remove a subnet/IP
ClearSplitTunnelIpNetworks - remove all subnets/IPs (no UI button for this yet, but can implement if needed)

All changes affect the WFP firewall that the windows client already uses for AllowLan so we don't
have to do any kernel-level or deeper config to split tunnels.

## How to test

1. Add a split tunnel subnet via CLI:
   `mullvad split-tunnel ip add 100.64.0.0/10`
2. List current exclusions: `mullvad split-tunnel ip list`
3. Connect to Mullvad VPN
4. Verify traffic to the excluded subnet bypasses the VPN
5. Verify all other traffic still routes through VPN
6. Remove the subnet: `mullvad split-tunnel ip remove 100.64.0.0/10`
7. Verify the subnet is blocked again
8. Test via desktop GUI: Settings > Split tunneling (IP)

I have done all of this myself as well to verify tailscale connections from
my self hosted server can get though the Mullvad firewall.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9968)
<!-- Reviewable:end -->
