### PR TITLE
SettingsManager no longer a singleton, pass date in AccountExpiry

### DIFF
--- a/ios/MullvadRESTTests/MullvadApiTests.swift
+++ b/ios/MullvadRESTTests/MullvadApiTests.swift
@@ -22,11 +22,11 @@ import XCTest
 class MullvadApiTests: XCTestCase {
     let encoder = JSONEncoder()
 
-    static let store = InMemorySettingsStore<SettingNotFound>()
+    let settingsManager = SettingsManager(store: InMemorySettingsStore<SettingNotFound>())
+    lazy var settingsStore = settingsManager.store
 
     override func setUp() {
         super.setUp()
-        SettingsManager.unitTestStore = MullvadApiTests.store
         RustLogging.initialize(logger: Logger(label: "Rust"))
     }
 

--- a/ios/MullvadRESTTests/RelayListCacheTests.swift
+++ b/ios/MullvadRESTTests/RelayListCacheTests.swift
@@ -21,11 +21,11 @@ import XCTest
 /// This test would fail on main where `StoredRelays` encoded a deserialized `relays`
 /// property via Codable, losing any fields not declared in `ServerRelaysResponse`.
 class RelayListCacheTests: XCTestCase {
-    static let store = InMemorySettingsStore<SettingNotFound>()
+    let settingsManager = SettingsManager(store: InMemorySettingsStore<SettingNotFound>())
+    lazy var settingsStore = settingsManager.store
 
     override func setUp() {
         super.setUp()
-        SettingsManager.unitTestStore = Self.store
         RustLogging.initialize(logger: Logger(label: "RelayListCacheTests"))
     }
 

--- a/ios/MullvadRustRuntime/MullvadAddressCacheKeychainStore.swift
+++ b/ios/MullvadRustRuntime/MullvadAddressCacheKeychainStore.swift
@@ -14,18 +14,20 @@ private let isSettingsStoreAvailable: Bool =
     Bundle.main
     .object(forInfoDictionaryKey: "ApplicationSecurityGroupIdentifier") != nil
 
+private let settingsManager = SettingsManager()
+
 /// Store the address cache, given to us by the Rust code,  to the keychain
 @_cdecl("swift_store_address_cache")
 func storeAddressCache(_ pointer: UnsafeRawPointer, dataSize: UInt64) {
     guard isSettingsStoreAvailable else { return }
     let data = Data(bytes: pointer, count: Int(dataSize))
     // if writing to the Keychain fails, it will do so silently.
-    try? SettingsManager.writeAddressCache(data)
+    try? settingsManager.writeAddressCache(data)
 }
 
 @_cdecl("swift_read_address_cache")
 func readAddressCache() -> SwiftData {
     guard isSettingsStoreAvailable else { return SwiftData(data: NSData()) }
-    let data = (try? SettingsManager.readAddressCache()) ?? Data()
+    let data = (try? settingsManager.readAddressCache()) ?? Data()
     return SwiftData(data: data as NSData)
 }

--- a/ios/MullvadSettings/AccessMethodRepository.swift
+++ b/ios/MullvadSettings/AccessMethodRepository.swift
@@ -65,8 +65,11 @@ public class AccessMethodRepository: AccessMethodRepositoryProtocol, @unchecked 
 
     private var cancellables: Set<Combine.AnyCancellable> = []
 
-    public init(shadowsocksCiphers: [String]) {
+    private let settingsStore: SettingsStore
+
+    public init(shadowsocksCiphers: [String], settingsStore: SettingsStore) {
         self.shadowsocksCiphers = shadowsocksCiphers
+        self.settingsStore = settingsStore
 
         accessMethodsSubject = CurrentValueSubject([])
         requestAccessMethodSubject = PassthroughSubject()
@@ -179,7 +182,7 @@ public class AccessMethodRepository: AccessMethodRepositoryProtocol, @unchecked 
         let parser = makeParser()
 
         do {
-            let data = try SettingsManager.store.read(key: .apiAccessMethods)
+            let data = try settingsStore.read(key: .apiAccessMethods)
             return try parser.parseUnversionedPayload(as: PersistentAccessMethodStore.self, from: data)
         } catch {
             logger.error("Could not load access method store: \(error)")
@@ -193,7 +196,7 @@ public class AccessMethodRepository: AccessMethodRepositoryProtocol, @unchecked 
         let parser = makeParser()
         let data = try parser.produceUnversionedPayload(store)
 
-        try SettingsManager.store.write(data, for: .apiAccessMethods)
+        try settingsStore.write(data, for: .apiAccessMethods)
     }
 
     private func makeParser() -> SettingsParser {

--- a/ios/MullvadSettings/CustomListRepository.swift
+++ b/ios/MullvadSettings/CustomListRepository.swift
@@ -35,7 +35,11 @@ public struct CustomListRepository: CustomListRepositoryProtocol {
         SettingsParser(decoder: JSONDecoder(), encoder: JSONEncoder())
     }()
 
-    public init() {}
+    let store: SettingsStore
+
+    public init(settingsStore: SettingsStore) {
+        self.store = settingsStore
+    }
 
     public func save(list: CustomList) throws {
         guard list.name.count <= NameInputFormatter.maxLength else {
@@ -53,10 +57,10 @@ public struct CustomListRepository: CustomListRepositoryProtocol {
             throw CustomRelayListError.duplicateName
         } else if let index = lists.firstIndex(where: { $0.id == list.id }) {
             lists[index] = list
-            try write(lists)
+            try write(lists, to: store)
         } else {
             lists.append(list)
-            try write(lists)
+            try write(lists, to: store)
         }
     }
 
@@ -65,7 +69,7 @@ public struct CustomListRepository: CustomListRepositoryProtocol {
             var lists = fetchAll()
             if let index = lists.firstIndex(where: { $0.id == id }) {
                 lists.remove(at: index)
-                try write(lists)
+                try write(lists, to: store)
             }
         } catch {
             logger.error(error: error)
@@ -73,24 +77,24 @@ public struct CustomListRepository: CustomListRepositoryProtocol {
     }
 
     public func fetch(by id: UUID) -> CustomList? {
-        try? read().first(where: { $0.id == id })
+        try? read(from: store).first(where: { $0.id == id })
     }
 
     public func fetchAll() -> [CustomList] {
-        (try? read()) ?? []
+        (try? read(from: store)) ?? []
     }
 }
 
 extension CustomListRepository {
-    private func read() throws -> [CustomList] {
-        let data = try SettingsManager.store.read(key: .customRelayLists)
+    private func read(from store: SettingsStore) throws -> [CustomList] {
+        let data = try store.read(key: .customRelayLists)
 
         return try settingsParser.parseUnversionedPayload(as: [CustomList].self, from: data)
     }
 
-    private func write(_ list: [CustomList]) throws {
+    private func write(_ list: [CustomList], to store: SettingsStore) throws {
         let data = try settingsParser.produceUnversionedPayload(list)
 
-        try SettingsManager.store.write(data, for: .customRelayLists)
+        try store.write(data, for: .customRelayLists)
     }
 }

--- a/ios/MullvadSettings/IPOverrideRepository.swift
+++ b/ios/MullvadSettings/IPOverrideRepository.swift
@@ -26,7 +26,11 @@ public final class IPOverrideRepository: IPOverrideRepositoryProtocol {
     nonisolated(unsafe) private let logger = Logger(label: "IPOverrideRepository")
     private let readWriteLock = NSLock()
 
-    public init() {}
+    private let settingsStore: SettingsStore
+
+    public init(settingsStore: SettingsStore) {
+        self.settingsStore = settingsStore
+    }
 
     public func add(_ overrides: [IPOverride]) {
         var storedOverrides = fetchAll()
@@ -63,7 +67,7 @@ public final class IPOverrideRepository: IPOverrideRepositoryProtocol {
     public func deleteAll() {
         do {
             try readWriteLock.withLock {
-                try SettingsManager.store.delete(key: .ipOverrides)
+                try settingsStore.delete(key: .ipOverrides)
                 overridesSubject.send([])
             }
         } catch {
@@ -81,7 +85,7 @@ public final class IPOverrideRepository: IPOverrideRepositoryProtocol {
     private func readIpOverrides() throws -> [IPOverride] {
         try readWriteLock.withLock {
             let parser = makeParser()
-            let data = try SettingsManager.store.read(key: .ipOverrides)
+            let data = try settingsStore.read(key: .ipOverrides)
             return try parser.parseUnversionedPayload(as: [IPOverride].self, from: data)
         }
     }
@@ -91,7 +95,7 @@ public final class IPOverrideRepository: IPOverrideRepositoryProtocol {
         let data = try parser.produceUnversionedPayload(overrides)
 
         try readWriteLock.withLock {
-            try SettingsManager.store.write(data, for: .ipOverrides)
+            try settingsStore.write(data, for: .ipOverrides)
             overridesSubject.send(overrides)
         }
     }

--- a/ios/MullvadSettings/MigrationManager.swift
+++ b/ios/MullvadSettings/MigrationManager.swift
@@ -24,9 +24,11 @@ public enum SettingsMigrationResult: Sendable {
 public struct MigrationManager {
     private let logger = Logger(label: "MigrationManager")
     private let cacheDirectory: URL
+    private let settingsManager: SettingsManager
 
-    public init(cacheDirectory: URL) {
+    public init(cacheDirectory: URL, settingsManager: SettingsManager) {
         self.cacheDirectory = cacheDirectory.appendingPathComponent("migrationState.json")
+        self.settingsManager = settingsManager
     }
 
     /// Migrate settings store if needed.
@@ -56,7 +58,7 @@ public struct MigrationManager {
             let resetStoreHandler = { (result: SettingsMigrationResult) in
                 // Reset store upon failure to migrate settings.
                 if case .failure = result {
-                    SettingsManager.resetStore()
+                    settingsManager.resetStore()
                 }
                 migrationCompleted(result)
             }

--- a/ios/MullvadSettings/RecentConnectionsRepository.swift
+++ b/ios/MullvadSettings/RecentConnectionsRepository.swift
@@ -33,8 +33,8 @@ final public class RecentConnectionsRepository: RecentConnectionsRepositoryProto
         recentConnectionsSubject.eraseToAnyPublisher()
     }
 
-    public init(store: SettingsStore, maxLimit: UInt = 50) {
-        self.store = store
+    public init(settingsStore: SettingsStore, maxLimit: UInt = 50) {
+        self.store = settingsStore
         self.maxLimit = maxLimit
     }
 

--- a/ios/MullvadSettings/SettingsManager.swift
+++ b/ios/MullvadSettings/SettingsManager.swift
@@ -14,38 +14,27 @@ private let keychainServiceName = "Mullvad VPN"
 private let accountTokenKey = "accountToken"
 private let accountExpiryKey = "accountExpiry"
 
-public enum SettingsManager {
-    nonisolated(unsafe) private static let logger = Logger(label: "SettingsManager")
+public struct SettingsManager: Sendable {
+    private let logger = Logger(label: "SettingsManager")
 
-    #if DEBUG
-        nonisolated(unsafe) private static var _store = KeychainSettingsStore(
-            serviceName: keychainServiceName,
-            accessGroup: ApplicationConfiguration.securityGroupIdentifier
-        )
+    public let store: SettingsStore
 
-        /// Alternative store used for tests.
-        nonisolated(unsafe) internal static var unitTestStore: SettingsStore?
+    public init(store: SettingsStore? = nil) {
+        self.store =
+            store
+            ?? KeychainSettingsStore(
+                serviceName: keychainServiceName,
+                accessGroup: ApplicationConfiguration.securityGroupIdentifier
+            )
+    }
 
-        public static var store: SettingsStore {
-            if let unitTestStore { return unitTestStore }
-            return _store
-        }
-
-    #else
-        public static let store: SettingsStore = KeychainSettingsStore(
-            serviceName: keychainServiceName,
-            accessGroup: ApplicationConfiguration.securityGroupIdentifier
-        )
-
-    #endif
-
-    private static func makeParser() -> SettingsParser {
+    private func makeParser() -> SettingsParser {
         SettingsParser(decoder: JSONDecoder(), encoder: JSONEncoder())
     }
 
     // MARK: - Last used account
 
-    public static func getLastUsedAccount() throws -> String {
+    public func getLastUsedAccount() throws -> String {
         let data = try store.read(key: .lastUsedAccount)
         guard let result = String(bytes: data, encoding: .utf8) else {
             throw StringDecodingError(data: data)
@@ -53,7 +42,7 @@ public enum SettingsManager {
         return result
     }
 
-    public static func setLastUsedAccount(_ string: String?) throws {
+    public func setLastUsedAccount(_ string: String?) throws {
         if let string {
             guard let data = string.data(using: .utf8) else {
                 throw StringEncodingError(string: string)
@@ -73,11 +62,11 @@ public enum SettingsManager {
 
     // MARK: - Should wipe settings
 
-    public static func getShouldWipeSettings() -> Bool {
+    public func getShouldWipeSettings() -> Bool {
         (try? store.read(key: .shouldWipeSettings)) != nil
     }
 
-    public static func setShouldWipeSettings() {
+    public func setShouldWipeSettings() {
         do {
             try store.write(Data(), for: .shouldWipeSettings)
         } catch {
@@ -90,7 +79,7 @@ public enum SettingsManager {
 
     // MARK: - Settings
 
-    public static func readSettings() throws -> LatestTunnelSettings {
+    public func readSettings() throws -> LatestTunnelSettings {
         let storedVersion: Int
         let data: Data
         let parser = makeParser()
@@ -114,7 +103,7 @@ public enum SettingsManager {
         }
     }
 
-    public static func writeSettings(_ settings: LatestTunnelSettings) throws {
+    public func writeSettings(_ settings: LatestTunnelSettings) throws {
         let parser = makeParser()
         let data = try parser.producePayload(settings, version: SchemaVersion.current.rawValue)
 
@@ -123,14 +112,14 @@ public enum SettingsManager {
 
     // MARK: - Device state
 
-    public static func readDeviceState() throws -> DeviceState {
+    public func readDeviceState() throws -> DeviceState {
         let data = try store.read(key: .deviceState)
         let parser = makeParser()
 
         return try parser.parseUnversionedPayload(as: DeviceState.self, from: data)
     }
 
-    public static func writeDeviceState(_ deviceState: DeviceState) throws {
+    public func writeDeviceState(_ deviceState: DeviceState) throws {
         let parser = makeParser()
         let data = try parser.produceUnversionedPayload(deviceState)
 
@@ -139,7 +128,7 @@ public enum SettingsManager {
 
     /// Removes all legacy settings, device state, tunnel settings and API access methods but keeps
     /// the last used account number stored.
-    public static func resetStore(policy: SettingsResetPolicy = .partially) {
+    public func resetStore(policy: SettingsResetPolicy = .partially) {
         logger.debug("Reset store.")
 
         let keys = policy.keys
@@ -157,17 +146,17 @@ public enum SettingsManager {
 
     // MARK: - API-side Address Cache
 
-    public static func writeAddressCache(_ cache: Data) throws {
+    public func writeAddressCache(_ cache: Data) throws {
         try store.write(cache, for: .addressCache)
     }
 
-    public static func readAddressCache() throws -> Data {
+    public func readAddressCache() throws -> Data {
         try store.read(key: .addressCache)
     }
 
     // MARK: - Private
 
-    private static func checkLatestSettingsVersion() throws {
+    private func checkLatestSettingsVersion() throws {
         let settingsVersion: Int
         do {
             let parser = makeParser()

--- a/ios/MullvadVPN/AppDelegate.swift
+++ b/ios/MullvadVPN/AppDelegate.swift
@@ -42,12 +42,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private var settingsObserver: TunnelBlockObserver!
     private var migrationManager: MigrationManager!
 
-    nonisolated(unsafe) private(set) var accessMethodRepository = AccessMethodRepository(
-        shadowsocksCiphers: ShadowsocksCipherService().getCiphers()
-    )
+    let settingsManager = SettingsManager()
+    nonisolated(unsafe) private(set) var accessMethodRepository: AccessMethodRepository!
+
     nonisolated(unsafe) private(set) var appPreferences = AppPreferences()
     private(set) var shadowsocksLoader: ShadowsocksLoader!
-    private(set) var ipOverrideRepository = IPOverrideRepository()
+    private(set) lazy var ipOverrideRepository = IPOverrideRepository(settingsStore: settingsManager.store)
     private(set) var relaySelector: RelaySelectorWrapper!
     private(set) var launchArguments = LaunchArguments()
     var apiContext: MullvadApiContext!
@@ -72,7 +72,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
 
         let containerURL = ApplicationConfiguration.containerURL
-        migrationManager = MigrationManager(cacheDirectory: containerURL)
+        migrationManager = MigrationManager(cacheDirectory: containerURL, settingsManager: settingsManager)
         configureLogging()
 
         let ipOverrideWrapper = IPOverrideWrapper(
@@ -90,7 +90,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             relayCache: ipOverrideWrapper
         )
 
-        let tunnelSettings = (try? SettingsManager.readSettings()) ?? LatestTunnelSettings()
+        let tunnelSettings = (try? settingsManager.readSettings()) ?? LatestTunnelSettings()
 
         shadowsocksLoader = ShadowsocksLoader(
             cache: shadowsocksCache,
@@ -101,6 +101,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         shadowsocksCacheCleaner = ShadowsocksCacheCleaner(cache: shadowsocksCache)
 
+        accessMethodRepository = AccessMethodRepository(
+            shadowsocksCiphers: ShadowsocksCipherService().getCiphers(),
+            settingsStore: settingsManager.store
+        )
         let opaqueAccessMethodSettingsWrapper = initAccessMethodSettingsWrapper(
             methods: accessMethodRepository.fetchAll()
         )
@@ -213,7 +217,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             accountsProxy: accountsProxy,
             devicesProxy: devicesProxy,
             apiProxy: apiProxy,
-            relaySelector: relaySelector
+            relaySelector: relaySelector,
+            settingsManager: settingsManager
         )
     }
 
@@ -244,7 +249,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             // Configure mock tunnel provider on simulator
             simulatorTunnelProviderHost = SimulatorTunnelProviderHost(
                 relaySelector: relaySelector,
-                apiTransportProvider: apiTransportProvider
+                apiTransportProvider: apiTransportProvider,
+                settingsManager: settingsManager
             )
             SimulatorTunnelProvider.shared.delegate = simulatorTunnelProviderHost
         #endif
@@ -543,7 +549,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             block: { [self] (finish: @escaping @Sendable (Error?) -> Void) in
                 MainActor.assumeIsolated {
                     migrationManager
-                        .migrateSettings(store: SettingsManager.store) { [self] migrationResult in
+                        .migrateSettings(store: settingsManager.store) { [self] migrationResult in
                             switch migrationResult {
                             case .success:
                                 // Tell the tunnel to re-read tunnel configuration after migration.
@@ -610,16 +616,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// If (1) is `false` and (2) is `true`, we know that the app has been freshly installed/reinstalled and is
     /// compatible, thus triggering a settings wipe.
     private func getWipeSettingsOperation() -> AsyncBlockOperation {
-        AsyncBlockOperation {
+        AsyncBlockOperation { [settingsManager] in
             let appHasNeverBeenLaunched =
-                !self.appPreferences.hasDoneFirstTimeLaunch && !SettingsManager.getShouldWipeSettings()
+                !self.appPreferences.hasDoneFirstTimeLaunch && !settingsManager.getShouldWipeSettings()
             let appWasLaunchedAfterReinstall =
-                !self.appPreferences.hasDoneFirstTimeLaunch && SettingsManager.getShouldWipeSettings()
+                !self.appPreferences.hasDoneFirstTimeLaunch && settingsManager.getShouldWipeSettings()
 
             if appHasNeverBeenLaunched {
-                try? SettingsManager.writeSettings(LatestTunnelSettings())
+                try? settingsManager.writeSettings(LatestTunnelSettings())
             } else if appWasLaunchedAfterReinstall {
-                if let deviceState = try? SettingsManager.readDeviceState(),
+                if let deviceState = try? settingsManager.readDeviceState(),
                     let accountData = deviceState.accountData,
                     let deviceData = deviceState.deviceData
                 {
@@ -632,8 +638,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     }
                 }
 
-                SettingsManager.resetStore(policy: .all)
-                try? SettingsManager.writeSettings(LatestTunnelSettings())
+                settingsManager.resetStore(policy: .all)
+                try? settingsManager.writeSettings(LatestTunnelSettings())
 
                 // Default access methods need to be repopulated again after settings wipe.
                 self.accessMethodRepository.addDefaultsMethods()
@@ -642,7 +648,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 try? self.relayCacheTracker.refreshCachedRelays()
             }
 
-            SettingsManager.setShouldWipeSettings()
+            settingsManager.setShouldWipeSettings()
         }
     }
 

--- a/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/ApplicationCoordinator.swift
@@ -59,6 +59,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
     private let relaySelectorWrapper: RelaySelectorWrapper
     private let breadcrumbsProvider: BreadcrumbsProvider
     private var breadcrumbsObserver: BreadcrumbsBlockObserver?
+    private let settingsManager: SettingsManager
     private let logRedactor: LogRedacting?
 
     private var outOfTimeTimer: Timer?
@@ -80,6 +81,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
         ipOverrideRepository: IPOverrideRepository,
         relaySelectorWrapper: RelaySelectorWrapper,
         breadcrumbsProvider: BreadcrumbsProvider,
+        settingsManager: SettingsManager,
         logRedactor: LogRedacting? = nil
     ) {
         self.tunnelManager = tunnelManager
@@ -95,6 +97,7 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
         self.relaySelectorWrapper = relaySelectorWrapper
         self.breadcrumbsProvider = breadcrumbsProvider
         self.logRedactor = logRedactor
+        self.settingsManager = settingsManager
 
         super.init()
 
@@ -529,7 +532,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
             navigationController: navigationContainer,
             tunnelManager: tunnelManager,
             devicesProxy: devicesProxy,
-            breadcrumbsProvider: breadcrumbsProvider
+            breadcrumbsProvider: breadcrumbsProvider,
+            settingsManager: settingsManager
         )
 
         coordinator.preferredAccountNumberPublisher = preferredAccountNumberSubject.eraseToAnyPublisher()
@@ -587,7 +591,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
     private func makeTunnelCoordinator() -> TunnelCoordinator {
         let tunnelCoordinator = TunnelCoordinator(
             tunnelManager: tunnelManager,
-            outgoingConnectionService: outgoingConnectionService
+            outgoingConnectionService: outgoingConnectionService,
+            settingsStore: settingsManager.store
         )
 
         tunnelCoordinator.showSelectLocationPicker = { [weak self] in
@@ -612,8 +617,8 @@ final class ApplicationCoordinator: Coordinator, Presenting, @preconcurrency Roo
             tunnelManager: tunnelManager,
             relaySelectorWrapper: relaySelectorWrapper,
             relayCacheTracker: relayCacheTracker,
-            customListRepository: CustomListRepository(),
-            recentConnectionsRepository: RecentConnectionsRepository(store: SettingsManager.store)
+            customListRepository: CustomListRepository(settingsStore: settingsManager.store),
+            recentConnectionsRepository: RecentConnectionsRepository(settingsStore: settingsManager.store)
         )
 
         locationCoordinator.didFinish = { [weak self] _ in

--- a/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/LoginCoordinator.swift
@@ -8,6 +8,7 @@
 
 import Combine
 import MullvadREST
+import MullvadSettings
 import MullvadTypes
 import Operations
 import Routing
@@ -34,21 +35,24 @@ final class LoginCoordinator: Coordinator, Presenting {
     }
 
     let navigationController: RootContainerViewController
+    let settingsManager: SettingsManager
 
     init(
         navigationController: RootContainerViewController,
         tunnelManager: TunnelManager,
         devicesProxy: DeviceHandling,
-        breadcrumbsProvider: BreadcrumbsProvider
+        breadcrumbsProvider: BreadcrumbsProvider,
+        settingsManager: SettingsManager
     ) {
         self.navigationController = navigationController
         self.tunnelManager = tunnelManager
         self.devicesProxy = devicesProxy
         self.breadcrumbsProvider = breadcrumbsProvider
+        self.settingsManager = settingsManager
     }
 
     func start(animated: Bool) {
-        let interactor = LoginInteractor(tunnelManager: tunnelManager)
+        let interactor = LoginInteractor(tunnelManager: tunnelManager, settingsManager: settingsManager)
         let loginController = LoginViewController(
             interactor: interactor,
             alertPresenter: AlertPresenter(context: self)

--- a/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodView.swift
+++ b/ios/MullvadVPN/Coordinators/Settings/APIAccess/List/ListAccessMethodView.swift
@@ -107,7 +107,8 @@ struct ListAccessMethodView<ViewModel>: View where ViewModel: ListAccessViewMode
             viewModel: ListAccessViewModelBridge(
                 interactor: ListAccessMethodInteractor(
                     repository: AccessMethodRepository(
-                        shadowsocksCiphers: []
+                        shadowsocksCiphers: [],
+                        settingsStore: SettingsManager().store
                     )
                 ),
                 delegate: nil

--- a/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
+++ b/ios/MullvadVPN/Coordinators/TunnelCoordinator.swift
@@ -28,7 +28,8 @@ class TunnelCoordinator: Coordinator, Presenting {
 
     init(
         tunnelManager: TunnelManager,
-        outgoingConnectionService: OutgoingConnectionServiceHandling
+        outgoingConnectionService: OutgoingConnectionServiceHandling,
+        settingsStore: SettingsStore
     ) {
         self.tunnelManager = tunnelManager
 
@@ -37,7 +38,7 @@ class TunnelCoordinator: Coordinator, Presenting {
             outgoingConnectionService: outgoingConnectionService
         )
 
-        controller = TunnelViewController(interactor: interactor)
+        controller = TunnelViewController(interactor: interactor, settingsStore: settingsStore)
 
         super.init()
 

--- a/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiry.swift
+++ b/ios/MullvadVPN/Notifications/Notification Providers/AccountExpiry.swift
@@ -27,8 +27,8 @@ struct AccountExpiry {
 
     var expiryDate: Date?
 
-    func nextTriggerDate(for trigger: Trigger) -> Date? {
-        let now = Date().secondsPrecision
+    func nextTriggerDate(for trigger: Trigger, after referenceDate: Date = Date()) -> Date? {
+        let referenceDate = referenceDate.secondsPrecision
         let triggerDates = triggerDates(for: trigger)
 
         // Get earliest trigger date and remove one day. Since we want to count whole days, If first
@@ -38,26 +38,26 @@ struct AccountExpiry {
             let expiryDate,
             let earliestDate = triggerDates.min(),
             let earliestTriggerDate = calendar.date(byAdding: .day, value: -1, to: earliestDate),
-            now <= expiryDate.secondsPrecision,
-            now > earliestTriggerDate.secondsPrecision
+            referenceDate <= expiryDate.secondsPrecision,
+            referenceDate > earliestTriggerDate.secondsPrecision
         else { return nil }
 
         let datesByTimeToTrigger = triggerDates.filter { date in
-            now.secondsPrecision <= date.secondsPrecision  // Ignore dates that have passed.
+            referenceDate.secondsPrecision <= date.secondsPrecision  // Ignore dates that have passed.
         }.sorted { date1, date2 in
-            abs(date1.timeIntervalSince(now)) < abs(date2.timeIntervalSince(now))
+            abs(date1.timeIntervalSince(referenceDate)) < abs(date2.timeIntervalSince(referenceDate))
         }
 
         return datesByTimeToTrigger.first
     }
 
-    func daysRemaining(for trigger: Trigger) -> DateComponents? {
-        let nextTriggerDate = nextTriggerDate(for: trigger)
+    func daysRemaining(for trigger: Trigger, referenceDate: Date = Date()) -> DateComponents? {
+        let nextTriggerDate = nextTriggerDate(for: trigger, after: referenceDate)
         guard let expiryDate, let nextTriggerDate else { return nil }
 
         let dateComponents = calendar.dateComponents(
             [.day],
-            from: Date().secondsPrecision,
+            from: referenceDate.secondsPrecision,
             to: max(nextTriggerDate, expiryDate).secondsPrecision
         )
 

--- a/ios/MullvadVPN/SceneDelegate.swift
+++ b/ios/MullvadVPN/SceneDelegate.swift
@@ -38,6 +38,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, @preconcurrency Setting
         appDelegate.tunnelManager
     }
 
+    private var settingsManager: SettingsManager {
+        appDelegate.settingsManager
+    }
+
     // MARK: - Private
 
     private func addTunnelObserver() {
@@ -83,6 +87,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, @preconcurrency Setting
             ipOverrideRepository: appDelegate.ipOverrideRepository,
             relaySelectorWrapper: appDelegate.relaySelector,
             breadcrumbsProvider: appDelegate.breadcrumbsProvider,
+            settingsManager: appDelegate.settingsManager,
             logRedactor: appDelegate.logRedactor
         )
 
@@ -180,7 +185,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, @preconcurrency Setting
         let launchViewController = LaunchViewController(
             launchArguments: appDelegate.launchArguments,
             tunnelManager: tunnelManager,
-            accessMethodRepository: accessMethodRepository)
+            accessMethodRepository: accessMethodRepository,
+            settingsManager: settingsManager)
 
         launchViewController.onAppReady = { [weak self] in
             guard let self = self else { return }

--- a/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
+++ b/ios/MullvadVPN/SimulatorTunnelProvider/SimulatorTunnelProviderHost.swift
@@ -26,16 +26,19 @@
         private let dispatchQueue = DispatchQueue(label: "SimulatorTunnelProviderHostQueue")
 
         public var onHandleProviderMessage: ((TunnelProviderMessage) -> Void)?
+        private let settingsManager: SettingsManager
 
         init(
             relaySelector: RelaySelectorProtocol,
-            apiTransportProvider: APITransportProvider
+            apiTransportProvider: APITransportProvider,
+            settingsManager: SettingsManager
         ) {
             self.relaySelector = relaySelector
             self.apiRequestProxy = APIRequestProxy(
                 dispatchQueue: dispatchQueue,
                 transportProvider: apiTransportProvider
             )
+            self.settingsManager = settingsManager
         }
 
         override func startTunnel(
@@ -177,7 +180,7 @@
         }
 
         private func pickRelays() throws -> SelectedRelays {
-            let settings = try SettingsManager.readSettings()
+            let settings = try settingsManager.readSettings()
             return try relaySelector.selectRelays(
                 tunnelSettings: settings,
                 connectionAttemptCount: 0
@@ -188,7 +191,7 @@
             guard let selectedRelays = selectedRelays else { return }
 
             do {
-                let settings = try SettingsManager.readSettings()
+                let settings = try settingsManager.readSettings()
                 observedState = .reconnecting(
                     ObservedConnectionState(
                         selectedRelays: selectedRelays,
@@ -213,7 +216,7 @@
             self.selectedRelays = selectedRelays
 
             do {
-                let settings = try SettingsManager.readSettings()
+                let settings = try settingsManager.readSettings()
                 observedState = .connected(
                     ObservedConnectionState(
                         selectedRelays: selectedRelays,

--- a/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/LoadTunnelConfigurationOperation.swift
@@ -15,10 +15,11 @@ import Operations
 class LoadTunnelConfigurationOperation: ResultOperation<Void>, @unchecked Sendable {
     private let logger = Logger(label: "LoadTunnelConfigurationOperation")
     private let interactor: TunnelInteractor
+    private let settingsManager: SettingsManager
 
-    init(dispatchQueue: DispatchQueue, interactor: TunnelInteractor) {
+    init(dispatchQueue: DispatchQueue, interactor: TunnelInteractor, settingsManager: SettingsManager) {
         self.interactor = interactor
-
+        self.settingsManager = settingsManager
         super.init(dispatchQueue: dispatchQueue)
     }
 
@@ -59,7 +60,7 @@ class LoadTunnelConfigurationOperation: ResultOperation<Void>, @unchecked Sendab
     }
 
     private func readSettings() -> Result<LatestTunnelSettings?, Error> {
-        Result { try SettingsManager.readSettings() }
+        Result { try settingsManager.readSettings() }
             .flatMapError { error in
                 if let error = error as? ReadSettingsVersionError,
                     let keychainError = error.underlyingError as? KeychainError, keychainError == .itemNotFound
@@ -79,7 +80,7 @@ class LoadTunnelConfigurationOperation: ResultOperation<Void>, @unchecked Sendab
     }
 
     private func readDeviceState() -> Result<DeviceState?, Error> {
-        Result { try SettingsManager.readDeviceState() }
+        Result { try settingsManager.readDeviceState() }
             .flatMapError { error in
                 if let error = error as? KeychainError, error == .itemNotFound {
                     logger.debug("Device state not found in keychain.")

--- a/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
+++ b/ios/MullvadVPN/TunnelManager/SetAccountOperation.swift
@@ -41,6 +41,7 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
     private let accountsProxy: RESTAccountHandling
     private let devicesProxy: DeviceHandling
     private let action: SetAccountAction
+    private let setLastUsedAccount: @Sendable (String) throws -> Void
 
     private let logger = Logger(label: "SetAccountOperation")
     private var tasks: [Cancellable] = []
@@ -50,12 +51,14 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
         interactor: TunnelInteractor,
         accountsProxy: RESTAccountHandling,
         devicesProxy: DeviceHandling,
-        action: SetAccountAction
+        action: SetAccountAction,
+        setLastUsedAccount: @escaping @Sendable (String) throws -> Void
     ) {
         self.interactor = interactor
         self.accountsProxy = accountsProxy
         self.devicesProxy = devicesProxy
         self.action = action
+        self.setLastUsedAccount = setLastUsedAccount
 
         super.init(dispatchQueue: dispatchQueue)
     }
@@ -208,7 +211,7 @@ class SetAccountOperation: ResultOperation<StoredAccountData?>, @unchecked Senda
         logger.debug("Store last used account.")
 
         do {
-            try SettingsManager.setLastUsedAccount(accountNumber)
+            try setLastUsedAccount(accountNumber)
         } catch {
             logger.error(error: error, message: "Failed to store last used account number.")
         }

--- a/ios/MullvadVPN/TunnelManager/TunnelManager.swift
+++ b/ios/MullvadVPN/TunnelManager/TunnelManager.swift
@@ -76,6 +76,8 @@ final class TunnelManager: @unchecked Sendable {
 
     private var observer: TunnelObserver?
 
+    private let settingsManager: SettingsManager
+
     // MARK: - Initialization
 
     init(
@@ -85,7 +87,8 @@ final class TunnelManager: @unchecked Sendable {
         accountsProxy: RESTAccountHandling,
         devicesProxy: DeviceHandling,
         apiProxy: APIQuerying,
-        relaySelector: RelaySelectorProtocol
+        relaySelector: RelaySelectorProtocol,
+        settingsManager: SettingsManager
     ) {
         self.backgroundTaskProvider = backgroundTaskProvider
         self.tunnelStore = tunnelStore
@@ -96,6 +99,7 @@ final class TunnelManager: @unchecked Sendable {
         self.operationQueue.name = "TunnelManager.operationQueue"
         self.operationQueue.underlyingQueue = internalQueue
         self.relaySelector = relaySelector
+        self.settingsManager = settingsManager
 
         NotificationCenter.default.addObserver(
             self,
@@ -186,7 +190,8 @@ final class TunnelManager: @unchecked Sendable {
     func loadConfiguration(completionHandler: @escaping @Sendable () -> Void) {
         let loadTunnelOperation = LoadTunnelConfigurationOperation(
             dispatchQueue: internalQueue,
-            interactor: TunnelInteractorProxy(self)
+            interactor: TunnelInteractorProxy(self),
+            settingsManager: settingsManager
         )
         loadTunnelOperation.completionQueue = .main
         loadTunnelOperation.completionHandler = { [weak self] completion in
@@ -384,7 +389,8 @@ final class TunnelManager: @unchecked Sendable {
             interactor: TunnelInteractorProxy(self),
             accountsProxy: accountsProxy,
             devicesProxy: devicesProxy,
-            action: action
+            action: action,
+            setLastUsedAccount: settingsManager.setLastUsedAccount
         )
 
         operation.completionQueue = .main
@@ -726,7 +732,7 @@ final class TunnelManager: @unchecked Sendable {
 
         if persist {
             do {
-                try SettingsManager.writeSettings(settings)
+                try settingsManager.writeSettings(settings)
             } catch {
                 logger.error(
                     error: error,
@@ -755,7 +761,7 @@ final class TunnelManager: @unchecked Sendable {
 
         if persist {
             do {
-                try SettingsManager.writeDeviceState(deviceState)
+                try settingsManager.writeDeviceState(deviceState)
             } catch {
                 logger.error(
                     error: error,
@@ -911,9 +917,9 @@ final class TunnelManager: @unchecked Sendable {
     /// Refresh device state from settings and update the in-memory value.
     /// Used to refresh device state when it's modified by packet tunnel during key rotation.
     private func refreshDeviceState() {
-        let operation = AsyncBlockOperation(dispatchQueue: internalQueue) {
+        let operation = AsyncBlockOperation(dispatchQueue: internalQueue) { [settingsManager] in
             do {
-                let newDeviceState = try SettingsManager.readDeviceState()
+                let newDeviceState = try settingsManager.readDeviceState()
 
                 self.setDeviceState(newDeviceState, persist: false)
             } catch {
@@ -1229,7 +1235,7 @@ final class TunnelManager: @unchecked Sendable {
 
     fileprivate func removeLastUsedAccount() {
         do {
-            try SettingsManager.setLastUsedAccount(nil)
+            try settingsManager.setLastUsedAccount(nil)
         } catch {
             logger.error(
                 error: error,

--- a/ios/MullvadVPN/View controllers/Launch/LaunchViewController.swift
+++ b/ios/MullvadVPN/View controllers/Launch/LaunchViewController.swift
@@ -16,10 +16,11 @@ class LaunchViewController: UIViewController {
 
     init(
         launchArguments: LaunchArguments, tunnelManager: TunnelManager,
-        accessMethodRepository: any AccessMethodRepositoryProtocol
+        accessMethodRepository: any AccessMethodRepositoryProtocol,
+        settingsManager: SettingsManager
     ) {
         self.appResetManager = AppResetManager(
-            launchArguments: launchArguments, tunnelManager: tunnelManager)
+            launchArguments: launchArguments, tunnelManager: tunnelManager, settingsManager: settingsManager)
         super.init(nibName: nil, bundle: nil)
         setupLaunchScreen()
         self.appResetManager.onAppReady = { [weak self] in

--- a/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
+++ b/ios/MullvadVPN/View controllers/Login/LoginInteractor.swift
@@ -13,6 +13,7 @@ final class LoginInteractor: @unchecked Sendable {
     private let tunnelManager: TunnelManager
     private let logger = Logger(label: "LoginInteractor")
     private var tunnelObserver: TunnelObserver?
+    private let settingsManager: SettingsManager
 
     var didCreateAccount: (@MainActor @Sendable () -> Void)?
     var suggestPreferredAccountNumber: (@Sendable (String) -> Void)?
@@ -21,8 +22,9 @@ final class LoginInteractor: @unchecked Sendable {
         getLastUsedAccount() != nil
     }
 
-    init(tunnelManager: TunnelManager) {
+    init(tunnelManager: TunnelManager, settingsManager: SettingsManager) {
         self.tunnelManager = tunnelManager
+        self.settingsManager = settingsManager
     }
 
     func setAccount(accountNumber: String) async throws {
@@ -38,7 +40,7 @@ final class LoginInteractor: @unchecked Sendable {
 
     func getLastUsedAccount() -> String? {
         do {
-            return try SettingsManager.getLastUsedAccount()
+            return try settingsManager.getLastUsedAccount()
         } catch {
             logger.error(
                 error: error,
@@ -50,7 +52,7 @@ final class LoginInteractor: @unchecked Sendable {
 
     func removeLastUsedAccount() {
         do {
-            try SettingsManager.setLastUsedAccount(nil)
+            try settingsManager.setLastUsedAccount(nil)
         } catch {
             logger.error(
                 error: error,

--- a/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/ConnectionView/ConnectionViewComponentPreview.swift
@@ -14,6 +14,7 @@ import PacketTunnelCore
 import SwiftUI
 
 struct ConnectionViewComponentPreview<Content: View>: View {
+    let settingsManager = SettingsManager()
     let showIndicators: Bool
     let connectedTunnelStatus = TunnelStatus(
         observedState: .connected(
@@ -66,7 +67,7 @@ struct ConnectionViewComponentPreview<Content: View>: View {
             tunnelStatus: connectedTunnelStatus,
             relayConstraints: RelayConstraints(),
             relayCache: RelayCache(cacheDirectory: ApplicationConfiguration.containerURL),
-            customListRepository: CustomListRepository()
+            customListRepository: CustomListRepository(settingsStore: settingsManager.store)
         )
         viewModel.outgoingConnectionInfo = OutgoingConnectionInfo(
             ipv4: .init(ip: .allHostsGroup, exitIP: true),

--- a/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
+++ b/ios/MullvadVPN/View controllers/Tunnel/TunnelViewController.swift
@@ -62,7 +62,7 @@ class TunnelViewController: UIViewController, RootContainment {
         false
     }
 
-    init(interactor: TunnelViewControllerInteractor) {
+    init(interactor: TunnelViewControllerInteractor, settingsStore: SettingsStore) {
         self.interactor = interactor
 
         tunnelState = interactor.tunnelStatus.state
@@ -70,7 +70,7 @@ class TunnelViewController: UIViewController, RootContainment {
             tunnelStatus: interactor.tunnelStatus,
             relayConstraints: interactor.tunnelSettings.relayConstraints,
             relayCache: RelayCache(cacheDirectory: ApplicationConfiguration.containerURL),
-            customListRepository: CustomListRepository()
+            customListRepository: CustomListRepository(settingsStore: settingsStore)
         )
         indicatorsViewViewModel = FeatureIndicatorsViewModel(
             tunnelSettings: interactor.tunnelSettings,

--- a/ios/MullvadVPNTests/MullvadSettings/APIAccessMethodsTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/APIAccessMethodsTests.swift
@@ -13,25 +13,17 @@ import XCTest
 @testable import MullvadTypes
 
 final class APIAccessMethodsTests: XCTestCase {
-    static let store = InMemorySettingsStore<SettingNotFound>()
-
-    override static func setUp() {
-        SettingsManager.unitTestStore = store
-    }
-
-    override static func tearDown() {
-        store.reset()
-    }
+    let store = InMemorySettingsStore<SettingNotFound>()
 
     override func tearDownWithError() throws {
-        let repository = AccessMethodRepository(shadowsocksCiphers: [])
+        let repository = AccessMethodRepository(shadowsocksCiphers: [], settingsStore: store)
         repository.fetchAll().forEach {
             repository.delete(id: $0.id)
         }
     }
 
     func testDefaultAccessMethodsExist() throws {
-        let repository = AccessMethodRepository(shadowsocksCiphers: [])
+        let repository = AccessMethodRepository(shadowsocksCiphers: [], settingsStore: store)
         let storedMethods = repository.fetchAll()
 
         let hasDirectMethod = storedMethods.contains { method in
@@ -51,7 +43,7 @@ final class APIAccessMethodsTests: XCTestCase {
     }
 
     func testAddingSocks5AccessMethod() throws {
-        let repository = AccessMethodRepository(shadowsocksCiphers: [])
+        let repository = AccessMethodRepository(shadowsocksCiphers: [], settingsStore: store)
 
         let uuid = UUID()
         let methodToStore = socks5AccessMethod(with: uuid)
@@ -63,7 +55,7 @@ final class APIAccessMethodsTests: XCTestCase {
     }
 
     func testAddingShadowSocksAccessMethod() throws {
-        let repository = AccessMethodRepository(shadowsocksCiphers: [])
+        let repository = AccessMethodRepository(shadowsocksCiphers: [], settingsStore: store)
 
         let uuid = UUID()
         let methodToStore = shadowsocksAccessMethod(with: uuid)
@@ -75,7 +67,7 @@ final class APIAccessMethodsTests: XCTestCase {
     }
 
     func testAddingDuplicateAccessMethodDoesNothing() throws {
-        let repository = AccessMethodRepository(shadowsocksCiphers: [])
+        let repository = AccessMethodRepository(shadowsocksCiphers: [], settingsStore: store)
 
         let methodToStore = socks5AccessMethod(with: UUID())
 
@@ -89,7 +81,7 @@ final class APIAccessMethodsTests: XCTestCase {
     }
 
     func testUpdatingAccessMethod() throws {
-        let repository = AccessMethodRepository(shadowsocksCiphers: [])
+        let repository = AccessMethodRepository(shadowsocksCiphers: [], settingsStore: store)
 
         let uuid = UUID()
         var methodToStore = socks5AccessMethod(with: uuid)
@@ -106,7 +98,7 @@ final class APIAccessMethodsTests: XCTestCase {
     }
 
     func testDeletingAccessMethod() throws {
-        let repository = AccessMethodRepository(shadowsocksCiphers: [])
+        let repository = AccessMethodRepository(shadowsocksCiphers: [], settingsStore: store)
         let uuid = UUID()
         let methodToStore = socks5AccessMethod(with: uuid)
 

--- a/ios/MullvadVPNTests/MullvadSettings/IPOverrideRepositoryTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/IPOverrideRepositoryTests.swift
@@ -12,16 +12,8 @@ import XCTest
 @testable import MullvadSettings
 
 final class IPOverrideRepositoryTests: XCTestCase {
-    static let store = InMemorySettingsStore<SettingNotFound>()
-    let repository = IPOverrideRepository()
-
-    override static func setUp() {
-        SettingsManager.unitTestStore = store
-    }
-
-    override static func tearDown() {
-        store.reset()
-    }
+    let store = InMemorySettingsStore<SettingNotFound>()
+    lazy var repository = IPOverrideRepository(settingsStore: store)
 
     override func tearDownWithError() throws {
         repository.deleteAll()

--- a/ios/MullvadVPNTests/MullvadSettings/IPOverrideTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/IPOverrideTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import MullvadSettings
 
 final class IPOverrideTests: XCTestCase {
-    let repository = IPOverrideRepository()
+    let repository = IPOverrideRepository(settingsStore: InMemorySettingsStore<SettingNotFound>())
 
     func testCanParseOverrides() throws {
         XCTAssertNoThrow(try parseData(from: overrides))

--- a/ios/MullvadVPNTests/MullvadSettings/MigrationManagerMultiProcessUpgradeTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/MigrationManagerMultiProcessUpgradeTests.swift
@@ -23,7 +23,7 @@ extension MigrationManagerTests {
         var settingsV1 = TunnelSettingsV1()
         settingsV1.relayConstraints = osakaRelayConstraints
 
-        try write(settings: settingsV1, version: SchemaVersion.v1.rawValue, in: Self.store)
+        try write(settings: settingsV1, version: SchemaVersion.v1.rawValue, in: store)
 
         let backgroundMigrationExpectation = expectation(description: "Migration from packet tunnel")
         let foregroundMigrationExpectation = expectation(description: "Migration from host")
@@ -31,7 +31,7 @@ extension MigrationManagerTests {
         nonisolated(unsafe) var migrationHappenedInHost = false
 
         packetTunnelProcess.async { [unowned self] in
-            manager.migrateSettings(store: MigrationManagerTests.store) { backgroundMigrationResult in
+            manager.migrateSettings(store: store) { backgroundMigrationResult in
                 if case .success = backgroundMigrationResult {
                     migrationHappenedInPacketTunnel = true
                 }
@@ -40,7 +40,7 @@ extension MigrationManagerTests {
         }
 
         hostProcess.async { [unowned self] in
-            manager.migrateSettings(store: MigrationManagerTests.store) { foregroundMigrationResult in
+            manager.migrateSettings(store: store) { foregroundMigrationResult in
                 if case .success = foregroundMigrationResult {
                     migrationHappenedInHost = true
                 }
@@ -53,7 +53,7 @@ extension MigrationManagerTests {
         // Migration happens either in one process, or the other.
         // This check guarantees it didn't happen in both simultaneously.
         XCTAssertNotEqual(migrationHappenedInPacketTunnel, migrationHappenedInHost)
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try SettingsManager(store: store).readSettings()
         XCTAssertEqual(osakaRelayConstraints, latestSettings.relayConstraints)
     }
 }

--- a/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadSettings/MigrationManagerTests.swift
@@ -14,23 +14,17 @@ import XCTest
 @testable import MullvadTypes
 
 final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
-    static let store = InMemorySettingsStore<SettingNotFound>()
+    let store = InMemorySettingsStore<SettingNotFound>()
+    lazy var settingsManager = SettingsManager(store: store)
 
     var manager: MigrationManager!
     var testFileURL: URL!
-    override static func setUp() {
-        SettingsManager.unitTestStore = store
-    }
-
-    override static func tearDown() {
-        store.reset()
-    }
 
     override func setUpWithError() throws {
         testFileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MigrationManagerTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: testFileURL, withIntermediateDirectories: true)
-        manager = MigrationManager(cacheDirectory: testFileURL)
+        manager = MigrationManager(cacheDirectory: testFileURL, settingsManager: settingsManager)
     }
 
     override func tearDownWithError() throws {
@@ -38,9 +32,8 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
     }
 
     func testNothingToMigrate() throws {
-        let store = Self.store
         let settings = LatestTunnelSettings()
-        try SettingsManager.writeSettings(settings)
+        try settingsManager.writeSettings(settings)
 
         let nothingToMigrateExpectation = expectation(description: "No migration")
         manager.migrateSettings(store: store) { result in
@@ -53,7 +46,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
     func testNothingToMigrateWhenSettingsAreNotFound() throws {
         let store = InMemorySettingsStore<KeychainError>()
-        SettingsManager.unitTestStore = store
+        settingsManager = SettingsManager(store: store)
 
         let nothingToMigrateExpectation = expectation(description: "No migration")
         manager.migrateSettings(store: store) { result in
@@ -62,14 +55,9 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
             }
         }
         wait(for: [nothingToMigrateExpectation], timeout: .UnitTest.timeout)
-
-        // Reset the `SettingsManager` unit test store to avoid affecting other tests
-        // since it's a globally shared instance
-        SettingsManager.unitTestStore = Self.store
     }
 
     func testFailedMigration() throws {
-        let store = Self.store
         let failedMigrationExpectation = expectation(description: "Failed migration")
         manager.migrateSettings(store: store) { result in
             if case .failure = result {
@@ -80,7 +68,6 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
     }
 
     func testFailedMigrationResetsSettings() throws {
-        let store = Self.store
         let data = Data("Migration test".utf8)
         try store.write(data, for: .settings)
         try store.write(data, for: .deviceState)
@@ -88,7 +75,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
         // Failed migration should reset settings and device state keys
         manager.migrateSettings(store: store) { _ in }
 
-        let assertDeletionFor: (SettingsKey) throws -> Void = { key in
+        let assertDeletionFor: (SettingsKey) throws -> Void = { [store] key in
             try XCTAssertThrowsError(store.read(key: key)) { thrownError in
                 XCTAssertTrue(thrownError is SettingNotFound)
             }
@@ -99,13 +86,12 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
     }
 
     func testFailedMigrationIfRecordedSettingsVersionHigherThanLatestSettings() throws {
-        let store = Self.store
         let settings = FutureVersionSettings()
-        try write(settings: settings, version: Int.max - 1, in: store)
+        try write(settings: settings, version: Int.max - 1, in: settingsManager.store)
 
         manager.migrateSettings(store: store) { _ in }
 
-        let assertDeletionFor: (SettingsKey) throws -> Void = { key in
+        let assertDeletionFor: (SettingsKey) throws -> Void = { [store] key in
             try XCTAssertThrowsError(store.read(key: key)) { thrownError in
                 XCTAssertTrue(thrownError is SettingNotFound)
             }
@@ -116,9 +102,8 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
     }
 
     func testFailedMigrationCorruptedSchemaResetsSettings() throws {
-        let store = Self.store
         let settings = FutureVersionSettings()
-        try write(settings: settings, version: -42, in: store)
+        try write(settings: settings, version: -42, in: settingsManager.store)
 
         let failedMigrationExpectation = expectation(description: "Failed migration")
         manager.migrateSettings(store: store) { result in
@@ -148,7 +133,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
         // Once the migration is done, settings should have been updated to the latest available version
         // Verify that the old settings are still valid
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try settingsManager.readSettings()
         XCTAssertEqual(settingsV7.relayConstraints, latestSettings.relayConstraints)
         XCTAssertEqual(settingsV7.tunnelQuantumResistance, latestSettings.tunnelQuantumResistance)
         XCTAssertEqual(settingsV7.wireGuardObfuscation, latestSettings.wireGuardObfuscation)
@@ -175,7 +160,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
         // Once the migration is done, settings should have been updated to the latest available version
         // Verify that the old settings are still valid
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try settingsManager.readSettings()
         XCTAssertEqual(settingsV6.relayConstraints, latestSettings.relayConstraints)
         XCTAssertEqual(settingsV6.tunnelQuantumResistance, latestSettings.tunnelQuantumResistance)
         XCTAssertEqual(settingsV6.wireGuardObfuscation, latestSettings.wireGuardObfuscation)
@@ -201,7 +186,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
         // Once the migration is done, settings should have been updated to the latest available version
         // Verify that the old settings are still valid
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try settingsManager.readSettings()
         XCTAssertEqual(settingsV5.relayConstraints, latestSettings.relayConstraints)
         XCTAssertEqual(settingsV5.tunnelQuantumResistance, latestSettings.tunnelQuantumResistance)
         XCTAssertEqual(settingsV5.wireGuardObfuscation, latestSettings.wireGuardObfuscation)
@@ -225,7 +210,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
         // Once the migration is done, settings should have been updated to the latest available version
         // Verify that the old settings are still valid
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try settingsManager.readSettings()
         XCTAssertEqual(settingsV4.relayConstraints, latestSettings.relayConstraints)
         XCTAssertEqual(settingsV4.tunnelQuantumResistance, latestSettings.tunnelQuantumResistance)
         XCTAssertEqual(settingsV4.wireGuardObfuscation, latestSettings.wireGuardObfuscation)
@@ -248,7 +233,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
         // Once the migration is done, settings should have been updated to the latest available version
         // Verify that the old settings are still valid
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try settingsManager.readSettings()
         XCTAssertEqual(settingsV3.relayConstraints, latestSettings.relayConstraints)
         XCTAssertEqual(settingsV3.wireGuardObfuscation, latestSettings.wireGuardObfuscation)
     }
@@ -263,7 +248,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
         try migrateToLatest(settingsV2, version: .v2)
 
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try settingsManager.readSettings()
         XCTAssertEqual(osakaRelayConstraints, latestSettings.relayConstraints)
     }
 
@@ -279,7 +264,7 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
 
         // Once the migration is done, settings should have been updated to the latest available version
         // Verify that the old settings are still valid
-        let latestSettings = try SettingsManager.readSettings()
+        let latestSettings = try settingsManager.readSettings()
         XCTAssertEqual(osakaRelayConstraints, latestSettings.relayConstraints)
     }
 
@@ -367,7 +352,6 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
             }
             """.utf8)
 
-        let store = Self.store
         let parser = SettingsParser(decoder: JSONDecoder(), encoder: JSONEncoder())
         let tunnelSettingsV4 = try parser.parsePayload(as: TunnelSettingsV4.self, from: oldSettingsJSON)
         try write(settings: tunnelSettingsV4, version: 4, in: store)
@@ -380,15 +364,14 @@ final class MigrationManagerTests: XCTestCase, @unchecked Sendable {
         }
         wait(for: [successfulMigrationExpectation], timeout: .UnitTest.timeout)
 
-        let latestSettingsData = try XCTUnwrap(store.read(key: .settings))
+        let latestSettingsData = try XCTUnwrap(settingsManager.store.read(key: .settings))
         let latestSettings = try parser.parsePayload(as: LatestTunnelSettings.self, from: latestSettingsData)
 
         XCTAssertEqual(latestSettings.tunnelQuantumResistance, .on)
     }
 
     private func migrateToLatest(_ settings: any TunnelSettings, version: SchemaVersion) throws {
-        let store = Self.store
-        try write(settings: settings, version: version.rawValue, in: store)
+        try write(settings: settings, version: version.rawValue, in: settingsManager.store)
 
         let successfulMigrationExpectation = expectation(description: "Successful migration")
         manager.migrateSettings(store: store) { result in

--- a/ios/MullvadVPNTests/MullvadVPN/Interactors/CustomListInteractorTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Interactors/CustomListInteractorTests.swift
@@ -7,11 +7,7 @@ import Testing
 @testable import MullvadTypes
 
 struct CustomListInteractorTests {
-    static let store = InMemorySettingsStore<SettingNotFound>()
-
-    init() {
-        SettingsManager.unitTestStore = CustomListInteractorTests.store
-    }
+    let store = InMemorySettingsStore<SettingNotFound>()
 
     private func makeDependencies() -> (
         customListInteractor: CustomListInteractor,

--- a/ios/MullvadVPNTests/MullvadVPN/Notifications/NotificationProviders/AccountExpiryTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/Notifications/NotificationProviders/AccountExpiryTests.swift
@@ -18,22 +18,28 @@ class AccountExpiryTests: XCTestCase {
     }
 
     func testDateNowDuration() {
-        let accountExpiry = AccountExpiry(expiryDate: Date())
-        XCTAssertNil(accountExpiry.nextTriggerDate(for: .system))
-        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .inApp))  // In-app expiry triggers on same date as well.
+        let expiryDate = Date()
+        let accountExpiry = AccountExpiry(expiryDate: expiryDate)
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .system, after: expiryDate))
+        // In-app expiry triggers on same date as well.
+        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .inApp, after: expiryDate))
     }
 
     func testDateInPastDuration() {
-        let accountExpiry = AccountExpiry(expiryDate: Date().addingTimeInterval(-10))
-        XCTAssertNil(accountExpiry.nextTriggerDate(for: .system))
-        XCTAssertNil(accountExpiry.nextTriggerDate(for: .inApp))
+        let referenceDate = Date()
+
+        let expiryDate = referenceDate.addingTimeInterval(-10)
+        let accountExpiry = AccountExpiry(expiryDate: expiryDate)
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .system, after: referenceDate))
+        XCTAssertNil(accountExpiry.nextTriggerDate(for: .inApp, after: referenceDate))
     }
 
     func testDateInFutureDuration() {
-        let accountExpiry = AccountExpiry(expiryDate: calendar.date(byAdding: .day, value: 1, to: Date()))
+        let referenceDate = Date()
+        let accountExpiry = AccountExpiry(expiryDate: calendar.date(byAdding: .day, value: 1, to: referenceDate))
 
-        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .system))
-        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .inApp))
+        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .system, after: referenceDate))
+        XCTAssertNotNil(accountExpiry.nextTriggerDate(for: .inApp, after: referenceDate))
     }
 
     func testNumberOfTriggerDates() {

--- a/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/TunnelManager/TunnelManagerTests.swift
@@ -15,7 +15,8 @@ import XCTest
 @testable import MullvadTypes
 
 class TunnelManagerTests: XCTestCase {
-    static let store = InMemorySettingsStore<SettingNotFound>()
+    let store = InMemorySettingsStore<SettingNotFound>()
+    lazy var settingsManager = SettingsManager(store: store)
 
     private let application: TunnelStore.BackgroundTaskProvidingObject = UIApplicationStub()
     private var tunnelObserver: TunnelObserver!
@@ -27,14 +28,6 @@ class TunnelManagerTests: XCTestCase {
     )
     var apiProxy = APIProxyStub()
     var apiContext: MullvadApiContext!
-
-    override static func setUp() {
-        SettingsManager.unitTestStore = store
-    }
-
-    override static func tearDown() {
-        store.reset()
-    }
 
     override func setUp() async throws {
         let shadowsocksLoader = ShadowsocksLoader(
@@ -57,7 +50,7 @@ class TunnelManagerTests: XCTestCase {
             accessMethodChangeListeners: []
         )
 
-        try SettingsManager.writeSettings(LatestTunnelSettings())
+        try settingsManager.writeSettings(LatestTunnelSettings())
     }
 
     override func tearDown() async throws {
@@ -74,7 +67,8 @@ class TunnelManagerTests: XCTestCase {
             accountsProxy: accountProxy,
             devicesProxy: devicesProxy,
             apiProxy: apiProxy,
-            relaySelector: RelaySelectorStub.nonFallible()
+            relaySelector: RelaySelectorStub.nonFallible(),
+            settingsManager: settingsManager
         )
 
         _ = try await tunnelManager.setNewAccount()
@@ -91,7 +85,8 @@ class TunnelManagerTests: XCTestCase {
             accountsProxy: accountProxy,
             devicesProxy: devicesProxy,
             apiProxy: apiProxy,
-            relaySelector: RelaySelectorStub.nonFallible()
+            relaySelector: RelaySelectorStub.nonFallible(),
+            settingsManager: settingsManager
         )
         _ = try await tunnelManager.setNewAccount()
         await tunnelManager.unsetAccount()
@@ -119,7 +114,8 @@ class TunnelManagerTests: XCTestCase {
             accountsProxy: accountProxy,
             devicesProxy: devicesProxy,
             apiProxy: apiProxy,
-            relaySelector: relaySelector
+            relaySelector: relaySelector,
+            settingsManager: settingsManager
         )
 
         let simulatorTunnelProviderHost = SimulatorTunnelProviderHost(
@@ -129,7 +125,8 @@ class TunnelManagerTests: XCTestCase {
                     apiContext: apiContext,
                     encoder: REST.Coding.makeJSONEncoder()
                 )
-            )
+            ),
+            settingsManager: settingsManager
         )
         SimulatorTunnelProvider.shared.delegate = simulatorTunnelProviderHost
 
@@ -190,7 +187,8 @@ class TunnelManagerTests: XCTestCase {
             accountsProxy: accountProxy,
             devicesProxy: devicesProxy,
             apiProxy: apiProxy,
-            relaySelector: relaySelector
+            relaySelector: relaySelector,
+            settingsManager: settingsManager
         )
 
         let simulatorTunnelProviderHost = SimulatorTunnelProviderHost(
@@ -200,7 +198,8 @@ class TunnelManagerTests: XCTestCase {
                     apiContext: apiContext,
                     encoder: REST.Coding.makeJSONEncoder()
                 )
-            )
+            ),
+            settingsManager: settingsManager
         )
 
         SimulatorTunnelProvider.shared.delegate = simulatorTunnelProviderHost
@@ -265,7 +264,8 @@ class TunnelManagerTests: XCTestCase {
             accountsProxy: accountProxy,
             devicesProxy: devicesProxy,
             apiProxy: apiProxy,
-            relaySelector: relaySelector
+            relaySelector: relaySelector,
+            settingsManager: settingsManager
         )
 
         let simulatorTunnelProviderHost = SimulatorTunnelProviderHost(
@@ -275,7 +275,8 @@ class TunnelManagerTests: XCTestCase {
                     apiContext: apiContext,
                     encoder: REST.Coding.makeJSONEncoder()
                 )
-            )
+            ),
+            settingsManager: settingsManager
         )
         SimulatorTunnelProvider.shared.delegate = simulatorTunnelProviderHost
         let tunnelObserver = TunnelBlockObserver(

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/CustomListRepositoryTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/CustomListRepositoryTests.swift
@@ -12,16 +12,8 @@ import XCTest
 @testable import MullvadSettings
 
 class CustomListRepositoryTests: XCTestCase {
-    nonisolated(unsafe) static let store = InMemorySettingsStore<SettingNotFound>()
-    private var repository = CustomListRepository()
-
-    override class func setUp() {
-        SettingsManager.unitTestStore = store
-    }
-
-    override class func tearDown() {
-        store.reset()
-    }
+    private let store = InMemorySettingsStore<SettingNotFound>()
+    private lazy var repository = CustomListRepository(settingsStore: store)
 
     override func tearDownWithError() throws {
         repository.fetchAll().forEach {

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/RecentConnectionsRepositoryTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/SelectLocation/RecentConnectionsRepositoryTests.swift
@@ -192,6 +192,6 @@ final class RecentConnectionsRepositoryTests {
     }
 
     private func makeRepository(max: UInt = 50) -> RecentConnectionsRepository {
-        return RecentConnectionsRepository(store: InMemorySettingsStore<SettingNotFound>(), maxLimit: max)
+        return RecentConnectionsRepository(settingsStore: InMemorySettingsStore<SettingNotFound>(), maxLimit: max)
     }
 }

--- a/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/DestinationDescriberTests.swift
+++ b/ios/MullvadVPNTests/MullvadVPN/View controllers/Tunnel/DestinationDescriberTests.swift
@@ -15,18 +15,15 @@ import XCTest
 @testable import MullvadSettings
 
 final class DestinationDescriberTests: XCTestCase {
-    static let store = InMemorySettingsStore<SettingNotFound>()
-    override static func setUp() {
-        SettingsManager.unitTestStore = store
-    }
+    let store = InMemorySettingsStore<SettingNotFound>()
 
-    override static func tearDown() {
+    override func tearDown() {
         store.reset()
     }
 
     func testDescribeList() throws {
         let relayCache = MockRelayCache()
-        let customListRepository = CustomListRepository()
+        let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
             relayCache: relayCache,
             customListRepository: customListRepository
@@ -50,7 +47,7 @@ final class DestinationDescriberTests: XCTestCase {
 
     func testDescribeSubsetOfList() throws {
         let relayCache = MockRelayCache()
-        let customListRepository = CustomListRepository()
+        let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
             relayCache: relayCache,
             customListRepository: customListRepository
@@ -74,7 +71,7 @@ final class DestinationDescriberTests: XCTestCase {
 
     func testDescribeCountryDestination() {
         let relayCache = MockRelayCache()
-        let customListRepository = CustomListRepository()
+        let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
             relayCache: relayCache,
             customListRepository: customListRepository
@@ -84,7 +81,7 @@ final class DestinationDescriberTests: XCTestCase {
 
     func testDescribeCityDestination() {
         let relayCache = MockRelayCache()
-        let customListRepository = CustomListRepository()
+        let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
             relayCache: relayCache,
             customListRepository: customListRepository
@@ -94,7 +91,7 @@ final class DestinationDescriberTests: XCTestCase {
 
     func testDescribeRelayDestination() {
         let relayCache = MockRelayCache()
-        let customListRepository = CustomListRepository()
+        let customListRepository = CustomListRepository(settingsStore: store)
         let describer = DestinationDescriber(
             relayCache: relayCache,
             customListRepository: customListRepository

--- a/ios/PacketTunnel/DeviceCheck/DeviceStateAccessor.swift
+++ b/ios/PacketTunnel/DeviceCheck/DeviceStateAccessor.swift
@@ -12,11 +12,13 @@ import MullvadTypes
 
 /// An object that provides access to `DeviceState` used by `DeviceCheckOperation`.
 struct DeviceStateAccessor: DeviceStateAccessorProtocol {
+    let settingsManager: SettingsManager
+
     func read() throws -> DeviceState {
-        try SettingsManager.readDeviceState()
+        try settingsManager.readDeviceState()
     }
 
     func write(_ deviceState: DeviceState) throws {
-        try SettingsManager.writeDeviceState(deviceState)
+        try settingsManager.writeDeviceState(deviceState)
     }
 }

--- a/ios/PacketTunnel/PacketTunnelProvider/DeviceChecker.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/DeviceChecker.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import MullvadREST
+import MullvadSettings
 import MullvadTypes
 import Operations
 import PacketTunnelCore
@@ -18,10 +19,12 @@ final class DeviceChecker {
 
     private let accountsProxy: RESTAccountHandling
     private let devicesProxy: DeviceHandling
+    private let settingsManager: SettingsManager
 
-    init(accountsProxy: RESTAccountHandling, devicesProxy: DeviceHandling) {
+    init(accountsProxy: RESTAccountHandling, devicesProxy: DeviceHandling, settingsManager: SettingsManager) {
         self.accountsProxy = accountsProxy
         self.devicesProxy = devicesProxy
+        self.settingsManager = settingsManager
     }
 
     /**
@@ -39,7 +42,7 @@ final class DeviceChecker {
         let checkOperation = DeviceCheckOperation(
             dispatchQueue: dispatchQueue,
             remoteSevice: DeviceCheckRemoteService(accountsProxy: accountsProxy, devicesProxy: devicesProxy),
-            deviceStateAccessor: DeviceStateAccessor(),
+            deviceStateAccessor: DeviceStateAccessor(settingsManager: settingsManager),
             rotateImmediatelyOnKeyMismatch: rotateKeyOnMismatch
         )
 

--- a/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/PacketTunnelProvider.swift
@@ -34,8 +34,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
     var accessMethodReceiver: MullvadAccessMethodReceiver!
     private var shadowsocksCacheCleaner: ShadowsocksCacheCleaner!
 
+    private let settingsManager = SettingsManager()
+    private var settingsStore: SettingsStore {
+        settingsManager.store
+    }
+
     override init() {
         Self.configureLogging()
+
         providerLogger = Logger(label: "PacketTunnelProvider")
         providerLogger.info("Starting new packet tunnel")
 
@@ -43,23 +49,26 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
 
         let ipOverrideWrapper = IPOverrideWrapper(
             relayCache: RelayCache(cacheDirectory: containerURL),
-            ipOverrideRepository: IPOverrideRepository()
+            ipOverrideRepository: IPOverrideRepository(settingsStore: settingsManager.store)
         )
+
         tunnelSettingsUpdater = SettingsUpdater(listener: tunnelSettingsListener)
-        migrationManager = MigrationManager(cacheDirectory: containerURL)
+        migrationManager = MigrationManager(cacheDirectory: containerURL, settingsManager: settingsManager)
 
         super.init()
 
         performSettingsMigration()
 
-        let settingsReader = TunnelSettingsManager(settingsReader: SettingsReader()) { [weak self] settings in
+        let settingsReader = TunnelSettingsManager(settingsReader: SettingsReader(settingsManager: settingsManager)) {
+            [weak self] settings in
             guard let self = self else { return }
             tunnelSettingsListener.onNewSettings?(settings.tunnelSettings)
         }
 
         let tunnelSettings = (try? settingsReader.read().tunnelSettings) ?? LatestTunnelSettings()
         let accessMethodRepository = AccessMethodRepository(
-            shadowsocksCiphers: ShadowsocksCipherService().getCiphers()
+            shadowsocksCiphers: ShadowsocksCipherService().getCiphers(),
+            settingsStore: settingsStore
         )
 
         setUpApiContextAndAccessMethodReceiver(
@@ -86,7 +95,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         let accountsProxy = proxyFactory.createAccountsProxy()
         let devicesProxy = proxyFactory.createDevicesProxy()
 
-        deviceChecker = DeviceChecker(accountsProxy: accountsProxy, devicesProxy: devicesProxy)
+        deviceChecker = DeviceChecker(
+            accountsProxy: accountsProxy,
+            devicesProxy: devicesProxy,
+            settingsManager: settingsManager
+        )
 
         #if DEBUG
             if PacketTunnelDebugSettings.useGotaTun {
@@ -177,7 +190,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, @unchecked Sendable {
         nonisolated(unsafe) var hasNotMigrated = true
         repeat {
             migrationManager.migrateSettings(
-                store: SettingsManager.store,
+                store: settingsManager.store,
                 migrationCompleted: { [unowned self] migrationResult in
                     switch migrationResult {
                     case .success:

--- a/ios/PacketTunnel/PacketTunnelProvider/SettingsReader.swift
+++ b/ios/PacketTunnel/PacketTunnelProvider/SettingsReader.swift
@@ -11,9 +11,13 @@ import MullvadSettings
 import PacketTunnelCore
 
 struct SettingsReader: SettingsReaderProtocol {
+    private let settingsManager: SettingsManager
+    init(settingsManager: SettingsManager) {
+        self.settingsManager = settingsManager
+    }
     func read() throws -> Settings {
-        let settings = try SettingsManager.readSettings()
-        let deviceState = try SettingsManager.readDeviceState()
+        let settings = try settingsManager.readSettings()
+        let deviceState = try settingsManager.readDeviceState()
         let deviceData = try deviceState.getDeviceData()
 
         return Settings(

--- a/ios/Shared/AppResetManager.swift
+++ b/ios/Shared/AppResetManager.swift
@@ -15,6 +15,7 @@ import UIKit
 final class AppResetManager {
     private let launchArguments: LaunchArguments
     private let tunnelManager: TunnelManager
+    private let settingsManager: SettingsManager
     private var tunnelObserver: TunnelObserver!
     let logger = Logger(label: "AppResetManager")
 
@@ -22,10 +23,13 @@ final class AppResetManager {
 
     init(
         launchArguments: LaunchArguments,
-        tunnelManager: TunnelManager
+        tunnelManager: TunnelManager,
+        settingsManager: SettingsManager
     ) {
         self.launchArguments = launchArguments
         self.tunnelManager = tunnelManager
+        self.settingsManager = settingsManager
+
         guard launchArguments.target.isUITest else { return }
         addObserver()
         Task {
@@ -82,7 +86,7 @@ final class AppResetManager {
 
     private func resetKeychain() {
         let policy = launchArguments.settingsResetPolicy
-        SettingsManager.resetStore(policy: policy.toSettingsResetPolicy)
+        settingsManager.resetStore(policy: policy.toSettingsResetPolicy)
         if policy.shouldReset(.settings) {
             tunnelManager.updateSettings([.reset])
         }


### PR DESCRIPTION
- Change SettingsManager to no longer be a singleton

    The singleton-choice hid when a method depends on the SettingsManager and resulted in having to switch out the static variable when under test. This limited our testing ability, after which we decided to investigate whether changing it to non-singleton would be possible.
    
    This change should be safe to do since the underlying data store, the iOS Keychain, is supposed to be [thread-safe][0].

[0]: https://archive.is/YdVHX

- Pass a referenceDate to determine expiry

    Even though the unit tests are pretty quick, there is a time difference between the following two `Date` initialisations in the code, resulting in a rare but legitimate failure:

    ```swift
    AccountExpiry(
      expiryDate: calendar.date(
      	byAdding: .day,
      	   value: interval,
    	      to: Date()
            )
    )
    ```
    
    and the comparison happening inside the `daysRemaining(for:)` method:
    
    ```swift
    func daysRemaining(for trigger: Trigger) -> DateComponents? {
        let nextTriggerDate = nextTriggerDate(for: trigger, after: Date())
        guard let expiryDate, let nextTriggerDate else { return nil }
    
        let dateComponents = calendar.dateComponents(
            [.day],
            from: referenceDate.secondsPrecision,
            to: max(nextTriggerDate, expiryDate).secondsPrecision
        )
    
        return dateComponents
    }
    ```
    
    Passing the date we're comparing to makes the dependency on `Date` explicit, and reduces the flakiness in the test suite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10360)
<!-- Reviewable:end -->
