### PR TITLE
Remove unused OSV Scanner ignores

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -6,50 +6,8 @@ id = "CVE-2024-21528"  # GHSA-g974-hxvm-x689
 ignoreUntil = 2026-04-16  # The vulnerability is ignored for 6 months as the affected library is not receiving updates and we can not patch the vulnerability without migrating to another library, which is no minor feat.
 reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"
 
-# tar: node-tar is Vulnerable to Arbitrary File Overwrite and Symlink Poisoning via Insufficient Path Sanitization
-[[IgnoredVulns]]
-id = "CVE-2026-23745"  # GHSA-8qq5-rm4j-mr97
-ignoreUntil = 2026-03-18
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
-
-# tar: Race Condition in node-tar Path Reservations via Unicode Ligature Collisions on macOS APFS
-[[IgnoredVulns]]
-id = "CVE-2026-23950"  # GHSA-r6q2-hw4h-h46w
-ignoreUntil = 2026-03-18
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
-
-# tar: node-tar Vulnerable to Arbitrary File Creation/Overwrite via Hardlink Path Traversal
-[[IgnoredVulns]]
-id = "CVE-2026-24842"  # GHSA-34x7-hfp2-rc4v
-ignoreUntil = 2026-03-18
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
-
 # ajv: ajv has ReDoS when using $data option
 [[IgnoredVulns]]
 id = "CVE-2025-69873"  # GHSA-2g4f-4pwh-qvx6
 ignoreUntil = 2026-08-04
 reason = "This vulnerability only concerns ReDoS and the package is only used in development by eslint and electron-builder. eslint explicitly does not use the $data option and electron-builder uses it to validate its config, which we fully dictate ourselves."
-
-# tar: Arbitrary File Read/Write via Hardlink Target Escape Through Symlink Chain in node-tar Extraction
-[[IgnoredVulns]]
-id = "CVE-2026-26960"  # GHSA-83g3-92jg-28cx
-ignoreUntil = 2026-03-18
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
-
-# tar: tar has Hardlink Path Traversal via Drive-Relative Linkpath
-[[IgnoredVulns]]
-id = "CVE-2026-29786"  # GHSA-qffp-2rhf-9h96
-ignoreUntil = 2026-03-18
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
-
-# tar: node-tar Symlink Path Traversal via Drive-Relative Linkpath
-[[IgnoredVulns]]
-id = "CVE-2026-31802"  # GHSA-9ppj-qmqm-q256
-ignoreUntil = 2026-03-18
-reason = "The vulnerable tar dependency does not handle arbitrary tar files as it is only used by grpc-tools. Unless the files uploaded by the grpc-tools team to node-precompiled-binaries.grpc.io are compromised an attack is not possible."
-
-# yauzl: yauzl contains an off-by-one error
-[[IgnoredVulns]]
-id = "CVE-2026-31988"  # GHSA-gmq8-994r-jv83
-ignoreUntil = 2026-04-12
-reason = "The DoS vulnerability is not applicable as the vulnerable getLastModDate method is not invoked by extract-zip."


### PR DESCRIPTION
This PR will:

- Remove unused OSV scanner ignores for `tar` and `yauzl`

---

With PR #9837 getting merged we no longer use `grpc-tools`, which was the reason for the `tar` dependency in our supply chain. As such, we can now remove the ignores for `tar`, as we no longer depend on it.

The ignore for `yauzl` is no longer needed as the vulnerability report was updated and the version we use is not affected.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10196)
<!-- Reviewable:end -->
