### PR TITLE
Fix race between early-boot service logger and filesystem mounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - GotaTun is now used as the userspace WireGuard implementation. It replaces wireguard-go.
+- `mullvad-early-boot-blocking.service` now waits for local file system to be mounted
+  (`After=local-fs.target`). This was assumed before, but not required (and is still not required).
 
 ### Fixed
 - Fix QUIC obfuscation not always being used if relays only had IPv6 addresses for QUIC.

--- a/dist-assets/linux/mullvad-early-boot-blocking.service
+++ b/dist-assets/linux/mullvad-early-boot-blocking.service
@@ -7,6 +7,9 @@
 Description=Mullvad early boot network blocker
 DefaultDependencies=no
 Before=basic.target mullvad-daemon.service
+# Mount local filesystems (/var) before starting the early-boot service,
+# else persisting logs will fail.
+After=local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Start early boot service after local filesystem has been mounted. This was assumed to be the case before (why else would we try to persists these logs to disk?), but it was not enforced with target dependencies in the `mullvad-early-boot-blocking.service` unit file. Mounting the local filesystem is still not required, but now systemd has the oppurtunity to synchronize these two events (fs mounting + `mullvad-early-boot-blocking.service` starting) properly.

Related: https://github.com/mullvad/mullvadvpn-app/pull/10225

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10226)
<!-- Reviewable:end -->
