### PR TITLE
Fix invalid shadowsocks ciphers crashing the app

### DIFF
--- a/ios/MullvadRESTTests/MullvadApiTests.swift
+++ b/ios/MullvadRESTTests/MullvadApiTests.swift
@@ -46,11 +46,7 @@ class MullvadApiTests: XCTestCase {
             domain: REST.encryptedDNSHostname,
             disableTls: true,
             shadowsocksProvider: shadowsocksLoader,
-            accessMethodWrapper: initAccessMethodSettingsWrapper(
-                methods:
-                    accessMethodsRepository
-                    .fetchAll()
-            ),
+            accessMethodWrapper: initAccessMethodSettingsWrapper(methods: accessMethodsRepository.fetchAll()),
             accessMethodChangeListeners: []
         )
 

--- a/ios/MullvadRESTTests/RelayListCacheTests.swift
+++ b/ios/MullvadRESTTests/RelayListCacheTests.swift
@@ -109,9 +109,7 @@ class RelayListCacheTests: XCTestCase {
             domain: REST.encryptedDNSHostname,
             disableTls: true,
             shadowsocksProvider: shadowsocksLoader,
-            accessMethodWrapper: initAccessMethodSettingsWrapper(
-                methods: accessMethodsRepository.fetchAll()
-            ),
+            accessMethodWrapper: initAccessMethodSettingsWrapper(methods: accessMethodsRepository.fetchAll()),
             accessMethodChangeListeners: []
         )
 

