### PR TITLE
Switch global allocator to mimalloc on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - GotaTun is now used as the userspace WireGuard implementation. It replaces wireguard-go.
+- Switch memory allocator to mimalloc to reduce fragmentation.
 - `mullvad-early-boot-blocking.service` now waits for local file system to be mounted
   (`After=local-fs.target`). This was assumed before, but not required (and is still not required).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2976,6 +2994,7 @@ dependencies = [
  "libc",
  "log",
  "log-panics",
+ "mimalloc",
  "mullvad-api",
  "mullvad-encrypted-dns-proxy",
  "mullvad-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,3 +193,4 @@ ring.opt-level = 3
 inherits = "release"
 debug = true
 strip = false
+lto = "thin"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -77,6 +77,7 @@ futures = { workspace = true }
 libc = "0.2"
 log = { workspace = true }
 log-panics = "2.0.0"
+mimalloc = { version = "0.1", optional = true }
 mullvad-api = { path = "../mullvad-api" }
 mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-fs = { path = "../mullvad-fs" }
@@ -175,6 +176,8 @@ features = ["Win32_System_SystemServices"]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override"]
 cgroup2 = ["talpid-core/cgroup2"]
+# Use mimalloc as the global allocator.
+mimalloc = ["dep:mimalloc"]
 multihop-pcap = ["talpid-core/multihop-pcap"]
 staggered-obfuscation = ["mullvad-relay-selector/staggered-obfuscation"]
 wireguard-go = ["talpid-core/wireguard-go"]

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -77,7 +77,6 @@ futures = { workspace = true }
 libc = "0.2"
 log = { workspace = true }
 log-panics = "2.0.0"
-mimalloc = { version = "0.1", optional = true }
 mullvad-api = { path = "../mullvad-api" }
 mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-fs = { path = "../mullvad-fs" }
@@ -125,6 +124,7 @@ hickory-resolver = { workspace = true }
 paranoid-android = "0.2.2"
 
 [target.'cfg(target_os="linux")'.dependencies]
+mimalloc = { version = "0.1", optional = true }
 talpid-dbus = { path = "../talpid-dbus" }
 
 [target.'cfg(target_os="macos")'.dependencies]
@@ -173,11 +173,12 @@ workspace = true
 features = ["Win32_System_SystemServices"]
 
 [features]
+default = ["default-allocator"]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override"]
 cgroup2 = ["talpid-core/cgroup2"]
-# Use mimalloc as the global allocator.
-mimalloc = ["dep:mimalloc"]
+# Use mimalloc as the global allocator. Only takes effect on Linux.
+default-allocator = ["dep:mimalloc"]
 multihop-pcap = ["talpid-core/multihop-pcap"]
 staggered-obfuscation = ["mullvad-relay-selector/staggered-obfuscation"]
 wireguard-go = ["talpid-core/wireguard-go"]

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -9,6 +9,10 @@ use mullvad_daemon::{
 };
 use talpid_types::ErrorExt;
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod cli;
 #[cfg(target_os = "linux")]
 mod early_boot_firewall;

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -9,7 +9,7 @@ use mullvad_daemon::{
 };
 use talpid_types::ErrorExt;
 
-#[cfg(feature = "mimalloc")]
+#[cfg(all(feature = "default-allocator", target_os = "linux"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
This greatly reduces memory fragmentation for GotaTun and makes `mullvad-daemon` only slightly larger (~120 KiB).

## Default allocator

- **Binary size (release):** 16.06 MiB (16,837,248 B)
- **Resident memory:** 500 MB+ after a few minutes of a reconnect loop:
  ```sh
  while :; do mullvad disconnect; mullvad connect -w; sleep 1; done
  ```
- **heaptrack** - `heaptrack ./target/release-debuginfo/mullvad-daemon -vvv`
    - Peak RSS: **586 MB**
    - Peak heap: **75.8 MB**

## mimalloc

- **Binary size (release):** 16.17 MiB (16,960,408 B). ~120 KiB larger
- **Resident memory:** ~160 MB under the same reconnect loop
- **Throughput (gotatun):** no difference vs default on `gotatun-cli` (~3.1 Gbps)

## Summary

All measurements on Linux.

| Metric | Default | mimalloc | Δ |
| --- | --- | --- | --- |
| Binary size | 16.06 MiB | 16.17 MiB | +120 KiB |
| Resident (reconnect loop) | 500 MB+ | ~160 MB | ~3x lower |
| Throughput (gotatun-cli) | ~3.1 Gbps | ~3.1 Gbps | - |

Fix DES-2688
Sibling PR: https://github.com/mullvad/gotatun/pull/27

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10277)
<!-- Reviewable:end -->
