### PR TITLE
Use lc state for OutOfTimeScreen to fix test stability

### DIFF
--- a/android/lib/feature/home/impl/src/androidTest/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeScreenTest.kt
+++ b/android/lib/feature/home/impl/src/androidTest/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeScreenTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import net.mullvad.mullvadvpn.feature.addtime.impl.AddTimeUiState
 import net.mullvad.mullvadvpn.feature.addtime.impl.AddTimeViewModel
 import net.mullvad.mullvadvpn.lib.common.Lc
+import net.mullvad.mullvadvpn.lib.common.toLc
 import net.mullvad.mullvadvpn.lib.model.TunnelState
 import net.mullvad.mullvadvpn.lib.ui.tag.PLAY_PAYMENT_INFO_ICON_TEST_TAG
 import net.mullvad.mullvadvpn.screen.test.createEdgeToEdgeComposeExtension
@@ -40,7 +41,7 @@ class OutOfTimeScreenTest {
     }
 
     private fun ComposeContext.initScreen(
-        state: OutOfTimeUiState = OutOfTimeUiState(),
+        state: Lc<Unit, OutOfTimeUiState> = OutOfTimeUiState().toLc(),
         onDisconnectClick: () -> Unit = {},
         onSettingsClick: () -> Unit = {},
         onAccountClick: () -> Unit = {},
@@ -63,7 +64,7 @@ class OutOfTimeScreenTest {
     @Test
     fun testDisableSitePayment() = composeExtension.use {
         // Arrange
-        initScreen(state = OutOfTimeUiState(deviceName = ""))
+        initScreen(state = OutOfTimeUiState(showSitePayment = false).toLc())
 
         // Assert
         onNodeWithText("Either buy credit on our website or redeem a voucher.", substring = true)
@@ -76,7 +77,7 @@ class OutOfTimeScreenTest {
 
         // Arrange
         initScreen(
-            state = OutOfTimeUiState(deviceName = "", showSitePayment = true),
+            state = OutOfTimeUiState(showSitePayment = true).toLc(),
             onAccountClick = mockClickListener,
         )
 
@@ -93,10 +94,10 @@ class OutOfTimeScreenTest {
         initScreen(
             state =
                 OutOfTimeUiState(
-                    tunnelState = TunnelState.Connecting(null, null, emptyList()),
-                    deviceName = "",
-                    showSitePayment = true,
-                ),
+                        tunnelState = TunnelState.Connecting(null, null, emptyList()),
+                        showSitePayment = true,
+                    )
+                    .toLc(),
             onDisconnectClick = mockClickListener,
         )
 
@@ -112,7 +113,7 @@ class OutOfTimeScreenTest {
         // Arrange
         val mockOnPlayPaymentInfoClick: () -> Unit = mockk(relaxed = true)
         initScreen(
-            state = OutOfTimeUiState(showSitePayment = true, verificationPending = true),
+            state = OutOfTimeUiState(showSitePayment = true, verificationPending = true).toLc(),
             onPlayPaymentInfoClick = mockOnPlayPaymentInfoClick,
         )
 
@@ -127,7 +128,9 @@ class OutOfTimeScreenTest {
     @Test
     fun testShowVerificationInProgress() = composeExtension.use {
         // Arrange
-        initScreen(state = OutOfTimeUiState(showSitePayment = true, verificationPending = true))
+        initScreen(
+            state = OutOfTimeUiState(showSitePayment = true, verificationPending = true).toLc()
+        )
 
         // Assert
         onNodeWithText("Google Play payment pending").assertExists()

--- a/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeScreen.kt
+++ b/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeScreen.kt
@@ -43,8 +43,10 @@ import net.mullvad.mullvadvpn.feature.addtime.api.AddTimeNavKey
 import net.mullvad.mullvadvpn.feature.addtime.api.VerificationPendingNavKey
 import net.mullvad.mullvadvpn.feature.home.api.ConnectNavKey
 import net.mullvad.mullvadvpn.feature.settings.api.SettingsNavKey
+import net.mullvad.mullvadvpn.lib.common.Lc
 import net.mullvad.mullvadvpn.lib.ui.component.ScaffoldWithTopBarAndDeviceName
 import net.mullvad.mullvadvpn.lib.ui.component.drawVerticalScrollbar
+import net.mullvad.mullvadvpn.lib.ui.designsystem.MullvadCircularProgressIndicatorLarge
 import net.mullvad.mullvadvpn.lib.ui.designsystem.NegativeButton
 import net.mullvad.mullvadvpn.lib.ui.designsystem.VariantButton
 import net.mullvad.mullvadvpn.lib.ui.resource.R
@@ -56,10 +58,11 @@ import net.mullvad.mullvadvpn.lib.ui.theme.color.AlphaScrollbar
 import net.mullvad.mullvadvpn.lib.ui.theme.color.positive
 import org.koin.androidx.compose.koinViewModel
 
-@Preview("Disconnected|Connecting|Error")
+@Preview("Disconnected|Connecting|Error|Loading")
 @Composable
 private fun PreviewOutOfTimeScreen(
-    @PreviewParameter(OutOfTimeScreenPreviewParameterProvider::class) state: OutOfTimeUiState
+    @PreviewParameter(OutOfTimeScreenPreviewParameterProvider::class)
+    state: Lc<Unit, OutOfTimeUiState>
 ) {
     AppTheme {
         OutOfTimeScreen(
@@ -109,7 +112,7 @@ fun OutOfTime(navigator: Navigator) {
 
 @Composable
 fun OutOfTimeScreen(
-    state: OutOfTimeUiState,
+    state: Lc<Unit, OutOfTimeUiState>,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onDisconnectClick: () -> Unit,
     onSettingsClick: () -> Unit,
@@ -121,20 +124,20 @@ fun OutOfTimeScreen(
     ScaffoldWithTopBarAndDeviceName(
         snackbarHostState = snackbarHostState,
         topBarColor =
-            if (state.tunnelState.isSecured()) {
+            if (state.contentOrNull()?.tunnelState?.isSecured() == true) {
                 MaterialTheme.colorScheme.positive
             } else {
                 MaterialTheme.colorScheme.error
             },
         iconTintColor =
-            if (state.tunnelState.isSecured()) {
+            if (state.contentOrNull()?.tunnelState?.isSecured() == true) {
                 MaterialTheme.colorScheme.onTertiary
             } else {
                 MaterialTheme.colorScheme.onError
             },
         onSettingsClicked = onSettingsClick,
         onAccountClicked = onAccountClick,
-        deviceName = state.deviceName,
+        deviceName = state.contentOrNull()?.deviceName,
         timeLeft = null,
     ) {
         Column(
@@ -154,15 +157,25 @@ fun OutOfTimeScreen(
                     )
                     .background(color = MaterialTheme.colorScheme.surface)
         ) {
-            Content(showSitePayment = state.showSitePayment)
-            Spacer(modifier = Modifier.weight(1f).defaultMinSize(minHeight = Dimens.verticalSpace))
-            // Button area
-            ButtonPanel(
-                state = state,
-                onDisconnectClick = onDisconnectClick,
-                onAddMoreTimeClick = onAddMoreTimeClick,
-                onInfoClick = onPlayPaymentInfoClick,
-            )
+            when (state) {
+                is Lc.Content -> {
+                    Content(showSitePayment = state.value.showSitePayment)
+                    Spacer(
+                        modifier =
+                            Modifier.weight(1f).defaultMinSize(minHeight = Dimens.verticalSpace)
+                    )
+                    // Button area
+                    ButtonPanel(
+                        state = state.value,
+                        onDisconnectClick = onDisconnectClick,
+                        onAddMoreTimeClick = onAddMoreTimeClick,
+                        onInfoClick = onPlayPaymentInfoClick,
+                    )
+                }
+                is Lc.Loading -> {
+                    Loading()
+                }
+            }
         }
     }
 }
@@ -231,4 +244,12 @@ private fun ButtonPanel(
         }
         VariantButton(onClick = onAddMoreTimeClick, text = stringResource(id = R.string.add_time))
     }
+}
+
+@Composable
+private fun ColumnScope.Loading() {
+    MullvadCircularProgressIndicatorLarge(
+        modifier =
+            Modifier.align(Alignment.CenterHorizontally).padding(vertical = Dimens.smallPadding)
+    )
 }

--- a/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeScreenPreviewParameterProvider.kt
+++ b/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeScreenPreviewParameterProvider.kt
@@ -4,25 +4,32 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import net.mullvad.mullvadvpn.feature.home.impl.TunnelStatePreviewData.generateConnectingState
 import net.mullvad.mullvadvpn.feature.home.impl.TunnelStatePreviewData.generateDisconnectedState
 import net.mullvad.mullvadvpn.feature.home.impl.TunnelStatePreviewData.generateErrorState
+import net.mullvad.mullvadvpn.lib.common.Lc
+import net.mullvad.mullvadvpn.lib.common.toLc
 
-class OutOfTimeScreenPreviewParameterProvider : PreviewParameterProvider<OutOfTimeUiState> {
-    override val values: Sequence<OutOfTimeUiState> =
+class OutOfTimeScreenPreviewParameterProvider :
+    PreviewParameterProvider<Lc<Unit, OutOfTimeUiState>> {
+    override val values: Sequence<Lc<Unit, OutOfTimeUiState>> =
         sequenceOf(
             OutOfTimeUiState(
-                tunnelState = generateDisconnectedState(),
-                "Heroic Frog",
-                showSitePayment = true,
-            ),
+                    tunnelState = generateDisconnectedState(),
+                    "Heroic Frog",
+                    showSitePayment = true,
+                )
+                .toLc(),
             OutOfTimeUiState(
-                tunnelState =
-                    generateConnectingState(featureIndicators = 0, quantumResistant = false),
-                "Strong Rabbit",
-                showSitePayment = true,
-            ),
+                    tunnelState =
+                        generateConnectingState(featureIndicators = 0, quantumResistant = false),
+                    "Strong Rabbit",
+                    showSitePayment = true,
+                )
+                .toLc(),
             OutOfTimeUiState(
-                tunnelState = generateErrorState(isBlocking = true),
-                deviceName = "Stable Horse",
-                showSitePayment = true,
-            ),
+                    tunnelState = generateErrorState(isBlocking = true),
+                    deviceName = "Stable Horse",
+                    showSitePayment = true,
+                )
+                .toLc(),
+            Lc.Loading(Unit),
         )
 }

--- a/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeUiState.kt
+++ b/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeUiState.kt
@@ -4,7 +4,11 @@ import net.mullvad.mullvadvpn.lib.model.TunnelState
 
 data class OutOfTimeUiState(
     val tunnelState: TunnelState = TunnelState.Disconnected(),
-    val deviceName: String = "",
+    val deviceName: String? = null,
     val showSitePayment: Boolean = false,
     val verificationPending: Boolean = false,
-)
+) {
+    init {
+        require(deviceName?.isBlank() != true) { "deviceName cannot be blank or empty" }
+    }
+}

--- a/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeViewModel.kt
+++ b/android/lib/feature/home/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeViewModel.kt
@@ -5,14 +5,17 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import net.mullvad.mullvadvpn.lib.common.Lc
 import net.mullvad.mullvadvpn.lib.common.constant.VIEW_MODEL_STOP_TIMEOUT
 import net.mullvad.mullvadvpn.lib.common.util.ACCOUNT_EXPIRY_POLL_INTERVAL
 import net.mullvad.mullvadvpn.lib.model.DisconnectReason
@@ -38,23 +41,25 @@ class OutOfTimeViewModel(
     private val _uiSideEffect = Channel<UiSideEffect>()
     val uiSideEffect = merge(_uiSideEffect.receiveAsFlow(), notOutOfTimeEffect())
 
-    val uiState =
+    val uiState: StateFlow<Lc<Unit, OutOfTimeUiState>> =
         combine(
                 connectionProxy.tunnelState,
-                deviceRepository.deviceState,
+                deviceRepository.deviceState.filterNotNull(),
                 paymentUseCase.paymentAvailability,
             ) { tunnelState, deviceState, paymentAvailability ->
-                OutOfTimeUiState(
-                    tunnelState = tunnelState,
-                    deviceName = deviceState?.displayName() ?: "",
-                    showSitePayment = !isPlayBuild,
-                    verificationPending = paymentAvailability.hasPendingPayment(),
+                Lc.Content(
+                    OutOfTimeUiState(
+                        tunnelState = tunnelState,
+                        deviceName = deviceState.displayName(),
+                        showSitePayment = !isPlayBuild,
+                        verificationPending = paymentAvailability.hasPendingPayment(),
+                    )
                 )
             }
             .stateIn(
                 viewModelScope,
                 SharingStarted.WhileSubscribed(VIEW_MODEL_STOP_TIMEOUT),
-                OutOfTimeUiState(),
+                Lc.Loading(Unit),
             )
 
     init {

--- a/android/lib/feature/home/impl/src/test/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeViewModelTest.kt
+++ b/android/lib/feature/home/impl/src/test/kotlin/net/mullvad/mullvadvpn/feature/home/impl/outoftime/OutOfTimeViewModelTest.kt
@@ -13,8 +13,12 @@ import kotlin.test.assertIs
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import net.mullvad.mullvadvpn.lib.common.Lc
 import net.mullvad.mullvadvpn.lib.common.test.TestCoroutineRule
 import net.mullvad.mullvadvpn.lib.model.AccountData
+import net.mullvad.mullvadvpn.lib.model.AccountNumber
+import net.mullvad.mullvadvpn.lib.model.Device
+import net.mullvad.mullvadvpn.lib.model.DeviceId
 import net.mullvad.mullvadvpn.lib.model.DeviceState
 import net.mullvad.mullvadvpn.lib.model.DisconnectReason
 import net.mullvad.mullvadvpn.lib.model.TunnelState
@@ -39,7 +43,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 class OutOfTimeViewModelTest {
 
     private val accountExpiryStateFlow = MutableStateFlow<AccountData?>(null)
-    private val accountStateFlow = MutableStateFlow<DeviceState?>(null)
+    private val accountStateFlow =
+        MutableStateFlow<DeviceState?>(DeviceState.LoggedIn(AccountNumber(""), MOCK_DEVICE))
     private val paymentAvailabilityFlow = MutableStateFlow<PaymentAvailability?>(null)
     private val purchaseResultFlow = MutableStateFlow<PurchaseResult?>(null)
     private val outOfTimeFlow = MutableStateFlow(true)
@@ -115,7 +120,8 @@ class OutOfTimeViewModelTest {
             awaitItem()
             tunnelState.emit(tunnelRealStateTestItem)
             val result = awaitItem()
-            assertEquals(tunnelRealStateTestItem, result.tunnelState)
+            assertIs<Lc.Content<OutOfTimeUiState>>(result)
+            assertEquals(tunnelRealStateTestItem, result.value.tunnelState)
         }
     }
 
@@ -161,8 +167,14 @@ class OutOfTimeViewModelTest {
         // Act, Assert
         viewModel.uiState.test {
             val result = awaitItem()
-            assertIs<OutOfTimeUiState>(result)
-            assertEquals(true, result.verificationPending)
+            assertIs<Lc.Content<OutOfTimeUiState>>(result)
+            assertEquals(true, result.value.verificationPending)
         }
+    }
+
+    companion object {
+        private val MOCK_DEVICE =
+            Device(id = DeviceId.fromString(UUID), name = "Test Device", creationDate = mockk())
+        private const val UUID = "12345678-1234-5678-1234-567812345678"
     }
 }

--- a/android/test/e2e/build.gradle.kts
+++ b/android/test/e2e/build.gradle.kts
@@ -21,6 +21,9 @@ android {
         minSdk = libs.versions.min.sdk.get().toInt()
         testApplicationId = "net.mullvad.mullvadvpn.test.e2e"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        // Required to run mock api tests via Android studio
+        testInstrumentationRunnerArguments["runnerBuilder"] =
+            "de.mannodermaus.junit5.AndroidJUnit5Builder"
         targetProjectPath = ":app"
 
         testInstrumentationRunnerArguments += buildMap {


### PR DESCRIPTION
The test `testInAppPurchaseForOutOfTime` is a bit flaky. As far as I can tell the flakiness comes from ui autmotar clicking very fast on the add time button before the screen is settled which causes the click to be discarded.

This is an attempt to make the test a bit less flaky by adding a loading state to the OutOfTimeScreen. As I am not able to reproduce the error locally this has no guarantee to actually help. But it is something we have decided to implement so I guess it does not hurt.

Fixes: DROID-1944 (partially)

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10380)
<!-- Reviewable:end -->
