### PR TITLE
Remove fdroid build type

### DIFF
--- a/.github/workflows/android-reproducible-builds.yml
+++ b/.github/workflows/android-reproducible-builds.yml
@@ -49,7 +49,7 @@ jobs:
 
   # Considered our source of truth.
   build-using-container:
-    name: Build fdroid variant using container
+    name: Build release variant using container
     runs-on: ubuntu-latest
     needs: set-up-env
     steps:
@@ -69,18 +69,18 @@ jobs:
           android/gradle.properties
 
       - name: Build app
-        run: ./building/containerized-build.sh android --fdroid
+        run: ./building/containerized-build.sh android --oss-only
 
       - name: Upload apks
         uses: actions/upload-artifact@v4
         with:
           name: apk-container
-          path: android/app/build/outputs/apk/ossProd/fdroid/app-oss-prod-fdroid-unsigned.apk
+          path: android/app/build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk
           if-no-files-found: error
           retention-days: 7
 
   build-using-fdroidserver:
-    name: Build fdroid variant using fdroidserver
+    name: Build release variant using fdroidserver
     runs-on: ubuntu-latest
     needs: set-up-env
     steps:
@@ -143,12 +143,12 @@ jobs:
         with:
           name: apk-fdroidserver
           path: |
-            build/net\.mullvad\.mullvadvpn/android/app/build/outputs/apk/ossProd/fdroid/app-oss-prod-fdroid-unsigned.apk
+            build/net\.mullvad\.mullvadvpn/android/app/build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk
           if-no-files-found: error
           retention-days: 7
 
   build-using-nix:
-    name: Build fdroid variant using nix
+    name: Build release variant using nix
     runs-on: ${{ matrix.runs-on }}
     needs: set-up-env
     strategy:
@@ -172,13 +172,13 @@ jobs:
       - uses: cachix/install-nix-action@v31
 
       - name: Build app
-        run: nix develop .#android -c buildFdroid
+        run: nix develop .#android -c buildRelease
 
       - name: Upload apks
         uses: actions/upload-artifact@v4
         with:
           name: apk-nix-${{ matrix.runs-on }}
-          path: android/app/build/outputs/apk/ossProd/fdroid/app-oss-prod-fdroid-unsigned.apk
+          path: android/app/build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk
           if-no-files-found: error
           retention-days: 7
 
@@ -209,7 +209,9 @@ jobs:
 
       - name: Compare apk against source of truth
         working-directory: ./artifacts
-        run: diff apk-container/app-oss-prod-fdroid-unsigned.apk ${{ matrix.artifact}}/app-oss-prod-fdroid-unsigned.apk
+        run: diff \
+          apk-container/app-oss-prod-release-unsigned.apk \
+          ${{ matrix.artifact}}/app-oss-prod-release-unsigned.apk
 
   # Included in this workflow since it's the only place
   # release artifacts are built. Should eventually be moved.
@@ -234,7 +236,7 @@ jobs:
 
       - name: Extract resources
         run: |
-          apktool d app-oss-prod-fdroid-unsigned.apk -s -o output
+          apktool d app-oss-prod-release-unsigned.apk -s -o output
 
       - name: Compare manifest permissions with checked in snapshot
         run: |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -98,11 +98,6 @@ android {
             )
         }
         getByName(BuildTypes.DEBUG) { isPseudoLocalesEnabled = true }
-        create(BuildTypes.FDROID) {
-            initWith(buildTypes.getByName(BuildTypes.RELEASE))
-            signingConfig = null
-            matchingFallbacks += BuildTypes.RELEASE
-        }
         create(BuildTypes.LEAK_CANARY) {
             initWith(buildTypes.getByName(BuildTypes.DEBUG))
             applicationIdSuffix = ".leakcanary"

--- a/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
+++ b/android/app/src/main/kotlin/net/mullvad/mullvadvpn/di/UiModule.kt
@@ -62,7 +62,6 @@ import net.mullvad.mullvadvpn.feature.vpnsettings.impl.VpnSettingsViewModel
 import net.mullvad.mullvadvpn.feature.vpnsettings.impl.dns.DnsDialogViewModel
 import net.mullvad.mullvadvpn.feature.vpnsettings.impl.mtu.MtuDialogViewModel
 import net.mullvad.mullvadvpn.lib.common.constant.BillingTypes
-import net.mullvad.mullvadvpn.lib.common.constant.BuildTypes
 import net.mullvad.mullvadvpn.lib.model.PackageName
 import net.mullvad.mullvadvpn.lib.model.RelayListType
 import net.mullvad.mullvadvpn.lib.payment.PaymentProvider
@@ -266,7 +265,7 @@ val uiModule = module {
             appVersionInfoRepository = get(),
             resources = get(),
             isPlayBuild = IS_PLAY_BUILD,
-            isFdroidBuild = IS_FDROID_BUILD,
+            isFdroidBuild = false,
             self = get(),
         )
     }
