### PR TITLE
Bump gotatun version number in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Changed
 - Location setting no longer defaults to Sweden, instead it uses you current location if it
   has available relays, and falls back to Sweden otherwise.
-- Update GotaTun from version `0.2.0` to `0.4.0`. This improves compliance with the
+- Update GotaTun from version `0.2.0` to `0.4.1`. This improves compliance with the
   WireGuard spec by implementing padding to multiples of 16 bytes, fixes a minor
   vulnerability when generating peer indices, and fixes another when registering incoming
   decoy packets for DAITA.


### PR DESCRIPTION
Update changelog entry about gotatun version bump to reflect status quo: https://github.com/mullvad/mullvadvpn-app/pull/9975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10020)
<!-- Reviewable:end -->
