### PR TITLE
Log more when 'mullvad-daemon --launch-daemon-status' fails

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -1112,6 +1112,7 @@ class ApplicationMain
           } else {
             log.error(
               `Error while checking launch daemon authorization status.
+                Status: ${error.code}
                 Stdout: ${stdout.toString()}
                 Stderr: ${stderr.toString()}`,
             );

--- a/mullvad-daemon/src/macos_launch_daemon.rs
+++ b/mullvad-daemon/src/macos_launch_daemon.rs
@@ -49,14 +49,19 @@ fn get_status_for_url(url: &NSURL) -> LaunchDaemonStatus {
     // (1.) is upheld by the virtue of url being a reference, since references are always valid.
     // (2.) is trivially upheld since Apple does not state safety requirements.
     let status = unsafe { SMAppService::statusForLegacyURL(url) };
+    let log_status = || log::debug!("SMAppService::statusForLegacyUrl returned {status:?}");
     match status {
         SMAppServiceStatus::NotRegistered | SMAppServiceStatus::NotFound => {
+            log_status();
             LaunchDaemonStatus::NotFound
         }
         SMAppServiceStatus::Enabled => LaunchDaemonStatus::Ok,
         SMAppServiceStatus::RequiresApproval => LaunchDaemonStatus::NotAuthorized,
         // Unknown status
-        _ => LaunchDaemonStatus::Unknown,
+        _ => {
+            log_status();
+            LaunchDaemonStatus::Unknown
+        }
     }
 }
 


### PR DESCRIPTION
We have seen some cases where the daemon is killed because it's not allowed to run as a background task. And it appears that the GUI does not explain this because `mullvad-daemon --launch-daemon-status` returns some unexpected result that we do not log:

```
[error] Failed to connect to daemon: Failed to connect before the deadline
[error] Failed to reconnect - Error: Failed to connect before the deadline
[error] Error while checking launch daemon authorization status.
                Stdout: 
                Stderr: 
```

Add some more logging to figure out why.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10211)
<!-- Reviewable:end -->
