### PR TITLE
Change UIApplicationStub to a reference-type

### DIFF
--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -34,11 +34,12 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
     init(application: BackgroundTaskProviding) {
         self.application = application
         NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(applicationDidBecomeActive(_:)),
-            name: UIApplication.didBecomeActiveNotification,
-            object: application
-        )
+            forName: UIApplication.didBecomeActiveNotification,
+            object: application,
+            queue: .main
+        ) { [weak self] notification in
+            self?.refreshStatus()
+        }
     }
 
     func getPersistentTunnels() -> [TunnelType] {
@@ -115,10 +116,6 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
             persistentTunnels.append(tunnel)
             logger.debug("New tunnel became persistent: \(tunnel.logFormat()).")
         }
-    }
-
-    @objc private func applicationDidBecomeActive(_ notification: Notification) {
-        refreshStatus()
     }
 
     private func refreshStatus() {

--- a/ios/MullvadVPN/TunnelManager/TunnelStore.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelStore.swift
@@ -20,6 +20,8 @@ protocol TunnelStoreProtocol: Sendable {
 
 /// Wrapper around system VPN tunnels.
 final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked Sendable {
+    typealias BackgroundTaskProvidingObject = BackgroundTaskProviding & AnyObject
+
     typealias TunnelType = Tunnel
     private let logger = Logger(label: "TunnelStore")
     private let lock = NSLock()
@@ -31,7 +33,7 @@ final class TunnelStore: TunnelStoreProtocol, TunnelStatusObserver, @unchecked S
     /// Newly created tunnels, stored as collection of weak boxes.
     private var newTunnels: [WeakBox<TunnelType>] = []
 
-    init(application: BackgroundTaskProviding) {
+    init(application: BackgroundTaskProvidingObject) {
         self.application = application
         NotificationCenter.default.addObserver(
             forName: UIApplication.didBecomeActiveNotification,

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
@@ -18,7 +18,7 @@ class TunnelManagerTests: XCTestCase {
     static let store = InMemorySettingsStore<SettingNotFound>()
     private var tunnelObserver: TunnelObserver!
 
-    var application: BackgroundTaskProviding!
+    var application: TunnelStore.BackgroundTaskProvidingObject!
     var relayCacheTracker: RelayCacheTrackerStub!
     var accountProxy: AccountsProxyStub!
     var devicesProxy: DevicesProxyStub!
@@ -66,7 +66,6 @@ class TunnelManagerTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        application = nil
         relayCacheTracker = nil
         accountProxy = nil
         devicesProxy = nil

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
@@ -16,13 +16,16 @@ import XCTest
 
 class TunnelManagerTests: XCTestCase {
     static let store = InMemorySettingsStore<SettingNotFound>()
+
+    private let application: TunnelStore.BackgroundTaskProvidingObject = UIApplicationStub()
     private var tunnelObserver: TunnelObserver!
 
-    var application: TunnelStore.BackgroundTaskProvidingObject!
-    var relayCacheTracker: RelayCacheTrackerStub!
-    var accountProxy: AccountsProxyStub!
-    var devicesProxy: DevicesProxyStub!
-    var apiProxy: APIProxyStub!
+    var relayCacheTracker = RelayCacheTrackerStub()
+    var accountProxy = AccountsProxyStub()
+    var devicesProxy = DevicesProxyStub(
+        deviceResult: .success(Device.mock(publicKey: WireGuard.PrivateKey().publicKey))
+    )
+    var apiProxy = APIProxyStub()
     var apiContext: MullvadApiContext!
 
     override static func setUp() {
@@ -34,12 +37,6 @@ class TunnelManagerTests: XCTestCase {
     }
 
     override func setUp() async throws {
-        application = UIApplicationStub()
-        relayCacheTracker = RelayCacheTrackerStub()
-        accountProxy = AccountsProxyStub()
-        devicesProxy = DevicesProxyStub(
-            deviceResult: .success(Device.mock(publicKey: WireGuard.PrivateKey().publicKey)))
-        apiProxy = APIProxyStub()
         let shadowsocksLoader = ShadowsocksLoader(
             cache: ShadowsocksConfigurationCacheStub(),
             relaySelector: ShadowsocksRelaySelectorStub(relays: .mock()),
@@ -66,10 +63,6 @@ class TunnelManagerTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        relayCacheTracker = nil
-        accountProxy = nil
-        devicesProxy = nil
-        apiProxy = nil
         tunnelObserver = nil
     }
 

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/UIApplication+Stubs.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/UIApplication+Stubs.swift
@@ -11,7 +11,7 @@ import UIKit
 
 @testable import MullvadTypes
 
-struct UIApplicationStub: BackgroundTaskProviding {
+final class UIApplicationStub: BackgroundTaskProviding {
     var backgroundTimeRemaining: TimeInterval { .infinity }
 
     func endBackgroundTask(_ identifier: UIBackgroundTaskIdentifier) {}


### PR DESCRIPTION
- Use the block-based syntax to subscribe to Notifications

    The previous method works fine as well, but is a bit more tricky in terms of managing the release of variables. Because of this, I'd propose to switch to the block-based syntax which allows us to use a `weak self` to avoid retain cycles.
    
    Arguments in favour: the previous code subscribed, but never actually unsubscribed (typically done in a `deinit`). This can, and in our case I believe it did, create a retain cycle. Since I assume only 1 instance of the TunnelStore is active in the application at any given time this would probably not be a problem, but it's still better to not have this.

- Change UIApplicationStub to a reference-type

    Xcode showed a crashing unit test with the message:

    ```text
    Object cannot be a Swift value type.
    
    TunnelStore.swift:36 TunnelStore.init(application:) 
    TunnelManagerTests.swift:125. TunnelManagerTests.
    testExitBlockedStateAfterSatisfyingConstraints()
    ```
    
    Tracing this down lead to the [NSNotificationManager.m] source on GitHub, which showed that the underlying Objective-C code defines the parameter as an `id` type, which means it should be an `NSObject` .
    
    This does not entirely resolve the crashing unit test I was chasing, but leaves the code in better shape than it was.

- Use default initializers for variables where possible

    Since `Xcode` initializes the class for every individual test, non-static variables can be initialised without having to deal with `Optional`.
    
    This generally:
    
    1. Makes the code a bit safer
    2. Leads to better stack traces in case something goes wrong
    3. Leans on the compiler to check whether something is `nil`
    
    Only the straightforward ones have been adjusted, and I would propose to use the boy scout rule to improve these as we go.


[NSNotificationManager.m]: https://github.com/apportable/Foundation/blob/master/System/Foundation/src/NSNotificationCenter.m

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10353)
<!-- Reviewable:end -->
