### PR TITLE
Fix bug on Linux where hot reload in `src/main` file froze window

### DIFF
--- a/desktop/packages/mullvad-vpn/vite-utils.ts
+++ b/desktop/packages/mullvad-vpn/vite-utils.ts
@@ -41,9 +41,11 @@ function pidTree(tree: PidTree) {
 }
 
 function killTree(tree: PidTree) {
-  if (tree.children) {
-    for (const child of tree.children) {
-      killTree(child);
+  if (process.platform === 'darwin') {
+    if (tree.children) {
+      for (const child of tree.children) {
+        killTree(child);
+      }
     }
   }
 


### PR DESCRIPTION
When a file in `src/main` is changed the `vite-plugin-electron` will kill the electron process and restart it. However, on Linux it seems like the electron window process freezes if we do that.

Killing the main electron process seems to kill all its children on Linux, but killing the children before the electron process seems to freeze the window. In order to fix this bug we only kill the electron process.

We will continue to manually kill the process children before the parent process on macOS, as the current implementation seems to work well on that platform.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9981)
<!-- Reviewable:end -->
