### PR TITLE
Enable stricter yaml linting

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Setup Rust cache
       uses: Swatinem/rust-cache@v2
       with:
-        add-job-id-key: "false" # Preserve cache across jobs
+        add-job-id-key: "false"  # Preserve cache across jobs
         cache-directories: >-
           ${{ inputs.rust-cache-targets == 'true' && env.CARGO_TARGET_DIR || '' }}
         cache-targets: ${{ inputs.rust-cache-targets }}

--- a/.github/pinact.yml
+++ b/.github/pinact.yml
@@ -4,4 +4,4 @@
 version: 3
 files:
   - pattern: .github/workflows/android-*.yml
-separator: " # "
+separator: "  # "

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ["${{ inputs.android_build_runner || 'android-build' }}"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
@@ -133,7 +133,7 @@ jobs:
     runs-on: ["${{ inputs.android_build_runner || 'android-build' }}"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Ensure correct container image is used
         run: echo "${{ needs.prepare.outputs.container_image }}" > ./building/android-container-image.txt
@@ -159,7 +159,7 @@ jobs:
           "${{ steps.build-tasks.outputs.tasks }}"
 
       - name: Upload apks
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: apks
           path: android/**/*.apk
@@ -188,7 +188,7 @@ jobs:
           - gradle-task: lint
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
@@ -221,11 +221,11 @@ jobs:
 
       - name: Checkout repository
         if: ${{ matrix.test-repeat != 0 }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         if: ${{ matrix.test-repeat != 0 }}
         with:
           name: apks
@@ -249,7 +249,7 @@ jobs:
         run: ./android/scripts/run-instrumented-tests-repeat.sh ${{ matrix.test-repeat }}
 
       - name: Upload instrumentation report (${{ matrix.test-type }})
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always() && matrix.test-repeat != 0
         with:
           name: ${{ matrix.test-type }}-instrumentation-report
@@ -282,11 +282,11 @@ jobs:
           echo "report_dir=$INNER_REPORT_DIR" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: apks
           path: android
@@ -318,7 +318,7 @@ jobs:
         run: ./android/scripts/run-instrumented-tests-repeat.sh ${{ needs.prepare.outputs.E2E_TEST_REPEAT }}
 
       - name: Upload e2e instrumentation report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: >
           always() && needs.prepare.outputs.E2E_TEST_INFRA_FLAVOR == 'stagemole'
         with:
@@ -351,17 +351,17 @@ jobs:
             path: android/test/e2e/build/outputs/apk
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: apks
           path: android
 
       - name: Run tests on Firebase Test Lab
-        uses: asadmansr/Firebase-Test-Lab-Action@505de6c4fc124883cdacf99015d626a2c979ffc8 # v1.0
+        uses: asadmansr/Firebase-Test-Lab-Action@505de6c4fc124883cdacf99015d626a2c979ffc8  # v1.0
         env:
           SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         with:

--- a/.github/workflows/android-audit.yml
+++ b/.github/workflows/android-audit.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: android-build
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
@@ -63,7 +63,7 @@ jobs:
         # https://github.com/NixOS/nixpkgs/issues/306373
         - /nix:/nix
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
@@ -89,7 +89,7 @@ jobs:
         # https://github.com/NixOS/nixpkgs/issues/306373
         - /nix:/nix
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/android-kotlin-format-check.yml
+++ b/.github/workflows/android-kotlin-format-check.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: android-build
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
@@ -50,7 +50,7 @@ jobs:
         - /nix:/nix
         - gradle-cache:/root/.gradle
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/android-reproducible-builds.yml
+++ b/.github/workflows/android-reproducible-builds.yml
@@ -54,7 +54,7 @@ jobs:
     needs: set-up-env
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.set-up-env.outputs.COMMIT_HASH }}
           submodules: true
@@ -69,7 +69,7 @@ jobs:
         run: ./building/containerized-build.sh android fullRelease
 
       - name: Upload apks
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: apk-container
           path: android/app/build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk
@@ -87,7 +87,7 @@ jobs:
           sudo apt-get -y install fdroidserver
 
       - name: Check out gradle properties
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.set-up-env.outputs.COMMIT_HASH }}
           path: app-gradle
@@ -117,7 +117,7 @@ jobs:
         run: fdroid init
 
       - name: Check out metadata
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: app-metadata
           sparse-checkout: |
@@ -136,7 +136,7 @@ jobs:
           fdroid build net.mullvad.mullvadvpn:1
 
       - name: Upload apks
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: apk-fdroidserver
           path: |
@@ -157,7 +157,7 @@ jobs:
           - runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.set-up-env.outputs.COMMIT_HASH }}
           submodules: true
