### PR TITLE
Fix select location view sometimes using wrong location type

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/SelectLocationViewContext.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/views/select-location/SelectLocationViewContext.tsx
@@ -40,18 +40,28 @@ export const useSelectLocationViewContext = (): SelectLocationViewContextProps =
 type SelectLocationViewProviderProps = React.PropsWithChildren;
 
 export function SelectLocationViewProvider({ children }: SelectLocationViewProviderProps) {
-  const locationTypeSelector = useSelector((state) => state.userInterface.selectLocationView);
   const { setSelectLocationView } = useActions(userInterface);
   const [searchTerm, setSearchTerm] = React.useState('');
   const relaySettings = useNormalRelaySettings();
-  const selectedLocation = useSelectedLocation(locationTypeSelector);
+  const locationTypeSelector = useSelector((state) => state.userInterface.selectLocationView);
 
-  const filteredCountries = useFilterCountryLocations(locationTypeSelector);
+  const locationType = React.useMemo(() => {
+    const allowEntryLocations = relaySettings?.wireguard.useMultihop;
+
+    if (allowEntryLocations) {
+      return locationTypeSelector;
+    }
+    return LocationType.exit;
+  }, [locationTypeSelector, relaySettings]);
+
+  const filteredCountries = useFilterCountryLocations(locationType);
   const filteredCountryLocations = useMapReduxCountriesToCountryLocations(
-    locationTypeSelector,
+    locationType,
     filteredCountries,
   );
   const searchedCountryLocations = useSearchCountryLocations(filteredCountryLocations, searchTerm);
+
+  const selectedLocation = useSelectedLocation(locationType);
 
   const filteredCustomListLocations = useMapCustomListsToLocations(
     searchedCountryLocations,
@@ -62,15 +72,6 @@ export function SelectLocationViewProvider({ children }: SelectLocationViewProvi
     filteredCustomListLocations,
     searchTerm,
   );
-
-  const locationType = React.useMemo(() => {
-    const allowEntryLocations = relaySettings?.wireguard.useMultihop;
-
-    if (allowEntryLocations) {
-      return locationTypeSelector;
-    }
-    return LocationType.exit;
-  }, [locationTypeSelector, relaySettings]);
 
   const value = React.useMemo(
     () => ({


### PR DESCRIPTION
This caused the incorrect location to be marked as selected under certain circumstances, could be reproduced with these steps:

1. Enable multihop
2. Go into select location view and select entry and exit locations
3. Click entry tab
4. Close select location view
5. Disable multihop
6. The entry location will now be shown as selected in the select location view

This should be fixed with the changes in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10184)
<!-- Reviewable:end -->
