### PR TITLE
Adjust verbosity argument for `mullvad-daemon` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Location setting no longer defaults to Sweden, instead it uses you current location if it
   has available relays, and falls back to Sweden otherwise.
+- `mullvad-daemon` now defaults to `ERROR` log level when `-v` is not specified.
+  `mullvad-daemon -vv` is used in system services to maintain previous `DEBUG` log level.
 - Update GotaTun from version `0.2.0` to `0.4.1`. This improves compliance with the
   WireGuard spec by implementing padding to multiples of 16 bytes, fixes a minor
   vulnerability when generating peer indices, and fixes another when registering incoming

--- a/dist-assets/linux/mullvad-daemon.service
+++ b/dist-assets/linux/mullvad-daemon.service
@@ -13,7 +13,7 @@ RequiresMountsFor=/opt/Mullvad\x20VPN/resources/
 [Service]
 Restart=always
 RestartSec=1
-ExecStart=/usr/bin/mullvad-daemon -v --disable-stdout-timestamps
+ExecStart=/usr/bin/mullvad-daemon -vv --disable-stdout-timestamps
 Environment="MULLVAD_RESOURCE_DIR=/opt/Mullvad VPN/resources/"
 
 [Install]

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -49,7 +49,7 @@ DAEMON_PLIST=$(cat <<-EOM
                 <key>ProgramArguments</key>
                 <array>
                         <string>$DAEMON_BINARY</string>
-                        <string>-v</string>
+                        <string>-vv</string>
                 </array>
 
                 <key>EnvironmentVariables</key>

--- a/mullvad-daemon/src/cli.rs
+++ b/mullvad-daemon/src/cli.rs
@@ -26,7 +26,7 @@ static ENV_DESC: LazyLock<String> = LazyLock::new(|| {
 #[derive(Debug, Parser)]
 #[command(author, version = mullvad_version::VERSION, about, long_about = None, after_help = &*ENV_DESC)]
 struct Cli {
-    /// Set the level of verbosity
+    /// Set the level of verbosity. Zero `-v` flag defaults to "Error" log level.
     #[arg(short='v', action = clap::ArgAction::Count)]
     verbosity: u8,
     /// Disable logging to file
@@ -127,8 +127,9 @@ fn create_config() -> Config {
     let app = Cli::parse();
 
     let log_level = match app.verbosity {
-        0 => log::LevelFilter::Info,
-        1 => log::LevelFilter::Debug,
+        0 => log::LevelFilter::Error,
+        1 => log::LevelFilter::Info,
+        2 => log::LevelFilter::Debug,
         _ => log::LevelFilter::Trace,
     };
 

--- a/mullvad-daemon/src/system_service.rs
+++ b/mullvad-daemon/src/system_service.rs
@@ -368,7 +368,7 @@ fn get_service_info() -> ServiceInfo {
         start_type: ServiceStartType::AutoStart,
         error_control: ServiceErrorControl::Normal,
         executable_path: env::current_exe().unwrap(),
-        launch_arguments: vec![OsString::from("--run-as-service"), OsString::from("-v")],
+        launch_arguments: vec![OsString::from("--run-as-service"), OsString::from("-vv")],
         dependencies: vec![
             // Base Filter Engine
             ServiceDependency::Service(OsString::from("BFE")),

--- a/test/test-runner/src/sys/linux.rs
+++ b/test/test-runner/src/sys/linux.rs
@@ -8,9 +8,9 @@ pub async fn set_daemon_log_level(verbosity_level: Verbosity) -> Result<(), test
     log::debug!("Setting log level");
 
     let verbosity = match verbosity_level {
-        Verbosity::Info => "",
-        Verbosity::Debug => "-v",
-        Verbosity::Trace => "-vv",
+        Verbosity::Info => "-v",
+        Verbosity::Debug => "-vv",
+        Verbosity::Trace => "-vvv",
     };
     let systemd_service_file_content = format!(
         r#"[Service]

--- a/test/test-runner/src/sys/windows.rs
+++ b/test/test-runner/src/sys/windows.rs
@@ -275,9 +275,9 @@ pub async fn set_daemon_log_level(verbosity_level: Verbosity) -> Result<(), test
     log::debug!("Setting log level");
 
     let verbosity = match verbosity_level {
-        Verbosity::Info => "",
-        Verbosity::Debug => "-v",
-        Verbosity::Trace => "-vv",
+        Verbosity::Info => "-v",
+        Verbosity::Debug => "-vv",
+        Verbosity::Trace => "-vvv",
     };
 
     let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)


### PR DESCRIPTION
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [x] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [x] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [x] Automatic tests are added for the change, if relevant. All new features must have tests.
* [x] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

(originally posted in https://github.com/mullvad/mullvadvpn-app/discussions/9994)

I would expect a program to default to `Error` logging level.
However, mullvad-daemon defaults to `Info` logging level, and subsequent `-v` only makes the log more verbose.

Related to https://github.com/mullvad/mullvadvpn-app/issues/9388. Querying the status of the tunnel regularly for a monitoring script spams the log entry every second.

This is also the case in nixpkgs. https://github.com/NixOS/nixpkgs/pull/499507

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10019)
<!-- Reviewable:end -->
