### PR TITLE
Update path to test-runner.sh in E2E tests workflow

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -238,7 +238,7 @@ jobs:
         run: |
           # Move test runner binaries to a known location. This is needed in the coming `upload-artifact` step.
           mkdir bin
-          test/scripts/build/test-runner.sh linux
+          test/scripts/build-scripts/test-runner.sh linux
           mv -t ./bin/ \
             "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/test-runner" \
             "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu/release/connection-checker"


### PR DESCRIPTION
The path was updated in #10242 and currently the E2E tests are broken due to the workflow path not being updated.

I triggered a small E2E test with the updated path and it seems to work fine: https://github.com/mullvad/mullvadvpn-app/actions/runs/24724336587

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10260)
<!-- Reviewable:end -->
