### PR TITLE
Fix duplicate connected notifications in GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Line wrap the file at 100 chars.                                              Th
   (`After=local-fs.target`). This was assumed before, but not required (and is still not required).
 
 ### Fixed
+- Fix duplicate "Connected"/"Disconnected" desktop notifications caused by the daemon sending
+  multiple consecutive tunnel state events for the same state.
 - Fix QUIC obfuscation not always being used if relays only had IPv6 addresses for QUIC.
 - Fix a bug with Shadowsocks-based API access methods where some ciphers were configurable by
   Mullvad VPN clients while not being supported by the system service.

--- a/desktop/packages/mullvad-vpn/src/main/notification-controller.ts
+++ b/desktop/packages/mullvad-vpn/src/main/notification-controller.ts
@@ -55,6 +55,7 @@ enum NotificationSuppressReason {
 
 export default class NotificationController {
   private reconnecting = false;
+  private lastTunnelState?: TunnelState['state'];
 
   private presentedNotifications: { [key: string]: boolean } = {};
   private activeNotifications: Set<Notification> = new Set();
@@ -111,10 +112,16 @@ export default class NotificationController {
     this.reconnecting =
       tunnelState.state === 'disconnecting' && tunnelState.details === 'reconnect';
 
+    const suppress = this.shouldSuppressDuplicateTunnelState(tunnelState);
+    this.lastTunnelState = tunnelState.state;
+
     if (notificationProvider) {
       const notification = notificationProvider.getSystemNotification();
 
       if (notification) {
+        if (suppress) {
+          return false;
+        }
         return this.notify(notification, isWindowVisible, areSystemNotificationsEnabled);
       } else {
         log.error(
@@ -211,6 +218,16 @@ export default class NotificationController {
       this.notifyImpl(systemNotification);
       return true;
     }
+  }
+
+  // The daemon can emit multiple consecutive events for the same tunnel state (e.g. a second
+  // 'connected' event once the exit IP becomes known). Suppress the repeat to avoid duplicate
+  // desktop notifications.
+  private shouldSuppressDuplicateTunnelState(tunnelState: TunnelState): boolean {
+    if (tunnelState.state !== this.lastTunnelState) {
+      return false;
+    }
+    return tunnelState.state === 'connected' || tunnelState.state === 'disconnected';
   }
 
   private notifyImpl(systemNotification: SystemNotification): Notification {

--- a/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
+++ b/desktop/packages/mullvad-vpn/test/unit/notification-evaluation.spec.ts
@@ -109,6 +109,63 @@ describe('System notifications', () => {
     expect(result).toBe(false);
   });
 
+  it('should only show one notification when two consecutive connected events arrive', () => {
+    const controller = createController();
+
+    const connectedState: TunnelState = {
+      state: 'connected',
+      details: {
+        endpoint: {
+          address: '1.2.3.4:1234',
+          protocol: 'udp',
+          quantumResistant: false,
+          daita: false,
+        },
+      },
+    };
+
+    const result1 = controller.notifyTunnelState(connectedState, false, false, true, true);
+    const result2 = controller.notifyTunnelState(connectedState, false, false, true, true);
+
+    expect(result1).toBe(true); // first transition: notify
+    expect(result2).toBe(false); // still connected: suppress
+  });
+
+  it('should only show one notification when two consecutive disconnected events arrive', () => {
+    const controller = createController();
+
+    const disconnectedState: TunnelState = { state: 'disconnected', lockedDown: false };
+
+    const result1 = controller.notifyTunnelState(disconnectedState, false, false, true, true);
+    const result2 = controller.notifyTunnelState(disconnectedState, false, false, true, true);
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(false);
+  });
+
+  it('should notify again after reconnecting', () => {
+    const controller = createController();
+
+    const connectedState: TunnelState = {
+      state: 'connected',
+      details: {
+        endpoint: {
+          address: '1.2.3.4:1234',
+          protocol: 'udp',
+          quantumResistant: false,
+          daita: false,
+        },
+      },
+    };
+    const connectingState: TunnelState = { state: 'connecting', featureIndicators: undefined };
+
+    controller.notifyTunnelState(connectedState, false, false, true, true);
+    controller.notifyTunnelState(connectingState, false, false, true, true); // leaves connected
+    const result = controller.notifyTunnelState(connectedState, false, false, true, true);
+
+    expect(result).toBe(true); // new connection: notify again
+  });
+
   it('Tunnel state notifications should respect notification setting', () => {
     const controller = createController();
 


### PR DESCRIPTION
The daemon sends multiple consecutive 'connected' tunnel state events (first without exit IP, then with IP from am.i.mullvad.net). I've implemented this by ignoring any consecutive disconnected or connected notifications rather than simply throttling (because that assumes the geoip lookup completes quickly).

Fix DES-2717

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10233)
<!-- Reviewable:end -->
