### PR TITLE
Clarify "Core foundation main loop exited" error

### DIFF
--- a/talpid-dns/src/macos.rs
+++ b/talpid-dns/src/macos.rs
@@ -427,8 +427,13 @@ impl DnsMonitor {
                 Ok(run_loop_source) => {
                     result_tx.send(Ok(())).unwrap();
                     run_dynamic_store_runloop(run_loop_source);
-                    // TODO(linus): This is critical. Improve later by sending error signal to Daemon
-                    log::error!("Core Foundation main loop exited! It should run forever");
+                    // the Core Foundation main loop should only exit when macOS is shut down.
+                    // If it exits in any other case, that would be a bug,
+                    // and DNS monitoring would break.
+                    //
+                    // If we start seeing this happen on a running system, we should add error
+                    // handling that tries to restart the main loop (or even the entire daemon).
+                    log::warn!("Core Foundation main loop exited! Is macOS shutting down?");
                 }
                 Err(e) => result_tx.send(Err(e)).unwrap(),
             }


### PR DESCRIPTION
The loop will exit when shutting down macOS. This is harmless and expected.
This PR clarifies demotes the log message to a warning, and clarifies the "This is critical" comment.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10410)
<!-- Reviewable:end -->
