### PR TITLE
Further split GotaTun apart from WireGuardGo

### DIFF
--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -1186,6 +1186,9 @@
 		F9E3BCF72DD35B78009986C3 /* ListAccessViewModelBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E3BCF62DD35B78009986C3 /* ListAccessViewModelBridge.swift */; };
 		F9EDB26C2EC4C0480015DE36 /* CustomListInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EDB26B2EC4C0420015DE36 /* CustomListInteractorTests.swift */; };
 		F9EDB26D2EC4C0CD0015DE36 /* CustomListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6389DA2B7E3BD6008E77E1 /* CustomListInteractor.swift */; };
+		2F169CDAE6E8C601F85C543E /* TunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */; };
+		D56CD86C4435C3F6AF2A2662 /* WireGuardGoTunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */; };
+		E79BD7E565693BF2BDA5D9E6 /* GotaTunTunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2735,6 +2738,9 @@
 		F9C579C72E8FE10400C90C50 /* LocationItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationItemView.swift; sourceTree = "<group>"; };
 		F9E3BCF62DD35B78009986C3 /* ListAccessViewModelBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAccessViewModelBridge.swift; sourceTree = "<group>"; };
 		F9EDB26B2EC4C0420015DE36 /* CustomListInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomListInteractorTests.swift; sourceTree = "<group>"; };
+		B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelImplementation.swift; sourceTree = "<group>"; };
+		DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardGoTunnelImplementation.swift; sourceTree = "<group>"; };
+		F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunTunnelImplementation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3769,6 +3775,9 @@
 				58342C032AAB61FB003BA12D /* State+Extensions.swift */,
 				58DDA18E2ABC32380039C360 /* Timings.swift */,
 				F04DD3D72C130DF600E03E28 /* TunnelSettingsManager.swift */,
+				E10A0001000000000000AA01 /* GotaTunActor.swift */,
+				F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */,
+				B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */,
 			);
 			path = Actor;
 			sourceTree = "<group>";
@@ -4166,7 +4175,6 @@
 			children = (
 				F09D616A2F5AD5E200C85C9E /* Localizable.xcstrings */,
 				58915D662A25F9F20066445B /* DeviceCheck */,
-				E10A0001000000000000AC01 /* GotaTunAdapter */,
 				7A9ED2A82F3CC057005BC0D9 /* Notifications */,
 				58F3F3682AA08E2200D3B0A4 /* PacketTunnelProvider */,
 				F059197A2C45404500C301F3 /* PostQuantum */,
@@ -4379,6 +4387,7 @@
 				58225D272A84F23B0083D7F1 /* PacketTunnelPathObserver.swift */,
 				58F3F3692AA08E3C00D3B0A4 /* PacketTunnelProvider.swift */,
 				5864AF7C2A9F4DC9008BC928 /* SettingsReader.swift */,
+				DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */,
 			);
 			path = PacketTunnelProvider;
 			sourceTree = "<group>";
@@ -4815,14 +4824,6 @@
 				016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */,
 			);
 			path = MullvadRustRuntimeTests;
