### PR TITLE
Assign ownership for sigstore files

### DIFF
--- a/code-owners.json
+++ b/code-owners.json
@@ -2,6 +2,8 @@
   "appteam-desktop": [
     "building/Dockerfile",
     "building/linux-container-image.txt",
+    "building/sigstore/mullvad/mullvadvpn-app-build@**",
+    "building/sigstore/mullvad/mullvadvpn-app-build-node-grpc-bindings@**",
     "ci/buildserver-build.sh",
     "ci/buildserver-config.sh",
     "ci/cargo-ci.sh",
@@ -30,6 +32,7 @@
   "appteam-android": [
     "android/**",
     "building/android-container-image.txt",
+    "building/sigstore/mullvad/mullvadvpn-app-build-android@**",
     "ci/android/**",
     "mullvad-jni/**"
   ],


### PR DESCRIPTION
Updating the container images currently causes the "no ownerless files" workflow to fail. Fix by having the sigstore files be owned by the desktop and Android team.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10238)
<!-- Reviewable:end -->