--- a/ios/MullvadRustRuntime/MullvadAccessMethodReceiver.swift
+++ b/ios/MullvadRustRuntime/MullvadAccessMethodReceiver.swift
@@ -13,13 +13,16 @@ import MullvadTypes
 public class MullvadAccessMethodReceiver {
     private var cancellables = Set<Combine.AnyCancellable>()
     let apiContext: MullvadApiContext
+    let validShadowsocksCiphers: [String]
 
     public init(
         apiContext: MullvadApiContext,
+        validShadowsocksCiphers: [String],
         accessMethodsDataSource: AnyPublisher<[PersistentAccessMethod], Never>,
         requestDataSource: AnyPublisher<PersistentAccessMethod, Never>
     ) {
         self.apiContext = apiContext
+        self.validShadowsocksCiphers = validShadowsocksCiphers
 
         requestDataSource.sink { [weak self] latestReachable in
             self?.saveLastReachable(latestReachable)

--- a/ios/MullvadRustRuntime/MullvadConnectionModeProvider.swift
+++ b/ios/MullvadRustRuntime/MullvadConnectionModeProvider.swift
@@ -8,9 +8,9 @@
 
 import MullvadTypes
 
-public func initAccessMethodSettingsWrapper(methods: [PersistentAccessMethod])
-    -> SwiftAccessMethodSettingsWrapper
-{
+public func initAccessMethodSettingsWrapper(methods: [PersistentAccessMethod]) -> SwiftAccessMethodSettingsWrapper {
+    let validShadowsocksCiphers = ShadowsocksCipherService().getCiphers()
+
     // 1. Get all the built in access methods, it is expected that they are always available
     let directMethod = methods.first(where: { $0.proxyConfiguration == .direct })!
     let bridgesMethod = methods.first(where: { $0.proxyConfiguration == .bridges })!
@@ -18,21 +18,27 @@ public func initAccessMethodSettingsWrapper(methods: [PersistentAccessMethod])
 
     // 2. Get the custom access methods
     let defaultMethods: [PersistentProxyConfiguration] = [.direct, .bridges, .encryptedDNS]
-    let customMethods = methods.filter { defaultMethods.contains($0.proxyConfiguration) == false }
+    let customMethods = methods.filter {
+        // Make sure we only use access methods with valid ciphers.
+        if case .shadowsocks(let config) = $0.proxyConfiguration {
+            guard validShadowsocksCiphers.contains(config.cipher) else {
+                return false
+            }
+        }
+
+        return !defaultMethods.contains($0.proxyConfiguration)
+    }
 
     // 3. Convert the builtin access methods
     let directMethodRaw = convertAccessMethod(accessMethod: directMethod)
     let bridgesMethodRaw = convertAccessMethod(accessMethod: bridgesMethod)
     let encryptedDNSMethodRaw = convertAccessMethod(accessMethod: encryptedDNSMethod)
 
-    var rawCustomMethods = ContiguousArray<UnsafeRawPointer?>([])
     // 4. Convert the custom access methods (all takes different parameters)
-    for method in customMethods {
-        let rawMethod = convertAccessMethod(accessMethod: method)
-        rawCustomMethods.append(rawMethod)
-    }
+    var rawCustomMethods = customMethods.map { convertAccessMethod(accessMethod: $0) }
 
     // 5. Reunite them all in one, and pass it to rust
+    let customMethodCount = rawCustomMethods.count
     return rawCustomMethods.withUnsafeMutableBufferPointer(
         {
             init_access_method_settings_wrapper(
@@ -40,7 +46,7 @@ public func initAccessMethodSettingsWrapper(methods: [PersistentAccessMethod])
                 bridgesMethodRaw,
                 encryptedDNSMethodRaw,
                 $0.baseAddress!,
-                UInt(customMethods.count)
+                UInt(customMethodCount)
             )
         }
     )

--- a/ios/MullvadRustRuntimeTests/MullvadConnectionModeProviderTests.swift
+++ b/ios/MullvadRustRuntimeTests/MullvadConnectionModeProviderTests.swift
@@ -1,0 +1,37 @@
+//
+//  MullvadConnectionModeProviderTests.swift
+//  MullvadVPN
+//
+//  Created by Jon Petersson on 2026-04-27.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadMockData
+import MullvadRustRuntime
+import MullvadTypes
+import XCTest
+
+class MullvadConnectionModeProviderTests: XCTestCase {
+    func testInvalidCipherDoesNotCauseExceptionInRust() {
+        var methods = AccessMethodRepositoryStub.stub.fetchAll()
+
+        let customMethod = PersistentAccessMethod(
+            id: UUID(),
+            name: "Method",
+            isEnabled: true,
+            proxyConfiguration: .shadowsocks(
+                PersistentProxyConfiguration.ShadowsocksConfiguration(
+                    server: .ipv4(.loopback),
+                    port: 1,
+                    password: "",
+                    cipher: "invalidCipher"
+                )
+            )
+        )
+
+        methods.append(customMethod)
+
+        _ = initAccessMethodSettingsWrapper(methods: methods)
+        XCTAssert(true)
+    }
+}

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -715,6 +715,7 @@
 		7ADCB2DA2B6A730400C88F89 /* IPOverrideRepositoryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADCB2D92B6A730400C88F89 /* IPOverrideRepositoryStub.swift */; };
 		7AE044BB2A935726003915D8 /* Routing.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A88DCD02A8FABBE00D2FF0E /* Routing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7AE16D802F97AEBE00A72A39 /* MultihopWhenNeededInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE16D7F2F97AEBE00A72A39 /* MultihopWhenNeededInfoView.swift */; };
+		7AE16DD02F9F7DCB00A72A39 /* MullvadConnectionModeProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE16DCF2F9F7DB100A72A39 /* MullvadConnectionModeProviderTests.swift */; };
 		7AE90B682C2D726000375A60 /* NSParagraphStyle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AE90B672C2D726000375A60 /* NSParagraphStyle+Extensions.swift */; };
 		7AEBA52A2C2179F20018BEC5 /* RelaySelectorWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AEBA5292C2179F20018BEC5 /* RelaySelectorWrapper.swift */; };
 		7AED35CC2BD13F60002A67D1 /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
