### PR TITLE
Upgrade tonic to 0.14.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,8 @@ dependencies = [
  "tipsy",
  "tokio",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
  "vec1",
 ]
@@ -4110,11 +4111,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -4491,9 +4493,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4501,15 +4503,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
@@ -4521,9 +4522,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4534,9 +4535,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -5676,7 +5677,8 @@ dependencies = [
  "talpid-types",
  "tokio",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
  "zeroize",
 ]
@@ -6134,9 +6136,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -6151,8 +6153,8 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "socket2 0.5.10",
+ "socket2 0.6.3",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
  "tower",
@@ -6163,9 +6165,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6173,6 +6198,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.106",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,8 @@ nsis-plugin-api = { path = "./mullvad-nsis/vendor/nsis-plugin-api" }
 once_cell = "1.16"
 pnet_packet = "0.35.0"
 proptest = "1.9"
-prost = "0.13.3"
-prost-types = "0.13.3"
+prost = "0.14.3"
+prost-types = "0.14.3"
 rand = "0.9.3"
 reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls"
@@ -125,8 +125,9 @@ thiserror = "2.0"
 tipsy = "0.7.0"
 tokio = { version = "1.44" }
 tokio-util = "0.7"
-tonic = "0.13.1"
-tonic-build = { version = "0.13.1", default-features = false }
+tonic = "0.14.6"
+tonic-prost = "0.14.6"
+tonic-prost-build = { version = "0.14.6", default-features = false }
 tower = { version = "0.5.1", features = ["util"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/mullvad-daemon/src/management_interface.rs
+++ b/mullvad-daemon/src/management_interface.rs
@@ -1284,7 +1284,6 @@ impl ManagementService for ManagementServiceImpl {
     ) -> ServiceResult<Self::AppUpgradeEventsListenStream> {
         log::debug!("app_upgrade_events_listen");
         let rx = self.app_upgrade_broadcast.subscribe();
-        #[expect(clippy::result_large_err)]
         let upgrade_event_stream =
             tokio_stream::wrappers::BroadcastStream::new(rx).map(|result| match result {
                 Ok(event) => Ok(event.into()),
@@ -1293,9 +1292,7 @@ impl ManagementService for ManagementServiceImpl {
                 ))),
             });
 
-        Ok(Response::new(
-            Box::new(upgrade_event_stream) as Self::AppUpgradeEventsListenStream
-        ))
+        Ok(Response::new(Box::new(upgrade_event_stream)))
     }
 
     async fn get_app_upgrade_cache_dir(&self, _: Request<()>) -> ServiceResult<String> {
@@ -1340,7 +1337,6 @@ impl ManagementService for ManagementServiceImpl {
     }
 }
 
-#[expect(clippy::result_large_err)]
 impl ManagementServiceImpl {
     /// Sends a command to the daemon and maps the error to an RPC error.
     fn send_command_to_daemon(&self, command: DaemonCommand) -> Result<(), Status> {

--- a/mullvad-ios/deny.toml
+++ b/mullvad-ios/deny.toml
@@ -17,6 +17,7 @@ allow = [
   "Unicode-DFS-2016",
   "Unicode-3.0",
   "CDLA-Permissive-2.0",
+  "Zlib",
 ]
 # Allow GPL3 licensed crates with permission to relicense like Mullvads own.
 exceptions = [

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -6,6 +6,9 @@ description = "Mullvad VPN IPC. Contains types and functions for IPC clients and
 repository.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-shear]
+ignored = ["tonic-prost"]
+
 [dependencies]
 chrono = { workspace = true }
 futures = { workspace = true }
@@ -20,14 +23,12 @@ thiserror = { workspace = true }
 tipsy = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 tower = { workspace = true }
 vec1 = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true, default-features = false, features = [
-  "prost",
-  "transport"
-] }
+tonic-prost-build = { workspace = true, features = ["transport"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["fs", "user"] }

--- a/mullvad-management-interface/build.rs
+++ b/mullvad-management-interface/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     // Compile both proto files together so they can reference each other
-    tonic_build::configure()
+    tonic_prost_build::configure()
+        .with_extended_rust_types(true)
         .compile_protos(
             &[
                 "proto/management_interface.proto",

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -6,6 +6,9 @@ description = "Uses the relay RPC service to set up PQ-safe peers, etc."
 repository.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-shear]
+ignored = ["tonic-prost"]
+
 [lib]
 crate-type = ["rlib", "staticlib"]
 
@@ -28,14 +31,12 @@ sha2 = { workspace = true }
 talpid-types = { path = "../talpid-types" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 tower = { workspace = true }
 zeroize = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true, default-features = false, features = [
-  "prost",
-  "transport",
-] }
+tonic-prost-build = { workspace = true, features = ["transport"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["socket"] }

--- a/talpid-tunnel-config-client/build.rs
+++ b/talpid-tunnel-config-client/build.rs
@@ -1,3 +1,6 @@
 fn main() {
-    tonic_build::compile_protos("proto/ephemeralpeer.proto").unwrap();
+    tonic_prost_build::configure()
+        .with_extended_rust_types(true)
+        .compile_protos(&["proto/ephemeralpeer.proto"], &["proto/"])
+        .unwrap();
 }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -2182,7 +2182,8 @@ dependencies = [
  "tipsy",
  "tokio",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
  "vec1",
 ]
@@ -2472,11 +2473,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -2725,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2735,15 +2737,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
@@ -2755,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -2768,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -4012,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -4029,8 +4030,8 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "socket2 0.5.10",
+ "socket2 0.6.3",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
  "tower",
@@ -4041,9 +4042,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4051,6 +4075,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.117",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -46,7 +46,7 @@ thiserror = "2.0"
 tipsy = "0.7.0"
 tokio = { version = "1.44", default-features = false }
 tokio-serial = "5.4.1"
-tonic = "0.13.1"
+tonic = "0.14.6"
 tower = "0.5.1"
 tun = "0.8.8"
 windows-sys = "0.52.0"


### PR DESCRIPTION
And related crates (`prost` et al). [This is supposedly the last breaking release of `tonic` before `grpc-rust` will become a thing](https://github.com/hyperium/tonic/releases/tag/v0.14.0).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10433)
<!-- Reviewable:end -->
