### PR TITLE
Stop daemon without leaking on SIGUSR1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Line wrap the file at 100 chars.                                              Th
 - `mullvad-early-boot-blocking.service` now waits for local file system to be mounted
   (`After=local-fs.target`). This was assumed before, but not required (and is still not required).
 - `mullvad-daemon` now installs the same shutdown handler for `SIGHUP` as `SIGINT` and `SIGTERM`.
+- `mullvad-daemon` now exits without tearing down firewall rules on `SIGUSR1`.
+  This is used to avoid leaking network traffic when restarting systemd service.
 
 #### macOS
 - Restart the GUI after an update if it was running.

--- a/dist-assets/linux/mullvad-daemon.service
+++ b/dist-assets/linux/mullvad-daemon.service
@@ -16,5 +16,10 @@ RestartSec=1
 ExecStart=/usr/bin/mullvad-daemon -vv --disable-stdout-timestamps
 Environment="MULLVAD_RESOURCE_DIR=/opt/Mullvad VPN/resources/"
 
+# SIGUSR1 causes the daemon to enter lockdown mode before stopping.
+# Lockdown mode is cleared when the daemon is started again.
+# This is used to prevent network leaks on `systemctl restart`
+RestartKillSignal=SIGUSR1
+
 [Install]
 WantedBy=multi-user.target

