### PR TITLE
Fix typos in all .md files

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run Playwright tests on Linux
         if: runner.os == 'Linux'
         working-directory: desktop
-        # The sandbox is disabled as a workaround for lacking userns permisisons which is required
+        # The sandbox is disabled as a workaround for lacking userns permissions which is required
         # since Ubuntu 24.04.
         run: NO_SANDBOX=1 npm run e2e:no-build -w mullvad-vpn -- --reporter=line
 

--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -238,7 +238,7 @@ Install on Fedora:
 sudo dnf install dist/mullvad-vpn-daemon_<version>_riscv64.rpm
 ```
 
-### Cross-compling for RISC-V from other hosts such as Debian/Ubuntu AMD64
+### Cross-compiling for RISC-V from other hosts such as Debian/Ubuntu AMD64
 
 Install dependencies:
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -941,7 +941,7 @@ This release is identical to 2024.3-beta1.
 - Fix issue where app stopped responding on ARM Macs.
 
 #### Linux
-- Fix RPM package containing unecessary files causing conflicts with other electron-builder based
+- Fix RPM package containing unnecessary files causing conflicts with other electron-builder based
   packages.
 
 
@@ -1631,7 +1631,7 @@ This release is for desktop only.
 - Allow provider constraint to specify multiple hosting providers.
 - Only download a new relay list if it has been modified.
 - Connect to the API only via TLS 1.3
-- Shrink account history capactity from 3 account entries to 1.
+- Shrink account history capacity from 3 account entries to 1.
 - Allow whitespace in account token in CLI.
 - Read account token from standard input unless given as an argument in CLI.
 - Make WireGuard automatic key rotation interval mandatory and between 1 and 7 days.
@@ -1766,7 +1766,7 @@ This release is for desktop only.
 
 ### Changed
 - Upgrade wireguard-go to v0.0.20201118.
-- Reduce logging about time outs when conneting to a WireGuard tunnel.
+- Reduce logging about time outs when connecting to a WireGuard tunnel.
 
 ### Fixed
 #### Android

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Before reporting issues, we recommend that you read the following documents:
 
 **Please do not report security vulnerabilities through GitHub issues or other
 public channels.** Instead please [create a vulnerability report on Github]. Or email our
-support on [support@mullvadvpn.net]. Preferrably encrypted with our [support's PGP] key.
+support on [support@mullvadvpn.net]. Preferably encrypted with our [support's PGP] key.
 
 [create a vulnerability report on Github]: https://github.com/mullvad/mullvadvpn-app/security/advisories/new
 [support@mullvadvpn.net]: mailto:support@mullvadvpn.net

--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -431,7 +431,7 @@ Identical to `android/2025.1-beta1`
 
 ## [android/2024.5] - 2024-10-09
 ### Fixed
-- Fix crash when in the edit custom list locations screen and changing app langauge.
+- Fix crash when in the edit custom list locations screen and changing app language.
 
 
 ## [android/2024.5-beta2] - 2024-09-24
@@ -818,7 +818,7 @@ that is the same as the git tag they receive: `android/<version>`.
 - Allow provider constraint to specify multiple hosting providers.
 - Only download a new relay list if it has been modified.
 - Connect to the API only via TLS 1.3
-- Shrink account history capactity from 3 account entries to 1.
+- Shrink account history capacity from 3 account entries to 1.
 - WireGuard key is now rotated sooner: every four days instead of seven.
 
 ### Fixed

--- a/android/docs/TestSuite.md
+++ b/android/docs/TestSuite.md
@@ -39,7 +39,7 @@ mullvad.test.e2e.prod.accountNumber.valid=INSERT_VALID_ACCOUNT_NUMBER_HERE
 mullvad.test.e2e.prod.accountNumber.invalid=1111222233334444
 
 # For running the e2e tests on the stagemole backend
-mullvad.test.e2e.stagemole.partnerAuth=INSER_PARTNER_AUTH_TOKEN_HERE
+mullvad.test.e2e.stagemole.partnerAuth=INSERT_PARTNER_AUTH_TOKEN_HERE
 mullvad.test.e2e.stagemole.accountNumber.invalid=1111222233334444
 
 # For running e2e tests that require the RAAS router

--- a/android/scripts/release/README.md
+++ b/android/scripts/release/README.md
@@ -5,7 +5,7 @@ Currently there are two release scripts that deal with different parts of the an
 ## `github-release`
 Download and verifies a release from releases.mullvad.net and push it to gihub with a changelog.
 
-### Prequisites
+### Prerequisites
 This script requires `sequoia-pgp` and `GitHub CLI`.
 See https://github.com/cli/cli#installation for more detailed instructions on how to install `GitHub CLI`.
 
@@ -34,7 +34,7 @@ It will ask you to make any final changes to the changelog. After that it will p
 ## `release`
 Add and remove supported versions and set the latest version.
 
-### Prequisites
+### Prerequisites
 This script requires `rust` and access to the build server.
 It is possible change supported versions and latest version without using rust by calling
 `publish-metadata-to-api` directly, but this requires manually downloading and editing the metadata files.

--- a/android/test/e2e/README.md
+++ b/android/test/e2e/README.md
@@ -1,6 +1,6 @@
 # End-to-end (e2e) test module
 ## Overview
-The tests in this module are end-to-end tests that rely on the publicly accessible Mullvad infrastucture and APIs. It's therefore required to provide a valid account number (not expired) that can be used to login, connect etc. It's also required to provide an invalid account number which for example is used for negative tests of the login flow. The invalid account number should not exist in the Mullvad infrastucture, however it must be at least 9 characters for some tests to properly run due to input validation.
+The tests in this module are end-to-end tests that rely on the publicly accessible Mullvad infrastructure and APIs. It's therefore required to provide a valid account number (not expired) that can be used to login, connect etc. It's also required to provide an invalid account number which for example is used for negative tests of the login flow. The invalid account number should not exist in the Mullvad infrastructure, however it must be at least 9 characters for some tests to properly run due to input validation.
 
 ## How to run the tests
 ### Locally

--- a/audits/2020-06-12-cure53.md
+++ b/audits/2020-06-12-cure53.md
@@ -58,7 +58,7 @@ were outside of our control.
 
 All issues that we implemented fixes for had their fixes merged before the final report
 was done and sent over to Mullvad. Version [2020.5-beta2] of the app has all found
-vulnerabilies fixed ([ios/2020.3] for iOS).
+vulnerabilities fixed ([ios/2020.3] for iOS).
 
 ### Identified vulnerabilities
 

--- a/ci/ios/test-router/router-config.nix
+++ b/ci/ios/test-router/router-config.nix
@@ -5,7 +5,7 @@ args@{
   # MAC address of the local area network interface
   wanMac,
   # MAC address of the upstream interface
-  lanIp, # IP adderss/subnet
+  lanIp, # IP address/subnet
   # The IPv4 address/subnet of the wg interface
   wgIpv4,
   # The IPv6 address/subnet of the wg interface

--- a/ci/linux-repository-builder/build-linux-repositories.sh
+++ b/ci/linux-repository-builder/build-linux-repositories.sh
@@ -6,7 +6,7 @@
 # you need to run three instances of this script.
 #
 # This script works on an $inbox_dir. In this directory it expects one directory per repository.
-# For each repository it will read all files having the .src extension 
+# For each repository it will read all files having the .src extension
 # These files are expected to contain a single line, a path to some directory where
 # it can read new artifacts for that product.
 # All deb and rpm files from that directory will be signed and moved over to a folder with
@@ -109,7 +109,7 @@ function process_inbox {
         # Recreate the artifact dir, cleaning it
         rm -rf "$artifact_dir" && mkdir -p "$artifact_dir" || exit 1
 
-        # The fact that we have processed one .src file is enough tro trigger a repository
+        # The fact that we have processed one .src file is enough to trigger a repository
         # rebuild. Because if a product would like to publish "no artifacts" they should
         # be able to create a .src file pointing to an empty directory
         found_new_artifacts="true"

--- a/desktop/packages/mullvad-vpn/scripts/README.md
+++ b/desktop/packages/mullvad-vpn/scripts/README.md
@@ -20,7 +20,7 @@ The `<repo>/scripts/localization` script is, among other things, calling into `f
 and `integrate-relay-locations.py` in this directory.
 
 * `fetch-relay-locations.py` fetches the relay list and extracts all country and city names.
