### PR TITLE
Fix never assume the daemon is stopped by the user intentionally

### DIFF
--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -206,13 +206,13 @@ async fn run_standalone(
     let daemon = create_daemon(log_dir, log_handle).await?;
 
     let shutdown_handle = daemon.shutdown_handle();
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     mullvad_daemon::shutdown::set_shutdown_signal_handler(move || {
         shutdown_handle.shutdown(mullvad_daemon::shutdown::is_shutdown_user_initiated())
     })
     .map_err(|e| e.display_chain())?;
 
-    #[cfg(any(windows, target_os = "android"))]
+    #[cfg(target_os = "android")]
     mullvad_daemon::shutdown::set_shutdown_signal_handler(move || shutdown_handle.shutdown(true))
         .map_err(|e| e.display_chain())?;
 

--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -46,7 +46,7 @@ pub fn is_shutdown_user_initiated() -> bool {
 /// Currently returns false all of the time to ensure that no leaks occur during shutdown.
 // FIXME: implement shutdown detection - the current implementation will always block network
 // traffic when the daemon is shut down.
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 pub fn is_shutdown_user_initiated() -> bool {
     false
 }


### PR DESCRIPTION
This PR fixes the same issue as identified in https://github.com/mullvad/mullvadvpn-app/pull/10291, but for Windows, which aligns the implementation with the stated intention from [this changelog entry](https://github.com/mullvad/mullvadvpn-app/commit/55ab6decf719e9769fe7864ec7961118c275f404):
> When the system process is being shut down and the target state is _secured_, maintain the
  blocking firewall rules unless it's possible to deduce that the system isn't shutting down and the
  system service is being stopped by the user intentionally. This is to prevent leaks that might
  occur during system shutdown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10328)
<!-- Reviewable:end -->
