### PR TITLE
Replace Fedora 42 VM with Fedora 44 in nightly E2E test runs

### DIFF
--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -50,7 +50,7 @@ jobs:
           # A list of VMs to run the tests on. These refer to the names defined
           # in $XDG_CONFIG_DIR/mullvad-test/config.json on the runner.
           all='["debian11","debian12","debian13","ubuntu2204","ubuntu2404","ubuntu2504","ubuntu2510","ubuntu2604","fedora41","fedora42","fedora43","fedora44"]'
-          default='["debian13","ubuntu2404","ubuntu2510","ubuntu2604","fedora42","fedora43"]'
+          default='["debian13","ubuntu2404","ubuntu2510","ubuntu2604","fedora43","fedora44"]'
           oses="${{ github.event.inputs.oses }}"
           echo "OSES: $oses"
           if [[ -z "$oses" || "$oses" == "null" ]]; then


### PR DESCRIPTION
Related to https://github.com/mullvad/mullvadvpn-app/pull/10297 - Fedora 44 just released as well! Fedora 42 will be EOL in just a couple of weeks, so let's per-emptively remove it from the nightly test runs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10318)
<!-- Reviewable:end -->
