### PR TITLE
Add support for Relay selector gRPC service

### DIFF
--- a/desktop/packages/management-interface/package.json
+++ b/desktop/packages/management-interface/package.json
@@ -17,12 +17,12 @@
       "types": "./dist/management_interface_pb.d.ts"
     },
     "./relay-selector": {
-      "default": "./dist/relay-selector.js",
-      "types": "./dist/relay-selector.d.ts"
+      "default": "./dist/relay_selector_grpc_pb.js",
+      "types": "./dist/relay_selector_grpc_pb.d.ts"
     },
     "./relay-selector/grpc-types": {
-      "default": "./dist/relay-selector.js",
-      "types": "./dist/relay-selector.d.ts"
+      "default": "./dist/relay_selector_pb.js",
+      "types": "./dist/relay_selector_pb.d.ts"
     }
   },
   "scripts": {

--- a/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
+++ b/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
@@ -54,9 +54,6 @@ import {
   ensureExists,
 } from './grpc-type-convertions';
 
-const DAEMON_RPC_PATH =
-  process.platform === 'win32' ? '//./pipe/Mullvad VPN' : '/var/run/mullvad-vpn';
-
 export class SubscriptionListener<T> {
   // Only meant to be used by DaemonRpc
   // @internal
@@ -88,7 +85,7 @@ export class DaemonRpc extends GrpcClient<ManagementServiceClient> {
   > = new Map();
 
   public constructor(connectionObserver?: ConnectionObserver) {
-    super(DAEMON_RPC_PATH, connectionObserver);
+    super(connectionObserver);
   }
 
   createClient(): ManagementServiceClient {

--- a/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
+++ b/desktop/packages/mullvad-vpn/src/main/daemon-rpc.ts
@@ -1,6 +1,7 @@
 import * as grpc from '@grpc/grpc-js';
 import { Empty } from 'google-protobuf/google/protobuf/empty_pb.js';
 import { BoolValue, StringValue } from 'google-protobuf/google/protobuf/wrappers_pb.js';
+import { ManagementServiceClient } from 'management-interface/management-interface';
 import * as grpcTypes from 'management-interface/management-interface/grpc-types';
 
 import {
@@ -79,7 +80,7 @@ export class SubscriptionListener<T> {
   }
 }
 
-export class DaemonRpc extends GrpcClient {
+export class DaemonRpc extends GrpcClient<ManagementServiceClient> {
   private nextSubscriptionId = 0;
   private subscriptions: Map<
     number,
@@ -88,6 +89,14 @@ export class DaemonRpc extends GrpcClient {
 
   public constructor(connectionObserver?: ConnectionObserver) {
     super(DAEMON_RPC_PATH, connectionObserver);
+  }
+
+  createClient(): ManagementServiceClient {
+    return new ManagementServiceClient(
+      this.prefixedRpcPath(),
+      grpc.credentials.createInsecure(),
+      this.channelOptions(),
+    );
   }
 
   public disconnect() {

--- a/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
@@ -44,8 +44,8 @@ export class ConnectionObserver {
   };
 }
 
-export class GrpcClient {
-  protected client: ManagementServiceClient;
+export abstract class GrpcClient<Client extends ManagementServiceClient> {
+  protected client: Client;
   private isConnectedValue = false;
   private isClosed = false;
   private reconnectionTimeout?: NodeJS.Timeout;
@@ -54,12 +54,10 @@ export class GrpcClient {
     private rpcPath: string,
     private connectionObserver?: ConnectionObserver,
   ) {
-    this.client = new ManagementServiceClient(
-      this.prefixedRpcPath(),
-      grpc.credentials.createInsecure(),
-      this.channelOptions(),
-    );
+    this.client = this.createClient();
   }
+
+  abstract createClient(): Client;
 
   public get isConnected() {
     return this.isConnectedValue;
@@ -68,11 +66,7 @@ export class GrpcClient {
   public reopen(connectionObserver?: ConnectionObserver) {
     if (this.isClosed) {
       this.isClosed = false;
-      this.client = new ManagementServiceClient(
-        this.prefixedRpcPath(),
-        grpc.credentials.createInsecure(),
-        this.channelOptions(),
-      );
+      this.client = this.createClient();
 
       this.connectionObserver = connectionObserver;
     }
@@ -166,7 +160,17 @@ export class GrpcClient {
     }
   }
 
-  private prefixedRpcPath(): string {
+  protected channelOptions(): grpc.ClientOptions {
+    return {
+      'grpc.max_reconnect_backoff_ms': 3000,
+      'grpc.initial_reconnect_backoff_ms': 3000,
+      'grpc.keepalive_time_ms': Math.pow(2, 30),
+      'grpc.keepalive_timeout_ms': Math.pow(2, 30),
+      'grpc.client_idle_timeout_ms': Math.pow(2, 30),
+    };
+  }
+
+  protected prefixedRpcPath(): string {
     return `${RPC_PATH_PREFIX}${this.rpcPath}`;
   }
 
@@ -183,16 +187,6 @@ export class GrpcClient {
     this.isConnectedValue = false;
 
     this.connectionObserver?.onClose(wasConnected, error);
-  }
-
-  private channelOptions(): grpc.ClientOptions {
-    return {
-      'grpc.max_reconnect_backoff_ms': 3000,
-      'grpc.initial_reconnect_backoff_ms': 3000,
-      'grpc.keepalive_time_ms': Math.pow(2, 30),
-      'grpc.keepalive_timeout_ms': Math.pow(2, 30),
-      'grpc.client_idle_timeout_ms': Math.pow(2, 30),
-    };
   }
 
   private connectivityChangeCallback(timeoutErr?: Error) {

--- a/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
@@ -8,6 +8,7 @@ import {
   UInt32Value,
 } from 'google-protobuf/google/protobuf/wrappers_pb.js';
 import { ManagementServiceClient } from 'management-interface/management-interface';
+import { RelaySelectorServiceClient } from 'management-interface/relay-selector';
 import { promisify } from 'util';
 
 import log from '../shared/logging';
@@ -47,7 +48,9 @@ export class ConnectionObserver {
 export const GRPC_CLIENT_PATH =
   process.platform === 'win32' ? '//./pipe/Mullvad VPN' : '/var/run/mullvad-vpn';
 
-export abstract class GrpcClient<Client extends ManagementServiceClient> {
+export abstract class GrpcClient<
+  Client extends ManagementServiceClient | RelaySelectorServiceClient,
+> {
   protected client: Client;
   private isConnectedValue = false;
   private isClosed = false;

--- a/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
+++ b/desktop/packages/mullvad-vpn/src/main/grpc-client.ts
@@ -44,6 +44,9 @@ export class ConnectionObserver {
   };
 }
 
+export const GRPC_CLIENT_PATH =
+  process.platform === 'win32' ? '//./pipe/Mullvad VPN' : '/var/run/mullvad-vpn';
+
 export abstract class GrpcClient<Client extends ManagementServiceClient> {
   protected client: Client;
   private isConnectedValue = false;
@@ -51,8 +54,8 @@ export abstract class GrpcClient<Client extends ManagementServiceClient> {
   private reconnectionTimeout?: NodeJS.Timeout;
 
   constructor(
-    private rpcPath: string,
     private connectionObserver?: ConnectionObserver,
+    private rpcPath: string = GRPC_CLIENT_PATH,
   ) {
     this.client = this.createClient();
   }

--- a/desktop/packages/mullvad-vpn/src/main/index.ts
+++ b/desktop/packages/mullvad-vpn/src/main/index.ts
@@ -66,6 +66,7 @@ import { isMacOs13OrNewer } from './platform-version';
 import * as problemReport from './problem-report';
 import { resolveBin } from './proc';
 import ReconnectionBackoff from './reconnection-backoff';
+import { RelaySelectorRpc } from './relay-selector-rpc';
 import Settings, { SettingsDelegate } from './settings';
 import TunnelStateHandler, {
   TunnelStateHandlerDelegate,
@@ -95,6 +96,7 @@ class ApplicationMain
     AccountDelegate
 {
   private daemonRpc: DaemonRpc;
+  private relaySelectorRpc: RelaySelectorRpc;
 
   private notificationController = new NotificationController(this);
   private version: Version;
@@ -146,6 +148,7 @@ class ApplicationMain
     this.daemonRpc = new DaemonRpc(
       new ConnectionObserver(this.onDaemonConnected, this.onDaemonDisconnected),
     );
+    this.relaySelectorRpc = new RelaySelectorRpc();
 
     this.version = new Version(this, this.daemonRpc, UPDATE_NOTIFICATION_DISABLED);
     this.settings = new Settings(this, this.daemonRpc, this.version.currentVersion);
@@ -516,6 +519,7 @@ class ApplicationMain
 
     const wasConnected = this.daemonRpc.isConnected;
     IpcMainEventChannel.navigation.notifyReset?.();
+    this.relaySelectorRpc.disconnect();
     this.daemonRpc.disconnect();
     this.onDaemonDisconnected(wasConnected, undefined, true);
   };
@@ -525,6 +529,7 @@ class ApplicationMain
     this.daemonRpc.reopen(
       new ConnectionObserver(this.onDaemonConnected, this.onDaemonDisconnected),
     );
+    this.relaySelectorRpc.reopen();
     this.connectToDaemon();
   };
 
@@ -757,6 +762,9 @@ class ApplicationMain
     void this.daemonRpc
       .connect()
       .catch((error) => log.error(`Unable to connect to daemon: ${error.message}`));
+    void this.relaySelectorRpc
+      .connect()
+      .catch((error) => log.error(`Unable to connect to relay selector: ${error.message}`));
   }
 
   private handleBootstrapError(_error?: Error) {

--- a/desktop/packages/mullvad-vpn/src/main/relay-selector-rpc.ts
+++ b/desktop/packages/mullvad-vpn/src/main/relay-selector-rpc.ts
@@ -1,0 +1,14 @@
+import * as grpc from '@grpc/grpc-js';
+import { RelaySelectorServiceClient } from 'management-interface/relay-selector';
+
+import { GrpcClient } from './grpc-client';
+
+export class RelaySelectorRpc extends GrpcClient<RelaySelectorServiceClient> {
+  createClient(): RelaySelectorServiceClient {
+    return new RelaySelectorServiceClient(
+      this.prefixedRpcPath(),
+      grpc.credentials.createInsecure(),
+      this.channelOptions(),
+    );
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,12 +38,12 @@ provide essential behavior can be hard to trace.
 ## Mullvad part of daemon
 
 ### Frontend <-> system service communication
-This is done via GRPC ([here's](../mullvad-management-interface/proto/management_interface.proto)
-the relevant proto file) over a Unix domain socket on desktop platforms and via a JNI on Android. In
-both cases, the frontends end up sending a message to the daemon that it then services. The
-servicing of any message must never block any other message. Frontends can also subscribe to
-messages from the daemon, to receive updates about the tunnel state, new settings, new relay lists,
-version information and device events.
+This is done via GRPC ([here's](../mullvad-management-interface/proto) the relevant proto files)
+over a Unix domain socket on desktop platforms and via a JNI on Android. In both cases, the
+frontends end up sending a message to the daemon that it then services. The servicing of any
+message must never block any other message. Frontends can also subscribe to messages from the
+daemon, to receive updates about the tunnel state, new settings, new relay lists, version
+information and device events.
 
 
 ### Talking to api.mullvad.net.


### PR DESCRIPTION
This PR will:

- Add basic support for using the Relay selector gRPC service.
  - Note: The service is defined in the new `relay_selector.proto` file, added in: #9793
- Restructure the `GrpcClient` class as an abstract method.
  - To allow it to use both the `ManagementServiceClient` and `RelaySelectorServiceClient` gRPC services.
- Update documentation regarding architecture to reflect that we have multiple `.proto` files

Note: The `RelaySelectorRpc` class does not utilize a `ConnectionObserver` as there is (currently at least) no setup/teardown logic required.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10445)
<!-- Reviewable:end -->
