### PR TITLE
Minor fixes to toml lint workflow file

### DIFF
--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -6,6 +6,8 @@ on:
       - "**.toml"
       - ".github/workflows/lint-toml.yml"
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -1,5 +1,4 @@
 name: TOML Validation
-
 on:
   pull_request:
     paths:
@@ -13,8 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: tombi-toml/setup-tombi@v1
+
       - name: Lint TOML files
         run: tombi lint
+
       - name: Validate TOML formatting
         run: tombi format --check --diff


### PR DESCRIPTION
I noticed a warning in [security score card](https://securityscorecards.dev/viewer/?uri=github.com/mullvad/mullvadvpn-app) about:

> Warn: no topLevel permission defined: .github/workflows/lint-toml.yml:1

So this PR fixes that. The second commit is an opinionated formatting change to be more consistent with the majority of other CI workflow files (no empty newline before `on:`, but empty newlines between all job steps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10313)
<!-- Reviewable:end -->
