### PR TITLE
Silence new hickory-net crate

### DIFF
--- a/mullvad-logging/src/lib.rs
+++ b/mullvad-logging/src/lib.rs
@@ -28,6 +28,7 @@ pub const SILENCED_CRATES: &[&str] = &[
     "rustls",
     "netlink_sys",
     "tracing",
+    "hickory_net",
     "hickory_proto",
     "hickory_server",
     "hickory_resolver",


### PR DESCRIPTION
Follow up to https://github.com/mullvad/mullvadvpn-app/pull/10357 where a new, noisy hickory crate was added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10377)
<!-- Reviewable:end -->