-			sourceTree = "<group>";
-		};
-		E10A0001000000000000AC01 /* GotaTunAdapter */ = {
-			isa = PBXGroup;
-			children = (
-				E10A0001000000000000AA01 /* GotaTunActor.swift */,
-			);
-			path = GotaTunAdapter;
 			sourceTree = "<group>";
 		};
 		F028A5472A336E1900C0CAA3 /* RedeemVoucher */ = {
@@ -6461,6 +6462,9 @@
 				F04AF92D2C466013004A8314 /* EphemeralPeerNegotiationState.swift in Sources */,
 				58FE25D92AA72A8F003D1918 /* AutoCancellingTask.swift in Sources */,
 				58C7A4582A863FB90060C66F /* TunnelMonitorProtocol.swift in Sources */,
+				E10A0001000000000000AB01 /* GotaTunActor.swift in Sources */,
+				E79BD7E565693BF2BDA5D9E6 /* GotaTunTunnelImplementation.swift in Sources */,
+				2F169CDAE6E8C601F85C543E /* TunnelImplementation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6994,7 +6998,7 @@
 				58C7A45B2A8640030060C66F /* PacketTunnelPathObserver.swift in Sources */,
 				580D6B8E2AB33BBF00B2D6E0 /* BlockedStateErrorMapper.swift in Sources */,
 				06AC116228F94C450037AF9A /* ApplicationConfiguration.swift in Sources */,
-				E10A0001000000000000AB01 /* GotaTunActor.swift in Sources */,
+				D56CD86C4435C3F6AF2A2662 /* WireGuardGoTunnelImplementation.swift in Sources */,
 				E10A0002000000000000AB04 /* PacketTunnelDebugSettings.swift in Sources */,
 				58CE38C728992C8700A6D6E5 /* WireGuardAdapterError+Localization.swift in Sources */,
 				58E511E828DDDF2400B0BCDE /* CodingErrors+CustomErrorDescription.swift in Sources */,

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -19,23 +19,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     private let internalQueue = DispatchQueue(label: "PacketTunnel-internalQueue")
     private let providerLogger: Logger
 
-    private var actor: (any PacketTunnelActorProtocol)!
+    /// The selected tunnel implementation (WireGuardGo or GotaTun).
+    private var implementation: TunnelImplementation!
     private var appMessageHandler: AppMessageHandler!
-    private var stateObserverTask: AnyTask?
     private var deviceChecker: DeviceChecker!
-    private var adapter: WgAdapter!
-    private var relaySelector: RelaySelectorWrapper!
-    private var ephemeralPeerExchangingPipeline: EphemeralPeerExchangingPipeline!
     private var newAppVersionSystemNoticationHandler: NewAppVersionSystemNotificationHandler!
     private let tunnelSettingsUpdater: SettingsUpdater
-    private let defaultPathObserver: PacketTunnelPathObserver
     private var migrationManager: MigrationManager
     let migrationFailureIterator = REST.RetryStrategy.failedMigrationRecovery.makeDelayIterator()
 
     private let tunnelSettingsListener = TunnelSettingsListener()
-    private lazy var ephemeralPeerReceiver = {
-        EphemeralPeerReceiver(tunnelProvider: adapter, keyReceiver: self)
-    }()
 
     var apiContext: MullvadApiContext!
     var accessMethodReceiver: MullvadAccessMethodReceiver!
@@ -54,8 +47,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         )
         tunnelSettingsUpdater = SettingsUpdater(listener: tunnelSettingsListener)
         migrationManager = MigrationManager(cacheDirectory: containerURL)
-
-        defaultPathObserver = PacketTunnelPathObserver(eventQueue: internalQueue)
 
         super.init()
 
@@ -99,29 +90,29 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
         #if DEBUG
             if PacketTunnelDebugSettings.useGotaTun {
-                providerLogger.info("Using GotaTunActor (debug)")
-                actor = GotaTunActor()
+                providerLogger.info("Using GotaTun implementation (debug)")
+                implementation = GotaTunTunnelImplementation()
             } else {
-                setUpWireGuardActor(
-                    ipOverrideWrapper: ipOverrideWrapper,
-                    settingsReader: settingsReader,
-                    apiTransportProvider: apiTransportProvider
-                )
+                implementation = makeWireGuardGoImplementation()
             }
         #else
-            setUpWireGuardActor(
-                ipOverrideWrapper: ipOverrideWrapper,
-                settingsReader: settingsReader,
-                apiTransportProvider: apiTransportProvider
-            )
+            implementation = makeWireGuardGoImplementation()
         #endif
+
+        implementation.setUp(
+            provider: self,
+            internalQueue: internalQueue,
+            ipOverrideWrapper: ipOverrideWrapper,
+            settingsReader: settingsReader,
+            apiTransportProvider: apiTransportProvider
+        )
 
         let apiRequestProxy = APIRequestProxy(
             dispatchQueue: internalQueue,
             transportProvider: apiTransportProvider
         )
         appMessageHandler = AppMessageHandler(
-            packetTunnelActor: actor,
+            packetTunnelActor: implementation.actor,
             apiRequestProxy: apiRequestProxy
         )
 