-* `intregrate-relay-locations.py` integrates the fetched relay locations into
+* `integrate-relay-locations.py` integrates the fetched relay locations into
 `../locales/relay-locations.pot`.
 
 ### Locking Python dependencies

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -31,7 +31,7 @@ Line wrap the file at 100 chars.                                              Th
 - Add support for obfuscating WireGuard tunnel traffic by LWO (Lightweight WireGuard Obfuscation).
   This helps circumvent censorship.
 - Add button to manually update relay list
-- Add support for the Ukranian language
+- Add support for the Ukrainian language
 
 [TunnelCrack]: https://tunnelcrack.mathyvanhoef.com/
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -16,7 +16,7 @@
 #    with a `PackageOverrides` entry. See below for rules. This should be avoided if feasible.
 #
 # Every ignored vulnerability/package entry must have an end date. It is not allowed to ignore
-# vulnerabilies indefinitely. This means specifying an `ignoreUntil` for `IgnoredVulns` entries
+# vulnerabilities indefinitely. This means specifying an `ignoreUntil` for `IgnoredVulns` entries
 # and `effectiveUntil` for `PackageOverrides` entries.
 # * The default should be to ignore a vulnerability for three months.
 # * A vulnerability can be ignored for up to a year at most (Use extremely sparsely).

