### PR TITLE
Bump gotatun to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,21 +350,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1690,12 +1666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,9 +1673,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gotatun"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edab90df8fab23febf092506e66e19b05eacd9e2e761e1d42c74aaea97c2c252"
+checksum = "7e852834d591d0a2011283fdf292236e36fe9c92d3dbbbd801049aa900ddd731"
 dependencies = [
  "aead",
  "base64",
@@ -1726,10 +1696,9 @@ dependencies = [
  "libc",
  "log",
  "maybenot",
- "nix 0.30.1",
+ "nix 0.31.2",
  "parking_lot",
  "pcap-file",
- "pnet_packet 0.35.0",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
@@ -1737,7 +1706,7 @@ dependencies = [
  "socket2 0.6.0",
  "thiserror 1.0.59",
  "tokio",
- "tun 0.8.5",
+ "tun 0.8.6",
  "typed-builder 0.21.0",
  "windows-sys 0.61.2",
  "x25519-dalek",
@@ -1759,7 +1728,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.18",
  "tracing",
 ]
 
@@ -1800,7 +1769,7 @@ dependencies = [
  "h3-datagram",
  "quinn",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.18",
 ]
 
 [[package]]
@@ -1872,7 +1841,7 @@ dependencies = [
  "ring",
  "rustls",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -1898,7 +1867,7 @@ dependencies = [
  "rustls",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -1921,10 +1890,10 @@ dependencies = [
  "ipnet",
  "prefix-trie",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.18",
  "tracing",
 ]
 
@@ -2439,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
  "serde",
 ]
@@ -2630,7 +2599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2953,7 +2922,7 @@ dependencies = [
  "shadowsocks",
  "talpid-time",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tokio-socks",
@@ -2986,7 +2955,7 @@ dependencies = [
  "serde",
  "serde_json",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "windows-sys 0.61.2",
  "winres",
@@ -3040,7 +3009,7 @@ dependencies = [
  "talpid-time",
  "talpid-types",
  "talpid-windows",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing-appender",
@@ -3070,7 +3039,7 @@ version = "0.0.0"
 dependencies = [
  "nix 0.30.1",
  "talpid-cgroup",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3121,7 +3090,7 @@ dependencies = [
  "mullvad-problem-report",
  "talpid-platform-metadata",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -3165,7 +3134,7 @@ dependencies = [
  "prost",
  "prost-types",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tipsy",
  "tokio",
  "tonic",
@@ -3194,7 +3163,7 @@ dependencies = [
  "rustls-pki-types",
  "socket2 0.5.8",
  "talpid-tunnel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing-subscriber",
  "typed-builder 0.21.0",
@@ -3219,7 +3188,7 @@ version = "0.0.0"
 dependencies = [
  "log",
  "once_cell",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "widestring",
  "windows-sys 0.61.2",
 ]
@@ -3237,7 +3206,7 @@ dependencies = [
  "regex",
  "talpid-platform-metadata",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing-subscriber",
  "uuid",
@@ -3256,7 +3225,7 @@ dependencies = [
  "proptest",
  "rand 0.9.2",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "vec1",
 ]
 
@@ -3307,7 +3276,7 @@ dependencies = [
  "talpid-core",
  "talpid-future",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing-subscriber",
  "windows-service",
@@ -3328,7 +3297,7 @@ dependencies = [
  "regex",
  "serde",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uuid",
  "vec1",
 ]
@@ -3358,7 +3327,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "strum",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "vec1",
  "zeroize",
@@ -3465,7 +3434,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3547,6 +3516,19 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -3792,15 +3774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
 dependencies = [
  "objc",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4393,7 +4366,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.8",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -4414,7 +4387,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4573,7 +4546,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.14",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4708,12 +4681,6 @@ dependencies = [
  "thiserror 1.0.59",
  "tokio",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -5022,7 +4989,7 @@ dependencies = [
  "shadowsocks-crypto",
  "socket2 0.5.8",
  "spin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tfo",
  "trait-variant",
@@ -5301,7 +5268,7 @@ dependencies = [
  "anyhow",
  "log",
  "nix 0.30.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5347,7 +5314,7 @@ dependencies = [
  "talpid-windows",
  "talpid-wireguard",
  "test-log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tun 0.5.5",
  "typed-builder 0.20.1",
@@ -5368,7 +5335,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "zbus",
  "zvariant",
@@ -5390,7 +5357,7 @@ dependencies = [
  "talpid-routing",
  "talpid-types",
  "talpid-windows",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "triggered",
  "which",
@@ -5427,7 +5394,7 @@ dependencies = [
  "nix 0.30.1",
  "socket2 0.5.8",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5458,7 +5425,7 @@ dependencies = [
  "system-configuration",
  "talpid-types",
  "talpid-windows",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "widestring",
  "windows-sys 0.61.2",
@@ -5484,10 +5451,10 @@ dependencies = [
  "talpid-routing",
  "talpid-types",
  "talpid-windows",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tun 0.5.5",
- "tun 0.8.5",
+ "tun 0.8.6",
  "windows-sys 0.61.2",
 ]
 
@@ -5523,7 +5490,7 @@ dependencies = [
  "jnix",
  "log",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
 ]
@@ -5535,7 +5502,7 @@ dependencies = [
  "futures",
  "socket2 0.5.8",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.61.2",
 ]
 
@@ -5573,10 +5540,10 @@ dependencies = [
  "talpid-tunnel-config-client",
  "talpid-types",
  "talpid-windows",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tun 0.8.5",
+ "tun 0.8.6",
  "tunnel-obfuscation",
  "widestring",
  "windows-sys 0.61.2",
@@ -5629,11 +5596,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5649,9 +5616,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5750,27 +5717,26 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5809,7 +5775,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.18",
 ]
 
 [[package]]
@@ -5845,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5986,7 +5952,7 @@ dependencies = [
  "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.18",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6041,7 +6007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -6117,7 +6083,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6150,9 +6116,9 @@ dependencies = [
 
 [[package]]
 name = "tun"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35f176015650e3bd849e85808d809e5b54da2ba7df983c5c3b601a2a8f1095e"
+checksum = "87dce40a7bfb165d8eb8e96f7463230f3d91b56aae21e0f1e56db60161962e1a"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6161,10 +6127,10 @@ dependencies = [
  "ipnet",
  "libc",
  "log",
- "nix 0.30.1",
- "thiserror 2.0.17",
+ "nix 0.31.2",
+ "thiserror 2.0.18",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.18",
  "windows-sys 0.61.2",
  "wintun-bindings",
 ]
@@ -6182,9 +6148,9 @@ dependencies = [
  "rand 0.8.5",
  "shadowsocks",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.18",
  "udp-over-tcp",
 ]
 
@@ -6985,7 +6951,7 @@ dependencies = [
  "neon",
  "talpid-types",
  "talpid-windows",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows 0.62.2",
 ]
 
@@ -7257,7 +7223,7 @@ dependencies = [
  "futures",
  "libloading 0.9.0",
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.61.2",
  "winreg 0.55.0",
 ]
@@ -7270,7 +7236,7 @@ dependencies = [
  "log",
  "maybenot-ffi",
  "talpid-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.61.2",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4.4.18", features = ["cargo", "derive"] }
 dirs = "6.0.0"
 futures = "0.3.15"
-gotatun = { version = "0.4.0" }
+gotatun = { version = "0.4.1" }
 hickory-proto = "0.25.2"
 hickory-resolver = "0.25.2"
 hickory-server = { version = "0.25.2", features = ["resolver"] }


### PR DESCRIPTION
This PR bumps `gotatun` to 0.4.1, which contains a crucial bug fix for handshakes being rejected if they did not complete in ~125 ms (on average). Full changelog can be found [here](https://github.com/mullvad/gotatun/blob/main/CHANGELOG.md#041---2026-03-11).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9975)
<!-- Reviewable:end -->