@@ -142,8 +133,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     ) {
         let startOptions = parseStartOptions(options ?? [:])
 
-        startObservingActorState()
-
         // Run device check during tunnel startup.
         // This check is allowed to push new key to server if there are some issues with it.
         startDeviceCheck(rotateKeyOnMismatch: true)
@@ -157,8 +146,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
                             "Failed to configure tunnel with initial config: \(error)"
                         )
                 } else {
-                    self.providerLogger.debug("Starting actor after initial configuration is applied")
-                    self.actor.start(options: startOptions)
+                    self.providerLogger.debug("Starting tunnel implementation after initial configuration is applied")
+                    Task { await self.implementation.startTunnel(options: startOptions) }
                 }
                 self.internalQueue.async {
                     completionHandler(error)
@@ -169,10 +158,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     override func stopTunnel(with reason: NEProviderStopReason) async {
         providerLogger.debug("stopTunnel: \(ProviderStopReasonWrapper(reason: reason))")
 
-        actor.stop()
-        await actor.waitUntilDisconnected()
-
-        stopObservingActorState()
+        await implementation.stopTunnel()
     }
 
     override func handleAppMessage(_ messageData: Data) async -> Data? {
@@ -180,11 +166,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     }
 
     override func sleep() async {
-        actor.onSleep()
+        await implementation.sleep()
     }
 
     override func wake() {
-        actor.onWake()
+        implementation.wake()
     }
 
     private func performSettingsMigration() {
@@ -267,58 +253,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         )
     }
 
