### PR TITLE
Fix regression where active streams would not be reset upon request

### DIFF
--- a/mullvad-api/src/https_client.rs
+++ b/mullvad-api/src/https_client.rs
@@ -500,10 +500,10 @@ impl RequestHandler {
     /// Process a single request from a connected [HttpsConnectorHandle].
     fn handle(&mut self, request: HttpsConnectorRequest) {
         let handles = {
+            let mut inner = self.connector.lock().unwrap();
             match request {
-                HttpsConnectorRequest::Reset => return,
+                HttpsConnectorRequest::Reset => std::mem::take(&mut inner.stream_handles),
                 HttpsConnectorRequest::SetConnectionMode(config) => {
-                    let mut inner = self.connector.lock().unwrap();
                     inner.proxy_config = InnerConnectionMode::from(config);
                     std::mem::take(&mut inner.stream_handles)
                 }


### PR DESCRIPTION
This is a small regression introduced during a "refactor" in https://github.com/mullvad/mullvadvpn-app/pull/10204.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10208)
<!-- Reviewable:end -->
