### PR TITLE
Rework login timeout

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/interactor/AppInteractor.kt
@@ -51,18 +51,18 @@ class AppInteractor(
         device.wait(Until.hasObject(By.pkg(targetPackageName).depth(0)), LONG_TIMEOUT)
     }
 
-    fun launchAndEnsureOnLoginPage() {
+    fun launchAndEnsureOnLoginPage(scope: LoginPage.() -> Unit = {}) {
         launch()
         on<PrivacyPage> { clickAgreeOnPrivacyDisclaimer() }
         clickAllowOnNotificationPermissionPromptIfApiLevel33AndAbove()
-        on<LoginPage>()
+        on<LoginPage>(scope)
     }
 
     fun launchAndLogIn(accountNumber: String) {
-        launchAndEnsureOnLoginPage()
-        on<LoginPage> {
+        launchAndEnsureOnLoginPage {
             enterAccountNumber(accountNumber)
             clickLoginButton()
+            assertSuccessfulLogin()
         }
     }
 

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/ConnectPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/ConnectPage.kt
@@ -9,7 +9,6 @@ import net.mullvad.mullvadvpn.lib.ui.tag.LOCATION_INFO_CONNECTION_OUT_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.SELECT_LOCATION_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.TOP_BAR_ACCOUNT_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.TOP_BAR_SETTINGS_BUTTON_TEST_TAG
-import net.mullvad.mullvadvpn.test.common.constant.LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.constant.VERY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectByCaseInsensitiveText
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
@@ -22,7 +21,7 @@ class ConnectPage internal constructor() : Page() {
     private val disconnectedSelector = By.text("DISCONNECTED")
 
     override fun assertIsDisplayed() {
-        uiDevice.findObjectWithTimeout(By.res(CONNECT_CARD_HEADER_TEST_TAG), LONG_TIMEOUT)
+        uiDevice.findObjectWithTimeout(By.res(CONNECT_CARD_HEADER_TEST_TAG))
     }
 
     fun clickSettings() {

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
@@ -49,9 +49,7 @@ class LoginPage internal constructor() : Page() {
     }
 
     fun assertLoginFailed() {
-        uiDevice
-            .findObject(By.res(LOGIN_TITLE_TEST_TAG))
-            .wait(Until.textEquals("Login failed"), DEFAULT_TIMEOUT)
+        uiDevice.findObjectWithTimeout(By.text("Login failed"), DEFAULT_TIMEOUT)
     }
 
     fun assertHasAccountHistory(accountNumber: String) {

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
@@ -5,7 +5,6 @@ import androidx.test.uiautomator.Until
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_SCREEN_DELETE_ACCOUNT_HISTORY_TEST_TAG
-import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_TITLE_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.TOP_BAR_SETTINGS_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.constant.EXTREMELY_LONG_TIMEOUT

--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/LoginPage.kt
@@ -5,9 +5,11 @@ import androidx.test.uiautomator.Until
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_SCREEN_DELETE_ACCOUNT_HISTORY_TEST_TAG
+import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_TITLE_TEST_TAG
 import net.mullvad.mullvadvpn.lib.ui.tag.TOP_BAR_SETTINGS_BUTTON_TEST_TAG
 import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.constant.EXTREMELY_LONG_TIMEOUT
+import net.mullvad.mullvadvpn.test.common.constant.VERY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 
 class LoginPage internal constructor() : Page() {
@@ -38,6 +40,18 @@ class LoginPage internal constructor() : Page() {
 
     fun toggleRevealInput() {
         uiDevice.findObjectWithTimeout(By.res(LOGIN_REVEAL_INPUT_BUTTON_TEST_TAG)).click()
+    }
+
+    fun assertSuccessfulLogin() {
+        // This can be improved, if we've entered the same account number in the TextField we might
+        // get a false positive.
+        uiDevice.findObjectWithTimeout(By.text("Logged in"), VERY_LONG_TIMEOUT)
+    }
+
+    fun assertLoginFailed() {
+        uiDevice
+            .findObject(By.res(LOGIN_TITLE_TEST_TAG))
+            .wait(Until.textEquals("Login failed"), DEFAULT_TIMEOUT)
     }
 
     fun assertHasAccountHistory(accountNumber: String) {

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/LoginTest.kt
@@ -1,7 +1,6 @@
 package net.mullvad.mullvadvpn.test.e2e
 
 import net.mullvad.mullvadvpn.test.common.page.ConnectPage
-import net.mullvad.mullvadvpn.test.common.page.LoginPage
 import net.mullvad.mullvadvpn.test.common.page.on
 import net.mullvad.mullvadvpn.test.e2e.misc.AccountTestRule
 import org.junit.jupiter.api.Disabled
@@ -16,12 +15,7 @@ class LoginTest : EndToEndTest() {
     fun testLoginWithValidCredentials() {
         val validTestAccountNumber = accountTestRule.validAccountNumber
 
-        app.launchAndEnsureOnLoginPage()
-
-        on<LoginPage> {
-            enterAccountNumber(validTestAccountNumber)
-            clickLoginButton()
-        }
+        app.launchAndLogIn(validTestAccountNumber)
 
         on<ConnectPage>()
     }
@@ -31,9 +25,7 @@ class LoginTest : EndToEndTest() {
     fun testLoginWithInvalidCredentials() {
         val invalidDummyAccountNumber = accountTestRule.invalidAccountNumber
 
-        app.launchAndEnsureOnLoginPage()
-
-        on<LoginPage> {
+        app.launchAndEnsureOnLoginPage {
             enterAccountNumber(invalidDummyAccountNumber)
             clickLoginButton()
             verifyShowingInvalidAccount()

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/PaymentTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/PaymentTest.kt
@@ -6,7 +6,6 @@ import net.mullvad.mullvadvpn.test.common.annotation.SkipForFlavors
 import net.mullvad.mullvadvpn.test.common.constant.VERY_LONG_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
 import net.mullvad.mullvadvpn.test.common.page.AddTimeBottomSheet
-import net.mullvad.mullvadvpn.test.common.page.LoginPage
 import net.mullvad.mullvadvpn.test.common.page.OutOfTimePage
 import net.mullvad.mullvadvpn.test.common.page.buyGooglePlayTime
 import net.mullvad.mullvadvpn.test.common.page.on
@@ -27,12 +26,7 @@ class PaymentTest : EndToEndTest() {
     fun testInAppPurchaseForOutOfTime() {
         val validTestAccountNumber = accountTestRule.validAccountNumber
 
-        app.launchAndEnsureOnLoginPage()
-
-        on<LoginPage> {
-            enterAccountNumber(validTestAccountNumber)
-            clickLoginButton()
-        }
+        app.launchAndLogIn(validTestAccountNumber)
 
         on<OutOfTimePage> { clickAddTime() }
 

--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/WebLinkTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/WebLinkTest.kt
@@ -1,6 +1,5 @@
 package net.mullvad.mullvadvpn.test.e2e
 
-import net.mullvad.mullvadvpn.test.common.page.LoginPage
 import net.mullvad.mullvadvpn.test.common.page.MullvadWebsite
 import net.mullvad.mullvadvpn.test.common.page.SettingsPage
 import net.mullvad.mullvadvpn.test.common.page.on
@@ -11,9 +10,7 @@ class WebLinkTest : EndToEndTest() {
     @Test
     @Disabled("Disabled due to broken in-browser text detection (DROID-2009)")
     fun testOpenFaqFromApp() {
-        app.launchAndEnsureOnLoginPage()
-
-        on<LoginPage> { clickSettings() }
+        app.launchAndEnsureOnLoginPage { clickSettings() }
 
         on<SettingsPage> { clickFaqAndGuides() }
 

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/CreateAccountMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/CreateAccountMockApiTest.kt
@@ -2,7 +2,6 @@ package net.mullvad.mullvadvpn.test.mockapi
 
 import androidx.test.uiautomator.By
 import net.mullvad.mullvadvpn.test.common.extension.findObjectWithTimeout
-import net.mullvad.mullvadvpn.test.common.page.LoginPage
 import net.mullvad.mullvadvpn.test.common.page.WelcomePage
 import net.mullvad.mullvadvpn.test.common.page.dismissStorePasswordPromptIfShown
 import net.mullvad.mullvadvpn.test.common.page.on
@@ -19,9 +18,7 @@ class CreateAccountMockApiTest : MockApiTest() {
             expectedAccountNumber = createdAccountNumber
             devicePendingToGetCreated = DUMMY_ID_2 to DUMMY_DEVICE_NAME_2
         }
-        app.launchAndEnsureOnLoginPage()
-
-        on<LoginPage> { clickCreateAccount() }
+        app.launchAndEnsureOnLoginPage { clickCreateAccount() }
 
         device.dismissStorePasswordPromptIfShown()
 
@@ -34,9 +31,7 @@ class CreateAccountMockApiTest : MockApiTest() {
     @Test
     fun testCreateAccountFailed() {
         // Arrange
-        app.launchAndEnsureOnLoginPage()
-
-        on<LoginPage> {
+        app.launchAndEnsureOnLoginPage {
             clickCreateAccount()
             device.findObjectWithTimeout(By.text("Failed to create account"))
         }

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/LoginMockApiTest.kt
@@ -1,39 +1,32 @@
 package net.mullvad.mullvadvpn.test.mockapi
 
-import androidx.test.uiautomator.By
-import androidx.test.uiautomator.Until
 import java.time.ZonedDateTime
-import net.mullvad.mullvadvpn.lib.ui.tag.LOGIN_TITLE_TEST_TAG
-import net.mullvad.mullvadvpn.test.common.constant.DEFAULT_TIMEOUT
 import net.mullvad.mullvadvpn.test.common.page.ConnectPage
 import net.mullvad.mullvadvpn.test.common.page.OutOfTimePage
 import net.mullvad.mullvadvpn.test.common.page.on
 import net.mullvad.mullvadvpn.test.mockapi.constant.DEFAULT_DEVICE_LIST
 import net.mullvad.mullvadvpn.test.mockapi.constant.DUMMY_DEVICE_NAME_2
 import net.mullvad.mullvadvpn.test.mockapi.constant.DUMMY_ID_2
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class LoginMockApiTest : MockApiTest() {
     @Test
     fun testLoginWithInvalidCredentials() {
         // Arrange
-        val validAccountNumber = "1234123412341234"
+        val invalidAccountNumber = "1234123412341234"
         apiRouter.apply {
             expectedAccountNumber = null
             accountExpiry = ZonedDateTime.now().plusHours(24)
         }
 
         // Act login with invalid credentials
-        app.launchAndLogIn(validAccountNumber)
+        app.launchAndEnsureOnLoginPage {
+            enterAccountNumber(invalidAccountNumber)
+            clickLoginButton()
 
-        // Assert
-        val result =
-            device
-                .findObject(By.res(LOGIN_TITLE_TEST_TAG))
-                .wait(Until.textEquals("Login failed"), DEFAULT_TIMEOUT)
-
-        assertTrue(result)
+            // Assert
+            assertLoginFailed()
+        }
     }
 
     @Test

--- a/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
+++ b/android/test/mockapi/src/main/kotlin/net/mullvad/mullvadvpn/test/mockapi/TooManyDevicesMockApiTest.kt
@@ -23,7 +23,10 @@ class TooManyDevicesMockApiTest : MockApiTest() {
         }
 
         // Act
-        app.launchAndLogIn(validAccountNumber)
+        app.launchAndEnsureOnLoginPage {
+            enterAccountNumber(validAccountNumber)
+            clickLoginButton()
+        }
 
         // Assert that we have too many devices
         on<TooManyDevicesPage> {


### PR DESCRIPTION
## Why

When testing https://github.com/mullvad/mullvadvpn-app/pull/10164 we saw another flaky test where login took too long (10s +). We do have some retry logic for it so we probably should let it run. 

## What

Previously we've increased the timeout of the ConnectPage being displayed, this is very blunt. So instead this PR identified the actual successful login instead and gives that more time to succeed.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10167)
<!-- Reviewable:end -->
