### PR TITLE
Fix RUSTSEC-2026-0119

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,15 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,18 +1319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,7 +1867,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "http",
  "idna",
  "ipnet",
@@ -1899,31 +1878,6 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
  "tracing",
  "url",
 ]
@@ -1951,27 +1905,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -1979,7 +1912,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -2011,8 +1944,8 @@ dependencies = [
  "data-encoding",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
- "hickory-resolver 0.26.1",
+ "hickory-proto",
+ "hickory-resolver",
  "ipnet",
  "prefix-trie",
  "serde",
@@ -3110,7 +3043,7 @@ dependencies = [
  "dirs",
  "either",
  "futures",
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "insta",
  "libc",
  "log",
@@ -3161,7 +3094,7 @@ dependencies = [
 name = "mullvad-encrypted-dns-proxy"
 version = "0.0.0"
 dependencies = [
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "log",
  "rustls",
  "serde",
@@ -5226,7 +5159,6 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "482831bf9d55acf3c98e211b6c852c3dfdf1d1b0d23fdf1d887c5a4b2acad4e4"
 dependencies = [
- "arc-swap",
  "base64",
  "blake3",
  "byte_string",
@@ -5234,10 +5166,8 @@ dependencies = [
  "cfg-if",
  "dynosaur",
  "futures",
- "hickory-resolver 0.25.2",
  "libc",
  "log",
- "notify",
  "percent-encoding",
  "pin-project",
  "sealed",
@@ -5568,7 +5498,7 @@ dependencies = [
  "csv",
  "either",
  "futures",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "hickory-server",
  "insta",
  "ipnetwork",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,13 +649,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1690,6 +1701,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1738,7 +1750,7 @@ dependencies = [
  "nix 0.31.2",
  "parking_lot",
  "pcap-file",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_core 0.6.4",
  "ring",
@@ -1863,32 +1875,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "hickory-proto 0.26.1",
+ "http",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "rustls",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2",
- "http",
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "ring",
- "rustls",
- "serde",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
  "tracing",
  "url",
 ]
@@ -1901,16 +1957,42 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "serde",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -1919,18 +2001,18 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-util",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "hickory-resolver 0.26.1",
  "ipnet",
  "prefix-trie",
  "serde",
@@ -2334,7 +2416,7 @@ dependencies = [
  "mullvad-version",
  "native-windows-gui",
  "objc_id",
- "rand",
+ "rand 0.9.4",
  "serde",
  "talpid-platform-metadata",
  "tokio",
@@ -2479,6 +2561,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,7 +2624,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c460f1b7afbfcb0810208d3b0efc6ac1d7574f5e379fa2c19fb957bb57678a"
 dependencies = [
- "jni",
+ "jni 0.19.0",
  "jnix-macros",
  "once_cell",
  "parking_lot",
@@ -2766,7 +2878,7 @@ dependencies = [
  "bincode",
  "enum-map",
  "flate2",
- "rand",
+ "rand 0.9.4",
  "rand_core 0.9.5",
  "rand_distr",
  "serde",
@@ -2780,7 +2892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b2682b6da446844fad3c7ced24be8c66853efefa4674a48072cfd6b45e4fb0d"
 dependencies = [
  "maybenot",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
 ]
 
@@ -2897,7 +3009,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2998,7 +3110,7 @@ dependencies = [
  "dirs",
  "either",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "insta",
  "libc",
  "log",
@@ -3019,7 +3131,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-service-management",
  "paranoid-android",
- "rand",
+ "rand 0.9.4",
  "regex",
  "serde",
  "serde_json",
@@ -3049,7 +3161,7 @@ dependencies = [
 name = "mullvad-encrypted-dns-proxy"
 version = "0.0.0"
 dependencies = [
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "log",
  "rustls",
  "serde",
@@ -3181,7 +3293,7 @@ dependencies = [
  "libc",
  "log",
  "quinn",
- "rand",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "socket2 0.5.10",
@@ -3248,7 +3360,7 @@ dependencies = [
  "log",
  "mullvad-types",
  "proptest",
- "rand",
+ "rand 0.9.4",
  "serde_json",
  "talpid-types",
  "thiserror 2.0.18",
@@ -3347,7 +3459,7 @@ dependencies = [
  "mullvad-api-constants",
  "mullvad-version",
  "proptest",
- "rand",
+ "rand 0.9.4",
  "rand_core 0.6.4",
  "reqwest",
  "serde",
@@ -3393,6 +3505,12 @@ name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -4373,10 +4491,11 @@ checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 
 [[package]]
 name = "prefix-trie"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
 dependencies = [
+ "either",
  "ipnet",
  "num-traits",
 ]
@@ -4419,7 +4538,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.1",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -4526,7 +4645,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4584,6 +4703,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4612,13 +4742,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -5098,7 +5234,7 @@ dependencies = [
  "cfg-if",
  "dynosaur",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libc",
  "log",
  "notify",
@@ -5130,12 +5266,12 @@ dependencies = [
  "aes-gcm",
  "camellia",
  "cfg-if",
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "ctr",
  "hkdf",
  "md-5",
- "rand",
+ "rand 0.9.4",
  "ring-compat",
  "sha1",
 ]
@@ -5179,6 +5315,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -5291,7 +5443,7 @@ dependencies = [
  "hex",
  "parking_lot",
  "pnet_packet 0.34.0",
- "rand",
+ "rand 0.9.4",
  "socket2 0.6.3",
  "thiserror 1.0.69",
  "tokio",
@@ -5354,7 +5506,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5362,6 +5525,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5395,7 +5568,7 @@ dependencies = [
  "csv",
  "either",
  "futures",
- "hickory-proto",
+ "hickory-proto 0.26.1",
  "hickory-server",
  "insta",
  "ipnetwork",
@@ -5410,7 +5583,7 @@ dependencies = [
  "pcap",
  "pfctl",
  "pnet_packet 0.35.0",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "socket2 0.5.10",
@@ -5463,7 +5636,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "resolv-conf",
- "system-configuration",
+ "system-configuration 0.5.1",
  "talpid-dbus",
  "talpid-routing",
  "talpid-types",
@@ -5481,7 +5654,7 @@ name = "talpid-future"
 version = "0.0.0"
 dependencies = [
  "proptest",
- "rand",
+ "rand 0.9.4",
  "talpid-time",
  "tokio",
 ]
@@ -5533,7 +5706,7 @@ dependencies = [
  "netlink-sys",
  "nix 0.31.2",
  "rtnetlink",
- "system-configuration",
+ "system-configuration 0.5.1",
  "talpid-types",
  "talpid-windows",
  "thiserror 2.0.18",
@@ -5641,7 +5814,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "proptest",
- "rand",
+ "rand 0.9.4",
  "rtnetlink",
  "socket2 0.5.10",
  "surge-ping",
@@ -6294,7 +6467,7 @@ dependencies = [
  "log",
  "mullvad-masque-proxy",
  "nix 0.31.2",
- "rand",
+ "rand 0.9.4",
  "shadowsocks",
  "talpid-types",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,10 @@ rustls-pki-types = "1.13.1"
 serde = "1.0.204"
 serde_json = "1.0.122"
 sha2 = "0.10"
-shadowsocks = { version = "1.23.2", features = ["stream-cipher"] }
+shadowsocks = { version = "1.23.2", default-features = false, features = [
+  "aead-cipher",
+  "stream-cipher"
+] }
 shadowsocks-crypto = { version = "0.6.2", features = ["v1-stream"] }
 socket2 = "0.5.7"
 strum = { version = "0.27" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"
 gotatun = { version = "0.6.0", default-features = false, features = ["ring"] }
-hickory-proto = "0.25.2"
-hickory-resolver = "0.25.2"
-hickory-server = { version = "0.25.2", features = ["resolver"] }
+hickory-proto = "0.26.1"
+hickory-resolver = "0.26.1"
+hickory-server = { version = "0.26.1", features = ["resolver"] }
 hyper-util = { version = "0.1.8", features = [
   "client",
   "client-legacy",

--- a/mullvad-daemon/src/android_dns.rs
+++ b/mullvad-daemon/src/android_dns.rs
@@ -2,7 +2,7 @@
 //! See [AndroidDnsResolver].
 
 use async_trait::async_trait;
-use hickory_resolver::{TokioResolver, config::*, name_server::TokioConnectionProvider};
+use hickory_resolver::{TokioResolver, config::*, net::runtime::TokioRuntimeProvider};
 use mullvad_api::DnsResolver;
 use std::{io, net::SocketAddr};
 use talpid_core::connectivity_listener::ConnectivityListener;
@@ -31,22 +31,23 @@ impl DnsResolver for AndroidDnsResolver {
             .map_err(|err| {
                 io::Error::other(format!("Failed to retrieve current servers: {err}"))
             })?;
-        let group = NameServerConfigGroup::from_ips_clear(&ips, 53, false);
-
+        let group = ips.into_iter().map(NameServerConfig::udp_and_tcp).collect();
         let config = ResolverConfig::from_parts(None, vec![], group);
+
         let mut opts = ResolverOpts::default();
         opts.attempts = 0;
         opts.use_hosts_file = ResolveHosts::Never;
-        let provider = TokioConnectionProvider::default();
-        let resolver = TokioResolver::builder_with_config(config, provider)
+
+        let resolver = TokioResolver::builder_with_config(config, TokioRuntimeProvider::default())
             .with_options(opts)
-            .build();
+            .build()
+            .map_err(|err| io::Error::other(format!("Failed to create DNS resolver: {err}")))?;
 
         let lookup = resolver
             .lookup_ip(host)
             .await
             .map_err(|err| io::Error::other(format!("lookup_ip failed: {err}")))?;
 
-        Ok(lookup.into_iter().map(|ip| (ip, 0).into()).collect())
+        Ok(lookup.iter().map(|ip| (ip, 0).into()).collect())
     }
 }

--- a/mullvad-encrypted-dns-proxy/src/config_resolver.rs
+++ b/mullvad-encrypted-dns-proxy/src/config_resolver.rs
@@ -3,14 +3,14 @@
 use crate::config;
 use core::fmt;
 use hickory_resolver::{
-    ResolveError, TokioResolver, config::*, name_server::TokioConnectionProvider,
+    TokioResolver,
+    config::*,
+    net::{NetError, runtime::TokioRuntimeProvider},
 };
 use rustls::ClientConfig;
 use std::{net::IpAddr, time::Duration};
 use tokio::time::error::Elapsed;
 
-/// The port to connect to the DoH resolvers over.
-const RESOLVER_PORT: u16 = 443;
 const DEFAULT_TIMEOUT: Duration = std::time::Duration::from_secs(10);
 
 pub struct Nameserver {
@@ -20,14 +20,14 @@ pub struct Nameserver {
 
 #[derive(Debug)]
 pub enum Error {
-    ResolutionError(ResolveError),
+    ProtocolError(NetError),
     Timeout(Elapsed),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::ResolutionError(err) => err.fmt(f),
+            Error::ProtocolError(err) => err.fmt(f),
             Error::Timeout(err) => err.fmt(f),
         }
     }
@@ -36,7 +36,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::ResolutionError(err) => err.source(),
+            Self::ProtocolError(err) => err.source(),
             Self::Timeout(err) => err.source(),
         }
     }
@@ -70,25 +70,21 @@ pub async fn resolve_configs(
     resolvers: &[Nameserver],
     domain: &str,
 ) -> Result<Vec<config::ProxyConfig>, Error> {
-    let mut nameservers = ResolverConfig::new();
+    let mut config = ResolverConfig::default();
     for resolver in resolvers.iter() {
-        let ns_config_group = NameServerConfigGroup::from_ips_https(
-            &resolver.addr,
-            RESOLVER_PORT,
-            resolver.name.clone(),
-            false,
-        )
-        .into_inner();
-        for ns_config in ns_config_group {
-            nameservers.add_name_server(ns_config);
+        let servers = ServerGroup {
+            ips: resolver.addr.as_slice(),
+            server_name: &resolver.name,
+            // De facto DoH URL: https://www.rfc-editor.org/rfc/rfc8484
+            path: "/dns-query",
+        };
+        for server in servers.https() {
+            config.add_name_server(server);
         }
     }
 
-    let mut resolver_config: ResolverOpts = Default::default();
-    resolver_config.tls_config = client_config_tls12();
-
-    resolver_config.timeout = Duration::from_secs(5);
-    resolve_config_with_resolverconfig(nameservers, resolver_config, domain, DEFAULT_TIMEOUT).await
+    resolve_config_with_resolverconfig(config, ResolverOpts::default(), domain, DEFAULT_TIMEOUT)
+        .await
 }
 
 pub async fn resolve_config_with_resolverconfig(
@@ -97,17 +93,22 @@ pub async fn resolve_config_with_resolverconfig(
     domain: &str,
     timeout: Duration,
 ) -> Result<Vec<config::ProxyConfig>, Error> {
-    let provider = TokioConnectionProvider::default();
+    let provider = TokioRuntimeProvider::default();
     let resolver = TokioResolver::builder_with_config(resolver_config, provider)
         .with_options(options)
-        .build();
+        .with_tls_config(client_config_tls12())
+        .build()
+        .map_err(Error::ProtocolError)?;
 
-    let lookup = tokio::time::timeout(timeout, resolver.ipv6_lookup(domain))
+    let lookup = tokio::time::timeout(timeout, resolver.lookup_ip(domain))
         .await
         .map_err(Error::Timeout)?
-        .map_err(Error::ResolutionError)?;
+        .map_err(Error::ProtocolError)?;
 
-    let addrs = lookup.into_iter().map(|aaaa_record| aaaa_record.0);
+    let addrs = lookup.iter().filter_map(|addr| match addr {
+        IpAddr::V4(_) => None,
+        IpAddr::V6(addr) => Some(addr),
+    });
 
     let mut proxy_configs = Vec::new();
     for addr in addrs {

--- a/talpid-core/src/resolver.rs
+++ b/talpid-core/src/resolver.rs
@@ -8,7 +8,7 @@
 //! See [start_resolver](crate::resolver::start_resolver).
 
 use std::{
-    io,
+    io, iter,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
     sync::{Arc, Weak},
@@ -21,26 +21,28 @@ use futures::{
 };
 
 use hickory_proto::{
-    ProtoErrorKind,
-    op::LowerQuery,
+    op::{HeaderCounts, LowerQuery, Metadata},
     rr::{LowerName, RecordType},
 };
 use hickory_server::{
-    ServerFuture,
-    authority::{
-        EmptyLookup, LookupObject, MessageRequest, MessageResponse, MessageResponseBuilder,
-    },
+    Server,
+    net::{DnsError, runtime::Time},
     proto::{
-        op::{Header, header::MessageType, op_code::OpCode},
-        rr::{Record, domain::Name, rdata, record_data::RData},
+        op::{Header, MessageType, OpCode},
+        rr::{RData, Record, domain::Name, rdata},
     },
     resolver::{
-        ResolveError, ResolveErrorKind, TokioResolver,
-        config::{NameServerConfigGroup, ResolverConfig, ResolverOpts},
+        //ResolveError, ResolveErrorKind, TokioResolver,
+        TokioResolver,
+        config::{ConnectionConfig, NameServerConfig, ResolverConfig},
         lookup::Lookup,
-        name_server::TokioConnectionProvider,
+        net::{NetError, runtime::TokioRuntimeProvider},
     },
     server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
+    zone_handler::{
+        AuthLookup, AuthLookupIter, MessageRequest, MessageResponse, MessageResponseBuilder,
+        UpdateRequest,
+    },
 };
 use rand::random_range;
 use socket2::{Domain, Protocol, Socket, Type};
@@ -172,7 +174,7 @@ enum ResolverMessage {
         dns_query: LowerQuery,
 
         /// Channel for the query response
-        response_tx: oneshot::Sender<std::result::Result<Box<dyn LookupObject>, ResolveError>>,
+        response_tx: oneshot::Sender<Result<Box<AuthLookup>, NetError>>,
     },
 
     /// Gracefully stop resolver
@@ -213,11 +215,11 @@ impl Resolver {
     pub fn resolve(
         &self,
         query: LowerQuery,
-        tx: oneshot::Sender<std::result::Result<Box<dyn LookupObject>, ResolveError>>,
+        tx: oneshot::Sender<Result<Box<AuthLookup>, NetError>>,
     ) {
         match self {
             Resolver::Blocking => {
-                let _ = tx.send(Self::resolve_blocked(query));
+                let _ = tx.send(Self::resolve_blocked(query).map(Box::new));
             }
             Resolver::Forwarding {
                 resolver,
@@ -226,19 +228,19 @@ impl Resolver {
                 let resolver = resolver.clone();
                 let filter_out_aaaa = *filter_out_aaaa && !*NEVER_FILTER_AAAA_QUERIES;
                 tokio::spawn(async move {
-                    let lookup = Self::resolve_forward(*resolver, query, filter_out_aaaa);
-                    let _ = tx.send(lookup.await);
+                    let lookup = Self::resolve_forward(*resolver, query, filter_out_aaaa)
+                        .await
+                        .map(Box::new);
+                    let _ = tx.send(lookup);
                 });
             }
         };
     }
 
     /// Resolution in blocked state will return spoofed records for captive portal domains.
-    fn resolve_blocked(
-        query: LowerQuery,
-    ) -> std::result::Result<Box<dyn LookupObject>, ResolveError> {
+    fn resolve_blocked(query: LowerQuery) -> Result<AuthLookup, NetError> {
         if !Self::is_captive_portal_domain(&query) {
-            return Ok(Box::new(EmptyLookup));
+            return Ok(AuthLookup::Empty);
         }
 
         let return_query = query.original().clone();
@@ -247,19 +249,19 @@ impl Resolver {
             TTL_SECONDS,
             return_query.query_type(),
         );
-        return_record.set_data(RData::A(rdata::A(RESOLVED_ADDR)));
+        return_record.data = RData::A(rdata::A(RESOLVED_ADDR));
 
-        log::debug!(
+        log::trace!(
             "Spoofing query for captive portal domain: {}",
             return_query.name()
         );
 
         let lookup = Lookup::new_with_deadline(
             return_query,
-            Arc::new([return_record]),
+            vec![return_record],
             Instant::now() + Duration::from_secs(3),
         );
-        Ok(Box::new(ForwardLookup(lookup)) as Box<_>)
+        Ok(AuthLookup::Resolved(lookup))
     }
 
     /// Determines whether a DNS query is allowable. Currently, this implies that the query is
@@ -273,19 +275,19 @@ impl Resolver {
         resolver: TokioResolver,
         query: LowerQuery,
         filter_out_aaaa: bool,
-    ) -> std::result::Result<Box<dyn LookupObject>, ResolveError> {
+    ) -> Result<AuthLookup, NetError> {
         let return_query = query.original().clone();
 
         if filter_out_aaaa && query.query_type() == RecordType::AAAA {
             log::trace!("Giving empty response to AAAA query");
-            return Ok(Box::new(EmptyLookup) as Box<_>);
+            return Ok(AuthLookup::Empty);
         }
 
         let lookup = resolver
             .lookup(return_query.name().clone(), return_query.query_type())
-            .await;
+            .await?;
 
-        lookup.map(|lookup| Box::new(ForwardLookup(lookup)) as Box<_>)
+        Ok(AuthLookup::Resolved(lookup))
     }
 }
 
@@ -414,8 +416,8 @@ impl LocalResolver {
     fn new_server(
         socket: UdpSocket,
         command_tx: Weak<mpsc::UnboundedSender<ResolverMessage>>,
-    ) -> Result<ServerFuture<ResolverImpl>, Error> {
-        let mut server = ServerFuture::new(ResolverImpl { tx: command_tx });
+    ) -> Result<Server<ResolverImpl>, Error> {
+        let mut server = Server::new(ResolverImpl { tx: command_tx });
 
         server.register_socket(socket);
 
@@ -543,9 +545,11 @@ impl LocalResolver {
                     new_config,
                     response_tx,
                 } => {
-                    log::debug!("Updating config: {new_config:?}");
-
-                    self.update_config(new_config);
+                    log::trace!("Updating config: {new_config:?}");
+                    if let Err(err) = self.update_config(new_config) {
+                        log::warn!("Failed to update DNS resolver config: {err}");
+                        continue;
+                    };
                     flush_system_cache();
                     let _ = response_tx.send(());
                 }
@@ -571,7 +575,7 @@ impl LocalResolver {
     }
 
     /// Update the current DNS config.
-    fn update_config(&mut self, config: Config) {
+    fn update_config(&mut self, config: Config) -> Result<(), NetError> {
         match config {
             Config::Blocking => self.blocking(),
             Config::Forwarding {
@@ -580,9 +584,10 @@ impl LocalResolver {
             } => {
                 // make sure not to accidentally forward queries to ourselves
                 dns_servers.retain(|addr| *addr != self.bound_to.ip());
-                self.forwarding(dns_servers, filter_out_aaaa);
+                self.forwarding(dns_servers, filter_out_aaaa)?;
             }
-        }
+        };
+        Ok(())
     }
 
     /// Turn into a blocking resolver.
@@ -591,22 +596,33 @@ impl LocalResolver {
     }
 
     /// Turn into a forwarding resolver (forward DNS queries to `dns_servers`).
-    fn forwarding(&mut self, dns_servers: Vec<IpAddr>, filter_out_aaaa: bool) {
-        let forward_server_config =
-            NameServerConfigGroup::from_ips_clear(&dns_servers, DNS_PORT, true);
+    fn forwarding(
+        &mut self,
+        dns_servers: Vec<IpAddr>,
+        filter_out_aaaa: bool,
+    ) -> Result<(), NetError> {
+        // TODO: Fix port
+        let forward_server_config = dns_servers
+            .into_iter()
+            .map(|ip| {
+                let mut udp = ConnectionConfig::udp();
+                udp.port = DNS_PORT;
+                let mut tcp = ConnectionConfig::tcp();
+                tcp.port = DNS_PORT;
+                NameServerConfig::new(ip, false, vec![udp, tcp])
+            })
+            .collect();
 
         let forward_config = ResolverConfig::from_parts(None, vec![], forward_server_config);
-        let resolver_opts = ResolverOpts::default();
-
         let resolver =
-            TokioResolver::builder_with_config(forward_config, TokioConnectionProvider::default())
-                .with_options(resolver_opts)
-                .build();
+            TokioResolver::builder_with_config(forward_config, TokioRuntimeProvider::default())
+                .build()?;
 
         self.inner_resolver = Resolver::Forwarding {
             resolver: Box::new(resolver),
             filter_out_aaaa,
         };
+        Ok(())
     }
 }
 
@@ -672,15 +688,6 @@ async fn detect_loopback_address_removal(addr: IpAddr) -> Result<(), talpid_rout
     }
 }
 
-type LookupResponse<'a> = MessageResponse<
-    'a,
-    'a,
-    Box<dyn Iterator<Item = &'a Record> + Send + 'a>,
-    std::iter::Empty<&'a Record>,
-    std::iter::Empty<&'a Record>,
-    std::iter::Empty<&'a Record>,
->;
-
 /// An implementation of [hickory_server::server::RequestHandler] that forwards queries to
 /// `FilteringResolver`.
 struct ResolverImpl {
@@ -690,80 +697,95 @@ struct ResolverImpl {
 impl ResolverImpl {
     fn build_response<'a>(
         message: &'a MessageRequest,
-        lookup: &'a dyn LookupObject,
+        lookup: &'a AuthLookup,
     ) -> LookupResponse<'a> {
-        let mut response_header = Header::new();
-        response_header.set_id(message.id());
-        response_header.set_op_code(OpCode::Query);
-        response_header.set_message_type(MessageType::Response);
-        response_header.set_authoritative(false);
-
+        let metadata = Metadata::new(message.id(), MessageType::Response, OpCode::Query);
         MessageResponseBuilder::from_message_request(message).build(
-            response_header,
+            metadata,
             lookup.iter(),
             // forwarder responses only contain query answers, no ns,soa or additionals
-            std::iter::empty(),
-            std::iter::empty(),
-            std::iter::empty(),
+            iter::empty(),
+            iter::empty(),
+            iter::empty(),
         )
     }
 
     /// This function is called when a DNS query is sent to the local resolver
-    async fn lookup<R: ResponseHandler>(&self, message: &Request, mut response_handler: R) {
-        if let Some(tx_ref) = self.tx.upgrade() {
-            let mut tx = (*tx_ref).clone();
-            // Flush all DNS queries
-            for query in message.queries() {
-                let (response_tx, response_rx) = oneshot::channel();
-                let _ = tx
-                    .send(ResolverMessage::Query {
-                        dns_query: query.clone(),
-                        response_tx,
-                    })
-                    .await;
+    async fn lookup<R: ResponseHandler>(&self, request: &Request, mut response_handler: R) {
+        let Some(tx_ref) = self.tx.upgrade() else {
+            return;
+        };
 
-                let lookup_result = response_rx.await;
-                let response_result = match lookup_result {
-                    Ok(Ok(ref lookup)) => {
-                        let response = Self::build_response(message, lookup.as_ref());
-                        response_handler.send_response(response).await
-                    }
-                    Err(_error) => return,
-                    Ok(Err(resolve_err)) => {
-                        if let ResolveErrorKind::Proto(proto) = resolve_err.kind()
-                            && let ProtoErrorKind::NoRecordsFound { response_code, .. } =
-                                proto.kind()
-                        {
-                            let response = MessageResponseBuilder::from_message_request(message)
-                                .error_msg(message.header(), *response_code);
-                            response_handler.send_response(response).await
-                        } else {
-                            let response = Self::build_response(message, &EmptyLookup);
-                            response_handler.send_response(response).await
-                        }
-                    }
-                };
-                if let Err(err) = response_result {
-                    log::error!("Failed to send response: {err}");
+        let message: &MessageRequest = request;
+
+        let mut tx = (*tx_ref).clone();
+        // Flush all DNS queries
+        for query in message.queries.queries() {
+            let (response_tx, response_rx) = oneshot::channel();
+            let _ = tx
+                .send(ResolverMessage::Query {
+                    dns_query: query.clone(),
+                    response_tx,
+                })
+                .await;
+
+            let Ok(lookup_result) = response_rx.await else {
+                // cancelled
+                return;
+            };
+            let response_result = match lookup_result {
+                Ok(ref lookup) => {
+                    let response = Self::build_response(message, lookup.as_ref());
+                    response_handler.send_response(response).await
                 }
+                Err(NetError::Dns(DnsError::ResponseCode(response_code))) => {
+                    let response = MessageResponseBuilder::from_message_request(message)
+                        .error_msg(&message.metadata, response_code);
+                    response_handler.send_response(response).await
+                }
+                Err(_) => {
+                    let response = Self::build_response(message, &AuthLookup::Empty);
+                    response_handler.send_response(response).await
+                }
+            };
+            if let Err(err) = response_result {
+                log::error!("Failed to send response: {err}");
             }
         }
     }
 }
 
+type LookupResponse<'a> = MessageResponse<
+    'a,
+    'a,
+    AuthLookupIter<'a>,
+    iter::Empty<&'a Record>,
+    iter::Empty<&'a Record>,
+    iter::Empty<&'a Record>,
+>;
+
 #[async_trait::async_trait]
 impl RequestHandler for ResolverImpl {
-    async fn handle_request<R: ResponseHandler>(
+    async fn handle_request<R: ResponseHandler, T: Time>(
         &self,
         request: &Request,
         response_handle: R,
     ) -> ResponseInfo {
+        let empty_header = || Header {
+            metadata: Metadata::new(0, MessageType::Query, OpCode::Query),
+            counts: HeaderCounts {
+                queries: 0,
+                answers: 0,
+                authorities: 0,
+                additionals: 0,
+            },
+        };
         if !request.src().ip().is_loopback() {
             log::error!("Dropping a stray request from outside: {}", request.src());
-            return Header::new().into();
+            return empty_header().into();
         }
-        if let MessageType::Query = request.message_type() {
-            match request.op_code() {
+        if let MessageType::Query = request.metadata.message_type {
+            match request.metadata.op_code {
                 OpCode::Query => {
                     self.lookup(request, response_handle).await;
                 }
@@ -773,32 +795,14 @@ impl RequestHandler for ResolverImpl {
             };
         }
 
-        return Header::new().into();
-    }
-}
-
-struct ForwardLookup(Lookup);
-
-/// This trait has to be reimplemented for the Lookup so that it can be sent back to the
-/// RequestHandler implementation.
-impl LookupObject for ForwardLookup {
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Record> + Send + 'a> {
-        Box::new(self.0.record_iter())
-    }
-
-    fn take_additionals(&mut self) -> Option<Box<dyn LookupObject>> {
-        None
+        return empty_header().into();
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use hickory_server::resolver::config::{NameServerConfigGroup, ResolverConfig};
+    use hickory_server::resolver::config::{NameServerConfig, ResolverConfig};
     use std::{net::UdpSocket, sync::Mutex, thread};
     use typed_builder::TypedBuilder;
 
@@ -816,14 +820,17 @@ mod test {
         .unwrap()
     }
 
-    fn get_test_resolver(addr: SocketAddr) -> hickory_server::resolver::TokioResolver {
-        let resolver_config = ResolverConfig::from_parts(
-            None,
-            vec![],
-            NameServerConfigGroup::from_ips_clear(&[addr.ip()], addr.port(), true),
-        );
-        TokioResolver::builder_with_config(resolver_config, TokioConnectionProvider::default())
+    fn get_test_resolver(addr: SocketAddr) -> TokioResolver {
+        let mut udp = ConnectionConfig::udp();
+        udp.port = addr.port();
+        let mut tcp = ConnectionConfig::tcp();
+        tcp.port = addr.port();
+        let nameservers = NameServerConfig::new(addr.ip(), false, vec![udp, tcp]);
+
+        let resolver_config = ResolverConfig::from_parts(None, vec![], vec![nameservers]);
+        TokioResolver::builder_with_config(resolver_config, TokioRuntimeProvider::default())
             .build()
+            .unwrap()
     }
 
     /// Test whether we can successfully bind the socket even if the address is already used to
@@ -894,7 +901,7 @@ mod test {
             for domain in &*ALLOWED_DOMAINS {
                 test_resolver.lookup(domain, RecordType::A).await?;
             }
-            Ok::<(), ResolveError>(())
+            Ok::<(), NetError>(())
         })
         .expect("Resolution of domains failed");
     }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -329,13 +329,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -453,6 +464,16 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1005,6 +1026,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1078,31 +1100,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "hickory-proto 0.26.1",
+ "http",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "rustls",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2",
- "http",
  "idna",
  "ipnet",
  "once_cell",
  "rand 0.9.4",
  "ring",
- "rustls",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
  "tracing",
  "url",
 ]
@@ -1115,15 +1181,41 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
  "parking_lot",
  "rand 0.9.4",
  "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
  "rustls",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -1494,6 +1586,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -1592,6 +1687,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,7 +1750,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c460f1b7afbfcb0810208d3b0efc6ac1d7574f5e379fa2c19fb957bb57678a"
 dependencies = [
- "jni",
+ "jni 0.19.0",
  "jnix-macros",
  "once_cell",
  "parking_lot",
@@ -1914,7 +2039,7 @@ version = "0.0.0"
 name = "mullvad-encrypted-dns-proxy"
 version = "0.0.0"
 dependencies = [
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "log",
  "rustls",
  "serde",
@@ -2036,6 +2161,12 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -2471,6 +2602,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2790,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2837,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -3016,7 +3175,7 @@ checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "io-kit-sys",
  "mach2",
@@ -3062,7 +3221,7 @@ dependencies = [
  "cfg-if",
  "dynosaur",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libc",
  "log",
  "notify",
@@ -3094,7 +3253,7 @@ dependencies = [
  "aes-gcm",
  "camellia",
  "cfg-if",
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "ctr",
  "hkdf",
@@ -3137,6 +3296,22 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -3292,6 +3467,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -112,15 +112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,18 +744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,15 +860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1113,7 +1083,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "h2",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "http",
  "idna",
  "ipnet",
@@ -1124,31 +1094,6 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tokio-rustls",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
  "tracing",
  "url",
 ]
@@ -1175,27 +1120,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -1203,7 +1127,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -1512,26 +1436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
-dependencies = [
- "bitflags 2.11.1",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,26 +1696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,7 +1923,7 @@ version = "0.0.0"
 name = "mullvad-encrypted-dns-proxy"
 version = "0.0.0"
 dependencies = [
- "hickory-resolver 0.26.1",
+ "hickory-resolver",
  "log",
  "rustls",
  "serde",
@@ -2221,33 +2105,6 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
-
-[[package]]
-name = "notify"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
-dependencies = [
- "bitflags 2.11.1",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
-dependencies = [
- "bitflags 2.11.1",
-]
 
 [[package]]
 name = "num-conv"
@@ -3213,7 +3070,6 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "482831bf9d55acf3c98e211b6c852c3dfdf1d1b0d23fdf1d887c5a4b2acad4e4"
 dependencies = [
- "arc-swap",
  "base64",
  "blake3",
  "byte_string",
@@ -3221,10 +3077,8 @@ dependencies = [
  "cfg-if",
  "dynosaur",
  "futures",
- "hickory-resolver 0.25.2",
  "libc",
  "log",
- "notify",
  "percent-encoding",
  "pin-project",
  "sealed",


### PR DESCRIPTION
This PR addresses [RUSTSEC-2026-0119: CPU exhaustion during message encoding due to O(n²) name compression](https://rustsec.org/advisories/RUSTSEC-2026-0119.html) by upgrading `hickory-proto` to a patched version (`>= 0.26.1`). A nice side-effect of this was that I discovered that while `shadowsocks-rs` pulled in `hickory-proto 0.25.2`, we could disable the `hickory-dns` feature of `shadowsocks-rs` completely. Our use of shadowsocks should never resolve hostnames anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10357)
<!-- Reviewable:end -->