@@ -286,7 +285,7 @@ val uiModule = module {
             systemVpnSettingsUseCase = get(),
             resources = get(),
             isPlayBuild = IS_PLAY_BUILD,
-            isFdroidBuild = IS_FDROID_BUILD,
+            isFdroidBuild = false,
             self = get(),
         )
     }
@@ -434,5 +433,4 @@ const val APP_PREFERENCES_NAME = "${BuildConfig.APPLICATION_ID}.app_preferences"
 const val KERMIT_FILE_LOG_DIR_NAME = "android_app_logs"
 
 private const val BOOT_COMPLETED_RECEIVER_COMPONENT_NAME = "BOOT_COMPLETED_RECEIVER_COMPONENT_NAME"
-private val IS_FDROID_BUILD = BuildConfig.BUILD_TYPE == BuildTypes.FDROID
 private val IS_PLAY_BUILD = BuildConfig.FLAVOR_billing == BillingTypes.PLAY

--- a/android/build.sh
+++ b/android/build.sh
@@ -9,16 +9,20 @@ GRADLE_BUILD_TYPE="release"
 GRADLE_TASKS=(createOssProdReleaseDistApk createPlayProdReleaseDistApk)
 BUILD_BUNDLE="no"
 BUNDLE_TASKS=(createPlayProdReleaseDistBundle)
+SKIP_CLEAN_CHECK="no"
+OSS_ONLY="no"
 
 while [ -n "${1:-""}" ]; do
     if [[ "${1:-""}" == "--dev-build" ]]; then
         GRADLE_BUILD_TYPE="debug"
         GRADLE_TASKS=(createOssProdDebugDistApk)
         BUNDLE_TASKS=(createOssProdDebugDistBundle)
-    elif [[ "${1:-""}" == "--fdroid" ]]; then
-        GRADLE_BUILD_TYPE="fdroid"
-        GRADLE_TASKS=(createOssProdFdroidDistApk)
-        BUNDLE_TASKS=(createOssProdFdroidDistBundle)
+    elif [[ "${1:-""}" == "--oss-only" ]]; then
+        OSS_ONLY="yes"
+        GRADLE_TASKS=(createOssProdReleaseDistApk)
+        BUNDLE_TASKS=(createOssProdReleaseDistBundle)
+    elif [[ "${1:-""}" == "--skip-clean-check" ]]; then
+        SKIP_CLEAN_CHECK="yes"
     elif [[ "${1:-""}" == "--app-bundle" ]]; then
         BUILD_BUNDLE="yes"
     fi
@@ -33,7 +37,7 @@ function assert_clean_working_directory {
     fi
 }
 
-if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
+if [[ "$GRADLE_BUILD_TYPE" == "release" && "$SKIP_CLEAN_CHECK" == "no" ]]; then
     assert_clean_working_directory
 fi
 
@@ -43,7 +47,7 @@ PRODUCT_VERSION=$(cargo run -q --bin mullvad-version versionName)
 echo "Building Mullvad VPN $PRODUCT_VERSION for Android"
 echo ""
 
