### PR TITLE
Fix flaky `testInAppPurchaseForOutOfTime` test

### DIFF
--- a/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/Page.kt
+++ b/android/test/common/src/main/kotlin/net/mullvad/mullvadvpn/test/common/page/Page.kt
@@ -12,10 +12,11 @@ sealed class Page {
 
 inline fun <reified T : Page> on(scope: T.() -> Unit = {}) {
     val page = T::class.java.getConstructor().newInstance()
-    // Wait for the screen to settle and so we don't proceed with actions too early. Otherwise, we
+
+    page.assertIsDisplayed()
+    // Wait for the screen to settle, and so we don't proceed with actions too early. Otherwise, we
     // might start clicking on the screen before it is in a resumed state.
     page.uiDevice.waitForStableInActiveWindow()
-    page.assertIsDisplayed()
 
     page.scope()
 }


### PR DESCRIPTION
## What

Address flakiness in the `testInAppPurchaseForOutOfTime` test.

## Why

Move the stable check until after the page is displayed. As the check could be incorrectly be made on a previous screen. E.g see the following scenario:
```
        on<LoginPage> {
            enterAccountNumber(validTestAccountNumber)
            clickLoginButton()
        }

        on<OutOfTimePage> { clickAddTime() }
```

After `clickLoginButton()` the LoginScreen loads and then shows "Logged In" for some time after success, this means the check of displaying the next page (`on<OutOfTimePage>`) started too early. The stable check was completed on the LoginScreen and not the OutOfTimePage.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10418)
<!-- Reviewable:end -->
