### PR TITLE
Replace Modal with Dialog component in DeviceListItem's ConfirmDialog

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/device-list-item/components/confirm-dialog/ConfirmDialog.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/device-list-item/components/confirm-dialog/ConfirmDialog.tsx
@@ -1,55 +1,59 @@
 import { sprintf } from 'sprintf-js';
 
 import { messages } from '../../../../../shared/gettext';
-import { Button, Text } from '../../../../lib/components';
+import { Dialog } from '../../../../lib/components/dialog';
+import { FlexColumn } from '../../../../lib/components/flex-column';
 import { formatHtml } from '../../../../lib/html-formatter';
 import { formatDeviceName } from '../../../../lib/utils';
-import { IModalAlertProps, ModalAlert, ModalAlertType, ModalMessage } from '../../../Modal';
 import { useDeviceListItemContext } from '../../DeviceListItemContext';
 import { useHandleRemoveDevice } from './hooks';
 
-export type ConfirmDialogProps = IModalAlertProps;
-
-export function ConfirmDialog({ isOpen }: ConfirmDialogProps) {
+export function ConfirmDialog({ isOpen }: { isOpen: boolean }) {
   const { device, hideConfirmDialog, deleting } = useDeviceListItemContext();
   const handleRemoveDevice = useHandleRemoveDevice();
 
   return (
-    <ModalAlert
-      isOpen={isOpen}
-      type={ModalAlertType.caution}
-      buttons={[
-        <Button key="remove" onClick={handleRemoveDevice} disabled={deleting}>
-          <Button.Text>
-            {
-              // TRANSLATORS: Button label for confirming removing a device.
-              messages.pgettext('device-management', 'Remove')
-            }
-          </Button.Text>
-        </Button>,
-        <Button key="back" onClick={hideConfirmDialog} disabled={deleting}>
-          <Button.Text>{messages.gettext('Back')}</Button.Text>
-        </Button>,
-      ]}
-      close={hideConfirmDialog}>
-      <ModalMessage>
-        {formatHtml(
-          sprintf(
-            // TRANSLATORS: Text displayed above button which logs out another device.
-            // TRANSLATORS: The text enclosed in "<b></b>" will appear bold.
-            // TRANSLATORS: Available placeholders:
-            // TRANSLATORS: %(deviceName)s - The name of the device to log out.
-            messages.pgettext('device-management', 'Remove <em>%(deviceName)s?</em>'),
-            { deviceName: formatDeviceName(device.name) },
-          ),
-        )}
-      </ModalMessage>
-      <Text variant="labelTinySemiBold" color="whiteAlpha60">
-        {messages.pgettext(
-          'device-management',
-          'The device will be removed from the list and logged out.',
-        )}
-      </Text>
-    </ModalAlert>
+    <Dialog open={isOpen} onOpenChange={hideConfirmDialog}>
+      <Dialog.Portal>
+        <Dialog.Popup>
+          <Dialog.PopupContent>
+            <Dialog.Icon icon="info-circle" />
+            <FlexColumn>
+              <Dialog.Text>
+                {formatHtml(
+                  sprintf(
+                    // TRANSLATORS: Text displayed above button which logs out another device.
+                    // TRANSLATORS: The text enclosed in "<b></b>" will appear bold.
+                    // TRANSLATORS: Available placeholders:
+                    // TRANSLATORS: %(deviceName)s - The name of the device to log out.
+                    messages.pgettext('device-management', 'Remove <em>%(deviceName)s?</em>'),
+                    { deviceName: formatDeviceName(device.name) },
+                  ),
+                )}
+              </Dialog.Text>
+              <Dialog.Text variant="labelTinySemiBold" color="whiteAlpha60">
+                {messages.pgettext(
+                  'device-management',
+                  'The device will be removed from the list and logged out.',
+                )}
+              </Dialog.Text>
+            </FlexColumn>
+            <Dialog.ButtonGroup>
+              <Dialog.Button onClick={handleRemoveDevice} disabled={deleting}>
+                <Dialog.Button.Text>
+                  {
+                    // TRANSLATORS: Button label for confirming removing a device.
+                    messages.pgettext('device-management', 'Remove')
+                  }
+                </Dialog.Button.Text>
+              </Dialog.Button>
+              <Dialog.Button onClick={hideConfirmDialog} disabled={deleting}>
+                <Dialog.Button.Text>{messages.gettext('Back')}</Dialog.Button.Text>
+              </Dialog.Button>
+            </Dialog.ButtonGroup>
+          </Dialog.PopupContent>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog>
   );
 }


### PR DESCRIPTION
The Modal component wraps its buttons in a container, and for each container it assigns a key based on an index. This causes issues with React's reconciliation algorithm when one of the buttons re-render due to its props changing, and this situation can cause a duplicate Button to be added to the DOM, as seen in the many mocked E2E tests which produce output like this:

https://github.com/mullvad/mullvadvpn-app/actions/runs/24143817556/job/70452233435?pr=10115#step:12:298

We could fix the Modal component's implementation to use a better key but since we are on our way to replace it with the Dialog component we should just spend our efforts there.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10271)
<!-- Reviewable:end -->
