### PR TITLE
Fix "start tunnel error" for GotaTun on Windows

### DIFF
--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -254,12 +254,8 @@ impl WireguardMonitor {
             let close_obfs_sender: sync_mpsc::Sender<CloseMsg> = moved_close_obfs_sender;
             let obfuscator = moved_obfuscator;
             #[cfg(windows)]
-            if cfg!(not(feature = "wireguard-go")) && userspace_wireguard {
-                // NOTE: For gotatun, we use the `tun` crate to create our tunnel interface.
-                // It will automatically configure the IP address and DNS servers using `netsh`.
-                // This is quite slow, so we need to wait for the interface to be created.
-                Self::wait_for_ip_addresses(&config, &iface_name).await?;
-            } else {
+            // NOTE: For gotatun, we use the `tun` crate to create our tunnel interface.
+            if cfg!(feature = "wireguard-go") || !userspace_wireguard {
                 Self::add_device_ip_addresses(&iface_name, &config.tunnel.addresses, setup_done_rx)
                     .await?;
             }
@@ -638,32 +634,6 @@ impl WireguardMonitor {
     fn allowed_traffic_after_tunnel_config() -> AllowedTunnelTraffic {
         // After ephemeral peer negotiation, allow all tunnel traffic again.
         AllowedTunnelTraffic::All
-    }
-
-    #[cfg(windows)]
-    async fn wait_for_ip_addresses(
-        config: &Config,
-        iface_name: &String,
-    ) -> std::result::Result<(), CloseMsg> {
-        log::debug!("Waiting for tunnel IP interfaces to arrive");
-        let luid = talpid_windows::net::luid_from_alias(iface_name).map_err(|error| {
-            log::error!("Failed to obtain tunnel interface LUID: {}", error);
-            CloseMsg::SetupError(Error::IpInterfacesError)
-        })?;
-        talpid_windows::net::wait_for_interfaces(luid, true, config.ipv6_gateway.is_some())
-            .await
-            .map_err(|error| {
-                log::error!("Failed to obtain tunnel interface LUID: {}", error);
-                CloseMsg::SetupError(Error::IpInterfacesError)
-            })?;
-        talpid_windows::net::wait_for_addresses(luid)
-            .await
-            .map_err(|error| {
-                log::error!("Failed to obtain tunnel interface LUID: {}", error);
-                CloseMsg::SetupError(Error::IpInterfacesError)
-            })?;
-        log::debug!("Done waiting for tunnel IP interfaces to arrive");
-        Ok(())
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Previously `wait_for_addresses` could fail if the device went to sleep in the middle of polling the DAD state (i.e. while connecting)*:

```
[2026-04-10 18:19:08.833] DEBUG talpid_wireguard: Waiting for tunnel IP interfaces to arrive
[2026-04-10 18:25:16.372] ERROR talpid_wireguard: Failed to obtain tunnel interface LUID: Timed out waiting on tunnel device
```

This would, rarely, cause the tunnel to get stuck in the error state.

We actually do not need poll the DAD state anymore because DAD is disabled in the tun crate now: https://github.com/meh/rust-tun/blob/895442dacc2f635283cc0cadeb33159a4a1da918/src/platform/windows/device.rs#L368

\* See [here](https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-createunicastipaddressentry) for why we even needed the polling, and why disabling DAD fixes it.

Fixes DES-2943

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10323)
<!-- Reviewable:end -->
