### PR TITLE
Remove `mullvad-nsis` during fdroid clean

### DIFF
--- a/.github/workflows/android-reproducible-builds.yml
+++ b/.github/workflows/android-reproducible-builds.yml
@@ -23,6 +23,7 @@ on:
       - 'flake*'
       - 'nix/android-*.nix'
       - 'nix/common-toolchain.nix'
+      - 'android/fdroid-build/metadata/net.mullvad.mullvadvpn.yml'
   push:
     tags:
       - 'android/**'

--- a/android/fdroid-build/metadata/net.mullvad.mullvadvpn.yml
+++ b/android/fdroid-build/metadata/net.mullvad.mullvadvpn.yml
@@ -36,12 +36,14 @@ Builds:
       - windows
       - building/sigstore
       - android/lib/billing
+      - mullvad-nsis
     prebuild:
       - sed -i -e 's|Repositories.GradlePlugins|"https://plugins.gradle.org/m2/"|'
         ../build.gradle.kts
       - sed -i -e '/billing/d' ../settings.gradle.kts
       - sed -i -e '/projects.lib.billing/d' build.gradle.kts
       - sed -i '/\"desktop\//d' ../../Cargo.toml
+      - sed -i '/\"mullvad-nsis\"/d' ../../Cargo.toml
     build:
       - NDK_PATH="$$NDK$$" source ../fdroid-build/env.sh
       - echo $NDK_TOOLCHAIN_DIR "$$NDK$$"


### PR DESCRIPTION
The mullvad-nsis create is not needed for Android builds and F-Droid scanner is complaining about a binary: `mullvad_tray_record.bin`

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10399)
<!-- Reviewable:end -->
