### PR TITLE
Log when split tunnel driver has been loaded

### DIFF
--- a/talpid-core/src/split_tunnel/windows/service.rs
+++ b/talpid-core/src/split_tunnel/windows/service.rs
@@ -160,12 +160,19 @@ fn start_and_wait_for_service(service: &Service) -> Result<(), Error> {
         if let windows_service::Error::Winapi(error) = &error
             && error.raw_os_error() == Some(ERROR_SERVICE_ALREADY_RUNNING as i32)
         {
+            log::debug!("Split tunnel service is already running");
             return Ok(());
         }
         return Err(Error::StartService(error));
     }
 
-    wait_for_status(service, ServiceState::Running)
+    log::debug!("Split tunnel service start pending");
+
+    wait_for_status(service, ServiceState::Running)?;
+
+    log::debug!("Split tunnel service started");
+
+    Ok(())
 }
 
 fn wait_for_status(service: &Service, target_state: ServiceState) -> Result<(), Error> {
@@ -181,7 +188,7 @@ fn wait_for_status(service: &Service, target_state: ServiceState) -> Result<(), 
             return Err(Error::StartTimeout);
         }
 
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        std::thread::sleep(std::time::Duration::from_millis(250));
     }
 
     Ok(())


### PR DESCRIPTION
To help figure out whether the source of [this](https://github.com/mullvad/mullvadvpn-app/blob/c04a90ab368ad962134e8265f745d53ac43e648f/talpid-core/src/split_tunnel/windows/mod.rs#L746-L748) timeout is due to driver load or `DeviceHandle::new()`.

# Todo

- [x] Backport to `prepare-2026.3`?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10440)
<!-- Reviewable:end -->
