### PR TITLE
Add ubuntu2604 to nightly end-to-end tests

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -50,7 +50,7 @@ jobs:
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
           all='["debian11","debian12","debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","ubuntu2604","fedora41","fedora42","fedora43","fedora44"]'
-          default='["debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","ubuntu2604","fedora42","fedora43"]'
+          default='["debian13","ubuntu2204","ubuntu2404","ubuntu2510","ubuntu2604","fedora42","fedora43"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -50,7 +50,7 @@ jobs:
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
           all='["debian11","debian12","debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","ubuntu2604","fedora41","fedora42","fedora43","fedora44"]'
-          default='["debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","fedora42","fedora43"]'
+          default='["debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","ubuntu2604","fedora42","fedora43"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -50,7 +50,7 @@ jobs:
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
           all='["debian11","debian12","debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","ubuntu2604","fedora41","fedora42","fedora43","fedora44"]'
-          default='["debian13","ubuntu2204","ubuntu2404","ubuntu2510","ubuntu2604","fedora42","fedora43"]'
+          default='["debian13","ubuntu2404","ubuntu2510","ubuntu2604","fedora42","fedora43"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then


### PR DESCRIPTION
This PR adds Ubuntu 26.04 as one of the default VMs to run for the desktop e2e github actions workflow, which means that it will be run as part of the nightly test runs.

This PR also removes the interim Ubuntu 25.04 release (it was kind of strange that we kept it this long), and the 22.04 LTS release. Officially we aim to support the 2 latest LTS releases. Both of these VMs can still be triggered manually for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10297)
<!-- Reviewable:end -->
