### PR TITLE
Silence Addressable gem in OSV scanner

### DIFF
--- a/ci/ios/upload-vm/osv-scanner.toml
+++ b/ci/ios/upload-vm/osv-scanner.toml
@@ -22,3 +22,9 @@ reason = "The faraday vulnerability is safe to ignore because fastlane will not 
 id = "CVE-2026-33210"  # GHSA-3m6g-2423-7cp3
 ignoreUntil = 2026-09-19
 reason = "This option isn't the default, and since we don't opt-in to use it, we are not impacted."
+
+# Addressable has a Regular Expression Denial of Service in Addressable templates.
+[[IgnoredVulns]]
+id = "CVE-2026-35611"  # GHSA-h27x-rffw-24p4
+ignoreUntil = 2026-10-15
+reason = "We do not supply any URI:s to fastlane, so we're not affected. Once Fastlane has updated Addressable we can update Fastlane and get rid of this ignore."

--- a/ios/osv-scanner.toml
+++ b/ios/osv-scanner.toml
@@ -22,3 +22,9 @@ reason = "The faraday vulnerability is safe to ignore because fastlane will not 
 id = "CVE-2026-33210"  # GHSA-3m6g-2423-7cp3
 ignoreUntil = 2026-09-19
 reason = "This option isn't the default, and since we don't opt-in to use it, we are not impacted."
+
+# Addressable has a Regular Expression Denial of Service in Addressable templates.
+[[IgnoredVulns]]
+id = "CVE-2026-35611"  # GHSA-h27x-rffw-24p4
+ignoreUntil = 2026-10-15
+reason = "We do not supply any URI:s to fastlane, so we're not affected. Once Fastlane has updated Addressable we can update Fastlane and get rid of this ignore."


### PR DESCRIPTION
This PR silences the Addressable gem in the iOS related OSV scanners. Once Fastlande starts using Addressable 2.9.0 we can update Fastlande and then remove the ignore.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10221)
<!-- Reviewable:end -->
