### PR TITLE
Upgrade rustls-webpki to fix RUSTSEC-2026-0104

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -2950,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
This PR addresses https://osv.dev/vulnerability/RUSTSEC-2026-0104 by upgrading rustls-webpki to a patched version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10299)
<!-- Reviewable:end -->
