### PR TITLE
Fix repo packages check in 3-verify-build

### DIFF
--- a/desktop/scripts/release/3-verify-build
+++ b/desktop/scripts/release/3-verify-build
@@ -40,23 +40,25 @@ function verify_repository_versions {
     print_versions_args+=( --beta )
   fi
 
+  deb_product_version=${PRODUCT_VERSION/-/\~}
   deb_version_output=$(./print-package-versions --deb "${print_versions_args[@]}")
-  deb_version=$(echo "$deb_version_output" | grep mullvad-vpn | awk '{print $2}' | sed 's/~/-/')
+  for arch in amd64 arm64; do
+    if ! echo "$deb_version_output" | grep -q "^mullvad-vpn/.* $deb_product_version $arch\$"; then
+      log_error "Missing or incorrect deb $arch version in repository (expected $deb_product_version)"
+      echo "$deb_version_output"
+      exit 1
+    fi
+  done
 
-  if [[ "$deb_version" != "$PRODUCT_VERSION" ]]; then
-    log_error "Incorrect deb version in repository ($deb_version)"
-    echo "$deb_version_output"
-    exit 1
-  fi
-
+  rpm_product_version=${PRODUCT_VERSION/-/\~}-1
   rpm_version_output=$(./print-package-versions --rpm "${print_versions_args[@]}")
-  rpm_version=$(echo "$rpm_version_output" | grep mullvad-vpn | awk '{print $2}' | sed 's/~/-/')
-
-  if [[ "$rpm_version" != "$PRODUCT_VERSION-1" ]]; then
-    log_error "Incorrect rpm version in repository ($rpm_version)"
-    echo "$rpm_version_output"
-    exit 1
-  fi
+  for arch in x86_64 aarch64; do
+    if ! echo "$rpm_version_output" | grep -q "^mullvad-vpn\.$arch .* $rpm_product_version "; then
+      log_error "Missing or incorrect rpm $arch version in repository (expected $rpm_product_version)"
+      echo "$rpm_version_output"
+      exit 1
+    fi
+  done
 }
 
 function wait_for_workflow_result {


### PR DESCRIPTION
https://github.com/mullvad/mullvadvpn-app/pull/10032 updated `print-package-versions` to print versions for arm builds as well, which broke `3-verify-build`. PR fixes `3-verify-build` by checking if both x86 and arm package versions are correct.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10213)
<!-- Reviewable:end -->