-if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
+if [[ "$GRADLE_BUILD_TYPE" == "release" && "$OSS_ONLY" == "no" ]]; then
     if [[ "$PRODUCT_VERSION" == *"-alpha"* || "$PRODUCT_VERSION" == *"-dev-"* ]]; then
         GRADLE_TASKS+=(
             createPlayDevmoleReleaseDistApk
@@ -80,7 +84,7 @@ fi
 # further up. Now verify that this is still true. The build process should never make the
 # working directory dirty.
 # This could for example happen if lockfiles are outdated, and the build process updates them.
-if [[ "$GRADLE_BUILD_TYPE" == "release" ]]; then
+if [[ "$GRADLE_BUILD_TYPE" == "release" && "$SKIP_CLEAN_CHECK" == "no" ]]; then
     assert_clean_working_directory
 fi
 

--- a/android/docs/BuildInstructions.md
+++ b/android/docs/BuildInstructions.md
@@ -273,12 +273,12 @@ To maximize reproducibility when building without the container:
 
 ### How to verify reproducible builds across environments
 
-A simple way to check that a build is reproducible across environments is to build the `fdroid` version of the app with and without the container and comparing the checksums of the produced APKs.
+A simple way to check that a build is reproducible across environments is to build the release version of the app with and without the container and comparing the checksums of the produced APKs.
 
-1. Build the app with the container: `../building/containerized-build.sh android --fdroid`
-1. Copy the resulting APK to a different folder as it will be overwritten in the following step: `app/build/outputs/apk/ossProd/fdroid/app-oss-prod-fdroid-unsigned.apk fdroid-container.apk`
-1. Build the app locally without the container: `./build.sh --fdroid`
-1. Compare the checksums of the two APKs: `sha256sum fdroid-container.apk app/build/outputs/apk/ossProd/fdroid/app-oss-prod-fdroid-unsigned.apk`
+1. Build the app with the container: `../building/containerized-build.sh android --oss-only`
+1. Copy the resulting APK to a different folder as it will be overwritten in the following step: `app/build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk release-container.apk`
+1. Build the app locally without the container: `./build.sh --oss-only`
+1. Compare the checksums of the two APKs: `sha256sum release-container.apk app/build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk`
 
 ## Verifying that an official release is reproducible
 

--- a/android/fdroid-build/metadata/net.mullvad.mullvadvpn.yml
+++ b/android/fdroid-build/metadata/net.mullvad.mullvadvpn.yml
@@ -28,7 +28,7 @@ Builds:
       - apt-get update
       - apt-get install -y build-essential protobuf-compiler libprotobuf-dev
     init: NDK_PATH="$$NDK$$" ../fdroid-build/init.sh
-    output: build/outputs/apk/ossProd/fdroid/app-oss-prod-fdroid-unsigned.apk
+    output: build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk
     rm:
       - desktop
       - graphics
@@ -51,7 +51,7 @@ Builds:
     build:
       - NDK_PATH="$$NDK$$" source ../fdroid-build/env.sh
       - echo $NDK_TOOLCHAIN_DIR "$$NDK$$"
-      - ../build.sh --fdroid
+      - ../build.sh --oss-only --skip-clean-check
     ndk: 27.3.13750724
 
 AutoUpdateMode: Version

--- a/android/gradle/build-logic/src/main/kotlin/utilities/BuildVariants.kt
+++ b/android/gradle/build-logic/src/main/kotlin/utilities/BuildVariants.kt
@@ -3,7 +3,6 @@ package utilities
 object BuildTypes {
     const val DEBUG = "debug"
     const val RELEASE = "release"
-    const val FDROID = "fdroid"
     const val LEAK_CANARY = "leakCanary"
 
     const val NON_MINIFIED = "nonMinified"

--- a/android/gradle/build-logic/src/main/kotlin/utilities/Utils.kt
+++ b/android/gradle/build-logic/src/main/kotlin/utilities/Utils.kt
@@ -5,9 +5,7 @@ import org.gradle.api.Project
 // This is a hack and will not work correctly under all scenarios.
 // See DROID-1696 for how we can improve this.
 fun Project.isReleaseBuild() =
-    gradle.startParameter.getTaskNames().any {
-        it.contains("release", ignoreCase = true) || it.contains("fdroid", ignoreCase = true)
-    }
+    gradle.startParameter.getTaskNames().any { it.contains("release", ignoreCase = true) }
 
 fun Project.generateRemapArguments(): String {
     val script = "${projectDir.parent}/../building/rustc-remap-path-prefix.sh"

--- a/android/gradle/build-logic/src/main/kotlin/utilities/VariantFilters.kt
+++ b/android/gradle/build-logic/src/main/kotlin/utilities/VariantFilters.kt
@@ -2,7 +2,6 @@ package utilities
 
 import utilities.BuildTypes.BENCHMARK
 import utilities.BuildTypes.DEBUG
-import utilities.BuildTypes.FDROID
 import utilities.BuildTypes.LEAK_CANARY
 import utilities.BuildTypes.NON_MINIFIED
 import utilities.BuildTypes.RELEASE
@@ -19,7 +18,6 @@ val ossProdAnyBuildType =
             when (it) {
                 DEBUG,
                 RELEASE,
-                FDROID,
                 LEAK_CANARY -> true
                 else -> false
             }

--- a/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/BuildTypes.kt
+++ b/android/lib/common/src/main/kotlin/net/mullvad/mullvadvpn/lib/common/constant/BuildTypes.kt
@@ -3,6 +3,5 @@ package net.mullvad.mullvadvpn.lib.common.constant
 object BuildTypes {
     const val DEBUG = "debug"
     const val RELEASE = "release"
-    const val FDROID = "fdroid"
     const val LEAK_CANARY = "leakCanary"
 }

--- a/nix/android-devshell.nix
+++ b/nix/android-devshell.nix
@@ -33,8 +33,8 @@ pkgs.devshell.mkShell {
       command = "$ANDROID_ROOT/gradlew -p $ANDROID_ROOT assembleOssProdDebug";
     }
     {
-      name = "buildFdroid";
-      command = "$ANDROID_ROOT/gradlew -p $ANDROID_ROOT assembleOssProdFdroid";
+      name = "buildRelease";
+      command = "$ANDROID_ROOT/gradlew -p $ANDROID_ROOT assembleOssProdRelease";
     }
   ];
 }


### PR DESCRIPTION
### What
This PR aims to remove the F-Droid build type.

### Why
The F-Droid build type does no longer serve the original purpose of disable signing, since all gradle builds are unsigned.

### How
The F-Droid build type is removed from our gradle config. Scripts have also been updated accordingly. The F-Droid marketplace check used to determine the download link has been disabled, meaning that all non-play download links will lead to the website. It will be re-implemented in a more dynamic way in a separate issue (DROID-2623).

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10187)
<!-- Reviewable:end -->
