### PR TITLE
Remove `wireguard-go` feature from mullvad-jni crate

### DIFF
--- a/mullvad-jni/Cargo.toml
+++ b/mullvad-jni/Cargo.toml
@@ -24,7 +24,6 @@ tokio = { workspace = true, features = ["rt"] }
 [features]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override", "mullvad-daemon/api-override"]
-wireguard-go = ["mullvad-daemon/wireguard-go"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
Follow up to https://github.com/mullvad/mullvadvpn-app/pull/10010

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10026)
<!-- Reviewable:end -->
