### PR TITLE
Clarify changelog entry about unsupported Shadowsocks ciphers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ Line wrap the file at 100 chars.                                              Th
 
 ### Fixed
 - Fix QUIC obfuscation not always being used if relays only had IPv6 addresses for QUIC.
-- Fix Shadowsocks being configurable by Mullvad VPN clients while not being supported by the system
-  service.
+- Fix a bug with Shadowsocks-based API access methods where some ciphers were configurable by
+  Mullvad VPN clients while not being supported by the system service.
 
 ### Security
 - Remove ability for renderer process to execute arbitrary binaries. This is a defence-in-depth


### PR DESCRIPTION
Title. Don't want to sound too alarmistic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10230)
<!-- Reviewable:end -->
