### PR TITLE
Update WireGuardNT to 1.1 and retire Mullvad fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Line wrap the file at 100 chars.                                              Th
 - Restart the GUI after an update if it was running.
 - `mullvad-daemon` now installs the same shutdown handler for `SIGHUP` as `SIGINT` and `SIGTERM`.
 
+#### Windows
+- Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at
+  <https://github.com/mullvad/wireguard-nt>.
+
 ### Fixed
 - Fix duplicate "Connected"/"Disconnected" desktop notifications caused by the daemon sending
   multiple consecutive tunnel state events for the same state.

--- a/desktop/packages/mullvad-vpn/tasks/distribution.cjs
+++ b/desktop/packages/mullvad-vpn/tasks/distribution.cjs
@@ -161,7 +161,7 @@ function newConfig() {
         },
         {
           from: distAssets(
-            path.join('binaries', '${env.TARGET_SUBDIR}', 'wireguard-nt/mullvad-wireguard.dll'),
+            path.join('binaries', '${env.TARGET_SUBDIR}', 'wireguard-nt/wireguard.dll'),
           ),
           to: '.',
         },

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -184,6 +184,45 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 !macroend
 
 !define RemoveWireGuardNt '!insertmacro "RemoveWireGuardNt"'
+
+#
+# RemoveAbandonedWireGuardNt
+#
+# Uninstall network adapters from the legacy `mullvad-wireguard.dll` fork
+# (hardware ID `MullvadWireGuard`) and remove the associated OEM INF from the
+# driver store.
+#
+!macro RemoveAbandonedWireGuardNt
+	Push $0
+	Push $1
+
+	mullvad_nsis::Log "RemoveAbandonedWireGuardNt()"
+
+	nsExec::ExecToStack '"$PLUGINSDIR\mullvad-setup.exe" driver remove wg-nt-abandoned'
+	Pop $0
+	Pop $1
+
+	${If} $0 != ${MVSETUP_OK}
+		IntFmt $0 "0x%X" $0
+		StrCpy $R0 "Failed to remove legacy MullvadWireGuard driver: error $0"
+		mullvad_nsis::LogWithDetails $R0 $1
+		Goto RemoveAbandonedWireGuardNt_return_only
+	${EndIf}
+
+	mullvad_nsis::Log "RemoveAbandonedWireGuardNt() completed successfully"
+
+	Push 0
+	Pop $R0
+
+	RemoveAbandonedWireGuardNt_return_only:
+
+	Pop $1
+	Pop $0
+
+!macroend
+
+!define RemoveAbandonedWireGuardNt '!insertmacro "RemoveAbandonedWireGuardNt"'
+
 #
 # RemoveAbandonedWintunAdapter
 #
@@ -752,6 +791,7 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 
 	${ExtractMullvadSetup}
 	${RemoveAbandonedWintunAdapter}
+	${RemoveAbandonedWireGuardNt}
 
 	${RemoveSplitTunnelDriver}
 

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -192,6 +192,8 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 # (hardware ID `MullvadWireGuard`) and remove the associated OEM INF from the
 # driver store.
 #
+# TODO: This can be removed once we no longer support upgrades from <= 2026.2.
+# Or perhaps earlier. Not removing old drivers is relatively harmless albeit not very nice.
 !macro RemoveAbandonedWireGuardNt
 	Push $0
 	Push $1

--- a/dist-assets/windows/installer.nsh
+++ b/dist-assets/windows/installer.nsh
@@ -93,7 +93,7 @@ ManifestSupportedOS "{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"
 
 	SetOutPath "$PLUGINSDIR"
 	File "${BUILD_RESOURCES_DIR}\binaries\$%TARGET_TRIPLE%\wintun\wintun.dll"
-	File "${BUILD_RESOURCES_DIR}\binaries\$%TARGET_TRIPLE%\wireguard-nt\mullvad-wireguard.dll"
+	File "${BUILD_RESOURCES_DIR}\binaries\$%TARGET_TRIPLE%\wireguard-nt\wireguard.dll"
 
 !macroend
 

