### PR TITLE
Add ignore for GHSA-wg6q-6289-32hp

### DIFF
--- a/android/gradle/osv-scanner.toml
+++ b/android/gradle/osv-scanner.toml
@@ -108,3 +108,9 @@ reason = "The app does not use netty for external http communication"
 id = "CVE-2026-33871"  # GHSA-w9fj-cfpg-grvv
 ignoreUntil = 2026-05-01
 reason = "The app does not use netty for external http communication"
+
+# Bouncy Castle Crypto Package For Java: Use of a Broken or Risky Cryptographic Algorithm vulnerability in bcpkix modules
+[[IgnoredVulns]]
+id = "CVE-2026-5588"  # GHSA-wg6q-6289-32hp
+ignoreUntil = 2026-08-01
+reason = "The app does not use dependency directly, it is used by AGP that builds the app, no impact on app"


### PR DESCRIPTION
Adds a ignore for GHSA-wg6q-6289-32hp, the affected dependency is used in our build chain by AGP. We are currently prevented from upgrading it to latest version due to upstream dependencies.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10236)
<!-- Reviewable:end -->
