### PR TITLE
Use fresh store for each custom list test

### DIFF
--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/CustomListRepositoryTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/CustomListRepositoryTests.swift
@@ -12,21 +12,10 @@ import XCTest
 @testable import MullvadSettings
 
 class CustomListRepositoryTests: XCTestCase {
-    nonisolated(unsafe) static let store = InMemorySettingsStore<SettingNotFound>()
     private var repository = CustomListRepository()
 
-    override class func setUp() {
-        SettingsManager.unitTestStore = store
-    }
-
-    override class func tearDown() {
-        store.reset()
-    }
-
-    override func tearDownWithError() throws {
-        repository.fetchAll().forEach {
-            repository.delete(id: $0.id)
-        }
+    override func setUp() {
+        SettingsManager.unitTestStore = InMemorySettingsStore<SettingNotFound>()
     }
 
     func testFailedAddingDuplicateCustomList() throws {

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/DestinationDescriberTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/DestinationDescriberTests.swift
@@ -15,13 +15,8 @@ import XCTest
 @testable import MullvadSettings
 
 final class DestinationDescriberTests: XCTestCase {
-    static let store = InMemorySettingsStore<SettingNotFound>()
-    override static func setUp() {
-        SettingsManager.unitTestStore = store
-    }
-
-    override static func tearDown() {
-        store.reset()
+    override func setUp() {
+        SettingsManager.unitTestStore = InMemorySettingsStore<SettingNotFound>()
     }
 
     func testDescribeList() throws {


### PR DESCRIPTION
The custom list tests that fail to be ran consecutively were dependent on having a cleared backing store. Since the backing store was shared across all tests and it was never cleared between test invocations, newer invocations for individual tests would fail due to the leftover state of previous invocations. I've addressed this by clearing the store every test run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10347)
<!-- Reviewable:end -->