@@ -166,7 +166,7 @@ jobs:
         run: |
           git fetch --no-tags origin 'refs/tags/android/*:refs/tags/android/*'
 
-      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f  # v31.10.5
 
       - name: Build app
         env:
@@ -174,7 +174,7 @@ jobs:
         run: nix develop .#android -c buildRelease
 
       - name: Upload apks
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: apk-nix-${{ matrix.runs-on }}
           path: android/app/build/outputs/apk/ossProd/release/app-oss-prod-release-unsigned.apk
@@ -191,13 +191,13 @@ jobs:
         artifact: [apk-fdroidserver, apk-nix-ubuntu-latest]
     steps:
       - name: Download apk-container (source of truth)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: apk-container
           path: artifacts/apk-container
 
       - name: Download ${{ matrix.artifact }} for comparison
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ matrix.artifact }}
           path: artifacts/${{ matrix.artifact }}
@@ -224,13 +224,13 @@ jobs:
         run: sudo apt-get install -y apktool
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.set-up-env.outputs.COMMIT_HASH }}
           submodules: true
 
       - name: Download container apk
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: apk-container
 

--- a/.github/workflows/android-static-analysis.yml
+++ b/.github/workflows/android-static-analysis.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
 
       - name: Scan code
-        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 # 0.4.5
+        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353  # 0.4.5
         with:
           args: '--type android --config android/config/config.mobsf --exit-warning android'

--- a/.github/workflows/android-validate-gradle-wrapper.yml
+++ b/.github/workflows/android-validate-gradle-wrapper.yml
@@ -14,5 +14,5 @@ jobs:
     name: Validate gradle wrapper
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e  # v6.1.0

--- a/.github/workflows/android-xml-format-check.yml
+++ b/.github/workflows/android-xml-format-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
       - name: Resolve container image
@@ -36,7 +36,7 @@ jobs:
       - name: Fix HOME path
         run: echo "HOME=/root" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
       - name: Run tidy

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,7 +6,7 @@ on:
       - .github/workflows/clippy.yml
       - 'ci/cargo-ci.sh'
       - clippy.toml
-      - '**/Cargo.toml' # Lint rules defined in toml files
+      - '**/Cargo.toml'  # Lint rules defined in toml files
       - '**/*.rs'
   workflow_dispatch:
 

--- a/.github/workflows/daemon.yml
+++ b/.github/workflows/daemon.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          add-job-id-key: "false" # Preserve cache across jobs
-          cache-targets: "false" # Only cache cargo registry
+          add-job-id-key: "false"  # Preserve cache across jobs
+          cache-targets: "false"  # Only cache cargo registry
 
       - name: Test crates
         run: ci/cargo-ci.sh test --workspace

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -203,7 +203,7 @@ jobs:
     name: Build Test Manager
     needs: prepare-linux
     # Note: libssl-dev is installed on the test server, so build test-manager there for the sake of simplicity
-    runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
+    runs-on: [self-hosted, desktop-test, Linux]  # app-test-linux
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -265,7 +265,7 @@ jobs:
       needs.get-app-version.result == 'success' &&
       needs.prepare-matrices.outputs.linux_matrix != '[]' &&
       needs.prepare-matrices.outputs.linux_matrix != ''
-    runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
+    runs-on: [self-hosted, desktop-test, Linux]  # app-test-linux
     timeout-minutes: 240
     strategy:
       fail-fast: false
@@ -393,7 +393,7 @@ jobs:
       needs.prepare-matrices.outputs.windows_matrix != '[]' &&
       needs.prepare-matrices.outputs.windows_matrix != ''
     name: Windows end-to-end tests
-    runs-on: [self-hosted, desktop-test, Linux] # app-test-linux
+    runs-on: [self-hosted, desktop-test, Linux]  # app-test-linux
     timeout-minutes: 240
     strategy:
       fail-fast: false
@@ -454,7 +454,7 @@ jobs:
       needs.prepare-matrices.outputs.macos_matrix != '[]' &&
       needs.prepare-matrices.outputs.macos_matrix != '' &&
       !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'
-    runs-on: [self-hosted, desktop-test, macOS] # app-test-macos-arm
+    runs-on: [self-hosted, desktop-test, macOS]  # app-test-macos-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -483,7 +483,7 @@ jobs:
       needs.prepare-matrices.outputs.macos_matrix != '[]' &&
       needs.prepare-matrices.outputs.macos_matrix != ''
     name: macOS end-to-end tests
