### PR TITLE
Attach shutdown signal handler to `SIGHUP` signal on macOS and Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,11 @@ Line wrap the file at 100 chars.                                              Th
 - Switch memory allocator to jemalloc to reduce fragmentation.
 - `mullvad-early-boot-blocking.service` now waits for local file system to be mounted
   (`After=local-fs.target`). This was assumed before, but not required (and is still not required).
+- `mullvad-daemon` now installs the same shutdown handler for `SIGHUP` as `SIGINT` and `SIGTERM`.
 
 #### macOS
 - Restart the GUI after an update if it was running.
+- `mullvad-daemon` now installs the same shutdown handler for `SIGHUP` as `SIGINT` and `SIGTERM`.
 
 ### Fixed
 - Fix duplicate "Connected"/"Disconnected" desktop notifications caused by the daemon sending

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "simple-signal",
  "talpid-core",
  "talpid-dbus",
  "talpid-dns",
@@ -5146,16 +5145,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "simple-signal"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f7da44adcc42667d57483bd93f81295f27d66897804b757573b61b6f13288b"
-dependencies = [
- "lazy_static",
- "libc",
-]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ anyhow = "1.0"
 bytes = "1.11.1"
 chrono = { version = "0.4.26", default-features = false }
 clap = { version = "4.4.18", features = ["cargo", "derive"] }
+ctrlc = "3.5"
 dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -120,14 +120,17 @@ mullvad-update = { path = "../mullvad-update", features = ["client"] }
 
 [target.'cfg(target_os="android")'.dependencies]
 async-trait = "0.1"
+ctrlc = { workspace = true }
 hickory-resolver = { workspace = true }
 paranoid-android = "0.2.2"
 
 [target.'cfg(target_os="linux")'.dependencies]
+ctrlc = { workspace = true, features = ["termination"] }
 talpid-dbus = { path = "../talpid-dbus" }
 tikv-jemallocator = { version = "0.6", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
+ctrlc = { workspace = true, features = ["termination"] }
 notify = "8.0.0"
 objc2-foundation = { version = "0.3.1", features = [
   "NSProcessInfo",
@@ -142,10 +145,9 @@ talpid-macos = { path = "../talpid-macos" }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["signal", "user"] }
-simple-signal = "1.1"
 
 [target.'cfg(windows)'.dependencies]
-ctrlc = "3.0"
+ctrlc = { workspace = true }
 dirs = { workspace = true }
 talpid-windows = { path = "../talpid-windows" }
 winapi = { version = "0.3", features = ["excpt", "winerror", "winnt"] }

--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -1,30 +1,13 @@
-#[cfg(unix)]
-mod platform {
-    use simple_signal::Signal;
-    use std::io;
+use ctrlc;
+use thiserror::Error;
 
-    pub fn set_shutdown_signal_handler(f: impl Fn() + 'static + Send) -> Result<(), io::Error> {
-        simple_signal::set_handler(&[Signal::Term, Signal::Int], move |s| {
-            log::debug!("Process received signal: {:?}", s);
-            f();
-        });
-        Ok(())
-    }
-}
+#[derive(Error, Debug)]
+#[error("Unable to attach ctrl-c handler")]
+pub struct Error(#[from] ctrlc::Error);
 
-#[cfg(windows)]
-mod platform {
-    #[derive(thiserror::Error, Debug)]
-    #[error("Unable to attach ctrl-c handler")]
-    pub struct Error(#[from] ctrlc::Error);
-
-    pub fn set_shutdown_signal_handler(f: impl Fn() + 'static + Send) -> Result<(), Error> {
-        ctrlc::set_handler(move || {
-            log::debug!("Process received Ctrl-c");
-            f();
-        })
-        .map_err(Error)
-    }
+pub fn set_shutdown_signal_handler(f: impl Fn() + 'static + Send) -> Result<(), Error> {
+    ctrlc::set_handler(f)?;
+    Ok(())
 }
 
 /// Returns true if systemd successfully reported that the machine is not shutting down or entering
@@ -50,5 +33,3 @@ pub fn is_shutdown_user_initiated() -> bool {
 pub fn is_shutdown_user_initiated() -> bool {
     false
 }
-
-pub use self::platform::*;


### PR DESCRIPTION
This PR adds the existing shutdown signal handler to the `SIGHUP` signal. We did not reserve it for any special purpose anyway (e.g. restarting the daemon). Dropped the dependency on the outdated [simple-signal](https://crates.io/crates/simple-signal) crate in favor of its maintained fork [ctrlc](https://crates.io/crates/ctrlc), which we depend on anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10327)
<!-- Reviewable:end -->
