### PR TITLE
Add support for running Desktop app gRPC bindings generator container on ARM hosts

### DIFF
--- a/desktop/packages/management-interface/scripts/container-run-generate-bindings.sh
+++ b/desktop/packages/management-interface/scripts/container-run-generate-bindings.sh
@@ -12,11 +12,20 @@ IMAGE_HASH="4c6c9f0924"
 IMAGE_NAME="ghcr.io/mullvad/mullvadvpn-app-build-node-grpc-bindings:$IMAGE_HASH"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PROTO_DIR="$( cd "$SCRIPT_DIR/../../../../mullvad-management-interface/proto" && pwd )"
 OUT_DIR="$SCRIPT_DIR/../dist"
+REPO_DIR="$( cd "$SCRIPT_DIR/../../../../" && pwd )"
+PROTO_DIR="$( cd "$REPO_DIR/mullvad-management-interface/proto" && pwd )"
+
+source "$REPO_DIR/scripts/utils/host"
+
+# If the host system is ARM-based we must specify the guest platform,
+# otherwise an error will be throw about mismatching architecture
+if [[ $HOST == "aarch64"* ]]; then
+    RUN_COMMANDS=(--platform linux/amd64)
+fi
 
 set -x
-exec "$CONTAINER_RUNNER" run --rm -it \
+exec "$CONTAINER_RUNNER" run --rm -it "${RUN_COMMANDS[@]}" \
     -v "$PROTO_DIR:/proto:Z" \
     -v "$OUT_DIR:/proto-bindings:Z" \
     "$IMAGE_NAME"


### PR DESCRIPTION
This PR will:

- Update the shell script which invokes the container which generates the Desktop app's gRPC bindings to work on ARM hosts.
  - In order to run the container on an ARM host the `--platform linux/amd64` argument must be used.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10199)
<!-- Reviewable:end -->
