### PR TITLE
Enable LWO without proxy socket when using GotaTun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,14 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Added
-
 #### Linux
 - Make it possible to build for RISC-V from source.
 - Add `--daemon-only` build option for deb and rpm packages for CLI usage.
 - GotaTun is now used as the userspace WireGuard implementation. It replaces wireguard-go.
 
 ### Changed
+- Optimize LWO performance when using GotaTun. This gives a 1.5 to 3 times speedup in our
+  benchmarks.
 - Location setting no longer defaults to Sweden, instead it uses your current location if it
   has available relays, and falls back to Sweden otherwise.
 - `mullvad-daemon` now defaults to `ERROR` log level when `-v` is not specified.

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -22,6 +22,8 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Changed
+- Optimize LWO performance. The throughput is around 3 times higher in our benchmarks.
 
 
 ## [android/2026.4-beta1] - 2026-04-13

--- a/talpid-wireguard/src/ephemeral.rs
+++ b/talpid-wireguard/src/ephemeral.rs
@@ -30,6 +30,7 @@ pub async fn config_ephemeral_peers(
     obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+    is_gotatun: bool,
 ) -> std::result::Result<(), CloseMsg> {
     let iface_name = {
         let tunnel = tunnel.lock().await;
@@ -50,6 +51,7 @@ pub async fn config_ephemeral_peers(
         obfuscation_mtu,
         obfuscator,
         close_obfs_sender,
+        is_gotatun,
     )
     .await?;
 
@@ -82,6 +84,7 @@ pub async fn config_ephemeral_peers(
     obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+    #[cfg(not(target_os = "android"))] is_gotatun: bool,
     #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
 ) -> Result<(), CloseMsg> {
     config_ephemeral_peers_inner(
@@ -91,6 +94,8 @@ pub async fn config_ephemeral_peers(
         obfuscation_mtu,
         obfuscator,
         close_obfs_sender,
+        #[cfg(not(target_os = "android"))]
+        is_gotatun,
         #[cfg(target_os = "android")]
         tun_provider,
     )
@@ -104,6 +109,7 @@ async fn config_ephemeral_peers_inner(
     obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+    #[cfg(not(target_os = "android"))] is_gotatun: bool,
     #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
 ) -> Result<(), CloseMsg> {
     let ephemeral_private_key = PrivateKey::new_from_random();
@@ -140,6 +146,8 @@ async fn config_ephemeral_peers_inner(
             obfuscation_mtu,
             obfuscator.clone(),
             close_obfs_sender,
+            #[cfg(not(target_os = "android"))]
+            is_gotatun,
             #[cfg(target_os = "android")]
             &tun_provider,
         )
@@ -175,6 +183,8 @@ async fn config_ephemeral_peers_inner(
         obfuscation_mtu,
         obfuscator,
         close_obfs_sender,
+        #[cfg(not(target_os = "android"))]
+        is_gotatun,
         #[cfg(target_os = "android")]
         &tun_provider,
     )
@@ -202,7 +212,7 @@ async fn reconfigure_tunnel(
             &mut config,
             obfuscation_mtu,
             close_obfs_sender,
-            #[cfg(target_os = "android")]
+            true, // is_gotatun: always true on Android
             tun_provider.clone(),
         )
         .await
@@ -233,6 +243,7 @@ async fn reconfigure_tunnel(
     obfuscation_mtu: u16,
     obfuscator: Arc<AsyncMutex<Option<ObfuscatorHandle>>>,
     close_obfs_sender: sync_mpsc::Sender<CloseMsg>,
+    is_gotatun: bool,
 ) -> Result<Config, CloseMsg> {
     let mut obfs_guard = obfuscator.lock().await;
     if let Some(obfuscator_handle) = obfs_guard.take() {
@@ -241,6 +252,7 @@ async fn reconfigure_tunnel(
             &mut config,
             obfuscation_mtu,
             close_obfs_sender,
+            is_gotatun,
         )
         .await
         .map_err(CloseMsg::ObfuscatorFailed)?;

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -42,7 +42,10 @@ use gotatun::tun::{
 };
 
 mod conversions;
+mod obfuscation;
+
 use conversions::to_gotatun_peer;
+use obfuscation::MaybeObfuscatingTransportFactory;
 
 #[cfg(target_os = "android")]
 type UdpFactory = AndroidUdpSocketFactory;
@@ -50,14 +53,16 @@ type UdpFactory = AndroidUdpSocketFactory;
 #[cfg(not(target_os = "android"))]
 type UdpFactory = UdpSocketFactory;
 
-type SinglehopDevice = Device<(UdpFactory, GotaTunDevice, GotaTunDevice)>;
+type TransportFactory = MaybeObfuscatingTransportFactory<UdpFactory>;
+
+type SinglehopDevice = Device<(TransportFactory, GotaTunDevice, GotaTunDevice)>;
 type ExitDevice = Device<(UdpChannelFactory, GotaTunDevice, GotaTunDevice)>;
 
 #[cfg(not(all(feature = "multihop-pcap", target_os = "linux")))]
-type EntryDevice = Device<(UdpFactory, TunChannelTx, TunChannelRx)>;
+type EntryDevice = Device<(TransportFactory, TunChannelTx, TunChannelRx)>;
 #[cfg(all(feature = "multihop-pcap", target_os = "linux"))]
 type EntryDevice = Device<(
-    UdpFactory,
+    TransportFactory,
     PcapSniffer<TunChannelTx>,
     PcapSniffer<TunChannelRx>,
 )>;
@@ -126,7 +131,7 @@ enum Devices {
 impl Devices {
     async fn stop(self) {
         match self {
-            Devices::Singlehop { device, .. } => {
+            Devices::Singlehop { device } => {
                 device.stop().await;
             }
             Devices::Multihop {
@@ -279,10 +284,12 @@ async fn create_devices(
     #[cfg(target_os = "android")] android_tun: Arc<Tun>,
 ) -> Result<Devices, TunnelError> {
     #[cfg(target_os = "android")]
-    let udp_factory = AndroidUdpSocketFactory { tun: android_tun };
+    let base_factory = AndroidUdpSocketFactory { tun: android_tun };
 
     #[cfg(not(target_os = "android"))]
-    let udp_factory = UdpSocketFactory;
+    let base_factory = UdpSocketFactory;
+
+    let factory = MaybeObfuscatingTransportFactory::from_config(base_factory, config);
 
     let mut devices = if let Some(exit_peer) = &config.exit_peer {
         // Multihop setup
@@ -332,12 +339,11 @@ async fn create_devices(
         let (tun_channel_tx, tun_channel_rx) = wrap_in_pcap_sniffer(tun_channel_tx, tun_channel_rx);
 
         let entry_device = DeviceBuilder::new()
-            .with_udp(udp_factory)
+            .with_udp(factory)
             .with_ip_pair(tun_channel_tx, tun_channel_rx)
             .build()
             .await
             .map_err(TunnelError::GotaTunDevice)?;
-
         Devices::Multihop {
             entry_device,
             exit_device,
@@ -345,13 +351,12 @@ async fn create_devices(
     } else {
         // Singlehop setup
 
-        let device: SinglehopDevice = DeviceBuilder::new()
-            .with_udp(udp_factory)
+        let device = DeviceBuilder::new()
+            .with_udp(factory)
             .with_ip(tun_dev)
             .build()
             .await
             .map_err(TunnelError::GotaTunDevice)?;
-
         Devices::Singlehop { device }
     };
 
@@ -360,93 +365,97 @@ async fn create_devices(
     Ok(devices)
 }
 
+/// Configure a gotatun entry or singlehop device
+async fn configure_entry_device(
+    device: &Device<impl DeviceTransports>,
+    config: &Config,
+    daita: Option<&DaitaSettings>,
+) -> Result<(), TunnelError> {
+    let private_key = StaticSecret::from(config.tunnel.private_key.to_bytes());
+    let entry_peer = to_gotatun_peer(&config.entry_peer, daita);
+    device
+        .write(async |device| {
+            device.clear_peers();
+            device.set_private_key(private_key).await;
+            device.add_peer(entry_peer);
+            #[cfg(target_os = "linux")]
+            if let Some(fwmark) = config.fwmark {
+                device.set_fwmark(fwmark)?;
+            }
+            Ok(())
+        })
+        .await
+        .flatten()
+        .map_err(|err| {
+            log::error!("Failed to set gotatun config: {err:#}");
+            TunnelError::SetConfigError
+        })
+}
+
+/// Configure gotatun exit device
+async fn configure_exit_device(
+    device: &Device<impl DeviceTransports>,
+    private_key: StaticSecret,
+    exit_peer: gotatun::device::Peer,
+) -> Result<(), TunnelError> {
+    device
+        .write(async |device| {
+            device.clear_peers();
+            device.set_private_key(private_key).await;
+            device.add_peer(exit_peer);
+        })
+        .await
+        .map_err(|err| {
+            log::error!("Failed to set gotatun config: {err:#}");
+            TunnelError::SetConfigError
+        })
+}
+
 /// (Re)Configure gotatun devices.
 async fn configure_devices(
     devices: &mut Devices,
     config: &Config,
     daita: Option<&DaitaSettings>,
 ) -> Result<(), TunnelError> {
-    let private_key = StaticSecret::from(config.tunnel.private_key.to_bytes());
-    let entry_peer = to_gotatun_peer(&config.entry_peer, daita);
-
     if let Some(exit_peer) = &config.exit_peer {
         log::trace!(
             "configuring gotatun multihop device (daita={})",
             daita.is_some()
         );
 
+        let private_key = StaticSecret::from(config.tunnel.private_key.to_bytes());
         let exit_peer = to_gotatun_peer(exit_peer, daita);
 
-        let Devices::Multihop {
-            entry_device,
-            exit_device,
-            ..
-        } = devices
-        else {
-            return Err(TunnelError::ConfigureGotaTunDevice(
-                ConfigureGotaTunDeviceError::ExpectedMultihopDevice,
-            ));
-        };
-
-        entry_device
-            .write(async |device| {
-                device.clear_peers();
-                device.set_private_key(private_key.clone()).await;
-                device.add_peer(entry_peer);
-                #[cfg(target_os = "linux")]
-                if let Some(fwmark) = config.fwmark {
-                    device.set_fwmark(fwmark)?;
-                }
-                Ok(())
-            })
-            .await
-            .flatten()
-            .map_err(|err| {
-                log::error!("Failed to set gotatun config: {err:#}");
-                TunnelError::SetConfigError
-            })?;
-
-        exit_device
-            .write(async |device| {
-                device.clear_peers();
-                device.set_private_key(private_key).await;
-                device.add_peer(exit_peer);
-            })
-            .await
-            .map_err(|err| {
-                log::error!("Failed to set gotatun config: {err:#}");
-                TunnelError::SetConfigError
-            })?;
+        match devices {
+            Devices::Multihop {
+                entry_device,
+                exit_device,
+            } => {
+                configure_entry_device(entry_device, config, daita).await?;
+                configure_exit_device(exit_device, private_key, exit_peer).await?;
+            }
+            _ => {
+                return Err(TunnelError::ConfigureGotaTunDevice(
+                    ConfigureGotaTunDeviceError::ExpectedMultihopDevice,
+                ));
+            }
+        }
     } else {
         log::trace!(
             "configuring gotatun singlehop device (daita={})",
             daita.is_some()
         );
 
-        let Devices::Singlehop { device } = devices else {
-            return Err(TunnelError::ConfigureGotaTunDevice(
-                ConfigureGotaTunDeviceError::ExpectedSinglehopDevice,
-            ));
-        };
-
-        let peer = entry_peer;
-        device
-            .write(async |device| {
-                device.clear_peers();
-                device.set_private_key(private_key).await;
-                device.add_peer(peer);
-                #[cfg(target_os = "linux")]
-                if let Some(fwmark) = config.fwmark {
-                    device.set_fwmark(fwmark)?;
-                }
-                Ok(())
-            })
-            .await
-            .flatten()
-            .map_err(|err| {
-                log::error!("Failed to set gotatun config: {err:#}");
-                TunnelError::SetConfigError
-            })?;
+        match devices {
+            Devices::Singlehop { device } => {
+                configure_entry_device(device, config, daita).await?;
+            }
+            _ => {
+                return Err(TunnelError::ConfigureGotaTunDevice(
+                    ConfigureGotaTunDeviceError::ExpectedSinglehopDevice,
+                ));
+            }
+        }
     }
 
     Ok(())
@@ -489,7 +498,6 @@ impl Tunnel for GotaTun {
             Some(Devices::Multihop {
                 entry_device,
                 exit_device,
-                ..
             }) => {
                 let mut stats = get_stats(entry_device).await;
                 stats.extend(get_stats(exit_device).await);

--- a/talpid-wireguard/src/gotatun/obfuscation/lwo.rs
+++ b/talpid-wireguard/src/gotatun/obfuscation/lwo.rs
@@ -1,0 +1,166 @@
+//! LWO obfuscation/deobfuscation wrappers for GotaTun UDP transports.
+
+use std::{io, net::SocketAddr};
+
+use gotatun::{
+    packet::{Packet, PacketBufPool},
+    udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
+};
+use talpid_types::net::obfuscation::{ObfuscatorConfig, Obfuscators};
+use tunnel_obfuscation::lwo;
+
+use crate::config::Config;
+
+/// A [`UdpSend`] wrapper that LWO-obfuscates every outgoing packet before forwarding it to the
+/// inner sender.
+///
+/// `tx_key` must be the **server** public key (the key used by the relay to deobfuscate).
+#[derive(Clone)]
+pub struct LwoSend<S: UdpSend> {
+    inner: S,
+    tx_key: [u8; 32],
+}
+
+impl<S: UdpSend> UdpSend for LwoSend<S> {
+    type SendManyBuf = S::SendManyBuf;
+
+    async fn send_to(&self, mut packet: Packet, destination: SocketAddr) -> io::Result<()> {
+        lwo::obfuscate_thread_local(&mut packet, &self.tx_key);
+        self.inner.send_to(packet, destination).await
+    }
+
+    fn max_number_of_packets_to_send(&self) -> usize {
+        self.inner.max_number_of_packets_to_send()
+    }
+
+    async fn send_many_to(
+        &self,
+        send_buf: &mut Self::SendManyBuf,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        obfuscate_all(packets, &self.tx_key);
+        self.inner.send_many_to(send_buf, packets).await
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.inner.local_addr()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_fwmark(&self, mark: u32) -> io::Result<()> {
+        self.inner.set_fwmark(mark)
+    }
+}
+
+/// A [`UdpRecv`] wrapper that LWO-deobfuscates every incoming packet after receiving it from the
+/// inner receiver.
+///
+/// `rx_key` must be the **client** public key (the key used by the client to deobfuscate).
+pub struct LwoRecv<R: UdpRecv> {
+    inner: R,
+    rx_key: [u8; 32],
+}
+
+impl<R: UdpRecv> UdpRecv for LwoRecv<R> {
+    type RecvManyBuf = R::RecvManyBuf;
+
+    async fn recv_from(&mut self, pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
+        let (mut packet, addr) = self.inner.recv_from(pool).await?;
+        lwo::deobfuscate(&mut packet, &self.rx_key);
+        Ok((packet, addr))
+    }
+
+    async fn recv_many_from(
+        &mut self,
+        recv_buf: &mut Self::RecvManyBuf,
+        pool: &mut PacketBufPool,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        // The trait contract appends to `packets`; only deobfuscate the entries the inner call
+        // actually added so we don't touch packets the caller already owned.
+        let start = packets.len();
+        self.inner.recv_many_from(recv_buf, pool, packets).await?;
+        deobfuscate_all(&mut packets[start..], &self.rx_key);
+        Ok(())
+    }
+
+    fn enable_udp_gro(&self) -> io::Result<()> {
+        self.inner.enable_udp_gro()
+    }
+}
+
+/// Apply LWO obfuscation to every packet in `packets`.
+fn obfuscate_all(packets: &mut [(Packet, SocketAddr)], tx_key: &[u8; 32]) {
+    for (packet, _) in packets.iter_mut() {
+        lwo::obfuscate_thread_local(packet, tx_key);
+    }
+}
+
+/// Apply LWO deobfuscation to every packet in `packets`.
+fn deobfuscate_all(packets: &mut [(Packet, SocketAddr)], rx_key: &[u8; 32]) {
+    for (packet, _) in packets.iter_mut() {
+        lwo::deobfuscate(packet, rx_key);
+    }
+}
+
+/// Extract LWO obfuscation keys from the tunnel config.
+///
+/// Returns `(tx_key, rx_key)` where:
+/// - `tx_key` is the server public key (used to obfuscate outgoing packets)
+/// - `rx_key` is the client public key (used to deobfuscate incoming packets)
+pub fn lwo_keys_from_config(config: &Config) -> Option<([u8; 32], [u8; 32])> {
+    match &config.obfuscator_config {
+        Some(Obfuscators::Single(ObfuscatorConfig::Lwo { .. })) => {
+            let tx_key = *config.entry_peer.public_key.as_bytes();
+            let rx_key = *config.tunnel.private_key.public_key().as_bytes();
+            Some((tx_key, rx_key))
+        }
+        _ => None,
+    }
+}
+
+/// A [`UdpTransportFactory`] that wraps another factory and applies LWO obfuscation inline.
+///
+/// * `tx_key` - server public key bytes, used to obfuscate outgoing packets.
+/// * `rx_key` - client public key bytes, used to deobfuscate incoming packets.
+pub struct LwoUdpTransportFactory<F: UdpTransportFactory> {
+    pub inner: F,
+    pub tx_key: [u8; 32],
+    pub rx_key: [u8; 32],
+}
+
+impl<F: UdpTransportFactory> UdpTransportFactory for LwoUdpTransportFactory<F> {
+    type SendV4 = LwoSend<F::SendV4>;
+    type SendV6 = LwoSend<F::SendV6>;
+    type RecvV4 = LwoRecv<F::RecvV4>;
+    type RecvV6 = LwoRecv<F::RecvV6>;
+
+    async fn bind(
+        &mut self,
+        params: &UdpTransportFactoryParams,
+    ) -> io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
+        let ((send_v4, recv_v4), (send_v6, recv_v6)) = self.inner.bind(params).await?;
+        Ok((
+            (
+                LwoSend {
+                    inner: send_v4,
+                    tx_key: self.tx_key,
+                },
+                LwoRecv {
+                    inner: recv_v4,
+                    rx_key: self.rx_key,
+                },
+            ),
+            (
+                LwoSend {
+                    inner: send_v6,
+                    tx_key: self.tx_key,
+                },
+                LwoRecv {
+                    inner: recv_v6,
+                    rx_key: self.rx_key,
+                },
+            ),
+        ))
+    }
+}

--- a/talpid-wireguard/src/gotatun/obfuscation/mod.rs
+++ b/talpid-wireguard/src/gotatun/obfuscation/mod.rs
@@ -1,0 +1,165 @@
+//! [`MaybeObfuscatingTransportFactory`] is an enum that either passes through to a plain UDP socket
+//! or applies obfuscation.
+
+mod lwo;
+
+use std::{io, net::SocketAddr};
+
+use gotatun::{
+    packet::{Packet, PacketBufPool},
+    udp::{UdpRecv, UdpSend, UdpTransportFactory, UdpTransportFactoryParams},
+};
+
+use crate::config::Config;
+
+use lwo::{LwoRecv, LwoSend, LwoUdpTransportFactory, lwo_keys_from_config};
+
+/// A [`UdpSend`] wrapper that optionally obfuscates outgoing packets.
+#[derive(Clone)]
+pub enum MaybeObfuscatingSend<S: UdpSend> {
+    Plain(S),
+    Lwo(LwoSend<S>),
+}
+
+impl<S: UdpSend> UdpSend for MaybeObfuscatingSend<S> {
+    type SendManyBuf = S::SendManyBuf;
+
+    async fn send_to(&self, packet: Packet, destination: SocketAddr) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.send_to(packet, destination).await,
+            Self::Lwo(inner) => inner.send_to(packet, destination).await,
+        }
+    }
+
+    fn max_number_of_packets_to_send(&self) -> usize {
+        match self {
+            Self::Plain(inner) => inner.max_number_of_packets_to_send(),
+            Self::Lwo(inner) => inner.max_number_of_packets_to_send(),
+        }
+    }
+
+    async fn send_many_to(
+        &self,
+        send_buf: &mut Self::SendManyBuf,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.send_many_to(send_buf, packets).await,
+            Self::Lwo(inner) => inner.send_many_to(send_buf, packets).await,
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        match self {
+            Self::Plain(inner) => inner.local_addr(),
+            Self::Lwo(inner) => inner.local_addr(),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_fwmark(&self, mark: u32) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.set_fwmark(mark),
+            Self::Lwo(inner) => inner.set_fwmark(mark),
+        }
+    }
+}
+
+/// A [`UdpRecv`] enum that either passes through to a plain receiver or applies deobfuscation.
+pub enum MaybeObfuscatingRecv<R: UdpRecv> {
+    Plain(R),
+    Lwo(LwoRecv<R>),
+}
+
+impl<R: UdpRecv> UdpRecv for MaybeObfuscatingRecv<R> {
+    type RecvManyBuf = R::RecvManyBuf;
+
+    async fn recv_from(&mut self, pool: &mut PacketBufPool) -> io::Result<(Packet, SocketAddr)> {
+        match self {
+            Self::Plain(inner) => inner.recv_from(pool).await,
+            Self::Lwo(inner) => inner.recv_from(pool).await,
+        }
+    }
+
+    async fn recv_many_from(
+        &mut self,
+        recv_buf: &mut Self::RecvManyBuf,
+        pool: &mut PacketBufPool,
+        packets: &mut Vec<(Packet, SocketAddr)>,
+    ) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.recv_many_from(recv_buf, pool, packets).await,
+            Self::Lwo(inner) => inner.recv_many_from(recv_buf, pool, packets).await,
+        }
+    }
+
+    fn enable_udp_gro(&self) -> io::Result<()> {
+        match self {
+            Self::Plain(inner) => inner.enable_udp_gro(),
+            Self::Lwo(inner) => inner.enable_udp_gro(),
+        }
+    }
+}
+
+/// A [`UdpTransportFactory`] that either passes through to a plain factory or wraps it with
+/// obfuscation.
+pub enum MaybeObfuscatingTransportFactory<F: UdpTransportFactory> {
+    Plain(F),
+    Lwo(LwoUdpTransportFactory<F>),
+}
+
+impl<F: UdpTransportFactory> MaybeObfuscatingTransportFactory<F> {
+    /// Create a transport factory from the tunnel config.
+    pub fn from_config(inner: F, config: &Config) -> Self {
+        match lwo_keys_from_config(config) {
+            Some((tx_key, rx_key)) => Self::Lwo(LwoUdpTransportFactory {
+                inner,
+                tx_key,
+                rx_key,
+            }),
+            // Use `Self::Plain` for proxy socket obfuscation or no obfuscation
+            None => Self::Plain(inner),
+        }
+    }
+}
+
+impl<F: UdpTransportFactory> UdpTransportFactory for MaybeObfuscatingTransportFactory<F> {
+    type SendV4 = MaybeObfuscatingSend<F::SendV4>;
+    type SendV6 = MaybeObfuscatingSend<F::SendV6>;
+    type RecvV4 = MaybeObfuscatingRecv<F::RecvV4>;
+    type RecvV6 = MaybeObfuscatingRecv<F::RecvV6>;
+
+    async fn bind(
+        &mut self,
+        params: &UdpTransportFactoryParams,
+    ) -> io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
+        match self {
+            Self::Plain(factory) => {
+                let ((sv4, rv4), (sv6, rv6)) = factory.bind(params).await?;
+                Ok((
+                    (
+                        MaybeObfuscatingSend::Plain(sv4),
+                        MaybeObfuscatingRecv::Plain(rv4),
+                    ),
+                    (
+                        MaybeObfuscatingSend::Plain(sv6),
+                        MaybeObfuscatingRecv::Plain(rv6),
+                    ),
+                ))
+            }
+            Self::Lwo(factory) => {
+                let ((sv4, rv4), (sv6, rv6)) = factory.bind(params).await?;
+                Ok((
+                    (
+                        MaybeObfuscatingSend::Lwo(sv4),
+                        MaybeObfuscatingRecv::Lwo(rv4),
+                    ),
+                    (
+                        MaybeObfuscatingSend::Lwo(sv6),
+                        MaybeObfuscatingRecv::Lwo(rv6),
+                    ),
+                ))
+            }
+        }
+    }
+}

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -158,7 +158,13 @@ impl WireguardMonitor {
         args: TunnelArgs<'_>,
         _log_path: Option<&Path>,
     ) -> Result<WireguardMonitor> {
-        let userspace_wireguard = *FORCE_USERSPACE_WIREGUARD || params.use_userspace_wg();
+        let is_single_lwo = params
+            .obfuscation
+            .as_ref()
+            .is_some_and(obfuscation::is_single_lwo);
+        let userspace_wireguard = *FORCE_USERSPACE_WIREGUARD
+            || params.use_userspace_wg()
+            || (is_single_lwo && cfg!(not(feature = "wireguard-go")));
         let route_mtu = args
             .runtime
             .block_on(get_route_mtu(params, &args.route_manager));

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -173,8 +173,12 @@ impl WireguardMonitor {
             .map(|ep| ep.address.ip())
             .collect();
 
+        // GotaTun is the userspace WireGuard implementation when the wireguard-go feature is off.
+        let is_gotatun = userspace_wireguard && cfg!(not(feature = "wireguard-go"));
+
         let (close_obfs_sender, close_obfs_listener) = sync_mpsc::channel();
         // Start obfuscation server and patch the WireGuard config to point the endpoint to it.
+        // For GotaTun + LWO, apply_obfuscation_config returns None and obfuscation is inline.
         let obfuscation_mtu = route_mtu;
         let obfuscator = args
             .runtime
@@ -182,6 +186,7 @@ impl WireguardMonitor {
                 &mut config,
                 obfuscation_mtu,
                 close_obfs_sender.clone(),
+                is_gotatun,
             ))?;
         // Adjust tunnel MTU again for obfuscation packet overhead
         if params.options.mtu.is_none()
@@ -286,6 +291,7 @@ impl WireguardMonitor {
                     obfuscation_mtu,
                     obfuscator.clone(),
                     ephemeral_obfs_sender,
+                    is_gotatun,
                 )
                 .await
                 {
@@ -428,7 +434,6 @@ impl WireguardMonitor {
         let mut config = crate::config::Config::from_parameters(params, tunnel_mtu)
             .map_err(Error::WireguardConfigError)?;
 
-        // Start obfuscation server and patch the WireGuard config to point the endpoint to it.
         let (close_obfs_sender, close_obfs_listener) = sync_mpsc::channel();
         let obfuscation_mtu = route_mtu;
         let obfuscator = args
@@ -437,6 +442,7 @@ impl WireguardMonitor {
                 &mut config,
                 obfuscation_mtu,
                 close_obfs_sender.clone(),
+                true, // is_gotatun
                 args.tun_provider.clone(),
             ))?;
         // Adjust MTU again for obfuscation packet overhead

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -90,7 +90,7 @@ pub async fn apply_obfuscation_config(
 }
 
 /// Returns `true` when the obfuscation config is a single LWO method.
-fn is_single_lwo(obfuscators: &Obfuscators) -> bool {
+pub fn is_single_lwo(obfuscators: &Obfuscators) -> bool {
     matches!(
         obfuscators,
         Obfuscators::Single(ObfuscatorConfig::Lwo { .. })

--- a/talpid-wireguard/src/obfuscation.rs
+++ b/talpid-wireguard/src/obfuscation.rs
@@ -22,20 +22,29 @@ use tunnel_obfuscation::{
 };
 
 /// Begin running obfuscation machine, if configured. This function will patch `config`'s endpoint
-/// to point to an endpoint on localhost
+/// to point to an endpoint on localhost.
 ///
 /// # Arguments
 ///
 /// * obfuscation_mtu - "MTU" including obfuscation overhead
+/// * is_gotatun - `true` when the userspace GotaTun implementation is in use
 pub async fn apply_obfuscation_config(
     config: &mut Config,
     obfuscation_mtu: u16,
     close_msg_sender: sync_mpsc::Sender<CloseMsg>,
+    is_gotatun: bool,
     #[cfg(target_os = "android")] tun_provider: Arc<Mutex<TunProvider>>,
 ) -> Result<Option<ObfuscatorHandle>> {
     let Some(ref obfuscator_config) = config.obfuscator_config else {
         return Ok(None);
     };
+
+    // When GotaTun is in use and LWO is configured, obfuscation is applied inline by
+    // MaybeObfuscatingTransportFactory.
+    if is_gotatun && is_single_lwo(obfuscator_config) {
+        log::debug!("GotaTun + LWO: skipping proxy, obfuscation will be applied inline");
+        return Ok(None);
+    }
 
     let settings = settings_from_config(
         config,
@@ -78,6 +87,14 @@ pub async fn apply_obfuscation_config(
         obfuscation_task,
         packet_overhead,
     }))
+}
+
+/// Returns `true` when the obfuscation config is a single LWO method.
+fn is_single_lwo(obfuscators: &Obfuscators) -> bool {
+    matches!(
+        obfuscators,
+        Obfuscators::Single(ObfuscatorConfig::Lwo { .. })
+    )
 }
 
 /// Patch the first peer in the WireGuard configuration to use the local proxy endpoint

--- a/tunnel-obfuscation/Cargo.toml
+++ b/tunnel-obfuscation/Cargo.toml
@@ -10,6 +10,10 @@ license.workspace = true
 harness = false
 name = "lwo"
 
+[[bench]]
+harness = false
+name = "obfuscation_throughput"
+
 [dependencies]
 async-trait = "0.1"
 futures = { workspace = true }

--- a/tunnel-obfuscation/benches/lwo.rs
+++ b/tunnel-obfuscation/benches/lwo.rs
@@ -1,20 +1,17 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::RngCore;
 use talpid_types::net::wireguard::PublicKey;
-use tunnel_obfuscation::lwo::new_rng;
 
 fn obfuscate(c: &mut Criterion) {
     let pubkey = PublicKey::from_base64("8Ka2l4T0tVrSR5pkcsvRG++mBlxfuf8XOxpqBkOCikU=").unwrap();
-    let mut rng = new_rng();
+    let rng = &mut rand::thread_rng();
 
     let mut group = c.benchmark_group("lwo");
     group.throughput(criterion::Throughput::Bytes(fake_packet().len() as u64));
     group.bench_function(BenchmarkId::new("obfuscate", fake_packet().len()), |b| {
         b.iter_batched(
             fake_packet,
-            |mut packet| {
-                tunnel_obfuscation::lwo::obfuscate(&mut rng, &mut packet, pubkey.as_bytes())
-            },
+            |mut packet| tunnel_obfuscation::lwo::obfuscate(rng, &mut packet, pubkey.as_bytes()),
             criterion::BatchSize::LargeInput,
         );
     });
@@ -23,15 +20,15 @@ fn obfuscate(c: &mut Criterion) {
 
 fn deobfuscate(c: &mut Criterion) {
     let pubkey = PublicKey::from_base64("8Ka2l4T0tVrSR5pkcsvRG++mBlxfuf8XOxpqBkOCikU=").unwrap();
-    let mut rng = new_rng();
+    let rng = &mut rand::thread_rng();
 
     let mut group = c.benchmark_group("lwo");
     group.throughput(criterion::Throughput::Bytes(
-        obfuscated_fake_packet(&mut rng, pubkey.as_bytes()).len() as u64,
+        obfuscated_fake_packet(rng, pubkey.as_bytes()).len() as u64,
     ));
     group.bench_function(BenchmarkId::new("deobfuscate", fake_packet().len()), |b| {
         b.iter_batched(
-            || obfuscated_fake_packet(&mut rng, pubkey.as_bytes()),
+            || obfuscated_fake_packet(rng, pubkey.as_bytes()),
             |mut packet| tunnel_obfuscation::lwo::deobfuscate(&mut packet, pubkey.as_bytes()),
             criterion::BatchSize::LargeInput,
         );

--- a/tunnel-obfuscation/benches/obfuscation_throughput.rs
+++ b/tunnel-obfuscation/benches/obfuscation_throughput.rs
@@ -1,0 +1,148 @@
+//! Benchmark: LWO proxy round-trip vs inline obfuscation
+//!
+//! Compares three scenarios for sending a single WireGuard UDP packet to a relay:
+//!
+//! 1. **baseline** - plain UDP send+recv, no obfuscation
+//! 2. **inline_lwo** - obfuscate in-process (`obfuscate_thread_local`) then send
+//! 3. **proxy_lwo** - send through the `Lwo` localhost proxy (old approach)
+//!
+//! The difference `proxy_lwo - inline_lwo` is the cost of the extra kernel
+//! round-trip.
+
+use core::hint::black_box;
+use criterion::{Criterion, criterion_group, criterion_main};
+use talpid_types::net::wireguard::PublicKey;
+use tokio::net::UdpSocket;
+use tunnel_obfuscation::{
+    Obfuscator,
+    lwo::{self, Lwo, Settings, obfuscate_thread_local},
+};
+
+/// Baseline: plain UDP send -> recv, no obfuscation.
+fn bench_baseline(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (sender, relay) = rt.block_on(async {
+        let relay = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        sender.connect(relay.local_addr().unwrap()).await.unwrap();
+        (sender, relay)
+    });
+
+    let packet = make_wg_data_packet();
+    let mut recv_buf = vec![0u8; 65535];
+
+    c.bench_function("baseline/send_recv", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                sender.send(black_box(&packet)).await.unwrap();
+                relay.recv(&mut recv_buf).await.unwrap();
+            });
+        });
+    });
+}
+
+/// Inline LWO: obfuscate in-process with `obfuscate_thread_local`, then send.
+fn bench_inline_lwo(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (client_key, server_key) = keys();
+    let tx_key = *server_key.as_bytes();
+    let rx_key = *client_key.as_bytes();
+
+    let (sender, relay) = rt.block_on(async {
+        let relay = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        sender.connect(relay.local_addr().unwrap()).await.unwrap();
+        (sender, relay)
+    });
+
+    let packet = make_wg_data_packet();
+    let mut recv_buf = vec![0u8; 65535];
+
+    c.bench_function("inline_lwo/send_recv", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let mut pkt = black_box(packet.clone());
+                obfuscate_thread_local(&mut pkt, &tx_key);
+                sender.send(&pkt).await.unwrap();
+                let n = relay.recv(&mut recv_buf).await.unwrap();
+                // Deobfuscate to confirm correctness (mirrors what LwoRecv does)
+                lwo::deobfuscate(&mut recv_buf[..n], &rx_key);
+            });
+        });
+    });
+}
+
+/// Proxy LWO: the old approach - WG sends to localhost proxy which re-sends to relay.
+/// Setup: WG socket -> Lwo proxy task -> relay socket.
+fn bench_proxy_lwo(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (client_key, server_key) = keys();
+
+    let (wg_socket, relay, proxy_addr) = rt.block_on(async {
+        let relay = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let settings = Settings {
+            server_addr: relay.local_addr().unwrap(),
+            client_public_key: client_key.clone(),
+            server_public_key: server_key.clone(),
+            #[cfg(target_os = "linux")]
+            fwmark: None,
+        };
+        let lwo = Lwo::new(&settings).await.unwrap();
+        let proxy_addr = lwo.endpoint();
+        tokio::spawn((Box::new(lwo) as Box<dyn Obfuscator>).run());
+
+        // Warm up: send one packet so the proxy connects its client socket
+        let wg = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let mut buf = make_wg_data_packet();
+        wg.send_to(&buf, proxy_addr).await.unwrap();
+        relay.recv(&mut buf).await.unwrap();
+
+        (wg, relay, proxy_addr)
+    });
+
+    let packet = make_wg_data_packet();
+    let mut recv_buf = vec![0u8; 65535];
+
+    c.bench_function("proxy_lwo/send_recv", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                wg_socket
+                    .send_to(black_box(&packet), proxy_addr)
+                    .await
+                    .unwrap();
+                relay.recv(&mut recv_buf).await.unwrap();
+            });
+        });
+    });
+}
+
+fn make_wg_data_packet() -> Vec<u8> {
+    // Minimal valid WireGuard data packet header (type=4) + 1200-byte payload
+    const DATA: u8 = 4;
+    const DATA_OVERHEAD: usize = 32;
+    const PAYLOAD: usize = 1200;
+    let mut p = vec![0u8; DATA_OVERHEAD + PAYLOAD];
+    p[0] = DATA;
+    p
+}
+
+fn keys() -> (PublicKey, PublicKey) {
+    let client = PublicKey::from_base64("8Ka2l4T0tVrSR5pkcsvRG++mBlxfuf8XOxpqBkOCikU=").unwrap();
+    let server = PublicKey::from_base64("4EkA4c160oQgN/YaNR9GN3gLMevXEfx5hnlc9jYmw14=").unwrap();
+    (client, server)
+}
+
+criterion_group!(benches, bench_baseline, bench_inline_lwo, bench_proxy_lwo);
+criterion_main!(benches);

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use rand::{RngCore, SeedableRng};
+use rand::RngCore;
 use talpid_types::net::wireguard::PublicKey;
 use tokio::{io, net::UdpSocket, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -184,9 +184,8 @@ async fn run_obfuscation(
     write_socket: Arc<UdpSocket>,
 ) {
     if sending {
-        let mut rng = new_rng();
         run_obfuscation_inner(
-            move |buf| obfuscate(&mut rng, buf, key.as_bytes()),
+            move |buf| obfuscate(&mut rand::thread_rng(), buf, key.as_bytes()),
             read_socket,
             write_socket,
         )
@@ -321,21 +320,12 @@ impl Obfuscator for Lwo {
     }
 }
 
-pub fn new_rng() -> impl RngCore {
-    rand::rngs::SmallRng::from_entropy()
-}
-
 /// Obfuscate a packet using a thread-local RNG.
 ///
 /// This is a convenience function for callers that do not want to manage their own RNG.
 /// Uses a per-thread [`rand::rngs::SmallRng`] initialized lazily on first use.
 pub fn obfuscate_thread_local(packet: &mut [u8], key: &[u8; 32]) {
-    use std::cell::UnsafeCell;
-    thread_local! {
-        static RNG: UnsafeCell<rand::rngs::SmallRng> = UnsafeCell::new(rand::rngs::SmallRng::from_entropy());
-    }
-    // SAFETY: The cell is thread-local and we only access it here.
-    RNG.with(|rng| obfuscate(unsafe { &mut *rng.get() }, packet, key));
+    obfuscate(&mut rand::thread_rng(), packet, key);
 }
 
 #[cfg(test)]
@@ -355,7 +345,7 @@ mod test {
         let mut packet = fake_packet();
         let original_packet = packet.clone();
 
-        let mut rng = new_rng();
+        let mut rng = &mut rand::thread_rng();
 
         obfuscate(&mut rng, &mut packet, &key);
         assert_ne!(packet, original_packet);
@@ -392,7 +382,7 @@ mod test {
 
         tokio::spawn(Box::new(lwo).run());
 
-        let mut rng = new_rng();
+        let mut rng = &mut rand::thread_rng();
 
         // Send a test message, verify it on the server
         let packet = fake_packet();

--- a/tunnel-obfuscation/src/lwo.rs
+++ b/tunnel-obfuscation/src/lwo.rs
@@ -325,6 +325,19 @@ pub fn new_rng() -> impl RngCore {
     rand::rngs::SmallRng::from_entropy()
 }
 
+/// Obfuscate a packet using a thread-local RNG.
+///
+/// This is a convenience function for callers that do not want to manage their own RNG.
+/// Uses a per-thread [`rand::rngs::SmallRng`] initialized lazily on first use.
+pub fn obfuscate_thread_local(packet: &mut [u8], key: &[u8; 32]) {
+    use std::cell::UnsafeCell;
+    thread_local! {
+        static RNG: UnsafeCell<rand::rngs::SmallRng> = UnsafeCell::new(rand::rngs::SmallRng::from_entropy());
+    }
+    // SAFETY: The cell is thread-local and we only access it here.
+    RNG.with(|rng| obfuscate(unsafe { &mut *rng.get() }, packet, key));
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This PR removes the extra proxy socket when using LWO with GotaTun. The throughput is 1.5-3 times greater than kernel WG+LWO with a proxy socket according to our benchmarks. The PR also enables GotaTun whenever LWO is enabled.

Unrolling `MaybeObfuscating{Send,Recv}` does not appear to give any speedup.

The same optimization can later be made to other obfuscation types.

Fix DES-2917

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10172)
<!-- Reviewable:end -->
