### PR TITLE
Fix touch area for expanding connection details

### DIFF
--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/HeaderView.swift
@@ -21,27 +21,31 @@ extension ConnectionView {
                     .accessibilityIdentifier(viewModel.accessibilityIdForSecureLabel.asString)
                     .accessibilityLabel(viewModel.localizedAccessibilityLabelForSecureLabel)
                     .accessibilityRemoveTraits(.isButton)
-                Group {
-                    Spacer()
-                    Button {
-                        withAnimation {
-                            isExpanded.toggle()
-                        }
-                    } label: {
-                        Image(.iconChevronUp)
-                            .renderingMode(.template)
-                            .rotationEffect(isExpanded ? .degrees(-180) : .degrees(0))
-                            .foregroundStyle(.white)
-                    }
-                    .accessibilityIdentifier(AccessibilityIdentifier.relayStatusCollapseButton.asString)
+
+                Spacer()
+
+                Image(.iconChevronUp)
+                    .renderingMode(.template)
+                    .rotationEffect(isExpanded ? .degrees(-180) : .degrees(0))
+                    .foregroundStyle(.white)
+                    .accessibilityRemoveTraits(.isImage)
                     .accessibilityLabel(
                         isExpanded
                             ? LocalizedStringKey("Collapse connection details")
                             : LocalizedStringKey("Expand connection details")
                     )
-                }
-                .showIf(viewModel.showsConnectionDetails)
             }
+            .accessibilityElement(children: .contain)
+            .showIf(viewModel.showsConnectionDetails)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation {
+                    isExpanded.toggle()
+                }
+            }
+            .accessibilityIdentifier(
+                AccessibilityIdentifier.relayStatusCollapseButton.asString
+            )
         }
     }
 }

--- a/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
+++ b/ios/MullvadVPNUITests/Pages/TunnelControlPage.swift
@@ -136,7 +136,7 @@ class TunnelControlPage: Page {
     }
 
     @discardableResult func tapRelayStatusExpandCollapseButton() -> Self {
-        let button = app.buttons[AccessibilityIdentifier.relayStatusCollapseButton]
+        let button = app.otherElements[AccessibilityIdentifier.relayStatusCollapseButton]
         button.tapWhenHittable(failOnUnmetCondition: false)
 
         return self


### PR DESCRIPTION
It fixes the touch area for expanding connection details so the entire row is tappable instead of only the chevron icon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/9987)
<!-- Reviewable:end -->
