### PR TITLE
Remove "Domain fronting" from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 
-### Added
-- Add support for API access method based on domain fronting.
-
 ### Changed
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at


### PR DESCRIPTION
This feature was reverted in #10419, but we forgot to remove the changelog entry in that PR. Then the backport of the changelog from the 2026.3 release branch moved the changelog entry into the unreleased section of the changelog.

Because of the situation above the initial commit adding the entry to the changelog could not be reverted, and instead this new commit was made to remove it from the changelog.

PRs involved:
- Yank domain fronting: #10419
- Backport changelog for 2026.3-beta1: #10434

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10446)
<!-- Reviewable:end -->
