### PR TITLE
Upgrade system-configuration to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
  "rustls",
  "serde",
  "smallvec",
- "system-configuration 0.7.0",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -5430,34 +5430,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -5566,7 +5545,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "resolv-conf",
- "system-configuration 0.5.1",
+ "system-configuration",
  "talpid-dbus",
  "talpid-routing",
  "talpid-types",
@@ -5636,7 +5615,7 @@ dependencies = [
  "netlink-sys",
  "nix 0.31.2",
  "rtnetlink",
- "system-configuration 0.5.1",
+ "system-configuration",
  "talpid-types",
  "talpid-windows",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,9 @@ either = "1.15.0"
 futures = "0.3.15"
 gotatun = { version = "0.6.0", default-features = false, features = ["ring"] }
 hickory-proto = "0.26.1"
-hickory-resolver = "0.26.1"
+hickory-resolver = { version = "0.26.1", default-features = false, features = [
+  "tokio"
+] }
 hickory-server = { version = "0.26.1", features = ["resolver"] }
 hyper-util = { version = "0.1.8", features = [
   "client",
@@ -116,6 +118,7 @@ shadowsocks-crypto = { version = "0.6.2", features = ["v1-stream"] }
 socket2 = "0.5.7"
 strum = { version = "0.27" }
 surge-ping = "0.8.4"
+system-configuration = "0.7.0"
 talpid-dbus = { path = "./talpid-dbus" }
 thiserror = "2.0"
 tipsy = "0.7.0"

--- a/talpid-dns/Cargo.toml
+++ b/talpid-dns/Cargo.toml
@@ -25,7 +25,7 @@ which = { version = "4.0", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 parking_lot = "0.12.0"
-system-configuration = "0.5.1"
+system-configuration.workspace = true
 talpid-routing = { path = "../talpid-routing" }
 
 [target.'cfg(windows)'.dependencies]

--- a/talpid-dns/src/macos.rs
+++ b/talpid-dns/src/macos.rs
@@ -16,7 +16,7 @@ use system_configuration::{
         dictionary::{CFDictionary, CFMutableDictionary},
         number::CFNumber,
         propertylist::CFPropertyList,
-        runloop::{CFRunLoop, kCFRunLoopCommonModes},
+        runloop::{CFRunLoop, CFRunLoopSource, kCFRunLoopCommonModes},
         string::CFString,
     },
     dynamic_store::{SCDynamicStore, SCDynamicStoreBuilder, SCDynamicStoreCallBackContext},
@@ -389,7 +389,9 @@ impl super::DnsMonitorT for DnsMonitor {
         let state = Arc::new(Mutex::new(State::new()));
         Self::spawn(state.clone())?;
         Ok(DnsMonitor {
-            store: SCDynamicStoreBuilder::new("mullvad-dns").build(),
+            store: SCDynamicStoreBuilder::new("mullvad-dns")
+                .build()
+                .ok_or(Error::DynamicStoreInitError)?,
             state,
         })
     }
@@ -416,14 +418,20 @@ impl DnsMonitor {
     /// for DNS changes.
     fn spawn(state: Arc<Mutex<State>>) -> Result<()> {
         let (result_tx, result_rx) = sync_mpsc::channel();
-        thread::spawn(move || match create_dynamic_store(state) {
-            Ok(store) => {
-                result_tx.send(Ok(())).unwrap();
-                run_dynamic_store_runloop(store);
-                // TODO(linus): This is critical. Improve later by sending error signal to Daemon
-                log::error!("Core Foundation main loop exited! It should run forever");
+        thread::spawn(move || {
+            match create_dynamic_store(state).and_then(|store| {
+                store
+                    .create_run_loop_source()
+                    .ok_or(Error::DynamicStoreInitError)
+            }) {
+                Ok(run_loop_source) => {
+                    result_tx.send(Ok(())).unwrap();
+                    run_dynamic_store_runloop(run_loop_source);
+                    // TODO(linus): This is critical. Improve later by sending error signal to Daemon
+                    log::error!("Core Foundation main loop exited! It should run forever");
+                }
+                Err(e) => result_tx.send(Err(e)).unwrap(),
             }
-            Err(e) => result_tx.send(Err(e)).unwrap(),
         });
         result_rx.recv().unwrap()
     }
@@ -459,7 +467,8 @@ fn create_dynamic_store(state: Arc<Mutex<State>>) -> Result<SCDynamicStore> {
 
     let store = SCDynamicStoreBuilder::new("talpid-dns-monitor")
         .callback_context(callback_context)
-        .build();
+        .build()
+        .ok_or(Error::DynamicStoreInitError)?;
 
     let mut store_container = store_container_copy.write().unwrap();
     *store_container = Some(StoreContainer {
@@ -480,8 +489,7 @@ fn create_dynamic_store(state: Arc<Mutex<State>>) -> Result<SCDynamicStore> {
     }
 }
 
-fn run_dynamic_store_runloop(store: SCDynamicStore) {
-    let run_loop_source = store.create_run_loop_source();
+fn run_dynamic_store_runloop(run_loop_source: CFRunLoopSource) {
     CFRunLoop::get_current().add_source(&run_loop_source, unsafe { kCFRunLoopCommonModes });
 
     log::trace!("Entering DNS CFRunLoop");

--- a/talpid-routing/Cargo.toml
+++ b/talpid-routing/Cargo.toml
@@ -37,7 +37,7 @@ rtnetlink = { workspace = true }
 bitflags = "2"
 libc = "0.2"
 nix = { workspace = true, features = ["fs", "net", "socket"] }
-system-configuration = "0.5.1"
+system-configuration.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 talpid-windows = { path = "../talpid-windows" }

--- a/talpid-routing/src/unix/macos/interface.rs
+++ b/talpid-routing/src/unix/macos/interface.rs
@@ -152,45 +152,55 @@ impl From<DefaultRoute> for RouteMessage {
 }
 
 impl PrimaryInterfaceMonitor {
-    pub fn new() -> (Self, UnboundedReceiver<Vec<InterfaceEvent>>) {
-        let store = SCDynamicStoreBuilder::new("talpid-routing").build();
+    pub fn new() -> Option<(Self, UnboundedReceiver<Vec<InterfaceEvent>>)> {
+        let store = SCDynamicStoreBuilder::new("talpid-routing").build()?;
         let prefs = SCPreferences::default(&CFString::new("talpid-routing"));
 
         let (tx, rx) = mpsc::unbounded();
         Self::start_listener(tx);
 
-        (Self { store, prefs }, rx)
+        Some((Self { store, prefs }, rx))
     }
 
     fn start_listener(tx: UnboundedSender<Vec<InterfaceEvent>>) {
         std::thread::spawn(|| {
-            let listener_store = SCDynamicStoreBuilder::new("talpid-routing-listener")
-                .callback_context(SCDynamicStoreCallBackContext {
-                    callout: Self::store_change_handler,
-                    info: tx,
-                })
-                .build();
+            let result = (|| -> Option<_> {
+                let listener_store = SCDynamicStoreBuilder::new("talpid-routing-listener")
+                    .callback_context(SCDynamicStoreCallBackContext {
+                        callout: Self::store_change_handler,
+                        info: tx,
+                    })
+                    .build()?;
 
-            let watch_keys: CFArray<CFString> = CFArray::from_CFTypes(&[
-                CFString::new(STATE_IPV4_KEY),
-                CFString::new(STATE_IPV6_KEY),
-            ]);
-            let watch_patterns = CFArray::from_CFTypes(&[CFString::new(STATE_SERVICE_PATTERN)]);
+                let watch_keys: CFArray<CFString> = CFArray::from_CFTypes(&[
+                    CFString::new(STATE_IPV4_KEY),
+                    CFString::new(STATE_IPV6_KEY),
+                ]);
+                let watch_patterns = CFArray::from_CFTypes(&[CFString::new(STATE_SERVICE_PATTERN)]);
 
-            if !listener_store.set_notification_keys(&watch_keys, &watch_patterns) {
-                log::error!("Failed to start interface listener");
-                return;
+                if !listener_store.set_notification_keys(&watch_keys, &watch_patterns) {
+                    log::error!("Failed to start interface listener");
+                    return None;
+                }
+
+                let run_loop_source = listener_store.create_run_loop_source()?;
+
+                // SAFETY: this is just a static string pointer, referencing it should be safe.
+                let run_loop_common_modes = unsafe { kCFRunLoopCommonModes };
+                Some((run_loop_source, run_loop_common_modes))
+            })();
+
+            match result {
+                Some((run_loop_source, run_loop_common_modes)) => {
+                    CFRunLoop::get_current().add_source(&run_loop_source, run_loop_common_modes);
+                    CFRunLoop::run_current();
+
+                    log::debug!("Interface listener exiting");
+                }
+                None => {
+                    log::error!("Failed to start interface listener");
+                }
             }
-
-            let run_loop_source = listener_store.create_run_loop_source();
-
-            // SAFETY: this is just a static string pointer, referencing it should be safe.
-            let run_loop_common_modes = unsafe { kCFRunLoopCommonModes };
-
-            CFRunLoop::get_current().add_source(&run_loop_source, run_loop_common_modes);
-            CFRunLoop::run_current();
-
-            log::debug!("Interface listener exiting");
         });
     }
 

--- a/talpid-routing/src/unix/macos/mod.rs
+++ b/talpid-routing/src/unix/macos/mod.rs
@@ -44,6 +44,10 @@ const BURST_LONGEST_BUFFER_PERIOD: Duration = Duration::from_secs(2);
 /// Errors that can happen in the macOS routing integration.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    /// Encountered an when creating a RouteManager.
+    #[error("Error creating a route manager - failed to create an interface monitor.")]
+    CreateRouteManager,
+
     /// Encountered an error when interacting with the routing socket
     #[error("Error occurred when interfacing with the routing table")]
     RoutingTable(#[source] watch::Error),
@@ -129,7 +133,7 @@ impl RouteManagerImpl {
         manage_tx: Weak<mpsc::UnboundedSender<RouteManagerCommand>>,
     ) -> Result<Self> {
         let (primary_interface_monitor, interface_change_rx) =
-            interface::PrimaryInterfaceMonitor::new();
+            interface::PrimaryInterfaceMonitor::new().ok_or(Error::CreateRouteManager)?;
 
         let (best_route_rx_v4, best_route_rx_v6) =
             DefaultRouteMonitor::start(primary_interface_monitor, interface_change_rx);

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -507,16 +507,6 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1189,18 +1179,13 @@ dependencies = [
  "futures-util",
  "hickory-net",
  "hickory-proto",
- "ipconfig",
  "ipnet",
- "jni 0.22.4",
  "moka",
- "ndk-context",
  "once_cell",
  "parking_lot",
  "rand 0.10.1",
- "resolv-conf",
  "rustls",
  "smallvec",
- "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -1530,19 +1515,6 @@ checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
  "mach2",
-]
-
-[[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2 0.6.3",
- "widestring",
- "windows-registry",
- "windows-result",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2115,12 +2087,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -2865,12 +2831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,7 +3062,7 @@ checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "io-kit-sys",
  "mach2",
@@ -3391,27 +3351,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4381,17 +4320,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"


### PR DESCRIPTION
Since https://github.com/mullvad/mullvadvpn-app/pull/10357, we had multiple versions of `system-configuration` in the dependency tree. This PR upgrades our direct use of `system-configuration` from `0.5` to `0.7`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10374)
<!-- Reviewable:end -->
