### PR TITLE
Backport "adjust early boot service verbosity" fix to the 2026.2 release branch

### DIFF
--- a/dist-assets/linux/mullvad-early-boot-blocking.service
+++ b/dist-assets/linux/mullvad-early-boot-blocking.service
@@ -10,7 +10,7 @@ Before=basic.target mullvad-daemon.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/mullvad-daemon --initialize-early-boot-firewall
+ExecStart=/usr/bin/mullvad-daemon -v --initialize-early-boot-firewall
 
 [Install]
 WantedBy=mullvad-daemon.service


### PR DESCRIPTION
This PR backports https://github.com/mullvad/mullvadvpn-app/pull/10197 to the 2026.2 release branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10198)
<!-- Reviewable:end -->
