### PR TITLE
Update deny.toml with the actual target triples we ship Rust code to

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,9 +4,15 @@
 # cargo deny will only evaluate dependencies pulled in by these
 # targets (the ones we ship Rust code to)
 targets = [
-  # Desktop
+  # Desktop - Linux
   { triple = "x86_64-unknown-linux-gnu" },
-  { triple = "x86_64-pc-windows-gnu" },
+  { triple = "aarch64-unknown-linux-gnu" },
+  { triple = "riscv64gc-unknown-linux-gnu" },
+  # Desktop - Windows
+  { triple = "i686-pc-windows-msvc" },
+  { triple = "x86_64-pc-windows-msvc" },
+  { triple = "aarch64-pc-windows-msvc" },
+  # Desktop - macOS
   { triple = "x86_64-apple-darwin" },
   { triple = "aarch64-apple-darwin" },
   # Android
@@ -15,7 +21,6 @@ targets = [
   { triple = "aarch64-linux-android" },
   { triple = "armv7-linux-androideabi" },
   # iOS
-  { triple = "x86_64-apple-ios" },
   { triple = "aarch64-apple-ios" },
 ]
 


### PR DESCRIPTION
The `targets` list in `deny.toml` dictates towards what targets `cargo deny` evaluates the dependency tree against. It was not really in sync with where we actually ship code.

Missing a target here might make us pull in a target specific dependency that has an incompatible license, or might be outright banned by us (such as for example `openssl-sys`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10387)
<!-- Reviewable:end -->
