### PR TITLE
Remove untracked git repositories on build server

### DIFF
--- a/ci/buildserver-build.sh
+++ b/ci/buildserver-build.sh
@@ -169,7 +169,7 @@ function checkout_ref {
     git reset --hard || return 1
 
     git submodule update
-    git clean -df
+    git clean -dff
 }
 
 function build_ref {


### PR DESCRIPTION
The build server refused to build some tags/commits after wireguard-go was removed as the repository still contained untracked files:

```
$ git clean -df
Skipping repository wireguard-go-rs/libwg/wireguard-go
```

Simply add another `-f` to remove untracked git repositories.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10408)
<!-- Reviewable:end -->