--- a/mullvad-setup/src/driver_setup/device.rs
+++ b/mullvad-setup/src/driver_setup/device.rs
@@ -1,16 +1,32 @@
-use std::{io, mem, ptr};
+use std::{
+    ffi::{OsStr, OsString},
+    io, mem,
+    os::windows::ffi::OsStringExt,
+    path::PathBuf,
+    ptr,
+};
 use windows_sys::{
     Win32::{
         Devices::DeviceAndDriverInstallation::{
-            DICS_FLAG_GLOBAL, DIGCF_PRESENT, DIREG_DRV, DiUninstallDevice, HDEVINFO,
-            SP_DEVINFO_DATA, SetupDiDestroyDeviceInfoList, SetupDiEnumDeviceInfo,
-            SetupDiGetClassDevsW, SetupDiOpenDevRegKey,
+            DICD_GENERATE_ID, DICS_FLAG_GLOBAL, DIGCF_PRESENT, DIREG_DRV, DiUninstallDevice,
+            HDEVINFO, SP_DEVINFO_DATA, SP_DRVINFO_DATA_V2_W, SP_DRVINFO_DETAIL_DATA_W,
+            SPDIT_COMPATDRIVER, SPDRP_HARDWAREID, SUOI_FORCEDELETE, SetupDiBuildDriverInfoList,
+            SetupDiCreateDeviceInfoListExW, SetupDiCreateDeviceInfoW, SetupDiDestroyDeviceInfoList,
+            SetupDiDestroyDriverInfoList, SetupDiEnumDeviceInfo, SetupDiEnumDriverInfoW,
+            SetupDiGetClassDevsW, SetupDiGetDeviceInfoListClass, SetupDiGetDeviceRegistryPropertyW,
+            SetupDiGetDriverInfoDetailW, SetupDiOpenDevRegKey, SetupDiSetDeviceRegistryPropertyW,
+            SetupUninstallOEMInfW,
         },
         Foundation::{ERROR_NO_MORE_ITEMS, FALSE, INVALID_HANDLE_VALUE},
         System::Registry::{HKEY, KEY_READ, RRF_RT_REG_SZ, RegCloseKey, RegGetValueW},
     },
     core::GUID,
 };
+
+use super::as_utf16_with_nul;
+
+const ERROR_INSUFFICIENT_BUFFER: i32 =
+    windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER as i32;
 
 /// Type that represents a device information set. Uses [SetupDiGetClassDevsW].
 ///
@@ -35,6 +51,73 @@ impl DeviceInfoSet {
         }
 
         Ok(DeviceInfoSet(device_info_set))
