### PR TITLE
Enable GotaTun by default on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Line wrap the file at 100 chars.                                              Th
 ### Added
 - Add port setting for LWO obfuscation.
 - Add list of recent server selections in the select location view.
+- GotaTun is now used as the userspace WireGuard implementation on all desktop platforms.
+  It replaces wireguard-go.
 
 ### Changed
 - Optimize LWO performance when using GotaTun. This gives a 1.5 to 3 times speedup in our

--- a/build.sh
+++ b/build.sh
@@ -34,11 +34,7 @@ UNIVERSAL="false"
 # If only the daemon should be built and packaged separately (.deb and .rpm).
 DAEMON_ONLY="false"
 # Use gotatun instead of wireguard-go.
-GOTATUN="false"
-# Enable GotaTun by default on macOS and Linux.
-if [[ "$(uname -s)" == "Darwin" ]] || [[ "$(uname -s)" == "Linux" ]]; then
-    GOTATUN="true"
-fi
+GOTATUN="true"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -52,7 +48,7 @@ while [[ "$#" -gt 0 ]]; do
             fi
             UNIVERSAL="true"
             ;;
-        --gotatun) GOTATUN="true";;
+        --wireguard-go) GOTATUN="false";;
         --daemon-only) DAEMON_ONLY="true";;
         *)
             log_error "Unknown parameter: $1"


### PR DESCRIPTION
This PR enables GotaTun by default on Windows as the userspace implementation of WireGuard instead of wireguard-go.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10108)
<!-- Reviewable:end -->
