### PR TITLE
Add ignore vulnerabilities for netty and bouncy castle

### DIFF
--- a/android/gradle/osv-scanner.toml
+++ b/android/gradle/osv-scanner.toml
@@ -108,3 +108,63 @@ reason = "The app does not use dependency directly, it is used by AGP that build
 id = "CVE-2026-0636"  # GHSA-c3fc-8qff-9hwx
 ignoreUntil = 2026-08-01
 reason = "The app does not use dependency directly, it is used by AGP that builds the app, no impact on app"
+
+# Netty Lz4FrameDecoder is vulnerable to resource exhaustion
+[[IgnoredVulns]]
+id = "CVE-2026-42583"  # GHSA-mj4r-2hfc-f8p6
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty vulnerable to HTTP Request Smuggling due to malformed Transfer-Encoding
+[[IgnoredVulns]]
+id = "CVE-2026-42585"  # GHSA-38f8-5428-x5cv
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty has HttpClientCodec response desynchronization
+[[IgnoredVulns]]
+id = "CVE-2026-42584"  # GHSA-57rv-r2g8-2cj3
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty: HttpContentDecompressor maxAllocation bypass when Content-Encoding set to br/zstd/snappy leads to decompression bomb DoS
+[[IgnoredVulns]]
+id = "CVE-2026-42587"  # GHSA-f6hv-jmp6-3vwv
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty vulnerable to HTTP Request Smuggling due to incorrect chunk size parsing
+[[IgnoredVulns]]
+id = "CVE-2026-42580"  # GHSA-m4cv-j2px-7723
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty: Start-Line Injection in DefaultHttpRequest.setUri() Allows HTTP Request Smuggling and RTSP Request Injection
+[[IgnoredVulns]]
+id = "CVE-2026-41417"  # GHSA-v8h7-rr48-vmmv
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty HTTP/1.0 TE+CL Coexistence Bypasses Smuggling Sanitization
+[[IgnoredVulns]]
+id = "CVE-2026-42581"  # GHSA-xxqh-mfjm-7mv9
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty has HTTP Header Injection via HttpProxyHandler Disabled Validation (Incomplete Fix CVE-2025-67735)
+[[IgnoredVulns]]
+id = "CVE-2026-42578"  # GHSA-45q3-82m4-75jr
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Netty epoll transport denial of service via RST on half-closed TCP connection
+[[IgnoredVulns]]
+id = "CVE-2026-42577"  # GHSA-rwm7-x88c-3g2p
+ignoreUntil = 2026-08-01
+reason = "The app does not use netty for external http communication"
+
+# Bouncy Castle Has Covert Timing Channel Vulnerability
+[[IgnoredVulns]]
+id = "CVE-2026-5598"  # GHSA-p93r-85wp-75v3
+ignoreUntil = 2026-08-01
+reason = "The app does not use dependency directly, it is used by AGP that builds the app, no impact on app"


### PR DESCRIPTION
We use netty for communicating with the daemon via grpc and to set up a mock server when running mock api tests. In the first scenario we use UDS and not http and in the other scenario we use http over local host.

Since all vulnerabilities related to netty are about an external actor sending malicous http requests they are not applicable to our application. It is possible to add more detail why the specific CVEs are not applicable to a client application, but since this covers all netty vulnerabilities I thought it was easier to just note this.

The bouncy castle vulnerability is not relevant since it is only used by AGP and not the app directly.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10378)
<!-- Reviewable:end -->
