### PR TITLE
Fix `single_use_lifetimes` lint conflict between stable and nightly

### DIFF
--- a/talpid-wireguard/src/config.rs
+++ b/talpid-wireguard/src/config.rs
@@ -3,7 +3,7 @@ use std::{
     ffi::CString,
     net::{Ipv4Addr, Ipv6Addr},
 };
-use talpid_types::net::wireguard::{PeerConfig, PrivateKey};
+use talpid_types::net::wireguard::PeerConfig;
 use talpid_types::net::{GenericTunnelOptions, obfuscation::Obfuscators, wireguard};
 
 /// Name to use for the tunnel device
@@ -122,12 +122,27 @@ impl Config {
     /// Returns a CString with the appropriate config for WireGuard-go
     // TODO: Consider outputting both overriding and additive configs
     pub fn to_userspace_format(&self) -> CString {
-        userspace_format(
-            &self.tunnel.private_key,
-            self.peers(),
-            #[cfg(target_os = "linux")]
-            self.fwmark,
-        )
+        let private_key = &self.tunnel.private_key;
+        let peers = self.peers();
+        // the order of insertion matters, public key entry denotes a new peer entry
+        let mut wg_conf = WgConfigBuffer::new();
+        wg_conf
+            .add::<&[u8]>("private_key", private_key.to_bytes().as_ref())
+            .add("listen_port", "0");
+
+        #[cfg(target_os = "linux")]
+        if let Some(fwmark) = self.fwmark {
+            wg_conf.add("fwmark", fwmark.to_string().as_str());
+        }
+
+        wg_conf.add("replace_peers", "true");
+
+        for peer in peers {
+            write_peer_to_config(&mut wg_conf, peer)
+        }
+
+        let bytes = wg_conf.into_config();
+        CString::new(bytes).expect("null bytes inside config")
     }
 
     /// Return whether the config connects to an exit peer from another remote peer.
@@ -216,34 +231,6 @@ impl WgConfigBuffer {
         self.buf.push(b'\n');
         self.buf
     }
-}
-
-/// Returns a CString with the appropriate config for WireGuard-go
-#[expect(single_use_lifetimes)]
-pub fn userspace_format<'a>(
-    private_key: &PrivateKey,
-    peers: impl Iterator<Item = &'a PeerConfig>,
-    #[cfg(target_os = "linux")] fwmark: Option<u32>,
-) -> CString {
-    // the order of insertion matters, public key entry denotes a new peer entry
-    let mut wg_conf = WgConfigBuffer::new();
-    wg_conf
-        .add::<&[u8]>("private_key", private_key.to_bytes().as_ref())
-        .add("listen_port", "0");
-
-    #[cfg(target_os = "linux")]
-    if let Some(fwmark) = fwmark {
-        wg_conf.add("fwmark", fwmark.to_string().as_str());
-    }
-
-    wg_conf.add("replace_peers", "true");
-
-    for peer in peers {
-        write_peer_to_config(&mut wg_conf, peer)
-    }
-
-    let bytes = wg_conf.into_config();
-    CString::new(bytes).expect("null bytes inside config")
 }
 
 fn write_peer_to_config(wg_conf: &mut WgConfigBuffer, peer: &PeerConfig) {


### PR DESCRIPTION
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10270)
<!-- Reviewable:end -->
