### PR TITLE
Reverse order of hops in MultihopSelectionView

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/MultihopSelection/MultihopSelectionView.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/MultihopSelection/MultihopSelectionView.swift
@@ -55,19 +55,28 @@ struct MultihopSelectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             if isExpanded {
+                var label: LocalizedStringKey {
+                    if let deviceLocationName {
+                        "Your device (\(deviceLocationName))"
+                    } else {
+                        "Your device"
+                    }
+                }
                 MultihopLabel(
-                    label: "Internet",
-                    image: Image.mullvadIconInternet,
+                    label: label,
+                    image: Image.mullvadSmartphone,
                     onIconPositionChange: { position in
-                        iconPositions[ViewPositionIdentifiers.internet] = position
+                        iconPositions[ViewPositionIdentifiers.yourDevice] = position
                     }
                 )
+                .transition(.move(edge: .top).combined(with: .opacity))
                 .padding(.horizontal, outerPadding + 8 + 2)
             }
+
             VStack(alignment: .leading, spacing: 3) {
                 VStack(alignment: .leading, spacing: spacing) {
                     ForEach(
-                        Array(hops.reversed().enumerated()),
+                        Array(hops.enumerated()),
                         id: \.element.multihopContext
                     ) {
                         index,
@@ -150,21 +159,13 @@ struct MultihopSelectionView: View {
                 }
                 .zIndex(1)
                 if isExpanded {
-                    var label: LocalizedStringKey {
-                        if let deviceLocationName {
-                            "Your device (\(deviceLocationName))"
-                        } else {
-                            "Your device"
-                        }
-                    }
                     MultihopLabel(
-                        label: label,
-                        image: Image.mullvadSmartphone,
+                        label: "Internet",
+                        image: Image.mullvadIconInternet,
                         onIconPositionChange: { position in
-                            iconPositions[ViewPositionIdentifiers.yourDevice] = position
+                            iconPositions[ViewPositionIdentifiers.internet] = position
                         }
                     )
-                    .transition(.move(edge: .top).combined(with: .opacity))
                     .padding(.horizontal, outerPadding + 8 + 2)
                 }
             }


### PR DESCRIPTION
This vertically reverses the multihop list in the selection view to have the entry at the top and the exit at the bottom. It now looks like:

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e5790336-bd1b-44ac-b0be-f7779df5c865" />


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10308)
<!-- Reviewable:end -->
