### PR TITLE
Prefer GotaTun for multihop on Windows

### DIFF
--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -26,5 +26,8 @@ insta = { workspace = true }
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.5.1", features = ["derive"] }
 
+[features]
+wireguard-go = []
+
 [lints]
 workspace = true

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -20,14 +20,14 @@ x25519-dalek = { version = "2.0.1", features = [
 ] }
 zeroize = { workspace = true }
 
-[features]
-wireguard-go = []
-
 [dev-dependencies]
 insta = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.5.1", features = ["derive"] }
+
+[features]
+wireguard-go = []
 
 [lints]
 workspace = true

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -20,6 +20,9 @@ x25519-dalek = { version = "2.0.1", features = [
 ] }
 zeroize = { workspace = true }
 
+[features]
+wireguard-go = []
+
 [dev-dependencies]
 insta = { workspace = true }
 

--- a/talpid-types/src/net/wireguard.rs
+++ b/talpid-types/src/net/wireguard.rs
@@ -56,7 +56,11 @@ impl TunnelParameters {
 
     /// Whether to use userspace WireGuard.
     pub fn use_userspace_wg(&self) -> bool {
-        cfg!(target_os = "macos") || self.options.userspace || self.options.daita
+        cfg!(target_os = "macos")
+            || self.options.userspace
+            || self.options.daita
+            // Always prefer GotaTun for multihop on Windows
+            || (cfg!(target_os = "windows") && cfg!(not(feature = "wireguard-go")) && self.connection.exit_peer.is_some())
     }
 }
 

--- a/talpid-wireguard/Cargo.toml
+++ b/talpid-wireguard/Cargo.toml
@@ -66,7 +66,8 @@ multihop-pcap = ["gotatun/pcap"]
 wireguard-go = [
   "dep:chrono",
   "dep:wireguard-go-rs",
-  "talpid-tunnel/wireguard-go"
+  "talpid-tunnel/wireguard-go",
+  "talpid-types/wireguard-go"
 ]
 
 [lints]


### PR DESCRIPTION
This PR enables GotaTun (when app is built with GotaTun) when multihop is enabled on Windows, since it is faster than wgnt multihop.

Fix DES-2965.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10250)
<!-- Reviewable:end -->
