### PR TITLE
Always build fdroid builds on build server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /ci/linux-repository-builder/ @faern @raksooo @tobias-jarvelov
 
 # Android build server files owned by android
-/ci/buildserver-build-android.sh @faern @rawa @albin-mullvad
+/ci/android/** @faern @rawa @albin-mullvad
 
 # Desktop release config specifying code signing key fingerprint
 /desktop/scripts/release/release-config.sh

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,12 +1,9 @@
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.github.triplet.gradle.androidpublisher.ReleaseStatus
-import java.io.FileInputStream
-import java.util.Properties
 import org.gradle.internal.extensions.stdlib.capitalized
 import utilities.BuildTypes
 import utilities.FlavorDimensions
 import utilities.Flavors
-import utilities.SigningConfigs
 import utilities.Variant
 import utilities.allPlayDebugReleaseVariants
 import utilities.appVersionProvider
@@ -38,14 +35,6 @@ val repoRootPath = rootProject.projectDir.absoluteFile.parentFile.absolutePath
 val relayListDirectory = file("$repoRootPath/dist-assets/relays/").absolutePath
 val changelogAssetsDirectory = "$repoRootPath/android/src/main/play/release-notes/"
 val rustJniLibsDir = layout.buildDirectory.dir("rustJniLibs/android").get()
-
-val credentialsPath = "${rootProject.projectDir}/credentials"
-val keystorePropertiesFile = file("$credentialsPath/keystore.properties")
-val keystoreProperties = Properties()
-
-if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
-}
 
 val appVersion = appVersionProvider.get()
 
@@ -98,20 +87,9 @@ android {
         generateLocaleConfig = false
     }
 
-    if (keystorePropertiesFile.exists()) {
-        signingConfigs {
-            create(SigningConfigs.RELEASE) {
-                storeFile = file("$credentialsPath/app-keys.jks")
-                storePassword = keystoreProperties.getProperty("storePassword")
-                keyAlias = keystoreProperties.getProperty("keyAlias")
-                keyPassword = keystoreProperties.getProperty("keyPassword")
-            }
-        }
-    }
-
     buildTypes {
         getByName(BuildTypes.RELEASE) {
-            signingConfig = signingConfigs.findByName(SigningConfigs.RELEASE)
+            signingConfig = null
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(
@@ -373,7 +351,7 @@ tasks.register("printVersion") {
 }
 
 play {
-    serviceAccountCredentials.set(file("$credentialsPath/play-api-key.json"))
+    System.getenv("PLAY_CREDENTIALS_PATH")?.let { serviceAccountCredentials.set(file(it)) }
     // Disable for all flavors by default. Only specific flavors should be enabled using
     // PlayConfigs.
     enabled = false

--- a/android/build.sh
+++ b/android/build.sh
@@ -9,8 +9,6 @@ GRADLE_BUILD_TYPE="release"
 GRADLE_TASKS=(createOssProdReleaseDistApk createPlayProdReleaseDistApk)
 BUILD_BUNDLE="no"
 BUNDLE_TASKS=(createPlayProdReleaseDistBundle)
-RUN_PLAY_PUBLISH_TASKS="no"
-PLAY_PUBLISH_TASKS=()
 
 while [ -n "${1:-""}" ]; do
     if [[ "${1:-""}" == "--dev-build" ]]; then
@@ -23,8 +21,6 @@ while [ -n "${1:-""}" ]; do
         BUNDLE_TASKS=(createOssProdFdroidDistBundle)
     elif [[ "${1:-""}" == "--app-bundle" ]]; then
         BUILD_BUNDLE="yes"
-    elif [[ "${1:-""}" == "--enable-play-publishing" ]]; then
-        RUN_PLAY_PUBLISH_TASKS="yes"
     fi
 
     shift 1
@@ -39,12 +35,6 @@ function assert_clean_working_directory {
 
 if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
     assert_clean_working_directory
-
-    if [ ! -f "$SCRIPT_DIR/credentials/keystore.properties" ]; then
-        echo "ERROR: No keystore.properties file found" >&2
-        echo "       Please configure the signing keys as described in the README" >&2
-        exit 1
-    fi
 fi
 
 echo "Computing build version..."
@@ -63,18 +53,6 @@ if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
             createPlayDevmoleReleaseDistBundle
             createPlayStagemoleReleaseDistBundle
         )
-    fi
-
-    if [[ "$PRODUCT_VERSION" != *"-dev-"* ]]; then
-        PLAY_PUBLISH_TASKS+=(
-            publishPlayProdReleaseBundle
-        )
-        if [[ "$PRODUCT_VERSION" == *"-alpha"* ]]; then
-            PLAY_PUBLISH_TASKS+=(
-                publishPlayDevmoleReleaseBundle
-                publishPlayStagemoleReleaseBundle
-            )
-        fi
     fi
 fi
 
@@ -104,10 +82,6 @@ fi
 # This could for example happen if lockfiles are outdated, and the build process updates them.
 if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
     assert_clean_working_directory
-fi
-
-if [[ "$RUN_PLAY_PUBLISH_TASKS" == "yes" && "${#PLAY_PUBLISH_TASKS[@]}" -ne 0 ]]; then
-    $GRADLE_CMD --console plain "${PLAY_PUBLISH_TASKS[@]}"
 fi
 
 echo "**********************************"

--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -6,7 +6,6 @@
 #     -v $CARGO_TARGET_VOLUME_NAME:/cargo-target:Z \
 #     -v $CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z \
 #     -v $GRADLE_CACHE_VOLUME_NAME:/root/.gradle:Z \
-#     -v $ANDROID_CREDENTIALS_DIR:/build/android/credentials:Z \
 #     -v /path/to/repository_root:/build:Z \
 #     mullvadvpn-app-build-android ./android/build.sh --dev-build
 #

--- a/android/docs/BuildInstructions.md
+++ b/android/docs/BuildInstructions.md
@@ -51,10 +51,13 @@ Run the following command to trigger a full debug build:
 
 ### Release build
 1. Configure a signing key by following [these instructions](#configure-signing-key).
-2. Run the following command after setting the `ANDROID_CREDENTIALS_DIR` environment variable to the
-directory configured in step 1:
+2. Run the following command to build:
 ```bash
 ../building/containerized-build.sh android --app-bundle
+```
+3. Sign the release artifacts using apksigner with the following command:
+```bash
+apksigner sign --ks app-keys.jks (MullvadVPN)(version)(.apk|.aab) 
 ```
 
 ## Build without the provided container
@@ -153,10 +156,13 @@ Run the following command to build a debug build:
 
 ### Release build
 1. Configure a signing key by following [these instructions](#configure-signing-key).
-2. Move, copy or symlink the directory from step 1 to [./credentials/](./credentials/) (`<repository>/android/credentials/`).
-3. Run the following command to build:
+2. Run the following command to build:
    ```bash
    ../android/build.sh --app-bundle
+   ```
+3. Sign the release artifacts using apksigner with the following command:
+   ```bash
+   apksigner sign --ks app-keys.jks (MullvadVPN)(version)(.apk|.aab) 
    ```
 
 ## Build using nix devshell
@@ -182,24 +188,10 @@ This is supported on Linux (x86_64) as well as macOS (x86_64 and aarch64).
    ```
 
 ## Configure signing key
-1. Create a directory to store the signing key, keystore and its configuration:
-   ```
-   export ANDROID_CREDENTIALS_DIR=/tmp/credentials
-   mkdir -p $ANDROID_CREDENTIALS_DIR
-   ```
-
-2. Generate a key/keystore named `app-keys.jks` in `ANDROID_CREDENTIALS_DIR` and make sure to write
+Generate a key/keystore named `app-keys.jks` and make sure to write
 down the used passwords:
-   ```
-   keytool -genkey -v -keystore $ANDROID_CREDENTIALS_DIR/app-keys.jks -alias release -keyalg RSA -keysize 4096 -validity 10000
-   ```
-
-3. Create a file named `keystore.properties` in `ANDROID_CREDENTIALS_DIR`. Enter the following, but
-replace `key-password` and `keystore-password` with the values from step 2:
    ```bash
-   keyAlias = release
-   keyPassword = key-password
-   storePassword = keystore-password
+   keytool -genkey -v -keystore app-keys.jks -alias release -keyalg RSA -keysize 4096 -validity 10000
    ```
 
 ## Creating an alpha release

--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -14,8 +14,8 @@ REPO_MOUNT_TARGET="/build"
 CARGO_TARGET_VOLUME_NAME=${CARGO_TARGET_VOLUME_NAME:-"cargo-target"}
 CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
 GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
-ANDROID_CREDENTIALS_DIR=${ANDROID_CREDENTIALS_DIR:-""}
 CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
+PLAY_CREDENTIALS_PATH=${PLAY_CREDENTIALS_PATH:-""}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -32,8 +32,11 @@ case ${1-:""} in
         container_image_name=$(cat "$SCRIPT_DIR/android-container-image.txt")
         optional_gradle_cache_volume=(-v "$GRADLE_CACHE_VOLUME_NAME:/root/.gradle:Z")
 
-        if [ -n "$ANDROID_CREDENTIALS_DIR" ]; then
-            optional_android_credentials_volume=(-v "$ANDROID_CREDENTIALS_DIR:$REPO_MOUNT_TARGET/android/credentials:Z")
+        if [ -n "$PLAY_CREDENTIALS_PATH" ]; then
+            optional_play_credentials_file=(
+                -v "$PLAY_CREDENTIALS_PATH:$REPO_MOUNT_TARGET/android/credentials/play-api-key.json:Z"
+                -e "PLAY_CREDENTIALS_PATH=$REPO_MOUNT_TARGET/android/credentials/play-api-key.json"
+            )
         fi
 
         shift 1
@@ -49,5 +52,5 @@ exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$CARGO_TARGET_VOLUME_NAME:/cargo-target:Z" \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \
-    "${optional_android_credentials_volume[@]}" \
+    "${optional_play_credentials_file[@]}" \
     "$container_image_name" bash -c "$*"

--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -52,7 +52,7 @@ function run_in_linux_container {
 function build {
     CARGO_TARGET_VOLUME_NAME="cargo-target-android" \
     CARGO_REGISTRY_VOLUME_NAME="cargo-registry-android" \
-    ./building/containerized-build.sh android --app-bundle || return 1
+    ./building/containerized-build.sh android "$@" || return 1
 
     mv dist/*.{aab,apk} "$artifact_dir" || return 1
 }
@@ -104,8 +104,11 @@ function build_sign_and_publish_ref {
     local artifact_dir="dist/$version"
     mkdir -p "$artifact_dir"
 
-    echo "Building Android app"
-    artifact_dir=$artifact_dir build || return 1
+    echo "Building Android app with bundle"
+    artifact_dir=$artifact_dir build --app-bundle || return 1
+
+    echo "Building Android app with fdroid"
+    artifact_dir=$artifact_dir build --fdroid || return 1
 
     # If there is a tag for this commit then we append that to the produced artifacts
     # A version suffix should only be created if there is a tag for this commit and it is not a release build

--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -13,12 +13,27 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$SCRIPT_DIR/mullvadvpn-app"
 LAST_BUILT_DIR="$SCRIPT_DIR/last-built"
 UPLOAD_DIR="/home/upload/upload"
-ANDROID_CREDENTIALS_DIR="$SCRIPT_DIR/credentials-android"
+PLAY_CREDENTIALS_PATH="$SCRIPT_DIR/credentials-android/play-api-key.json"
 
 BRANCHES_TO_BUILD=("origin/main")
 TAG_PATTERN_TO_BUILD="^android/"
+SPECIFIC_REF=""
 
-function upload {
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ref) SPECIFIC_REF="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1"; exit 1 ;;
+    esac
+done
+
+if [[ -z ${YUBIKEY_PIN-} ]]; then
+    read -rsp "YUBIKEY_PIN = " YUBIKEY_PIN
+    echo ""
+    export YUBIKEY_PIN
+fi
+
+# Move files for CDN upload by: buildserver-upload.sh
+function prepare_for_cdn_upload {
     version=$1
 
     files=( * )
@@ -35,10 +50,9 @@ function run_in_linux_container {
 # Builds the app artifacts and move them to the passed in `artifact_dir`.
 # Must pass `artifact_dir` to show where to move the built artifacts.
 function build {
-    ANDROID_CREDENTIALS_DIR=$ANDROID_CREDENTIALS_DIR \
-        CARGO_TARGET_VOLUME_NAME="cargo-target-android" \
-        CARGO_REGISTRY_VOLUME_NAME="cargo-registry-android" \
-        ./building/containerized-build.sh android --app-bundle --enable-play-publishing || return 1
+    CARGO_TARGET_VOLUME_NAME="cargo-target-android" \
+    CARGO_REGISTRY_VOLUME_NAME="cargo-registry-android" \
+    ./building/containerized-build.sh android --app-bundle || return 1
 
     mv dist/*.{aab,apk} "$artifact_dir" || return 1
 }
@@ -67,7 +81,7 @@ function checkout_ref {
     git clean -df
 }
 
-function build_ref {
+function build_sign_and_publish_ref {
     ref=$1
     tag=${2:-""}
 
@@ -110,7 +124,15 @@ function build_ref {
         version="$version$version_suffix"
     fi
 
-    (cd "$artifact_dir" && upload "$version") || return 1
+    # Sign all artifacts
+    YUBIKEY_PIN=$YUBIKEY_PIN \
+    "$SCRIPT_DIR/sign.sh" "$artifact_dir"/MullvadVPN-*.{aab,apk} \
+    || return 1
+
+    PLAY_CREDENTIALS_PATH="$PLAY_CREDENTIALS_PATH" \
+    "$SCRIPT_DIR/upload-play.sh" "$artifact_dir" "$version" || echo "Failed to upload bundle $version"
+
+    (cd "$artifact_dir" && prepare_for_cdn_upload "$version") || return 1
     # shellcheck disable=SC2216
     yes | rm -r "$artifact_dir"
 
@@ -129,17 +151,22 @@ while true; do
 
     git fetch --prune --tags 2> /dev/null || continue
 
+    if [[ -n "$SPECIFIC_REF" ]]; then
+        build_sign_and_publish_ref "$SPECIFIC_REF" || echo "Failed to build $SPECIFIC_REF"
+        exit 0
+    fi
+
     # Only build android/* tags.
     # Tags can't include spaces so SC2207 isn't a problem here
     # shellcheck disable=SC2207
     tags=( $(git tag | grep "$TAG_PATTERN_TO_BUILD") )
 
     for tag in "${tags[@]}"; do
-        build_ref "refs/tags/$tag" "$tag" || echo "Failed to build tag $tag"
+        build_sign_and_publish_ref "refs/tags/$tag" "$tag" || echo "Failed to build tag $tag"
     done
 
     for branch in "${BRANCHES_TO_BUILD[@]}"; do
-        build_ref "refs/remotes/$branch" || echo "Failed to build branch $tag"
+        build_sign_and_publish_ref "refs/remotes/$branch" || echo "Failed to build branch $branch"
     done
 
     sleep 240

--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -50,9 +50,11 @@ function run_in_linux_container {
 # Builds the app artifacts and move them to the passed in `artifact_dir`.
 # Must pass `artifact_dir` to show where to move the built artifacts.
 function build {
+    local build_flag=$1
+    
     CARGO_TARGET_VOLUME_NAME="cargo-target-android" \
     CARGO_REGISTRY_VOLUME_NAME="cargo-registry-android" \
-    ./building/containerized-build.sh android "$@" || return 1
+    ./building/containerized-build.sh android "$build_flag" || return 1
 
     mv dist/*.{aab,apk} "$artifact_dir" || return 1
 }

--- a/ci/android/build-server/sign.sh
+++ b/ci/android/build-server/sign.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Given a directory will sign all artifacts (apk and aab files) in that directory.
+# Requires a YUBIKEY PIN and credentials directory to be set up beforehand.
+
+set -eu
+shopt -s nullglob
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_DIR="$SCRIPT_DIR/mullvadvpn-app"
+PROVIDER_ARG="$SCRIPT_DIR/signing/pkcs11_java.cfg"
+APKSIGNER_CMD="${APKSIGNER_CMD:-apksigner}"
+KEY_ALIAS="X.509 Certificate for PIV Authentication"
+MIN_SDK_VERSION="26"
+
+if [[ -z ${YUBIKEY_PIN-} ]]; then
+    echo "YUBIKEY_PIN pin must be set."
+    exit 1
+fi
+
+function main {
+    if [[ $# -eq 0 ]]; then
+        echo "Please specify which files to sign"
+        exit 1
+    fi
+
+    for artifact_file in "$@"; do
+        sign_artifact "$artifact_file"
+    done
+}
+
+function sign_artifact {
+    local artifact_file="$1"
+
+    $APKSIGNER_CMD -J-add-exports="jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED" sign \
+    --ks NONE --ks-type PKCS11 --ks-key-alias "$KEY_ALIAS" \
+    --provider-class sun.security.pkcs11.SunPKCS11 --provider-arg "$PROVIDER_ARG" \
+    --min-sdk-version "$MIN_SDK_VERSION" \
+    --in "$artifact_file" <<< "$YUBIKEY_PIN"
+}
+
+main "$@"

--- a/ci/android/build-server/signing/pkcs11_java.cfg
+++ b/ci/android/build-server/signing/pkcs11_java.cfg
@@ -1,0 +1,4 @@
+name = YKCS11
+description = SunPKCS11 via YKCS11
+library = /usr/lib64/libykcs11.so.2
+slotListIndex = 1

--- a/ci/android/build-server/upload-play.sh
+++ b/ci/android/build-server/upload-play.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Given a directory and a version will upload aab files matching the flavor and version to Google Play.
+
+set -eu
+shopt -s nullglob
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PLAY_UPLOAD_DIR=""
+
+trap '[[ -n "${PLAY_UPLOAD_DIR:-}" ]] && rm -rf "$PLAY_UPLOAD_DIR"' EXIT
+
+if [[ -z ${PLAY_CREDENTIALS_PATH-} ]]; then
+    echo "PLAY_CREDENTIALS_PATH must be set"
+    exit 1
+fi
+
+function main {
+    if [[ $# -eq 0 || $# -eq 1 ]]; then
+        echo "Please specify a artifact directory and version"
+        exit 1
+    fi
+
+    if [[ $# -gt 2 ]]; then
+        echo "Too many arguments"
+        exit 1
+    fi
+
+    local artifact_dir="$1"
+    local version="$2"
+
+    if [[ ! -d "$artifact_dir" || -z "$(ls -A "$artifact_dir")" ]]; then
+        echo "Missing or empty artifact directory"
+        exit 1
+    fi
+
+    upload_bundles "$artifact_dir" "$version"
+}
+
+# Upload bundle files to Google play.
+# It has to be done for one bundle at a time due to how the publish task works,
+# see the upload_bundle function for more information.
+function upload_bundles {
+    artifact_dir="$1"
+    version="$2"
+
+    PLAY_UPLOAD_DIR="$artifact_dir/play_upload"
+    mkdir -p "$PLAY_UPLOAD_DIR"
+
+    if [[ "$version" != *"-dev-"* ]]; then
+            upload_bundle "$PLAY_UPLOAD_DIR" "publishPlayProdReleaseBundle" "$artifact_dir/MullvadVPN-$version.play.aab" 
+        if [[ "$version" == *"-alpha"* ]]; then
+            upload_bundle "$PLAY_UPLOAD_DIR" "publishPlayDevmoleReleaseBundle" "$artifact_dir/MullvadVPN-$version.play.devmole.aab"
+            upload_bundle "$PLAY_UPLOAD_DIR" "publishPlayStagemoleReleaseBundle" "$artifact_dir/MullvadVPN-$version.play.stagemole.aab"
+        fi
+    fi
+}
+
+# Due to to the publish task only being able to upload all files in a folder
+# we need to upload one bundle at a time by copying into an upload dir.
+function upload_bundle {
+    upload_dir=$1
+    publish_task=$2
+    bundle_file=$3
+
+    rm -r "${upload_dir:?}/"* 2>/dev/null || true
+    cp "$bundle_file" "$upload_dir/"
+
+    PLAY_CREDENTIALS_PATH="$PLAY_CREDENTIALS_PATH" \
+    "$SCRIPT_DIR/mullvadvpn-app/building/container-run.sh" android ./android/gradlew -p android "$publish_task" --artifact-dir "../$upload_dir"
+}
+
+main "$@"

--- a/code-owners.json
+++ b/code-owners.json
@@ -31,7 +31,7 @@
   "appteam-android": [
     "android/**",
     "building/android-container-image.txt",
-    "ci/buildserver-build-android.sh",
+    "ci/android/**",
     "mullvad-jni/**"
   ],
   "appteam-lead": [


### PR DESCRIPTION
This is the first step to enable self-hosting of an fdroid server.

After building the app with `--app-bundle` argument, we will also build it with the `--fdroid` argument.

This is so we can produce fdroid artifacts which we later will upload to our self-hosted fdroid server.

Edit: Update to reflect that this PR no longer intends change the `android/build.sh` file.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10100)
<!-- Reviewable:end -->
