### PR TITLE
Add correct Windows targets in setup-rust script

### DIFF
--- a/scripts/setup-rust
+++ b/scripts/setup-rust
@@ -16,7 +16,7 @@ ANDROID_COMPONENTS="rust-analyzer"
 IOS_TARGETS="aarch64-apple-ios-sim aarch64-apple-ios x86_64-apple-ios"
 IOS_COMPONENTS="rust-analyzer"
 
-WINDOWS_TARGETS="x86_64-pc-windows-msvc x86_64-pc-windows-gnu i686-pc-windows-msvc"
+WINDOWS_TARGETS="x86_64-pc-windows-msvc aarch64-pc-windows-msvc i686-pc-windows-msvc"
 WINDOWS_COMPONENTS="rust-analyzer"
 
 LINUX_TARGETS="aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu"

--- a/scripts/setup-rust-post-checkout
+++ b/scripts/setup-rust-post-checkout
@@ -13,10 +13,17 @@ if [[ ! -f "$SETUP_RUST_SCRIPT" ]]; then
     exit 0
 fi
 
-if [[ -z ${MULLVAD_SETUP_PLATFORM+x} ]]; then
-    echo "MULLVAD_SETUP_PLATFORM is not set, must be set to one of the following: " >&2
-    echo "\`android\`, \`ios\`, \`windows\`, \`linux\`, \`macos\`" >&2
-    exit 1
+if [[ -z "$MULLVAD_SETUP_PLATFORM" ]]; then
+    case "$(uname -s)" in
+        Linux) MULLVAD_SETUP_PLATFORM="linux" ;;
+        Darwin) MULLVAD_SETUP_PLATFORM="macos" ;;
+        MINGW*|CYGWIN*|MSYS*) MULLVAD_SETUP_PLATFORM="windows" ;;
+        *)
+            echo "Unable to detect current platform, MULLVAD_SETUP_PLATFORM must be set to one of: " >&2
+            echo "\`android\`, \`ios\`, \`windows\`, \`linux\`, \`macos\`" >&2
+            exit 1
+            ;;
+    esac
 fi
 
 git diff-tree --exit-code "$1".."$2" --quiet -- rust-toolchain.toml


### PR DESCRIPTION
The `setup-rust` script is currently missing a target for aarch64. Also removed the gcc/gnu target since we do not use that on Windows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10245)
<!-- Reviewable:end -->
