### PR TITLE
Drop JDK 17 from nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,6 @@
             pkgs
             nixpkgs
             android-nixpkgs
-            system
             common-toolchain
             ;
         };

--- a/nix/android-devshell.nix
+++ b/nix/android-devshell.nix
@@ -7,6 +7,7 @@ pkgs.devshell.mkShell {
     inherit pkgs;
     inherit (android-toolchain)
       android-sdk
+      jdk
       buildToolsVersion
       ndkVersion
       minSdkVersion

--- a/nix/android-env.nix
+++ b/nix/android-env.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   android-sdk,
+  jdk,
   buildToolsVersion,
   ndkVersion,
   minSdkVersion,
@@ -19,7 +20,7 @@ in
 [
   {
     name = "JAVA_HOME";
-    value = "${pkgs.jdk17}";
+    value = "${jdk}";
   }
   {
     name = "PROTOC_GEN_GRPC_JAVA_PLUGIN";

--- a/nix/android-toolchain.nix
+++ b/nix/android-toolchain.nix
@@ -2,7 +2,6 @@
   pkgs,
   nixpkgs,
   android-nixpkgs,
-  system,
   common-toolchain,
 }:
 let
@@ -22,16 +21,23 @@ let
   buildToolsVersion = versions."build-tools";
   minSdkVersion = versions."min-sdk";
   ndkVersion = versions.ndk;
+  jdk = pkgs."jdk${versions."jvm-toolchain"}";
 
-  android-sdk = android-nixpkgs.sdk.${system} (
-    sdkPkgs: with sdkPkgs; [
-      (builtins.getAttr "platforms-android-${compileSdkVersion}-${compileSdkMinorVersion}" sdkPkgs)
-      (builtins.getAttr "build-tools-${builtins.replaceStrings [ "." ] [ "-" ] buildToolsVersion}" sdkPkgs)
-      (builtins.getAttr "ndk-${builtins.replaceStrings [ "." ] [ "-" ] ndkVersion}" sdkPkgs)
-      cmdline-tools-latest
-      platform-tools
-    ]
-  );
+  android-sdk =
+    (import "${android-nixpkgs}" {
+      pkgs = pkgs // {
+        openjdk = jdk;
+      };
+    }).sdk
+      (
+        sdkPkgs: with sdkPkgs; [
+          (builtins.getAttr "platforms-android-${compileSdkVersion}-${compileSdkMinorVersion}" sdkPkgs)
+          (builtins.getAttr "build-tools-${builtins.replaceStrings [ "." ] [ "-" ] buildToolsVersion}" sdkPkgs)
+          (builtins.getAttr "ndk-${builtins.replaceStrings [ "." ] [ "-" ] ndkVersion}" sdkPkgs)
+          cmdline-tools-latest
+          platform-tools
+        ]
+      );
 
   rust-toolchain = common-toolchain.rust-toolchain-base.override {
     extensions = [ "rust-analyzer" ];
@@ -47,6 +53,7 @@ in
   inherit
     android-sdk
     rust-toolchain
+    jdk
     buildToolsVersion
     ndkVersion
     minSdkVersion
@@ -58,7 +65,7 @@ in
       android-sdk
       rust-toolchain
       pkgs.protoc-gen-grpc-java
-      pkgs.jdk17
+      jdk
       pkgs.python314
     ]
     ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];


### PR DESCRIPTION
### What
Drops JDK 17 from our devshell.

### Why
We no longer needed JDK 17 since we've migrated our app to JDK 21.

### How
Updates our devshell so that it automatically extracts the JVM version from our version catalog and uses it as part of the SDK installation. At the time of writing that is JDK 21.

Fixes: DROID-2622

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10205)
<!-- Reviewable:end -->
