### PR TITLE
Fix: Allow IPv6 addresses as Socks5/Shadowsocks endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Line wrap the file at 100 chars.                                              Th
 - Fix QUIC obfuscation not always being used if relays only had IPv6 addresses for QUIC.
 - Fix a bug with Shadowsocks-based API access methods where some ciphers were configurable by
   Mullvad VPN clients while not being supported by the system service.
+- Fix IPv6 addresses not being allowed as endpoints for Socks5 and Shadowsocks API access methods.
 
 #### Linux
 - Fix 'mullvad split-tunnel clear' getting stuck.

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -302,7 +302,7 @@ mod proxy {
         fn try_from(value: proto::Shadowsocks) -> Result<Self, Self::Error> {
             let ip = value.ip.parse::<Ipv4Addr>().map_err(|_| {
                 FromProtobufTypeError::invalid_argument(
-                    "Could not parse Socks5 (remote) message from protobuf",
+                    "Could not parse Shadowsocks message from protobuf",
                 )
             })?;
 

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -226,7 +226,7 @@ pub fn try_transport_protocol_from_i32(
 }
 
 mod proxy {
-    use std::net::Ipv4Addr;
+    use std::net::IpAddr;
 
     use crate::types::{FromProtobufTypeError, proto};
     use talpid_types::net::proxy::{
@@ -261,7 +261,7 @@ mod proxy {
 
         fn try_from(value: proto::Socks5Local) -> Result<Self, Self::Error> {
             use crate::types::conversions::net::try_transport_protocol_from_i32;
-            let remote_ip = value.remote_ip.parse::<Ipv4Addr>().map_err(|_| {
+            let remote_ip = value.remote_ip.parse::<IpAddr>().map_err(|_| {
                 FromProtobufTypeError::invalid_argument(
                     "Could not parse Socks5 (local) message from protobuf",
                 )
@@ -278,7 +278,7 @@ mod proxy {
         type Error = FromProtobufTypeError;
 
         fn try_from(value: proto::Socks5Remote) -> Result<Self, Self::Error> {
-            let ip = value.ip.parse::<Ipv4Addr>().map_err(|_| {
+            let ip = value.ip.parse::<IpAddr>().map_err(|_| {
                 FromProtobufTypeError::invalid_argument(
                     "Could not parse Socks5 (remote) message from protobuf",
                 )
@@ -300,7 +300,7 @@ mod proxy {
         type Error = FromProtobufTypeError;
 
         fn try_from(value: proto::Shadowsocks) -> Result<Self, Self::Error> {
-            let ip = value.ip.parse::<Ipv4Addr>().map_err(|_| {
+            let ip = value.ip.parse::<IpAddr>().map_err(|_| {
                 FromProtobufTypeError::invalid_argument(
                     "Could not parse Shadowsocks message from protobuf",
                 )


### PR DESCRIPTION
This PR fixes a longstanding bug where Socks5/Shadowsocks configs containing an IPv6 endpoint were rejected. As it turns out, we only tried to parse custom endpoints as IPv4 addresses..

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10332)
<!-- Reviewable:end -->
