### PR TITLE
Resolve password prompt on `xcodebuild`-cli usage

### DIFF
--- a/ios/TestPlans/MullvadVPNUITestsAll.xctestplan
+++ b/ios/TestPlans/MullvadVPNUITestsAll.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "diagnosticCollectionPolicy" : "Never",
     "targetForVariableExpansion" : {
       "containerPath" : "container:MullvadVPN.xcodeproj",
       "identifier" : "58CE5E5F224146200008646E",


### PR DESCRIPTION
While running the UI Tests for iOS on a local physical device and aborting them via `ctrl+c`, a password prompt would appear that did not actually accept input. The only way out was to background the process and then kill it via `kill -9`.

This would happen both on manual interruption, using `ctrl+c`, and on test-failures.

The behavior was introduced in [Xcode 16.4] (the previous major version at time of writing) and is still relevant:

> **New Features**
>
> The command devicectl diagnose now obtains a sysdiagnose from your
> Mac and all available devices by default. (104845318)

The value of `Collect Test Diagnostics on Failure` was configured as  `when testing with xcodebuild`, which matches this scenario (and  likely CI as well). This also explains why the issue does not appear when running tests via `Xcode`.

After identifying the origin of the password prompt, changing this to `never` rids us of this behaviour. 

**Trade-off**: This was likely never used, so we don't lose  meaniningful functionality. Enabling it _would_ collect _device_ diagnostics (hardware, configuration, paths, loaded libraries), which I don't think are needed at this point.

**Rationale**: The configuration of our build machines is known or can be inspected in different ways.

**Additional information**: The same diagnostic can be triggered by running `xcrun devicectl  diagnose <identifier>`, where the identifier can be found using `xcrun devicectl list devices`.

[Xcode 16.4]: https://archive.is/v2NzU

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10331)
<!-- Reviewable:end -->
