### PR TITLE
Fix `mullvad split-tunnel clear` getting stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Line wrap the file at 100 chars.                                              Th
 - Fix a bug with Shadowsocks-based API access methods where some ciphers were configurable by
   Mullvad VPN clients while not being supported by the system service.
 
+#### Linux
+- Fix 'mullvad split-tunnel clear' getting stuck.
+
 ### Security
 - Remove ability for renderer process to execute arbitrary binaries. This is a defence-in-depth
   measure to ensure that the renderer process does not have any capabilities beyond that of a

--- a/talpid-cgroup/src/v1.rs
+++ b/talpid-cgroup/src/v1.rs
@@ -24,7 +24,7 @@ pub struct CGroup1 {
     /// Absolute path of the cgroup, e.g. `/sys/fs/cgroup/net_cls/foobar`
     path: PathBuf,
 
-    /// `cgroup.procs` is used to add and list PIDs in the cgroup2.
+    /// `cgroup.procs` is used to add and list PIDs in the cgroup.
     procs: File,
 }
 
@@ -89,7 +89,7 @@ impl CGroup1 {
         Self::open(child_path)
     }
 
-    /// Try to clone the cgroup2 handle.
+    /// Try to clone the cgroup handle.
     ///
     /// This is fallible because cloning file descriptors can fail.
     pub fn try_clone(&self) -> Result<Self, super::Error> {
@@ -102,7 +102,7 @@ impl CGroup1 {
         })
     }
 
-    /// Assign a process to this cgroup2.
+    /// Assign a process to this cgroup.
     pub fn add_pid(&self, pid: Pid) -> Result<(), super::Error> {
         // Format the PID as a string
         let mut pid_buf = [0u8; 16];
@@ -111,12 +111,12 @@ impl CGroup1 {
 
         // Write PID to `cgroup.procs`.
         nix::unistd::write(&self.procs, pid_str.to_bytes())
-            .with_context(|| anyhow!("Failed to add process {pid} to cgroup2"))?;
+            .with_context(|| anyhow!("Failed to add process {pid} to cgroup"))?;
 
         Ok(())
     }
 
-    /// List all PIDs in this cgroup2.
+    /// List all PIDs in this cgroup.
     pub fn list_pids(&mut self) -> Result<Vec<pid_t>, super::Error> {
         let mut file = &self.procs;
         let mut pids = String::new();

--- a/talpid-core/src/split_tunnel/linux/mod.rs
+++ b/talpid-core/src/split_tunnel/linux/mod.rs
@@ -218,13 +218,9 @@ impl Inner {
 
     /// Removes all PIDs from the Cgroup.
     fn clear(&mut self) -> Result<(), Error> {
-        let mut pids = self.list()?;
-        while !pids.is_empty() {
-            for pid in pids {
-                let pid = Pid::from_raw(pid);
-                self.remove(pid)?;
-            }
-            pids = self.list()?;
+        for pid in self.list()? {
+            let pid = Pid::from_raw(pid);
+            self.remove(pid)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Reading from mullvad-exclude's `cgroup.procs` immediately after moving a process to its parent causes it to be moved back to the mullvad-exclude cgroup. This causes 'mullvad split tunnel clear' to never complete.

Fix DES-2945.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10229)
<!-- Reviewable:end -->
