### PR TITLE
Ignore `node-gettext` for 4 months

### DIFF
--- a/desktop/osv-scanner.toml
+++ b/desktop/osv-scanner.toml
@@ -3,7 +3,7 @@
 # node-gettext: Prototype Pullution via the addTranslations function
 [[IgnoredVulns]]
 id = "CVE-2024-21528"  # GHSA-g974-hxvm-x689
-ignoreUntil = 2026-04-16  # The vulnerability is ignored for 6 months as the affected library is not receiving updates and we can not patch the vulnerability without migrating to another library, which is no minor feat.
+ignoreUntil = 2026-08-16  # The vulnerability is ignored for 4 months as no patch for the affected library exists and we can not address the vulnerability without migrating to another library, which is no minor feat.
 reason = "There is no fix yet and we don't send untrusted input to the first argument of addTranslations"
 
 # ajv: ajv has ReDoS when using $data option


### PR DESCRIPTION
Note:
The library has seen a new patch version (3.0.1), but the vulnerability exists in that version as well. The security advisory just has not been updated to include that version.

EDIT: Seeing as the library did see an update this year (first one in 5 years) I [reached out to the maintainer](https://github.com/alexanderwallin/node-gettext/issues/72) to see if this vulnerability could be patched, as it has been already in another fork.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10263)
<!-- Reviewable:end -->
