### PR TITLE
Bump split tunnel driver load timeout

### DIFF
--- a/talpid-core/src/split_tunnel/windows/mod.rs
+++ b/talpid-core/src/split_tunnel/windows/mod.rs
@@ -336,6 +336,9 @@ enum Request {
 type RequestResponseTx = sync_mpsc::Sender<Result<(), Error>>;
 type RequestTx = sync_mpsc::Sender<(Request, RequestResponseTx)>;
 
+const START_TIMEOUT: Duration = service::WAIT_STATUS_TIMEOUT
+    .checked_add(Duration::from_secs(5))
+    .unwrap();
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Default, PartialEq, Clone)]
@@ -744,7 +747,9 @@ impl InitializedSplitTunnelState {
         });
 
         let handle = init_rx
-            .recv_timeout(REQUEST_TIMEOUT)
+            // NOTE: The timeout is needed in case the ST device is unresponsive. This can
+            // cause `DeviceHandle::new` to block forever on IOCTL calls.
+            .recv_timeout(START_TIMEOUT)
             .map_err(|_| Error::RequestThreadStuck)??;
 
         let handle_copy = handle.clone();

--- a/talpid-core/src/split_tunnel/windows/service.rs
+++ b/talpid-core/src/split_tunnel/windows/service.rs
@@ -17,7 +17,10 @@ const SPLIT_TUNNEL_SERVICE: &str = "mullvad-split-tunnel";
 const SPLIT_TUNNEL_DISPLAY_NAME: &str = "Mullvad Split Tunnel Service";
 const DRIVER_FILENAME: &str = "mullvad-split-tunnel.sys";
 
-const WAIT_STATUS_TIMEOUT: Duration = Duration::from_secs(8);
+// TODO: Starting 'mullvad-split-tunnel' can take some time during boot. So we need a very
+// generous timeout here. It might make sense to redesign split tunneling to not block the rest
+// of the tunnel state machine from starting up, especially if split tunneling is disabled.
+pub const WAIT_STATUS_TIMEOUT: Duration = Duration::from_mins(2);
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/talpid-core/src/split_tunnel/windows/service.rs
+++ b/talpid-core/src/split_tunnel/windows/service.rs
@@ -156,17 +156,20 @@ fn install_driver(scm: &ServiceManager, syspath: &Path) -> Result<(), Error> {
 fn start_and_wait_for_service(service: &Service) -> Result<(), Error> {
     log::debug!("Starting split tunnel service");
 
-    if let Err(error) = service.start::<&OsStr>(&[]) {
-        if let windows_service::Error::Winapi(error) = &error
-            && error.raw_os_error() == Some(ERROR_SERVICE_ALREADY_RUNNING as i32)
-        {
-            log::debug!("Split tunnel service is already running");
-            return Ok(());
+    match service.start::<&OsStr>(&[]) {
+        Ok(()) => {
+            log::debug!("Split tunnel service start pending");
         }
-        return Err(Error::StartService(error));
+        Err(error)
+            if let windows_service::Error::Winapi(error) = &error
+                && error.raw_os_error() == Some(ERROR_SERVICE_ALREADY_RUNNING as i32) =>
+        {
+            // Service started, but we don't know if its state is yet "running"
+            // (never mind what the error is called).
+            log::debug!("Split tunnel service already started. Checking state");
+        }
+        Err(error) => return Err(Error::StartService(error)),
     }
-
-    log::debug!("Split tunnel service start pending");
 
     wait_for_status(service, ServiceState::Running)?;
 


### PR DESCRIPTION
The effective timeout was previously `REQUEST_TIMEOUT` (5 s). This increases it to 2 minutes, to fix a common problem of it taking a long time to load during boot.

# Todo

- [x] Backport to prepare-2026.3

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10447)
<!-- Reviewable:end -->
