### PR TITLE
Switch default global allocator to jemalloc on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Line wrap the file at 100 chars.                                              Th
 
 #### Linux
 - GotaTun is now used as the userspace WireGuard implementation. It replaces wireguard-go.
+- Switch memory allocator to jemalloc to reduce fragmentation.
 - `mullvad-early-boot-blocking.service` now waits for local file system to be mounted
   (`After=local-fs.target`). This was assumed before, but not required (and is still not required).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,7 +2599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3008,6 +3008,7 @@ dependencies = [
  "talpid-types",
  "talpid-windows",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tracing-appender",
@@ -5612,6 +5613,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,3 +193,4 @@ ring.opt-level = 3
 inherits = "release"
 debug = true
 strip = false
+lto = "thin"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -125,6 +125,7 @@ paranoid-android = "0.2.2"
 
 [target.'cfg(target_os="linux")'.dependencies]
 talpid-dbus = { path = "../talpid-dbus" }
+tikv-jemallocator = { version = "0.6", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 notify = "8.0.0"
@@ -172,9 +173,12 @@ workspace = true
 features = ["Win32_System_SystemServices"]
 
 [features]
+default = ["default-allocator"]
 # Allow the API server to use to be configured
 api-override = ["mullvad-api/api-override"]
 cgroup2 = ["talpid-core/cgroup2"]
+# Use jemalloc as the global allocator. Only takes effect on Linux.
+default-allocator = ["dep:tikv-jemallocator"]
 multihop-pcap = ["talpid-core/multihop-pcap"]
 staggered-obfuscation = ["mullvad-relay-selector/staggered-obfuscation"]
 wireguard-go = ["talpid-core/wireguard-go"]

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -9,6 +9,10 @@ use mullvad_daemon::{
 };
 use talpid_types::ErrorExt;
 
+#[cfg(all(feature = "default-allocator", target_os = "linux"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod cli;
 #[cfg(target_os = "linux")]
 mod early_boot_firewall;


### PR DESCRIPTION
Supersedes #10277.

Maybe slightly worse than mimalloc in terms of memory usage when spamming reconnects, and definitely binary size, but still a lot better than the system allocator. And arguably a safer choice.

| Metric | Default | jemalloc | Δ |
| --- | --- | --- | --- |
| Binary size | 16.06 MiB | 16.59 MiB | +542 KiB |
| Resident (reconnect loop) | 500 MB+ | ~170 MB | ~2.9x lower |
| Throughput (gotatun-cli) | ~3.1 Gbps | ~3.1 Gbps | - |

Fix DES-2688

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10316)
<!-- Reviewable:end -->
