### PR TITLE
Perform `brew update` only once

### DIFF
--- a/.github/actions/ios/setup-project-toolchain/action.yml
+++ b/.github/actions/ios/setup-project-toolchain/action.yml
@@ -36,15 +36,17 @@ runs:
       run: rustup target add ${{ inputs.ios_rust_target }}
       shell: bash
 
+    - name: Update brew's internal repository
+      run: brew update
+      shell: bash
+
     - name: Install xcbeautify
       run: |
-        brew update
         brew install xcbeautify
       shell: bash
 
     - name: Install protobuf
       run: |
-        brew update
         brew install protobuf
       shell: bash
 


### PR DESCRIPTION
We have some failing builds due to `flock` files being left behind after a `brew update`.

Running `brew update && brew update` results in a failure, indicating something is left behind.

In my chase of this I've tried different variants, but it consistently comes down to `brew`. As `brew` reported that some of the `taps` should be removed (`brew untap` both `homebrew/core` and `homebrew/cask`), I wondered if they were contributing to this which they weren't.

Some changes were made to the runners which lead to believe this can be a regression. Created an issue for this at the corresponding GitHub repository:  https://github.com/actions/runner-images/issues/13965

Alternatively, I played around with [`git config --global core.fsmonitor`](https://github.com/orgs/Homebrew/discussions/5478#discussioncomment-10129263) setting it to both `true` and `false` to no avail:

- `true`: https://github.com/mullvad/mullvadvpn-app/actions/runs/25036050563
- `false`: https://github.com/mullvad/mullvadvpn-app/actions/runs/25036101496/job/73328106283

Seems like we either accept only being able to do it once or to manually delete those lock files before we do a `brew update`. Since we do not strictly need the double `brew update`, I'd go with reducing it for now.

This leaves us in a better state once the image is corrected and removing lock files of a different program feels a bit iffy to me.

---

<details>
  <summary>Log for reference</summary>

```
# Installing xcbeautify, which does not actually install due to
already being present
Run brew update
  brew update
  brew install xcbeautify
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    SOURCE_PACKAGES_PATH: .spm
==> Updating Homebrew...
To restore the stashed changes to /opt/homebrew/Library/Taps/homebrew
/homebrew-core, run:
  cd /opt/homebrew/Library/Taps/homebrew/homebrew-core && git stash 
  pop
==> Homebrew's analytics have entirely moved to our InfluxDB instance
  in the EU.
  We gather less data than before and have destroyed all Google
  Analytics data: https://docs.brew.sh/Analytics
  Please reconsider re-enabling analytics to help our volunteer
  maintainers with: brew analytics on
==> Homebrew is run entirely by unpaid volunteers. Please consider
  donating:
  https://github.com/Homebrew/brew#donations

Updated 4 taps (hashicorp/tap, aws/tap, homebrew/core and homebrew/
cask).
==> New Formulae
floresta: Lightweight and embeddable Bitcoin client, built for
sovereignty forgecode: AI-enhanced terminal development environment
lazymake: Modern TUI for Makefiles
try: Quickly manage and navigate project directories for experiments
vite-plus: Unified toolchain and entry point for web development
==> New Casks
hop: View and edit HWP documents
paranoia-file-text-encryption: File and text encryptor with
steganography and post-quantum key exchange

==> Outdated Formulae
certifi
cmake
gh
kotlin
node@22
pydantic
simdutf

You have 7 outdated formulae installed.
You can upgrade them with brew upgrade
or list them with brew outdated.
Warning: xcbeautify 3.2.1 is already installed and up-to-date.
To reinstall 3.2.1, run:
  brew reinstall xcbeautify

# Install Protobuf, which fails
Run brew update
  brew update
  brew install protobuf
  shell: /bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    SOURCE_PACKAGES_PATH: .spm
lockf: 200: already locked
Error: Another `brew update` process is already running.
Please wait for it to finish or terminate it to continue.
```
</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10289)
<!-- Reviewable:end -->
