### PR TITLE
Fix users that got the wrong entry location set

### DIFF
--- a/mullvad-daemon/src/migrations/mod.rs
+++ b/mullvad-daemon/src/migrations/mod.rs
@@ -53,6 +53,7 @@ mod v11;
 mod v12;
 mod v13;
 mod v14;
+mod v15;
 mod v2;
 mod v3;
 mod v4;
@@ -222,6 +223,7 @@ async fn migrate_settings(
     v12::migrate(settings)?;
     v13::migrate(settings)?;
     v14::migrate(settings)?;
+    v15::migrate(settings)?;
 
     Ok(migration_data)
 }

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_any_entry_location_not_replaced-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_any_entry_location_not_replaced-2.snap
@@ -1,0 +1,13 @@
+---
+source: mullvad-daemon/src/migrations/v15.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "entry_location": "any"
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_any_entry_location_not_replaced.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_any_entry_location_not_replaced.snap
@@ -1,0 +1,13 @@
+---
+source: mullvad-daemon/src/migrations/v15.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "entry_location": "any"
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_bad_entry_location_replaced-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_bad_entry_location_replaced-2.snap
@@ -1,0 +1,13 @@
+---
+source: mullvad-daemon/src/migrations/v15.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "entry_location": "any"
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_bad_entry_location_replaced.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_bad_entry_location_replaced.snap
@@ -1,0 +1,19 @@
+---
+source: mullvad-daemon/src/migrations/v15.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": ""
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_good_entry_location_not_replaced-2.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_good_entry_location_not_replaced-2.snap
@@ -1,0 +1,19 @@
+---
+source: mullvad-daemon/src/migrations/v15.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_good_entry_location_not_replaced.snap
+++ b/mullvad-daemon/src/migrations/snapshots/mullvad_daemon__migrations__v15__test__v15_to_v16_migration_good_entry_location_not_replaced.snap
@@ -1,0 +1,19 @@
+---
+source: mullvad-daemon/src/migrations/v15.rs
+expression: "serde_json::to_string_pretty(&old_settings).unwrap()"
+---
+{
+  "relay_settings": {
+    "normal": {
+      "wireguard_constraints": {
+        "entry_location": {
+          "only": {
+            "location": {
+              "country": "se"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mullvad-daemon/src/migrations/v15.rs
+++ b/mullvad-daemon/src/migrations/v15.rs
@@ -1,0 +1,119 @@
+use super::Result;
+use mullvad_types::settings::SettingsVersion;
+use serde_json::json;
+
+const WIREGUARD_ENTRY_LOCATION_KEY: &str = "entry_location";
+
+/// NOTE: This migration has been closed.
+///
+/// This migration handles:
+/// - Migrates users that have their entry location set to Country("") to any
+pub fn migrate(settings: &mut serde_json::Value) -> Result<()> {
+    if !version_matches(settings) {
+        return Ok(());
+    }
+
+    log::info!("Migrating settings format to V16");
+
+    migrate_entry_location(settings);
+
+    settings["settings_version"] = json!(SettingsVersion::V16);
+
+    Ok(())
+}
+
+fn migrate_entry_location(settings: &mut serde_json::Value) -> Option<()> {
+    let wireguard_constraints = settings
+        .get_mut("relay_settings")
+        .and_then(|relay_settings| relay_settings.get_mut("normal"))
+        .and_then(|normal_relay_settings| normal_relay_settings.get_mut("wireguard_constraints"))
+        .and_then(|wireguard_constraints| wireguard_constraints.as_object_mut())?;
+
+    let entry_location_value = &wireguard_constraints[WIREGUARD_ENTRY_LOCATION_KEY];
+
+    let bad_entry_location = json!({ "only": {
+        "location": {
+          "country": ""
+        }
+      }
+    });
+
+    if entry_location_value == &bad_entry_location {
+        wireguard_constraints.insert(WIREGUARD_ENTRY_LOCATION_KEY.to_string(), json!("any"));
+    }
+
+    Some(())
+}
+
+fn version_matches(settings: &serde_json::Value) -> bool {
+    settings
+        .get("settings_version")
+        .map(|version| version == SettingsVersion::V15 as u64)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_v15_to_v16_migration_bad_entry_location_replaced() {
+        let mut old_settings = json!({
+            "relay_settings": {
+              "normal": {
+                "wireguard_constraints": {
+                    "entry_location": {
+                        "only": {
+                            "location": {
+                                "country": ""
+                            }
+                        }
+                    }
+                }
+              }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_entry_location(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    #[test]
+    fn test_v15_to_v16_migration_any_entry_location_not_replaced() {
+        let mut old_settings = json!({
+            "relay_settings": {
+              "normal": {
+                "wireguard_constraints": {
+                    "entry_location": "any"
+                }
+              }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_entry_location(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+
+    #[test]
+    fn test_v15_to_v16_migration_good_entry_location_not_replaced() {
+        let mut old_settings = json!({
+            "relay_settings": {
+              "normal": {
+                "wireguard_constraints": {
+                    "entry_location": {
+                        "only": {
+                            "location": {
+                                "country": "se"
+                            }
+                        }
+                    }
+                }
+              }
+            }
+        });
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+        migrate_entry_location(&mut old_settings).unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&old_settings).unwrap());
+    }
+}

--- a/mullvad-types/src/settings/mod.rs
+++ b/mullvad-types/src/settings/mod.rs
@@ -20,7 +20,7 @@ mod dns;
 /// latest version that exists in `SettingsVersion`.
 /// This should be bumped when a new version is introduced along with a migration
 /// being added to `mullvad-daemon`.
-pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V15;
+pub const CURRENT_SETTINGS_VERSION: SettingsVersion = SettingsVersion::V16;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Copy)]
 #[repr(u32)]
@@ -39,6 +39,7 @@ pub enum SettingsVersion {
     V13 = 13,
     V14 = 14,
     V15 = 15,
+    V16 = 16,
 }
 
 impl<'de> Deserialize<'de> for SettingsVersion {
@@ -61,6 +62,7 @@ impl<'de> Deserialize<'de> for SettingsVersion {
             v if v == SettingsVersion::V13 as u32 => Ok(SettingsVersion::V13),
             v if v == SettingsVersion::V14 as u32 => Ok(SettingsVersion::V14),
             v if v == SettingsVersion::V15 as u32 => Ok(SettingsVersion::V15),
+            v if v == SettingsVersion::V16 as u32 => Ok(SettingsVersion::V16),
             v => Err(serde::de::Error::custom(format!(
                 "{v} is not a valid SettingsVersion"
             ))),


### PR DESCRIPTION
This checks the entry location using a settings migration so that users who have an invalid entry location gets moved back to `Constraint.Any` which is what they had before.

~I added a reconnect since if you were blocked before updating the app it will not unblock you. If we feel that it is too much we can remove that since a user could just reconnect again to unblock themself.~
Removed this since I don't really think it is suitable.

Edit: Moved the check from the kotlin code to a settings migration in the daemon.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10395)
<!-- Reviewable:end -->
