### PR TITLE
Make IAN settings available regardless of logged-in status

### DIFF
--- a/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
@@ -238,19 +238,19 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
 
     private func updateDataSnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+        snapshot.appendSections([.vpnSettings])
         let isLoggedIn = interactor.deviceState.isLoggedIn
         if isLoggedIn {
-            snapshot.appendSections([.vpnSettings])
             snapshot.appendItems(
                 [
                     .daita,
                     .multihop,
                     .vpnSettings,
-                    .includeAllNetworks,
                 ], toSection: .vpnSettings)
-
-            snapshot.appendItems([], toSection: .vpnSettings)
         }
+
+        snapshot.appendItems([.includeAllNetworks], toSection: .vpnSettings)
+        snapshot.appendItems([], toSection: .vpnSettings)
 
         snapshot.appendSections([.apiAccess])
         snapshot.appendItems([.apiAccess], toSection: .apiAccess)

--- a/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsDataSource.swift
@@ -250,7 +250,6 @@ final class SettingsDataSource: UITableViewDiffableDataSource<SettingsDataSource
         }
 
         snapshot.appendItems([.includeAllNetworks], toSection: .vpnSettings)
-        snapshot.appendItems([], toSection: .vpnSettings)
 
         snapshot.appendSections([.apiAccess])
         snapshot.appendItems([.apiAccess], toSection: .apiAccess)


### PR DESCRIPTION
This modifies the SwettingsDataSource to ensure that one VPN setting ("Force all apps", colloquially known as IAN) is also available in the logged-out state. This affords users who have locked themselves out of the network by removing the device from another device a way of recovering connectivity.
<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10324)
<!-- Reviewable:end -->
