### PR TITLE
Implement `IPAddressRange` and `DaitaConfiguration` types in `MullvadTypes` 

### DIFF
--- a/ios/MullvadMockData/MullvadTypes/DeviceMock.swift
+++ b/ios/MullvadMockData/MullvadTypes/DeviceMock.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 import MullvadTypes
-import WireGuardKitTypes  // IPAddressRange
+
+import class WireGuardKitTypes.PublicKey
 
 extension Device {
     public static func mock(publicKey: WireGuard.PublicKey) -> Device {

--- a/ios/MullvadMockData/MullvadTypes/DeviceMock.swift
+++ b/ios/MullvadMockData/MullvadTypes/DeviceMock.swift
@@ -9,8 +9,6 @@
 import Foundation
 import MullvadTypes
 
-import class WireGuardKitTypes.PublicKey
-
 extension Device {
     public static func mock(publicKey: WireGuard.PublicKey) -> Device {
         Device(

--- a/ios/MullvadRustRuntimeTests/IPAddressRangeTests.swift
+++ b/ios/MullvadRustRuntimeTests/IPAddressRangeTests.swift
@@ -1,0 +1,227 @@
+//
+//  IPAddressRangeTests.swift
+//  MullvadRustRuntimeTests
+//
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadTypes
+import Network
+import XCTest
+
+final class IPAddressRangeTests: XCTestCase {
+    // MARK: - IPv4 String Parsing
+
+    func testParseIPv4WithPrefix() {
+        let range = IPAddressRange(from: "192.168.1.0/24")
+        XCTAssertNotNil(range)
+        XCTAssertEqual("\(range!.address)", "192.168.1.0")
+        XCTAssertEqual(range!.networkPrefixLength, 24)
+    }
+
+    func testParseIPv4WithoutPrefix() {
+        let range = IPAddressRange(from: "10.0.0.1")
+        XCTAssertNotNil(range)
+        XCTAssertEqual("\(range!.address)", "10.0.0.1")
+        XCTAssertEqual(range!.networkPrefixLength, 32)
+    }
+
+    func testParseIPv4DefaultRoute() {
+        let range = IPAddressRange(from: "0.0.0.0/0")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 0)
+    }
+
+    func testParseIPv4FullMask() {
+        let range = IPAddressRange(from: "255.255.255.255/32")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 32)
+    }
+
+    func testParseIPv4PrefixClampedToMax() {
+        let range = IPAddressRange(from: "192.168.1.1/33")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 32)
+    }
+
+    func testParseInvalidString() {
+        XCTAssertNil(IPAddressRange(from: "invalid"))
+    }
+
+    func testParseTrailingSlash() {
+        XCTAssertNil(IPAddressRange(from: "192.168.1.1/"))
+    }
+
+    func testParseEmptyString() {
+        XCTAssertNil(IPAddressRange(from: ""))
+    }
+
+    // MARK: - IPv6 String Parsing
+
+    func testParseIPv6WithPrefix() {
+        let range = IPAddressRange(from: "::ff/64")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 64)
+    }
+
+    func testParseIPv6WithoutPrefix() {
+        let range = IPAddressRange(from: "::1")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 128)
+    }
+
+    func testParseIPv6DefaultRoute() {
+        let range = IPAddressRange(from: "::/0")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 0)
+    }
+
+    func testParseIPv6FullAddress() {
+        let range = IPAddressRange(from: "fe80::1/128")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 128)
+    }
+
+    func testParseIPv6PrefixClampedToMax() {
+        let range = IPAddressRange(from: "::1/129")
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range!.networkPrefixLength, 128)
+    }
+
+    // MARK: - String Representation Roundtrip
+
+    func testStringRepresentationRoundtripIPv4() {
+        let original = "192.168.1.0/24"
+        let range = IPAddressRange(from: original)!
+        XCTAssertEqual(range.description, original)
+    }
+
+    func testStringRepresentationRoundtripIPv6() {
+        let range = IPAddressRange(from: "::/0")!
+        XCTAssertEqual(range.description, "::/0")
+    }
+
+    // MARK: - Subnet Mask IPv4
+
+    func testSubnetMaskIPv4Zero() {
+        let range = IPAddressRange(from: "0.0.0.0/0")!
+        XCTAssertEqual("\(range.subnetMask())", "0.0.0.0")
+    }
+
+    func testSubnetMaskIPv4Slash8() {
+        let range = IPAddressRange(from: "10.0.0.0/8")!
+        XCTAssertEqual("\(range.subnetMask())", "255.0.0.0")
+    }
+
+    func testSubnetMaskIPv4Slash24() {
+        let range = IPAddressRange(from: "192.168.1.0/24")!
+        XCTAssertEqual("\(range.subnetMask())", "255.255.255.0")
+    }
+
+    func testSubnetMaskIPv4Slash32() {
+        let range = IPAddressRange(from: "192.168.1.1/32")!
+        XCTAssertEqual("\(range.subnetMask())", "255.255.255.255")
+    }
+
+    // MARK: - Subnet Mask IPv6
+
+    func testSubnetMaskIPv6Zero() {
+        let range = IPAddressRange(from: "::/0")!
+        let mask = range.subnetMask()
+        XCTAssertEqual(mask.rawValue, Data(repeating: 0, count: 16))
+    }
+
+    func testSubnetMaskIPv6Slash64() {
+        let range = IPAddressRange(from: "::1/64")!
+        let mask = range.subnetMask()
+        var expected = Data(repeating: 0xff, count: 8)
+        expected.append(Data(repeating: 0, count: 8))
+        XCTAssertEqual(mask.rawValue, expected)
+    }
+
+    func testSubnetMaskIPv6Slash128() {
+        let range = IPAddressRange(from: "::1/128")!
+        let mask = range.subnetMask()
+        XCTAssertEqual(mask.rawValue, Data(repeating: 0xff, count: 16))
+    }
+
+    // MARK: - Masked Address
+
+    func testMaskedAddressIPv4() {
+        let range = IPAddressRange(from: "192.168.1.100/24")!
+        XCTAssertEqual("\(range.maskedAddress())", "192.168.1.0")
+    }
+
+    func testMaskedAddressIPv4Slash8() {
+        let range = IPAddressRange(from: "10.20.30.40/8")!
+        XCTAssertEqual("\(range.maskedAddress())", "10.0.0.0")
+    }
+
+    // MARK: - Codable
+
+    func testCodableRoundtrip() throws {
+        let range = IPAddressRange(from: "10.64.0.1/32")!
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(range)
+        let decoded = try JSONDecoder().decode(IPAddressRange.self, from: data)
+        XCTAssertEqual(range, decoded)
+    }
+
+    func testDecodeSingleStringValue() throws {
+        let json = "\"10.64.0.1/32\""
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(IPAddressRange.self, from: data)
+        XCTAssertEqual("\(decoded.address)", "10.64.0.1")
+        XCTAssertEqual(decoded.networkPrefixLength, 32)
+    }
+
+    func testDecodeIPv6SingleStringValue() throws {
+        let json = "\"::ff/64\""
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(IPAddressRange.self, from: data)
+        XCTAssertEqual(decoded.networkPrefixLength, 64)
+    }
+
+    func testDecodeInvalidStringThrows() {
+        let json = "\"not-an-ip\""
+        let data = json.data(using: .utf8)!
+        XCTAssertThrowsError(try JSONDecoder().decode(IPAddressRange.self, from: data))
+    }
+
+    func testEncodesAsSingleString() throws {
+        let range = IPAddressRange(from: "192.168.1.0/24")!
+        let data = try JSONEncoder().encode(range)
+        let string = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(string, "\"192.168.1.0/24\"")
+    }
+
+    // MARK: - Equatable / Hashable
+
+    func testEqualRanges() {
+        let a = IPAddressRange(from: "10.0.0.1/24")!
+        let b = IPAddressRange(from: "10.0.0.1/24")!
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    func testUnequalPrefix() {
+        let a = IPAddressRange(from: "10.0.0.1/24")!
+        let b = IPAddressRange(from: "10.0.0.1/32")!
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testUnequalAddress() {
+        let a = IPAddressRange(from: "10.0.0.1/24")!
+        let b = IPAddressRange(from: "10.0.0.2/24")!
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - Direct Init
+
+    func testDirectInit() {
+        let address = IPv4Address("192.168.1.1")!
+        let range = IPAddressRange(address: address, networkPrefixLength: 24)
+        XCTAssertEqual("\(range.address)", "192.168.1.1")
+        XCTAssertEqual(range.networkPrefixLength, 24)
+    }
+}

--- a/ios/MullvadRustRuntimeTests/IPAddressRangeTests.swift
+++ b/ios/MullvadRustRuntimeTests/IPAddressRangeTests.swift
@@ -219,8 +219,7 @@ final class IPAddressRangeTests: XCTestCase {
     // MARK: - Direct Init
 
     func testDirectInit() {
-        let address = IPv4Address("192.168.1.1")!
-        let range = IPAddressRange(address: address, networkPrefixLength: 24)
+        let range = IPAddressRange(address: .ipv4(IPv4Address("192.168.1.1")!), networkPrefixLength: 24)
         XCTAssertEqual("\(range.address)", "192.168.1.1")
         XCTAssertEqual(range.networkPrefixLength, 24)
     }

--- a/ios/MullvadSettings/StoredDeviceData.swift
+++ b/ios/MullvadSettings/StoredDeviceData.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import MullvadTypes
-@preconcurrency import WireGuardKitTypes  // IPAddressRange
 
 public struct StoredDeviceData: Codable, Equatable, Sendable {
     /// Device creation date.

--- a/ios/MullvadSettings/TunnelSettingsV1.swift
+++ b/ios/MullvadSettings/TunnelSettingsV1.swift
@@ -9,7 +9,9 @@
 import Foundation
 import MullvadTypes
 import Network
-import WireGuardKitTypes  // IPAddressRange
+
+import class WireGuardKitTypes.PrivateKey
+import class WireGuardKitTypes.PublicKey
 
 /// A struct that holds the configuration passed via `NETunnelProviderProtocol`.
 public struct TunnelSettingsV1: Codable, Equatable, TunnelSettings {

--- a/ios/MullvadSettings/TunnelSettingsV1.swift
+++ b/ios/MullvadSettings/TunnelSettingsV1.swift
@@ -10,9 +10,6 @@ import Foundation
 import MullvadTypes
 import Network
 
-import class WireGuardKitTypes.PrivateKey
-import class WireGuardKitTypes.PublicKey
-
 /// A struct that holds the configuration passed via `NETunnelProviderProtocol`.
 public struct TunnelSettingsV1: Codable, Equatable, TunnelSettings {
     public var relayConstraints = RelayConstraints()

--- a/ios/MullvadTypes/AnyIPAddress.swift
+++ b/ios/MullvadTypes/AnyIPAddress.swift
@@ -98,6 +98,16 @@ public enum AnyIPAddress: IPAddress, Codable, Equatable, CustomDebugStringConver
         innerAddress.isMulticast
     }
 
+    public var isIPv4: Bool {
+        if case .ipv4 = self { return true }
+        return false
+    }
+
+    public var isIPv6: Bool {
+        if case .ipv6 = self { return true }
+        return false
+    }
+
     public var debugDescription: String {
         switch self {
         case let .ipv4(ipv4Address):

--- a/ios/MullvadTypes/DaitaConfiguration.swift
+++ b/ios/MullvadTypes/DaitaConfiguration.swift
@@ -1,0 +1,29 @@
+//
+//  DaitaConfiguration.swift
+//  MullvadTypes
+//
+//  Created by Mullvad VPN.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+/// Contains arguments needed to initialize DAITA for a WireGuard device.
+public struct DaitaConfiguration: Equatable, Sendable {
+    /// Contains a string describing a set of DAITA machines.
+    public let machines: String
+    /// Maximum amount of DAITA events to enqueue at any given time.
+    public let maxEvents: UInt32
+    /// Maximum amount of DAITA actions to enqueue at any given time.
+    public let maxActions: UInt32
+    /// Maximum amount of DAITA padding to enqueue at any given time.
+    public let maxPadding: Double
+    /// Maximum amount of DAITA blocking to enqueue at any given time.
+    public let maxBlocking: Double
+
+    public init(machines: String, maxEvents: UInt32, maxActions: UInt32, maxPadding: Double, maxBlocking: Double) {
+        self.machines = machines
+        self.maxEvents = maxEvents
+        self.maxActions = maxActions
+        self.maxPadding = maxPadding
+        self.maxBlocking = maxBlocking
+    }
+}

--- a/ios/MullvadTypes/IPAddressRange.swift
+++ b/ios/MullvadTypes/IPAddressRange.swift
@@ -1,0 +1,147 @@
+//
+//  IPAddressRange.swift
+//  MullvadTypes
+//
+//  Created by Mullvad VPN.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import Network
+
+public struct IPAddressRange: Sendable {
+    public let address: IPAddress
+    public let networkPrefixLength: UInt8
+
+    public init(address: IPAddress, networkPrefixLength: UInt8) {
+        self.address = address
+        self.networkPrefixLength = networkPrefixLength
+    }
+}
+
+extension IPAddressRange: Equatable {
+    public static func == (lhs: IPAddressRange, rhs: IPAddressRange) -> Bool {
+        lhs.address.rawValue == rhs.address.rawValue && lhs.networkPrefixLength == rhs.networkPrefixLength
+    }
+}
+
+extension IPAddressRange: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(address.rawValue)
+        hasher.combine(networkPrefixLength)
+    }
+}
+
+extension IPAddressRange: Codable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+
+        if let ipAddressRange = IPAddressRange(from: value) {
+            self = ipAddressRange
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "Invalid IPAddressRange representation"
+                )
+            )
+        }
+    }
+}
+
+extension IPAddressRange: CustomStringConvertible {
+    public var description: String {
+        "\(address)/\(networkPrefixLength)"
+    }
+}
+
+extension IPAddressRange {
+    public init?(from string: String) {
+        guard let parsed = IPAddressRange.parseAddressString(string) else { return nil }
+        address = parsed.0
+        networkPrefixLength = parsed.1
+    }
+
+    private static func parseAddressString(_ string: String) -> (IPAddress, UInt8)? {
+        // Split "192.168.1.0/24" into address ("192.168.1.0") and prefix length ("24")
+        let parts = string.split(separator: "/", maxSplits: 1)
+        guard let addressPart = parts.first else { return nil }
+
+        // Parse the address part as either IPv4 or IPv6
+        let address: IPAddress
+        if let addr = IPv4Address(String(addressPart)) {
+            address = addr
+        } else if let addr = IPv6Address(String(addressPart)) {
+            address = addr
+        } else {
+            return nil
+        }
+
+        let maxNetworkPrefixLength: UInt8 = address is IPv4Address ? 32 : 128
+
+        // If a prefix length is provided, parse it; otherwise default to the maximum for the address family
+        if parts.count > 1 {
+            guard let prefixLength = UInt8(parts[1]) else { return nil }
+            return (address, min(prefixLength, maxNetworkPrefixLength))
+        } else {
+            return (address, maxNetworkPrefixLength)
+        }
+    }
+
+    public func subnetMask() -> IPAddress {
+        switch address {
+        case is IPv4Address:
+            let mask = networkPrefixLength > 0 ? ~UInt32(0) << (32 - networkPrefixLength) : UInt32(0)
+            let bytes = Data([
+                UInt8(truncatingIfNeeded: mask >> 24),
+                UInt8(truncatingIfNeeded: mask >> 16),
+                UInt8(truncatingIfNeeded: mask >> 8),
+                UInt8(truncatingIfNeeded: mask >> 0),
+            ])
+            return IPv4Address(bytes)!
+
+        case is IPv6Address:
+            var bytes = Data(repeating: 0, count: 16)
+            for i in 0..<Int(networkPrefixLength / 8) {
+                bytes[i] = 0xff
+            }
+            let nibble = networkPrefixLength % 32
+            if nibble != 0 {
+                let mask = ~UInt32(0) << (32 - nibble)
+                let i = Int(networkPrefixLength / 32 * 4)
+                bytes[i + 0] = UInt8(truncatingIfNeeded: mask >> 24)
+                bytes[i + 1] = UInt8(truncatingIfNeeded: mask >> 16)
+                bytes[i + 2] = UInt8(truncatingIfNeeded: mask >> 8)
+                bytes[i + 3] = UInt8(truncatingIfNeeded: mask >> 0)
+            }
+            return IPv6Address(bytes)!
+
+        default:
+            fatalError("Unsupported address type: \(type(of: address))")
+        }
+    }
+
+    public func maskedAddress() -> IPAddress {
+        let subnet = subnetMask().rawValue
+        var masked = Data(address.rawValue)
+        assert(subnet.count == masked.count)
+        for i in 0..<subnet.count {
+            masked[i] &= subnet[i]
+        }
+
+        switch address {
+        case is IPv4Address:
+            return IPv4Address(masked)!
+        case is IPv6Address:
+            return IPv6Address(masked)!
+        default:
+            fatalError("Unsupported address type: \(type(of: address))")
+        }
+    }
+}

--- a/ios/MullvadTypes/IPAddressRange.swift
+++ b/ios/MullvadTypes/IPAddressRange.swift
@@ -10,10 +10,10 @@ import Foundation
 import Network
 
 public struct IPAddressRange: Sendable {
-    public let address: IPAddress
+    public let address: AnyIPAddress
     public let networkPrefixLength: UInt8
 
-    public init(address: IPAddress, networkPrefixLength: UInt8) {
+    public init(address: AnyIPAddress, networkPrefixLength: UInt8) {
         self.address = address
         self.networkPrefixLength = networkPrefixLength
     }
@@ -68,22 +68,19 @@ extension IPAddressRange {
         networkPrefixLength = parsed.1
     }
 
-    private static func parseAddressString(_ string: String) -> (IPAddress, UInt8)? {
+    private static func parseAddressString(_ string: String) -> (AnyIPAddress, UInt8)? {
         // Split "192.168.1.0/24" into address ("192.168.1.0") and prefix length ("24")
         let parts = string.split(separator: "/", maxSplits: 1)
         guard let addressPart = parts.first else { return nil }
 
         // Parse the address part as either IPv4 or IPv6
-        let address: IPAddress
-        if let addr = IPv4Address(String(addressPart)) {
-            address = addr
-        } else if let addr = IPv6Address(String(addressPart)) {
-            address = addr
-        } else {
-            return nil
-        }
+        guard let address = AnyIPAddress(String(addressPart)) else { return nil }
 
-        let maxNetworkPrefixLength: UInt8 = address is IPv4Address ? 32 : 128
+        let maxNetworkPrefixLength: UInt8 =
+            switch address {
+            case .ipv4: 32
+            case .ipv6: 128
+            }
 
         // If a prefix length is provided, parse it; otherwise default to the maximum for the address family
         if parts.count > 1 {
@@ -96,7 +93,7 @@ extension IPAddressRange {
 
     public func subnetMask() -> IPAddress {
         switch address {
-        case is IPv4Address:
+        case .ipv4:
             let mask = networkPrefixLength > 0 ? ~UInt32(0) << (32 - networkPrefixLength) : UInt32(0)
             let bytes = Data([
                 UInt8(truncatingIfNeeded: mask >> 24),
@@ -106,7 +103,7 @@ extension IPAddressRange {
             ])
             return IPv4Address(bytes)!
 
-        case is IPv6Address:
+        case .ipv6:
             var bytes = Data(repeating: 0, count: 16)
             for i in 0..<Int(networkPrefixLength / 8) {
                 bytes[i] = 0xff
@@ -121,27 +118,21 @@ extension IPAddressRange {
                 bytes[i + 3] = UInt8(truncatingIfNeeded: mask >> 0)
             }
             return IPv6Address(bytes)!
-
-        default:
-            fatalError("Unsupported address type: \(type(of: address))")
         }
     }
 
     public func maskedAddress() -> IPAddress {
         let subnet = subnetMask().rawValue
         var masked = Data(address.rawValue)
-        assert(subnet.count == masked.count)
         for i in 0..<subnet.count {
             masked[i] &= subnet[i]
         }
 
         switch address {
-        case is IPv4Address:
+        case .ipv4:
             return IPv4Address(masked)!
-        case is IPv6Address:
+        case .ipv6:
             return IPv6Address(masked)!
-        default:
-            fatalError("Unsupported address type: \(type(of: address))")
         }
     }
 }

--- a/ios/MullvadTypes/RESTTypes.swift
+++ b/ios/MullvadTypes/RESTTypes.swift
@@ -7,7 +7,8 @@
 //
 
 import Foundation
-@preconcurrency import WireGuardKitTypes  // IPAddressRange
+
+import class WireGuardKitTypes.PublicKey
 
 public struct Account: Codable, Equatable, Sendable {
     public let id: String

--- a/ios/MullvadTypes/RESTTypes.swift
+++ b/ios/MullvadTypes/RESTTypes.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-import class WireGuardKitTypes.PublicKey
-
 public struct Account: Codable, Equatable, Sendable {
     public let id: String
     public let expiry: Date

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		016EE03A2F850C5A0035B25C /* WireGuardKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */; };
 		016EE03C2F8524EB0035B25C /* WireGuardKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE03B2F8524EB0035B25C /* WireGuardKey.swift */; };
 		016EE0422F8540B00035B25C /* IPAddressRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0412F8540B00035B25C /* IPAddressRange.swift */; };
+		016EE0442F8640B00035B25C /* DaitaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0432F8640B00035B25C /* DaitaConfiguration.swift */; };
 		01B2FF862D70B914004AED35 /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
 		01C981E82F43C3410002D284 /* BlockedStateReason+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */; };
 		01C981E92F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */; };
@@ -1722,6 +1723,7 @@
 		016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKeyTests.swift; sourceTree = "<group>"; };
 		016EE03B2F8524EB0035B25C /* WireGuardKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKey.swift; sourceTree = "<group>"; };
 		016EE0412F8540B00035B25C /* IPAddressRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPAddressRange.swift; sourceTree = "<group>"; };
+		016EE0432F8640B00035B25C /* DaitaConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaitaConfiguration.swift; sourceTree = "<group>"; };
 		01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockedStateReason+Localization.swift"; sourceTree = "<group>"; };
 		01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelStateAccessibilityAnnouncer.swift; sourceTree = "<group>"; };
 		01C981EA2F45D5C20002D284 /* TunnelControlPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelControlPageTests.swift; sourceTree = "<group>"; };
@@ -3212,6 +3214,7 @@
 		581943F228F8014500B0CB5E /* MullvadTypes */ = {
 			isa = PBXGroup;
 			children = (
+				016EE0432F8640B00035B25C /* DaitaConfiguration.swift */,
 				016EE0412F8540B00035B25C /* IPAddressRange.swift */,
 				449EBA242B975B7C00DFA4EB /* Protocols */,
 				588D7ED72AF3A533005DF40A /* AccessMethodKind.swift */,
@@ -7019,6 +7022,7 @@
 				F0ADF1CD2CFDFF3100299F09 /* StringConversionError.swift in Sources */,
 				A9A8A8EB2A262AB30086D569 /* FileCache.swift in Sources */,
 				A90C48692C36BF3900DCB94C /* TunnelProvider.swift in Sources */,
+				016EE0442F8640B00035B25C /* DaitaConfiguration.swift in Sources */,
 				016EE0422F8540B00035B25C /* IPAddressRange.swift in Sources */,
 				01FFF95F2F0BE13900BDAF45 /* SelectedEndpoint.swift in Sources */,
 				44EC6C5A2E3BB3F60087F54A /* PersistentProxyConfiguration.swift in Sources */,

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		016EE0382F850C0E0035B25C /* WireGuardKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0372F850C0E0035B25C /* WireGuardKey.swift */; };
 		016EE03A2F850C5A0035B25C /* WireGuardKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */; };
 		016EE03C2F8524EB0035B25C /* WireGuardKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE03B2F8524EB0035B25C /* WireGuardKey.swift */; };
+		016EE0422F8540B00035B25C /* IPAddressRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0412F8540B00035B25C /* IPAddressRange.swift */; };
 		01B2FF862D70B914004AED35 /* MullvadRustRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A992DA1D2C24709F00DE7CE5 /* MullvadRustRuntime.framework */; };
 		01C981E82F43C3410002D284 /* BlockedStateReason+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */; };
 		01C981E92F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */; };
