### PR TITLE
Redact logs on demand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,7 @@ dependencies = [
  "mullvad-encrypted-dns-proxy",
  "mullvad-logging",
  "mullvad-types",
+ "regex",
  "shadowsocks",
  "talpid-future",
  "talpid-tunnel-config-client",

--- a/ios/MullvadLogging/CustomFormatLogHandler.swift
+++ b/ios/MullvadLogging/CustomFormatLogHandler.swift
@@ -16,10 +16,12 @@ public struct CustomFormatLogHandler: @unchecked Sendable, LogHandler {
 
     private let label: String
     private let streams: [TextOutputStream]
+    private let redactor: LogRedacting
 
-    public init(label: String, streams: [TextOutputStream]) {
+    public init(label: String, streams: [TextOutputStream], redactor: LogRedacting) {
         self.label = label
         self.streams = streams
+        self.redactor = redactor
     }
 
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
@@ -47,7 +49,8 @@ public struct CustomFormatLogHandler: @unchecked Sendable, LogHandler {
         let prettyMetadata = Self.formatMetadata(mergedMetadata)
         let metadataOutput = prettyMetadata.isEmpty ? "" : " \(prettyMetadata)"
         let timestamp = Date().logFormatted
-        let formattedMessage = "[\(timestamp)][\(label)][\(level)]\(metadataOutput) \(message)\n"
+        let redactedMessage = redactor.redact(message.description)
+        let formattedMessage = "[\(timestamp)][\(label)][\(level)]\(metadataOutput) \(redactedMessage)\n"
 
         for var stream in streams {
             stream.write(formattedMessage)

--- a/ios/MullvadLogging/LogRedacting.swift
+++ b/ios/MullvadLogging/LogRedacting.swift
@@ -1,0 +1,16 @@
+//
+//  LogRedacting.swift
+//  MullvadLogging
+//
+//  Created by Emīls on 2026-04-29.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+
+/// A type that can redact sensitive information from strings.
+public protocol LogRedacting: Sendable {
+    /// Returns a copy of `string` with sensitive information replaced by placeholders.
+    func redact(_ string: String) -> String
+    func addCustomString(_ string: String)
+}

--- a/ios/MullvadLogging/LoggerBuilder.swift
+++ b/ios/MullvadLogging/LoggerBuilder.swift
@@ -31,7 +31,6 @@ public final class LoggerBuilder: @unchecked Sendable {
 
     private var logRotationErrors: [Error] = []
     private var outputs: [LoggerOutput] = []
-
     private let metadata: Logger.Metadata
     private var logLevel: Logger.Level = .debug
 
@@ -66,7 +65,7 @@ public final class LoggerBuilder: @unchecked Sendable {
         }
     }
 
-    public func install() {
+    public func install(_ redactor: LogRedacting) {
         Self.lock.withLock {
             guard Self.initializedLoggingSystem == false else { return }
             Self.initializedLoggingSystem = true
@@ -75,7 +74,7 @@ public final class LoggerBuilder: @unchecked Sendable {
                 let logHandlers: [LogHandler] = outputs.map { output in
                     switch output {
                     case let .fileOutput(stream):
-                        return CustomFormatLogHandler(label: label, streams: [stream])
+                        return CustomFormatLogHandler(label: label, streams: [stream], redactor: redactor)
 
                     case let .osLogOutput(subsystem):
                         return OSLogHandler(subsystem: subsystem, category: label)

--- a/ios/MullvadRESTTests/MullvadApiTests.swift
+++ b/ios/MullvadRESTTests/MullvadApiTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadLogging
 import MullvadMockData
 import MullvadRustRuntime
 import MullvadTypes
@@ -26,7 +27,7 @@ class MullvadApiTests: XCTestCase {
     override func setUp() {
         super.setUp()
         SettingsManager.unitTestStore = MullvadApiTests.store
-        RustLogging.initialize()
+        RustLogging.initialize(logger: Logger(label: "Rust"))
     }
 
     func makeApiProxy(port: UInt16) throws -> APIQuerying {

--- a/ios/MullvadRESTTests/RelayListCacheTests.swift
+++ b/ios/MullvadRESTTests/RelayListCacheTests.swift
@@ -5,6 +5,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadLogging
 import MullvadMockData
 import MullvadRustRuntime
 import MullvadTypes
@@ -25,7 +26,7 @@ class RelayListCacheTests: XCTestCase {
     override func setUp() {
         super.setUp()
         SettingsManager.unitTestStore = Self.store
-        RustLogging.initialize()
+        RustLogging.initialize(logger: Logger(label: "RelayListCacheTests"))
     }
 
     func testRelayListWithUnknownFieldsSurvivesFullPipeline() async throws {

--- a/ios/MullvadRustRuntime/Array+String.swift
+++ b/ios/MullvadRustRuntime/Array+String.swift
@@ -1,0 +1,31 @@
+//
+//  Array+String.swift
+//  MullvadVPN
+//
+//  Created by Mojgan on 2026-04-30.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+import Foundation
+
+extension Array where Element == String {
+    func withCStringArray<T>(
+        _ body: (UnsafePointer<UnsafePointer<CChar>?>?, UInt) -> T
+    ) -> T {
+        let mutablePtrs = self.compactMap { strdup($0)! }
+
+        defer {
+            for ptr in mutablePtrs {
+                free(ptr)
+            }
+        }
+
+        // Wrap each pointer as optional
+        let optionalPtrs: [UnsafePointer<CChar>?] = mutablePtrs.map {
+            UnsafePointer($0)
+        }
+
+        return optionalPtrs.withUnsafeBufferPointer { buffer in
+            body(buffer.baseAddress, UInt(buffer.count))
+        }
+    }
+}

--- a/ios/MullvadRustRuntime/RustLogRedactor.swift
+++ b/ios/MullvadRustRuntime/RustLogRedactor.swift
@@ -1,0 +1,49 @@
+//
+//  RustLogRedactor.swift
+//  MullvadRustRuntime
+//
+//  Created by Emīls on 2026-01-30.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import Foundation
+import MullvadLogging
+
+/// Log redactor backed by Rust regex, conforming to `LogRedacting`.
+///
+/// All state (compiled regexes and container paths) is immutable after construction,
+/// making this safe to use from multiple threads without synchronization.
+public final class RustLogRedactor: LogRedacting, @unchecked Sendable {
+    private let handle: OpaquePointer
+
+    /// Creates a new redactor with predefined redaction rules.
+    ///
+    /// - Parameters:
+    ///   - containerPaths: File system paths whose contents should be redacted
+    public init(containerPaths: [String] = []) {
+        handle = containerPaths.withCStringArray { containerPathsPtr, containerPathsSize in
+            create_log_redactor(containerPathsPtr, containerPathsSize)
+        }
+    }
+
+    deinit {
+        log_redactor_free(handle)
+    }
+
+    public func redact(_ string: String) -> String {
+        guard let resultPtr = string.withCString({ log_redactor_redact(handle, $0) }) else {
+            return string
+        }
+        defer { log_redactor_free_string(resultPtr) }
+        return String(cString: resultPtr)
+    }
+
+    public func addCustomString(_ string: String) {
+        guard !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        string.withCString {
+            log_redactor_add_custom_string(handle, $0)
+        }
+    }
+}

--- a/ios/MullvadRustRuntime/RustLogging.swift
+++ b/ios/MullvadRustRuntime/RustLogging.swift
@@ -9,16 +9,35 @@
 import Foundation
 import MullvadLogging
 
-/// Global logger instance for Rust logs
-private let rustLogger = Logger(label: "Rust")
+/// Box holding a Logger instance so it can be passed as an opaque pointer through Rust FFI.
+private final class LoggerBox {
+    let logger: Logger
+
+    init(_ logger: Logger) {
+        self.logger = logger
+    }
+}
 
 /// C-compatible logging callback function.
 /// This must be a global function (not a closure) to be passed as a C function pointer.
-private func rustLogCallback(level: UInt8, messagePtr: UnsafePointer<CChar>?) {
-    guard let messagePtr else { return }
+///
+/// The `context` parameter is an opaque pointer to a `LoggerBox` that travels through Rust
+/// and back, so this callback doesn't rely on any global state.
+///
+/// Thread safety: this callback may be invoked concurrently from any thread.
+private func rustLogCallback(
+    context: UnsafeMutableRawPointer?,
+    level: UInt8,
+    targetPtr: UnsafePointer<CChar>?,
+    messagePtr: UnsafePointer<CChar>?
+) {
+    guard let context, let targetPtr, let messagePtr else { return }
+
+    let box = Unmanaged<LoggerBox>.fromOpaque(context).takeUnretainedValue()
+    let target = String(cString: targetPtr)
     let message = String(cString: messagePtr)
 
-    let level: Logger.Level =
+    let logLevel: Logger.Level =
         switch level {
         case 1:
             .error
@@ -34,11 +53,7 @@ private func rustLogCallback(level: UInt8, messagePtr: UnsafePointer<CChar>?) {
             .debug
         }
 
-    rustLogger
-        .log(
-            level: level,
-            "\(message.trimmingCharacters(in: .whitespacesAndNewlines))"
-        )
+    box.logger.log(level: logLevel, "\(message)", metadata: ["rust": .string(target)])
 }
 
 /// Initializes the Rust logging system to forward logs to Swift's Logger.
@@ -46,9 +61,11 @@ private func rustLogCallback(level: UInt8, messagePtr: UnsafePointer<CChar>?) {
 /// This function should be called once early in the application lifecycle,
 /// before any Rust code that uses logging is invoked.
 public enum RustLogging {
-    /// Initialize Rust logging to forward to Swift Logger.
+    /// Initialize Rust logging to forward to the given Swift Logger.
     /// Safe to call multiple times - only the first call has effect.
-    public static func initialize() {
-        init_rust_logging(rustLogCallback)
+    public static func initialize(logger: Logger) {
+        let box = LoggerBox(logger)
+        let context = Unmanaged.passRetained(box).toOpaque()
+        init_rust_logging(rustLogCallback, context)
     }
 }

--- a/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
+++ b/ios/MullvadRustRuntime/include/mullvad_rust_runtime.h
@@ -24,6 +24,8 @@ typedef struct DomainFrontingConfigContext DomainFrontingConfigContext;
 
 typedef struct ExchangeCancelToken ExchangeCancelToken;
 
+typedef struct LogRedactor LogRedactor;
+
 typedef struct Map Map;
 
 typedef struct RequestCancelHandle RequestCancelHandle;
@@ -121,10 +123,15 @@ typedef struct EphemeralPeerParameters {
 
 /**
  * Callback function type for logging.
+ * - `context`: Opaque pointer to a Swift Logger instance, passed back on each invocation.
  * - `level`: The log level (1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace)
+ * - `target`: Null-terminated UTF-8 string containing the module/target name
  * - `message`: Null-terminated UTF-8 string containing the log message
+ *
+ * # Thread safety
+ * This callback may be invoked concurrently from any thread.
  */
-typedef void (*LogCallback)(uint8_t level, const char *message);
+typedef void (*LogCallback)(void *context, uint8_t level, const char *target, const char *message);
 
 typedef struct ProxyHandle {
   void *context;
@@ -859,16 +866,65 @@ struct ExchangeCancelToken *request_ephemeral_peer(const uint8_t *public_key,
                                                    struct EphemeralPeerParameters peer_parameters);
 
 /**
- * Initialize the Rust logger with a Swift callback.
+ * Create a new log redactor with the given container paths.
  *
- * This function should be called once early in the application lifecycle,
- * before any Rust code that uses logging is invoked.
+ * # Safety
+ * - `paths` must be a valid pointer to an array of `paths_count` pointers to null-terminated
+ *   UTF-8 strings, or null if `paths_count` is 0.
+ * - The returned pointer must be freed by calling `log_redactor_free`.
+ */
+struct LogRedactor *create_log_redactor(const char *const *paths, uintptr_t paths_count);
+
+/**
+ * Redact sensitive information from a string using the given redactor.
+ *
+ * # Safety
+ * - `redactor` must be a valid pointer returned by `create_log_redactor`.
+ * - `input` must be a valid pointer to a null-terminated UTF-8 string.
+ * - The returned pointer must be freed by calling `log_redactor_free_string`.
+ */
+char *log_redactor_redact(const struct LogRedactor *redactor, const char *input);
+
+/**
+ * Free a string returned by `log_redactor_redact`.
+ *
+ * # Safety
+ * - `ptr` must be a pointer returned by `log_redactor_redact`, or null.
+ * - `ptr` must not have been freed before.
+ */
+void log_redactor_free_string(char *ptr);
+
+/**
+ * Add a custom string to the log redactor.
+ *
+ * # Safety
+ * - `redactor` must be a valid pointer returned by `create_log_redactor`.
+ * - `input` must be a valid pointer to a null-terminated UTF-8 string.
+ */
+void log_redactor_add_custom_string(struct LogRedactor *redactor, const char *input);
+
+/**
+ * Free a log redactor created by `create_log_redactor`.
+ *
+ * # Safety
+ * - `redactor` must be a pointer returned by `create_log_redactor`, or null.
+ * - `redactor` must not have been freed before.
+ * - `redactor` must not be used after this call.
+ */
+void log_redactor_free(struct LogRedactor *redactor);
+
+/**
+ * Initialize the Rust logger with a Swift callback and context.
+ *
+ * The `context` pointer is passed back to `callback` on each log event, allowing
+ * the Swift side to recover a Logger instance without relying on global state.
  *
  * # Safety
  * - `callback` must be a valid function pointer that remains valid for the lifetime of the program.
+ * - `context` must be a valid pointer that remains valid for the lifetime of the program.
  * - This function is safe to call multiple times, but only the first call will have an effect.
  */
-void init_rust_logging(LogCallback callback);
+void init_rust_logging(LogCallback callback, void *context);
 
 int32_t start_udp2tcp_obfuscator_proxy(const uint8_t *peer_address,
                                        uintptr_t peer_address_len,

--- a/ios/MullvadRustRuntimeTests/EphemeralPeerExchangeActorTests.swift
+++ b/ios/MullvadRustRuntimeTests/EphemeralPeerExchangeActorTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadLogging
 import NetworkExtension
 import XCTest
 
@@ -18,7 +19,7 @@ class EphemeralPeerExchangeActorTests: XCTestCase {
     var tunnelProvider: TunnelProviderStub!
 
     override func setUpWithError() throws {
-        RustLogging.initialize()
+        RustLogging.initialize(logger: Logger(label: "Rust"))
         tunnelProvider = TunnelProviderStub()
     }
 

--- a/ios/MullvadRustRuntimeTests/RustLoggingTests.swift
+++ b/ios/MullvadRustRuntimeTests/RustLoggingTests.swift
@@ -1,0 +1,84 @@
+//
+//  RustLoggingTests.swift
+//  MullvadRustRuntimeTests
+//
+//  Created by Emīls on 2026-04-29.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadLogging
+import XCTest
+
+@testable import MullvadRustRuntime
+
+/// Captured log entry from the Rust logging callback.
+private struct CapturedLog {
+    let level: UInt8
+    let target: String
+    let message: String
+}
+
+/// Mutable storage shared between the test and the C callback via an opaque pointer.
+private final class LogCapture {
+    var logs: [CapturedLog] = []
+}
+
+/// C-compatible callback that captures log data into the `LogCapture` context.
+private func testLogCallback(
+    context: UnsafeMutableRawPointer?,
+    level: UInt8,
+    targetPtr: UnsafePointer<CChar>?,
+    messagePtr: UnsafePointer<CChar>?
+) {
+    guard let context, let targetPtr, let messagePtr else { return }
+    let capture = Unmanaged<LogCapture>.fromOpaque(context).takeUnretainedValue()
+    capture.logs.append(
+        CapturedLog(
+            level: level,
+            target: String(cString: targetPtr),
+            message: String(cString: messagePtr)
+        ))
+}
+
+/// Tests for the Rust → Swift logging callback mechanism.
+final class RustLoggingTests: XCTestCase {
+    /// Verify that a context pointer round-trips correctly through the C callback,
+    /// and that log parameters are passed through faithfully.
+    func testCallbackContextRoundTrip() {
+        let capture = LogCapture()
+        let context = Unmanaged.passUnretained(capture).toOpaque()
+
+        // Simulate what Rust does: call the callback directly with test data
+        "mullvad_ios::logging".withCString { target in
+            "Test message from Rust".withCString { message in
+                testLogCallback(context: context, level: 3, targetPtr: target, messagePtr: message)
+            }
+        }
+
+        XCTAssertEqual(capture.logs.count, 1, "Expected exactly one log entry")
+
+        let entry = capture.logs[0]
+        XCTAssertEqual(entry.level, 3)
+        XCTAssertEqual(entry.target, "mullvad_ios::logging")
+        XCTAssertEqual(entry.message, "Test message from Rust")
+    }
+
+    /// Verify that null parameters are handled gracefully (callback returns early).
+    func testCallbackIgnoresNullParameters() {
+        let capture = LogCapture()
+        let context = Unmanaged.passUnretained(capture).toOpaque()
+
+        // Null target and message — callback should bail out
+        testLogCallback(context: context, level: 1, targetPtr: nil, messagePtr: nil)
+        XCTAssertTrue(capture.logs.isEmpty, "Callback should ignore null parameters")
+
+        // Null context — callback should bail out
+        "target".withCString { target in
+            "message".withCString { message in
+                testLogCallback(context: nil, level: 1, targetPtr: target, messagePtr: message)
+            }
+        }
+        XCTAssertTrue(capture.logs.isEmpty, "Callback should ignore null context")
+    }
+
+}

--- a/ios/MullvadRustRuntimeTests/TunnelObfuscationTests.swift
+++ b/ios/MullvadRustRuntimeTests/TunnelObfuscationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadLogging
 import MullvadRustRuntime
 import MullvadTypes
 import Network
@@ -17,7 +18,7 @@ final class TunnelObfuscationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        RustLogging.initialize()
+        RustLogging.initialize(logger: Logger(label: "Rust"))
     }
 
     func testRunningUdpOverTcpObfuscatorProxy() async throws {

--- a/ios/MullvadVPN.xcodeproj/project.pbxproj
+++ b/ios/MullvadVPN.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		014E8C2A2F28B09700837D0A /* MullvadLogging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58D223F3294C8FF00029F5F8 /* MullvadLogging.framework */; };
 		014E8C302F294FB000837D0A /* relays-test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 014E8C2F2F294FB000837D0A /* relays-test-data.json */; };
 		014E8C312F294FB000837D0A /* relays-test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 014E8C2F2F294FB000837D0A /* relays-test-data.json */; };
+		014E8C372F2BC60300837D0A /* LogRedactorBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014E8C352F2BC60300837D0A /* LogRedactorBenchmarkTests.swift */; };
+		014E8C3A2F2D594400837D0A /* RustLogRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014E8C392F2D594400837D0A /* RustLogRedactor.swift */; };
 		016EE0382F850C0E0035B25C /* WireGuardKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0372F850C0E0035B25C /* WireGuardKey.swift */; };
 		016EE03A2F850C5A0035B25C /* WireGuardKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */; };
 		016EE03C2F8524EB0035B25C /* WireGuardKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016EE03B2F8524EB0035B25C /* WireGuardKey.swift */; };
@@ -65,6 +67,9 @@
 		06799AF128F98E4800ACD94E /* RESTSubmitVoucherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FAE67328F83CA40033DD93 /* RESTSubmitVoucherResponse.swift */; };
 		0697D6E728F01513007A9E99 /* APITransportMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697D6E628F01513007A9E99 /* APITransportMonitor.swift */; };
 		06AC116228F94C450037AF9A /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
+		0E64F2F65442F45A89B82589 /* RustLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D702C13944A82CAF175A4443 /* RustLoggingTests.swift */; };
+		2F169CDAE6E8C601F85C543E /* TunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */; };
+		4084C59D0F3955182E3C8340 /* LogRedacting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0064CB0EF9AACDC812F39635 /* LogRedacting.swift */; };
 		44075DFB2CDA4F7400F61139 /* UDPOverTCPObfuscationSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44075DFA2CDA4F7400F61139 /* UDPOverTCPObfuscationSettingsViewModel.swift */; };
 		440870822D7A00B70038972F /* UIImage+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440870812D7A00B00038972F /* UIImage+Assets.swift */; };
 		440870832D809B550038972F /* UIImage+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440870812D7A00B00038972F /* UIImage+Assets.swift */; };
@@ -938,6 +943,9 @@
 		A9E0317F2ACC331C0095D843 /* TunnelStatusBlockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E0317D2ACC32920095D843 /* TunnelStatusBlockObserver.swift */; };
 		A9E034642ABB302000E59A5A /* UIEdgeInsets+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E034632ABB302000E59A5A /* UIEdgeInsets+Extensions.swift */; };
 		A9EE85612DF1BE2900F2D769 /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE85602DF1BE2900F2D769 /* TermsOfServiceView.swift */; };
+		BF434ABF6F9543C9BABD3CBA /* FloatingSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B364DC07F3CF4B63A5B1BB6C /* FloatingSearchBar.swift */; };
+		C1EA193A1103489C981B6E59 /* EnvironmentValues+DismissSearchFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AB4F0478E4995ABAF99AF /* EnvironmentValues+DismissSearchFocus.swift */; };
+		D56CD86C4435C3F6AF2A2662 /* WireGuardGoTunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */; };
 		E10A0001000000000000AB01 /* GotaTunActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0001000000000000AA01 /* GotaTunActor.swift */; };
 		E10A0002000000000000AB01 /* PacketTunnelDebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */; };
 		E10A0002000000000000AB02 /* PacketTunnelDebugSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */; };
