### PR TITLE
Configure IP addresses without `netsh` for GotaTun

### DIFF
--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -50,13 +50,6 @@ impl WindowsTunProvider {
 
     /// Open a tunnel using the current tunnel config.
     pub fn open_tun(&mut self) -> Result<WindowsTun, Error> {
-        let (first_addr, remaining_addrs) = self
-            .config
-            .addresses
-            .split_first()
-            .map(|(first, rest)| (Some(first), rest))
-            .unwrap_or((None, &[]));
-
         let mut tunnel_device = {
             let mut builder = TunnelDeviceBuilder::default();
 
@@ -64,12 +57,6 @@ impl WindowsTunProvider {
             // metric value set for the route itself. Setting the interface metric to 1 gives tunnel
             // routes the highest possible priority.
             builder.config.metric(1);
-
-            // TODO: have tun either not use netsh or not set any default address at all
-            // TODO: tun can only set a single address
-            if let Some(addr) = first_addr {
-                builder.config.address(*addr);
-            }
 
             /// Tunnel adapter name
             const ADAPTER_NAME: &str = "Mullvad";
@@ -93,7 +80,9 @@ impl WindowsTunProvider {
             builder.create()?
         };
 
-        for ip in remaining_addrs {
+        // TODO: `tun` currently cannot handle IPv6 without using netsh,
+        // so we add IPs ourselves.
+        for ip in &self.config.addresses {
             tunnel_device.set_ip(*ip)?;
         }
 


### PR DESCRIPTION
`tun` spawns `netsh` as a subprocess to configure the IP address of the wintun interface, which is much slower than using Windows APIs (see below).

PR fixes this by setting the IP addresses ourselves instead of through `tun`.

We could probably upstream improvements to `tun`. It seems like the latest version (0.8.7) does no longer use `netsh` except for IPv6.

## Connection time (`mullvad connect -w`)

| Variant | Average (10 runs) | Speedup |
|---|---|---|
| with netsh (main) | 3.824 s | - |
| without netsh | 0.512 s | ~7.5x faster |

Variation was small (all within ~150 ms of mean).

**Test conditions**
- Relay: Sweden (any relay)
- Settings: No PQ, no obfuscation
- 10 iterations per variant, 10 s wait between attempts

<details>
<summary>Benchmark script</summary>

```bash
total=0
for i in $(seq 1 10); do
  mullvad disconnect -w >/dev/null
  sleep 10
  start=$(date +%s%3N)
  mullvad connect -w >/dev/null
  end=$(date +%s%3N)
  elapsed=$(( end - start ))
  printf "run %2d: %d.%03d s\n" "$i" $(( elapsed / 1000 )) $(( elapsed % 1000 ))
  total=$(( total + elapsed ))
done
avg=$(( total / 10 ))
printf "\naverage: %d.%03d s (over 10 runs)\n" $(( avg / 1000 )) $(( avg % 1000 ))
```

</details

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10267)
<!-- Reviewable:end -->