+    }
+
+    /// Return an empty device information set for the given device class. Uses
+    /// [`SetupDiCreateDeviceInfoListExW`].
+    ///
+    /// [`SetupDiCreateDeviceInfoListExW`]: https://learn.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupdicreatedeviceinfolistexw
+    pub fn empty(class_guid: GUID) -> io::Result<Self> {
+        // SAFETY: `class_guid` points to a valid GUID; the optional pointer args are NULL.
+        let device_info_set = unsafe {
+            SetupDiCreateDeviceInfoListExW(
+                &raw const class_guid,
+                ptr::null_mut(),
+                ptr::null(),
+                ptr::null(),
+            )
+        };
+
+        if device_info_set == INVALID_HANDLE_VALUE as isize {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(DeviceInfoSet(device_info_set))
+    }
+
+    /// Create a phantom device-info element in this set, in the set's class,
+    /// with the given name. Uses [`SetupDiCreateDeviceInfoW`] with `DICD_GENERATE_ID`.
+    ///
+    /// [`SetupDiCreateDeviceInfoW`]: https://learn.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupdicreatedeviceinfow
+    pub fn create_device(&self, device_name: &str) -> io::Result<DeviceInfo<'_>> {
+        let class_guid = self.class_guid()?;
+        let mut data = SP_DEVINFO_DATA {
+            cbSize: mem::size_of::<SP_DEVINFO_DATA>() as u32,
+            ..Default::default()
+        };
+        let name_utf16 = as_utf16_with_nul(device_name);
+        // SAFETY: `self.0` is a valid HDEVINFO; `name_utf16` is NUL-terminated UTF-16;
+        // `class_guid` came from `SetupDiGetDeviceInfoListClass` on this set; `data.cbSize` is set.
+        let ok = unsafe {
+            SetupDiCreateDeviceInfoW(
+                self.0,
+                name_utf16.as_ptr(),
+                &raw const class_guid,
+                ptr::null(),
+                ptr::null_mut(),
+                DICD_GENERATE_ID,
+                &raw mut data,
+            )
+        };
+        if ok == FALSE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(DeviceInfo { data, set: self })
+    }
+
+    /// Return the device setup class GUID this set is associated with (the one
+    /// passed to `SetupDiGetClassDevsW` / `SetupDiCreateDeviceInfoListExW`).
+    /// Uses [`SetupDiGetDeviceInfoListClass`].
+    ///
+    /// [`SetupDiGetDeviceInfoListClass`]: https://learn.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupdigetdeviceinfolistclass
+    fn class_guid(&self) -> io::Result<GUID> {
+        let mut class_guid = GUID::default();
+        // SAFETY: `self.0` is a valid HDEVINFO; `class_guid` is a writable GUID.
+        let ok = unsafe { SetupDiGetDeviceInfoListClass(self.0, &raw mut class_guid) };
+        if ok == FALSE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(class_guid)
     }
 
     /// Return an iterator over the device info set.