-    private func setUpWireGuardActor(
-        ipOverrideWrapper: IPOverrideWrapper,
-        settingsReader: sending TunnelSettingsManager,
-        apiTransportProvider: APITransportProvider
-    ) {
-        adapter = WgAdapter(packetTunnelProvider: self)
-
-        let pinger = TunnelPinger(pingProvider: adapter.icmpPingProvider, replyQueue: internalQueue)
-
-        let tunnelMonitor = TunnelMonitor(
-            eventQueue: internalQueue,
-            pinger: pinger,
-            tunnelDeviceInfo: adapter,
-            timings: TunnelMonitorTimings()
-        )
-
-        relaySelector = RelaySelectorWrapper(
-            relayCache: ipOverrideWrapper
-        )
-
-        actor = PacketTunnelActor(
-            timings: PacketTunnelActorTimings(),
-            tunnelAdapter: adapter,
-            tunnelMonitor: tunnelMonitor,
-            defaultPathObserver: defaultPathObserver,
-            blockedStateErrorMapper: BlockedStateErrorMapper(),
-            relaySelector: relaySelector,
-            settingsReader: settingsReader,
-            protocolObfuscator: ProtocolObfuscator<TunnelObfuscator>()
-        )
-
-        // Since PacketTunnelActor depends on the path observer, start observing after actor has been initalized.
-        startDefaultPathObserver()
-
-        ephemeralPeerExchangingPipeline = EphemeralPeerExchangingPipeline(
-            EphemeralPeerExchangeActor(
-                packetTunnel: ephemeralPeerReceiver,
-                onFailure: self.ephemeralPeerExchangeFailed,
-                iteratorProvider: { REST.RetryStrategy.postQuantumKeyExchange.makeDelayIterator() }
-            ),
-            onUpdateConfiguration: { [unowned self] configuration in
-                let channel = OneshotChannel()
-                actor.changeEphemeralPeerNegotiationState(
-                    configuration: configuration,
-                    reconfigurationSemaphore: channel
-                )
-                await channel.receive()
-            },
-            onFinish: { [unowned self] in
-                actor.notifyEphemeralPeerNegotiated()
-            }
-        )
+    private func makeWireGuardGoImplementation() -> WireGuardGoTunnelImplementation {
+        let wgImpl = WireGuardGoTunnelImplementation()
+        wgImpl.onDeviceCheck = { [weak self] in self?.startDeviceCheck() }
+        return wgImpl
     }
 
     private func initialTunnelNetworkSettings() -> NETunnelNetworkSettings {
@@ -386,76 +324,6 @@ extension PacketTunnelProvider {
     }
 }
 
-// MARK: - Network path monitor observing
-
-extension PacketTunnelProvider {
-
-    private func startDefaultPathObserver() {
-        providerLogger.trace("Start default path observer.")
-
-        defaultPathObserver.start { [weak self] networkPath in
-            self?.actor.updateNetworkReachability(networkPathStatus: networkPath)
-        }
-    }
-
-    private func stopDefaultPathObserver() {
-        providerLogger.trace("Stop default path observer.")
-
-        defaultPathObserver.stop()
-    }
-}
-
-// MARK: - State observer
-
-extension PacketTunnelProvider {
-    private func startObservingActorState() {
-        stopObservingActorState()
-
-        stateObserverTask = Task {
-            let stateStream = await self.actor.observedStates
-            var lastConnectionAttempt: UInt = 0
-
-            for await newState in stateStream {
-                if case .connected = newState {
-                    // Instead of setting the `reasserting` flag to true when we lose connectivity, we can wait until we restore connectivity. This will decrease the amount of path updates that are issued. There's also no need to signal to the system that anything is broken - instead we just want to invalidate old sockets when a new relay connection is up - the only way to do that is to toggle this flag.
-                    self.reasserting = true
-                    self.reasserting = false
-                }
-
-                switch newState {
-                case let .reconnecting(observedConnectionState), let .connecting(observedConnectionState):
-                    let connectionAttempt = observedConnectionState.connectionAttemptCount
-
-                    // Start device check every second failure attempt to connect.
-                    if lastConnectionAttempt != connectionAttempt, connectionAttempt > 0,
-                        connectionAttempt.isMultiple(of: 2)
-                    {
-                        startDeviceCheck()
-                    }
-
-                    // Cache last connection attempt to filter out repeating calls.
-                    lastConnectionAttempt = connectionAttempt
-
-                case let .negotiatingEphemeralPeer(observedConnectionState, privateKey):
-                    await ephemeralPeerExchangingPipeline.startNegotiation(
-                        observedConnectionState,
-                        privateKey: privateKey
-                    )
-                case .disconnected:
-                    stopDefaultPathObserver()
-                case .initial, .connected, .disconnecting, .error:
-                    break
-                }
-            }
-        }
-    }
-
-    private func stopObservingActorState() {
-        stateObserverTask?.cancel()
-        stateObserverTask = nil
-    }
-}
-
 // MARK: - Device check
 
 extension PacketTunnelProvider {
@@ -473,7 +341,7 @@ extension PacketTunnelProvider {
             switch error {
             case is DeviceCheckError:
                 providerLogger.error("\(error.description) Forcing a log out")
-                actor.setErrorState(reason: .deviceLoggedOut)
+                implementation.actor.setErrorState(reason: .deviceLoggedOut)
             default:
                 providerLogger
                     .error(
@@ -484,46 +352,16 @@ extension PacketTunnelProvider {
         case let .success(keyRotationResult):
             if let blockedStateReason = keyRotationResult.blockedStateReason {
                 providerLogger.error("Entering blocked state after unsuccessful device check: \(blockedStateReason)")
-                actor.setErrorState(reason: blockedStateReason)
+                implementation.actor.setErrorState(reason: blockedStateReason)
                 return
             }
 
             switch keyRotationResult.keyRotationStatus {
             case let .attempted(date), let .succeeded(date):
-                actor.notifyKeyRotation(date: date)
+                implementation.actor.notifyKeyRotation(date: date)
             case .noAction:
                 break
             }
         }
-    }
-}
-
-extension PacketTunnelProvider: EphemeralPeerReceiving {
-    func receivePostQuantumKey(
-        _ key: WireGuard.PreSharedKey,
-        ephemeralKey: WireGuard.PrivateKey,
-        daitaParameters: MullvadTypes.DaitaV2Parameters?
-    ) async {
-        await ephemeralPeerExchangingPipeline.receivePostQuantumKey(
-            key,
-            ephemeralKey: ephemeralKey,
-            daitaParameters: daitaParameters
-        )
-    }
-
-    public func receiveEphemeralPeerPrivateKey(
-        _ ephemeralPeerPrivateKey: WireGuard.PrivateKey,
-        daitaParameters: MullvadTypes.DaitaV2Parameters?
-    ) async {
-        await ephemeralPeerExchangingPipeline.receiveEphemeralPeerPrivateKey(
-            ephemeralPeerPrivateKey,
-            daitaParameters: daitaParameters
-        )
-    }
-
-    func ephemeralPeerExchangeFailed() {
-        // Do not try reconnecting to the `.current` relay, else the actor's `State` equality check will fail
-        // and it will not try to reconnect
-        actor.reconnect(to: .random, reconnectReason: .connectionLoss)
     }
 }

--- a/ios/PacketTunnel/PacketTunnelProvider/WireGuardGoTunnelImplementation.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/WireGuardGoTunnelImplementation.swift
@@ -1,0 +1,223 @@
+//
+//  WireGuardGoTunnelImplementation.swift
+//  PacketTunnel
+//
+//  Created by Mullvad VPN.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+import MullvadREST
+import MullvadRustRuntime
+import MullvadSettings
+import MullvadTypes
+@preconcurrency import NetworkExtension
+import PacketTunnelCore
+
+/// WireGuardGo tunnel implementation.
+/// Owns the WgAdapter, TunnelMonitor, state observer, path observer,
+/// and ephemeral peer exchange pipeline.
+final class WireGuardGoTunnelImplementation: TunnelImplementation, @unchecked Sendable {
+    private let logger = Logger(label: "WireGuardGoTunnelImplementation")
+    private weak var provider: NEPacketTunnelProvider?
+
+    // WG-specific infrastructure
+    private var adapter: WgAdapter!
+    private var relaySelector: RelaySelectorWrapper!
+    private var ephemeralPeerExchangingPipeline: EphemeralPeerExchangingPipeline!
+    private var stateObserverTask: AnyTask?
+    private var defaultPathObserver: PacketTunnelPathObserver!
+    private lazy var ephemeralPeerReceiver: EphemeralPeerReceiver = {
+        EphemeralPeerReceiver(tunnelProvider: adapter, keyReceiver: self)
+    }()
+
+    private var _actor: PacketTunnelActor!
+    var actor: any PacketTunnelActorProtocol { _actor }
+
+    /// Callback to trigger a device check from the picker (shared infrastructure).
+    var onDeviceCheck: (() -> Void)?
+
+    func setUp(
+        provider: NEPacketTunnelProvider,
+        internalQueue: DispatchQueue,
+        ipOverrideWrapper: IPOverrideWrapper,
+        settingsReader: sending TunnelSettingsManager,
+        apiTransportProvider: APITransportProvider
+    ) {
+        self.provider = provider
+
+        defaultPathObserver = PacketTunnelPathObserver(eventQueue: internalQueue)
+
+        adapter = WgAdapter(packetTunnelProvider: provider)
+
+        let pinger = TunnelPinger(pingProvider: adapter.icmpPingProvider, replyQueue: internalQueue)
+
+        let tunnelMonitor = TunnelMonitor(
+            eventQueue: internalQueue,
+            pinger: pinger,
+            tunnelDeviceInfo: adapter,
+            timings: TunnelMonitorTimings()
+        )
+
+        relaySelector = RelaySelectorWrapper(
+            relayCache: ipOverrideWrapper
+        )
+
+        _actor = PacketTunnelActor(
+            timings: PacketTunnelActorTimings(),
+            tunnelAdapter: adapter,
+            tunnelMonitor: tunnelMonitor,
+            defaultPathObserver: defaultPathObserver,
+            blockedStateErrorMapper: BlockedStateErrorMapper(),
+            relaySelector: relaySelector,
+            settingsReader: settingsReader,
+            protocolObfuscator: ProtocolObfuscator<TunnelObfuscator>()
+        )
+
+        // Since PacketTunnelActor depends on the path observer, start observing after actor has been initalized.
+        startDefaultPathObserver()
+
+        ephemeralPeerExchangingPipeline = EphemeralPeerExchangingPipeline(
+            EphemeralPeerExchangeActor(
+                packetTunnel: ephemeralPeerReceiver,
+                onFailure: self.ephemeralPeerExchangeFailed,
+                iteratorProvider: { REST.RetryStrategy.postQuantumKeyExchange.makeDelayIterator() }
+            ),
+            onUpdateConfiguration: { [weak self] configuration in
+                guard let self else { return }
+                let channel = OneshotChannel()
+                _actor.changeEphemeralPeerNegotiationState(
+                    configuration: configuration,
+                    reconfigurationSemaphore: channel
+                )
+                await channel.receive()
+            },
+            onFinish: { [weak self] in
+                self?._actor.notifyEphemeralPeerNegotiated()
+            }
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    func startTunnel(options: StartOptions) async {
+        startObservingActorState()
+        actor.start(options: options)
+    }
+
+    func stopTunnel() async {
+        actor.stop()
+        await actor.waitUntilDisconnected()
+        stopObservingActorState()
+    }
+
+    func sleep() async {
+        actor.onSleep()
+    }
+
+    func wake() {
+        actor.onWake()
+    }
+}
+
+// MARK: - State observer
+
+extension WireGuardGoTunnelImplementation {
+    private func startObservingActorState() {
+        stopObservingActorState()
+
+        stateObserverTask = Task {
+            let stateStream = await self._actor.observedStates
+            var lastConnectionAttempt: UInt = 0
+
+            for await newState in stateStream {
+                if case .connected = newState {
+                    // Toggle reasserting to invalidate old sockets when a new relay connection is up.
+                    self.provider?.reasserting = true
+                    self.provider?.reasserting = false
+                }
+
+                switch newState {
+                case let .reconnecting(observedConnectionState), let .connecting(observedConnectionState):
+                    let connectionAttempt = observedConnectionState.connectionAttemptCount
+
+                    // Start device check every second failure attempt to connect.
+                    if lastConnectionAttempt != connectionAttempt, connectionAttempt > 0,
+                        connectionAttempt.isMultiple(of: 2)
+                    {
+                        onDeviceCheck?()
+                    }
+
+                    // Cache last connection attempt to filter out repeating calls.
+                    lastConnectionAttempt = connectionAttempt
+
+                case let .negotiatingEphemeralPeer(observedConnectionState, privateKey):
+                    await ephemeralPeerExchangingPipeline.startNegotiation(
+                        observedConnectionState,
+                        privateKey: privateKey
+                    )
+                case .disconnected:
+                    stopDefaultPathObserver()
+                case .initial, .connected, .disconnecting, .error:
+                    break
+                }
+            }
+        }
+    }
+
+    private func stopObservingActorState() {
+        stateObserverTask?.cancel()
+        stateObserverTask = nil
+    }
+}
+
+// MARK: - Network path monitor observing
+
+extension WireGuardGoTunnelImplementation {
+    private func startDefaultPathObserver() {
+        logger.trace("Start default path observer.")
+
+        defaultPathObserver.start { [weak self] networkPath in
+            self?._actor.updateNetworkReachability(networkPathStatus: networkPath)
+        }
+    }
+
+    private func stopDefaultPathObserver() {
+        logger.trace("Stop default path observer.")
+
+        defaultPathObserver.stop()
+    }
+}
+
+// MARK: - EphemeralPeerReceiving
+
+extension WireGuardGoTunnelImplementation: EphemeralPeerReceiving {
+    func receivePostQuantumKey(
+        _ key: WireGuard.PreSharedKey,
+        ephemeralKey: WireGuard.PrivateKey,
+        daitaParameters: MullvadTypes.DaitaV2Parameters?
+    ) async {
+        await ephemeralPeerExchangingPipeline.receivePostQuantumKey(
+            key,
+            ephemeralKey: ephemeralKey,
+            daitaParameters: daitaParameters
+        )
+    }
+
+    public func receiveEphemeralPeerPrivateKey(
+        _ ephemeralPeerPrivateKey: WireGuard.PrivateKey,
+        daitaParameters: MullvadTypes.DaitaV2Parameters?
+    ) async {
+        await ephemeralPeerExchangingPipeline.receiveEphemeralPeerPrivateKey(
+            ephemeralPeerPrivateKey,
+            daitaParameters: daitaParameters
+        )
+    }
+
+    func ephemeralPeerExchangeFailed() {
+        // Do not try reconnecting to the `.current` relay, else the actor's `State` equality check will fail
+        // and it will not try to reconnect
+        actor.reconnect(to: .random, reconnectReason: .connectionLoss)
+    }
+}

--- a/ios/PacketTunnelCore/Actor/GotaTunActor.swift
+++ b/ios/PacketTunnelCore/Actor/GotaTunActor.swift
@@ -10,19 +10,18 @@ import Foundation
 import MullvadLogging
 import MullvadTypes
 import Network
-import PacketTunnelCore
 
 /// Stub actor for GotaTun tunnel implementation.
 /// Implements `PacketTunnelActorProtocol` with no-op methods — the real
 /// GotaTun logic will be filled in later.
-final class GotaTunActor: PacketTunnelActorProtocol, @unchecked Sendable {
+public final class GotaTunActor: PacketTunnelActorProtocol, @unchecked Sendable {
     private let logger = Logger(label: "GotaTunActor")
 
-    var observedState: ObservedState {
+    public var observedState: ObservedState {
         get async { .disconnected }
     }
 
-    var observedStates: AsyncStream<ObservedState> {
+    public var observedStates: AsyncStream<ObservedState> {
         get async {
             AsyncStream { continuation in
                 continuation.yield(.disconnected)
@@ -31,51 +30,51 @@ final class GotaTunActor: PacketTunnelActorProtocol, @unchecked Sendable {
         }
     }
 
-    init() {
+    public init() {
         logger.info("GotaTunActor initialized (stub)")
     }
 
-    func start(options: StartOptions) {
+    public func start(options: StartOptions) {
         logger.info("start called (no-op)")
     }
 
-    func stop() {
+    public func stop() {
         logger.info("stop called (no-op)")
     }
 
-    func waitUntilDisconnected() async {
+    public func waitUntilDisconnected() async {
         logger.info("waitUntilDisconnected called (no-op)")
     }
 
-    func onSleep() {
+    public func onSleep() {
         logger.info("onSleep called (no-op)")
     }
 
-    func onWake() {
+    public func onWake() {
         logger.info("onWake called (no-op)")
     }
 
-    func updateNetworkReachability(networkPathStatus: NWPath.Status) {
+    public func updateNetworkReachability(networkPathStatus: NWPath.Status) {
         logger.info("updateNetworkReachability called (no-op)")
     }
 
-    func reconnect(to nextRelays: NextRelays, reconnectReason: ActorReconnectReason) {
+    public func reconnect(to nextRelays: NextRelays, reconnectReason: ActorReconnectReason) {
         logger.info("reconnect called (no-op)")
     }
 
-    func notifyKeyRotation(date: Date?) {
+    public func notifyKeyRotation(date: Date?) {
         logger.info("notifyKeyRotation called (no-op)")
     }
 
-    func setErrorState(reason: BlockedStateReason) {
+    public func setErrorState(reason: BlockedStateReason) {
         logger.info("setErrorState called (no-op)")
     }
 
-    func notifyEphemeralPeerNegotiated() {
+    public func notifyEphemeralPeerNegotiated() {
         logger.info("notifyEphemeralPeerNegotiated called (no-op)")
     }
 
-    func changeEphemeralPeerNegotiationState(
+    public func changeEphemeralPeerNegotiationState(
         configuration: EphemeralPeerNegotiationState,
         reconfigurationSemaphore: OneshotChannel
     ) {

--- a/ios/PacketTunnelCore/Actor/GotaTunTunnelImplementation.swift
+++ b/ios/PacketTunnelCore/Actor/GotaTunTunnelImplementation.swift
@@ -1,0 +1,54 @@
+//
+//  GotaTunTunnelImplementation.swift
+//  PacketTunnel
+//
+//  Created by Mullvad VPN.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadLogging
+import MullvadREST
+@preconcurrency import NetworkExtension
+
+/// GotaTun tunnel implementation.
+/// Unlike WireGuardGo, this implementation does NOT use an external state observer.
+/// State transitions are handled internally by the GotaTun actor.
+public final class GotaTunTunnelImplementation: TunnelImplementation, @unchecked Sendable {
+    private let logger = Logger(label: "GotaTunTunnelImplementation")
+
+    private let _actor = GotaTunActor()
+    public var actor: any PacketTunnelActorProtocol { _actor }
+
+    public init() {}
+
+    public func setUp(
+        provider: NEPacketTunnelProvider,
+        internalQueue: DispatchQueue,
+        ipOverrideWrapper: IPOverrideWrapper,
+        settingsReader: sending TunnelSettingsManager,
+        apiTransportProvider: APITransportProvider
+    ) {
+        // GotaTun-specific setup will go here when the actor is no longer a stub.
+        // The actor will internally manage state transitions, path observation,
+        // and system API calls through its own mechanisms.
+    }
+
+    public func startTunnel(options: StartOptions) async {
+        // NO startObservingActorState() - this is the key architectural difference.
+        // The GotaTun actor handles state internally.
+        actor.start(options: options)
+    }
+
+    public func stopTunnel() async {
+        actor.stop()
+        await actor.waitUntilDisconnected()
+    }
+
+    public func sleep() async {
+        actor.onSleep()
+    }
+
+    public func wake() {
+        actor.onWake()
+    }
+}

--- a/ios/PacketTunnelCore/Actor/TunnelImplementation.swift
+++ b/ios/PacketTunnelCore/Actor/TunnelImplementation.swift
@@ -1,0 +1,40 @@
+//
+//  TunnelImplementation.swift
+//  PacketTunnel
+//
+//  Created by Mullvad VPN.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadREST
+@preconcurrency import NetworkExtension
+
+/// Protocol for tunnel backend implementations.
+/// The picker (`PacketTunnelProvider`) delegates all lifecycle events to the active implementation.
+public protocol TunnelImplementation: AnyObject {
+    /// The underlying actor that handles tunnel state.
+    var actor: any PacketTunnelActorProtocol { get }
+
+    /// Called once after init to wire up dependencies.
+    /// The `provider` reference is the real `NEPacketTunnelProvider` that iOS instantiated,
+    /// needed for system calls like `reasserting` and `setTunnelNetworkSettings`.
+    func setUp(
+        provider: NEPacketTunnelProvider,
+        internalQueue: DispatchQueue,
+        ipOverrideWrapper: IPOverrideWrapper,
+        settingsReader: sending TunnelSettingsManager,
+        apiTransportProvider: APITransportProvider
+    )
+
+    /// Called when the tunnel is starting, after initial network settings have been applied.
+    func startTunnel(options: StartOptions) async
+
+    /// Called when the tunnel is stopping. Must wait until disconnected before returning.
+    func stopTunnel() async
+
+    /// Called when the device is going to sleep.
+    func sleep() async
+
+    /// Called when the device wakes up.
+    func wake()
+}


### PR DESCRIPTION
I was not happy with how intertwined the previous GotaTun introduction is. This addresses that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10311)
<!-- Reviewable:end -->
