### PR TITLE
Update GotaTun to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,9 +1691,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gotatun"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011b0c02e571262b965413848b5e1e25810a9a1b8cea2ce373ea67e8f2174197"
+checksum = "ee896ae91b1a90a10642d58ced8721560dc399ceeaba66d9cab14ad1db846936"
 dependencies = [
  "aead",
  "base64",
@@ -1724,6 +1724,7 @@ dependencies = [
  "socket2 0.6.3",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util 0.7.18",
  "tun 0.8.7",
  "typed-builder 0.21.2",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ ctrlc = "3.5"
 dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"
-gotatun = { version = "0.5.1" }
+gotatun = { version = "0.6.0", default-features = false, features = ["ring"] }
 hickory-proto = "0.25.2"
 hickory-resolver = "0.25.2"
 hickory-server = { version = "0.25.2", features = ["resolver"] }


### PR DESCRIPTION
See all changes here: https://github.com/mullvad/gotatun/blob/5db364a8d34d7f359f8a316d3276e1059f08f5f6/CHANGELOG.md

The main ones: (1) Fix an issue where the wintun device being deleted wasn't handled properly, and (2) add support for `aws-lc-rs` as the crypto backend.

`ring` is still used for now.

Fix DES-2946

Related PR: https://github.com/mullvad/mullvadvpn-app/pull/10254

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10340)
<!-- Reviewable:end -->
