### PR TITLE
Remove cache migration from installer on Windows

### DIFF
--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -365,40 +365,6 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 !define InstallTrayIcon '!insertmacro "InstallTrayIcon"'
 
 #
-# MigrateCache
-#
-# Move old cache files to the new cache directory.
-# This is for upgrades from versions <= 2020.8-beta2.
-#
-!macro MigrateCache
-
-	log::Log "MigrateCache()"
-
-	Push $0
-	Push $1
-
-	cleanup::MigrateCache
-
-	Pop $0
-	Pop $1
-
-	${If} $0 != ${MULLVAD_SUCCESS}
-		log::Log "Failed to migrate cache: $1"
-		Goto MigrateCache_return
-	${EndIf}
-
-	log::Log "MigrateCache() completed successfully"
-
-	MigrateCache_return:
-
-	Pop $1
-	Pop $0
-
-!macroend
-
-!define MigrateCache '!insertmacro "MigrateCache"'
-
-#
 # RemoveLogsAndCache
 #
 # Call into helper DLL instructing it to remove all logs and cache
@@ -812,7 +778,6 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 	SetShellVarContext current
 	RMDir /r "$LOCALAPPDATA\mullvad-vpn-updater"
 
-	${MigrateCache}
 	${RemoveRelayCache}
 	${RemoveApiAddressCache}
 

--- a/windows/nsis-plugins/src/cleanup/cleaningops.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleaningops.cpp
@@ -114,50 +114,6 @@ size_t EqualTokensCount(It lhsBegin, It lhsEnd, It rhsBegin, It rhsEnd)
 namespace cleaningops
 {
 
-//
-// Migrate cache for versions <= 2020.8-beta2.
-//
-void MigrateCacheServiceUser()
-{
-	const auto newCacheDir = GetSystemCacheDirectory();
-	common::fs::Mkdir(newCacheDir);
-
-	const auto localAppData = GetSystemUserLocalAppData();
-
-	const auto oldCacheDir = std::filesystem::path(localAppData).append(L"Mullvad VPN");
-
-	common::fs::ScopedNativeFileSystem nativeFileSystem;
-
-	common::security::AddAdminToObjectDacl(oldCacheDir, SE_FILE_OBJECT);
-
-	{
-		common::fs::FileEnumerator files(oldCacheDir);
-
-		auto notNamedSet = std::make_unique<common::fs::FilterNotNamedSet>();
-
-		notNamedSet->addObject(L"account-history.json");
-		notNamedSet->addObject(L"settings.json");
-		notNamedSet->addObject(L"device.json");
-
-		files.addFilter(std::move(notNamedSet));
-		files.addFilter(std::make_unique<common::fs::FilterFiles>());
-
-		WIN32_FIND_DATAW file;
-
-		while (files.next(file))
-		{
-			const auto source = std::filesystem::path(files.getDirectory()).append(file.cFileName);
-			const auto target = std::filesystem::path(newCacheDir).append(file.cFileName);
-			std::filesystem::rename(source, target);
-		}
-	}
-
-	//
-	// This fails unless the directory is empty. Settings remain in this directory.
-	//
-	RemoveDirectoryW(std::wstring(L"\\\\?\\").append(oldCacheDir).c_str());
-}
-
 void RemoveLogsCacheCurrentUser()
 {
 	const auto localAppData = common::fs::GetKnownFolderPath(FOLDERID_LocalAppData);

--- a/windows/nsis-plugins/src/cleanup/cleaningops.h
+++ b/windows/nsis-plugins/src/cleanup/cleaningops.h
@@ -3,8 +3,6 @@
 namespace cleaningops
 {
 
-void MigrateCacheServiceUser();
-
 void RemoveLogsCacheCurrentUser();
 void RemoveLogsCacheOtherUsers();
 void RemoveLogsServiceUser();

--- a/windows/nsis-plugins/src/cleanup/cleanup.cpp
+++ b/windows/nsis-plugins/src/cleanup/cleanup.cpp
@@ -79,36 +79,6 @@ void __declspec(dllexport) NSISCALL RemoveLogsAndCache
 	pushint(success ? NsisStatus::SUCCESS : NsisStatus::GENERAL_ERROR);
 }
 
-void __declspec(dllexport) NSISCALL MigrateCache
-(
-	HWND hwndParent,
-	int string_size,
-	LPTSTR variables,
-	stack_t** stacktop,
-	extra_parameters* extra,
-	...
-)
-{
-	EXDLL_INIT();
-
-	try
-	{
-		cleaningops::MigrateCacheServiceUser();
-		pushstring(L"");
-		pushint(NsisStatus::SUCCESS);
-	}
-	catch (std::exception &err)
-	{
-		pushstring(common::string::ToWide(err.what()).c_str());
-		pushint(NsisStatus::GENERAL_ERROR);
-	}
-	catch (...)
-	{
-		pushstring(L"Unspecified error");
-		pushint(NsisStatus::GENERAL_ERROR);
-	}
-}
-
 void __declspec(dllexport) NSISCALL RemoveSettings
 (
 	HWND hwndParent,

--- a/windows/nsis-plugins/src/cleanup/cleanup.def
+++ b/windows/nsis-plugins/src/cleanup/cleanup.def
@@ -4,7 +4,6 @@ EXPORTS
 
 CloseHoggingProcesses
 IsEmptyDir
-MigrateCache
 RemoveLogsAndCache
 RemoveSettings
 RemoveRelayCache


### PR DESCRIPTION
Gets rid of the misleading error in `install.log`:

```
[2026-04-10 16:11:02.905] MigrateCache()
[2026-04-10 16:11:03.231] Failed to migrate cache: Retrieve DACL for object: 0x00000002: The system cannot find the file specified. (security.cpp: 105)
```

This code only affected upgrades from 2020.8-beta2 or older.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10175)
<!-- Reviewable:end -->
