### PR TITLE
docs: document browser auto-launch case in split tunneling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Line wrap the file at 100 chars.                                              Th
 
 ## [Unreleased]
 ### Changed
+- Document case where browsers auto-launched at startup by an excluded background service
+  inherit the excluded status.
+
 #### Windows
 - Update `wireguard-nt` to version 1.1. This retires the Mullvad fork at
   <https://github.com/mullvad/wireguard-nt>.

--- a/docs/split-tunneling.md
+++ b/docs/split-tunneling.md
@@ -89,3 +89,24 @@ unexpectedly excluded, simply because the parent is excluded.
 The limitations due to IPC are perhaps especially noticeable on macOS, since WebKit relies on other
 processes to render web pages. This means that many browsers, including Safari, cannot be excluded
 from the VPN.
+
+A subtle variant of the link-clicking case described above occurs when an excluded background
+service is configured to open the user's default browser at system startup. This is a common
+pattern for locally-running services that come with a web-based admin UI and an "open browser on
+startup" option enabled by default. The service starts with Windows, spawns the browser to load
+its local web UI, and the browser process inherits the excluded status from the service.
+
+Because browsers use a launcher process model where the spawned `firefox.exe` or `chrome.exe`
+forwards URLs to an existing instance via IPC and exits, the inherited status can persist
+on the long-running browser session that opens the user's saved tabs. The user sees a normal
+browser, the Mullvad app UI shows "Connected", and the only externally visible symptom is that the
+public IP reported by sites is the user's real ISP IP.
+
+DNS continues to be sent through the tunnel because the system DNS resolver runs in its own
+process tree, so DNS leak tests pass and reinforce the incorrect impression that the browser is
+tunneled.
+
+Workaround: in the settings of any excluded background service that has an auto-launch-browser
+option, disable that option. The service continues running in the background; only the auto-spawn
+of an external browser at startup is suppressed. Manual access to the service's web UI via a
+bookmark or by typing the URL into an already-running browser is not affected.


### PR DESCRIPTION
## Summary

Documents a specific case of the parent-process exclusion inheritance already described in `docs/split-tunneling.md`: browsers auto-launched at startup by excluded background services.

## Motivation

The docs already describe what happens when a user clicks a link inside an excluded app: the new browser window inherits the excluded status. There's a related case they don't cover: when an excluded background service auto-opens the default browser at boot. The browser inherits the excluded status from the service, and that status sticks around on the long-running browser session that restores the user's tabs.

The mechanism is the same as the link-click case, but the symptoms differ enough that users don't recognize their situation in the current docs. The Mullvad app UI shows "Connected", DNS leak tests pass as DNS goes through a separate process tree, and only the public IP test reveals the leak. I ran into this myself and it took a while to figure out why my browser was leaking while every other check looked clean.

## Changes

One new subsection added to `docs/split-tunneling.md` after the existing "clicking a link in an excluded app" paragraph. Covers the auto-launch mechanism, why DNS tests still pass, and a generic workaround that applies to any service doing this.

Also adds an entry to `CHANGELOG.md` under `[Unreleased]`.

## Testing

Docs-only change, no code touched. Behavior matches what I observed on Windows 10 Build 19045 with Mullvad VPN 2026.2 and Firefox 151.0.1, with an excluded background service set to launch the default browser at startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10455)
<!-- Reviewable:end -->
