### PR TITLE
Rename smartRoutingState to directOnlyState with Codable migration su…

### DIFF
--- a/ios/MullvadSettings/DAITASettings.swift
+++ b/ios/MullvadSettings/DAITASettings.swift
@@ -1,17 +1,22 @@
-//
-//  DAITASettings.swift
-//  MullvadSettings
-//
-//  Created by Mojgan on 2024-08-08.
-//  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+////
+////  DAITASettings.swift
+////  MullvadSettings
+////
+////  Created by Mojgan on 2024-08-08.
+////  Copyright © 2026 Mullvad VPN AB. All rights reserved.
+////
 //
 
 import Foundation
 
-/// Whether DAITA is enabled.
+/// Whether DAITA is enabled
 public enum DAITAState: Codable, Sendable {
     case on
     case off
+
+    public var isEnabled: Bool {
+        self == .on
+    }
 }
 
 /// Whether "direct only" is enabled, meaning no automatic routing to DAITA relays.
@@ -20,12 +25,7 @@ public enum DirectOnlyState: Codable, Sendable {
     case off
 
     public var isEnabled: Bool {
-        get {
-            self == .on
-        }
-        set {
-            self = newValue ? .on : .off
-        }
+        self == .on
     }
 }
 
@@ -39,16 +39,21 @@ public struct DAITASettings: Codable, Equatable, Sendable {
     public let state: DAITAState = .off
 
     public var daitaState: DAITAState
-    /// > Warning: Deprecated and should only be used in multihop migration.
-    public var directOnlyState: DirectOnlyState = .off
+
+    @available(
+        *, deprecated,
+        message: "Deprecated: Do not use this API in new implementations. It is supported only for multihop migration."
+    )
+    public var directOnlyState: DirectOnlyState
 
     public var isEnabled: Bool {
         get { daitaState == .on }
         set { daitaState = newValue ? .on : .off }
     }
 
-    public init(daitaState: DAITAState = .off) {
+    public init(daitaState: DAITAState = .off, directOnlyState: DirectOnlyState = .off) {
         self.daitaState = daitaState
+        self.directOnlyState = directOnlyState
     }
 
     public init(from decoder: any Decoder) throws {
@@ -57,6 +62,13 @@ public struct DAITASettings: Codable, Equatable, Sendable {
         daitaState =
             try container.decodeIfPresent(DAITAState.self, forKey: .daitaState)
             ?? container.decodeIfPresent(DAITAState.self, forKey: .state)
+            ?? .off
+
+        directOnlyState =
+            try container.decodeIfPresent(
+                DirectOnlyState.self,
+                forKey: .directOnlyState
+            )
             ?? .off
     }
 }


### PR DESCRIPTION
This PR supports renaming smartRoutingState to directOnlyState with Codable migration support.

We noticed that after upgrading the app, the Direct only value was no longer preserved correctly. The issue was caused by missing mapping from the old settings key to the new one.

**How to test:**
1. install the app from TestFlight
2. change the Direct only value
3. install the current build
4. verify that the value is preserved in Tunnel Settings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10398)
<!-- Reviewable:end -->
