### PR TITLE
feat(tray): toggle window visibility on left-click

### DIFF
--- a/desktop/packages/mullvad-vpn/src/main/user-interface.ts
+++ b/desktop/packages/mullvad-vpn/src/main/user-interface.ts
@@ -579,7 +579,7 @@ export default class UserInterface implements WindowControllerDelegate {
           this.tray?.on('right-click', () =>
             this.popUpContextMenu(this.delegate.isLoggedIn(), this.delegate.getTunnelState()),
           );
-          this.tray?.on('click', () => this.windowController.show());
+          this.tray?.on('click', () => this.windowController.toggle());
         } else {
           this.tray?.on('right-click', () => this.windowController.hide());
           this.tray?.on('click', () => this.windowController.toggle());
@@ -605,7 +605,7 @@ export default class UserInterface implements WindowControllerDelegate {
         });
         break;
       case 'linux':
-        this.tray?.on('click', () => this.windowController.show());
+        this.tray?.on('click', () => this.windowController.toggle());
         break;
     }
   }


### PR DESCRIPTION
## Summary
- On Linux and on Windows with an unpinned window, left-clicking the tray icon previously only showed the window — there was no way to hide it back via the tray.
- Switch both cases to `windowController.toggle()`, matching the existing behaviour on macOS and on Windows with a pinned window. Clicking the tray icon while the window is open now hides it again.

## Test plan
- [ ] Linux: open the app, left-click the tray icon — window hides. Click again — window shows.
- [ ] Windows (unpinned window): same as above.
- [ ] Windows (pinned window): regression check — toggle still works.
- [ ] macOS: regression check — toggle still works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10452)
<!-- Reviewable:end -->
