### PR TITLE
Send a Slack notification on a non-successful iOS E2E workflow

### DIFF
--- a/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
@@ -1,0 +1,28 @@
+---
+name: iOS end-to-end nightly tests monitor
+on:
+  # https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run
+  workflow_run:
+    workflows: ["iOS end-to-end nightly tests"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  notify-on-failed-workflow:
+    # Payload of workflow_run:
+    # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2026-03-10#get-a-workflow-run
+    if: "${{ github.event.workflow_run.conclusion != 'successful' }}"
+    name: Notify team on nightly E2E failure
+    runs-on: [ubuntu-latest]
+    timeout-minutes: 5
+    steps:
+      - name: Send custom event details to a Slack workflow
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.IOS_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          # workflow_run.html_url returns the full url of the workflow we're responding too.
+          payload: |
+            run_url: "${{ github.event.workflow_run.html_url }}"


### PR DESCRIPTION
This commit introduces a notification on any case of a `completed` but unsuccessful workflow (i.e. where the conclusion is not `success`).

**Rationale**: We currently send a notification if the E2E tests run and fail. Due to runner issues some scheduled nightly runs never get executed. 
As we only get notified of failing runs, we assume that "No news is good news", but that is not necessarily true.

According to [this GitHub documentation][1] we should be able to monitor whether the iOS E2E test workflow is
completed, which fits wanting to be informed about _both_ failed tests and scheduled runs, regardless of the reason.

**How to test**: ~We should be able to execute the workflow using this PR/branch.~ According to the [documentation][2] this will only run on the `default` branch:

> This event will only trigger a workflow run if the workflow file
> exists on the default branch.

**Technical details**:

- [Workflow_run][3] has 3 `action types`: `requested`, `in_progress` and `completed`.
- The `workflow_run` payload is documented [here][4].

**Note**: As I did not delete the original notification in `ios-end-to-end-tests-nightly.yml`, failed runs will notify us twice right now. 
I'd propose to remove that notification _after_ we've observed this notification to work consistently.

**Caveat**: I did come across https://github.com/orgs/community/discussions/21090, but given the
amount of time that has passed, I'm curious to see if that issue has been resolved in the meantime.

[1]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
[2]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run
[3]: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=completed#workflow_run
[4]: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2026-03-10#get-a-workflow-run


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10237)
<!-- Reviewable:end -->
