### PR TITLE
Set MTU in Windows tun provider

### DIFF
--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -80,6 +80,7 @@ impl WindowsTunProvider {
             const ADAPTER_GUID: u128 = 0xAFE4_3773_E1F8_4EBB_8536_576A_B86A_FE9A;
 
             builder.config.tun_name(ADAPTER_NAME);
+            builder.config.mtu(self.config.mtu);
             builder
                 .config
                 .platform_config(|cfg: &mut tun08::PlatformConfig| {

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -571,8 +571,6 @@ fn get_tunnel_for_userspace(
     tun_config.ipv6_gateway = config.ipv6_gateway;
     tun_config.mtu = config.mtu;
 
-    // FIXME: mtu is not set
-
     let _ = routes;
 
     #[cfg(windows)]


### PR DESCRIPTION
Currently, the initial MTU is set to `2^16 - 1`, which incidentally causes a panic when multihop is enabled.

This only affects GotaTun.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10248)
<!-- Reviewable:end -->
