### PR TITLE
Remove wireguard-go support

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -309,7 +309,6 @@ cargo {
     val isReleaseBuild = isReleaseBuild()
     val generateDebugSymbolsForReleaseBuilds =
         getBooleanProperty("mullvad.app.build.cargo.generateDebugSymbolsForReleaseBuilds")
-    val enableGotaTun = getBooleanProperty("mullvad.app.build.gotatun.enable")
     val enableApiOverride = !isReleaseBuild || appVersion.isDev || appVersion.isAlpha
     module = repoRootPath
     libname = "mullvad-jni"
@@ -328,9 +327,6 @@ cargo {
             buildList {
                     if (enableApiOverride) {
                         add("api-override")
-                    }
-                    if (!enableGotaTun) {
-                        add("wireguard-go")
                     }
                 }
                 .toTypedArray()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -43,9 +43,6 @@ mullvad.app.build.keepDebugSymbols=false
 # when debugging to the Rust native libs from Android Studio.
 mullvad.app.build.replaceRustPathPrefix=true
 
-# Enable/Disable GotaTun
-mullvad.app.build.gotatun.enable=true
-
 ## E2E tests ##
 
 # To run e2e tests you need to provide credentails for the enviroment you


### PR DESCRIPTION
We've migrated to [GotaTun](https://github.com/mullvad/gotatun) 4 months ago, and it has been a huge success, we kept wireguard-go support in the android app to quickly be able to release if we would need to. However, now with GotaTun out the door, and performing way better there is no point in keeping the wireguard-go support.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10010)
<!-- Reviewable:end -->
