### PR TITLE
Restart GUI after update on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Line wrap the file at 100 chars.                                              Th
 - `mullvad-early-boot-blocking.service` now waits for local file system to be mounted
   (`After=local-fs.target`). This was assumed before, but not required (and is still not required).
 
+#### macOS
+- Restart the GUI after an update if it was running.
+
 ### Fixed
 - Fix duplicate "Connected"/"Disconnected" desktop notifications caused by the daemon sending
   multiple consecutive tunnel state events for the same state.

--- a/dist-assets/pkg-scripts/postinstall
+++ b/dist-assets/pkg-scripts/postinstall
@@ -109,3 +109,20 @@ ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/_mullvad" "$ZSH_COMPLETI
 if [[ -d "$FISH_COMPLETIONS_DIR" ]]; then
     ln -sf "$INSTALL_DIR/Mullvad VPN.app/Contents/Resources/mullvad.fish" "$FISH_COMPLETIONS_DIR/mullvad.fish"
 fi
+
+# Relaunch the GUI if it was running before the upgrade.
+GUI_RUNNING_MARKER="/var/run/mullvad-gui-was-running"
+if [[ -f "$GUI_RUNNING_MARKER" ]]; then
+    rm -f "$GUI_RUNNING_MARKER"
+
+    # Identify the console user. $USER is not trustworthy as it may be root if `sudo installer` is used.
+    CONSOLE_USER=$(stat -f "%Su" /dev/console)
+    if [[ -n "$CONSOLE_USER" && "$CONSOLE_USER" != "root" && "$CONSOLE_USER" != "loginwindow" ]]; then
+        CONSOLE_UID=$(id -u "$CONSOLE_USER")
+        launchctl asuser "$CONSOLE_UID" sudo -u "$CONSOLE_USER" \
+            open -a "$INSTALL_DIR/Mullvad VPN.app" \
+            || echo "Failed to relaunch GUI as $CONSOLE_USER"
+    else
+        echo "No console user; skipping GUI relaunch"
+    fi
+fi

--- a/dist-assets/pkg-scripts/preinstall
+++ b/dist-assets/pkg-scripts/preinstall
@@ -53,5 +53,14 @@ fi
 rm "$NEW_CACHE_DIR/relays.json" || true
 rm "$NEW_CACHE_DIR/api-ip-address.txt" || true
 
+# Record whether the GUI is running so postinstall can relaunch it. /var/run is
+# root-only writable, so an unprivileged user can't plant the marker.
+GUI_RUNNING_MARKER="/var/run/mullvad-gui-was-running"
+if pgrep -x "Mullvad VPN" >/dev/null 2>&1; then
+    : > "$GUI_RUNNING_MARKER"
+else
+    rm -f "$GUI_RUNNING_MARKER"
+fi
+
 # Kill the GUI before proceeding with the upgrade.
 pkill -x "Mullvad VPN" && sleep 1 || echo "Unable to kill GUI, not running?"


### PR DESCRIPTION
This restarts the GUI after an update on macOS, if it was running prior to the update.

To do this we have to remember whether the app was running before we killed it, and relaunch it in `postinstall`.

Fix DES-928

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10278)
<!-- Reviewable:end -->
