### PR TITLE
Add Ubuntu 26.04 VM for end-to-end tests

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -16,7 +16,7 @@ on:
         description: "Space-delimited list of targets to run tests on, e.g. `debian13 ubuntu2404`. \
           Available images:\n
           `debian11 debian12 debian13 \
-          ubuntu2204 ubuntu2404 ubuntu2504 ubuntu2510 \
+          ubuntu2204 ubuntu2404 ubuntu2504 ubuntu2510 ubuntu2604 \
           fedora41 fedora42 fedora43 fedora44 \
           windows10 windows11 \
           macos12 macos13 macos14 macos15 macos26`.\n
@@ -49,7 +49,7 @@ jobs:
         run: |
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
-          all='["debian11","debian12","debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","fedora41","fedora42","fedora43","fedora44"]'
+          all='["debian11","debian12","debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","ubuntu2604","fedora41","fedora42","fedora43","fedora44"]'
           default='["debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","fedora42","fedora43"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"

--- a/test/scripts/ssh-setup.sh
+++ b/test/scripts/ssh-setup.sh
@@ -113,8 +113,13 @@ EOF
 }
 
 function create_test_user_linux {
-    echo "Adding test user account"
-    useradd -m "$UNPRIVILEGED_USER"
+    # Only create user if it does not yet exist.
+    if id -u "$UNPRIVILEGED_USER" &> /dev/null; then
+        echo "User $UNPRIVILEGED_USER already exists"
+    else
+        echo "Adding test user account '$UNPRIVILEGED_USER'"
+        useradd -m "$UNPRIVILEGED_USER"
+    fi
     echo "$UNPRIVILEGED_USER:$UNPRIVILEGED_USER" | chpasswd
 }
 


### PR DESCRIPTION
This PR adds the option to run the desktop end-to-end tests on Ubuntu 26.04. Note that this PR does not enable the new VM by default, since Ubuntu 26.04 is still in beta.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10235)
<!-- Reviewable:end -->
