### PR TITLE
Add optional yubikey pin to container script

### DIFF
--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -16,6 +16,7 @@ CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
 GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
 CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
 PLAY_CREDENTIALS_PATH=${PLAY_CREDENTIALS_PATH:-""}
+YUBIKEY_PIN=${YUBIKEY_PIN:-""}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -31,11 +32,19 @@ case ${1-:""} in
     android)
         container_image_name=$(cat "$SCRIPT_DIR/android-container-image.txt")
         optional_gradle_cache_volume=(-v "$GRADLE_CACHE_VOLUME_NAME:/root/.gradle:Z")
+        optional_android_vars=()
 
         if [ -n "$PLAY_CREDENTIALS_PATH" ]; then
-            optional_play_credentials_file=(
+            optional_android_vars+=(
                 -v "$PLAY_CREDENTIALS_PATH:$REPO_MOUNT_TARGET/android/credentials/play-api-key.json:Z"
                 -e "PLAY_CREDENTIALS_PATH=$REPO_MOUNT_TARGET/android/credentials/play-api-key.json"
+            )
+        fi
+
+        if [ -n "$YUBIKEY_PIN" ]; then
+            echo "$YUBIKEY_PIN" | "$CONTAINER_RUNNER" secret create --replace YUBIKEY_PIN -
+            optional_android_vars+=(
+                --secret "YUBIKEY_PIN,type=env"
             )
         fi
 
@@ -52,5 +61,5 @@ exec "$CONTAINER_RUNNER" run --rm -it \
     -v "$CARGO_TARGET_VOLUME_NAME:/cargo-target:Z" \
     -v "$CARGO_REGISTRY_VOLUME_NAME:/root/.cargo/registry:Z" \
     "${optional_gradle_cache_volume[@]}" \
-    "${optional_play_credentials_file[@]}" \
+    "${optional_android_vars[@]}" \
     "$container_image_name" bash -c "$*"

--- a/building/container-run.sh
+++ b/building/container-run.sh
@@ -16,7 +16,6 @@ CARGO_REGISTRY_VOLUME_NAME=${CARGO_REGISTRY_VOLUME_NAME:-"cargo-registry"}
 GRADLE_CACHE_VOLUME_NAME=${GRADLE_CACHE_VOLUME_NAME:-"gradle-cache"}
 CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
 PLAY_CREDENTIALS_PATH=${PLAY_CREDENTIALS_PATH:-""}
-YUBIKEY_PIN=${YUBIKEY_PIN:-""}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -41,8 +40,7 @@ case ${1-:""} in
             )
         fi
 
-        if [ -n "$YUBIKEY_PIN" ]; then
-            echo "$YUBIKEY_PIN" | "$CONTAINER_RUNNER" secret create --replace YUBIKEY_PIN -
+        if "$CONTAINER_RUNNER" secret inspect YUBIKEY_PIN &>/dev/null; then
             optional_android_vars+=(
                 --secret "YUBIKEY_PIN,type=env"
             )

--- a/ci/android/build-server/sign.sh
+++ b/ci/android/build-server/sign.sh
@@ -11,11 +11,16 @@ PROVIDER_ARG="$SCRIPT_DIR/signing/pkcs11_java.cfg"
 APKSIGNER_CMD="${APKSIGNER_CMD:-apksigner}"
 KEY_ALIAS="X.509 Certificate for PIV Authentication"
 MIN_SDK_VERSION="28"
+CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
 
 if [[ -z ${YUBIKEY_PIN-} ]]; then
     echo "YUBIKEY_PIN pin must be set."
     exit 1
 fi
+
+echo "$YUBIKEY_PIN" | "$CONTAINER_RUNNER" secret create --replace YUBIKEY_PIN -
+cleanup() { "$CONTAINER_RUNNER" secret rm YUBIKEY_PIN 2>/dev/null || true; }
+trap cleanup EXIT
 
 function main {
     if [[ $# -eq 0 ]]; then

--- a/ci/android/build-server/sign.sh
+++ b/ci/android/build-server/sign.sh
@@ -18,7 +18,7 @@ if [[ -z ${YUBIKEY_PIN-} ]]; then
     exit 1
 fi
 
-echo "$YUBIKEY_PIN" | "$CONTAINER_RUNNER" secret create --replace YUBIKEY_PIN -
+printf '%s' "$YUBIKEY_PIN" | "$CONTAINER_RUNNER" secret create --replace YUBIKEY_PIN -
 cleanup() { "$CONTAINER_RUNNER" secret rm YUBIKEY_PIN 2>/dev/null || true; }
 trap cleanup EXIT
 


### PR DESCRIPTION
### What
Add support to pass an optional `YUBIKEY_PIN` to our Android container via the `container-run.sh` script.

### Why
To enable signing in our Android container using a Yubikey, however that also require some additional packages and configuration changes to the container.

### How
The `YUBIKEY_PIN` env var is now picked up by `container-run.sh` and passed as a secret to the container where it's also exposed as an env var. 

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10135)
<!-- Reviewable:end -->
