### PR TITLE
Switch out winreg for windows_registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Line wrap the file at 100 chars.                                              Th
 - Restart the GUI after an update if it was running.
 - `mullvad-daemon` now installs the same shutdown handler for `SIGHUP` as `SIGINT` and `SIGTERM`.
 
+#### Windows
+- Switch winreg out for windows_registry.
+
 ### Fixed
 - Fix duplicate "Connected"/"Disconnected" desktop notifications caused by the daemon sending
   multiple consecutive tunnel state events for the same state.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5544,6 +5544,7 @@ dependencies = [
  "triggered",
  "which",
  "windows-registry",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -526,27 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "c2rust-bitfields"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b9a85391b09c224053f3c45344f0639822e641f9d2b4f351bb3152600742d"
-dependencies = [
- "c2rust-bitfields-derive",
-]
-
-[[package]]
-name = "c2rust-bitfields-derive"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153187c06ed005d5cb75ed9f0a2f274836f54f6b2efdc1f45136e728764875f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "unicode-ident",
-]
-
-[[package]]
 name = "cacao"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +753,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1187,7 +1166,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1410,7 +1389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1739,7 +1718,7 @@ dependencies = [
  "tokio-util 0.7.18",
  "tun 0.8.7",
  "typed-builder 0.21.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "x25519-dalek",
  "zerocopy",
 ]
@@ -3637,7 +3616,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4917,7 +4896,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5019,7 +4998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5313,7 +5292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5524,9 +5503,9 @@ dependencies = [
  "typed-builder 0.20.1",
  "widestring",
  "windows 0.58.0",
+ "windows-registry",
  "windows-service",
  "windows-sys 0.61.2",
- "winreg 0.55.0",
  "wmi",
 ]
 
@@ -5564,8 +5543,8 @@ dependencies = [
  "tokio",
  "triggered",
  "which",
+ "windows-registry",
  "windows-sys 0.61.2",
- "winreg 0.55.0",
 ]
 
 [[package]]