@@ -68,11 +151,44 @@ impl DeviceInfoSet {
 
 impl Drop for DeviceInfoSet {
     fn drop(&mut self) {
-        // SAFETY: `self.0` was returned by `SetupDiGetClassDevsW` and is only destroyed here.
+        // SAFETY: `self.0` was returned by `SetupDiGetClassDevsW` (or
+        // `SetupDiCreateDeviceInfoListExW`) and is only destroyed here.
         unsafe {
             SetupDiDestroyDeviceInfoList(self.0);
         }
     }
+}
+
+/// Return the file names of every driver (in the driver store) that is
+/// compatible with a device of class `class_guid` whose hardware ID is
+/// `hardware_id`.
+///
+/// Uses the same SetupAPI dance as `WireGuardDeleteDriver`: build an empty device-info
+/// list, add a phantom element with the desired hardware ID, then enumerate `SPDIT_COMPATDRIVER`.
+pub fn list_compatible_driver_inf_names(
+    class_guid: GUID,
+    hardware_id: &str,
+) -> io::Result<Vec<OsString>> {
+    let set = DeviceInfoSet::empty(class_guid)?;
+    let mut device = set.create_device(hardware_id)?;
+    device.set_hardware_id(hardware_id)?;
+    device.compat_driver_inf_names()
+}
+
+/// Uninstall an OEM INF from the driver store by its simple file name (e.g. `oem42.inf`).
+/// Uses [`SetupUninstallOEMInfW`] with `SUOI_FORCEDELETE`.
+///
+/// [`SetupUninstallOEMInfW`]: https://learn.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupuninstalloeminfw
+pub fn uninstall_oem_inf(inf_name: &OsStr) -> io::Result<()> {
+    let inf_filename_utf16 = as_utf16_with_nul(inf_name);
+    // SAFETY: `inf_filename_utf16` is a NUL-terminated UTF-16 string; reserved must be null.
+    let result = unsafe {
+        SetupUninstallOEMInfW(inf_filename_utf16.as_ptr(), SUOI_FORCEDELETE, ptr::null())
+    };
+    if result == FALSE {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 /// Type that represents a device information element from a [DeviceInfoSet].
@@ -114,6 +230,183 @@ impl DeviceInfo<'_> {
     /// Returns the GUID string (e.g. `{AFE43773-...}`).
     pub fn get_device_net_cfg_instance_id(&self) -> io::Result<String> {
         DevRegKey::open(self)?.get_string_value("NetCfgInstanceId")
+    }
+
+    /// Read the device's `HardwareID` property (`SPDRP_HARDWAREID`), which is a
+    /// `REG_MULTI_SZ` list of hardware IDs.
+    pub fn get_hardware_ids(&self) -> io::Result<Vec<String>> {
+        let mut buffer = vec![0u16; 512];
+        let mut required: u32 = 0;
+        loop {
+            // SAFETY: `self.set.0` and `self.data` are valid and belong to the same enumeration;
+            // `buffer` is sized by its length in bytes.
+            let result = unsafe {
+                SetupDiGetDeviceRegistryPropertyW(
+                    self.set.0,
+                    &raw const self.data,
+                    SPDRP_HARDWAREID,
+                    ptr::null_mut(),
+                    buffer.as_mut_ptr().cast(),
+                    // current size of `buffer` in bytes.
+                    (2 * buffer.len()) as u32,
+                    &raw mut required,
+                )
+            };
+            let required = (required / 2) as usize; // bytes -> u16s
+            if result != FALSE {
+                buffer.truncate(required);
+                break;
+            }
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(ERROR_INSUFFICIENT_BUFFER) && required > buffer.len() {
+                buffer.resize(required, 0);
+                continue;
+            }
+            return Err(err);
+        }
+
+        // Split on NULs (REG_MULTI_SZ)
+        Ok(buffer
+            .split(|&c| c == 0)
+            .filter(|s| !s.is_empty())
+            .map(String::from_utf16_lossy)
+            .collect())
+    }
+
+    /// Set the device's `HardwareID` property (`SPDRP_HARDWAREID`) to the
+    /// single given hardware ID.
+    ///
+    /// # Panics
+    ///
+    /// This panics if `hardware_id.len()` is above `size_of::MAX / 2 - 2`.
+    pub fn set_hardware_id(&mut self, hardware_id: &str) -> io::Result<()> {
+        // SPDRP_HARDWAREID is REG_MULTI_SZ (NUL-delimited list), so terminate with two NULs.
+        let multi_sz: Vec<u16> = hardware_id.encode_utf16().chain([0u16, 0u16]).collect();
+        let byte_len = u32::try_from(multi_sz.len() * 2).expect("hardware ID size fits u32");
+        // SAFETY: `self.set.0` and `self.data` are valid; `multi_sz` is a double-NUL-terminated
+        // UTF-16 buffer of size `byte_len` bytes.
+        let ok = unsafe {
+            SetupDiSetDeviceRegistryPropertyW(
+                self.set.0,
+                &raw mut self.data,
+                SPDRP_HARDWAREID,
+                multi_sz.as_ptr().cast::<u8>(),
+                byte_len,
+            )
+        };
+        if ok == FALSE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Build the list of drivers in the driver store compatible with this
+    /// device (`SPDIT_COMPATDRIVER`) and return the simple file names of their
+    /// INFs.
+    ///
+    /// [`SetupUninstallOEMInfW`]: https://learn.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupuninstalloeminfw
+    pub fn compat_driver_inf_names(&mut self) -> io::Result<Vec<OsString>> {
+        CompatDriverInfoList::build(self)?.inf_names()
+    }
+}
+
+/// A compatible-driver list (`SPDIT_COMPATDRIVER`) built for a [`DeviceInfo`].
+struct CompatDriverInfoList<'d, 'a> {
+    device: &'d mut DeviceInfo<'a>,
+}
+
+impl<'d, 'a: 'd> CompatDriverInfoList<'d, 'a> {
+    /// Build a compatible driver list for the given `device` using [`SetupDiBuildDriverInfoList`].
+    ///
+    /// [`SetupDiBuildDriverInfoList`]: https://learn.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupdibuilddriverinfolist
+    pub fn build(device: &'d mut DeviceInfo<'a>) -> io::Result<Self> {
+        // SAFETY: `device.set.0` and `device.data` are valid and belong to the same set.
+        let ok = unsafe {
+            SetupDiBuildDriverInfoList(device.set.0, &raw mut device.data, SPDIT_COMPATDRIVER)
+        };
+        if ok == FALSE {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { device })
+    }
+
+    /// List the filenames of each compatible driver's INF.
+    pub fn inf_names(&self) -> io::Result<Vec<OsString>> {
+        let mut inf_names = Vec::new();
+        for idx in 0u32.. {
+            let mut drvinfo_data = SP_DRVINFO_DATA_V2_W {
+                cbSize: mem::size_of::<SP_DRVINFO_DATA_V2_W>() as u32,
+                ..Default::default()
+            };
+            // SAFETY: `self.device.set.0`, `self.device.data`, and `drvinfo_data` are valid.
+            let ok = unsafe {
+                SetupDiEnumDriverInfoW(
+                    self.device.set.0,
+                    &raw const self.device.data,
+                    SPDIT_COMPATDRIVER,
+                    idx,
+                    &raw mut drvinfo_data,
+                )
+            };
+            if ok == FALSE {
+                let err = io::Error::last_os_error();
+                if err.raw_os_error() == Some(ERROR_NO_MORE_ITEMS as i32) {
+                    break;
+                }
+                return Err(err);
+            }
+
+            let mut detail = SP_DRVINFO_DETAIL_DATA_W {
+                cbSize: mem::size_of::<SP_DRVINFO_DETAIL_DATA_W>() as u32,
+                ..Default::default()
+            };
+            let mut required: u32 = 0;
+            // SAFETY: All pointer args are valid; `detail` is sized correctly via `cbSize`.
+            let ok = unsafe {
+                SetupDiGetDriverInfoDetailW(
+                    self.device.set.0,
+                    &raw const self.device.data,
+                    &raw const drvinfo_data,
+                    &raw mut detail,
+                    mem::size_of::<SP_DRVINFO_DETAIL_DATA_W>() as u32,
+                    &raw mut required,
+                )
+            };
+            // ERROR_INSUFFICIENT_BUFFER means the variable-length compatible-IDs tail did
+            // not fit, but `InfFileName` lives in the fixed-size header and is populated.
+            if ok == FALSE {
+                let err = io::Error::last_os_error();
+                if err.raw_os_error() != Some(ERROR_INSUFFICIENT_BUFFER) {
+                    return Err(err);
+                }
+            }
+
+            let inf_path = detail
+                .InfFileName
+                .split(|&c| c == 0)
+                .next()
+                .expect("path is null-terminated");
+            let inf_path = OsString::from_wide(inf_path);
+            if let Some(file_name) = PathBuf::from(inf_path).file_name() {
+                inf_names.push(file_name.to_os_string());
+            }
+        }
+
+        Ok(inf_names)
+    }
+}
+
+impl Drop for CompatDriverInfoList<'_, '_> {
+    fn drop(&mut self) {
+        // SAFETY: `self.device.set.0` and `self.device.data` are valid for as long as
+        // this struct exists, and the driver info list was built with `SPDIT_COMPATDRIVER`.
+        unsafe {
+            SetupDiDestroyDriverInfoList(
+                self.device.set.0,
+                &raw const self.device.data,
+                SPDIT_COMPATDRIVER,
+            );
+        }
     }
 }
 
@@ -170,10 +463,7 @@ impl DevRegKey {
         let mut buffer: Vec<u16> = vec![0u16; 128];
         let mut buffer_byte_len: u32 = (buffer.len() * 2) as u32;
 
-        let value_name: Vec<u16> = value_name
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        let value_name = as_utf16_with_nul(value_name);
 
         // SAFETY: `self.key` is valid; `value_name` is NUL-terminated; `buffer` is sized by `buffer_byte_len`.
         let status = unsafe {

--- a/mullvad-setup/src/driver_setup/mod.rs
+++ b/mullvad-setup/src/driver_setup/mod.rs
@@ -56,12 +56,12 @@ pub fn remove_wintun_abandoned_device() -> Result<(), Error> {
     Ok(())
 }
 
-/// Dynamically load `mullvad-wireguard.dll` (from the same directory as this
+/// Dynamically load `wireguard.dll` (from the same directory as this
 /// executable) and call `WireGuardDeleteDriver`.
 pub fn remove_wg_nt() -> Result<(), Error> {
-    // SAFETY: `WireGuardDeleteDriver` exported by `mullvad-wireguard.dll` has
+    // SAFETY: `WireGuardDeleteDriver` exported by `wireguard.dll` has
     // the signature `BOOL WireGuardDeleteDriver(void)`.
-    unsafe { call_delete_driver_fn("mullvad-wireguard.dll", "WireGuardDeleteDriver") }?;
+    unsafe { call_delete_driver_fn("wireguard.dll", "WireGuardDeleteDriver") }?;
     tracing::info!("Removed WireGuardNT driver");
     Ok(())
 }

--- a/mullvad-setup/src/driver_setup/mod.rs
+++ b/mullvad-setup/src/driver_setup/mod.rs
@@ -2,7 +2,8 @@ mod device;
 mod service;
 mod split_tunnel;
 
-use std::{io, path::PathBuf, ptr};
+use std::os::windows::ffi::OsStrExt;
+use std::{ffi::OsStr, io, path::PathBuf, ptr};
 use windows_sys::Win32::{
     Devices::DeviceAndDriverInstallation::GUID_DEVCLASS_NET,
     Foundation::{FALSE, FreeLibrary, HMODULE},
@@ -14,6 +15,9 @@ use device::DeviceInfoSet;
 
 // Wintun adapter GUID that may have been left behind
 const WINTUN_ABANDONED_GUID: &str = "{AFE43773-E1F8-4EBB-8536-576AB86AFE9A}";
+
+// Hardware ID used by the legacy `mullvad-wireguard.dll` fork of WireGuardNT.
+const MULLVAD_WG_HARDWARE_ID: &str = "MullvadWireGuard";
 
 /// Reset split tunnel driver state, stop and delete the `mullvad-split-tunnel`
 /// service.
@@ -66,6 +70,64 @@ pub fn remove_wg_nt() -> Result<(), Error> {
     Ok(())
 }
 
+/// Remove leftovers from the legacy `mullvad-wireguard.dll` fork: network
+/// adapters with hardware ID `MullvadWireGuard` and the OEM INF in the driver
+/// store. Unlike [`remove_wg_nt`] this needs to not depend on `mullvad-wireguard.dll`
+/// is no longer shipped.
+pub fn remove_wg_nt_abandoned() -> Result<(), Error> {
+    let removed_devices = uninstall_devices_by_hardware_id(MULLVAD_WG_HARDWARE_ID)?;
+    if removed_devices > 0 {
+        tracing::info!("Uninstalled {removed_devices} legacy MullvadWireGuard device(s)");
+    }
+
+    remove_network_driver_by_hardware_id(MULLVAD_WG_HARDWARE_ID)?;
+
+    Ok(())
+}
+
+/// Enumerate `GUID_DEVCLASS_NET` and uninstall every device whose hardware ID
+/// list contains `hardware_id` (case-insensitive). Returns the number of
+/// devices that were uninstalled.
+//
+// Uninstalling a device invalidates the device info set, so we rebuild it
+// after each removal.
+// TODO: Check if this is actually true.
+fn uninstall_devices_by_hardware_id(hardware_id: &str) -> Result<usize, Error> {
+    let mut removed = 0;
+    'outer: loop {
+        let device_info_set =
+            DeviceInfoSet::new(GUID_DEVCLASS_NET).map_err(Error::DeviceEnumeration)?;
+        for info in device_info_set.iter() {
+            let device_info = info.map_err(Error::DeviceEnumeration)?;
+            if let Ok(ids) = device_info.get_hardware_ids()
+                && ids.iter().any(|id| id.eq_ignore_ascii_case(hardware_id))
+            {
+                device_info
+                    .uninstall_device()
+                    .map_err(Error::DeviceEnumeration)?;
+                removed += 1;
+                continue 'outer;
+            }
+        }
+        return Ok(removed);
+    }
+}
+
+/// Uninstall every INF in the driver store that matches the class `GUID_DEVCLASS_NET`
+/// and the given hardware ID.
+fn remove_network_driver_by_hardware_id(hardware_id: &str) -> Result<(), Error> {
+    let inf_names = device::list_compatible_driver_inf_names(GUID_DEVCLASS_NET, hardware_id)
+        .map_err(Error::DeviceEnumeration)?;
+    for inf_name in inf_names {
+        device::uninstall_oem_inf(&inf_name).map_err(Error::DeviceEnumeration)?;
+        tracing::info!(
+            "Uninstalled legacy MullvadWireGuard OEM INF: {}",
+            inf_name.to_string_lossy()
+        );
+    }
+    Ok(())
+}
+
 struct Dll {
     handle: HMODULE,
 }
@@ -73,7 +135,7 @@ struct Dll {
 impl Dll {
     /// - path: Path to a dll library.
     fn load(path: PathBuf) -> Result<Self, Error> {
-        let dll_path = encode_as_utf16(path);
+        let dll_path = as_utf16_with_nul(path);
         // SAFETY: `dll_path` is a NUL-terminated UTF-16 string; the reserved handle is NULL as required.
         let handle: HMODULE = unsafe {
             LoadLibraryExW(
@@ -138,9 +200,7 @@ fn dll_path(dll_name: &str) -> io::Result<PathBuf> {
     std::env::current_exe().map(|path| path.parent().unwrap().join(dll_name))
 }
 
-fn encode_as_utf16(path: PathBuf) -> Vec<u16> {
-    path.to_string_lossy()
-        .encode_utf16()
-        .chain(std::iter::once(0))
-        .collect()
+/// Encode `s` as a NUL-terminated UTF-16/WTF-16 string.
+fn as_utf16_with_nul(s: impl AsRef<OsStr>) -> Vec<u16> {
+    s.as_ref().encode_wide().chain(std::iter::once(0)).collect()
 }

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -164,6 +164,9 @@ enum DriverRemoveCommand {
     SplitTunnel,
     /// Remove the WireGuard-NT driver (loads wireguard.dll from the same directory)
     WgNt,
+    /// Uninstall legacy MullvadWireGuard adapters and remove the OEM INF from
+    /// the driver store (no DLL required)
+    WgNtAbandoned,
     /// Remove the Wintun driver (loads wintun.dll from the same directory)
     Wintun,
     /// Uninstall an abandoned Wintun network adapter with the legacy GUID
@@ -193,6 +196,7 @@ async fn main() {
         Cli::Driver(DriverCommand::Remove(cmd)) => match cmd {
             DriverRemoveCommand::SplitTunnel => driver_setup::remove_split_tunnel(),
             DriverRemoveCommand::WgNt => driver_setup::remove_wg_nt(),
+            DriverRemoveCommand::WgNtAbandoned => driver_setup::remove_wg_nt_abandoned(),
             DriverRemoveCommand::Wintun => driver_setup::remove_wintun(),
             DriverRemoveCommand::WintunAbandonedDevice => {
                 driver_setup::remove_wintun_abandoned_device()

--- a/mullvad-setup/src/main.rs
+++ b/mullvad-setup/src/main.rs
@@ -162,7 +162,7 @@ enum DriverCommand {
 enum DriverRemoveCommand {
     /// Reset split tunnel driver, uninstall the ST device, stop and delete the service
     SplitTunnel,
-    /// Remove the WireGuard-NT driver (loads mullvad-wireguard.dll from the same directory)
+    /// Remove the WireGuard-NT driver (loads wireguard.dll from the same directory)
     WgNt,
     /// Remove the Wintun driver (loads wintun.dll from the same directory)
     Wintun,

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -1071,6 +1071,7 @@ mod tests {
             address: WgIpAddr::from("1.3.3.0".parse::<Ipv4Addr>().unwrap()),
             address_family: AF_INET,
             cidr: 24,
+            flags: 0,
         },
     });
 

--- a/talpid-wireguard/src/wireguard_nt/mod.rs
+++ b/talpid-wireguard/src/wireguard_nt/mod.rs
@@ -11,7 +11,7 @@ use futures::SinkExt;
 use ipnetwork::IpNetwork;
 use once_cell::sync::OnceCell;
 use std::{
-    ffi::{CStr, c_uchar},
+    ffi::CStr,
     fmt,
     future::Future,
     io,
@@ -111,7 +111,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// Failed to load WireGuardNT
-    #[error("Failed to load mullvad-wireguard.dll")]
+    #[error("Failed to load wireguard.dll")]
     LoadDll(#[source] io::Error),
 
     /// Failed to create tunnel interface
@@ -213,6 +213,7 @@ struct WgAllowedIp {
     address: WgIpAddr,
     address_family: u16,
     cidr: u8,
+    flags: u32,
 }
 
 impl WgAllowedIp {
@@ -222,6 +223,7 @@ impl WgAllowedIp {
             address,
             address_family,
             cidr,
+            flags: 0,
         })
     }
 
@@ -325,7 +327,6 @@ struct WgPeer {
     rx_bytes: u64,
     last_handshake: u64,
     allowed_ips_count: u32,
-    constant_packet_size: c_uchar,
 }
 
 #[derive(Clone, Copy)]
@@ -639,8 +640,7 @@ unsafe impl Sync for WgNtDll {}
 
 impl WgNtDll {
     pub fn new(resource_dir: &Path) -> io::Result<Self> {
-        let wg_nt_dll =
-            U16CString::from_os_str_truncate(resource_dir.join("mullvad-wireguard.dll"));
+        let wg_nt_dll = U16CString::from_os_str_truncate(resource_dir.join("wireguard.dll"));
 
         let handle = unsafe {
             LoadLibraryExW(
@@ -830,7 +830,6 @@ fn serialize_config(config: &Config) -> Result<Vec<MaybeUninit<u8>>> {
             rx_bytes: 0,
             last_handshake: 0,
             allowed_ips_count: u32::try_from(peer.allowed_ips.len()).unwrap(),
-            constant_packet_size: 0,
         };
 
         buffer.extend(as_uninit_byte_slice(&wg_peer));
@@ -1067,7 +1066,6 @@ mod tests {
             rx_bytes: 0,
             last_handshake: 0,
             allowed_ips_count: 1,
-            constant_packet_size: 0,
         },
         p0_allowed_ip_0: WgAllowedIp {
             address: WgIpAddr::from("1.3.3.0".parse::<Ipv4Addr>().unwrap()),


### PR DESCRIPTION
This updates WireGuardNT to 1.1 and also deprecates our fork at https://github.com/mullvad/wireguard-nt. We no longer need it as GotaTun provides multihop and DAITA support now.

Related PR: https://github.com/mullvad/mullvadvpn-app-binaries/pull/125

Fix DES-2941

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10405)
<!-- Reviewable:end -->
