### PR TITLE
Fix mullvad-ios builds breaking due to new shadowsocks cipher type

### DIFF
--- a/mullvad-ios/src/api_client/helpers.rs
+++ b/mullvad-ios/src/api_client/helpers.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use shadowsocks::crypto::available_ciphers;
-use talpid_types::net::proxy::{Shadowsocks, Socks5Remote, SocksAuth};
+use talpid_types::net::proxy::{Shadowsocks, ShadowsocksCipher, Socks5Remote, SocksAuth};
 
 use super::get_string;
 
@@ -56,6 +56,7 @@ pub unsafe extern "C" fn new_shadowsocks_access_method_setting(
 
     let password = unsafe { get_string(c_password) };
     let cipher = unsafe { get_string(c_cipher) };
+    let cipher = ShadowsocksCipher::new(&cipher).unwrap();
 
     let shadowsocks_configuration = Shadowsocks {
         endpoint,


### PR DESCRIPTION
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10209)
<!-- Reviewable:end -->
