### PR TITLE
Make `Intersection` drive work on enums

### DIFF
--- a/mullvad-types/intersection-derive/src/lib.rs
+++ b/mullvad-types/intersection-derive/src/lib.rs
@@ -5,7 +5,22 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
 
-/// Derive macro for the [`Intersection`] trait on structs.
+/// Derive macro for the [`Intersection`] trait on structs and enums.
+///
+/// ## Structs
+///
+/// For structs with named fields, the intersection is computed field-by-field.
+/// Every field type must implement `Intersection`. If any field's intersection
+/// returns `None`, the whole result is `None`.
+///
+/// ## Enums
+///
+/// For enums, the intersection is defined variant-by-variant:
+///
+/// - **Same variant, same variant:** the inner fields are intersected. For unit
+///   variants this is always `Some(Variant)`. For newtype variants `V(T)`,
+///   this is `Some(V(a.intersection(b)?))`.
+/// - **Different variants:** always `None`.
 #[proc_macro_derive(Intersection)]
 pub fn intersection_derive(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
@@ -19,14 +34,18 @@ mod inner {
     use syn::{DeriveInput, Error, spanned::Spanned};
 
     pub(crate) fn derive(input: DeriveInput) -> TokenStream {
-        if let syn::Data::Struct(data) = &input.data {
-            derive_for_struct(&input, data).unwrap_or_else(Error::into_compile_error)
-        } else {
-            syn::Error::new(
+        match &input.data {
+            syn::Data::Struct(data) => {
+                derive_for_struct(&input, data).unwrap_or_else(Error::into_compile_error)
+            }
+            syn::Data::Enum(data) => {
+                derive_for_enum(&input, data).unwrap_or_else(Error::into_compile_error)
+            }
+            syn::Data::Union(_) => syn::Error::new(
                 input.span(),
-                "Deriving `Intersection` is only supported for structs",
+                "Deriving `Intersection` is not supported for unions",
             )
-            .into_compile_error()
+            .into_compile_error(),
         }
     }
 
@@ -61,6 +80,67 @@ mod inner {
                     ::core::option::Option::Some(Self {
                         #field_conversions
                     })
+                }
+            }
+        })
+    }
+
+    pub(crate) fn derive_for_enum(
+        input: &DeriveInput,
+        data: &syn::DataEnum,
+    ) -> syn::Result<TokenStream> {
+        let my_type = &input.ident;
+        let mut match_arms = quote! {};
+
+        for variant in &data.variants {
+            let variant_name = &variant.ident;
+
+            match &variant.fields {
+                // Unit variant: `Variant ∩ Variant = Some(Variant)`
+                syn::Fields::Unit => {
+                    match_arms.append_all(quote! {
+                        (Self::#variant_name, Self::#variant_name) => {
+                            ::core::option::Option::Some(Self::#variant_name)
+                        }
+                    });
+                }
+                // Newtype variant: `V(a) ∩ V(b) = Some(V(a.intersection(b)?))`
+                syn::Fields::Unnamed(fields) => {
+                    if fields.unnamed.len() != 1 {
+                        return Err(syn::Error::new(
+                            variant.span(),
+                            "Deriving `Intersection` on enums only supports unit and \
+                             single-field tuple variants",
+                        ));
+                    }
+                    match_arms.append_all(quote! {
+                        (Self::#variant_name(__a), Self::#variant_name(__b)) => {
+                            ::core::option::Option::Some(
+                                Self::#variant_name(Intersection::intersection(__a, __b)?)
+                            )
+                        }
+                    });
+                }
+                syn::Fields::Named(_) => {
+                    return Err(syn::Error::new(
+                        variant.span(),
+                        "Deriving `Intersection` on enums does not support struct variants",
+                    ));
+                }
+            }
+        }
+
+        // Wildcard: different variants → None
+        match_arms.append_all(quote! {
+            _ => ::core::option::Option::None,
+        });
+
+        Ok(quote! {
+            impl Intersection for #my_type {
+                fn intersection(self, other: Self) -> ::core::option::Option<Self> {
+                    match (self, other) {
+                        #match_arms
+                    }
                 }
             }
         })

--- a/mullvad-types/src/constraints/mod.rs
+++ b/mullvad-types/src/constraints/mod.rs
@@ -133,3 +133,71 @@ impl_intersection_partialeq!(relay_constraints::Ownership);
 impl_intersection_partialeq!(talpid_types::net::TransportProtocol);
 impl_intersection_partialeq!(talpid_types::net::IpVersion);
 impl_intersection_partialeq!(relay_constraints::AllowedIps);
+
+#[cfg(test)]
+mod tests {
+    use crate::Intersection;
+
+    // ── Struct derive ─────────────────────────────────────────────────────────
+
+    /// A simple struct where every field implements `Intersection` via `PartialEq`.
+    #[derive(Debug, PartialEq, Intersection)]
+    struct Point {
+        x: u16,
+        y: u16,
+    }
+
+    #[test]
+    fn struct_same_fields_intersect() {
+        let a = Point { x: 1, y: 2 };
+        let b = Point { x: 1, y: 2 };
+        assert_eq!(a.intersection(b), Some(Point { x: 1, y: 2 }));
+    }
+
+    #[test]
+    fn struct_differing_field_yields_none() {
+        let a = Point { x: 1, y: 2 };
+        let b = Point { x: 1, y: 99 };
+        assert_eq!(a.intersection(b), None);
+    }
+
+    // ── Enum derive ───────────────────────────────────────────────────────────
+
+    #[derive(Debug, Clone, PartialEq, Intersection)]
+    enum Color {
+        /// Unit variant — no inner data.
+        Red,
+        Green,
+        /// Newtype variant — inner value must itself implement `Intersection`.
+        Custom(u16),
+    }
+
+    /// Same unit variant × same unit variant → `Some`.
+    #[test]
+    fn enum_unit_same_variant_intersects() {
+        assert_eq!(Color::Red.intersection(Color::Red), Some(Color::Red));
+        assert_eq!(Color::Green.intersection(Color::Green), Some(Color::Green));
+    }
+
+    /// Different variants → `None`.
+    #[test]
+    fn enum_different_variants_yield_none() {
+        assert_eq!(Color::Red.intersection(Color::Green), None);
+        assert_eq!(Color::Green.intersection(Color::Custom(1)), None);
+    }
+
+    /// Same newtype variant, same inner value → `Some`.
+    #[test]
+    fn enum_newtype_same_value_intersects() {
+        assert_eq!(
+            Color::Custom(42).intersection(Color::Custom(42)),
+            Some(Color::Custom(42))
+        );
+    }
+
+    /// Same newtype variant, differing inner value → `None`.
+    #[test]
+    fn enum_newtype_different_value_yields_none() {
+        assert_eq!(Color::Custom(1).intersection(Color::Custom(2)), None);
+    }
+}

--- a/mullvad-types/src/wireguard.rs
+++ b/mullvad-types/src/wireguard.rs
@@ -10,7 +10,7 @@ pub const MIN_ROTATION_INTERVAL: Duration = Duration::from_hours(24);
 pub const MAX_ROTATION_INTERVAL: Duration = Duration::from_hours(30 * 24);
 pub const DEFAULT_ROTATION_INTERVAL: Duration = MAX_ROTATION_INTERVAL;
 
-#[derive(Serialize, Deserialize, Default, Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Copy, Clone, Debug, PartialEq, Eq, Intersection)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum QuantumResistantState {
@@ -26,12 +26,6 @@ impl QuantumResistantState {
             On => true,
             Off => false,
         }
-    }
-}
-
-impl Intersection for QuantumResistantState {
-    fn intersection(self, other: Self) -> Option<Self> {
-        if self == other { Some(self) } else { None }
     }
 }
 


### PR DESCRIPTION
For enums, the intersection is defined variant-by-variant:
- Same variant, same variant: the inner fields are intersected. For unit variants this is always `Some(Variant)`. For newtype variants `V(T)`, this is `Some(V(a.intersection(b)?))`.
- Different variants: always `None`.

Note that it does not compile enum with tuple variants with more than one element or struct variants.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10219)
<!-- Reviewable:end -->