-    runs-on: [self-hosted, desktop-test, macOS] # app-test-macos-arm
+    runs-on: [self-hosted, desktop-test, macOS]  # app-test-macos-arm
     timeout-minutes: 240
     strategy:
       fail-fast: false

--- a/.github/workflows/git-commit-message-style.yml
+++ b/.github/workflows/git-commit-message-style.yml
@@ -21,13 +21,13 @@ jobs:
           pattern: '^(\P{Z}|[ \t\n])+$'
           flags: 'u'
           error: 'Detected unicode whitespace character in commit message.'
-          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
-          accessToken: ${{ secrets.GITHUB_TOKEN }} # only required if checkAllCommitMessages is true
+          checkAllCommitMessages: 'true'  # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }}  # only required if checkAllCommitMessages is true
 
       # Git commit messages should follow our guidelines. This action enforces that.
       # Guidelines:  https://github.com/mullvad/coding-guidelines/blob/main/README.md#git
       - name: Check against guidelines
-        uses: mristin/opinionated-commit-message@d50df0f84391a481867d2982506853a9a654fc04 #master @ 2025-12-10
+        uses: mristin/opinionated-commit-message@d50df0f84391a481867d2982506853a9a654fc04  # master @ 2025-12-10
         with:
           # Commit messages are allowed to be subject only, no body
           allow-one-liners: 'true'

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -18,6 +18,6 @@ jobs:
       contents: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@2a387edfbe02a11d856b89172f6e978100177eb4" # v2.3.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@2a387edfbe02a11d856b89172f6e978100177eb4"  # v2.3.2
     with:
       checkout-submodules: true

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -19,6 +19,6 @@ jobs:
       contents: read
 
     # yamllint disable rule:line-length
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@2a387edfbe02a11d856b89172f6e978100177eb4" # v2.3.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@2a387edfbe02a11d856b89172f6e978100177eb4"  # v2.3.2
     with:
       checkout-submodules: false

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          add-job-id-key: "false" # Preserve cache across jobs
-          cache-targets: "false" # Only cache cargo registry
+          add-job-id-key: "false"  # Preserve cache across jobs
+          cache-targets: "false"  # Only cache cargo registry
 
       - name: Check rust docs
         run: ci/cargo-ci.sh doc --workspace --document-private-items --no-deps --keep-going

--- a/.github/workflows/testframework-clippy.yml
+++ b/.github/workflows/testframework-clippy.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - .github/workflows/testframework-clippy.yml
       - 'test/**/*.rs'
-      - 'test/**/Cargo.toml' # Lint rules defined in toml files
+      - 'test/**/Cargo.toml'  # Lint rules defined in toml files
       - clippy.toml
       - 'ci/cargo-ci.sh'
   workflow_dispatch:

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Fix HOME path
         run: echo "HOME=/root" >> $GITHUB_ENV
 
-      - name: Install system dependencies # Needed to build test-manager, and is not included in the app container.
+      - name: Install system dependencies  # Needed to build test-manager, and is not included in the app container.
         run: apt update && apt install -y pkg-config libssl-dev libpcap-dev
 
       - name: Checkout repository

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get install yamllint
-      - run: yamllint .
+      - run: yamllint --strict .

--- a/.yamllint
+++ b/.yamllint
@@ -6,4 +6,5 @@ rules:
     max: 120
   indentation:
     spaces: 2
+  document-start: disable
   truthy: disable

--- a/.yamllint
+++ b/.yamllint
@@ -6,3 +6,4 @@ rules:
     max: 120
   indentation:
     spaces: 2
+  truthy: disable

--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,10 @@
 ---
 extends: default
 
+ignore: |
+  dist/
+  **/node_modules/
+
 rules:
   line-length:
     max: 120

--- a/android/config/detekt.yml
+++ b/android/config/detekt.yml
@@ -2,10 +2,10 @@ build:
   maxIssues: 0
   excludeCorrectable: false
   weights:
-    # complexity: 2
-    # LongParameterList: 1
-    # style: 1
-    # comments: 1
+  # complexity: 2
+  # LongParameterList: 1
+  # style: 1
+  # comments: 1
 
 config:
   validation: true
@@ -18,18 +18,18 @@ processors:
   active: true
   exclude:
     - 'DetektProgressListener'