@@ -948,6 +956,7 @@
 		E1187ABD289BBB850024E748 /* OutOfTimeContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1187ABB289BBB850024E748 /* OutOfTimeContentView.swift */; };
 		E158B360285381C60002F069 /* String+AccountFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E158B35F285381C60002F069 /* String+AccountFormatting.swift */; };
 		E1FD0DF528AA7CE400299DB4 /* StatusActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FD0DF428AA7CE400299DB4 /* StatusActivityView.swift */; };
+		E79BD7E565693BF2BDA5D9E6 /* GotaTunTunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */; };
 		F006CCFC2B99CC8400C6C2AC /* EditLocationsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F006CCFB2B99CC8400C6C2AC /* EditLocationsCoordinator.swift */; };
 		F0077EEE2C52844800DAB2AA /* KeyExchangingResultStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FBD98E2C4A60CC00EE5323 /* KeyExchangingResultStub.swift */; };
 		F01528BB2BFF3FEE00B01D00 /* ShadowsocksRelaySelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01528BA2BFF3FEE00B01D00 /* ShadowsocksRelaySelector.swift */; };
@@ -1019,6 +1028,8 @@
 		F08B6B7C2C528C6300D0A121 /* SingleHopEphemeralPeerExchanger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05919782C45402E00C301F3 /* SingleHopEphemeralPeerExchanger.swift */; };
 		F08B6B7D2C528C6300D0A121 /* EphemeralPeerExchangingPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05919762C453FAF00C301F3 /* EphemeralPeerExchangingPipeline.swift */; };
 		F08B6B7E2C528C6300D0A121 /* MultiHopEphemeralPeerExchanger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F059197C2C454C9200C301F3 /* MultiHopEphemeralPeerExchanger.swift */; };