@@ -5763,7 +5742,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6484,7 +6463,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6795,7 +6774,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7316,26 +7295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
-dependencies = [
- "cfg-if",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "winres"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7346,18 +7305,16 @@ dependencies = [
 
 [[package]]
 name = "wintun-bindings"
-version = "0.7.35"
+version = "0.7.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447c9485fa394cfd85e12d7875ac8e726dc88dd242368205d65b957603b0cba4"
+checksum = "4d94caf41ce60c37c9215c68f124835c401d2ec4f9b3b6431b491c79b3cdd335"
 dependencies = [
  "blocking",
- "c2rust-bitfields",
  "futures",
  "libloading 0.9.0",
  "log",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
- "winreg 0.56.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2396,7 +2396,7 @@ dependencies = [
  "socket2 0.6.3",
  "widestring",
  "windows-registry",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-sys 0.61.2",
 ]
 
@@ -5502,7 +5502,7 @@ dependencies = [
  "tun 0.5.5",
  "typed-builder 0.20.1",
  "widestring",
- "windows 0.58.0",
+ "windows",
  "windows-registry",
  "windows-service",
  "windows-sys 0.61.2",
@@ -5544,7 +5544,7 @@ dependencies = [
  "triggered",
  "which",
  "windows-registry",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-sys 0.61.2",
 ]
 
@@ -6786,22 +6786,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -6812,20 +6802,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -6834,11 +6811,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6847,20 +6824,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -6888,17 +6854,6 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "windows-interface"
 version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
@@ -6920,7 +6875,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -6931,17 +6886,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6962,16 +6908,6 @@ dependencies = [
  "bitflags 1.3.2",
  "widestring",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7106,7 +7042,7 @@ dependencies = [
  "talpid-types",
  "talpid-windows",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -7423,8 +7359,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ widestring = "1.2"
 windows = "0.62.2"
 windows-registry = "0.6.1"
 windows-sys = "0.61.2"
-winreg = "0.55"
 wmi = "0.18.1"
 # We cannot use zerocopy "0.8.32" or above due to https://github.com/google/zerocopy/issues/2880
 # TODO: Update the version when the issue is resolved

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ widestring = "1.2"
 windows = "0.62.2"
 windows-registry = "0.6.1"
 windows-result = "0.4.1"
-
 windows-sys = "0.61.2"
 wmi = "0.18.1"
 # We cannot use zerocopy "0.8.32" or above due to https://github.com/google/zerocopy/issues/2880

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,8 @@ webpki-roots = "1.0.4"
 widestring = "1.2"
 windows = "0.62.2"
 windows-registry = "0.6.1"
+windows-result = "0.4.1"
+
 windows-sys = "0.61.2"
 wmi = "0.18.1"
 # We cannot use zerocopy "0.8.32" or above due to https://github.com/google/zerocopy/issues/2880

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,7 @@ deny = [
   { name = "tokio", version = "0" },
   { name = "time", version = "0.1" },
   { name = "rand", version = "<0.9.3 " },
+  { name = "winreg" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,7 @@ deny = [
   { name = "tokio", version = "0" },
   { name = "time", version = "0.1" },
   { name = "rand", version = "<0.9.3 " },
+  # We are using windows-registry, so we want to avoid also using winreg
   { name = "winreg" },
 ]
 

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -69,8 +69,8 @@ serde = { workspace = true, features = ["derive"] }
 talpid-windows = { path = "../talpid-windows" }
 widestring = { workspace = true }
 windows = "0.58.0"
+windows-registry = { workspace = true }
 windows-service = "0.6.0"
-winreg = { workspace = true, features = ["transactions"] }
 wmi = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/talpid-core/Cargo.toml
+++ b/talpid-core/Cargo.toml
@@ -68,7 +68,7 @@ parking_lot = "0.12.0"
 serde = { workspace = true, features = ["derive"] }
 talpid-windows = { path = "../talpid-windows" }
 widestring = { workspace = true }
-windows = "0.58.0"
+windows = { workspace = true }
 windows-registry = { workspace = true }
 windows-service = "0.6.0"
 wmi = { workspace = true }

--- a/talpid-core/src/tunnel_state_machine/tunnel_monitor.rs
+++ b/talpid-core/src/tunnel_state_machine/tunnel_monitor.rs
@@ -172,15 +172,15 @@ impl TunnelMonitor {
 
 #[cfg(target_os = "windows")]
 fn is_ipv6_enabled_in_os() -> bool {
-    use winreg::{RegKey, enums::*};
+    use windows_registry::LOCAL_MACHINE;
 
     const IPV6_DISABLED_ON_TUNNELS_MASK: u32 = 0x01;
 
     // Check registry if IPv6 is disabled on tunnel interfaces, as documented in
     // https://support.microsoft.com/en-us/help/929852/guidance-for-configuring-ipv6-in-windows-for-advanced-users
-    let globally_enabled = RegKey::predef(HKEY_LOCAL_MACHINE)
-        .open_subkey(r"SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters")
-        .and_then(|ipv6_config| ipv6_config.get_value("DisabledComponents"))
+    let globally_enabled = LOCAL_MACHINE
+        .open(r"SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters")
+        .and_then(|ipv6_config| ipv6_config.get_u32("DisabledComponents"))
         .map(|ipv6_disabled_bits: u32| (ipv6_disabled_bits & IPV6_DISABLED_ON_TUNNELS_MASK) == 0)
         .unwrap_or(true);
 

--- a/talpid-dns/Cargo.toml
+++ b/talpid-dns/Cargo.toml
@@ -32,6 +32,7 @@ talpid-routing = { path = "../talpid-routing" }
 once_cell = { workspace = true }
 talpid-windows = { path = "../talpid-windows" }
 windows-registry = { workspace = true }
+windows-result = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/talpid-dns/Cargo.toml
+++ b/talpid-dns/Cargo.toml
@@ -31,7 +31,7 @@ talpid-routing = { path = "../talpid-routing" }
 [target.'cfg(windows)'.dependencies]
 once_cell = { workspace = true }
 talpid-windows = { path = "../talpid-windows" }
-winreg = { workspace = true, features = ["transactions"] }
+windows-registry = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/talpid-dns/src/windows/tcpip.rs
+++ b/talpid-dns/src/windows/tcpip.rs
@@ -73,12 +73,10 @@ impl DnsMonitor {
 
 fn set_dns(interface: &GUID, servers: &[IpAddr]) -> Result<(), Error> {
     let transaction = Transaction::new()
-        .map_err(|error| windows_result_code_to_io(error.code().0))
+        .map_err(windows_result_code_to_io)
         .map_err(Error::SetResolvers)?;
     let result = match set_dns_inner(&transaction, interface, servers) {
-        Ok(()) => transaction
-            .commit()
-            .map_err(|error| windows_result_code_to_io(error.code().0)),
+        Ok(()) => transaction.commit().map_err(windows_result_code_to_io),
         Err(error) => {
             std::mem::drop(transaction);
             Err(error)
@@ -132,7 +130,7 @@ fn config_interface(
     {
         Ok(adapter_key) => Ok(adapter_key),
         Err(error) => {
-            let io_err = windows_result_code_to_io(error.code().0);
+            let io_err = windows_result_code_to_io(error);
             if nameservers.is_empty() && io_err.kind() == io::ErrorKind::NotFound {
                 return Ok(());
             }
@@ -143,10 +141,10 @@ fn config_interface(
     if !nameservers.is_empty() {
         adapter_key
             .set_string("NameServer", nameservers.join(","))
-            .map_err(|error| windows_result_code_to_io(error.code().0))?;
+            .map_err(windows_result_code_to_io)?;
     } else {
         adapter_key.remove_value("NameServer").or_else(|error| {
-            let io_err = windows_result_code_to_io(error.code().0);
+            let io_err = windows_result_code_to_io(error);
             if io_err.kind() == io::ErrorKind::NotFound {
                 Ok(())
             } else {
@@ -185,11 +183,10 @@ fn string_from_guid(guid: &GUID) -> String {
     String::from_utf16(&buffer[0..length]).unwrap()
 }
 
-// all windows_registry functions return a windows_result::error::Error, which is not defined in
-// the public API of windows_registry. So this function needs to take the inner error code.
-fn windows_result_code_to_io(hresult: i32) -> io::Error {
+fn windows_result_code_to_io(error: windows_result::Error) -> io::Error {
     // windows_result::error::Error hresults needs to be truncated to the first 2 bytes to get the
     // OS code that works with io::Error. Inverse of the function performed here:
     // https://docs.rs/windows-result/0.4.1/src/windows_result/hresult.rs.html#129
+    let hresult = error.code().0;
     io::Error::from_raw_os_error(hresult & 0x0000FFFF)
 }

--- a/talpid-dns/src/windows/tcpip.rs
+++ b/talpid-dns/src/windows/tcpip.rs
@@ -2,12 +2,8 @@ use super::{DnsMonitorT, ResolvedDnsConfig};
 use std::{io, net::IpAddr};
 use talpid_types::ErrorExt;
 use talpid_windows::net::{guid_from_luid, luid_from_alias};
+use windows_registry::{LOCAL_MACHINE, Transaction};
 use windows_sys::{Win32::System::Com::StringFromGUID2, core::GUID};
-use winreg::{
-    RegKey,
-    enums::{HKEY_LOCAL_MACHINE, KEY_SET_VALUE},
-    transaction::Transaction,
-};
 
 /// Errors that can happen when configuring DNS on Windows.
 #[derive(thiserror::Error, Debug)]
@@ -76,10 +72,17 @@ impl DnsMonitor {
 }
 
 fn set_dns(interface: &GUID, servers: &[IpAddr]) -> Result<(), Error> {
-    let transaction = Transaction::new().map_err(Error::SetResolvers)?;
+    let transaction = Transaction::new()
+        .map_err(|error| windows_result_code_to_io(error.code().0))
+        .map_err(Error::SetResolvers)?;
     let result = match set_dns_inner(&transaction, interface, servers) {
-        Ok(()) => transaction.commit(),
-        Err(error) => transaction.rollback().and(Err(error)),
+        Ok(()) => transaction
+            .commit()
+            .map_err(|error| windows_result_code_to_io(error.code().0)),
+        Err(error) => {
+            std::mem::drop(transaction);
+            Err(error)
+        }
     };
     result.map_err(Error::SetResolvers)
 }
@@ -120,34 +123,40 @@ fn config_interface(
 
     let reg_path =
         format!(r#"SYSTEM\CurrentControlSet\Services\{service}\Parameters\Interfaces\{guid}"#,);
-    let adapter_key = match RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey_transacted_with_flags(
-        reg_path,
-        transaction,
-        KEY_SET_VALUE,
-    ) {
+    let adapter_key = match LOCAL_MACHINE
+        .options()
+        .read()
+        .write()
+        .transaction(transaction)
+        .open(reg_path)
+    {
         Ok(adapter_key) => Ok(adapter_key),
         Err(error) => {
-            if nameservers.is_empty() && error.kind() == io::ErrorKind::NotFound {
+            let io_err = windows_result_code_to_io(error.code().0);
+            if nameservers.is_empty() && io_err.kind() == io::ErrorKind::NotFound {
                 return Ok(());
             }
-            Err(error)
+            Err(io_err)
         }
     }?;
 
     if !nameservers.is_empty() {
-        adapter_key.set_value("NameServer", &nameservers.join(","))?;
+        adapter_key
+            .set_string("NameServer", nameservers.join(","))
+            .map_err(|error| windows_result_code_to_io(error.code().0))?;
     } else {
-        adapter_key.delete_value("NameServer").or_else(|error| {
-            if error.kind() == io::ErrorKind::NotFound {
+        adapter_key.remove_value("NameServer").or_else(|error| {
+            let io_err = windows_result_code_to_io(error.code().0);
+            if io_err.kind() == io::ErrorKind::NotFound {
                 Ok(())
             } else {
-                Err(error)
+                Err(io_err)
             }
         })?;
     }
 
     // Try to disable LLMNR on the interface
-    if let Err(error) = adapter_key.set_value("EnableMulticast", &0u32) {
+    if let Err(error) = adapter_key.set_u32("EnableMulticast", 0) {
         log::error!(
             "{}\nService: {service}",
             error.display_chain_with_msg("Failed to disable LLMNR on the tunnel interface")
@@ -174,4 +183,13 @@ fn string_from_guid(guid: &GUID) -> String {
     assert!(length > 0);
     let length = length - 1;
     String::from_utf16(&buffer[0..length]).unwrap()
+}
+
+// all windows_registry functions return a windows_result::error::Error, which is not defined in
+// the public API of windows_registry. So this function needs to take the inner error code.
+fn windows_result_code_to_io(hresult: i32) -> io::Error {
+    // windows_result::error::Error hresults needs to be truncated to the first 2 bytes to get the
+    // OS code that works with io::Error. Inverse of the function performed here:
+    // https://docs.rs/windows-result/0.4.1/src/windows_result/hresult.rs.html#129
+    io::Error::from_raw_os_error(hresult & 0x0000FFFF)
 }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -3759,9 +3759,9 @@ dependencies = [
  "tokio",
  "tokio-serial",
  "tokio-util",
+ "windows-registry",
  "windows-service",
  "windows-sys 0.45.0",
- "winreg",
 ]
 
 [[package]]
@@ -4595,6 +4595,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4896,16 +4907,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winreg"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "wintun-bindings"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -49,6 +49,7 @@ tokio-serial = "5.4.1"
 tonic = "0.14.6"
 tower = "0.5.1"
 tun = "0.8.8"
+windows-registry = "0.6.1"
 windows-sys = "0.52.0"
 
 [workspace.lints.clippy]

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -53,8 +53,8 @@ nix = { workspace = true, features = ["user"] }
 
 [target.'cfg(windows)'.dependencies]
 talpid-windows = { path = "../../talpid-windows" }
+windows-registry = { workspace = true }
 windows-service = "0.6"
-winreg = "0.55"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.45.0"

--- a/test/test-runner/src/sys/windows.rs
+++ b/test/test-runner/src/sys/windows.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::io;
+use std::os::windows::ffi::OsStringExt;
 use std::path::Path;
 use test_rpc::mullvad_daemon::ServiceStatus;
 use test_rpc::{meta::OsVersion, mullvad_daemon::Verbosity};
@@ -372,16 +373,22 @@ pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), 
             .map_err(|e| test_rpc::Error::Registry(e.to_string()))?;
     }
     // Persist the changed environment variables, such that we can retrieve them at will.
-    use winreg::{RegKey, enums::*};
-    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    use windows_registry::LOCAL_MACHINE;
     let path = Path::new(MULLVAD_WIN_REGISTRY).join("Environment");
-    let (registry, _) = hklm.create_subkey(&path).map_err(|error| {
-        test_rpc::Error::Registry(format!("Failed to open Mullvad VPN subkey: {error}"))
-    })?;
-    for (k, v) in env {
-        registry.set_value(k, &v).map_err(|error| {
-            test_rpc::Error::Registry(format!("Failed to set Environment var: {error}"))
-        })?;
+
+    // Extra scope is needed because registry is not send. So it needs to be out of scope before
+    // an await boundary is crossed.
+    {
+        let registry = LOCAL_MACHINE
+            .create(path.to_string_lossy())
+            .map_err(|error| {
+                test_rpc::Error::Registry(format!("Failed to open Mullvad VPN subkey: {error}"))
+            })?;
+        for (k, v) in env {
+            registry.set_string(k, &v).map_err(|error| {
+                test_rpc::Error::Registry(format!("Failed to set Environment var: {error}"))
+            })?;
+        }
     }
 
     // Restart service
@@ -392,29 +399,27 @@ pub async fn set_daemon_environment(env: HashMap<String, String>) -> Result<(), 
 }
 
 pub fn get_system_path_var() -> Result<String, test_rpc::Error> {
-    use winreg::{enums::*, *};
+    use windows_registry::LOCAL_MACHINE;
 
-    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    let key = hklm
-        .open_subkey("SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment")
+    let key = LOCAL_MACHINE
+        .open("SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment")
         .map_err(|error| {
             test_rpc::Error::Registry(format!("Failed to open Environment subkey: {error}"))
         })?;
 
     let path: String = key
-        .get_value("Path")
+        .get_string("Path")
         .map_err(|error| test_rpc::Error::Registry(format!("Failed to get PATH: {error}")))?;
 
     Ok(path)
 }
 
 pub async fn get_daemon_environment() -> Result<HashMap<String, String>, test_rpc::Error> {
-    use winreg::{RegKey, enums::*};
+    use windows_registry::LOCAL_MACHINE;
 
     let env =
         tokio::task::spawn_blocking(|| -> Result<HashMap<String, String>, test_rpc::Error> {
-            let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-            let key = hklm.open_subkey(MULLVAD_WIN_REGISTRY).map_err(|error| {
+            let key = LOCAL_MACHINE.open(MULLVAD_WIN_REGISTRY).map_err(|error| {
                 test_rpc::Error::Registry(format!("Failed to open Mullvad VPN subkey: {error}"))
             })?;
 
@@ -422,15 +427,28 @@ pub async fn get_daemon_environment() -> Result<HashMap<String, String>, test_rp
             // trim that!
             let trim = |string: String| string.trim_matches('"').to_owned();
             let env = key
-                .open_subkey("Environment")
+                .open("Environment")
                 .map_err(|error| {
                     test_rpc::Error::Registry(
                         format!("Failed to open Environment subkey: {error}",),
                     )
                 })?
-                .enum_values()
-                .filter_map(|x| x.inspect_err(|err| log::trace!("{err}")).ok())
-                .map(|(k, v)| (trim(k), trim(v.to_string())))
+                .values()
+                .map_err(|error| {
+                    test_rpc::Error::Registry(
+                        format!("Failed to open Environment subkey: {error}",),
+                    )
+                })?
+                .map(|(k, v)| {
+                    (
+                        trim(k),
+                        trim(
+                            OsString::from_wide(v.as_wide())
+                                .to_string_lossy()
+                                .into_owned(),
+                        ),
+                    )
+                })
                 .collect();
             Ok(env)
         })


### PR DESCRIPTION
The dependency tree contained both `winreg` and `windows_registry`. Of the two crates, `winreg` was used in fewer transitive dependencies and was easier to remove. This change eliminates `winreg` from the entire dependency tree.

The change can be tested with the following steps
- Install the build on windows
- Set the system environment variable `TALPID_DNS_MODULE` to `tcpip`
- Restart the `mullvad-daemon` system service
- Verify there are no DNS leaks after connecting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10435)
<!-- Reviewable:end -->
