### PR TITLE
Increase timeout for test wireguard obfuscation auto

### DIFF
--- a/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
+++ b/android/test/e2e/src/main/kotlin/net/mullvad/mullvadvpn/test/e2e/ConnectionTest.kt
@@ -142,8 +142,10 @@ class ConnectionTest : EndToEndTest() {
 
             on<ConnectPage> {
                 clickConnect()
-                // Currently it takes ~45 seconds to connect with wg obfuscation automatic and UDP
+                // Currently it takes ~60 seconds to connect with wg obfuscation automatic and UDP
                 // traffic blocked so we need to be very forgiving
+                // The order of obfuscation methods in automatic mode can be found here:
+                // mullvad-relay-selector/src/relay_selector/mod.rs
                 waitForConnectedLabel(timeout = VERY_FORGIVING_WIREGUARD_OFF_CONNECTION_TIMEOUT)
             }
         }
@@ -512,7 +514,7 @@ class ConnectionTest : EndToEndTest() {
         block().forEach { firewallClient.createRule(it) }
 
     companion object {
-        const val VERY_FORGIVING_WIREGUARD_OFF_CONNECTION_TIMEOUT = 60000L
+        const val VERY_FORGIVING_WIREGUARD_OFF_CONNECTION_TIMEOUT = 80000L
         const val UNSUCCESSFUL_CONNECTION_TIMEOUT = 30000L
         const val ANY_IPV4_ADDRESS = "0.0.0.0/0"
     }


### PR DESCRIPTION
Since the automatic selection order has changed we need to wait longer until UDP-over-TCP is selected

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10351)
<!-- Reviewable:end -->
