### PR TITLE
Fix button width in api access form

### DIFF
--- a/desktop/packages/mullvad-vpn/src/renderer/components/ProxyForm.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/components/ProxyForm.tsx
@@ -179,7 +179,7 @@ export function ProxyFormButtons() {
         <Button width="fit" onClick={onCancel}>
           <Button.Text>{messages.gettext('Cancel')}</Button.Text>
         </Button>
-        <Button onClick={onSave} disabled={!formSubmittable}>
+        <Button width="fit" onClick={onSave} disabled={!formSubmittable}>
           <Button.Text>{isNew ? messages.gettext('Add') : messages.gettext('Save')}</Button.Text>
         </Button>
       </FlexRow>

--- a/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
+++ b/desktop/packages/mullvad-vpn/src/renderer/lib/components/button/Button.tsx
@@ -48,7 +48,6 @@ export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'vari
       --transition-duration: 0.15s;
 
       display: flex;
-      flex: var(--size);
       align-items: center;
       padding: ${spacings.tiny} ${spacings.small};
       gap: ${spacings.small};
@@ -67,6 +66,7 @@ export const StyledButton = styled.button<TransientProps<Pick<ButtonProps, 'vari
         } else if ($width === 'fit') {
           return css`
             width: fit-content;
+            max-width: 100%;
           `;
         }
         return null;


### PR DESCRIPTION
Fixes add and save buttons in API access form line breaking far before necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10319)
<!-- Reviewable:end -->
