### PR TITLE
Switch `protoc` for `protox`

### DIFF
--- a/.github/actions/mullvad-build-env/action.yml
+++ b/.github/actions/mullvad-build-env/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: "Space-separated Rustup components to install (e.g. rustfmt, clippy)"
     default: clippy
     required: false
-  protoc-token:
-    description: "Token for setup-protoc (defaults to GITHUB_TOKEN)"
-    default: "${{ github.token }}"
-    required: false
   rust-cache-targets:
     description: >-
       Determines whether workspace `target` directories are cached. If `false`,
@@ -56,11 +52,6 @@ runs:
         # `cache-bin` causes `~/.cargo/bin/rustup` to be deleted for self-hosted runners
         # See https://github.com/Swatinem/rust-cache/issues/16
         cache-bin: false
-
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ inputs.protoc-token }}
 
     - name: Checkout Mullvad binaries submodule
       # macOS does not depend on any of our binaries.

--- a/.github/workflows/testframework.yml
+++ b/.github/workflows/testframework.yml
@@ -81,11 +81,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build test runner
         working-directory: test
         run: ../ci/cargo-ci.sh build

--- a/BuildInstructions.md
+++ b/BuildInstructions.md
@@ -36,14 +36,6 @@ on your platform please submit an issue or a pull request.
 
     Install the `msi` hosted here: https://github.com/volta-cli/volta
 
