### PR TITLE
Print path of early-boot log directory if logger fails to initialize

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -70,7 +70,7 @@ async fn run() -> Result<(), String> {
 
         #[cfg(target_os = "linux")]
         cli::Command::InitializeEarlyBootFirewall => {
-            init_early_boot_logging(config);
+            init_early_boot_logging(config).ok();
 
             crate::early_boot_firewall::initialize_firewall()
                 .await
@@ -129,7 +129,7 @@ fn init_daemon_logging(
 
 /// Initialize logging to stderr and to the [`EARLY_BOOT_LOG_FILENAME`]
 #[cfg(target_os = "linux")]
-fn init_early_boot_logging(config: &cli::Config) -> Option<logging::LogHandle> {
+fn init_early_boot_logging(config: &cli::Config) -> Result<logging::LogHandle, String> {
     let log_file_location = get_log_dir(config)
         .ok()
         .flatten()
@@ -140,12 +140,17 @@ fn init_early_boot_logging(config: &cli::Config) -> Option<logging::LogHandle> {
 
     // If it's possible to log to the filesystem - attempt to do so, but failing that mustn't stop
     // the daemon from starting here.
-    init_logger(config, log_file_location)
-        .or_else(|e| {
-            eprintln!("Failed to initialize early-boot logging to file: '{e}'");
-            init_logger(config, None)
+    init_logger(config, log_file_location.clone())
+        .inspect_err(|err| {
+            eprintln!(
+                "Failed to initialize early-boot logging to file {location} ",
+                location = log_file_location
+                    .map(|l| format!("({:?})", l.log_path()))
+                    .unwrap_or("".to_string()),
+            );
+            eprintln!("{err}");
         })
-        .ok()
+        .or_else(|_| init_logger(config, None))
 }
 
 /// Initialize logging to stderr and to file (if provided).
@@ -176,13 +181,11 @@ fn init_logger(
 }
 
 fn get_log_dir(config: &cli::Config) -> Result<Option<PathBuf>, String> {
-    if config.log_to_file {
-        Ok(Some(mullvad_paths::log_dir().map_err(|e| {
-            e.display_chain_with_msg("Unable to get log directory")
-        })?))
-    } else {
-        Ok(None)
-    }
+    config
+        .log_to_file
+        .then(mullvad_paths::log_dir)
+        .transpose()
+        .map_err(|e| e.display_chain_with_msg("Unable to get log directory"))
 }
 
 async fn run_standalone(


### PR DESCRIPTION
Previously, the target log path was not included in the print to stderr in case the logger failed to initialize during the early-boot procedure. This PR adds the path. In the image, the last boot has this patch applied while the earlier boot attempts do not.
<img width="1914" height="1134" alt="image" src="https://github.com/user-attachments/assets/591d49f5-c668-40c0-86bd-b79511fd144f" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10225)
<!-- Reviewable:end -->