+		F09035B32FAB708D004635A3 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F09035B22FAB708D004635A3 /* SystemConfiguration.framework */; };
+		F09035B52FAB724C004635A3 /* LogRedactorComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09035B42FAB724C004635A3 /* LogRedactorComparisonTests.swift */; };
 		F09084682C6E88ED001CD36E /* DaitaPromptAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09084672C6E88ED001CD36E /* DaitaPromptAlert.swift */; };
 		F09444132ECCA4B30059606A /* RecentListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09444122ECCA4990059606A /* RecentListDataSource.swift */; };
 		F09444142ECCA4B30059606A /* RecentListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09444122ECCA4990059606A /* RecentListDataSource.swift */; };
@@ -1039,6 +1050,7 @@
 		F09D616B2F5AD5E200C85C9E /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = F09D616A2F5AD5E200C85C9E /* Localizable.xcstrings */; };
 		F0A005572F3DFDDC00B09EFC /* NotificationPromptPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A005562F3DFDCF00B09EFC /* NotificationPromptPage.swift */; };
 		F0A086902C22D6A700BF83E7 /* TunnelSettingsStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A0868F2C22D6A700BF83E7 /* TunnelSettingsStrategyTests.swift */; };
+		F0A607C52FAA0A4B00094833 /* Array+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A607C42FAA0A4B00094833 /* Array+String.swift */; };
 		F0A7EBB22CEF6C79005BB671 /* ConsolidatedApplicationLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A7EBB12CEF6C79005BB671 /* ConsolidatedApplicationLogTests.swift */; };
 		F0A7EBB62CF092CC005BB671 /* ApplicationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BFA5CB22A7CE1F00A6173D /* ApplicationConfiguration.swift */; };
 		F0A89CB32D9D6C2100580C27 /* MullvadDeviceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A89CB22D9D6C1400580C27 /* MullvadDeviceProxy.swift */; };
@@ -1134,8 +1146,6 @@
 		F0FA16152D7F3E16007E2546 /* Collection+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AF9BE8F2A39F26000DBFEDB /* Collection+Sorting.swift */; };
 		F0FADDEA2BE90AAA000D0B02 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F1EF8C2BE8FF0A00CED01D /* LaunchArguments.swift */; };
 		F0FADDEC2BE90AB0000D0B02 /* LaunchArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F1EF8C2BE8FF0A00CED01D /* LaunchArguments.swift */; };
-		BF434ABF6F9543C9BABD3CBA /* FloatingSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B364DC07F3CF4B63A5B1BB6C /* FloatingSearchBar.swift */; };
-		C1EA193A1103489C981B6E59 /* EnvironmentValues+DismissSearchFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323AB4F0478E4995ABAF99AF /* EnvironmentValues+DismissSearchFocus.swift */; };
 		F90052522E6B06AD0085C80E /* SelectLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90052512E6B06AA0085C80E /* SelectLocationView.swift */; };
 		F90052562E6EEB290085C80E /* SelectLocationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90052552E6EEB290085C80E /* SelectLocationViewModel.swift */; };
 		F90A988A2E042D040020F64F /* ClearBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90A98892E042D040020F64F /* ClearBackgroundView.swift */; };
@@ -1186,9 +1196,6 @@
 		F9E3BCF72DD35B78009986C3 /* ListAccessViewModelBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E3BCF62DD35B78009986C3 /* ListAccessViewModelBridge.swift */; };
 		F9EDB26C2EC4C0480015DE36 /* CustomListInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9EDB26B2EC4C0420015DE36 /* CustomListInteractorTests.swift */; };
 		F9EDB26D2EC4C0CD0015DE36 /* CustomListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6389DA2B7E3BD6008E77E1 /* CustomListInteractor.swift */; };
-		2F169CDAE6E8C601F85C543E /* TunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */; };
-		D56CD86C4435C3F6AF2A2662 /* WireGuardGoTunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */; };
-		E79BD7E565693BF2BDA5D9E6 /* GotaTunTunnelImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1722,9 +1729,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0064CB0EF9AACDC812F39635 /* LogRedacting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedacting.swift; sourceTree = "<group>"; };
 		0107F3F82F56E3ED0012451B /* RelayCacheTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayCacheTrackerTests.swift; sourceTree = "<group>"; };
 		0107F4212F5B97F30012451B /* RelayListCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayListCacheTests.swift; sourceTree = "<group>"; };
 		014E8C2F2F294FB000837D0A /* relays-test-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "relays-test-data.json"; sourceTree = "<group>"; };
+		014E8C352F2BC60300837D0A /* LogRedactorBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactorBenchmarkTests.swift; sourceTree = "<group>"; };
+		014E8C392F2D594400837D0A /* RustLogRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLogRedactor.swift; sourceTree = "<group>"; };
 		016EE0372F850C0E0035B25C /* WireGuardKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKey.swift; sourceTree = "<group>"; };
 		016EE0392F850C5A0035B25C /* WireGuardKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKeyTests.swift; sourceTree = "<group>"; };
 		016EE03B2F8524EB0035B25C /* WireGuardKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardKey.swift; sourceTree = "<group>"; };
@@ -1766,6 +1776,7 @@
 		06FAE67828F83CA50033DD93 /* StorePaymentOutcome.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorePaymentOutcome.swift; sourceTree = "<group>"; };
 		06FAE67A28F83CA50033DD93 /* DeviceHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceHandling.swift; sourceTree = "<group>"; };
 		06FAE67B28F83CA50033DD93 /* REST.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = REST.swift; sourceTree = "<group>"; };
+		323AB4F0478E4995ABAF99AF /* EnvironmentValues+DismissSearchFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+DismissSearchFocus.swift"; sourceTree = "<group>"; };
 		44075DFA2CDA4F7400F61139 /* UDPOverTCPObfuscationSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UDPOverTCPObfuscationSettingsViewModel.swift; sourceTree = "<group>"; };
 		440870812D7A00B00038972F /* UIImage+Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Assets.swift"; sourceTree = "<group>"; };
 		440E5AAF2CDBD67D00B09614 /* StatefulPreviewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatefulPreviewWrapper.swift; sourceTree = "<group>"; };
@@ -2510,6 +2521,10 @@
 		A9EC20E72A5D3A8C0040D56E /* CoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatesTests.swift; sourceTree = "<group>"; };
 		A9EE85602DF1BE2900F2D769 /* TermsOfServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceView.swift; sourceTree = "<group>"; };
 		A9F360332AAB626300F53531 /* VPNConnectionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNConnectionProtocol.swift; sourceTree = "<group>"; };
+		B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelImplementation.swift; sourceTree = "<group>"; };
+		B364DC07F3CF4B63A5B1BB6C /* FloatingSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingSearchBar.swift; sourceTree = "<group>"; };
+		D702C13944A82CAF175A4443 /* RustLoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustLoggingTests.swift; sourceTree = "<group>"; };
+		DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardGoTunnelImplementation.swift; sourceTree = "<group>"; };
 		E10A0001000000000000AA01 /* GotaTunActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunActor.swift; sourceTree = "<group>"; };
 		E10A0002000000000000AA01 /* PacketTunnelDebugSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelDebugSettings.swift; sourceTree = "<group>"; };
 		E1187ABA289BBB850024E748 /* OutOfTimeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfTimeViewController.swift; sourceTree = "<group>"; };
@@ -2586,6 +2601,8 @@
 		F07CFF1F29F2720E008C0343 /* NewDeviceNotificationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewDeviceNotificationProvider.swift; sourceTree = "<group>"; };
 		F07F1BD42E4A361E003FB336 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		F08096FA2E4A325600D8B0CF /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F09035B22FAB708D004635A3 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		F09035B42FAB724C004635A3 /* LogRedactorComparisonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactorComparisonTests.swift; sourceTree = "<group>"; };
 		F09084672C6E88ED001CD36E /* DaitaPromptAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaitaPromptAlert.swift; sourceTree = "<group>"; };
 		F09444122ECCA4990059606A /* RecentListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentListDataSource.swift; sourceTree = "<group>"; };
 		F09A29782A9F8A9B00EA3B6F /* LogoutDialogueView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogoutDialogueView.swift; sourceTree = "<group>"; };
@@ -2606,6 +2623,7 @@
 		F0A005562F3DFDCF00B09EFC /* NotificationPromptPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPromptPage.swift; sourceTree = "<group>"; };
 		F0A0868F2C22D6A700BF83E7 /* TunnelSettingsStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSettingsStrategyTests.swift; sourceTree = "<group>"; };
 		F0A163882C47B46300592300 /* SingleHopEphemeralPeerExchangerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleHopEphemeralPeerExchangerTests.swift; sourceTree = "<group>"; };
+		F0A607C42FAA0A4B00094833 /* Array+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+String.swift"; sourceTree = "<group>"; };
 		F0A66C992E4A3607006F190A /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		F0A7EBB12CEF6C79005BB671 /* ConsolidatedApplicationLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsolidatedApplicationLogTests.swift; sourceTree = "<group>"; };
 		F0A89CB22D9D6C1400580C27 /* MullvadDeviceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MullvadDeviceProxy.swift; sourceTree = "<group>"; };
@@ -2687,8 +2705,7 @@
 		F0FA160D2D7F2C3D007E2546 /* MockRelayCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRelayCache.swift; sourceTree = "<group>"; };
 		F0FA160F2D7F2FC0007E2546 /* RelayFilterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayFilterViewModelTests.swift; sourceTree = "<group>"; };
 		F0FBD98E2C4A60CC00EE5323 /* KeyExchangingResultStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyExchangingResultStub.swift; sourceTree = "<group>"; };
-		323AB4F0478E4995ABAF99AF /* EnvironmentValues+DismissSearchFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+DismissSearchFocus.swift"; sourceTree = "<group>"; };
-		B364DC07F3CF4B63A5B1BB6C /* FloatingSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingSearchBar.swift; sourceTree = "<group>"; };
+		F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunTunnelImplementation.swift; sourceTree = "<group>"; };
 		F90052512E6B06AA0085C80E /* SelectLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationView.swift; sourceTree = "<group>"; };
 		F90052552E6EEB290085C80E /* SelectLocationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectLocationViewModel.swift; sourceTree = "<group>"; };
 		F90A98892E042D040020F64F /* ClearBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearBackgroundView.swift; sourceTree = "<group>"; };
@@ -2738,9 +2755,6 @@
 		F9C579C72E8FE10400C90C50 /* LocationItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationItemView.swift; sourceTree = "<group>"; };
 		F9E3BCF62DD35B78009986C3 /* ListAccessViewModelBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAccessViewModelBridge.swift; sourceTree = "<group>"; };
 		F9EDB26B2EC4C0420015DE36 /* CustomListInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomListInteractorTests.swift; sourceTree = "<group>"; };
-		B24C2F93919B5526A741ADA8 /* TunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelImplementation.swift; sourceTree = "<group>"; };
-		DD68970B0A1DEEA01FB25D9E /* WireGuardGoTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardGoTunnelImplementation.swift; sourceTree = "<group>"; };
-		F678736F5403E23B77CA9990 /* GotaTunTunnelImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotaTunTunnelImplementation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2905,6 +2919,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F09035B32FAB708D004635A3 /* SystemConfiguration.framework in Frameworks */,
 				014E8C2A2F28B09700837D0A /* MullvadLogging.framework in Frameworks */,
 				A9173C372C36CD2B00F6A08C /* MullvadTypes.framework in Frameworks */,
 				44A262672D63745C00085380 /* WireGuardKitTypes in Frameworks */,