-- Install a protobuf compiler (version 3.15 and up), it can be installed on most major Linux distros
-  via the package name `protobuf-compiler`, `protobuf` on macOS via Homebrew, and on Windows
-  binaries are available on their GitHub [page](https://github.com/protocolbuffers/protobuf/releases)
-  and they have to be put in `%PATH`. An additional package might also be required depending on
-  Linux distro:
-  - `protobuf-devel` on Fedora.
-  - `libprotobuf-dev` and `protobuf-compiler` on Debian/Ubuntu.
-
 - **`bash` must be installed and available in PATH on all platforms**. This is required for building
   the desktop app:
 - Bash version 4.0 or later is required for all platforms and must be added to your PATH environment variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Line wrap the file at 100 chars.                                              Th
 - Optimize LWO performance. This gives a 1.5 to 3 times speedup in our benchmarks.
 - Change [default retry connection attempts](docs/relay-selector.md). LWO is now the third default
   constraint. The relative order among the following constraints is preserved.
+- Remove `protoc` as a build-time dependency.
 
 #### Linux
 - Switch memory allocator to jemalloc to reduce fragmentation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,6 +2757,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,6 +2869,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3170,6 +3232,7 @@ dependencies = [
  "nix 0.31.2",
  "prost",
  "prost-types",
+ "protox",
  "talpid-types",
  "thiserror 2.0.18",
  "tipsy",
@@ -4513,12 +4576,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "logos",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5652,6 +5754,7 @@ dependencies = [
  "pqcrypto-hqc",
  "pqcrypto-traits",
  "prost",
+ "protox",
  "rand_core 0.6.4",
  "sha2",
  "talpid-types",
@@ -6477,6 +6580,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6249,8 +6249,7 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+source = "git+https://github.com/MarkusPettersson98/tonic?rev=0a7661b5f084ad0bc43873b704bb64f8276cc555#0a7661b5f084ad0bc43873b704bb64f8276cc555"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6272,8 +6271,7 @@ dependencies = [
 [[package]]
 name = "tonic-prost-build"
 version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+source = "git+https://github.com/MarkusPettersson98/tonic?rev=0a7661b5f084ad0bc43873b704bb64f8276cc555#0a7661b5f084ad0bc43873b704bb64f8276cc555"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ tokio = { version = "1.44" }
 tokio-util = "0.7"
 tonic = "0.14.6"
 tonic-prost = "0.14.6"
-tonic-prost-build = { version = "0.14.6", default-features = false }
+tonic-prost-build = { git = "https://github.com/MarkusPettersson98/tonic", rev = "0a7661b5f084ad0bc43873b704bb64f8276cc555", default-features = false }
 tower = { version = "0.5.1", features = ["util"] }
 tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ pnet_packet = "0.35.0"
 proptest = "1.9"
 prost = "0.14.3"
 prost-types = "0.14.3"
+protox = { version = "0.9.1", default-features = false }
 rand = "0.9.3"
 reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls"

--- a/building/Dockerfile
+++ b/building/Dockerfile
@@ -64,21 +64,6 @@ ENV PATH=/root/.cargo/bin:$PATH
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc" \
     PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu
 
-# === protobuf (for compiling .proto files) ===
-
-RUN apt-get update -y && \
-    apt-get install -y --mark-auto cmake g++ && \
-    rm -rf /var/lib/apt/lists/* && \
-    git clone https://github.com/protocolbuffers/protobuf.git && \
-    cd protobuf && \
-    git reset --hard "$PROTOBUF_COMMIT_REF" && \
-    git submodule update --init --recursive && \
-    cmake . -DCMAKE_CXX_STANDARD=14 && \
-    cmake --build . -j $(nproc) && \
-    cmake --install . && \
-    cd .. && rm -rf protobuf && \
-    apt-get autoremove -y
-
 # === Volta for npm + node ===
 
 ENV PATH=/root/.volta/bin:$PATH

--- a/mullvad-management-interface/Cargo.toml
+++ b/mullvad-management-interface/Cargo.toml
@@ -28,6 +28,7 @@ tower = { workspace = true }
 vec1 = { workspace = true }
 
 [build-dependencies]
+protox.workspace = true
 tonic-prost-build = { workspace = true, features = ["transport"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/mullvad-management-interface/build.rs
+++ b/mullvad-management-interface/build.rs
@@ -1,14 +1,14 @@
 fn main() {
+    let fds = protox::compile(
+        ["management_interface.proto", "relay_selector.proto"],
+        ["proto/"],
+    )
+    .unwrap();
+
     // Compile both proto files together so they can reference each other
     tonic_prost_build::configure()
         .with_extended_rust_types(true)
-        .compile_protos(
-            &[
-                "proto/management_interface.proto",
-                "proto/relay_selector.proto",
-            ],
-            &["proto/"],
-        )
+        .compile_fds(fds)
         .unwrap();
 
     // Enable DAITA by default on desktop and android

--- a/nix/common-toolchain.nix
+++ b/nix/common-toolchain.nix
@@ -9,6 +9,5 @@ in
     pkgs.git
     pkgs.gcc
     pkgs.gnumake
-    pkgs.protobuf
   ];
 }

--- a/talpid-tunnel-config-client/Cargo.toml
+++ b/talpid-tunnel-config-client/Cargo.toml
@@ -36,6 +36,7 @@ tower = { workspace = true }
 zeroize = { workspace = true }
 
 [build-dependencies]
+protox.workspace = true
 tonic-prost-build = { workspace = true, features = ["transport"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/talpid-tunnel-config-client/build.rs
+++ b/talpid-tunnel-config-client/build.rs
@@ -1,6 +1,4 @@
 fn main() {
-    tonic_prost_build::configure()
-        .with_extended_rust_types(true)
-        .compile_protos(&["proto/ephemeralpeer.proto"], &["proto/"])
-        .unwrap();
+    let fds = protox::compile(["ephemeralpeer.proto"], ["proto/"]).unwrap();
+    tonic_prost_build::configure().compile_fds(fds).unwrap();
 }

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -4145,8 +4145,7 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+source = "git+https://github.com/MarkusPettersson98/tonic?rev=0a7661b5f084ad0bc43873b704bb64f8276cc555#0a7661b5f084ad0bc43873b704bb64f8276cc555"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4168,8 +4167,7 @@ dependencies = [
 [[package]]
 name = "tonic-prost-build"
 version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+source = "git+https://github.com/MarkusPettersson98/tonic?rev=0a7661b5f084ad0bc43873b704bb64f8276cc555#0a7661b5f084ad0bc43873b704bb64f8276cc555"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -269,6 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitfield-struct"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2015,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2092,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2177,6 +2239,7 @@ dependencies = [
  "nix 0.31.2",
  "prost",
  "prost-types",
+ "protox",
  "talpid-types",
  "thiserror 2.0.18",
  "tipsy",
@@ -2768,12 +2831,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "logos",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4263,6 +4365,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/test/README.md
+++ b/test/README.md
@@ -30,11 +30,10 @@ For macOS, the host machine must be macOS. All other platforms assume that the h
 
 ### macOS
 
-Normally, you would use Tart here. It can be installed with Homebrew. You'll also need
-`wireguard-tools`, a protobuf compiler, and OpenSSL:
+Normally, you would use Tart here. It can be installed with Homebrew. You'll also need OpenSSL:
 
 ```bash
-brew install cirruslabs/cli/tart wireguard-tools pkg-config openssl protobuf
+brew install cirruslabs/cli/tart pkg-config openssl
 ```
 
 #### Wireshark
@@ -56,10 +55,9 @@ For running tests on Linux and Windows guests, you will need these tools and lib
 
 #### Fedora
 ```bash
-dnf install git gcc protobuf-devel libpcap-devel qemu \
-    podman golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq \
-    dbus-devel pkgconf-pkg-config swtpm edk2-ovmf \
-    wireguard-tools
+dnf install git gcc libpcap-devel qemu podman \
+    golang-github-rootless-containers-rootlesskit slirp4netns dnsmasq \
+    dbus-devel pkgconf-pkg-config swtpm edk2-ovmf
 ```
 
 


### PR DESCRIPTION
This PR swaps out `protoc` for [protox](https://github.com/andrewhickman/protox), as pure Rust implementation of a protobuf compiler. This allows us to add it as a build-time dependency in the crates where we compile .proto files, and we can get rid of `protoc` as a dependency. This is nice, since build/dev environments do not need to install `protoc` anymore (Thus invalidating https://github.com/mullvad/mullvadvpn-app/pull/10431, for example).

Blocked on https://github.com/hyperium/tonic/pull/2647.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10437)
<!-- Reviewable:end -->
