### PR TITLE
 Fix multihop selection test

### DIFF
--- a/ios/MullvadVPNUITests/RelayTests.swift
+++ b/ios/MullvadVPNUITests/RelayTests.swift
@@ -602,11 +602,8 @@ class RelayTests: LoggedInWithTimeUITestCase {
             .tapLocationCellExpandButton(
                 withName: BaseUITestCase.testsDefaultQuicCountryName
             )
-            .tapLocationCellExpandButton(
-                withName: BaseUITestCase.testsDefaultQuicCityName
-            )
             .tapLocationCell(
-                withName: BaseUITestCase.testsDefaultQuicRelayName
+                withName: BaseUITestCase.testsDefaultQuicCityName
             )
 
         TunnelControlPage(app)


### PR DESCRIPTION
**What is being observed?**

testMultihopSelection view fails intermittently. The test ends up looking for the relay hostnames in the connection panel whilst 

**Reproduction steps**

Run the test multiple times. 

**What needs to be done to fix this?**

Change the test so that it can reliably dismiss the location view.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10355)
<!-- Reviewable:end -->
