### PR TITLE
Migrate test workspace `rustls` crypto provider to `aws-lc-rs` (and enforce `X25519MLKEM768`)

### DIFF
--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -157,6 +157,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +309,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -407,6 +431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,8 +473,10 @@ dependencies = [
  "clap",
  "ping",
  "reqwest",
+ "rustls",
  "serde",
  "socket2 0.5.10",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -687,6 +722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "duplicate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +902,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1670,6 +1717,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2869,6 +2926,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2894,6 +2952,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -47,6 +47,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "am-i-mullvad-client"
+version = "0.0.0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,14 +485,12 @@ dependencies = [
 name = "connection-checker"
 version = "0.0.0"
 dependencies = [
+ "am-i-mullvad-client",
  "anyhow",
  "clap",
  "ping",
- "reqwest",
- "rustls",
- "serde",
  "socket2 0.5.10",
- "webpki-roots",
+ "tokio",
 ]
 
 [[package]]
@@ -1293,7 +1307,6 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "log",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -2821,9 +2834,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3566,21 +3577,16 @@ dependencies = [
 name = "test-rpc"
 version = "0.0.0"
 dependencies = [
+ "am-i-mullvad-client",
  "bytes",
  "colored",
  "futures",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
  "log",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "tarpc",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
  "tokio-util",
 ]
 
@@ -3588,6 +3594,7 @@ dependencies = [
 name = "test-runner"
 version = "0.0.0"
 dependencies = [
+ "am-i-mullvad-client",
  "bytes",
  "chrono",
  "dirs",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -32,6 +32,7 @@ log = "0.4"
 nix = { version = "0.30.1", features = ["ioctl", "net", "signal", "socket"] }
 ping = "0.7.1"
 rand = "0.9.3"
+rustls = { version = "0.23", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 socket2 = "0.5.7"
@@ -51,6 +52,7 @@ tokio = { version = "1.44", features = [
 tokio-serial = "5.4.1"
 tonic = "0.13.1"
 tower = "0.5.1"
+webpki-roots = "1.0"
 windows-sys = "0.52.0"
 
 [workspace.lints.clippy]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "am-i-mullvad-client",
   "connection-checker",
   "socks-server",
   "test-manager",
@@ -23,8 +24,10 @@ colored = "2.0.0"
 dirs = "6.0.0"
 env_logger = "0.11.7"
 futures = "0.3"
-hyper-util = { version = "0.1.8", features = [
-  "client",
+http-body-util = "0.1.2"
+hyper = { version = "1.4.1", default-features = false }
+hyper-rustls = { version = "0.27.3", default-features = false }
+hyper-util = { version = "0.1.8", default-features = false, features = [
   "client-legacy",
   "http2",
 ] }
@@ -40,19 +43,10 @@ surge-ping = "0.8"
 tarpc = { version = "0.31", features = ["serde-transport", "serde1", "tokio1"] }
 thiserror = "2.0"
 tipsy = "0.7.0"
-tokio = { version = "1.44", features = [
-  "fs",
-  "io-util",
-  "macros",
-  "process",
-  "rt",
-  "rt-multi-thread",
-  "time",
-] }
+tokio = { version = "1.44", default-features = false }
 tokio-serial = "5.4.1"
 tonic = "0.13.1"
 tower = "0.5.1"
-webpki-roots = "1.0"
 windows-sys = "0.52.0"
 
 [workspace.lints.clippy]

--- a/test/am-i-mullvad-client/Cargo.toml
+++ b/test/am-i-mullvad-client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "am-i-mullvad-client"
+edition.workspace = true
+rust-version.workspace = true
+description = "Async client for the am.i.mullvad.net geoip endpoint"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+bytes = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true }
+hyper-rustls = { workspace = true, features = ["aws-lc-rs", "http2"] }
+hyper-util = { workspace = true }
+rustls = { workspace = true, features = ["aws-lc-rs"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
+
+[lints]
+workspace = true

--- a/test/am-i-mullvad-client/src/lib.rs
+++ b/test/am-i-mullvad-client/src/lib.rs
@@ -1,0 +1,136 @@
+//! Minimal async client for the am.i.mullvad.net geoip endpoint.
+//!
+//! Pins the Let's Encrypt root certificate, enforces TLS 1.3 with X25519MLKEM768 only,
+//! and disables SNI.
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::{Request, Uri, header};
+use hyper_util::client::legacy::Client;
+use rustls::{
+    ClientConfig,
+    pki_types::{CertificateDer, pem::PemObject},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    net::IpAddr,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+const LE_ROOT_CERT: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pem");
+
+const USER_AGENT: &str = "mullvad-app-testing";
+
+/// Response body returned by the am.i.mullvad.net `/json` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AmIMullvadResponse {
+    /// Public IP the request was observed coming from.
+    pub ip: IpAddr,
+    /// `true` if `ip` is the exit IP of a Mullvad VPN relay.
+    pub mullvad_exit_ip: bool,
+    /// Hostname of the exit relay (e.g. `se-got-wg-001`) when `mullvad_exit_ip` is `true`,
+    /// `None` otherwise.
+    pub mullvad_exit_ip_hostname: Option<String>,
+}
+
+/// IP version selector for the am.i.mullvad.net endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpVersion {
+    V4,
+    V6,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// The supplied `mullvad_host` produced a URL that does not parse.
+    #[error("Invalid URL")]
+    InvalidUrl(#[from] hyper::http::uri::InvalidUri),
+    /// Connecting to the endpoint failed (TCP, TLS handshake, DNS, etc.).
+    #[error("HTTP connection failed")]
+    Connect(#[from] hyper_util::client::legacy::Error),
+    /// The server replied with a non-2xx status code.
+    #[error("Unexpected status code: {0}")]
+    UnexpectedStatus(u16),
+    /// Failed to read the response body off the wire after the headers were received.
+    #[error("Failed to read response body")]
+    ReadResponseBody(#[from] hyper::Error),
+    /// The response body did not parse as the expected JSON shape.
+    #[error("Failed to parse response body")]
+    ParseResponseBody(#[from] serde_json::Error),
+    /// The request did not complete within the supplied timeout.
+    #[error("Request timed out")]
+    Timeout,
+}
+
+/// Look up the current geoip status from `https://ipv4.am.i.{mullvad_host}/json`
+/// (or the `ipv6.` variant when `ip_version` is `IpVersion::V6`).
+///
+/// # Errors
+///
+/// See [`Error`] variant documentation for different failure reasons
+pub async fn geoip_lookup(
+    mullvad_host: &str,
+    ip_version: IpVersion,
+    timeout: Duration,
+) -> Result<AmIMullvadResponse, Error> {
+    let prefix = match ip_version {
+        IpVersion::V4 => "ipv4",
+        IpVersion::V6 => "ipv6",
+    };
+    let uri = Uri::try_from(format!("https://{prefix}.am.i.{mullvad_host}/json"))?;
+    tokio::time::timeout(timeout, http_get(uri))
+        .await
+        .map_err(|_| Error::Timeout)?
+}
+
+/// A lazily computed TLS client config with the settings we want
+/// for TLS connections to mullvad https endpoints in general.
+static CLIENT_CONFIG: LazyLock<ClientConfig> = LazyLock::new(|| {
+    let provider = rustls::crypto::CryptoProvider {
+        kx_groups: vec![rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768],
+        ..rustls::crypto::aws_lc_rs::default_provider()
+    };
+    let mut config = ClientConfig::builder_with_provider(Arc::new(provider))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .expect("aws-lc-rs crypto provider should support TLS 1.3")
+        .with_root_certificates(create_pinned_cert_store())
+        .with_no_client_auth();
+    // The server certificate covers the relevant am.i.mullvad.net hostnames; SNI is omitted
+    // so the destination subdomain is not visible in the ClientHello.
+    config.enable_sni = false;
+    config
+});
+
+async fn http_get(url: Uri) -> Result<AmIMullvadResponse, Error> {
+    let https = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config(CLIENT_CONFIG.clone())
+        .https_only()
+        .enable_http2()
+        .build();
+
+    let client: Client<_, Full<Bytes>> =
+        Client::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+    let request = Request::get(url)
+        .header(header::ACCEPT, "application/json")
+        .header(header::USER_AGENT, USER_AGENT)
+        .body(Full::default())
+        .expect("Static headers and a validated URI never fail to build");
+    let response = client.request(request).await?;
+    if !response.status().is_success() {
+        return Err(Error::UnexpectedStatus(response.status().as_u16()));
+    }
+    let bytes = response.into_body().collect().await?.to_bytes();
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+/// Creates and returns a certificate store with the single trusted bundled CA
+fn create_pinned_cert_store() -> rustls::RootCertStore {
+    let cert = CertificateDer::from_pem_slice(LE_ROOT_CERT)
+        .expect("Bundled LE root cert PEM is malformed");
+    let mut cert_store = rustls::RootCertStore::empty();
+    cert_store
+        .add(cert)
+        .expect("Bundled LE root cert is invalid");
+    cert_store
+}

--- a/test/connection-checker/Cargo.toml
+++ b/test/connection-checker/Cargo.toml
@@ -13,10 +13,12 @@ ping = { workspace = true }
 reqwest = { version = "0.12.23", default-features = false, features = [
   "blocking",
   "json",
-  "rustls-tls"
+  "rustls-tls-webpki-roots-no-provider",
 ] }
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 serde = { workspace = true, features = ["derive"] }
 socket2 = { workspace = true, features = ["all"] }
+webpki-roots = { workspace = true }
 
 [lints]
 workspace = true

--- a/test/connection-checker/Cargo.toml
+++ b/test/connection-checker/Cargo.toml
@@ -7,18 +7,12 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+am-i-mullvad-client = { path = "../am-i-mullvad-client" }
 anyhow = "1.0.99"
 clap = { workspace = true, features = ["derive"] }
 ping = { workspace = true }
-reqwest = { version = "0.12.23", default-features = false, features = [
-  "blocking",
-  "json",
-  "rustls-tls-webpki-roots-no-provider",
-] }
-rustls = { workspace = true, features = ["aws-lc-rs"] }
-serde = { workspace = true, features = ["derive"] }
 socket2 = { workspace = true, features = ["all"] }
-webpki-roots = { workspace = true }
+tokio = { workspace = true, features = ["rt", "time"] }
 
 [lints]
 workspace = true

--- a/test/connection-checker/src/cli.rs
+++ b/test/connection-checker/src/cli.rs
@@ -38,7 +38,12 @@ pub struct Opt {
     #[clap(long, requires = "leak", default_value = "Hello there!")]
     pub payload: String,
 
-    /// URL to perform the connection check against. For example, https://am.i.mullvad.net/json.
+    /// Mullvad host to query, e.g. `mullvad.net`. The lookup hits
+    /// `https://ipv4.am.i.<host>/json` (or `ipv6.` if `--ipv6` is set).
     #[clap(long)]
-    pub url: String,
+    pub mullvad_host: String,
+
+    /// Use the IPv6 variant of the am.i.mullvad endpoint.
+    #[clap(long)]
+    pub ipv6: bool,
 }

--- a/test/connection-checker/src/main.rs
+++ b/test/connection-checker/src/main.rs
@@ -42,13 +42,15 @@ fn test_connection(opt: &Opt) {
 fn build_tls_config() -> rustls::ClientConfig {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    rustls::ClientConfig::builder_with_provider(Arc::new(
-        rustls::crypto::aws_lc_rs::default_provider(),
-    ))
-    .with_safe_default_protocol_versions()
-    .expect("aws-lc-rs should support default TLS versions")
-    .with_root_certificates(root_store)
-    .with_no_client_auth()
+    let provider = rustls::crypto::CryptoProvider {
+        kx_groups: vec![rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768],
+        ..rustls::crypto::aws_lc_rs::default_provider()
+    };
+    rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+        .with_safe_default_protocol_versions()
+        .expect("aws-lc-rs should support default TLS versions")
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
 }
 
 /// Check if connected to Mullvad and print the result to stdout

--- a/test/connection-checker/src/main.rs
+++ b/test/connection-checker/src/main.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context, anyhow};
 use clap::Parser;
-use reqwest::blocking::Client;
 use serde::Deserialize;
-use std::{io::stdin, time::Duration};
+use std::{io::stdin, sync::Arc, time::Duration};
 
 use connection_checker::{
     cli::Opt,
@@ -40,6 +39,18 @@ fn test_connection(opt: &Opt) {
     am_i_mullvad(opt);
 }
 
+fn build_tls_config() -> rustls::ClientConfig {
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("aws-lc-rs should support default TLS versions")
+    .with_root_certificates(root_store)
+    .with_no_client_auth()
+}
+
 /// Check if connected to Mullvad and print the result to stdout
 fn am_i_mullvad(opt: &Opt) {
     #[derive(Debug, Deserialize)]
@@ -50,7 +61,10 @@ fn am_i_mullvad(opt: &Opt) {
 
     let url = &opt.url;
 
-    let client = Client::new();
+    let client = reqwest::blocking::Client::builder()
+        .use_preconfigured_tls(build_tls_config())
+        .build()
+        .expect("Failed to build HTTP client");
     let result: Result<Response, _> = client
         .get(url)
         .timeout(Duration::from_secs(opt.timeout))

--- a/test/connection-checker/src/main.rs
+++ b/test/connection-checker/src/main.rs
@@ -1,7 +1,6 @@
-use anyhow::{Context, anyhow};
 use clap::Parser;
-use serde::Deserialize;
-use std::{io::stdin, sync::Arc, time::Duration};
+use std::{io::stdin, time::Duration};
+use tokio::runtime::Runtime;
 
 use connection_checker::{
     cli::Opt,
@@ -10,6 +9,10 @@ use connection_checker::{
 
 fn main() {
     let opt = Opt::parse();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build tokio runtime");
 
     if opt.interactive {
         let stdin = stdin();
@@ -17,14 +20,14 @@ fn main() {
             if line.is_err() {
                 break;
             };
-            test_connection(&opt);
+            test_connection(&opt, &runtime);
         }
     } else {
-        test_connection(&opt);
+        test_connection(&opt, &runtime);
     }
 }
 
-fn test_connection(opt: &Opt) {
+fn test_connection(opt: &Opt, runtime: &Runtime) {
     if let Some(destination) = opt.leak {
         if opt.leak_tcp {
             let _ = send_tcp(opt, destination);
@@ -36,43 +39,21 @@ fn test_connection(opt: &Opt) {
             let _ = send_ping(opt, destination.ip());
         }
     }
-    am_i_mullvad(opt);
-}
-
-fn build_tls_config() -> rustls::ClientConfig {
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let provider = rustls::crypto::CryptoProvider {
-        kx_groups: vec![rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768],
-        ..rustls::crypto::aws_lc_rs::default_provider()
-    };
-    rustls::ClientConfig::builder_with_provider(Arc::new(provider))
-        .with_safe_default_protocol_versions()
-        .expect("aws-lc-rs should support default TLS versions")
-        .with_root_certificates(root_store)
-        .with_no_client_auth()
+    am_i_mullvad(opt, runtime);
 }
 
 /// Check if connected to Mullvad and print the result to stdout
-fn am_i_mullvad(opt: &Opt) {
-    #[derive(Debug, Deserialize)]
-    struct Response {
-        ip: String,
-        mullvad_exit_ip_hostname: Option<String>,
-    }
-
-    let url = &opt.url;
-
-    let client = reqwest::blocking::Client::builder()
-        .use_preconfigured_tls(build_tls_config())
-        .build()
-        .expect("Failed to build HTTP client");
-    let result: Result<Response, _> = client
-        .get(url)
-        .timeout(Duration::from_secs(opt.timeout))
-        .send()
-        .and_then(|r| r.json())
-        .with_context(|| anyhow!("Failed to GET {url}"));
+fn am_i_mullvad(opt: &Opt, runtime: &Runtime) {
+    let ip_version = if opt.ipv6 {
+        am_i_mullvad_client::IpVersion::V6
+    } else {
+        am_i_mullvad_client::IpVersion::V4
+    };
+    let result = runtime.block_on(am_i_mullvad_client::geoip_lookup(
+        &opt.mullvad_host,
+        ip_version,
+        Duration::from_secs(opt.timeout),
+    ));
 
     match result {
         Ok(response) => {

--- a/test/socks-server/Cargo.toml
+++ b/test/socks-server/Cargo.toml
@@ -11,7 +11,7 @@ fast-socks5 = "0.9.5"
 futures = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
 
 [lints]
 workspace = true

--- a/test/test-manager/Cargo.toml
+++ b/test/test-manager/Cargo.toml
@@ -20,7 +20,7 @@ duplicate = { version = "2.0.0", default-features = false }
 env_logger = { workspace = true }
 futures = { workspace = true }
 glob = "0.3"
-hyper-util = { workspace = true }
+hyper-util = { workspace = true, features = ["tokio"] }
 inventory = "0.3"
 ipnetwork = "0.21.1"
 itertools = "0.10.5"
@@ -46,7 +46,16 @@ talpid-types = { path = "../../talpid-types" }
 test_macro = { path = "./test_macro" }
 test-rpc = { path = "../test-rpc" }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = [
+  "fs",
+  "io-util",
+  "macros",
+  "net",
+  "process",
+  "rt",
+  "rt-multi-thread",
+  "time"
+] }
 tokio-serial = { workspace = true }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 tonic = { workspace = true }

--- a/test/test-manager/src/tests/helpers.rs
+++ b/test/test-manager/src/tests/helpers.rs
@@ -36,7 +36,7 @@ use std::{
     time::{Duration, Instant},
 };
 use talpid_types::net::wireguard::{PeerConfig, PrivateKey, TunnelConfig};
-use test_rpc::{AmIMullvad, ServiceClient, SpawnOpts, meta::Os, package::Package};
+use test_rpc::{AmIMullvadResponse, ServiceClient, SpawnOpts, meta::Os, package::Package};
 use tokio::time::sleep;
 
 pub const THROTTLE_RETRY_DELAY: Duration = Duration::from_secs(120);
@@ -529,7 +529,7 @@ where
     Ok(test_context.rpc_provider.new_client().await)
 }
 
-pub async fn geoip_lookup_with_retries(rpc: &ServiceClient) -> Result<AmIMullvad, Error> {
+pub async fn geoip_lookup_with_retries(rpc: &ServiceClient) -> Result<AmIMullvadResponse, Error> {
     const MAX_ATTEMPTS: usize = 5;
     const BEFORE_RETRY_DELAY: Duration = Duration::from_secs(2);
 
@@ -1033,11 +1033,6 @@ impl ConnChecker {
         log::debug!("spawning connection checker");
 
         let opts = {
-            let ipvx = match self.leak_destination {
-                SocketAddr::V4(..) => "ipv4",
-                SocketAddr::V6(..) => "ipv6",
-            };
-
             let mut args = [
                 "--interactive",
                 "--timeout",
@@ -1050,11 +1045,15 @@ impl ConnChecker {
                 "--leak-tcp",
                 "--leak-udp",
                 "--leak-icmp",
-                "--url",
-                &format!("https://{ipvx}.am.i.{}/json", TEST_CONFIG.mullvad_host),
+                "--mullvad-host",
+                &TEST_CONFIG.mullvad_host,
             ]
             .map(String::from)
             .to_vec();
+
+            if matches!(self.leak_destination, SocketAddr::V6(..)) {
+                args.push("--ipv6".to_string());
+            }
 
             if let Some(payload) = &self.payload {
                 args.push("--payload".to_string());

--- a/test/test-rpc/Cargo.toml
+++ b/test/test-rpc/Cargo.toml
@@ -13,9 +13,9 @@ futures = { workspace = true }
 http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["client", "http2"] }
 hyper-rustls = { version = "0.27.3", default-features = false, features = [
+  "aws-lc-rs",
   "http1",
   "logging",
-  "ring",
   "webpki-roots"
 ] }
 hyper-util = { workspace = true }
@@ -27,8 +27,8 @@ tarpc = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { version = "0.26.0", default-features = false, features = [
+  "aws-lc-rs",
   "logging",
-  "ring",
 ] }
 
 [dependencies.tokio-util]

--- a/test/test-rpc/Cargo.toml
+++ b/test/test-rpc/Cargo.toml
@@ -7,29 +7,16 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+am-i-mullvad-client = { path = "../am-i-mullvad-client" }
 bytes = { workspace = true }
 colored = { workspace = true }
 futures = { workspace = true }
-http-body-util = "0.1.2"
-hyper = { version = "1.4.1", features = ["client", "http2"] }
-hyper-rustls = { version = "0.27.3", default-features = false, features = [
-  "aws-lc-rs",
-  "http1",
-  "logging",
-  "webpki-roots"
-] }
-hyper-util = { workspace = true }
 log = { workspace = true }
-rustls-pki-types = "1.13.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tarpc = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
-tokio-rustls = { version = "0.26.0", default-features = false, features = [
-  "aws-lc-rs",
-  "logging",
-] }
+tokio = { workspace = true, features = ["io-util", "rt", "sync", "time"] }
 
 [dependencies.tokio-util]
 version = "0.7"

--- a/test/test-rpc/src/client.rs
+++ b/test/test-rpc/src/client.rs
@@ -207,7 +207,7 @@ impl ServiceClient {
     }
 
     /// Fetch the current location.
-    pub async fn geoip_lookup(&self, mullvad_host: String) -> Result<AmIMullvad, Error> {
+    pub async fn geoip_lookup(&self, mullvad_host: String) -> Result<AmIMullvadResponse, Error> {
         self.client
             .geoip_lookup(tarpc::context::current(), mullvad_host)
             .await?

--- a/test/test-rpc/src/lib.rs
+++ b/test/test-rpc/src/lib.rs
@@ -84,13 +84,20 @@ impl Error {
     }
 }
 
-/// Response from am.i.mullvad.net
-#[derive(Debug, Serialize, Deserialize)]
-pub struct AmIMullvad {
-    pub ip: IpAddr,
-    pub mullvad_exit_ip: bool,
-    /// Will be `None` when not connected via mullvad relay
-    pub mullvad_exit_ip_hostname: Option<String>,
+pub use am_i_mullvad_client::AmIMullvadResponse;
+
+impl From<am_i_mullvad_client::Error> for Error {
+    fn from(err: am_i_mullvad_client::Error) -> Self {
+        use am_i_mullvad_client::Error as E;
+        match err {
+            E::InvalidUrl(_) => Error::InvalidUrl,
+            E::ParseResponseBody(_) => Error::DeserializeBody,
+            E::Timeout => Error::Timeout,
+            E::Connect(e) => Error::HttpRequest(e.to_string()),
+            E::ReadResponseBody(e) => Error::HttpRequest(e.to_string()),
+            E::UnexpectedStatus(code) => Error::HttpRequest(format!("Unexpected status: {code}")),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -195,7 +202,7 @@ mod service {
         ) -> Result<(), Error>;
 
         /// Fetch the current location.
-        async fn geoip_lookup(mullvad_host: String) -> Result<AmIMullvad, Error>;
+        async fn geoip_lookup(mullvad_host: String) -> Result<AmIMullvadResponse, Error>;
 
         /// Returns the IP of the given interface.
         async fn get_interface_ip(interface: String) -> Result<IpAddr, Error>;

--- a/test/test-rpc/src/net.rs
+++ b/test/test-rpc/src/net.rs
@@ -18,9 +18,9 @@ use tokio_rustls::rustls::{
 const LE_ROOT_CERT: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pem");
 
 static CLIENT_CONFIG: LazyLock<ClientConfig> = LazyLock::new(|| {
-    ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+    ClientConfig::builder_with_provider(Arc::new(rustls::crypto::aws_lc_rs::default_provider()))
         .with_protocol_versions(&[&rustls::version::TLS13])
-        .expect("ring crypto provider should support TLS 1.3")
+        .expect("aws-lc-rs crypto provider should support TLS 1.3")
         .with_root_certificates(read_cert_store().expect("Failed to parse pem file"))
         .with_no_client_auth()
 });

--- a/test/test-rpc/src/net.rs
+++ b/test/test-rpc/src/net.rs
@@ -18,7 +18,11 @@ use tokio_rustls::rustls::{
 const LE_ROOT_CERT: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pem");
 
 static CLIENT_CONFIG: LazyLock<ClientConfig> = LazyLock::new(|| {
-    ClientConfig::builder_with_provider(Arc::new(rustls::crypto::aws_lc_rs::default_provider()))
+    let provider = rustls::crypto::CryptoProvider {
+        kx_groups: vec![rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768],
+        ..rustls::crypto::aws_lc_rs::default_provider()
+    };
+    ClientConfig::builder_with_provider(Arc::new(provider))
         .with_protocol_versions(&[&rustls::version::TLS13])
         .expect("aws-lc-rs crypto provider should support TLS 1.3")
         .with_root_certificates(read_cert_store().expect("Failed to parse pem file"))

--- a/test/test-rpc/src/net.rs
+++ b/test/test-rpc/src/net.rs
@@ -1,33 +1,7 @@
-use crate::{AmIMullvad, Error};
-use bytes::Bytes;
+use crate::Error;
 use futures::channel::oneshot;
-use http_body_util::{BodyExt, Full};
-use hyper::Uri;
-use hyper_util::client::legacy::Client;
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::{
-    net::SocketAddr,
-    sync::{Arc, LazyLock},
-    time::Duration,
-};
-use tokio_rustls::rustls::{
-    self, ClientConfig,
-    pki_types::{CertificateDer, pem::PemObject},
-};
-
-const LE_ROOT_CERT: &[u8] = include_bytes!("../../../mullvad-api/le_root_cert.pem");
-
-static CLIENT_CONFIG: LazyLock<ClientConfig> = LazyLock::new(|| {
-    let provider = rustls::crypto::CryptoProvider {
-        kx_groups: vec![rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768],
-        ..rustls::crypto::aws_lc_rs::default_provider()
-    };
-    ClientConfig::builder_with_provider(Arc::new(provider))
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .expect("aws-lc-rs crypto provider should support TLS 1.3")
-        .with_root_certificates(read_cert_store().expect("Failed to parse pem file"))
-        .with_no_client_auth()
-});
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct SockHandleId(pub usize);
@@ -80,65 +54,4 @@ impl Drop for SockHandle {
     fn drop(&mut self) {
         self.stop()
     }
-}
-
-pub async fn geoip_lookup(mullvad_host: String, timeout: Duration) -> Result<AmIMullvad, Error> {
-    let uri = Uri::try_from(format!("https://ipv4.am.i.{mullvad_host}/json"))
-        .map_err(|_| Error::InvalidUrl)?;
-    http_get_with_timeout(uri, timeout).await
-}
-
-pub async fn http_get<T: DeserializeOwned>(url: Uri) -> Result<T, Error> {
-    log::debug!("GET {url}");
-
-    let https = hyper_rustls::HttpsConnectorBuilder::new()
-        .with_tls_config(CLIENT_CONFIG.clone())
-        .https_only()
-        .enable_http1()
-        .build();
-
-    let client: Client<_, Full<Bytes>> =
-        Client::builder(hyper_util::rt::TokioExecutor::new()).build(https);
-    let body = client
-        .get(url)
-        .await
-        .map_err(|error| Error::HttpRequest(error.to_string()))?
-        .into_body();
-
-    // TODO: limit length
-    let bytes = body
-        .collect()
-        .await
-        .map_err(|error| {
-            log::error!("Failed to collect response body: {}", error);
-            Error::DeserializeBody
-        })?
-        .to_bytes();
-
-    serde_json::from_slice(&bytes).map_err(|error| {
-        log::error!("Failed to deserialize response: {}", error);
-        Error::DeserializeBody
-    })
-}
-
-pub async fn http_get_with_timeout<T: DeserializeOwned>(
-    url: Uri,
-    timeout: Duration,
-) -> Result<T, Error> {
-    tokio::time::timeout(timeout, http_get(url))
-        .await
-        .map_err(|_| Error::HttpRequest("Request timed out".into()))?
-}
-
-fn read_cert_store() -> Result<rustls::RootCertStore, rustls_pki_types::pem::Error> {
-    let mut cert_store = rustls::RootCertStore::empty();
-
-    let certs = CertificateDer::pem_reader_iter(&mut std::io::BufReader::new(LE_ROOT_CERT))
-        .collect::<Result<Vec<_>, _>>()?;
-    let (num_certs_added, num_failures) = cert_store.add_parsable_certificates(certs);
-    if num_failures > 0 || num_certs_added != 1 {
-        panic!("Failed to add root cert");
-    }
-
-    Ok(cert_store)
 }

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+am-i-mullvad-client = { path = "../am-i-mullvad-client" }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 dirs = { workspace = true }
@@ -23,7 +24,16 @@ tarpc = { workspace = true }
 test-rpc = { path = "../test-rpc" }
 thiserror = { workspace = true }
 tipsy = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = [
+  "fs",
+  "io-util",
+  "macros",
+  "net",
+  "process",
+  "rt",
+  "rt-multi-thread",
+  "time"
+] }
 tokio-serial = { workspace = true }
 
 [dependencies.tokio-util]

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -187,7 +187,7 @@ impl Service for TestServer {
         self,
         ctx: context::Context,
         mullvad_host: String,
-    ) -> Result<test_rpc::AmIMullvad, test_rpc::Error> {
+    ) -> Result<test_rpc::AmIMullvadResponse, test_rpc::Error> {
         let timeout = ctx
             .deadline
             .duration_since(SystemTime::now())
@@ -196,7 +196,13 @@ impl Service for TestServer {
             .and_then(|d| d.checked_sub(Duration::from_millis(500)))
             .unwrap_or_default();
 
-        test_rpc::net::geoip_lookup(mullvad_host, timeout).await
+        am_i_mullvad_client::geoip_lookup(
+            &mullvad_host,
+            am_i_mullvad_client::IpVersion::V4,
+            timeout,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn resolve_hostname(


### PR DESCRIPTION
I'm exploring moving from `ring` to `aws-lc-rs` as the provider of cryptographic primitives in the app. I'm doing this for two main reasons:
* `ring` is unmaintained
* `ring` does not support PQ-safe TLS key exchange (`X25519MLKEM768`)

Preferably we'll switch the app in one go, so we never are in a state that the app needs both `ring` and `aws-lc-rs`. I have worked on enabling this in the past week, with upstream PRs such as https://github.com/mullvad/gotatun/pull/122 and https://github.com/shadowsocks/shadowsocks-rust/pull/2112.

Now when I'm getting closer, I propose that we switch the test workspace over to AWS-LC in order to dogfood ourselves this crypto implementation a little bit. See if it works as intended before we start messing around with app code.

This PR also enforce `X25519MLKEM768` in the TLS clients in the test workspace, to also dogfood usage of that key exchange method.

It's unfortunate that we have so many implementations of the client that talks to am.i.mullvad.net. I would love to consolidate some of those. But I felt that was outside the scope of this PR.

This PR is a prequel to #10254.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10366)
<!-- Reviewable:end -->
