### PR TITLE
Fix custom lists using filtered locations instead of searched

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/SelectLocationViewContext.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/SelectLocationViewContext.tsx
@@ -54,7 +54,7 @@ export function SelectLocationViewProvider({ children }: SelectLocationViewProvi
   const searchedCountryLocations = useSearchCountryLocations(filteredCountryLocations, searchTerm);
 
   const filteredCustomListLocations = useMapCustomListsToLocations(
-    filteredCountryLocations,
+    searchedCountryLocations,
     searchTerm,
     selectedLocation,
   );


### PR DESCRIPTION
Fixes custom list using filtered locations instead of searched, which caused it to show incorrect states for locations in custom lists when searching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10170)
<!-- Reviewable:end -->
