### PR TITLE
Remove Golang from build container Dockerfile

### DIFF
--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -28,9 +28,6 @@ LABEL org.opencontainers.image.licenses=GPL-3.0-or-later
 
 ENV CARGO_TARGET_DIR=/cargo-target/target
 
-ARG GOLANG_VERSION=1.21.3 \
-    GOLANG_HASH=1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8
-
 # Pinned to commit hash for tag v4.24.3
 ARG PROTOBUF_COMMIT_REF=ee1355459c9ce7ffe264bc40cfdc7b7623d37e99
 
@@ -89,16 +86,5 @@ ENV PATH=/root/.volta/bin:$PATH
 # versions from package.json, but `node --version` triggers an install
 COPY desktop/package.json .
 RUN curl https://get.volta.sh | bash && node --version && rm package.json
-
-# === Golang ===
-
-# Install golang
-# Checksum from: https://go.dev/dl/
-RUN curl -Lo go.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
-    echo "${GOLANG_HASH} go.tgz" | sha256sum -c - && \
-    tar -C /usr/local -xzf go.tgz && \
-    rm go.tgz
-ENV PATH=/usr/local/go/bin:$PATH
-
 
 WORKDIR /build


### PR DESCRIPTION
Update base Dockerfile to remove Golang, since all app version built by this container no longer depend on wireguard-go.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10247)
<!-- Reviewable:end -->
