### PR TITLE
Fix typo in mullvad-exclude error message

### DIFF
--- a/mullvad-exclude/src/main.rs
+++ b/mullvad-exclude/src/main.rs
@@ -21,7 +21,7 @@ mod inner {
         #[error("Invalid arguments")]
         InvalidArguments,
 
-        #[error("Cannot assing process to cgroup")]
+        #[error("Cannot assign process to cgroup")]
         AddProcToCGroup(#[from] talpid_cgroup::Error),
 
         #[error("Failed to drop root user privileges for the process")]


### PR DESCRIPTION
I was dealing with some ugly cgroup v2/v1/net_cls shenanigans with the recent changes to split-tunelling implementation (I use Void Linux which uses runit instead of systemd which does a lot less cgroup orchestration) and I've noticed this typo.

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [x] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:




👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10390)
<!-- Reviewable:end -->
