### PR TITLE
Only use the `workflow_run` workflow to notify about failing iOS E2E nightly runs

### DIFF
--- a/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly-notification.yml
@@ -13,7 +13,10 @@ jobs:
   notify-on-failed-workflow:
     # Payload of workflow_run:
     # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2026-03-10#get-a-workflow-run
-    if: "${{ github.event.workflow_run.conclusion != 'successful' }}"
+    #
+    # Valid values for conclusion are listed on:
+    # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#check-statuses-and-conclusions
+    if: "${{ github.event.workflow_run.conclusion != 'success' }}"
     name: Notify team on nightly E2E failure
     runs-on: [ubuntu-latest]
     timeout-minutes: 5

--- a/.github/workflows/ios-end-to-end-tests-nightly.yml
+++ b/.github/workflows/ios-end-to-end-tests-nightly.yml
@@ -22,18 +22,3 @@ jobs:
     with:
       arg_tests_json_key: "nightly"
     secrets: inherit
-
-  notify-on-failure:
-    if: failure()
-    name: Notify team on nightly E2E failure
-    runs-on: [self-hosted, macOS, ios-test]
-    needs: reuse-e2e-workflow
-    timeout-minutes: 5
-    steps:
-      - name: Send custom event details to a Slack workflow
-        uses: slackapi/slack-github-action@v2.1.1
-        with:
-          webhook: ${{ secrets.IOS_SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            run_url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
- Remove duplicate iOS E2E tests-notifications

    After testing and observing, we'll now use the `workflow_run` method
of observing a workflow's result to trigger failure notifications when needed.

    **Impact**: Right now we receive a **duplicate** notification if the nightly run fails due to failing tests (as described in
9d89d7316104b2cbd158f78d94bdf824d2274d69). Removing this delegates the notification responsibility entirely to the `ios-end-to-end-nightly-monitor`-workflow, which also offers observability when the run is cancelled, amongst [other][1] possible reasons.

[1]: https://archive.is/4IM5j#check-statuses-and-conclusions

- Correct `successful` to `success`

    According to [this documentation][1], I should've written `success` instead of `successful`, and this is also double checked by querying the API:

    ```sh
    curl -SsfL -H @headers $GITHUB_API | jq '{ state, conclusion }'
    {
      "state": null,
      "conclusion": "success"
    }
    ```

[1]: https://archive.is/4IM5j#check-statuses-and-conclusions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10253)
<!-- Reviewable:end -->
