### PR TITLE
Fix system file manager not being used

### DIFF
--- a/android/lib/feature/serveripoverride/impl/src/main/java/net/mullvad/mullvadvpn/feature/serveripoverride/impl/ServerIpOverridesScreen.kt
+++ b/android/lib/feature/serveripoverride/impl/src/main/java/net/mullvad/mullvadvpn/feature/serveripoverride/impl/ServerIpOverridesScreen.kt
@@ -95,6 +95,8 @@ private fun PreviewServerIpOverridesScreen(
     }
 }
 
+private val SUPPORTED_SERVER_IP_OVERRIDE_FILE_TYPES = arrayOf("application/json", "text/plain")
+
 @Composable
 fun SharedTransitionScope.ServerIpOverrides(
     navArgs: ServerIpOverrideNavKey,
@@ -121,7 +123,7 @@ fun SharedTransitionScope.ServerIpOverrides(
     val resultStore = LocalResultStore.current
 
     val openFileLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) {
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
             if (it != null) {
                 vm.importFile(it)
             }
@@ -132,7 +134,7 @@ fun SharedTransitionScope.ServerIpOverrides(
     resultStore.consumeResult<ImportOverrideByTextNavResult> { vm.importText(it.text) }
 
     resultStore.consumeResult<ImportOverrideByFileNavResult> {
-        openFileLauncher.launch("application/json")
+        openFileLauncher.launch(SUPPORTED_SERVER_IP_OVERRIDE_FILE_TYPES)
     }
 
     // On successful clear of overrides, show snackbar

--- a/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ForbiddenApiTest.kt
+++ b/android/test/arch/src/test/kotlin/net/mullvad/mullvadvpn/test/arch/ForbiddenApiTest.kt
@@ -1,0 +1,15 @@
+package net.mullvad.mullvadvpn.test.arch
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.jupiter.api.Test
+
+class ForbiddenApiTest {
+    // Avoid usage of ActivityResultContracts.GetContent() since
+    // it doesn't work with some file managers. See: DROID-2692
+    @Test
+    fun `ensure ActivityResultContracts GetContent is not used`() =
+        Konsist.scopeFromProduction().files.assertFalse {
+            it.text.contains("ActivityResultContracts.GetContent()")
+        }
+}


### PR DESCRIPTION
Using OpenDocument instead of GetContent forces the system file manager to be used via the storage access framework, which correctly opens the file URI (GetContent could return null depending on what file manager app was used).

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10394)
<!-- Reviewable:end -->
