### PR TITLE
Fix bug in `ObfuscationQuery`

### DIFF
--- a/mullvad-relay-selector/src/relay_selector/detailer.rs
+++ b/mullvad-relay-selector/src/relay_selector/detailer.rs
@@ -23,7 +23,7 @@ use talpid_types::net::{
     wireguard::{PeerConfig, PublicKey},
 };
 
-use crate::query::ObfuscationQuery;
+use crate::query::ObfuscationMode;
 
 use super::{WireguardConfig, query::WireguardRelayQuery};
 
@@ -184,7 +184,7 @@ fn get_port_for_wireguard_relay(
     query: &WireguardRelayQuery,
     data: &EndpointData,
 ) -> Result<u16, Error> {
-    let port = if let ObfuscationQuery::Port(port) = query.obfuscation {
+    let port = if let Constraint::Only(ObfuscationMode::Port(port)) = query.obfuscation {
         port.get()
     } else {
         Constraint::Any

--- a/mullvad-relay-selector/src/relay_selector/matcher.rs
+++ b/mullvad-relay-selector/src/relay_selector/matcher.rs
@@ -11,7 +11,7 @@ use mullvad_types::{
 };
 use talpid_types::net::IpVersion;
 
-use super::query::{ObfuscationQuery, RelayQuery, WireguardRelayQuery};
+use super::query::{ObfuscationMode, RelayQuery, WireguardRelayQuery};
 
 /// Filter a list of relays and their endpoints based on constraints.
 /// Only relays with (and including) matching endpoints are returned.
@@ -94,31 +94,34 @@ fn filter_on_obfuscation(
     relay_list: &RelayList,
     relay: &WireguardRelay,
 ) -> bool {
-    use ObfuscationQuery::*;
+    use ObfuscationMode::*;
     match &query.obfuscation {
-        // Shadowsocks has relay-specific constraints
-        Shadowsocks(settings) => {
-            let wg_data = &relay_list.wireguard;
-            filter_on_shadowsocks(
-                &wg_data.shadowsocks_port_ranges,
-                query.ip_version.as_ref(),
-                settings,
-                relay.endpoint(),
-            )
-        }
-        // QUIC is only enabled on some relays
-        Quic => match relay.endpoint().quic() {
-            Some(quic) => match query.ip_version {
-                Constraint::Any => true,
-                Constraint::Only(IpVersion::V4) => quic.in_ipv4().next().is_some(),
-                Constraint::Only(IpVersion::V6) => quic.in_ipv6().next().is_some(),
+        Constraint::Any => true,
+        Constraint::Only(mode) => match mode {
+            // Shadowsocks has relay-specific constraints
+            Shadowsocks(settings) => {
+                let wg_data = &relay_list.wireguard;
+                filter_on_shadowsocks(
+                    &wg_data.shadowsocks_port_ranges,
+                    query.ip_version.as_ref(),
+                    settings,
+                    relay.endpoint(),
+                )
+            }
+            // QUIC is only enabled on some relays
+            Quic => match relay.endpoint().quic() {
+                Some(quic) => match query.ip_version {
+                    Constraint::Any => true,
+                    Constraint::Only(IpVersion::V4) => quic.in_ipv4().next().is_some(),
+                    Constraint::Only(IpVersion::V6) => quic.in_ipv6().next().is_some(),
+                },
+                None => false,
             },
-            None => false,
+            // LWO is only enabled on some relays
+            Lwo(_) => relay.endpoint().lwo,
+            // Other relays are compatible with this query
+            Off | Port(_) | Udp2tcp(_) => true,
         },
-        // LWO is only enabled on some relays
-        Lwo(_) => relay.endpoint().lwo,
-        // Other relays are compatible with this query
-        Off | Auto | Port(_) | Udp2tcp(_) => true,
     }
 }
 

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -12,7 +12,7 @@ use relays::{Multihop, Singlehop, WireguardConfig};
 use crate::{
     detailer::wireguard_endpoint,
     error::{EndpointErrorDetails, Error},
-    query::{ObfuscationQuery, RelayQuery, RelayQueryExt, WireguardRelayQuery},
+    query::{ObfuscationMode, RelayQuery, RelayQueryExt, WireguardRelayQuery},
 };
 
 use either::Either;
@@ -277,7 +277,7 @@ impl<'a> TryFrom<NormalConfig<'a>> for RelayQuery {
                 entry_location,
                 entry_providers,
                 entry_ownership,
-                obfuscation: ObfuscationQuery::from(obfuscation_settings),
+                obfuscation: query::obfuscation_constraint_from_settings(obfuscation_settings),
                 daita: Constraint::Only(daita),
                 daita_use_multihop_if_necessary: Constraint::Only(daita_use_multihop_if_necessary),
                 quantum_resistant: Constraint::Only(quantum_resistant),
@@ -544,7 +544,7 @@ impl RelaySelector {
         // DAITA & obfuscation should only be enabled for the entry relay
         let mut wireguard_constraints = exit_relay_query.wireguard_constraints().clone();
         wireguard_constraints.daita = Constraint::Only(false);
-        wireguard_constraints.obfuscation = ObfuscationQuery::Off;
+        wireguard_constraints.obfuscation = Constraint::Only(ObfuscationMode::Off);
         exit_relay_query.set_wireguard_constraints(wireguard_constraints);
 
         let exit_candidates =
@@ -608,7 +608,7 @@ impl RelaySelector {
         // DAITA & Obfuscation should only be enabled for the entry relay
         let mut wg_constraints = exit_relay_query.wireguard_constraints().clone();
         wg_constraints.daita = Constraint::Only(false);
-        wg_constraints.obfuscation = ObfuscationQuery::Off;
+        wg_constraints.obfuscation = Constraint::Only(ObfuscationMode::Off);
         exit_relay_query.set_wireguard_constraints(wg_constraints);
 
         // Opportunistically filter on `include_in_country`.
@@ -711,32 +711,36 @@ impl RelaySelector {
         };
         let box_obfuscation_error = |error: helpers::Error| Error::NoObfuscator(Box::new(error));
 
-        match &query.wireguard_constraints().obfuscation {
-            ObfuscationQuery::Off => Ok(None),
+        let mode = match &query.wireguard_constraints().obfuscation {
+            Constraint::Only(mode) => mode,
             #[cfg(not(feature = "staggered-obfuscation"))]
-            ObfuscationQuery::Auto => Ok(None),
-            ObfuscationQuery::Port(_) => Ok(None),
+            Constraint::Any => return Ok(None),
             #[cfg(feature = "staggered-obfuscation")]
-            ObfuscationQuery::Auto => {
+            Constraint::Any => {
                 let shadowsocks_ports = &parsed_relays.wireguard.shadowsocks_port_ranges;
                 let udp2tcp_ports = &parsed_relays.wireguard.udp2tcp_ports;
-                helpers::get_multiplexer_obfuscator(
+                return helpers::get_multiplexer_obfuscator(
                     udp2tcp_ports,
                     shadowsocks_ports,
                     obfuscator_relay,
                     endpoint,
                 )
                 .map(Some)
-                .map_err(box_obfuscation_error)
+                .map_err(box_obfuscation_error);
             }
-            ObfuscationQuery::Udp2tcp(settings) => {
+        };
+
+        match mode {
+            ObfuscationMode::Off => Ok(None),
+            ObfuscationMode::Port(_) => Ok(None),
+            ObfuscationMode::Udp2tcp(settings) => {
                 let udp2tcp_ports = &parsed_relays.wireguard.udp2tcp_ports;
 
                 helpers::get_udp2tcp_obfuscator(settings, udp2tcp_ports, obfuscator_relay, endpoint)
                     .map(|obfs| Some(obfs.into()))
                     .map_err(box_obfuscation_error)
             }
-            ObfuscationQuery::Shadowsocks(settings) => {
+            ObfuscationMode::Shadowsocks(settings) => {
                 let port_ranges = &parsed_relays.wireguard.shadowsocks_port_ranges;
                 let obfuscation = helpers::get_shadowsocks_obfuscator(
                     settings,
@@ -749,11 +753,11 @@ impl RelaySelector {
 
                 Ok(Some(obfuscation))
             }
-            ObfuscationQuery::Quic => {
+            ObfuscationMode::Quic => {
                 let ip_version = query.wireguard_constraints().ip_version;
                 Ok(helpers::get_quic_obfuscator(obfuscator_relay, ip_version).map(Into::into))
             }
-            ObfuscationQuery::Lwo(settings) => {
+            ObfuscationMode::Lwo(settings) => {
                 let port_ranges = &parsed_relays.wireguard.port_ranges;
                 let obfuscation =
                     helpers::get_lwo_obfuscator(obfuscator_relay, endpoint, port_ranges, *settings)

--- a/mullvad-relay-selector/src/relay_selector/query.rs
+++ b/mullvad-relay-selector/src/relay_selector/query.rs
@@ -139,11 +139,7 @@ impl RelayQuery {
     /// end to end tests where you must use the management interface
     /// to apply settings to the daemon.
     pub fn into_settings(self) -> (RelayConstraints, ObfuscationSettings) {
-        let obfuscation = self
-            .wireguard_constraints
-            .obfuscation
-            .clone()
-            .into_settings();
+        let obfuscation = obfuscation_to_settings(self.wireguard_constraints.obfuscation.clone());
         let constraints = RelayConstraints {
             location: self.location,
             providers: self.providers,
@@ -203,17 +199,19 @@ pub struct WireguardRelayQuery {
     pub entry_location: Constraint<LocationConstraint>,
     pub entry_providers: Constraint<Providers>,
     pub entry_ownership: Constraint<Ownership>,
-    pub obfuscation: ObfuscationQuery,
+    pub obfuscation: Constraint<ObfuscationMode>,
     pub daita: Constraint<bool>,
     pub daita_use_multihop_if_necessary: Constraint<bool>,
     pub quantum_resistant: Constraint<QuantumResistantState>,
 }
 
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
-pub enum ObfuscationQuery {
+/// Represents a specific obfuscation method (or explicit "off").
+///
+/// This enum does *not* have an `Auto` variant — that role is played by
+/// `Constraint::Any` on the wrapping `Constraint<ObfuscationMode>`.
+#[derive(Debug, Clone, Eq, PartialEq, Intersection)]
+pub enum ObfuscationMode {
     Off,
-    #[default]
-    Auto,
     Port(WireguardPortSettings),
     Udp2tcp(Udp2TcpObfuscationSettings),
     Shadowsocks(ShadowsocksSettings),
@@ -221,34 +219,33 @@ pub enum ObfuscationQuery {
     Lwo(LwoSettings),
 }
 
-impl ObfuscationQuery {
-    fn into_settings(self) -> ObfuscationSettings {
+impl ObfuscationMode {
+    pub(crate) fn into_settings(self) -> ObfuscationSettings {
         let selected_obfuscation = match self {
-            ObfuscationQuery::Off => SelectedObfuscation::Off,
-            ObfuscationQuery::Auto => SelectedObfuscation::Auto,
-            ObfuscationQuery::Quic => SelectedObfuscation::Quic,
-            ObfuscationQuery::Lwo(settings) => {
+            ObfuscationMode::Off => SelectedObfuscation::Off,
+            ObfuscationMode::Quic => SelectedObfuscation::Quic,
+            ObfuscationMode::Lwo(settings) => {
                 return ObfuscationSettings {
                     selected_obfuscation: SelectedObfuscation::Lwo,
                     lwo: settings,
                     ..Default::default()
                 };
             }
-            ObfuscationQuery::Port(wireguard_port) => {
+            ObfuscationMode::Port(wireguard_port) => {
                 return ObfuscationSettings {
                     selected_obfuscation: SelectedObfuscation::WireguardPort,
                     wireguard_port,
                     ..Default::default()
                 };
             }
-            ObfuscationQuery::Udp2tcp(settings) => {
+            ObfuscationMode::Udp2tcp(settings) => {
                 return ObfuscationSettings {
                     selected_obfuscation: SelectedObfuscation::Udp2Tcp,
                     udp2tcp: settings,
                     ..Default::default()
                 };
             }
-            ObfuscationQuery::Shadowsocks(settings) => {
+            ObfuscationMode::Shadowsocks(settings) => {
                 return ObfuscationSettings {
                     selected_obfuscation: SelectedObfuscation::Shadowsocks,
                     shadowsocks: settings,
@@ -263,41 +260,36 @@ impl ObfuscationQuery {
     }
 }
 
-impl From<ObfuscationSettings> for ObfuscationQuery {
-    /// A query for obfuscation settings.
-    ///
-    /// Note that this drops obfuscation protocol specific constraints from [`ObfuscationSettings`]
-    /// when the selected obfuscation type is auto.
-    fn from(obfuscation: ObfuscationSettings) -> Self {
-        use SelectedObfuscation::*;
-        match obfuscation.selected_obfuscation {
-            Off => ObfuscationQuery::Off,
-            Auto => ObfuscationQuery::Auto,
-            WireguardPort => ObfuscationQuery::Port(obfuscation.wireguard_port),
-            Udp2Tcp => ObfuscationQuery::Udp2tcp(obfuscation.udp2tcp),
-            Shadowsocks => ObfuscationQuery::Shadowsocks(obfuscation.shadowsocks),
-            Quic => ObfuscationQuery::Quic,
-            Lwo => ObfuscationQuery::Lwo(obfuscation.lwo),
-        }
+pub(crate) fn obfuscation_to_settings(
+    constraint: Constraint<ObfuscationMode>,
+) -> ObfuscationSettings {
+    match constraint {
+        Constraint::Any => ObfuscationSettings {
+            selected_obfuscation: SelectedObfuscation::Auto,
+            ..Default::default()
+        },
+        Constraint::Only(mode) => mode.into_settings(),
     }
 }
 
-impl Intersection for ObfuscationQuery {
-    fn intersection(self, other: Self) -> Option<Self> {
-        match (self, other) {
-            (ObfuscationQuery::Off, _) | (_, ObfuscationQuery::Off) => Some(ObfuscationQuery::Off),
-            (ObfuscationQuery::Auto, other) | (other, ObfuscationQuery::Auto) => Some(other),
-            (ObfuscationQuery::Udp2tcp(a), ObfuscationQuery::Udp2tcp(b)) => {
-                Some(ObfuscationQuery::Udp2tcp(a.intersection(b)?))
-            }
-            (ObfuscationQuery::Shadowsocks(a), ObfuscationQuery::Shadowsocks(b)) => {
-                Some(ObfuscationQuery::Shadowsocks(a.intersection(b)?))
-            }
-            (ObfuscationQuery::Lwo(a), ObfuscationQuery::Lwo(b)) => {
-                Some(ObfuscationQuery::Lwo(a.intersection(b)?))
-            }
-            _ => None,
-        }
+/// Convert [`ObfuscationSettings`] into a `Constraint<ObfuscationMode>`.
+///
+/// `SelectedObfuscation::Auto` maps to `Constraint::Any`.
+///
+/// Note: this drops protocol-specific constraints from [`ObfuscationSettings`]
+/// when the selected obfuscation type is auto.
+pub fn obfuscation_constraint_from_settings(
+    obfuscation: ObfuscationSettings,
+) -> Constraint<ObfuscationMode> {
+    use SelectedObfuscation::*;
+    match obfuscation.selected_obfuscation {
+        Auto => Constraint::Any,
+        Off => Constraint::Only(ObfuscationMode::Off),
+        WireguardPort => Constraint::Only(ObfuscationMode::Port(obfuscation.wireguard_port)),
+        Udp2Tcp => Constraint::Only(ObfuscationMode::Udp2tcp(obfuscation.udp2tcp)),
+        Shadowsocks => Constraint::Only(ObfuscationMode::Shadowsocks(obfuscation.shadowsocks)),
+        Quic => Constraint::Only(ObfuscationMode::Quic),
+        Lwo => Constraint::Only(ObfuscationMode::Lwo(obfuscation.lwo)),
     }
 }
 
@@ -316,7 +308,7 @@ impl WireguardRelayQuery {
             entry_location: Constraint::Any,
             entry_providers: Constraint::Any,
             entry_ownership: Constraint::Any,
-            obfuscation: ObfuscationQuery::Auto,
+            obfuscation: Constraint::Any,
             daita: Constraint::Any,
             daita_use_multihop_if_necessary: Constraint::Any,
             quantum_resistant: Constraint::Any,
@@ -369,7 +361,7 @@ pub mod builder {
         wireguard::QuantumResistantState,
     };
 
-    use super::{ObfuscationQuery, RelayQuery};
+    use super::{ObfuscationMode, RelayQuery};
 
     // Re-exports
     pub use mullvad_types::relay_constraints::{
@@ -608,7 +600,8 @@ pub mod builder {
                 daita: self.settings.daita,
                 quantum_resistant: self.settings.quantum_resistant,
             };
-            self.query.wireguard_constraints.obfuscation = ObfuscationQuery::Port(port);
+            self.query.wireguard_constraints.obfuscation =
+                Constraint::Only(ObfuscationMode::Port(port));
             RelayQueryBuilder {
                 query: self.query,
                 settings,
@@ -630,7 +623,8 @@ pub mod builder {
                 daita: self.settings.daita,
                 quantum_resistant: self.settings.quantum_resistant,
             };
-            self.query.wireguard_constraints.obfuscation = ObfuscationQuery::Udp2tcp(obfuscation);
+            self.query.wireguard_constraints.obfuscation =
+                Constraint::Only(ObfuscationMode::Udp2tcp(obfuscation));
             RelayQueryBuilder {
                 query: self.query,
                 settings: protocol,
@@ -652,7 +646,7 @@ pub mod builder {
                 quantum_resistant: self.settings.quantum_resistant,
             };
             self.query.wireguard_constraints.obfuscation =
-                ObfuscationQuery::Shadowsocks(obfuscation);
+                Constraint::Only(ObfuscationMode::Shadowsocks(obfuscation));
             RelayQueryBuilder {
                 query: self.query,
                 settings: protocol,
@@ -661,7 +655,7 @@ pub mod builder {
 
         /// Enable QUIC obfuscation.
         pub fn quic(mut self) -> RelayQueryBuilder<Multihop, Quic, Daita, QuantumResistant> {
-            self.query.wireguard_constraints.obfuscation = ObfuscationQuery::Quic;
+            self.query.wireguard_constraints.obfuscation = Constraint::Only(ObfuscationMode::Quic);
             RelayQueryBuilder {
                 query: self.query,
                 settings: Settings {
@@ -676,7 +670,7 @@ pub mod builder {
         /// Enable LWO obfuscation.
         pub fn lwo(mut self) -> RelayQueryBuilder<Multihop, Lwo, Daita, QuantumResistant> {
             self.query.wireguard_constraints.obfuscation =
-                ObfuscationQuery::Lwo(LwoSettings::default());
+                Constraint::Only(ObfuscationMode::Lwo(LwoSettings::default()));
             RelayQueryBuilder {
                 query: self.query,
                 settings: Settings {
@@ -697,7 +691,7 @@ pub mod builder {
         pub fn udp2tcp_port(mut self, port: u16) -> Self {
             self.settings.obfuscation.port = Constraint::Only(port);
             self.query.wireguard_constraints.obfuscation =
-                ObfuscationQuery::Udp2tcp(self.settings.obfuscation.clone());
+                Constraint::Only(ObfuscationMode::Udp2tcp(self.settings.obfuscation.clone()));
             self
         }
     }
@@ -742,7 +736,7 @@ mod test {
     };
     use proptest::prelude::*;
 
-    use super::{Intersection, ObfuscationQuery};
+    use super::Intersection;
 
     // Define proptest combinators for the `Constraint` type.
 
@@ -820,11 +814,11 @@ mod test {
             prop_assert_eq!(left, right);
         }
 
-        /// When obfuscation is set to automatic in [`ObfuscationSettings`], the query should not
-        /// contain any specific obfuscation protocol settings.
+        /// When obfuscation is set to automatic in [`ObfuscationSettings`], the query should
+        /// convert to `Constraint::Any`.
         #[test]
         fn test_auto_obfuscation_settings(port1 in constraint(proptest::arbitrary::any::<u16>()), port2 in constraint(proptest::arbitrary::any::<u16>())) {
-            let query = ObfuscationQuery::from(ObfuscationSettings {
+            let query = super::obfuscation_constraint_from_settings(ObfuscationSettings {
                 selected_obfuscation: SelectedObfuscation::Auto,
                 udp2tcp: Udp2TcpObfuscationSettings {
                     port: port1,
@@ -835,7 +829,7 @@ mod test {
                 wireguard_port: port1.into(),
                 lwo: LwoSettings { port: port1 },
             });
-            assert_eq!(query, ObfuscationQuery::Auto);
+            assert_eq!(query, Constraint::Any);
         }
     }
 }

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -16,9 +16,10 @@ use talpid_types::net::{
 use mullvad_relay_selector::{
     Config, Error, GetRelay, MultihopConstraints, Predicate, RETRY_ORDER, Reason, RelaySelector,
     SelectedObfuscator, WireguardConfig,
-    query::{ObfuscationQuery, builder::RelayQueryBuilder},
+    query::{ObfuscationMode, builder::RelayQueryBuilder},
 };
 use mullvad_types::{
+    constraints::Constraint,
     endpoint::MullvadEndpoint,
     location::Location,
     relay_constraints::{GeographicLocationConstraint, Ownership, Providers, RelayOverride},
@@ -334,12 +335,15 @@ fn test_retry_order() {
                 ));
 
                 assert!(match &query.wireguard_constraints().obfuscation {
-                    ObfuscationQuery::Auto => true,
-                    ObfuscationQuery::Off | ObfuscationQuery::Port(_) => obfuscator.is_none(),
-                    ObfuscationQuery::Quic
-                    | ObfuscationQuery::Udp2tcp(_)
-                    | ObfuscationQuery::Shadowsocks(_)
-                    | ObfuscationQuery::Lwo(_) => obfuscator.is_some(),
+                    Constraint::Any => true,
+                    Constraint::Only(ObfuscationMode::Off | ObfuscationMode::Port(_)) =>
+                        obfuscator.is_none(),
+                    Constraint::Only(
+                        ObfuscationMode::Quic
+                        | ObfuscationMode::Udp2tcp(_)
+                        | ObfuscationMode::Shadowsocks(_)
+                        | ObfuscationMode::Lwo(_),
+                    ) => obfuscator.is_some(),
                 });
             }
             _ => unreachable!(),
@@ -789,10 +793,7 @@ fn test_selecting_endpoint_with_auto_obfuscation() {
     let relay_selector = default_relay_selector();
 
     let query = RelayQueryBuilder::new().build();
-    assert_eq!(
-        query.wireguard_constraints().obfuscation,
-        ObfuscationQuery::Auto
-    );
+    assert_eq!(query.wireguard_constraints().obfuscation, Constraint::Any);
 
     for _ in 0..100 {
         let relay = relay_selector.get_relay_by_query(query.clone()).unwrap();


### PR DESCRIPTION
The `Intersection` trait did not handle QUIC and LWO correctly, causing them to be missed in the retry order.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10178)
<!-- Reviewable:end -->
