### PR TITLE
Update relay selector retry order

### DIFF
--- a/docs/relay-selector.md
+++ b/docs/relay-selector.md
@@ -42,11 +42,11 @@ constraints the following default ones will take effect
 
 - The first attempt will connect to a relay on a random port
 - The second attempt will connect to a relay over IPv6 (if IPv6 is configured on the host) on a random port
-- The third attempt will connect to a relay on a random port using Shadowsocks for obfuscation
-- The fourth attempt will connect to a relay using QUIC for obfuscation
-- The fifth attempt will connect to a relay on a random port using [UDP2TCP obfuscation](https://github.com/mullvad/udp-over-tcp)
-- The sixth attempt will connect to a relay over IPv6 on a random port using UDP2TCP obfuscation (if IPv6 is configured on the host)
-- The seventh attempt will connect to a relay using LWO
+- The third attempt will connect to a relay using LWO
+- The fourth attempt will connect to a relay on a random port using Shadowsocks for obfuscation
+- The fifth attempt will connect to a relay using QUIC for obfuscation
+- The sixth attempt will connect to a relay on a random port using [UDP2TCP obfuscation](https://github.com/mullvad/udp-over-tcp)
+- The seventh attempt will connect to a relay over IPv6 on a random port using UDP2TCP obfuscation (if IPv6 is configured on the host)
 
 ### Default constraints for tunnel endpoints on iOS
 

--- a/mullvad-relay-selector/src/relay_selector/mod.rs
+++ b/mullvad-relay-selector/src/relay_selector/mod.rs
@@ -51,18 +51,18 @@ pub static RETRY_ORDER: LazyLock<Vec<RelayQuery>> = LazyLock::new(|| {
         // 2
         RelayQueryBuilder::new().ip_version(IpVersion::V6).build(),
         // 3
-        RelayQueryBuilder::new().shadowsocks().build(),
+        RelayQueryBuilder::new().lwo().build(),
         // 4
-        RelayQueryBuilder::new().quic().build(),
+        RelayQueryBuilder::new().shadowsocks().build(),
         // 5
-        RelayQueryBuilder::new().udp2tcp().build(),
+        RelayQueryBuilder::new().quic().build(),
         // 6
+        RelayQueryBuilder::new().udp2tcp().build(),
+        // 7
         RelayQueryBuilder::new()
             .udp2tcp()
             .ip_version(IpVersion::V6)
             .build(),
-        // 7
-        RelayQueryBuilder::new().lwo().build(),
     ]
 });
 

--- a/mullvad-relay-selector/tests/relay_selector.rs
+++ b/mullvad-relay-selector/tests/relay_selector.rs
@@ -262,18 +262,18 @@ mod relay_selection {
             // 2
             RelayQueryBuilder::new().ip_version(IpVersion::V6).build(),
             // 3
-            RelayQueryBuilder::new().shadowsocks().build(),
+            RelayQueryBuilder::new().lwo().build(),
             // 4
-            RelayQueryBuilder::new().quic().build(),
+            RelayQueryBuilder::new().shadowsocks().build(),
             // 5
-            RelayQueryBuilder::new().udp2tcp().build(),
+            RelayQueryBuilder::new().quic().build(),
             // 6
+            RelayQueryBuilder::new().udp2tcp().build(),
+            // 7
             RelayQueryBuilder::new()
                 .udp2tcp()
                 .ip_version(IpVersion::V6)
                 .build(),
-            // 7
-            RelayQueryBuilder::new().lwo().build(),
         ];
 
         assert!(


### PR DESCRIPTION
Change order of retry attempts such that LWO is used as the third attempt instead of Shadowsocks. It barely carries any penalty in connection speeds nor CPU usage (better battery usage on mobile devices) compared to vanila WireGuard.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10337)
<!-- Reviewable:end -->
