### PR TITLE
Disable tls12 features and enforce TLS 1.3 in test workspace

### DIFF
--- a/mullvad-api/Cargo.toml
+++ b/mullvad-api/Cargo.toml
@@ -47,7 +47,6 @@ tokio = { workspace = true, features = [
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
   "logging",
   "ring",
-  "tls12",
 ] }
 tokio-socks = "0.5.1"
 tower = { workspace = true }

--- a/test/test-rpc/Cargo.toml
+++ b/test/test-rpc/Cargo.toml
@@ -29,7 +29,6 @@ tokio = { workspace = true }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
   "logging",
   "ring",
-  "tls12"
 ] }
 
 [dependencies.tokio-util]

--- a/test/test-rpc/src/net.rs
+++ b/test/test-rpc/src/net.rs
@@ -19,8 +19,8 @@ const LE_ROOT_CERT: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pe
 
 static CLIENT_CONFIG: LazyLock<ClientConfig> = LazyLock::new(|| {
     ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
-        .with_safe_default_protocol_versions()
-        .unwrap()
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .expect("ring crypto provider should support TLS 1.3")
         .with_root_certificates(read_cert_store().expect("Failed to parse pem file"))
         .with_no_client_auth()
 });


### PR DESCRIPTION
For some reason we explicitly enable the `tls12` (TLS 1.2) features in two places. I'm not sure why. We should always use only TLS 1.3. This fixes that. It also upgrades the TLS client in `test-rpc` to only use TLS 1.3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10217)
<!-- Reviewable:end -->