--- a/talpid-dbus/README.md
+++ b/talpid-dbus/README.md
@@ -2,7 +2,7 @@
 Communicate with different system components over Dbus.
 
 ## zbus
-Enable the `zbus` feature to use [zbus] as the Dbus backend. This is experimental and inomplete, but functional!
+Enable the `zbus` feature to use [zbus] as the Dbus backend. This is experimental and incomplete, but functional!
 The following table list the system components that `talpid-dbus` can communicate with using `zbus` instead of [dbus-rs].
 
 | System component | `zbus` |

--- a/test/README.md
+++ b/test/README.md
@@ -69,7 +69,7 @@ apt install qemu-utils qemu-system-x86 libpcap-dev slirp4netns rootlesskit dnsma
 ```
 
 ##### Note for Debian
-By default `sysctl` is only invokable by root.
+By default `sysctl` is only invocable by root.
 
 ## Setting up testing environment
 
@@ -127,7 +127,7 @@ For example, building `test-runner` for Windows would look like this:
 ```
 
 #### Linux
-Using `podman` is the recommended way to build the `test-runner`. See the [Linux section under Prerequisities](#prerequisites) for more details.
+Using `podman` is the recommended way to build the `test-runner`. See the [Linux section under Prerequisites](#prerequisites) for more details.
 
 ``` bash
 ./scripts/container-run.sh ./scripts/build-scripts/test-runner.sh linux

--- a/test/docs/BUILD_OS_IMAGE.md
+++ b/test/docs/BUILD_OS_IMAGE.md
@@ -115,7 +115,7 @@ Now you should [add your new VM to the test-manager config](./test-manager/READM
 
 * For UEFI, use OVMF, which is available in the `edk2-ovmf` package.
 
-  `OVMF_VARS` is used writeable UEFI variables. Copy it to the root directory:
+  `OVMF_VARS` is used writable UEFI variables. Copy it to the root directory:
 
   ```
   cp /usr/share/OVMF/OVMF_VARS.secboot.fd .
@@ -219,7 +219,7 @@ This can be achieved as follows:
 
 ## Windows Security
 
-Windows Defender ocasionally kills the `test-runner` because it believes it to be a trojan. This can be worked around by excluding `E:` and [the folder containing the standalone e2e GUI test executable](../../desktop/packages/mullvad-vpn/README.md) following this guide: https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26.
+Windows Defender occasionally kills the `test-runner` because it believes it to be a trojan. This can be worked around by excluding `E:` and [the folder containing the standalone e2e GUI test executable](../../desktop/packages/mullvad-vpn/README.md) following this guide: https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26.
 
 ## Finishing setup
 

--- a/test/scripts/run/ci.sh
+++ b/test/scripts/run/ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script is invoked by the GitHub workflow file below to launch the desktop end to end test framwork.
+# This script is invoked by the GitHub workflow file below to launch the desktop end to end test framework.
 # <https://github.com/mullvad/mullvadvpn-app/blob/main/.github/workflows/desktop-e2e.yml>
 
 # TODO: Break this down into multiple, smaller scripts and compose them in this file.

--- a/test/test-manager/README.md
+++ b/test/test-manager/README.md
@@ -20,7 +20,7 @@ pub async fn test(
 ```
 
 The `test_function` macro allows you to write tests for the MullvadVPN App in a
-format which is very similiar to [standard Rust unit
+format which is very similar to [standard Rust unit
 tests](https://doc.rust-lang.org/book/ch11-01-writing-tests.html). A more
 detailed writeup on how the `#[test_function]` macro works is given as a
 doc-comment in [test_macro::test_function](./test_macro/src/lib.rs).


### PR DESCRIPTION
Besides \*.md files, also corrected a few typos in
".github/workflows/frontend.yml"
"osv-scanner.toml"
"ci/ios/test-router/router-config.nix"
"ci/linux-repository-builder/build-linux-repositories.sh" "test/scripts/run/ci.sh"

The typos were picked using [`typos`](https://github.com/crate-ci/typos) and i manually changed text, filtering out false-positives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10402)
<!-- Reviewable:end -->
