### PR TITLE
Fix `gotatun` UDP socket bind error on some macOS versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,9 +1745,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gotatun"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee896ae91b1a90a10642d58ced8721560dc399ceeaba66d9cab14ad1db846936"
+checksum = "f651f6918282441ff9637ce3186aa2500dd236029c53e84bc5ff0c879702e048"
 dependencies = [
  "aead",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,9 +1745,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gotatun"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f651f6918282441ff9637ce3186aa2500dd236029c53e84bc5ff0c879702e048"
+checksum = "08e81edfb0f5289200018c31d9aeaa1090ae7575fdb499073dd1b24ea8874c60"
 dependencies = [
  "aead",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ ctrlc = "3.5"
 dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"
-gotatun = { version = "0.6.0", default-features = false, features = ["ring"] }
+gotatun = { version = "0.7.0", default-features = false, features = ["ring"] }
 hickory-proto = "0.26.1"
 hickory-resolver = { version = "0.26.1", default-features = false, features = [
   "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ ctrlc = "3.5"
 dirs = "6.0.0"
 either = "1.15.0"
 futures = "0.3.15"
-gotatun = { version = "0.7.0", default-features = false, features = ["ring"] }
+gotatun = { version = "0.7.1", default-features = false, features = ["ring"] }
 hickory-proto = "0.26.1"
 hickory-resolver = { version = "0.26.1", default-features = false, features = [
   "tokio"

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -157,6 +157,7 @@ pub enum ConfigureGotaTunDeviceError {
 #[cfg(target_os = "android")]
 struct AndroidUdpSocketFactory {
     pub tun: Arc<Tun>,
+    pub udp: UdpSocketFactory,
 }
 
 #[cfg(target_os = "android")]
@@ -170,8 +171,7 @@ impl UdpTransportFactory for AndroidUdpSocketFactory {
         &mut self,
         params: &gotatun::udp::UdpTransportFactoryParams,
     ) -> std::io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
-        let ((udp_v4_tx, udp_v4_rx), (udp_v6_tx, udp_v6_rx)) =
-            UdpSocketFactory.bind(params).await?;
+        let ((udp_v4_tx, udp_v4_rx), (udp_v6_tx, udp_v6_rx)) = self.udp.bind(params).await?;
 
         self.tun.bypass(&udp_v4_tx).unwrap();
         self.tun.bypass(&udp_v6_tx).unwrap();
@@ -271,98 +271,6 @@ pub async fn open_gotatun_tunnel(
     );
 
     Ok(gotatun)
-}
-
-/// Create and configure gotatun devices.
-///
-/// Will create an [EntryDevice] and an [ExitDevice] if `config` is a multihop config,
-/// and a [SinglehopDevice] otherwise.
-async fn create_devices(
-    config: &Config, // TODO: do not include config to reduce confusion
-    daita: Option<&DaitaSettings>,
-    tun_dev: GotaTunDevice,
-    #[cfg(target_os = "android")] android_tun: Arc<Tun>,
-) -> Result<Devices, TunnelError> {
-    #[cfg(target_os = "android")]
-    let base_factory = AndroidUdpSocketFactory { tun: android_tun };
-
-    #[cfg(not(target_os = "android"))]
-    let base_factory = UdpSocketFactory;
-
-    let factory = MaybeObfuscatingTransportFactory::from_config(base_factory, config);
-
-    let mut devices = if let Some(exit_peer) = &config.exit_peer {
-        // Multihop setup
-
-        let source_v4 = config
-            .tunnel
-            .addresses
-            .iter()
-            .find_map(|ip| match ip {
-                &IpAddr::V4(ipv4_addr) => Some(ipv4_addr),
-                IpAddr::V6(..) => None,
-            })
-            .unwrap_or(Ipv4Addr::UNSPECIFIED);
-
-        let source_v6 = config
-            .tunnel
-            .addresses
-            .iter()
-            .find_map(|ip| match ip {
-                &IpAddr::V6(ipv6_addr) => Some(ipv6_addr),
-                IpAddr::V4(..) => None,
-            })
-            .unwrap_or(Ipv6Addr::UNSPECIFIED);
-
-        // Calculate length of extra headers, assuming no optional header fields (i.e. IP options)
-        let multihop_overhead = match exit_peer.endpoint.ip() {
-            IpAddr::V4(..) => Ipv4Header::LEN + UdpHeader::LEN + WgData::OVERHEAD,
-            IpAddr::V6(..) => Ipv6Header::LEN + UdpHeader::LEN + WgData::OVERHEAD,
-        };
-
-        let exit_mtu = tun_dev.mtu();
-        let entry_mtu = exit_mtu.increase(multihop_overhead as u16).unwrap(/* TODO: this can happen if tun mtu is max i think*/);
-
-        let (tun_channel_tx, tun_channel_rx, udp_channels) =
-            new_udp_tun_channel(PACKET_CHANNEL_CAPACITY, source_v4, source_v6, entry_mtu);
-
-        let exit_device = DeviceBuilder::new()
-            .with_udp(udp_channels)
-            .with_ip(tun_dev)
-            .build()
-            .await
-            .map_err(TunnelError::GotaTunDevice)?;
-
-        // Hacky way of dumping entry<->exit traffic to a unix socket which wireshark can read.
-        // See docs on wrap_in_pcap_sniffer for an explanation.
-        #[cfg(all(feature = "multihop-pcap", target_os = "linux"))]
-        let (tun_channel_tx, tun_channel_rx) = wrap_in_pcap_sniffer(tun_channel_tx, tun_channel_rx);
-
-        let entry_device = DeviceBuilder::new()
-            .with_udp(factory)
-            .with_ip_pair(tun_channel_tx, tun_channel_rx)
-            .build()
-            .await
-            .map_err(TunnelError::GotaTunDevice)?;
-        Devices::Multihop {
-            entry_device,
-            exit_device,
-        }
-    } else {
-        // Singlehop setup
-
-        let device = DeviceBuilder::new()
-            .with_udp(factory)
-            .with_ip(tun_dev)
-            .build()
-            .await
-            .map_err(TunnelError::GotaTunDevice)?;
-        Devices::Singlehop { device }
-    };
-
-    configure_devices(&mut devices, config, daita).await?;
-
-    Ok(devices)
 }
 
 /// Configure a gotatun entry or singlehop device
@@ -557,6 +465,141 @@ impl Tunnel for GotaTun {
     }
 }
 
+/// Create and configure gotatun devices.
+///
+/// Will create an [EntryDevice] and an [ExitDevice] if `config` is a multihop config,
+/// and a [SinglehopDevice] otherwise.
+async fn create_devices(
+    config: &Config, // TODO: do not include config to reduce confusion
+    daita: Option<&DaitaSettings>,
+    tun_dev: GotaTunDevice,
+    #[cfg(target_os = "android")] android_tun: Arc<Tun>,
+) -> Result<Devices, TunnelError> {
+    async fn create_devices_inner(
+        config: &Config, // TODO: do not include config to reduce confusion
+        daita: Option<&DaitaSettings>,
+        tun_dev: GotaTunDevice,
+        #[cfg(target_os = "android")] android_tun: Arc<Tun>,
+        optimize_buffer_size: bool,
+    ) -> Result<Devices, TunnelError> {
+        let factory = udp_obfuscator_factory(
+            config,
+            optimize_buffer_size,
+            #[cfg(target_os = "android")]
+            android_tun,
+        );
+        let mut devices = if let Some(exit_peer) = &config.exit_peer {
+            // Multihop setup
+
+            let source_v4 = config
+                .tunnel
+                .addresses
+                .iter()
+                .find_map(|ip| match ip {
+                    &IpAddr::V4(ipv4_addr) => Some(ipv4_addr),
+                    IpAddr::V6(..) => None,
+                })
+                .unwrap_or(Ipv4Addr::UNSPECIFIED);
+
+            let source_v6 = config
+                .tunnel
+                .addresses
+                .iter()
+                .find_map(|ip| match ip {
+                    &IpAddr::V6(ipv6_addr) => Some(ipv6_addr),
+                    IpAddr::V4(..) => None,
+                })
+                .unwrap_or(Ipv6Addr::UNSPECIFIED);
+
+            // Calculate length of extra headers, assuming no optional header fields (i.e. IP options)
+            let multihop_overhead = match exit_peer.endpoint.ip() {
+                IpAddr::V4(..) => Ipv4Header::LEN + UdpHeader::LEN + WgData::OVERHEAD,
+                IpAddr::V6(..) => Ipv6Header::LEN + UdpHeader::LEN + WgData::OVERHEAD,
+            };
+
+            let exit_mtu = tun_dev.mtu();
+            let entry_mtu = exit_mtu.increase(multihop_overhead as u16).unwrap(/* TODO: this can happen if tun mtu is max i think*/);
+
+            let (tun_channel_tx, tun_channel_rx, udp_channels) =
+                new_udp_tun_channel(PACKET_CHANNEL_CAPACITY, source_v4, source_v6, entry_mtu);
+
+            let exit_device = DeviceBuilder::new()
+                .with_udp(udp_channels)
+                .with_ip(tun_dev)
+                .build()
+                .await
+                .map_err(TunnelError::GotaTunDevice)?;
+
+            // Hacky way of dumping entry<->exit traffic to a unix socket which wireshark can read.
+            // See docs on wrap_in_pcap_sniffer for an explanation.
+            #[cfg(all(feature = "multihop-pcap", target_os = "linux"))]
+            let (tun_channel_tx, tun_channel_rx) =
+                wrap_in_pcap_sniffer(tun_channel_tx, tun_channel_rx);
+
+            let entry_device = DeviceBuilder::new()
+                .with_udp(factory)
+                .with_ip_pair(tun_channel_tx, tun_channel_rx)
+                .build()
+                .await
+                .map_err(TunnelError::GotaTunDevice)?;
+            Devices::Multihop {
+                entry_device,
+                exit_device,
+            }
+        } else {
+            // Singlehop setup
+
+            let device = DeviceBuilder::new()
+                .with_udp(factory)
+                .with_ip(tun_dev)
+                .build()
+                .await
+                .map_err(TunnelError::GotaTunDevice)?;
+            Devices::Singlehop { device }
+        };
+
+        configure_devices(&mut devices, config, daita).await?;
+
+        Ok(devices)
+    }
+
+    match create_devices_inner(
+        config,
+        daita,
+        tun_dev.clone(),
+        #[cfg(target_os = "android")]
+        android_tun.clone(),
+        true,
+    )
+    .await
+    {
+        Ok(devices) => Ok(devices),
+        // Empirically, creating devices may fail when binding the UDP socket due to
+        // us wanting to tweak the UDP socket buffer sizes to a larger value than
+        // the OS default (suspected hardware related issues / limitations). In that
+        // case, `os error 55 ("No buffer space available")`  has been observed.
+        //
+        // Try to bind UDP sockets with default buffer sizes.
+        #[cfg(unix)]
+        Err(TunnelError::GotaTunDevice(ref err @ gotatun::device::Error::Bind(ref io_err, _)))
+            if let Some(errno) = io_err.raw_os_error()
+                && nix::errno::Errno::from_raw(errno) == nix::errno::Errno::ENOBUFS =>
+        {
+            log::error!("Failed to bind UDP socket: {err} - retrying with default buffer sizes");
+            create_devices_inner(
+                config,
+                daita,
+                tun_dev,
+                #[cfg(target_os = "android")]
+                android_tun.clone(),
+                false,
+            )
+            .await
+        }
+        Err(err) => Err(err),
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn get_tunnel_for_userspace(
     tun_provider: Arc<Mutex<TunProvider>>,
@@ -703,4 +746,46 @@ where
     let ip_recv = PcapSniffer::new(ip_recv, w, start_time);
 
     (ip_send, ip_recv)
+}
+
+/// Provide a [`UdpSocketFactory`] for the entry-device.
+///
+/// - `optimize_buffer_size`: if UDP socket buffer sizes should be tweaked. Empirically this might
+///   now always succeed due to suspected hardware related issues / limitations.
+fn udp_obfuscator_factory(
+    config: &Config,
+    optimize_buffer_size: bool,
+    #[cfg(target_os = "android")] android_tun: Arc<Tun>,
+) -> MaybeObfuscatingTransportFactory<UdpFactory> {
+    let factory = cfg_select! {
+        target_os = "android" => {
+            AndroidUdpSocketFactory {
+                tun: android_tun,
+                udp: udp_socket_factory(optimize_buffer_size),
+            }
+        },
+        _ => { udp_socket_factory(optimize_buffer_size) }
+    };
+    MaybeObfuscatingTransportFactory::from_config(factory, config)
+}
+
+/// Provide a [`UdpSocketFactory`] for the entry-device.
+///
+/// - `optimize_buffer_size`: if UDP socket buffer sizes should be tweaked.
+///   This could be beneficial for performance reasons.
+#[inline(always)]
+fn udp_socket_factory(optimize_buffer_size: bool) -> UdpSocketFactory {
+    /// See [`DeviceBuilder::udp_send_buffer_size`] for details.
+    const UDP_SEND_BUFFER_SIZE: usize = 7 * 1024 * 1024; // 7 MB (mirror the default of `gotatun-cli`)
+    /// See [`DeviceBuilder::udp_recv_buffer_size`] for details.
+    const UDP_RECV_BUFFER_SIZE: usize = 7 * 1024 * 1024;
+
+    if optimize_buffer_size {
+        UdpSocketFactory {
+            recv_buffer_size: Some(UDP_RECV_BUFFER_SIZE),
+            send_buffer_size: Some(UDP_SEND_BUFFER_SIZE),
+        }
+    } else {
+        UdpSocketFactory::default()
+    }
 }

--- a/talpid-wireguard/src/gotatun/mod.rs
+++ b/talpid-wireguard/src/gotatun/mod.rs
@@ -33,6 +33,7 @@ use std::{
 };
 use talpid_tunnel::tun_provider::{self, Tun, TunProvider};
 use talpid_tunnel_config_client::DaitaSettings;
+use talpid_types::net::wireguard::PeerConfig;
 use tun::{AbstractDevice, AsyncDevice};
 
 #[cfg(all(feature = "multihop-pcap", target_os = "linux"))]
@@ -104,7 +105,8 @@ impl GotaTun {
             #[cfg(target_os = "android")]
             android_tun.clone(),
         )
-        .await?;
+        .await
+        .map_err(TunnelError::GotaTunDevice)?;
 
         Ok(Self {
             config,
@@ -118,40 +120,80 @@ impl GotaTun {
 }
 
 enum Devices {
-    Singlehop {
-        device: SinglehopDevice,
-    },
+    Singlehop(Singlehop),
+    Multihop(Multihop),
+}
 
-    Multihop {
-        entry_device: EntryDevice,
-        exit_device: ExitDevice,
-    },
+struct Singlehop {
+    device: SinglehopDevice,
+}
+
+impl Singlehop {
+    /// (Re)Configure the gotatun device.
+    async fn configure(
+        &mut self,
+        config: &Config,
+        daita: Option<&DaitaSettings>,
+    ) -> Result<(), gotatun::device::Error> {
+        log::trace!(
+            "configuring gotatun singlehop device (daita={})",
+            daita.is_some()
+        );
+        configure_entry_device(&self.device, config, daita).await
+    }
+
+    async fn stop(self) {
+        self.device.stop().await
+    }
+}
+
+struct Multihop {
+    entry_device: EntryDevice,
+    exit_device: ExitDevice,
+}
+
+impl Multihop {
+    /// (Re)Configure gotatun devices.
+    ///
+    /// Take precaution to ensure that `exit_peer` is linked to `config`.
+    async fn configure(
+        &mut self,
+        config: &Config,
+        // TODO: Express relationship between `config` and `exit_peer` at the type level.
+        exit_peer: &PeerConfig,
+        daita: Option<&DaitaSettings>,
+    ) -> Result<(), gotatun::device::Error> {
+        let private_key = StaticSecret::from(config.tunnel.private_key.to_bytes());
+        let exit_peer = to_gotatun_peer(exit_peer, daita);
+
+        log::trace!(
+            "configuring gotatun multihop device (daita={})",
+            daita.is_some()
+        );
+
+        configure_entry_device(&self.entry_device, config, daita).await?;
+        configure_exit_device(&self.exit_device, private_key, exit_peer).await?;
+
+        Ok(())
+    }
+
+    async fn stop(self) {
+        let Multihop {
+            entry_device,
+            exit_device,
+        } = self;
+        exit_device.stop().await;
+        entry_device.stop().await;
+    }
 }
 
 impl Devices {
     async fn stop(self) {
         match self {
-            Devices::Singlehop { device } => {
-                device.stop().await;
-            }
-            Devices::Multihop {
-                entry_device,
-                exit_device,
-            } => {
-                exit_device.stop().await;
-                entry_device.stop().await;
-            }
+            Devices::Singlehop(device) => device.stop().await,
+            Devices::Multihop(devices) => devices.stop().await,
         }
     }
-}
-
-/// Errors that can happen when setting up / restarting / reconfiguring GotaTun devices.
-#[derive(thiserror::Error, Debug)]
-pub enum ConfigureGotaTunDeviceError {
-    #[error("Multihop devices were provided with a single config")]
-    ExpectedSinglehopDevice,
-    #[error("Single devices were provided with a multihop config")]
-    ExpectedMultihopDevice,
 }
 
 #[cfg(target_os = "android")]
@@ -278,7 +320,7 @@ async fn configure_entry_device(
     device: &Device<impl DeviceTransports>,
     config: &Config,
     daita: Option<&DaitaSettings>,
-) -> Result<(), TunnelError> {
+) -> Result<(), gotatun::device::Error> {
     let private_key = StaticSecret::from(config.tunnel.private_key.to_bytes());
     let entry_peer = to_gotatun_peer(&config.entry_peer, daita);
     device
@@ -294,9 +336,8 @@ async fn configure_entry_device(
         })
         .await
         .flatten()
-        .map_err(|err| {
+        .inspect_err(|err| {
             log::error!("Failed to set gotatun config: {err:#}");
-            TunnelError::SetConfigError
         })
 }
 
@@ -305,7 +346,7 @@ async fn configure_exit_device(
     device: &Device<impl DeviceTransports>,
     private_key: StaticSecret,
     exit_peer: gotatun::device::Peer,
-) -> Result<(), TunnelError> {
+) -> Result<(), gotatun::device::Error> {
     device
         .write(async |device| {
             device.clear_peers();
@@ -313,60 +354,9 @@ async fn configure_exit_device(
             device.add_peer(exit_peer);
         })
         .await
-        .map_err(|err| {
+        .inspect_err(|err| {
             log::error!("Failed to set gotatun config: {err:#}");
-            TunnelError::SetConfigError
         })
-}
-
-/// (Re)Configure gotatun devices.
-async fn configure_devices(
-    devices: &mut Devices,
-    config: &Config,
-    daita: Option<&DaitaSettings>,
-) -> Result<(), TunnelError> {
-    if let Some(exit_peer) = &config.exit_peer {
-        log::trace!(
-            "configuring gotatun multihop device (daita={})",
-            daita.is_some()
-        );
-
-        let private_key = StaticSecret::from(config.tunnel.private_key.to_bytes());
-        let exit_peer = to_gotatun_peer(exit_peer, daita);
-
-        match devices {
-            Devices::Multihop {
-                entry_device,
-                exit_device,
-            } => {
-                configure_entry_device(entry_device, config, daita).await?;
-                configure_exit_device(exit_device, private_key, exit_peer).await?;
-            }
-            _ => {
-                return Err(TunnelError::ConfigureGotaTunDevice(
-                    ConfigureGotaTunDeviceError::ExpectedMultihopDevice,
-                ));
-            }
-        }
-    } else {
-        log::trace!(
-            "configuring gotatun singlehop device (daita={})",
-            daita.is_some()
-        );
-
-        match devices {
-            Devices::Singlehop { device } => {
-                configure_entry_device(device, config, daita).await?;
-            }
-            _ => {
-                return Err(TunnelError::ConfigureGotaTunDevice(
-                    ConfigureGotaTunDeviceError::ExpectedSinglehopDevice,
-                ));
-            }
-        }
-    }
-
-    Ok(())
 }
 
 #[async_trait::async_trait]
@@ -402,11 +392,11 @@ impl Tunnel for GotaTun {
         }
 
         let stats = match self.devices.as_ref() {
-            Some(Devices::Singlehop { device }) => get_stats(device).await,
-            Some(Devices::Multihop {
+            Some(Devices::Singlehop(Singlehop { device })) => get_stats(device).await,
+            Some(Devices::Multihop(Multihop {
                 entry_device,
                 exit_device,
-            }) => {
+            })) => {
                 let mut stats = get_stats(entry_device).await;
                 stats.extend(get_stats(exit_device).await);
                 stats
@@ -425,41 +415,87 @@ impl Tunnel for GotaTun {
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), TunnelError>> + Send + 'a>> {
         Box::pin(async move {
             self.config = config;
-
-            // if we're switching to/from multihop, we'll need to tear down the old device(s)
+            // If we're switching to/from multihop, we'll need to tear down the old device(s)
             // and set them up with the new DeviceTransports
-            // TODO: Debug configure_devices. Currently we need to tear down the old devices
-            // after having exchanged tunnel params with the ephemeral peer. Empirically this
-            // is true for both DAITA & PQ.
-            // let recreate_devices = old_config.is_multihop() != self.config.is_multihop();
-            let recreate_devices = true;
-
-            if recreate_devices {
-                // TODO: devices should never be None while this GotaTun instance is running.
-                debug_assert!(self.devices.is_some());
-                if let Some(devices) = self.devices.take() {
-                    devices.stop().await;
-                }
-            }
-
-            match &mut self.devices {
-                Some(devices) => {
-                    configure_devices(devices, &self.config, daita.as_ref()).await?;
-                }
-                None => {
-                    self.devices = Some(
-                        create_devices(
-                            &self.config,
-                            daita.as_ref(),
-                            self.tun_dev.clone(),
-                            #[cfg(target_os = "android")]
-                            self.android_tun.clone(),
-                        )
-                        .await?,
+            let devices = match self.devices.take() {
+                // Switching from singlehop to multihop
+                Some(Devices::Singlehop(device))
+                    if let Some(_exit_peer) = self.config.exit_peer.as_ref() =>
+                {
+                    // Tear down old device and recreate new multihop devices.
+                    device.stop().await;
+                    create_devices(
+                        &self.config,
+                        daita.as_ref(),
+                        self.tun_dev.clone(),
+                        #[cfg(target_os = "android")]
+                        self.android_tun.clone(),
                     )
+                    .await
+                    .map_err(TunnelError::GotaTunDevice)?
                 }
+                // FIXME: When re-configuring a device with a new `psk`, `gotatun` seemingly
+                // borks out. A known workaround is to tear down the old device and set up a new
+                // one.
+                Some(Devices::Singlehop(device))
+                    if let Some(_psk) = self.config.entry_peer.psk.as_ref() =>
+                {
+                    // Tear down old device and recreate new multihop devices.
+                    device.stop().await;
+                    create_devices(
+                        &self.config,
+                        daita.as_ref(),
+                        self.tun_dev.clone(),
+                        #[cfg(target_os = "android")]
+                        self.android_tun.clone(),
+                    )
+                    .await
+                    .map_err(TunnelError::GotaTunDevice)?
+                }
+                // Simply reconfigure the singlehop device.
+                Some(Devices::Singlehop(mut device)) => {
+                    device
+                        .configure(&self.config, daita.as_ref())
+                        .await
+                        .map_err(TunnelError::GotaTunDevice)?;
+                    Devices::Singlehop(device)
+                }
+                // Simply reconfigure the multihop devices.
+                Some(Devices::Multihop(mut devices))
+                    if let Some(exit_peer) = self.config.exit_peer.as_ref() =>
+                {
+                    devices
+                        .configure(&self.config, exit_peer, daita.as_ref())
+                        .await
+                        .map_err(TunnelError::GotaTunDevice)?;
+                    Devices::Multihop(devices)
+                }
+                // Switching from multihop to singlehop
+                Some(Devices::Multihop(devices)) => {
+                    // Tear down old devices and recreate new singlehop device.
+                    devices.stop().await;
+                    create_devices(
+                        &self.config,
+                        daita.as_ref(),
+                        self.tun_dev.clone(),
+                        #[cfg(target_os = "android")]
+                        self.android_tun.clone(),
+                    )
+                    .await
+                    .map_err(TunnelError::GotaTunDevice)?
+                }
+                None => create_devices(
+                    &self.config,
+                    daita.as_ref(),
+                    self.tun_dev.clone(),
+                    #[cfg(target_os = "android")]
+                    self.android_tun.clone(),
+                )
+                .await
+                .map_err(TunnelError::GotaTunDevice)?,
             };
 
+            self.devices = Some(devices);
             Ok(())
         })
     }
@@ -474,23 +510,22 @@ async fn create_devices(
     daita: Option<&DaitaSettings>,
     tun_dev: GotaTunDevice,
     #[cfg(target_os = "android")] android_tun: Arc<Tun>,
-) -> Result<Devices, TunnelError> {
+) -> Result<Devices, gotatun::device::Error> {
     async fn create_devices_inner(
         config: &Config, // TODO: do not include config to reduce confusion
         daita: Option<&DaitaSettings>,
         tun_dev: GotaTunDevice,
         #[cfg(target_os = "android")] android_tun: Arc<Tun>,
         optimize_buffer_size: bool,
-    ) -> Result<Devices, TunnelError> {
+    ) -> Result<Devices, gotatun::device::Error> {
         let factory = udp_obfuscator_factory(
             config,
             optimize_buffer_size,
             #[cfg(target_os = "android")]
             android_tun,
         );
-        let mut devices = if let Some(exit_peer) = &config.exit_peer {
+        let devices = if let Some(exit_peer) = &config.exit_peer {
             // Multihop setup
-
             let source_v4 = config
                 .tunnel
                 .addresses
@@ -527,8 +562,7 @@ async fn create_devices(
                 .with_udp(udp_channels)
                 .with_ip(tun_dev)
                 .build()
-                .await
-                .map_err(TunnelError::GotaTunDevice)?;
+                .await?;
 
             // Hacky way of dumping entry<->exit traffic to a unix socket which wireshark can read.
             // See docs on wrap_in_pcap_sniffer for an explanation.
@@ -540,12 +574,13 @@ async fn create_devices(
                 .with_udp(factory)
                 .with_ip_pair(tun_channel_tx, tun_channel_rx)
                 .build()
-                .await
-                .map_err(TunnelError::GotaTunDevice)?;
-            Devices::Multihop {
+                .await?;
+            let mut devices = Multihop {
                 entry_device,
                 exit_device,
-            }
+            };
+            devices.configure(config, exit_peer, daita).await?;
+            Devices::Multihop(devices)
         } else {
             // Singlehop setup
 
@@ -553,12 +588,11 @@ async fn create_devices(
                 .with_udp(factory)
                 .with_ip(tun_dev)
                 .build()
-                .await
-                .map_err(TunnelError::GotaTunDevice)?;
-            Devices::Singlehop { device }
+                .await?;
+            let mut device = Singlehop { device };
+            device.configure(config, daita).await?;
+            Devices::Singlehop(device)
         };
-
-        configure_devices(&mut devices, config, daita).await?;
 
         Ok(devices)
     }
@@ -581,11 +615,11 @@ async fn create_devices(
         //
         // Try to bind UDP sockets with default buffer sizes.
         #[cfg(unix)]
-        Err(TunnelError::GotaTunDevice(ref err @ gotatun::device::Error::Bind(ref io_err, _)))
+        Err(ref err @ gotatun::device::Error::Bind(ref io_err, _))
             if let Some(errno) = io_err.raw_os_error()
                 && nix::errno::Errno::from_raw(errno) == nix::errno::Errno::ENOBUFS =>
         {
-            log::error!("Failed to bind UDP socket: {err} - retrying with default buffer sizes");
+            log::error!("Failed to bind UDP socket - retrying with default buffer sizes");
             create_devices_inner(
                 config,
                 daita,

--- a/talpid-wireguard/src/lib.rs
+++ b/talpid-wireguard/src/lib.rs
@@ -1013,7 +1013,7 @@ pub enum TunnelError {
     /// tunnel again will likely fail with the same error. An error was encountered during tunnel
     /// configuration which can't be dealt with gracefully.
     #[error("Failed to start wireguard tunnel")]
-    FatalStartWireguardError(#[source] Box<dyn std::error::Error + Send>),
+    FatalStartWireguardError(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     /// Failed to tear down wireguard tunnel.
     #[error("Failed to tear down wireguard tunnel")]
@@ -1077,10 +1077,6 @@ pub enum TunnelError {
     /// GotaTun device error
     #[error("GotaTun: {0:?}")]
     GotaTunDevice(::gotatun::device::Error),
-
-    /// Failed to configure GotaTun device.
-    #[error("Failed to configure the GotaTun device")]
-    ConfigureGotaTunDevice(#[source] gotatun::ConfigureGotaTunDeviceError),
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Some earlier macOS versions (14 and prior) does not seem to play nicely when [gotatun sets a large send/recv buffer size on its UDP socket](https://github.com/mullvad/gotatun/blob/31f860df959a895b82bc565cb333049db18727fe/gotatun/src/udp/socket/mod.rs#L98-L99) - we see the following error: `No buffer space available (os error 55)`.

This PR together with https://github.com/mullvad/gotatun/pull/134 adjusts the buffer sizes such that os error 55 is no longer triggered when setting up a `gotatun` tunnel by limiting the adjusted buffer sizes to 1MB for <macOS 15 while keeping the current buffer sizes (7MB) for all other operating systems. See the upstream PR for technical details of the socket options at play.

Fix in action: https://github.com/mullvad/mullvadvpn-app/actions/runs/26169876464

### TODO
- [x] Cut a new `gotatun` release and fix the temporary git dependency.
- [ ] Backport to `prepare-2026.3`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10444)
<!-- Reviewable:end -->