-  # - 'KtFileCountProcessor'
-  # - 'PackageCountProcessor'
-  # - 'ClassCountProcessor'
-  # - 'FunctionCountProcessor'
-  # - 'PropertyCountProcessor'
-  # - 'ProjectComplexityProcessor'
-  # - 'ProjectCognitiveComplexityProcessor'
-  # - 'ProjectLLOCProcessor'
-  # - 'ProjectCLOCProcessor'
-  # - 'ProjectLOCProcessor'
-  # - 'ProjectSLOCProcessor'
-  # - 'LicenseHeaderLoaderExtension'
+    # - 'KtFileCountProcessor'
+    # - 'PackageCountProcessor'
+    # - 'ClassCountProcessor'
+    # - 'FunctionCountProcessor'
+    # - 'PropertyCountProcessor'
+    # - 'ProjectComplexityProcessor'
+    # - 'ProjectCognitiveComplexityProcessor'
+    # - 'ProjectLLOCProcessor'
+    # - 'ProjectCLOCProcessor'
+    # - 'ProjectLOCProcessor'
+    # - 'ProjectSLOCProcessor'
+    # - 'LicenseHeaderLoaderExtension'
 
 console-reports:
   active: true
@@ -39,7 +39,7 @@ console-reports:
     - 'NotificationReport'
     - 'FindingsReport'
     - 'FileBasedFindingsReport'
-  #  - 'LiteFindingsReport'
+    #  - 'LiteFindingsReport'
 
 output-reports:
   active: true
@@ -205,7 +205,7 @@ complexity:
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
-      # Configuration maybe should change when this has been merged: https://github.com/detekt/detekt/issues/6516
+    # Configuration maybe should change when this has been merged: https://github.com/detekt/detekt/issues/6516
     active: true
     excludes:
       - '**/test/**'

--- a/android/test/firebase/e2e-play-stagemole.yml
+++ b/android/test/firebase/e2e-play-stagemole.yml
@@ -7,16 +7,16 @@ default:
   use-orchestrator: true
   num-flaky-test-attempts: 1
   device:
-    - {model: shiba, version: 34, locale: en, orientation: portrait} # pixel 8
-    - {model: felix, version: 34, locale: en, orientation: portrait} # pixel fold
-    - {model: tangorpro, version: 33, locale: en, orientation: portrait} # pixel tablet
-    - {model: oriole, version: 32, locale: en, orientation: portrait} # pixel 6
-    - {model: oriole, version: 31, locale: en, orientation: portrait} # pixel 6
-    - {model: redfin, version: 30, locale: en, orientation: portrait} # pixel 5
-    - {model: crownqlteue, version: 29, locale: en, orientation: portrait} # galaxy note9
-    - {model: blueline, version: 28, locale: en, orientation: portrait} # pixel 3
-    - {model: cactus, version: 27, locale: en, orientation: portrait} # redmi 6a
-    - {model: starqlteue, version: 26, locale: en, orientation: portrait} # galaxy s9
+    - {model: shiba, version: 34, locale: en, orientation: portrait}  # pixel 8
+    - {model: felix, version: 34, locale: en, orientation: portrait}  # pixel fold
+    - {model: tangorpro, version: 33, locale: en, orientation: portrait}  # pixel tablet
+    - {model: oriole, version: 32, locale: en, orientation: portrait}  # pixel 6
+    - {model: oriole, version: 31, locale: en, orientation: portrait}  # pixel 6
+    - {model: redfin, version: 30, locale: en, orientation: portrait}  # pixel 5
+    - {model: crownqlteue, version: 29, locale: en, orientation: portrait}  # galaxy note9
+    - {model: blueline, version: 28, locale: en, orientation: portrait}  # pixel 3
+    - {model: cactus, version: 27, locale: en, orientation: portrait}  # redmi 6a
+    - {model: starqlteue, version: 26, locale: en, orientation: portrait}  # galaxy s9
   environment-variables:
     clearPackageData: "true"
     runnerBuilder: "de.mannodermaus.junit5.AndroidJUnit5Builder"


### PR DESCRIPTION
In general we deny warnings from linters and formatters and similar in CI. Anything producing a warning when running locally should error in CI. Because we should not have code that triggers lots of warnings when running tooling locally. If there is a lint we do not want, it should instead be configured to not trigger a warning at all. Otherwise the amount of warnings grow, and it becomes increasingly hard to use the tooling locally to check the quality of the work one is doing while developing, as there are lots of stray warnings left by others.

This PR is probably best reviewed per commit. As the "important" change is very much mixed with the cleanup stuff when viewing the entire PR diff.

The important change here is that I just threw on `--strict` on the yamllint invocation in CI. This made all existing warnings into errors. And the last commit then fix these warnings.

I disable the `truthy` lint as it has always caused a lot of warnings on github action files on things that are seemingly unfixable. This issue stems from yamllint using YAML 1.1, where `on` is a boolean. But github uses YAML 1.2, where `on` is just a string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10314)
<!-- Reviewable:end -->
