### PR TITLE
Fix testInAppPurchaseForOutOfTime

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/AddTimeBottomSheet.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/AddTimeBottomSheet.kt
@@ -2,6 +2,7 @@ package net.mullvad.mullvadvpn.test.common.page
 
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.waitForStableInActiveWindow
 import net.mullvad.mullvadvpn.lib.ui.tag.ADD_TIME_BOTTOM_SHEET_TITLE_TEST_TAG
 import net.mullvad.mullvadvpn.test.common.constant.LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
@@ -21,5 +22,6 @@ class AddTimeBottomSheet internal constructor() : Page() {
 fun UiDevice.buyGooglePlayTime() {
     findObjectWithTimeout(By.text("1-tap buy"), LONG_TIMEOUT)
     findObjectWithTimeout(By.text("1-tap buy")).click()
-    waitForIdle()
+    waitForStableInActiveWindow()
+    findObjectWithTimeout(By.text("Close"), LONG_TIMEOUT).click()
 }


### PR DESCRIPTION
After moving out AddTime bottom sheet to become its own screen the OutOfTimeScreen is no longer in RESUMED state showing the bottom sheet. This means we have to close the bottom sheet for the OutOfTimeScreen to be active.

E2E run:
https://github.com/mullvad/mullvadvpn-app/actions/runs/24229587121

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10164)
<!-- Reviewable:end -->
