### PR TITLE
Add the Logger parameter to the MullvadAPIWrapper

### DIFF
--- a/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
+++ b/ios/MullvadVPNUITests/Networking/MullvadAPIWrapper.swift
@@ -8,6 +8,7 @@
 
 import CryptoKit
 import Foundation
+import MullvadLogging
 import MullvadRustRuntime
 import XCTest
 
@@ -33,7 +34,7 @@ class MullvadAPIWrapper: @unchecked Sendable {
         .infoDictionary?["ApiEndpoint"] as! String
 
     init() throws {
-        RustLogging.initialize()
+        RustLogging.initialize(logger: Logger(label: "APIWrapperTests"))
         let apiAddress = try Self.getAPIIPAddress() + ":" + Self.getAPIPort()
         let hostname = Self.hostName
         mullvadAPI = try MullvadApi(apiAddress: apiAddress, hostname: hostname)


### PR DESCRIPTION
This parameter is now required, and we've forgotten to pass it in the UI Tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10385)
<!-- Reviewable:end -->