@@ -3074,6 +3089,8 @@
 				A902E7A52D3FB0D9007F844A /* LogFileOutputStreamTests.swift */,
 				A9C7B62B2EB9F71D002CABB1 /* LoggerBuilderTests.swift */,
 				44B02E3A2BC5732D008EDF34 /* LoggingTests.swift */,
+				014E8C352F2BC60300837D0A /* LogRedactorBenchmarkTests.swift */,
+				F09035B42FAB724C004635A3 /* LogRedactorComparisonTests.swift */,
 				7AA513852BC91C6B00D081A4 /* LogRotationTests.swift */,
 			);
 			path = MullvadLogging;
@@ -3718,6 +3735,7 @@
 		584F991F2902CBDD001F858D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F09035B22FAB708D004635A3 /* SystemConfiguration.framework */,
 				A9C75BC12C2D8C9E00B4CDF5 /* libmullvad_ios.a */,
 				A944F2712B8E02E800473F4C /* libmullvad_ios.a */,
 				584023282A407F5F007B27AC /* libmullvad_ios.a */,
@@ -4262,6 +4280,7 @@
 		58D223F4294C8FF00029F5F8 /* MullvadLogging */ = {
 			isa = PBXGroup;
 			children = (
+				0064CB0EF9AACDC812F39635 /* LogRedacting.swift */,
 				58D223F5294C8FF00029F5F8 /* MullvadLogging.h */,
 				581943E328F8010400B0CB5E /* CustomFormatLogHandler.swift */,
 				581943E228F8010400B0CB5E /* Date+LogFormat.swift */,
@@ -4786,6 +4805,7 @@
 		A992DA1E2C24709F00DE7CE5 /* MullvadRustRuntime */ = {
 			isa = PBXGroup;
 			children = (
+				F0A607C42FAA0A4B00094833 /* Array+String.swift */,
 				A948809A2BC9308D0090A44C /* EphemeralPeerExchangeActor.swift */,
 				A9EB4F9C2B7FAB21002A2D7A /* EphemeralPeerNegotiator.swift */,
 				A9A557F42B7E3E5C0017ADA8 /* EphemeralPeerReceiver.swift */,
@@ -4801,12 +4821,13 @@
 				A992DA1F2C24709F00DE7CE5 /* MullvadRustRuntime.h */,
 				A98207F02D91A0AC00654558 /* MullvadShadowsocksBridgeProvider.swift */,
 				01D13C202F11130500EC63DE /* RustLogging.swift */,
+				014E8C392F2D594400837D0A /* RustLogRedactor.swift */,
 				F0EEFB9E2D8D60E1007FE4B3 /* RustProblemReportRequest.swift */,
 				58DFF7D92B02862E00F864E0 /* ShadowsocksCipherService.swift */,
 				F0A89CB62D9D922300580C27 /* String+UnsafePointer.swift */,
 				44DFB71B2F3DD8A6002C528E /* SwiftData.swift */,
-				016EE0372F850C0E0035B25C /* WireGuardKey.swift */,
 				584023212A406BF5007B27AC /* TunnelObfuscator.swift */,
+				016EE0372F850C0E0035B25C /* WireGuardKey.swift */,
 			);
 			path = MullvadRustRuntime;
 			sourceTree = "<group>";
@@ -4814,9 +4835,9 @@
 		A9D9A4C12C36D53C004088DD /* MullvadRustRuntimeTests */ = {
 			isa = PBXGroup;
 			children = (
-				7AE16DCF2F9F7DB100A72A39 /* MullvadConnectionModeProviderTests.swift */,
 				A98F1B502C19C48D003C869E /* EphemeralPeerExchangeActorTests.swift */,
 				A9C308392C19DDA7008715F1 /* MullvadPostQuantum+Stubs.swift */,
+				D702C13944A82CAF175A4443 /* RustLoggingTests.swift */,
 				585A02EC2A4B28F300C6CAFF /* TCPConnection.swift */,
 				58695A9F2A4ADA9200328DB3 /* TunnelObfuscationTests.swift */,
 				585A02EA2A4B285800C6CAFF /* UDPConnection.swift */,
@@ -6186,6 +6207,7 @@
 				7AF36A9A2CA2964200E1D497 /* AnyIPAddressTests.swift in Sources */,
 				A9A5FA422ACB05D90083449F /* DeviceStateAccessorProtocol.swift in Sources */,
 				7A5869C32B5820CE00640D27 /* IPOverrideRepositoryTests.swift in Sources */,
+				014E8C372F2BC60300837D0A /* LogRedactorBenchmarkTests.swift in Sources */,
 				A9A5FA392ACB05910083449F /* UIColor+Palette.swift in Sources */,
 				7A5468AD2C6B5E4B00590086 /* LocationRelays.swift in Sources */,
 				F97C38DF2DEEDB0F006DCB08 /* Color+Mullvad.swift in Sources */,
@@ -6317,6 +6339,7 @@
 				A9A5FA282ACB05160083449F /* WgKeyRotation.swift in Sources */,
 				449872E42B7CB96300094DDC /* TunnelSettingsUpdateTests.swift in Sources */,
 				F0A7EBB22CEF6C79005BB671 /* ConsolidatedApplicationLogTests.swift in Sources */,
+				F09035B52FAB724C004635A3 /* LogRedactorComparisonTests.swift in Sources */,
 				A9B6AC182ADE8F4300F7802A /* MigrationManagerTests.swift in Sources */,
 				7A9BE5AB2B909A1700E2A7D0 /* LocationDataSourceProtocol.swift in Sources */,
 				A9A5FA2A2ACB05160083449F /* CoordinatesTests.swift in Sources */,
@@ -7093,6 +7116,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4084C59D0F3955182E3C8340 /* LogRedacting.swift in Sources */,
 				7AED35CC2BD13F60002A67D1 /* ApplicationConfiguration.swift in Sources */,
 				E10A0002000000000000AB05 /* PacketTunnelDebugSettings.swift in Sources */,
 				7AED35CD2BD13FC4002A67D1 /* ApplicationTarget.swift in Sources */,
@@ -7238,11 +7262,13 @@
 				44DFB71C2F3DD8AB002C528E /* SwiftData.swift in Sources */,
 				7AB931262D43D22F005FCEBA /* MullvadApiResponse.swift in Sources */,
 				A98207F32D9ACE4C00654558 /* MullvadAccessMethodReceiver.swift in Sources */,
+				F0A607C52FAA0A4B00094833 /* Array+String.swift in Sources */,
 				A9173C322C36CCDD00F6A08C /* EphemeralPeerReceiver.swift in Sources */,
 				A96D0B452D675F0400DD6C59 /* MullvadConnectionModeProvider.swift in Sources */,
 				4491AC7B2ECF5FE4005789DF /* MullvadAddressCacheKeychainStore.swift in Sources */,
 				7A99D3712D56222000891FF7 /* MullvadApiCancellable.swift in Sources */,
 				01D13C212F11130500EC63DE /* RustLogging.swift in Sources */,
+				014E8C3A2F2D594400837D0A /* RustLogRedactor.swift in Sources */,
 				A93969812CE606190032A7A0 /* Maybenot.swift in Sources */,
 				016EE0382F850C0E0035B25C /* WireGuardKey.swift in Sources */,
 				F05919802C45515200C301F3 /* EphemeralPeerExchangeActor.swift in Sources */,
@@ -7258,7 +7284,7 @@
 				A9D9A4D22C36DBAF004088DD /* MullvadPostQuantum+Stubs.swift in Sources */,
 				F08B6B772C52878400D0A121 /* EphemeralPeerExchangeActorTests.swift in Sources */,
 				016EE03A2F850C5A0035B25C /* WireGuardKeyTests.swift in Sources */,
-				7AE16DD02F9F7DCB00A72A39 /* MullvadConnectionModeProviderTests.swift in Sources */,
+				0E64F2F65442F45A89B82589 /* RustLoggingTests.swift in Sources */,
 				A9D9A4CF2C36D54E004088DD /* TCPConnection.swift in Sources */,
 				A9D9A4CE2C36D54E004088DD /* TunnelObfuscationTests.swift in Sources */,
 				A9D9A4CC2C36D54E004088DD /* UnsafeListener.swift in Sources */,

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -57,6 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     let notificationSettingsListener = NotificationSettingsListener()
     private var notificationSettingsUpdater: NotificationSettingsUpdater!
+    nonisolated(unsafe) private(set) var logRedactor: LogRedacting!
 
     // MARK: - Application lifecycle
 
@@ -151,9 +152,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             relaySelector: relaySelector
         )
 
-        settingsObserver = TunnelBlockObserver(didUpdateTunnelSettings: { _, settings in
-            tunnelSettingsListener.onNewSettings?(settings)
-        })
+        settingsObserver = TunnelBlockObserver(
+            didLoadConfiguration: { [weak self] tunnelManager in
+                // Redact legacy numbers that do not match the account number regex.
+                self?.logRedactor.addCustomString(tunnelManager.deviceState.accountData?.number ?? "")
+            },
+            didUpdateTunnelSettings: { _, settings in
+                tunnelSettingsListener.onNewSettings?(settings)
+            })
         tunnelManager.addObserver(settingsObserver)
 
         storePaymentManager = StorePaymentManager(
@@ -417,6 +423,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let header = "MullvadVPN version \(Bundle.main.productVersion)"
         let loggerBuilder = LoggerBuilder.shared
 
+        // Create the Rust-backed log redactor with container paths
+        let redactor = RustLogRedactor(containerPaths: [ApplicationConfiguration.containerURL.path])
+        self.logRedactor = redactor
+
         loggerBuilder.addFileOutput(
             fileURL: ApplicationConfiguration.newLogFileURL(for: .mainApp, in: ApplicationConfiguration.containerURL),
             header: header
@@ -424,10 +434,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         #if DEBUG
             loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.mainApp.bundleIdentifier)
         #endif
-        loggerBuilder.install()
+        loggerBuilder.install(redactor)
 
         // Initialize Rust logging to forward to Swift Logger
-        RustLogging.initialize()
+        RustLogging.initialize(logger: Logger(label: "Rust"))
 
         logger = Logger(label: "AppDelegate")
     }

--- a/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
+++ b/ios/MullvadVPN/Classes/ConsolidatedApplicationLog.swift
@@ -7,11 +7,10 @@
 //
 
 import Foundation
+import MullvadLogging
 
 private let kLogDelimiter = "===================="
 private let kRedactedPlaceholder = "[REDACTED]"
-private let kRedactedAccountPlaceholder = "[REDACTED ACCOUNT NUMBER]"
-private let kRedactedContainerPlaceholder = "[REDACTED CONTAINER PATH]"
 
 class ConsolidatedApplicationLog: TextOutputStreamable, @unchecked Sendable {
     typealias Metadata = KeyValuePairs<MetadataKey, String>
@@ -27,28 +26,19 @@ class ConsolidatedApplicationLog: TextOutputStreamable, @unchecked Sendable {
         let content: String
     }
 
-    let redactCustomStrings: [String]?
-    let applicationGroupContainers: [URL]
+    let redactor: LogRedacting?
     let metadata: Metadata
 
     private let logQueue = DispatchQueue(label: "com.mullvad.consolidation.logs.queue")
     private var logs: [LogAttachment] = []
 
     init(
-        redactCustomStrings: [String]? = nil,
-        redactContainerPathsForSecurityGroupIdentifiers securityGroupIdentifiers: [String],
+        redactor: LogRedacting? = nil,
         bufferSize: UInt64
     ) {
         metadata = Self.makeMetadata()
-        self.redactCustomStrings = redactCustomStrings
+        self.redactor = redactor
         self.bufferSize = bufferSize
-
-        applicationGroupContainers =
-            securityGroupIdentifiers
-            .compactMap { securityGroupIdentifier -> URL? in
-                FileManager.default
-                    .containerURL(forSecurityApplicationGroupIdentifier: securityGroupIdentifier)
-            }
     }
 
     func addLogFiles(fileURLs: [URL], completion: (@Sendable () -> Void)? = nil) {
@@ -169,74 +159,10 @@ class ConsolidatedApplicationLog: TextOutputStreamable, @unchecked Sendable {
         }
     }
 
-    private func redactCustomStrings(in string: String) -> String {
-        guard let customStrings = redactCustomStrings,
-            !customStrings.isEmpty
-        else {
-            return string
-        }
-        return customStrings.reduce(string) { resultString, redact in
-            resultString.replacingOccurrences(of: redact, with: kRedactedPlaceholder)
-        }
-    }
-
     private func redact(string: String) -> String {
-        var result = string
-        result = redactContainerPaths(string: result)
-        result = redactAccountNumber(string: result)
-        result = redactIPv4Address(string: result)
-        result = redactIPv6Address(string: result)
-        result = redactCustomStrings(in: result)
-        return result
-    }
-
-    private func redactContainerPaths(string: String) -> String {
-        applicationGroupContainers.reduce(string) { resultString, containerURL -> String in
-            resultString.replacingOccurrences(
-                of: containerURL.path,
-                with: kRedactedContainerPlaceholder
-            )
-        }
-    }
-
-    private func redactAccountNumber(string: String) -> String {
-        // swift-format-ignore: NeverUseForceTry
-        redact(
-            regularExpression: try! NSRegularExpression(pattern: #"\d{16}"#),
-            string: string,
-            replacementString: kRedactedAccountPlaceholder
-        )
-    }
-
-    private func redactIPv4Address(string: String) -> String {
-        redact(
-            regularExpression: NSRegularExpression.ipv4RegularExpression,
-            string: string,
-            replacementString: kRedactedPlaceholder
-        )
-    }
-
-    private func redactIPv6Address(string: String) -> String {
-        redact(
-            regularExpression: NSRegularExpression.ipv6RegularExpression,
-            string: string,
-            replacementString: kRedactedPlaceholder
-        )
-    }
-
-    private func redact(
-        regularExpression: NSRegularExpression,
-        string: String,
-        replacementString: String
-    ) -> String {
-        let nsRange = NSRange(string.startIndex..<string.endIndex, in: string)
-        let template = NSRegularExpression.escapedTemplate(for: replacementString)
-
-        return regularExpression.stringByReplacingMatches(
-            in: string,
-            options: [],
-            range: nsRange,
-            withTemplate: template
-        )
+        // Apply full redaction (IPs, accounts, container paths) for backward compatibility
+        // with logs from previous releases that didn't have on-the-fly redaction.
+        // Double-redacting already-redacted text is a no-op.
+        redactor?.redact(string) ?? string
     }
 }

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import MullvadLogging
 import MullvadREST
 import MullvadRustRuntime
 import MullvadSettings
@@ -58,6 +59,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
     private let relaySelectorWrapper: RelaySelectorWrapper
     private let breadcrumbsProvider: BreadcrumbsProvider
     private var breadcrumbsObserver: BreadcrumbsBlockObserver?
+    private let logRedactor: LogRedacting?
 
     private var outOfTimeTimer: Timer?
 
@@ -77,7 +79,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
         accessMethodRepository: AccessMethodRepositoryProtocol,
         ipOverrideRepository: IPOverrideRepository,
         relaySelectorWrapper: RelaySelectorWrapper,
-        breadcrumbsProvider: BreadcrumbsProvider
+        breadcrumbsProvider: BreadcrumbsProvider,
+        logRedactor: LogRedacting? = nil
     ) {
         self.tunnelManager = tunnelManager
         self.storePaymentManager = storePaymentManager
@@ -91,6 +94,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
         self.ipOverrideRepository = ipOverrideRepository
         self.relaySelectorWrapper = relaySelectorWrapper
         self.breadcrumbsProvider = breadcrumbsProvider
+        self.logRedactor = logRedactor
 
         super.init()
 
@@ -660,7 +664,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
             tunnelManager: tunnelManager,
             apiProxy: apiProxy,
             relayCacheTracker: relayCacheTracker,
-            ipOverrideRepository: ipOverrideRepository
+            ipOverrideRepository: ipOverrideRepository,
+            redactor: logRedactor
         )
 
         let navigationController = CustomNavigationController()
@@ -717,7 +722,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
             tunnelManager: tunnelManager,
             apiProxy: apiProxy,
             relayCacheTracker: relayCacheTracker,
-            ipOverrideRepository: ipOverrideRepository
+            ipOverrideRepository: ipOverrideRepository,
+            redactor: logRedactor
         )
         let coordinator = VPNSettingsCoordinator(
             navigationController: CustomNavigationController(),

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -82,7 +82,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, @preconcurrency Setting
             accessMethodRepository: accessMethodRepository,
             ipOverrideRepository: appDelegate.ipOverrideRepository,
             relaySelectorWrapper: appDelegate.relaySelector,
-            breadcrumbsProvider: appDelegate.breadcrumbsProvider
+            breadcrumbsProvider: appDelegate.breadcrumbsProvider,
+            logRedactor: appDelegate.logRedactor
         )
 
         appCoordinator?.onShowSettings = { [weak self] in

--- a/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
+++ b/ios/MullvadVPN/View controllers/ProblemReport/ProblemReportInteractor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MullvadLogging
 import MullvadREST
 import MullvadTypes
 import Operations
@@ -18,13 +19,11 @@ final class ProblemReportInteractor: @unchecked Sendable {
     private var reportedString = ""
     private var requestCancellable: Cancellable?
 
-    init(apiProxy: APIQuerying, tunnelManager: TunnelManager) {
+    init(apiProxy: APIQuerying, tunnelManager: TunnelManager, redactor: LogRedacting?) {
         self.apiProxy = apiProxy
         self.tunnelManager = tunnelManager
-        let redactCustomStrings = [tunnelManager.deviceState.accountData?.number].compactMap { $0 }
         self.consolidatedLog = ConsolidatedApplicationLog(
-            redactCustomStrings: redactCustomStrings.isEmpty ? nil : redactCustomStrings,
-            redactContainerPathsForSecurityGroupIdentifiers: [ApplicationConfiguration.securityGroupIdentifier],
+            redactor: redactor,
             bufferSize: ApplicationConfiguration.logMaximumFileSize
         )
     }

--- a/ios/MullvadVPN/View controllers/Settings/SettingsInteractorFactory.swift
+++ b/ios/MullvadVPN/View controllers/Settings/SettingsInteractorFactory.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadLogging
 import MullvadREST
 import MullvadSettings
 
@@ -13,6 +14,7 @@ final class SettingsInteractorFactory {
     private let apiProxy: APIQuerying
     private let relayCacheTracker: RelayCacheTracker
     private let ipOverrideRepository: IPOverrideRepositoryProtocol
+    private let redactor: LogRedacting?
 
     let tunnelManager: TunnelManager
 
@@ -20,12 +22,14 @@ final class SettingsInteractorFactory {
         tunnelManager: TunnelManager,
         apiProxy: APIQuerying,
         relayCacheTracker: RelayCacheTracker,
-        ipOverrideRepository: IPOverrideRepositoryProtocol
+        ipOverrideRepository: IPOverrideRepositoryProtocol,
+        redactor: LogRedacting? = nil
     ) {
         self.tunnelManager = tunnelManager
         self.apiProxy = apiProxy
         self.relayCacheTracker = relayCacheTracker
         self.ipOverrideRepository = ipOverrideRepository
+        self.redactor = redactor
     }
 
     func makeVPNSettingsInteractor() -> VPNSettingsInteractor {
@@ -33,7 +37,7 @@ final class SettingsInteractorFactory {
     }
 
     func makeProblemReportInteractor() -> ProblemReportInteractor {
-        ProblemReportInteractor(apiProxy: apiProxy, tunnelManager: tunnelManager)
+        ProblemReportInteractor(apiProxy: apiProxy, tunnelManager: tunnelManager, redactor: redactor)
     }
 
     func makeSettingsInteractor() -> SettingsInteractor {

--- a/ios/MullvadVPNTests/MullvadLogging/LogRedactorBenchmarkTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LogRedactorBenchmarkTests.swift
@@ -1,0 +1,46 @@
+//
+//  LogRedactorBenchmarkTests.swift
+//  MullvadVPNTests
+//
+//  Created by Emīls on 2026-01-29.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadRustRuntime
+import XCTest
+
+/// Benchmark for Rust log redaction over a representative mix of log entries.
+final class LogRedactorBenchmarkTests: XCTestCase {
+
+    /// Representative mix of log entries covering all redaction patterns and the common no-match case.
+    let logEntries = [
+        // IPv4
+        "[2026-01-29 10:30:45][TunnelManager][info] Connected to 192.168.1.1 successfully",
+        // IPv6
+        "[2026-01-29 10:30:45][TunnelManager][info] Connected to 2001:db8:85a3::8a2e:370:7334 successfully",
+        // Account number
+        "[2026-01-29 10:30:45][Auth][info] Login attempt for account 1234567890123456",
+        // No match (common case)
+        "[2026-01-29 10:30:45][AppDelegate][debug] Application started successfully",
+        // Long line with multiple IPs
+        """
+        [2026-01-29 10:30:45][TunnelManager][info] pid=12345 session=abc123 \
+        Tunnel connection established. Primary endpoint: 192.168.1.1:51820, \
+        backup endpoint: 10.0.0.1:51820. IPv6 addresses: 2001:db8:85a3::8a2e:370:7334, \
+        fe80::1%en0. Account verification completed for user session. \
+        DNS servers configured: 192.168.1.53, 8.8.8.8, 2001:4860:4860::8888. \
+        Gateway: 192.168.1.254. Network interface ready.
+        """,
+    ]
+
+    func testBenchmarkRustRedactor() {
+        let rustRedactor = RustLogRedactor()
+        let options = XCTMeasureOptions()
+        options.iterationCount = 10_000
+        measure(options: options) {
+            for entry in logEntries {
+                _ = rustRedactor.redact(entry)
+            }
+        }
+    }
+}

--- a/ios/MullvadVPNTests/MullvadLogging/LogRedactorComparisonTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LogRedactorComparisonTests.swift
@@ -1,0 +1,199 @@
+//
+//  LogRedactorComparisonTests.swift
+//  MullvadVPNTests
+//
+//  Created on 2026-01-30.
+//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+//
+
+import MullvadRustRuntime
+import XCTest
+
+/// Tests verifying the Rust FFI log redactor produces correct output.
+final class LogRedactorComparisonTests: XCTestCase {
+    let rustRedactor = RustLogRedactor()
+
+    // MARK: - IPv4 Tests
+
+    func testIPv4Redaction() {
+        XCTAssertEqual(
+            rustRedactor.redact("Connected to 192.168.1.1 successfully"),
+            "Connected to [REDACTED] successfully"
+        )
+        XCTAssertEqual(
+            rustRedactor.redact("Primary: 192.168.1.1, Secondary: 10.0.0.1"),
+            "Primary: [REDACTED], Secondary: [REDACTED]"
+        )
+        XCTAssertEqual(
+            rustRedactor.redact("Endpoint: 192.168.1.1:51820"),
+            "Endpoint: [REDACTED]:51820"
+        )
+        XCTAssertEqual(
+            rustRedactor.redact("Range: 0.0.0.0 to 255.255.255.255"),
+            "Range: [REDACTED] to [REDACTED]"
+        )
+        // Should not match invalid IPs
+        XCTAssertEqual(
+            rustRedactor.redact("Invalid IP: 999.999.999.999"),
+            "Invalid IP: 999.999.999.999"
+        )
+    }
+
+    // MARK: - IPv6 Tests
+
+    func testIPv6Redaction() {
+        let cases: [(input: String, shouldRedact: Bool)] = [
+            ("Address: 2001:0db8:85a3:0000:0000:8a2e:0370:7334", true),
+            ("Address: 2001:db8:85a3::8a2e:370:7334", true),
+            ("Loopback: ::1", true),
+            ("Link-local: fe80::1%en0", true),
+            ("Mapped: ::ffff:192.168.1.1", true),
+            ("Full: 1:2:3:4:5:6:7:8", true),
+            ("Compressed: 1::8", true),
+            ("Empty: ::", true),
+            ("Address: 2001:db81", false),
+        ]
+
+        for (input, shouldRedact) in cases {
+            let result = rustRedactor.redact(input)
+            if shouldRedact {
+                XCTAssertTrue(
+                    result.contains("[REDACTED]"),
+                    "Expected redaction for: \(input), got: \(result)"
+                )
+            } else {
+                XCTAssertEqual(
+                    input,
+                    result
+                )
+            }
+        }
+    }
+
+    // MARK: - Account Number Tests
+
+    func testAccountRedaction() {
+        XCTAssertEqual(
+            rustRedactor.redact("Account: 1234567890123456"),
+            "Account: [REDACTED ACCOUNT NUMBER]"
+        )
+        // 15 digits — should NOT match
+        XCTAssertEqual(
+            rustRedactor.redact("Short number: 123456789012345"),
+            "Short number: 123456789012345"
+        )
+    }
+
+    // MARK: - Combined Tests
+
+    func testCombinedRedaction() {
+        let input = "User 1234567890123456 connected to 192.168.1.1 via 2001:db8::1"
+        let result = rustRedactor.redact(input)
+        XCTAssertFalse(result.contains("1234567890123456"))
+        XCTAssertFalse(result.contains("192.168.1.1"))
+        XCTAssertFalse(result.contains("2001:db8::1"))
+    }
+
+    func testFullLogLineRedaction() {
+        let inputs = [
+            "[2026-01-29 10:30:45][TunnelManager][info] Connected to 192.168.1.1 successfully",
+            "[2026-01-29 10:30:45][TunnelManager][info] Connected to 2001:db8:85a3::8a2e:370:7334 successfully",
+            "[2026-01-29 10:30:45][Auth][info] Login attempt for account 1234567890123456",
+        ]
+
+        for input in inputs {
+            let result = rustRedactor.redact(input)
+            XCTAssertTrue(result.contains("[REDACTED"), "Expected redaction in: \(input)")
+            // Metadata should be preserved
+            XCTAssertTrue(result.contains("[2026-01-29 10:30:45]"))
+        }
+    }
+
+    // MARK: - Container Path Tests
+
+    func testContainerPathRedaction() {
+        let containerPath = "/var/mobile/Containers/Shared/AppGroup/ABCD1234-5678-90AB-CDEF-1234567890AB"
+        let redactor = RustLogRedactor(containerPaths: [containerPath])
+        let input = "Reading file at \(containerPath)/Logs/app.log"
+        let result = redactor.redact(input)
+        XCTAssertFalse(result.contains(containerPath))
+        XCTAssertTrue(result.contains("[REDACTED CONTAINER PATH]"))
+    }
+
+    func testCustoStringRedaction() {
+        let id = UUID().uuidString
+        let input = "Legacy account number: \(id)"
+        let redactor = RustLogRedactor()
+        redactor.addCustomString(input)
+        let result = redactor.redact(input)
+        XCTAssertFalse(result.contains(id))
+        XCTAssertTrue(result.contains("[REDACTED]"))
+    }
+
+    func testMultipleContainerPaths() {
+        let path1 = "/var/mobile/Containers/Shared/AppGroup/AAAA1111-2222-3333-4444-555566667777"
+        let path2 = "/var/mobile/Containers/Data/Application/BBBB1111-2222-3333-4444-555566667777"
+        let redactor = RustLogRedactor(containerPaths: [path1, path2])
+        let input = "Read \(path1)/a.log and \(path2)/b.log"
+        let result = redactor.redact(input)
+        XCTAssertEqual(
+            result,
+            "Read [REDACTED CONTAINER PATH]/a.log and [REDACTED CONTAINER PATH]/b.log"
+        )
+    }
+
+    // MARK: - Edge Cases
+
+    func testEmptyInput() {
+        XCTAssertEqual(rustRedactor.redact(""), "")
+    }
+
+    func testNoMatchInputUnchanged() {
+        let input = "Application started successfully"
+        XCTAssertEqual(rustRedactor.redact(input), input)
+    }
+
+    // MARK: - MAC Address Tests
+
+    func testMACAddressRedactionColonSeparated() {
+        XCTAssertEqual(
+            rustRedactor.redact("Interface MAC: aa:bb:cc:dd:ee:ff"),
+            "Interface MAC: [REDACTED]"
+        )
+    }
+
+    func testMACAddressRedactionDashSeparated() {
+        XCTAssertEqual(
+            rustRedactor.redact("Interface MAC: AA-BB-CC-DD-EE-FF"),
+            "Interface MAC: [REDACTED]"
+        )
+    }
+
+    func testMACAddressRedactionMixedCase() {
+        XCTAssertEqual(
+            rustRedactor.redact("MAC is 0A:1b:2C:3d:4E:5f on en0"),
+            "MAC is [REDACTED] on en0"
+        )
+    }
+
+    func testRedactorWithNoContainerPaths() {
+        let redactor = RustLogRedactor()
+        let input = "Connected to 192.168.1.1 for account 1234567890123456"
+        let result = redactor.redact(input)
+        XCTAssertEqual(
+            result,
+            "Connected to [REDACTED] for account [REDACTED ACCOUNT NUMBER]"
+        )
+    }
+
+    func testCombinedIPsAccountsAndContainerPaths() {
+        let containerPath = "/var/mobile/Containers/Shared/AppGroup/ABCD1234-5678-90AB-CDEF-1234567890AB"
+        let redactor = RustLogRedactor(containerPaths: [containerPath])
+        let input = "User 1234567890123456 at 10.0.0.1 wrote to \(containerPath)/data.db via 2001:db8::1"
+        let result = redactor.redact(input)
+        XCTAssertFalse(result.contains("1234567890123456"))
+        XCTAssertFalse(result.contains("10.0.0.1"))
+        XCTAssertFalse(result.contains(containerPath))
+        XCTAssertFalse(result.contains("2001:db8::1"))
+    }
+}

--- a/ios/MullvadVPNTests/MullvadLogging/LoggerBuilderTests.swift
+++ b/ios/MullvadVPNTests/MullvadLogging/LoggerBuilderTests.swift
@@ -9,13 +9,16 @@
 import Testing
 
 @testable import MullvadLogging
+@testable import MullvadRustRuntime
 
 struct LoggerBuilderTests {
 
     @Test func installIsIdempotent() async throws {
-        LoggerBuilder.shared.install()
+        let redactedLogger = RustLogRedactor()
+
+        LoggerBuilder.shared.install(redactedLogger)
         // This should crash if the `install` function is not idempotent
-        LoggerBuilder.shared.install()
-        LoggerBuilder.shared.install()
+        LoggerBuilder.shared.install(redactedLogger)
+        LoggerBuilder.shared.install(redactedLogger)
     }
 }

--- a/ios/MullvadVPNTests/MullvadVPN/Log/ConsolidatedApplicationLogTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Log/ConsolidatedApplicationLogTests.swift
@@ -6,20 +6,19 @@
 //  Copyright © 2026 Mullvad VPN AB. All rights reserved.
 //
 
+import MullvadLogging
+import MullvadRustRuntime
 import XCTest
 
 final class ConsolidatedApplicationLogTests: XCTestCase, @unchecked Sendable {
     nonisolated(unsafe) var consolidatedLog: ConsolidatedApplicationLog!
-    let mockRedactStrings = ["sensitive", "secret"]
-    let mockSecurityGroupIdentifiers = ["group1", "group2"]
     var createdMockFiles: [URL] = []
     let kRedactedPlaceholder = "[REDACTED]"
 
     override func setUp() {
         super.setUp()
         consolidatedLog = ConsolidatedApplicationLog(
-            redactCustomStrings: mockRedactStrings,
-            redactContainerPathsForSecurityGroupIdentifiers: mockSecurityGroupIdentifiers,
+            redactor: RustLogRedactor(),
             bufferSize: 65_536
         )
         createdMockFiles = []
@@ -79,6 +78,34 @@ final class ConsolidatedApplicationLogTests: XCTestCase, @unchecked Sendable {
         await fulfillment(of: [expectation], timeout: 1)
     }
 
+    /// Verifies that log files from pre-2026.3 releases (which lack on-the-fly redaction)
+    /// have their sensitive content fully redacted at collection time.
+    func testOldLogFileContentIsRedactedAtCollectionTime() async {
+        let expectation = self.expectation(description: "Old log file processed")
+        let mockFile = createMockFile(content: oldReleaseLogContent, fileName: "\(generateRandomName()).log")
+
+        consolidatedLog.addLogFiles(fileURLs: [mockFile]) {
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation], timeout: 1)
+        let output = consolidatedLog.string
+
+        // IPs that were NOT redacted on-the-fly in the old release must be redacted now
+        XCTAssertFalse(output.contains("192.168.1.1"), "IPv4 address should be redacted")
+        XCTAssertFalse(output.contains("10.64.0.1"), "IPv4 address should be redacted")
+        XCTAssertFalse(output.contains("2001:db8:85a3::8a2e:370:7334"), "IPv6 address should be redacted")
+        XCTAssertFalse(output.contains("1234567890123456"), "Account number should be redacted")
+
+        // Redaction placeholders should be present
+        XCTAssertTrue(output.contains("[REDACTED]"), "Should contain IP redaction placeholders")
+        XCTAssertTrue(output.contains("[REDACTED ACCOUNT NUMBER]"), "Should contain account redaction placeholder")
+
+        // Non-sensitive content should survive
+        XCTAssertTrue(output.contains("MullvadVPN version 2024.5"), "Version header should be preserved")
+        XCTAssertTrue(output.contains("Refresh device state"), "Normal log text should be preserved")
+    }
+
     // MARK: - Private functions
 
     private func createMockFile(content: String, fileName: String) -> URL {
@@ -103,25 +130,31 @@ final class ConsolidatedApplicationLogTests: XCTestCase, @unchecked Sendable {
 
 extension ConsolidatedApplicationLogTests {
     private var content: String {
-        return """
-            MullvadVPN version xxxx.x
-            [22/11/2024 @ 08:52:22][AppDelegate][debug] Registered app refresh task.
-            [22/11/2024 @ 08:52:22][AppDelegate][debug] Registered address cache update task.
-            [22/11/2024 @ 08:52:22][AppDelegate][debug] Registered private key rotation task.
-            [22/11/2024 @ 08:52:23][TunnelManager][debug] Refresh device state
-            and tunnel status
-            due to application becoming active.
-            [22/11/2024 @ 08:52:23][RelayCacheTracker][debug] Start periodic relay updates.
-            [22/11/2024 @ 08:52:23][AddressCache.Tracker][debug] Start periodic address cache updates.
-            [22/11/2024 @ 08:52:23][AddressCache.Tracker][debug] Schedule address cache update at 23/11/2024 @ 08:49:52.
-            [22/11/2024 @ 08:52:23][AppDelegate][debug] Attempted migration from UI Process, but found nothing to do.
-            [22/11/2024 @ 08:52:23][TunnelManager][debug] Refresh tunnel status for new tunnel.
-            [22/11/2024 @ 08:52:23][REST.NetworkOperation][debug] name=get-access-token.2
-            Send request
-            to /auth/v1/token via 127.0.0.1 using encrypted-dns-url-session.
-            [22/11/2024 @ 08:52:23][ApplicationRouter][debug] Presenting .main.
-            [22/11/2024 @ 08:52:23][REST.NetworkOperation][debug] name=get-access-token.2 Response: 200.
-            [22/11/2024 @ 08:52:23][AppDelegate][debug] Finished initialization.
-            """
+        """
+        MullvadVPN version xxxx.x
+        [22/11/2024 @ 08:52:22][AppDelegate][debug] Registered app refresh task.
+        [22/11/2024 @ 08:52:22][AppDelegate][debug] Registered address cache update task.
+        [22/11/2024 @ 08:52:23][TunnelManager][debug] Refresh device state
+        and tunnel status
+        due to application becoming active.
+        [22/11/2024 @ 08:52:23][AppDelegate][debug] Finished initialization.
+        """
+    }
+
+    /// Simulates a log file from a pre-2026.3 release that did NOT have on-the-fly redaction.
+    /// Contains raw IPs, account numbers, and other sensitive data that must be redacted
+    /// at collection time.
+    private var oldReleaseLogContent: String {
+        """
+        MullvadVPN version 2024.5
+        [15/03/2025 @ 10:30:01][AppDelegate][debug] Registered app refresh task.
+        [15/03/2025 @ 10:30:01][TunnelManager][debug] Refresh device state and tunnel status.
+        [15/03/2025 @ 10:30:02][REST.NetworkOperation][debug] name=get-access-token.2 \
+        Send request to /auth/v1/token via 192.168.1.1 using encrypted-dns-url-session.
+        [15/03/2025 @ 10:30:02][TunnelManager][info] Connected to 2001:db8:85a3::8a2e:370:7334 successfully.
+        [15/03/2025 @ 10:30:02][TunnelManager][info] Tunnel established. Local IP: 10.64.0.1
+        [15/03/2025 @ 10:30:03][Auth][info] Login attempt for account 1234567890123456 completed.
+        [15/03/2025 @ 10:30:03][AppDelegate][debug] Finished initialization.
+        """
     }
 }

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -290,7 +290,7 @@ extension PacketTunnelProvider {
     private static func configureLogging() {
         let loggerBuilder = LoggerBuilder.shared
         let header = "PacketTunnel version \(Bundle.main.productVersion)"
-
+        let redactor = RustLogRedactor(containerPaths: [ApplicationConfiguration.containerURL.path])
         loggerBuilder.addFileOutput(
             fileURL: ApplicationConfiguration.newLogFileURL(
                 for: .packetTunnel,
@@ -301,10 +301,10 @@ extension PacketTunnelProvider {
         #if DEBUG
             loggerBuilder.addOSLogOutput(subsystem: ApplicationTarget.packetTunnel.bundleIdentifier)
         #endif
-        loggerBuilder.install()
+        loggerBuilder.install(redactor)
 
         // Initialize Rust logging to forward to Swift Logger
-        RustLogging.initialize()
+        RustLogging.initialize(logger: Logger(label: "Rust"))
     }
 
     private func parseStartOptions(_ options: [String: NSObject]) -> StartOptions {

--- a/mullvad-ios/Cargo.toml
+++ b/mullvad-ios/Cargo.toml
@@ -21,6 +21,7 @@ mullvad-api = { path = "../mullvad-api", default-features = false }
 mullvad-encrypted-dns-proxy = { path = "../mullvad-encrypted-dns-proxy" }
 mullvad-logging = { path = "../mullvad-logging" }
 mullvad-types = { path = "../mullvad-types" }
+regex = "1"
 shadowsocks = { workspace = true }
 talpid-future = { path = "../talpid-future" }
 talpid-tunnel-config-client = { path = "../talpid-tunnel-config-client" }

--- a/mullvad-ios/src/lib.rs
+++ b/mullvad-ios/src/lib.rs
@@ -7,6 +7,7 @@ use tokio::runtime::{Builder, Handle, Runtime};
 
 mod api_client;
 mod ephemeral_peer_proxy;
+mod log_redactor;
 mod logging;
 pub mod tunnel_obfuscator_proxy;
 mod wireguard_key;

--- a/mullvad-ios/src/log_redactor.rs
+++ b/mullvad-ios/src/log_redactor.rs
@@ -1,0 +1,255 @@
+//! Stateful log redaction exposed to Swift via FFI.
+//!
+//! `LogRedactor` holds compiled regexes and container paths, all immutable after construction.
+//! Since there is no interior mutability, the struct is `Send + Sync` and safe to use
+//! concurrently from multiple threads without locks.
+
+use regex::Regex;
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+
+const REDACTED: &str = "[REDACTED]";
+const REDACTED_ACCOUNT: &str = "[REDACTED ACCOUNT NUMBER]";
+const REDACTED_CONTAINER_PATH: &str = "[REDACTED CONTAINER PATH]";
+
+pub struct LogRedactor {
+    ipv4_regex: Regex,
+    ipv6_regex: Regex,
+    account_regex: Regex,
+    mac_regex: Regex,
+    container_paths: Vec<String>,
+    custom_strings: Vec<String>,
+}
+
+impl LogRedactor {
+    pub fn new(container_paths: Vec<String>, custom_strings: Vec<String>) -> Self {
+        Self {
+            ipv4_regex: Regex::new(
+                r"\b(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b",
+            )
+            .unwrap(),
+            ipv6_regex: Regex::new(
+                r"(?x)
+                (
+                ([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|
+                ([0-9a-fA-F]{1,4}:){1,7}:|
+                ([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|
+                ([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|
+                ([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|
+                ([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|
+                ([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|
+                [0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|
+                :((:[0-9a-fA-F]{1,4}){1,7}|:)|
+                fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|
+                ::(ffff(:0{1,4}){0,1}:){0,1}
+                ((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}
+                (25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|
+                ([0-9a-fA-F]{1,4}:){1,4}:
+                ((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}
+                (25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])
+                )",
+            )
+            .unwrap(),
+            account_regex: Regex::new(r"\d{16}").unwrap(),
+            mac_regex: Regex::new(r"(?i)(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}").unwrap(),
+            container_paths,
+            custom_strings,
+        }
+    }
+
+    fn redact_custom_strings<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        // Can probably me made a lot faster with aho-corasick if optimization is ever needed.
+        let mut out = Cow::from(input);
+        for redact in &self.custom_strings {
+            out = out.replace(redact, "[REDACTED]").into()
+        }
+        out
+    }
+
+    pub fn add_custom_string(&mut self, input: &str) {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        if !self.custom_strings.iter().any(|s| s == trimmed) {
+            self.custom_strings.push(trimmed.to_string());
+        }
+    }
+
+    /// Redact sensitive information from the input string.
+    ///
+    /// Returns `Cow::Borrowed(input)` when nothing was redacted (zero allocation).
+    /// Returns `Cow::Owned(...)` when at least one redaction was applied.
+    pub fn redact(&self, input: &str) -> Option<String> {
+        macro_rules! current {
+            ($owned:expr, $input:expr) => {
+                $owned.as_deref().unwrap_or($input)
+            };
+        }
+
+        let mut owned: Option<String> = None;
+
+        // Container path replacement first (simple string ops, cheapest)
+        for path in self.container_paths.iter() {
+            let s = current!(owned, input);
+            if s.contains(path.as_str()) {
+                owned = Some(s.replace(path.as_str(), REDACTED_CONTAINER_PATH));
+            }
+        }
+
+        // Regex-based redaction — each step only allocates if there's a match
+        if let Cow::Owned(s) = self
+            .ipv4_regex
+            .replace_all(current!(owned, input), REDACTED)
+        {
+            owned = Some(s);
+        }
+        if let Cow::Owned(s) = self
+            .ipv6_regex
+            .replace_all(current!(owned, input), REDACTED)
+        {
+            owned = Some(s);
+        }
+        if let Cow::Owned(s) = self
+            .account_regex
+            .replace_all(current!(owned, input), REDACTED_ACCOUNT)
+        {
+            owned = Some(s);
+        }
+        if let Cow::Owned(s) = self.mac_regex.replace_all(current!(owned, input), REDACTED) {
+            owned = Some(s);
+        }
+        if let Cow::Owned(s) = self.redact_custom_strings(current!(owned, input)) {
+            owned = Some(s);
+        }
+
+        owned
+    }
+}
+
+/// Create a new log redactor with the given container paths.
+///
+/// # Safety
+/// - `paths` must be a valid pointer to an array of `paths_count` pointers to null-terminated
+///   UTF-8 strings, or null if `paths_count` is 0.
+/// - The returned pointer must be freed by calling `log_redactor_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn create_log_redactor(
+    paths: *const *const libc::c_char,
+    paths_count: usize,
+) -> *mut LogRedactor {
+    // SAFETY:
+    // `paths` is either null or a pointer to `paths_count` null-terminated C-strings.
+    let container_paths = unsafe { ptr_array_to_vec(paths, paths_count) };
+    Box::into_raw(Box::new(LogRedactor::new(container_paths, Vec::new())))
+}
+
+/// Converts a C array of C string pointers into a `Vec<String>`.
+///
+/// Strings must be valid UTF-8, null entries and invalid UTF-8 strings are ignored.
+/// Returns an empty vector if `ptr` is null or `count == 0`.
+///
+/// # Safety
+/// - `ptr` must be either null or point to a valid array of `count` pointers.
+/// - Each element must be either null or a valid, null-terminated C string.
+/// - All pointers must be valid for reads for the duration of this call.
+unsafe fn ptr_array_to_vec(ptr: *const *const libc::c_char, count: usize) -> Vec<String> {
+    if ptr.is_null() || count == 0 {
+        return Vec::new();
+    }
+
+    unsafe { std::slice::from_raw_parts(ptr, count) }
+        .iter()
+        .filter_map(|&p| {
+            if p.is_null() {
+                return None;
+            }
+
+            // # Safety
+            // - `p` must point to a valid, null-terminated C string.
+            // - The pointed-to string must contain valid UTF-8.
+            unsafe { CStr::from_ptr(p) }
+                .to_str()
+                .ok()
+                .map(str::to_owned)
+        })
+        .collect()
+}
+
+/// Redact sensitive information from a string using the given redactor.
+///
+/// # Safety
+/// - `redactor` must be a valid pointer returned by `create_log_redactor`.
+/// - `input` must be a valid pointer to a null-terminated UTF-8 string.
+/// - The returned pointer must be freed by calling `log_redactor_free_string`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn log_redactor_redact(
+    redactor: *const LogRedactor,
+    input: *const libc::c_char,
+) -> *mut libc::c_char {
+    if redactor.is_null() || input.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let redactor = unsafe { &*redactor };
+    let input_str = match unsafe { CStr::from_ptr(input) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    let result = redactor.redact(input_str);
+    match result {
+        None => std::ptr::null_mut(),
+        Some(s) => match CString::new(s) {
+            Ok(cstring) => cstring.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+    }
+}
+
+/// Free a string returned by `log_redactor_redact`.
+///
+/// # Safety
+/// - `ptr` must be a pointer returned by `log_redactor_redact`, or null.
+/// - `ptr` must not have been freed before.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn log_redactor_free_string(ptr: *mut libc::c_char) {
+    if !ptr.is_null() {
+        drop(unsafe { CString::from_raw(ptr) });
+    }
+}
+
+/// Add a custom string to the log redactor.
+///
+/// # Safety
+/// - `redactor` must be a valid pointer returned by `create_log_redactor`.
+/// - `input` must be a valid pointer to a null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub extern "C" fn log_redactor_add_custom_string(
+    redactor: *mut LogRedactor,
+    input: *const libc::c_char,
+) {
+    if redactor.is_null() || input.is_null() {
+        return;
+    }
+
+    let redactor = unsafe { &mut *redactor };
+    let Ok(input_str) = unsafe { CStr::from_ptr(input) }.to_str() else {
+        return;
+    };
+
+    redactor.add_custom_string(input_str);
+}
+
+/// Free a log redactor created by `create_log_redactor`.
+///
+/// # Safety
+/// - `redactor` must be a pointer returned by `create_log_redactor`, or null.
+/// - `redactor` must not have been freed before.
+/// - `redactor` must not be used after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn log_redactor_free(redactor: *mut LogRedactor) {
+    if !redactor.is_null() {
+        drop(unsafe { Box::from_raw(redactor) });
+    }
+}

--- a/mullvad-ios/src/logging.rs
+++ b/mullvad-ios/src/logging.rs
@@ -1,124 +1,162 @@
 //! FFI logging bridge that forwards Rust logs to Swift.
 //!
-//! This module provides a tracing subscriber that calls a Swift callback for each log event,
-//! allowing Rust logs to be captured by Swift's logging infrastructure.
+//! This module provides a tracing layer that calls a Swift callback for each log event,
+//! allowing Rust logs to be captured by Swift's logging infrastructure with structured data.
+//!
+//! The callback receives an opaque context pointer (a Swift Logger instance) that travels
+//! through Rust and back, so the Swift side doesn't rely on any global state.
 
 use mullvad_logging::{EnvFilter, LevelFilter, silence_crates};
-use std::io::Write;
-use std::{
-    ffi::CStr,
-    sync::{Mutex, MutexGuard},
-};
+use std::ffi::CString;
+use std::fmt::Write;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
 use tracing_subscriber::Layer;
-use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::layer::Context;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 /// Callback function type for logging.
+/// - `context`: Opaque pointer to a Swift Logger instance, passed back on each invocation.
 /// - `level`: The log level (1=Error, 2=Warn, 3=Info, 4=Debug, 5=Trace)
+/// - `target`: Null-terminated UTF-8 string containing the module/target name
 /// - `message`: Null-terminated UTF-8 string containing the log message
-pub type LogCallback = extern "C" fn(level: u8, message: *const libc::c_char);
+///
+/// # Thread safety
+/// This callback may be invoked concurrently from any thread.
+pub type LogCallback = extern "C" fn(
+    context: *mut libc::c_void,
+    level: u8,
+    target: *const libc::c_char,
+    message: *const libc::c_char,
+);
 
 /// Default log level
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::DEBUG;
 
-/// Factory for creating writers that forward to Swift.
-struct SwiftMakeWriter {
-    callback: LogCallback,
-    buffer: Mutex<Vec<u8>>,
+/// Visitor that extracts the message and module path from a tracing event.
+///
+/// When logs come through the `log` crate (bridged via tracing-log), the module
+/// path is stored as a field named `log.module_path` rather than in the metadata.
+struct MessageVisitor {
+    message: String,
+    module_path: Option<String>,
 }
 
-impl SwiftMakeWriter {
-    fn new(callback: LogCallback) -> Self {
+impl MessageVisitor {
+    fn new() -> Self {
         Self {
-            callback,
-            buffer: Mutex::new(Vec::with_capacity(1024)),
+            message: String::with_capacity(256),
+            module_path: None,
         }
     }
 
-    fn make_writer_for_level<'a>(&'a self, tracing_level: tracing::Level) -> SwiftWriter<'a> {
-        let buffer = self.buffer.lock().expect("Failed to acquire logging lock");
+    fn into_parts(self) -> (String, Option<String>) {
+        (self.message, self.module_path)
+    }
+}
 
-        let level = match tracing_level {
-            tracing::Level::ERROR => 1u8,
-            tracing::Level::WARN => 2u8,
-            tracing::Level::INFO => 3u8,
-            tracing::Level::DEBUG => 4u8,
-            tracing::Level::TRACE => 5u8,
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(&mut self.message, "{:?}", value);
+        } else if field.name() == "log.module_path" {
+            // Debug formatting adds quotes around strings, so trim them
+            self.module_path = Some(format!("{:?}", value).trim_matches('"').to_string());
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else if field.name() == "log.module_path" {
+            self.module_path = Some(value.to_string());
+        }
+    }
+}
+
+/// A tracing layer that forwards structured log events to Swift via FFI.
+struct SwiftLayer {
+    callback: LogCallback,
+    context: *mut libc::c_void,
+}
+
+// SAFETY: The context pointer points to a Swift Logger instance that is retained
+// by the Swift side for the lifetime of the program. The callback is a static
+// function pointer. Both are safe to send across threads.
+unsafe impl Send for SwiftLayer {}
+unsafe impl Sync for SwiftLayer {}
+
+impl SwiftLayer {
+    fn new(callback: LogCallback, context: *mut libc::c_void) -> Self {
+        Self { callback, context }
+    }
+
+    fn level_to_u8(level: &tracing::Level) -> u8 {
+        match *level {
+            tracing::Level::ERROR => 1,
+            tracing::Level::WARN => 2,
+            tracing::Level::INFO => 3,
+            tracing::Level::DEBUG => 4,
+            tracing::Level::TRACE => 5,
+        }
+    }
+}
+
+impl<S> Layer<S> for SwiftLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let level = Self::level_to_u8(metadata.level());
+
+        // Extract the message and module path using the visitor pattern
+        let mut visitor = MessageVisitor::new();
+        event.record(&mut visitor);
+        let (message, module_path) = visitor.into_parts();
+
+        // For log crate events, use the extracted module path from fields.
+        // For native tracing events, fall back to metadata.target().
+        let target = module_path
+            .as_deref()
+            .or_else(|| metadata.module_path())
+            .unwrap_or_else(|| metadata.target());
+
+        // Convert to C strings for FFI
+        let Ok(target_cstring) = CString::new(target) else {
+            return;
         };
 
-        SwiftWriter {
-            callback: self.callback,
+        let Ok(message_cstring) = CString::new(message) else {
+            return;
+        };
+
+        (self.callback)(
+            self.context,
             level,
-            buffer,
-        }
+            target_cstring.as_ptr(),
+            message_cstring.as_ptr(),
+        );
     }
 }
 
-impl<'a> MakeWriter<'a> for SwiftMakeWriter {
-    type Writer = SwiftWriter<'a>;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        self.make_writer_for_level(tracing::Level::DEBUG)
-    }
-
-    fn make_writer_for(&'a self, meta: &tracing::Metadata<'_>) -> Self::Writer {
-        self.make_writer_for_level(*meta.level())
-    }
-}
-
-/// Writer that buffers output and sends to Swift on flush/drop.
-struct SwiftWriter<'a> {
-    callback: LogCallback,
-    level: u8,
-    buffer: MutexGuard<'a, Vec<u8>>,
-}
-
-impl Write for SwiftWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.buffer.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        if self.buffer.is_empty() {
-            return Ok(());
-        }
-        self.buffer.push(b'\0');
-        if let Ok(message) = CStr::from_bytes_until_nul(&self.buffer) {
-            (self.callback)(self.level, message.as_ptr());
-        }
-        self.buffer.truncate(0);
-        Ok(())
-    }
-}
-
-impl Drop for SwiftWriter<'_> {
-    fn drop(&mut self) {
-        let _ = self.flush();
-    }
-}
-
-/// Initialize the Rust logger with a Swift callback.
+/// Initialize the Rust logger with a Swift callback and context.
 ///
-/// This function should be called once early in the application lifecycle,
-/// before any Rust code that uses logging is invoked.
+/// The `context` pointer is passed back to `callback` on each log event, allowing
+/// the Swift side to recover a Logger instance without relying on global state.
 ///
 /// # Safety
 /// - `callback` must be a valid function pointer that remains valid for the lifetime of the program.
+/// - `context` must be a valid pointer that remains valid for the lifetime of the program.
 /// - This function is safe to call multiple times, but only the first call will have an effect.
 #[unsafe(no_mangle)]
-pub extern "C" fn init_rust_logging(callback: LogCallback) {
+pub extern "C" fn init_rust_logging(callback: LogCallback, context: *mut libc::c_void) {
     let env_filter = EnvFilter::builder()
         .with_default_directive(DEFAULT_LOG_LEVEL.into())
         .from_env_lossy();
 
-    let layer = tracing_subscriber::fmt::layer()
-        .with_writer(SwiftMakeWriter::new(callback))
-        .with_ansi(false)
-        .without_time()
-        .with_level(false)
-        .with_filter(silence_crates(env_filter));
+    let layer = SwiftLayer::new(callback, context).with_filter(silence_crates(env_filter));
 
     let _ = tracing_subscriber::registry().with(layer).try_init();
 }


### PR DESCRIPTION
We have 2 issues with logging - redaction is dog slow and the redactor is redacting the rust module path. With these changes we hope to achieve the following:
- redact only the log message
- redact it before it hits the log file, in production
- redact old log files that were constructed before we introduced live redaction
- 

I have removed the old redaction, and benchmarked the new one to feel confident that this will not have any significant impact on CPU use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10348)
<!-- Reviewable:end -->