@@ -1720,6 +1721,7 @@
 		016EE0372F850C0E0035B25C /* WireGuardKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKey.swift; sourceTree = "<group>"; };
 		016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKeyTests.swift; sourceTree = "<group>"; };
 		016EE03B2F8524EB0035B25C /* WireGuardKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKey.swift; sourceTree = "<group>"; };
+		016EE0412F8540B00035B25C /* IPAddressRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPAddressRange.swift; sourceTree = "<group>"; };
 		01C981E52F43C3410002D284 /* BlockedStateReason+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockedStateReason+Localization.swift"; sourceTree = "<group>"; };
 		01C981E62F43C3410002D284 /* TunnelStateAccessibilityAnnouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelStateAccessibilityAnnouncer.swift; sourceTree = "<group>"; };
 		01C981EA2F45D5C20002D284 /* TunnelControlPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelControlPageTests.swift; sourceTree = "<group>"; };
@@ -3210,6 +3212,7 @@
 		581943F228F8014500B0CB5E /* MullvadTypes */ = {
 			isa = PBXGroup;
 			children = (
+				016EE0412F8540B00035B25C /* IPAddressRange.swift */,
 				449EBA242B975B7C00DFA4EB /* Protocols */,
 				588D7ED72AF3A533005DF40A /* AccessMethodKind.swift */,
 				584D26BE270C550B004EA533 /* AnyIPAddress.swift */,
@@ -7016,6 +7019,7 @@
 				F0ADF1CD2CFDFF3100299F09 /* StringConversionError.swift in Sources */,
 				A9A8A8EB2A262AB30086D569 /* FileCache.swift in Sources */,
 				A90C48692C36BF3900DCB94C /* TunnelProvider.swift in Sources */,
+				016EE0422F8540B00035B25C /* IPAddressRange.swift in Sources */,
 				01FFF95F2F0BE13900BDAF45 /* SelectedEndpoint.swift in Sources */,
 				44EC6C5A2E3BB3F60087F54A /* PersistentProxyConfiguration.swift in Sources */,
 				016EE03C2F8524EB0035B25C /* WireGuardKey.swift in Sources */,

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManaging.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManaging.swift
@@ -10,9 +10,6 @@ import Foundation
 import MullvadREST
 import MullvadTypes
 
-import class WireGuardKitTypes.PrivateKey
-import class WireGuardKitTypes.PublicKey
-
 protocol DeviceManaging {
     var currentDeviceId: String? { get }
     func getDevices(_ completionHandler: @escaping @Sendable (Result<[Device], Error>) -> Void) -> Cancellable

--- a/ios/MullvadVPN/View controllers/DeviceList/DeviceManaging.swift
+++ b/ios/MullvadVPN/View controllers/DeviceList/DeviceManaging.swift
@@ -9,7 +9,9 @@
 import Foundation
 import MullvadREST
 import MullvadTypes
-import WireGuardKitTypes  // IPAddressRange
+
+import class WireGuardKitTypes.PrivateKey
+import class WireGuardKitTypes.PublicKey
 
 protocol DeviceManaging {
     var currentDeviceId: String? { get }

--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
@@ -11,8 +11,10 @@ import MullvadSettings
 import MullvadTypes
 import Operations
 import PacketTunnelCore
-@preconcurrency import WireGuardKitTypes  // For IPAddressRange
 import XCTest
+
+@preconcurrency import class WireGuardKitTypes.PrivateKey
+@preconcurrency import class WireGuardKitTypes.PublicKey
 
 @testable import MullvadMockData
 

--- a/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/PacketTunnel/DeviceCheck/DeviceCheckOperationTests.swift
@@ -13,9 +13,6 @@ import Operations
 import PacketTunnelCore
 import XCTest
 
-@preconcurrency import class WireGuardKitTypes.PrivateKey
-@preconcurrency import class WireGuardKitTypes.PublicKey
-
 @testable import MullvadMockData
 
 class DeviceCheckOperationTests: XCTestCase {

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
@@ -12,8 +12,6 @@ import Network
 import Operations
 import XCTest
 
-import class WireGuardKitTypes.PrivateKey
-
 @testable import MullvadMockData
 
 class StartTunnelOperationTests: XCTestCase {

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/StartTunnelOperationTests.swift
@@ -10,8 +10,9 @@ import MullvadSettings
 import MullvadTypes
 import Network
 import Operations
-import WireGuardKitTypes  // For IPAddressRange
 import XCTest
+
+import class WireGuardKitTypes.PrivateKey
 
 @testable import MullvadMockData
 

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/WgKeyRotationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/WgKeyRotationTests.swift
@@ -10,8 +10,6 @@ import MullvadSettings
 import MullvadTypes
 import XCTest
 
-import class WireGuardKitTypes.PrivateKey
-
 final class WgKeyRotationTests: XCTestCase {
     func testKeyRotationLifecycle() {
         let data = StoredDeviceData.mock(

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/WgKeyRotationTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/WgKeyRotationTests.swift
@@ -8,8 +8,9 @@
 
 import MullvadSettings
 import MullvadTypes
-import WireGuardKitTypes  // For IPAddressRange
 import XCTest
+
+import class WireGuardKitTypes.PrivateKey
 
 final class WgKeyRotationTests: XCTestCase {
     func testKeyRotationLifecycle() {

--- a/ios/PacketTunnel/PostQuantum/MultiHopEphemeralPeerExchanger.swift
+++ b/ios/PacketTunnel/PostQuantum/MultiHopEphemeralPeerExchanger.swift
@@ -12,9 +12,6 @@ import MullvadSettings
 import MullvadTypes
 import PacketTunnelCore
 
-import class WireGuardKitTypes.PreSharedKey
-import class WireGuardKitTypes.PrivateKey
-
 final class MultiHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
     let entry: SelectedRelay
     let exit: SelectedRelay

--- a/ios/PacketTunnel/PostQuantum/MultiHopEphemeralPeerExchanger.swift
+++ b/ios/PacketTunnel/PostQuantum/MultiHopEphemeralPeerExchanger.swift
@@ -11,7 +11,9 @@ import MullvadRustRuntime
 import MullvadSettings
 import MullvadTypes
 import PacketTunnelCore
-import WireGuardKitTypes  // IPAddressRange
+
+import class WireGuardKitTypes.PreSharedKey
+import class WireGuardKitTypes.PrivateKey
 
 final class MultiHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
     let entry: SelectedRelay

--- a/ios/PacketTunnel/PostQuantum/SingleHopEphemeralPeerExchanger.swift
+++ b/ios/PacketTunnel/PostQuantum/SingleHopEphemeralPeerExchanger.swift
@@ -11,7 +11,9 @@ import MullvadRustRuntime
 import MullvadSettings
 import MullvadTypes
 import PacketTunnelCore
-import WireGuardKitTypes  // IPAddressRange
+
+import class WireGuardKitTypes.PreSharedKey
+import class WireGuardKitTypes.PrivateKey
 
 struct SingleHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
     let exit: SelectedRelay

--- a/ios/PacketTunnel/PostQuantum/SingleHopEphemeralPeerExchanger.swift
+++ b/ios/PacketTunnel/PostQuantum/SingleHopEphemeralPeerExchanger.swift
@@ -12,9 +12,6 @@ import MullvadSettings
 import MullvadTypes
 import PacketTunnelCore
 
-import class WireGuardKitTypes.PreSharedKey
-import class WireGuardKitTypes.PrivateKey
-
 struct SingleHopEphemeralPeerExchanger: EphemeralPeerExchangingProtocol {
     let exit: SelectedRelay
     let keyExchanger: EphemeralPeerExchangeActorProtocol

--- a/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
+++ b/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
@@ -132,10 +132,16 @@ extension WgAdapter: TunnelDeviceInfoProtocol {
     }
 }
 
+private extension MullvadTypes.IPAddressRange {
+    var asWireGuardKitType: WireGuardKitTypes.IPAddressRange {
+        WireGuardKitTypes.IPAddressRange(from: description)!
+    }
+}
+
 private extension TunnelAdapterConfiguration {
     var asWgConfig: TunnelConfiguration {
         var interfaceConfig = InterfaceConfiguration(privateKey: privateKey.wgKey)
-        interfaceConfig.addresses = interfaceAddresses
+        interfaceConfig.addresses = interfaceAddresses.map { $0.asWireGuardKitType }
         interfaceConfig.dns = dns.map { DNSServer(address: $0) }
         interfaceConfig.listenPort = 0
 
@@ -143,7 +149,7 @@ private extension TunnelAdapterConfiguration {
         if let peer {
             var peerConfig = PeerConfiguration(publicKey: peer.publicKey.wgKey)
             peerConfig.endpoint = peer.endpoint.wgEndpoint
-            peerConfig.allowedIPs = allowedIPs
+            peerConfig.allowedIPs = allowedIPs.map { $0.asWireGuardKitType }
             peerConfig.preSharedKey = peer.preSharedKey?.wgKey
             peers.append(peerConfig)
         }

--- a/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
+++ b/ios/PacketTunnel/WireGuardAdapter/WgAdapter.swift
@@ -35,20 +35,21 @@ class WgAdapter: TunnelAdapterProtocol, @unchecked Sendable {
         )
     }
 
-    func start(configuration: TunnelAdapterConfiguration, daita: DaitaConfiguration?) async throws {
+    func start(configuration: TunnelAdapterConfiguration, daita: MullvadTypes.DaitaConfiguration?) async throws {
         let wgConfig = configuration.asWgConfig
+        let wgDaita = daita?.asWireGuardKitType
         do {
             try await adapter.stop()
-            try await adapter.start(tunnelConfiguration: wgConfig, daita: daita)
+            try await adapter.start(tunnelConfiguration: wgConfig, daita: wgDaita)
         } catch WireGuardAdapterError.invalidState {
-            try await adapter.start(tunnelConfiguration: wgConfig, daita: daita)
+            try await adapter.start(tunnelConfiguration: wgConfig, daita: wgDaita)
         }
     }
 
     func startMultihop(
         entryConfiguration: TunnelAdapterConfiguration? = nil,
         exitConfiguration: TunnelAdapterConfiguration,
-        daita: DaitaConfiguration?
+        daita: MullvadTypes.DaitaConfiguration?
     ) async throws {
 
         if exitConfiguration.peer?.endpoint.ip is IPv6Address, entryConfiguration != nil {
@@ -64,18 +65,19 @@ class WgAdapter: TunnelAdapterProtocol, @unchecked Sendable {
             logger.info("\(entryConfiguration.peers)")
         }
 
+        let wgDaita = daita?.asWireGuardKitType
         do {
             try await adapter.stop()
             try await adapter.startMultihop(
                 entryConfiguration: entryConfiguration,
                 exitConfiguration: exitConfiguration,
-                daita: daita
+                daita: wgDaita
             )
         } catch WireGuardAdapterError.invalidState {
             try await adapter.startMultihop(
                 entryConfiguration: entryConfiguration,
                 exitConfiguration: exitConfiguration,
-                daita: daita
+                daita: wgDaita
             )
         }
     }
@@ -135,6 +137,18 @@ extension WgAdapter: TunnelDeviceInfoProtocol {
 private extension MullvadTypes.IPAddressRange {
     var asWireGuardKitType: WireGuardKitTypes.IPAddressRange {
         WireGuardKitTypes.IPAddressRange(from: description)!
+    }
+}
+
+private extension MullvadTypes.DaitaConfiguration {
+    var asWireGuardKitType: WireGuardKitTypes.DaitaConfiguration {
+        WireGuardKitTypes.DaitaConfiguration(
+            machines: machines,
+            maxEvents: maxEvents,
+            maxActions: maxActions,
+            maxPadding: maxPadding,
+            maxBlocking: maxBlocking
+        )
     }
 }
 

--- a/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
+++ b/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
@@ -9,7 +9,10 @@
 import Foundation
 import MullvadTypes
 import Network
-import WireGuardKitTypes  // For IPAddressRange
+
+import class WireGuardKitTypes.PreSharedKey
+import class WireGuardKitTypes.PrivateKey
+import class WireGuardKitTypes.PublicKey
 
 /// Error returned when there is an endpoint but its public key is invalid.
 public struct PublicKeyError: LocalizedError {

--- a/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
+++ b/ios/PacketTunnelCore/Actor/ConfigurationBuilder.swift
@@ -10,10 +10,6 @@ import Foundation
 import MullvadTypes
 import Network
 
-import class WireGuardKitTypes.PreSharedKey
-import class WireGuardKitTypes.PrivateKey
-import class WireGuardKitTypes.PublicKey
-
 /// Error returned when there is an endpoint but its public key is invalid.
 public struct PublicKeyError: LocalizedError {
     let endpoint: SelectedEndpoint

--- a/ios/PacketTunnelCore/Actor/ConnectionConfigurationBuilder.swift
+++ b/ios/PacketTunnelCore/Actor/ConnectionConfigurationBuilder.swift
@@ -9,7 +9,8 @@
 import Foundation
 import MullvadTypes
 import Network
-import WireGuardKitTypes  // For IPAddressRange
+
+import class WireGuardKitTypes.PrivateKey
 
 protocol Configuration {
     var name: String { get }

--- a/ios/PacketTunnelCore/Actor/ConnectionConfigurationBuilder.swift
+++ b/ios/PacketTunnelCore/Actor/ConnectionConfigurationBuilder.swift
@@ -10,8 +10,6 @@ import Foundation
 import MullvadTypes
 import Network
 
-import class WireGuardKitTypes.PrivateKey
-
 protocol Configuration {
     var name: String { get }
     func make() throws -> ConnectionConfiguration

--- a/ios/PacketTunnelCore/Actor/EphemeralPeerNegotiationState.swift
+++ b/ios/PacketTunnelCore/Actor/EphemeralPeerNegotiationState.swift
@@ -9,9 +9,6 @@
 import MullvadREST
 import MullvadTypes
 
-@preconcurrency import class WireGuardKitTypes.PreSharedKey
-@preconcurrency import class WireGuardKitTypes.PrivateKey
-
 public enum EphemeralPeerNegotiationState: Equatable, Sendable {
     case single(EphemeralPeerRelayConfiguration)
     case multi(entry: EphemeralPeerRelayConfiguration, exit: EphemeralPeerRelayConfiguration)

--- a/ios/PacketTunnelCore/Actor/EphemeralPeerNegotiationState.swift
+++ b/ios/PacketTunnelCore/Actor/EphemeralPeerNegotiationState.swift
@@ -8,7 +8,9 @@
 
 import MullvadREST
 import MullvadTypes
-@preconcurrency import WireGuardKitTypes  // For IPAddressRange
+
+@preconcurrency import class WireGuardKitTypes.PreSharedKey
+@preconcurrency import class WireGuardKitTypes.PrivateKey
 
 public enum EphemeralPeerNegotiationState: Equatable, Sendable {
     case single(EphemeralPeerRelayConfiguration)

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -9,7 +9,9 @@
 import Foundation
 import MullvadTypes
 import Network
-import WireGuardKitTypes  // For IPAddressRange
+
+import class WireGuardKitTypes.PrivateKey
+import class WireGuardKitTypes.PublicKey
 
 extension PacketTunnelActor {
     /**

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+ErrorState.swift
@@ -10,9 +10,6 @@ import Foundation
 import MullvadTypes
 import Network
 
-import class WireGuardKitTypes.PrivateKey
-import class WireGuardKitTypes.PublicKey
-
 extension PacketTunnelActor {
     /**
      Transition actor to error state.

--- a/ios/PacketTunnelCore/Actor/PacketTunnelActor+PostQuantum.swift
+++ b/ios/PacketTunnelCore/Actor/PacketTunnelActor+PostQuantum.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import MullvadTypes
-import WireGuardKitTypes  // For DaitaConfiguration
 
 extension PacketTunnelActor {
     /**

--- a/ios/PacketTunnelCore/Actor/Protocols/SettingsReaderProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/SettingsReaderProtocol.swift
@@ -11,8 +11,6 @@ import MullvadSettings
 import MullvadTypes
 import Network
 
-@preconcurrency import class WireGuardKitTypes.PrivateKey
-
 /// A type that implements a reader that can return settings required by `PacketTunnelActor` in order to configure the tunnel.
 public protocol SettingsReaderProtocol {
     /**

--- a/ios/PacketTunnelCore/Actor/Protocols/SettingsReaderProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/SettingsReaderProtocol.swift
@@ -10,7 +10,8 @@ import Foundation
 import MullvadSettings
 import MullvadTypes
 import Network
-@preconcurrency import WireGuardKitTypes  // For IPAddressRange
+
+@preconcurrency import class WireGuardKitTypes.PrivateKey
 
 /// A type that implements a reader that can return settings required by `PacketTunnelActor` in order to configure the tunnel.
 public protocol SettingsReaderProtocol {

--- a/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
@@ -11,10 +11,6 @@ import MullvadTypes
 import Network
 import NetworkExtension
 
-@preconcurrency import class WireGuardKitTypes.PreSharedKey
-@preconcurrency import class WireGuardKitTypes.PrivateKey
-@preconcurrency import class WireGuardKitTypes.PublicKey
-
 /// Protocol describing interface for any kind of adapter implementing a VPN tunnel.
 public protocol TunnelAdapterProtocol: Sendable {
     /// Start tunnel adapter or update active configuration.

--- a/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
@@ -11,7 +11,6 @@ import MullvadTypes
 import Network
 import NetworkExtension
 
-@preconcurrency import struct WireGuardKitTypes.DaitaConfiguration
 @preconcurrency import class WireGuardKitTypes.PreSharedKey
 @preconcurrency import class WireGuardKitTypes.PrivateKey
 @preconcurrency import class WireGuardKitTypes.PublicKey

--- a/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
@@ -81,7 +81,7 @@ public struct TunnelInterfaceSettings: Equatable, Sendable {
         var routes = [NEIPv4Route]()
         routes.append(NEIPv4Route.default())
 
-        for range in self.interfaceAddresses where range.address is IPv4Address {
+        for range in self.interfaceAddresses where range.address.isIPv4 {
             addresses.append("\(range.address)")
             subnetMasks.append("\(range.subnetMask())")
 
@@ -103,7 +103,7 @@ public struct TunnelInterfaceSettings: Equatable, Sendable {
         var prefixLengths = [NSNumber]()
         var routes = [NEIPv6Route]()
 
-        for range in self.interfaceAddresses where range.address is IPv6Address {
+        for range in self.interfaceAddresses where range.address.isIPv6 {
             addresses.append("\(range.address)")
             prefixLengths.append(NSNumber(value: min(120, range.networkPrefixLength)))
 

--- a/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
+++ b/ios/PacketTunnelCore/Actor/Protocols/TunnelAdapterProtocol.swift
@@ -10,7 +10,11 @@ import Foundation
 import MullvadTypes
 import Network
 import NetworkExtension
-@preconcurrency import WireGuardKitTypes  // For IPAddressRange, DaitaConfiguration
+
+@preconcurrency import struct WireGuardKitTypes.DaitaConfiguration
+@preconcurrency import class WireGuardKitTypes.PreSharedKey
+@preconcurrency import class WireGuardKitTypes.PrivateKey
+@preconcurrency import class WireGuardKitTypes.PublicKey
 
 /// Protocol describing interface for any kind of adapter implementing a VPN tunnel.
 public protocol TunnelAdapterProtocol: Sendable {

--- a/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
@@ -10,8 +10,6 @@ import Foundation
 import MullvadTypes
 import PacketTunnelCore
 
-import class WireGuardKitTypes.PrivateKey
-
 @testable import MullvadSettings
 
 /// Settings reader stub that can be configured with a block to provide the desired behavior when testing.

--- a/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/SettingsReaderStub.swift
@@ -9,7 +9,8 @@
 import Foundation
 import MullvadTypes
 import PacketTunnelCore
-import WireGuardKitTypes  // For IPAddressRange
+
+import class WireGuardKitTypes.PrivateKey
 
 @testable import MullvadSettings
 

--- a/ios/PacketTunnelCoreTests/Mocks/TunnelAdapterDummy.swift
+++ b/ios/PacketTunnelCoreTests/Mocks/TunnelAdapterDummy.swift
@@ -7,9 +7,8 @@
 //
 
 import Foundation
+import MullvadTypes
 import PacketTunnelCore
-
-@testable import WireGuardKitTypes  // For DaitaConfiguration, TunnelAdapterConfiguration
 
 /// Dummy tunnel adapter that does nothing and reports no errors.
 class TunnelAdapterDummy: TunnelAdapterProtocol, @unchecked Sendable {

--- a/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
+++ b/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
@@ -9,8 +9,9 @@
 @preconcurrency import Combine
 import MullvadTypes
 import Network
-import WireGuardKitTypes  // For IPAddressRange
 import XCTest
+
+import class WireGuardKitTypes.PrivateKey
 
 @testable import MullvadMockData
 @testable import MullvadREST

--- a/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
+++ b/ios/PacketTunnelCoreTests/PacketTunnelActorTests.swift
@@ -11,8 +11,6 @@ import MullvadTypes
 import Network
 import XCTest
 
-import class WireGuardKitTypes.PrivateKey
-
 @testable import MullvadMockData
 @testable import MullvadREST
 @testable import MullvadSettings


### PR DESCRIPTION
Another GotaTun PR where we're replacing the `IPAddressRange` and `DaitaConfiguration` types from WireGuardKit with our own.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10173)
<!-- Reviewable:end -->
