### PR TITLE
Mitigate `arduino/setup-protoc` being stuck on node 20

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -59,6 +59,10 @@ runs:
 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
+      env:
+        # Workaround for arduino/setup-protoc#112
+        # TODO: Remove this once setup/protoc upstream ships node24.
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       with:
         repo-token: ${{ inputs.protoc-token }}
 

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -81,10 +81,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/mullvad-build-env
 
       - name: Build test runner
         working-directory: test


### PR DESCRIPTION
Follow up to https://github.com/mullvad/mullvadvpn-app/pull/10411 - [arduino/setup-protoc](https://github.com/arduino/setup-protoc) still has not been updated to use node >20 ([issue #112](https://github.com/arduino/setup-protoc/issues/112)), which means that it will stop working in ~2 weeks. As is suggested by the deprecation warning, one can force the use of a later node version by setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`:
<img width="1874" height="1102" alt="image" src="https://github.com/user-attachments/assets/9701bcfd-ab29-4023-9ed8-0bf0e17c1617" />

[This will keep working for a couple of more months at least.](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10431)
<!-- Reviewable:end -->