@@ -2364,6 +2365,7 @@
 		7ADCB2D72B6A6EB300C88F89 /* AnyRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRelay.swift; sourceTree = "<group>"; };
 		7ADCB2D92B6A730400C88F89 /* IPOverrideRepositoryStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPOverrideRepositoryStub.swift; sourceTree = "<group>"; };
 		7AE16D7F2F97AEBE00A72A39 /* MultihopWhenNeededInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultihopWhenNeededInfoView.swift; sourceTree = "<group>"; };
+		7AE16DCF2F9F7DB100A72A39 /* MullvadConnectionModeProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadConnectionModeProviderTests.swift; sourceTree = "<group>"; };
 		7AE90B672C2D726000375A60 /* NSParagraphStyle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSParagraphStyle+Extensions.swift"; sourceTree = "<group>"; };
 		7AEBA5292C2179F20018BEC5 /* RelaySelectorWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RelaySelectorWrapper.swift; sourceTree = "<group>"; };
 		7AEF7F192AD00F52006FE45D /* AppMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppMessageHandler.swift; sourceTree = "<group>"; };
@@ -4797,13 +4799,14 @@
 		A9D9A4C12C36D53C004088DD /* MullvadRustRuntimeTests */ = {
 			isa = PBXGroup;
 			children = (
-				016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */,
+				7AE16DCF2F9F7DB100A72A39 /* MullvadConnectionModeProviderTests.swift */,
 				A98F1B502C19C48D003C869E /* EphemeralPeerExchangeActorTests.swift */,
 				A9C308392C19DDA7008715F1 /* MullvadPostQuantum+Stubs.swift */,
 				585A02EC2A4B28F300C6CAFF /* TCPConnection.swift */,
 				58695A9F2A4ADA9200328DB3 /* TunnelObfuscationTests.swift */,
 				585A02EA2A4B285800C6CAFF /* UDPConnection.swift */,
 				585A02E82A4B283000C6CAFF /* UnsafeListener.swift */,
+				016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */,
 			);
 			path = MullvadRustRuntimeTests;
 			sourceTree = "<group>";
@@ -7241,6 +7244,7 @@
 				A9D9A4D22C36DBAF004088DD /* MullvadPostQuantum+Stubs.swift in Sources */,
 				F08B6B772C52878400D0A121 /* EphemeralPeerExchangeActorTests.swift in Sources */,
 				016EE03A2F850C5A0035B25C /* WireGuardKeyTests.swift in Sources */,
+				7AE16DD02F9F7DCB00A72A39 /* MullvadConnectionModeProviderTests.swift in Sources */,
 				A9D9A4CF2C36D54E004088DD /* TCPConnection.swift in Sources */,
 				A9D9A4CE2C36D54E004088DD /* TunnelObfuscationTests.swift in Sources */,
 				A9D9A4CC2C36D54E004088DD /* UnsafeListener.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -116,6 +116,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         accessMethodReceiver = MullvadAccessMethodReceiver(
             apiContext: apiContext,
+            validShadowsocksCiphers: accessMethodRepository.shadowsocksCiphers,
             accessMethodsDataSource: accessMethodRepository.accessMethodsPublisher,
             requestDataSource: accessMethodRepository.requestAccessMethodPublisher
         )

--- a/ios/MullvadVPN/StorePaymentManager/StorePaymentManager.swift
+++ b/ios/MullvadVPN/StorePaymentManager/StorePaymentManager.swift
@@ -229,7 +229,7 @@ final actor StorePaymentManager: @unchecked Sendable {
 
         switch result {
         case let .success(accountData):
-            logger.info("Successfully updated account data. New expiry: \(accountData.expiry.logFormatted)")
+            logger.info("Successfully updated account data. New expiry: \(accountData.expiry.safeLogFormatted)")
             await interactor.updateAccountData(for: accountData)
 
         case let .failure(error):

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
@@ -48,7 +48,8 @@ class TunnelManagerTests: XCTestCase {
         )
 
         let opaqueAccessMethodSettingsWrapper = initAccessMethodSettingsWrapper(
-            methods: AccessMethodRepositoryStub.stub.fetchAll())
+            methods: AccessMethodRepositoryStub.stub.fetchAll()
+        )
 
         apiContext = try MullvadApiContext(
             host: REST.defaultAPIHostname,

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -261,6 +261,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     ) {
         accessMethodReceiver = MullvadAccessMethodReceiver(
             apiContext: apiContext,
+            validShadowsocksCiphers: accessMethodRepository.shadowsocksCiphers,
             accessMethodsDataSource: accessMethodRepository.accessMethodsPublisher,
             requestDataSource: accessMethodRepository.requestAccessMethodPublisher
         )


### PR DESCRIPTION
Sending an invalid shadowsocks cipher to the Rust layer causes a crash. This PR fixes this by validating the ciphers before initializing stored custom access methods.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10284)
<!-- Reviewable:end -->
