### PR TITLE
Fix missing `nix` feature for `test-manager`

### DIFF
--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -32,7 +32,7 @@ mullvad-management-interface = { path = "../../mullvad-management-interface" }
 mullvad-relay-selector = { path = "../../mullvad-relay-selector" }
 mullvad-types = { path = "../../mullvad-types" }
 mullvad-version = { path = "../../mullvad-version" }
-nix = { workspace = true }
+nix = { workspace = true, features = ["user"] }
 pcap = { version = "1.3", features = ["capture-stream"] }
 pnet_base = "0.34.0"
 pnet_packet = "0.34.0"
@@ -55,9 +55,6 @@ uuid = "1.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pnet_datalink = "0.35.0"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-nix.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Presumably a regression introduced in https://github.com/mullvad/mullvadvpn-app/pull/10287.

Error in action: https://github.com/mullvad/mullvadvpn-app/actions/runs/25109684148/job/73580103438
Patched run: https://github.com/mullvad/mullvadvpn-app/actions/runs/25110277873

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10330)
<!-- Reviewable:end -->