--- a/mullvad-daemon/Cargo.toml
+++ b/mullvad-daemon/Cargo.toml
@@ -103,8 +103,9 @@ tokio = { workspace = true, features = [
   "fs",
   "io-util",
   "rt-multi-thread",
+  "signal",
   "sync",
-  "time"
+  "time",
 ] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing-appender = { workspace = true }

--- a/mullvad-daemon/src/api.rs
+++ b/mullvad-daemon/src/api.rs
@@ -138,10 +138,9 @@ pub fn allowed_clients(connection_mode: &ApiConnectionMode) -> AllowedClients {
 
 #[cfg(target_os = "android")]
 pub(crate) fn create_bypass_tx(
-    event_sender: &DaemonEventSender,
+    daemon_tx: DaemonEventSender<DaemonCommand>,
 ) -> Option<mpsc::Sender<mullvad_api::SocketBypassRequest>> {
     let (bypass_tx, mut bypass_rx) = mpsc::channel(1);
-    let daemon_tx = event_sender.to_specialized_sender();
     tokio::spawn(async move {
         while let Some((raw_fd, done_tx)) = bypass_rx.next().await {
             if daemon_tx

--- a/mullvad-daemon/src/geoip.rs
+++ b/mullvad-daemon/src/geoip.rs
@@ -8,7 +8,7 @@ use talpid_core::mpsc::Sender;
 use talpid_future::retry::{ExponentialBackoff, Jittered, retry_future};
 use talpid_types::ErrorExt;
 
-use crate::{DaemonEventSender, InternalDaemonEvent};
+use crate::DaemonEventSender;
 
 // Define the Mullvad connection checking api endpoint.
 //
@@ -45,15 +45,18 @@ const LOCATION_RETRY_STRATEGY: Jittered<ExponentialBackoff> =
 /// Handler for request to am.i.mullvad.net, manages in-flight request and validity of responses.
 pub(crate) struct GeoIpHandler {
     /// Unique ID for each request. If the ID attached to the
-    /// [`InternalDaemonEvent::LocationEvent`] used by [`crate::Daemon::handle_location_event`] to
+    /// The [`LocationEventData`] used by [`crate::Daemon::handle_location_event`] to
     /// determine if the location belongs to the current tunnel state.
     pub request_id: usize,
     rest_service: RequestServiceHandle,
-    location_sender: DaemonEventSender,
+    location_sender: DaemonEventSender<LocationEventData>,
 }
 
 impl GeoIpHandler {
-    pub fn new(rest_service: RequestServiceHandle, location_sender: DaemonEventSender) -> Self {
+    pub fn new(
+        rest_service: RequestServiceHandle,
+        location_sender: DaemonEventSender<LocationEventData>,
+    ) -> Self {
         Self {
             request_id: 0,
             rest_service,
@@ -62,7 +65,7 @@ impl GeoIpHandler {
     }
 
     /// Send a location request to am.i.mullvad.net. When it arrives, send an
-    /// [`InternalDaemonEvent::LocationEvent`], which triggers an update of the current
+    /// [`LocationEventData`], which triggers an update of the current
     /// tunnel state with the `ipv4` and/or `ipv6` fields filled in.
     pub fn send_geo_location_request(&mut self, use_ipv6: bool) {
         // Increment request ID
@@ -75,11 +78,10 @@ impl GeoIpHandler {
         let location_sender = self.location_sender.clone();
         tokio::spawn(async move {
             if let Ok(location) = get_geo_location_with_retry(use_ipv6, rest_service).await {
-                let _ =
-                    location_sender.send(InternalDaemonEvent::LocationEvent(LocationEventData {
-                        request_id,
-                        location,
-                    }));
+                let _ = location_sender.send(LocationEventData {
+                    request_id,
+                    location,
+                });
             }
         });
     }

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -411,7 +411,10 @@ pub enum DaemonCommand {
     SetObfuscationSettings(ResponseTx<(), settings::Error>, ObfuscationSettings),
     /// Saves the target tunnel state and enters a blocking state. The state is restored
     /// upon restart.
-    PrepareRestart(bool),
+    PrepareRestart {
+        // If true, also shut down the daemon
+        shutdown: bool,
+    },
     /// Causes a socket to bypass the tunnel. This has no effect when connected. It is only used
     /// to bypass the tunnel in blocking states.
     #[cfg(target_os = "android")]
@@ -1607,7 +1610,7 @@ impl Daemon {
             SetObfuscationSettings(tx, settings) => {
                 self.on_set_obfuscation_settings(tx, settings).await
             }
-            PrepareRestart(shutdown) => self.on_prepare_restart(shutdown),
+            PrepareRestart { shutdown } => self.on_prepare_restart(shutdown),
             #[cfg(target_os = "android")]
             BypassSocket(fd, tx) => self.on_bypass_socket(fd, tx),
             #[cfg(target_os = "android")]

--- a/mullvad-daemon/src/lib.rs
+++ b/mullvad-daemon/src/lib.rs
@@ -536,6 +536,12 @@ impl From<(AccessMethodEvent, oneshot::Sender<()>)> for InternalDaemonEvent {
     }
 }
 
+impl From<LocationEventData> for InternalDaemonEvent {
+    fn from(location_event: LocationEventData) -> Self {
+        InternalDaemonEvent::LocationEvent(location_event)
+    }
+}
+
 pub struct DaemonCommandChannel {
     sender: DaemonCommandSender,
     receiver: mpsc::UnboundedReceiver<InternalDaemonEvent>,
@@ -562,7 +568,7 @@ impl DaemonCommandChannel {
     fn destructure(
         self,
     ) -> (
-        DaemonEventSender,
+        DaemonEventSender<InternalDaemonEvent>,
         mpsc::UnboundedReceiver<InternalDaemonEvent>,
     ) {
         let event_sender = DaemonEventSender::new(Arc::downgrade(&self.sender.0));
@@ -592,15 +598,12 @@ impl DaemonCommandSender {
     }
 }
 
-pub(crate) struct DaemonEventSender<E = InternalDaemonEvent> {
+pub struct DaemonEventSender<E> {
     sender: Weak<mpsc::UnboundedSender<InternalDaemonEvent>>,
     _event: PhantomData<E>,
 }
 
-impl<E> Clone for DaemonEventSender<E>
-where
-    InternalDaemonEvent: From<E>,
-{
+impl<E> Clone for DaemonEventSender<E> {
     fn clone(&self) -> Self {
         DaemonEventSender {
             sender: self.sender.clone(),
@@ -609,7 +612,7 @@ where
     }
 }
 
-impl DaemonEventSender {
+impl DaemonEventSender<InternalDaemonEvent> {
     pub fn new(sender: Weak<mpsc::UnboundedSender<InternalDaemonEvent>>) -> Self {
         DaemonEventSender {
             sender,
@@ -641,14 +644,12 @@ where
     }
 }
 
-impl<E> DaemonEventSender<E>
-where
-    InternalDaemonEvent: From<E>,
-{
-    pub fn to_unbounded_sender<T>(&self) -> mpsc::UnboundedSender<T>
+impl<E> DaemonEventSender<E> {
+    pub(crate) fn to_unbounded_sender<T>(&self) -> mpsc::UnboundedSender<T>
     where
         T: Send + 'static,
         E: From<T>,
+        InternalDaemonEvent: From<E>,
     {
         let (tx, mut rx) = mpsc::unbounded::<T>();
         let sender = self.sender.clone();
@@ -672,7 +673,7 @@ pub struct Daemon {
     #[cfg(target_os = "linux")]
     exclude_pids: split_tunnel::PidManager,
     rx: mpsc::UnboundedReceiver<InternalDaemonEvent>,
-    tx: DaemonEventSender,
+    tx: DaemonEventSender<InternalDaemonEvent>,
     reconnection_job: Option<AbortHandle>,
     management_interface: ManagementInterfaceServer,
     migration_complete: migrations::MigrationComplete,
@@ -776,7 +777,7 @@ impl Daemon {
             &config.cache_dir,
             true,
             #[cfg(target_os = "android")]
-            api::create_bypass_tx(&internal_event_tx),
+            api::create_bypass_tx(internal_event_tx.to_specialized_sender()),
         )
         .await
         .map_err(Error::InitRpcFactory)?;
@@ -1098,6 +1099,11 @@ impl Daemon {
         Ok(daemon)
     }
 
+    /// Get a [`DaemonCommand`] message sender.
+    pub fn commands(&self) -> DaemonEventSender<DaemonCommand> {
+        self.tx.to_specialized_sender()
+    }
+
     /// Consume the `Daemon` and run the main event loop. Blocks until an error happens or a
     /// shutdown event is received.
     pub async fn run(mut self) -> Result<(), Error> {
@@ -1396,9 +1402,9 @@ impl Daemon {
 
         if self.settings.update_default_location {
             let (tx, _) = oneshot::channel();
-            let _ = self.tx.send(InternalDaemonEvent::Command(
-                DaemonCommand::UpdateDefaultLocationCountry(tx),
-            ));
+            let _ = self
+                .commands()
+                .send(DaemonCommand::UpdateDefaultLocationCountry(tx));
         }
 
         self.management_interface
@@ -1462,7 +1468,7 @@ impl Daemon {
     fn schedule_reconnect(&mut self, delay: Duration) {
         self.unschedule_reconnect();
 
-        let daemon_command_tx = self.tx.to_specialized_sender();
+        let daemon_command_tx = self.commands();
         let (future, abort_handle) = abortable(Box::pin(async move {
             tokio::time::sleep(delay).await;
             log::debug!("Attempting to reconnect");
@@ -3606,7 +3612,7 @@ impl Daemon {
 
 #[derive(Clone)]
 pub struct DaemonShutdownHandle {
-    tx: DaemonEventSender,
+    tx: DaemonEventSender<InternalDaemonEvent>,
 }
 
 impl DaemonShutdownHandle {

--- a/mullvad-daemon/src/main.rs
+++ b/mullvad-daemon/src/main.rs
@@ -205,6 +205,9 @@ async fn run_standalone(
 
     let daemon = create_daemon(log_dir, log_handle).await?;
 
+    #[cfg(target_os = "linux")]
+    mullvad_daemon::shutdown::install_sigusr1_shutdown_handler(&daemon)?;
+
     let shutdown_handle = daemon.shutdown_handle();
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     mullvad_daemon::shutdown::set_shutdown_signal_handler(move || {

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -124,13 +124,14 @@ impl ManagementService for ManagementServiceImpl {
         log::debug!("prepare_restart");
         // Note: The old `PrepareRestart` behavior never shutdown the daemon.
         let shutdown = false;
-        self.send_command_to_daemon(DaemonCommand::PrepareRestart(shutdown))?;
+        self.send_command_to_daemon(DaemonCommand::PrepareRestart { shutdown })?;
         Ok(Response::new(()))
     }
 
     async fn prepare_restart_v2(&self, shutdown: Request<bool>) -> ServiceResult<()> {
         log::debug!("prepare_restart_v2");
-        self.send_command_to_daemon(DaemonCommand::PrepareRestart(shutdown.into_inner()))?;
+        let shutdown = shutdown.into_inner();
+        self.send_command_to_daemon(DaemonCommand::PrepareRestart { shutdown })?;
         Ok(Response::new(()))
     }
 

--- a/mullvad-daemon/src/migrations/device.rs
+++ b/mullvad-daemon/src/migrations/device.rs
@@ -23,7 +23,7 @@ pub(crate) fn generate_device(
     migration_data: MigrationData,
     mut migration_complete: MigrationComplete,
     rest_handle: mullvad_api::rest::MullvadRestHandle,
-    daemon_tx: DaemonEventSender,
+    daemon_tx: DaemonEventSender<InternalDaemonEvent>,
 ) {
     tokio::spawn(async move {
         let wg_data: Option<WireguardData> = migration_data.wg_data.and_then(|data| {

--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -43,6 +43,8 @@ use tokio::{
     io::{self, AsyncWriteExt},
 };
 
+use crate::{DaemonEventSender, InternalDaemonEvent};
+
 mod account_history;
 mod device;
 mod v1;
@@ -227,7 +229,7 @@ async fn migrate_settings(
 pub(crate) fn migrate_device(
     migration_data: MigrationData,
     rest_handle: mullvad_api::rest::MullvadRestHandle,
-    daemon_tx: crate::DaemonEventSender,
+    daemon_tx: DaemonEventSender<InternalDaemonEvent>,
 ) -> MigrationComplete {
     let migration_complete = MigrationComplete::new(false);
     device::generate_device(

--- a/mullvad-daemon/src/shutdown.rs
+++ b/mullvad-daemon/src/shutdown.rs
@@ -33,3 +33,27 @@ pub fn is_shutdown_user_initiated() -> bool {
 pub fn is_shutdown_user_initiated() -> bool {
     false
 }
+
+/// Install a signal handler for `SIGUSR1`.
+///
+/// The signal handler will request [`crate::Daemon`] to shut down without tearing down the
+/// firewall. This is useful for when the daemon is expected to only be _temporarily_ shut down,
+/// such as when rebooting or updating the system.
+#[cfg(target_os = "linux")]
+pub fn install_sigusr1_shutdown_handler(daemon: &crate::Daemon) -> Result<(), String> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let commands = daemon.commands();
+    let mut sigusr1 = signal(SignalKind::user_defined1())
+        .map_err(|e| format!("Failed to install SIGUSR1 signal handler: {e:?}"))?;
+
+    tokio::spawn(async move {
+        use talpid_core::mpsc::Sender;
+
+        sigusr1.recv().await;
+        log::warn!("SIGUSR1 caught, shutting down.");
+        commands.send(crate::DaemonCommand::PrepareRestart { shutdown: true })
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
- Add a signal handler for SIGUSR1 that shuts the daemon down without tearing down the firewall (unless in an unsecured state).
- Set `RestartKillSignal=SIGUSR1` in systemd service to make `systemctl reload` leak-safe.

### Future Work
- Look into whether install-scripts can be simplified.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10344)
<!-- Reviewable:end -->
