### PR TITLE
Fix access violation by updating wmi-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Line wrap the file at 100 chars.                                              Th
 #### Linux
 - Fix 'mullvad split-tunnel clear' getting stuck.
 
+#### Windows
+- Fix potential access violation during cleanup on ARM64.
+
 ### Security
 - Remove ability for renderer process to execute arbitrary binaries. This is a defence-in-depth
   measure to ensure that the renderer process does not have any capabilities beyond that of a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5302,7 +5302,6 @@ dependencies = [
  "typed-builder 0.20.1",
  "widestring",
  "windows 0.58.0",
- "windows-core 0.58.0",
  "windows-service",
  "windows-sys 0.61.2",
  "winreg 0.55.0",
@@ -7235,17 +7234,17 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.14.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdda506bdee26ba617bd814538b690e14f59e8185345344cff113a8be21c005"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
 dependencies = [
  "chrono",
  "futures",
  "log",
  "serde",
- "thiserror 1.0.59",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ widestring = "1.2"
 windows = "0.62.2"
 windows-sys = "0.61.2"
 winreg = "0.55"
+wmi = "0.18.1"
 # We cannot use zerocopy "0.8.32" or above due to https://github.com/google/zerocopy/issues/2880
 # TODO: Update the version when the issue is resolved
 zerocopy = "=0.8.31"

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -69,10 +69,9 @@ serde = { workspace = true, features = ["derive"] }
 talpid-windows = { path = "../talpid-windows" }
 widestring = { workspace = true }
 windows = "0.58.0"
-windows-core = "0.58.0"
 windows-service = "0.6.0"
 winreg = { workspace = true, features = ["transactions"] }
-wmi = "0.14.0"
+wmi = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/talpid-core/src/firewall/windows/hyperv.rs
+++ b/talpid-core/src/firewall/windows/hyperv.rs
@@ -1,8 +1,4 @@
-use windows::Win32::System::Wmi::{
-    IWbemClassObject, WBEM_E_NOT_FOUND, WBEM_FLAG_RETURN_WBEM_COMPLETE,
-};
-use windows_core::{BSTR, PCWSTR, VARIANT};
-use wmi::result_enumerator::IWbemClassWrapper;
+use wmi::{IWbemClassWrapper, WMIConnection, WMIError};
 
 /// Name of the blocking Hyper-V rule.
 const BLOCK_OUTBOUND_RULE_ELEMENT_NAME: &str = "Mullvad VPN outbound block-all rule";
@@ -18,37 +14,35 @@ const BLOCK_INBOUND_RULE_UUID: &str = "{95a5e2c6-ebd5-45e5-9495-12c5d807cd91}";
 
 const WMI_NAMESPACE: &str = "root\\standardcimv2";
 
+/// HRESULT returned when a WMI object is not found.
+/// See <https://learn.microsoft.com/en-us/windows/win32/wmisdk/wmi-error-constants>.
+const WBEM_E_NOT_FOUND: i32 = 0x80041002u32 as i32;
+
 /// Errors occurring while configuring Hyper-V firewall rules
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Failed to initialize the COM library")]
-    InitializeCom(#[source] wmi::WMIError),
     #[error("Failed to connect to the WMI namespace '{WMI_NAMESPACE}'")]
-    ConnectWmi(#[source] wmi::WMIError),
+    ConnectWmi(#[source] WMIError),
     #[error("Failed to obtain Hyper-V rule class")]
-    ObtainHyperVClass(#[source] wmi::WMIError),
+    ObtainHyperVClass(#[source] WMIError),
     #[error("Failed to create new instance of Hyper-V rule class")]
-    NewRuleInstance(#[source] windows_core::Error),
+    NewRuleInstance(#[source] WMIError),
     #[error("Failed to set rule setting: {0}")]
-    SetRuleKey(&'static str, #[source] windows_core::Error),
+    SetRuleKey(&'static str, #[source] WMIError),
     #[error(r#"Failed to put the rule "{0}""#)]
-    PutInstance(&'static str, #[source] windows_core::Error),
+    PutInstance(&'static str, #[source] WMIError),
     #[error(r#"Failed to delete rule "{0}""#)]
-    DeleteInstance(&'static str, #[source] windows_core::Error),
+    DeleteInstance(&'static str, #[source] WMIError),
 }
 
 /// Initialize WMI connection to the ROOT\StandardCIMV2 namespace, which may be used for
 /// interacting with Hyper-V rules.
-pub fn init_wmi() -> Result<wmi::WMIConnection, Error> {
-    let con = wmi::WMIConnection::with_namespace_path(
-        WMI_NAMESPACE,
-        wmi::COMLibrary::new().map_err(Error::InitializeCom)?,
-    )
-    .map_err(Error::ConnectWmi)?;
+pub fn init_wmi() -> Result<WMIConnection, Error> {
+    let con = WMIConnection::with_namespace_path(WMI_NAMESPACE).map_err(Error::ConnectWmi)?;
 
     // Test whether the class is available
     let _ = con
-        .get_raw_by_path("MSFT_NetFirewallHyperVRule")
+        .get_object("MSFT_NetFirewallHyperVRule")
         .map_err(Error::ObtainHyperVClass)?;
 
     Ok(con)
@@ -66,9 +60,9 @@ pub fn init_wmi() -> Result<wmi::WMIConnection, Error> {
 ///
 /// `con` must be a valid WMI connection for the `root\standardcimv2` WMI namespace. Such a connection
 /// can be initialized using [`init_wmi`].
-pub fn add_blocking_hyperv_firewall_rules(con: &wmi::WMIConnection) -> Result<(), Error> {
+pub fn add_blocking_hyperv_firewall_rules(con: &WMIConnection) -> Result<(), Error> {
     let class = con
-        .get_raw_by_path("MSFT_NetFirewallHyperVRule")
+        .get_object("MSFT_NetFirewallHyperVRule")
         .map_err(Error::ObtainHyperVClass)?;
 
     add_blocking_rule(
@@ -94,55 +88,39 @@ enum Direction {
 }
 
 fn add_blocking_rule(
-    con: &wmi::WMIConnection,
+    con: &WMIConnection,
     rule_class: &IWbemClassWrapper,
     element_name: &'static str,
     instance_id: &str,
     direction: Direction,
 ) -> Result<(), Error> {
-    // SAFETY: We have a valid class wrapper, so spawning instances is safe
-    let instance = unsafe { rule_class.inner.SpawnInstance(0) }.map_err(Error::NewRuleInstance)?;
+    let instance = rule_class
+        .spawn_instance()
+        .map_err(Error::NewRuleInstance)?;
 
-    put_instance_property(
-        &instance,
-        "ElementName",
-        &VARIANT::from(BSTR::from(element_name)),
-    )?;
-    put_instance_property(
-        &instance,
-        "InstanceID",
-        &VARIANT::from(BSTR::from(instance_id)),
-    )?;
+    instance
+        .put_property("ElementName", element_name)
+        .map_err(|err| Error::SetRuleKey("ElementName", err))?;
+    instance
+        .put_property("InstanceID", instance_id)
+        .map_err(|err| Error::SetRuleKey("InstanceID", err))?;
 
     // Action: 4 = block
-    put_instance_property(&instance, "Action", &VARIANT::from(4))?;
+    instance
+        .put_property("Action", 4i32)
+        .map_err(|err| Error::SetRuleKey("Action", err))?;
 
     // Enabled: 1 = enabled
-    put_instance_property(&instance, "Enabled", &VARIANT::from(1))?;
+    instance
+        .put_property("Enabled", 1i32)
+        .map_err(|err| Error::SetRuleKey("Enabled", err))?;
 
-    put_instance_property(&instance, "Direction", &VARIANT::from(direction as i32))?;
+    instance
+        .put_property("Direction", direction as i32)
+        .map_err(|err| Error::SetRuleKey("Direction", err))?;
 
-    // SAFETY: We have a valid instance
-    unsafe {
-        con.svc
-            .PutInstance(&instance, WBEM_FLAG_RETURN_WBEM_COMPLETE, None, None)
-            .map_err(|error| Error::PutInstance(element_name, error))
-    }
-}
-
-/// Set property for a WMI class instance `inst`.
-fn put_instance_property(
-    inst: &IWbemClassObject,
-    prop: &'static str,
-    val: &VARIANT,
-) -> Result<(), Error> {
-    let utf16_prop: Vec<_> = prop.encode_utf16().chain(std::iter::once(0u16)).collect();
-
-    // SAFETY: All arguments are valid and properly null-terminated
-    unsafe {
-        inst.Put(PCWSTR(utf16_prop.as_ptr()), 0, val, 0)
-            .map_err(|error| Error::SetRuleKey(prop, error))
-    }
+    con.put_instance(&instance)
+        .map_err(|error| Error::PutInstance(element_name, error))
 }
 
 /// Remove Hyper-V rule previously added by [`add_blocking_hyperv_firewall_rules`]. See the
@@ -152,7 +130,7 @@ fn put_instance_property(
 ///
 /// `con` must be a valid WMI connection for the `root\standardcimv2` WMI namespace. Such a connection
 /// can be initialized using [`init_wmi`].
-pub fn remove_blocking_hyperv_firewall_rules(con: &wmi::WMIConnection) -> Result<(), Error> {
+pub fn remove_blocking_hyperv_firewall_rules(con: &WMIConnection) -> Result<(), Error> {
     remove_blocking_rule(
         con,
         BLOCK_INBOUND_RULE_ELEMENT_NAME,
@@ -166,26 +144,19 @@ pub fn remove_blocking_hyperv_firewall_rules(con: &wmi::WMIConnection) -> Result
 }
 
 fn remove_blocking_rule(
-    con: &wmi::WMIConnection,
+    con: &WMIConnection,
     element_name: &'static str,
     instance_id: &str,
 ) -> Result<(), Error> {
-    let rule_path = BSTR::from(format!(
-        r#"MSFT_NetFirewallHyperVRule.InstanceID="{instance_id}""#
-    ));
-    // SAFETY: All arguments are valid.
-    unsafe {
-        con.svc
-            .DeleteInstance(&rule_path, WBEM_FLAG_RETURN_WBEM_COMPLETE, None, None)
-            .or_else(|error| map_deletion_err(element_name, error))
-    }
+    let rule_path = format!(r#"MSFT_NetFirewallHyperVRule.InstanceID="{instance_id}""#);
+    con.delete_instance(&rule_path)
+        .or_else(|error| map_deletion_err(element_name, error))
 }
 
-fn map_deletion_err(element_name: &'static str, err: windows_core::Error) -> Result<(), Error> {
-    if err.code().0 == WBEM_E_NOT_FOUND.0 {
+fn map_deletion_err(element_name: &'static str, err: WMIError) -> Result<(), Error> {
+    match err {
         // If the rule doesn't exist, do nothing
-        Ok(())
-    } else {
-        Err(Error::DeleteInstance(element_name, err))
+        WMIError::HResultError { hres } if hres == WBEM_E_NOT_FOUND => Ok(()),
+        _ => Err(Error::DeleteInstance(element_name, err)),
     }
 }


### PR DESCRIPTION
This fixes an access violation on ARM64 during cleanup of `WMIConnection`/COM in a thread-local context, see https://github.com/ohadravid/wmi-rs/issues/136#issuecomment-3422618627.

The issue was apparently that Rust calls `drop` for thread-local objects *after* the COM refcount has already been decremented for a thread. For the last thread referencing the `WMIConnection` this resulted in a use after free. The fix/workaround involves using `CoIncrementMTAUsage` to prevent COM from being deinitialized when threads are destroyed.

Fix DES-2969

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10255)
<!-- Reviewable:end -->
