### PR TITLE
Fix flashing on select location screen

### DIFF
--- a/android/lib/feature/location/impl/src/androidTest/kotlin/net/mullvad/mullvadvpn/feature/location/impl/SelectLocationScreenTest.kt
+++ b/android/lib/feature/location/impl/src/androidTest/kotlin/net/mullvad/mullvadvpn/feature/location/impl/SelectLocationScreenTest.kt
@@ -129,6 +129,7 @@ class SelectLocationScreenTest {
                                     hierarchy = Hierarchy.Parent,
                                 )
                             },
+                        recentsEnabled = false,
                     )
                 )
             )
@@ -165,6 +166,7 @@ class SelectLocationScreenTest {
                     SelectLocationListUiState(
                         relayListItems = listOf(RelayListItem.CustomListFooter(false)),
                         relayListType = RelayListType.Single,
+                        recentsEnabled = false,
                     )
                 )
             )
@@ -197,6 +199,7 @@ class SelectLocationScreenTest {
                     SelectLocationListUiState(
                         relayListItems = listOf(RelayListItem.CustomListItem(customList)),
                         relayListType = RelayListType.Single,
+                        recentsEnabled = false,
                     )
                 )
             )
@@ -234,6 +237,7 @@ class SelectLocationScreenTest {
                     SelectLocationListUiState(
                         relayListItems = listOf(RelayListItem.RecentListItem(item = recent)),
                         relayListType = RelayListType.Single,
+                        recentsEnabled = false,
                     )
                 )
             )
@@ -271,6 +275,7 @@ class SelectLocationScreenTest {
                     SelectLocationListUiState(
                         relayListItems = listOf(RelayListItem.CustomListItem(item = customList)),
                         relayListType = RelayListType.Single,
+                        recentsEnabled = false,
                     )
                 )
             )
@@ -323,6 +328,7 @@ class SelectLocationScreenTest {
                                 )
                             ),
                         relayListType = RelayListType.Single,
+                        recentsEnabled = false,
                     )
                 )
             )
@@ -376,6 +382,7 @@ class SelectLocationScreenTest {
                                     selectedItem = selectableItem.id,
                                 ),
                             relayListType = RelayListType.Single,
+                            recentsEnabled = false,
                         )
                     )
                 )
@@ -420,6 +427,7 @@ class SelectLocationScreenTest {
                                     selectedItem = selectableItem.id,
                                 ),
                             relayListType = RelayListType.Single,
+                            recentsEnabled = false,
                         )
                     )
                 )
@@ -463,6 +471,7 @@ class SelectLocationScreenTest {
                                 locationItems = emptyList(),
                                 selectedItem = null,
                             ),
+                        recentsEnabled = false,
                     )
                 )
             )

--- a/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/SelectLocationScreen.kt
+++ b/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/SelectLocationScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AddLocationAlt
 import androidx.compose.material.icons.outlined.WrongLocation
@@ -640,7 +639,6 @@ private fun RelayLists(
     }
 
     val lazyListStates = remember { mutableStateMapOf<RelayListType, LazyListState>() }
-    val scrollToLists = remember { mutableSetOf<RelayListType>() }
 
     Crossfade(relayListType) {
         when (it) {
@@ -655,9 +653,7 @@ private fun RelayLists(
                             onAddCustomList = onAddCustomList,
                             onEditCustomLists = onEditCustomLists,
                             onUpdateBottomSheetState = onUpdateBottomSheetState,
-                            lazyListState =
-                                lazyListStates.getOrPut(it, { rememberLazyListState() }),
-                            scrollToList = scrollToLists.add(it),
+                            lazyListStates = lazyListStates,
                         )
 
                     MultihopRelayListType.EXIT ->
@@ -669,9 +665,7 @@ private fun RelayLists(
                             onAddCustomList = onAddCustomList,
                             onEditCustomLists = onEditCustomLists,
                             onUpdateBottomSheetState = onUpdateBottomSheetState,
-                            lazyListState =
-                                lazyListStates.getOrPut(it, { rememberLazyListState() }),
-                            scrollToList = scrollToLists.add(it),
+                            lazyListStates = lazyListStates,
                         )
                 }
 
@@ -684,8 +678,7 @@ private fun RelayLists(
                     onAddCustomList = onAddCustomList,
                     onEditCustomLists = onEditCustomLists,
                     onUpdateBottomSheetState = onUpdateBottomSheetState,
-                    lazyListState = lazyListStates.getOrPut(it, { rememberLazyListState() }),
-                    scrollToList = scrollToLists.add(it),
+                    lazyListStates = lazyListStates,
                 )
         }
     }

--- a/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationList.kt
+++ b/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationList.kt
@@ -1,26 +1,27 @@
 package net.mullvad.mullvadvpn.feature.location.impl.list
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
@@ -31,14 +32,13 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlin.Unit
 import kotlinx.coroutines.flow.first
 import net.mullvad.mullvadvpn.feature.location.api.LocationBottomSheetState
-import net.mullvad.mullvadvpn.feature.location.impl.ContentType
 import net.mullvad.mullvadvpn.feature.location.impl.CustomListHeader
 import net.mullvad.mullvadvpn.feature.location.impl.relayListContent
 import net.mullvad.mullvadvpn.lib.common.Lce
 import net.mullvad.mullvadvpn.lib.common.compose.CollectSideEffectWithLifecycle
-import net.mullvad.mullvadvpn.lib.common.compose.animateScrollAndCentralizeItem
 import net.mullvad.mullvadvpn.lib.common.compose.animateScrollCentralizeItem
 import net.mullvad.mullvadvpn.lib.model.CustomListId
 import net.mullvad.mullvadvpn.lib.model.GeoLocationId
@@ -47,6 +47,7 @@ import net.mullvad.mullvadvpn.lib.model.RelayItemId
 import net.mullvad.mullvadvpn.lib.model.RelayListType
 import net.mullvad.mullvadvpn.lib.ui.component.drawVerticalScrollbar
 import net.mullvad.mullvadvpn.lib.ui.component.relaylist.RelayListItem
+import net.mullvad.mullvadvpn.lib.ui.designsystem.ListTokens
 import net.mullvad.mullvadvpn.lib.ui.designsystem.MullvadCircularProgressIndicatorLarge
 import net.mullvad.mullvadvpn.lib.ui.designsystem.PrimaryButton
 import net.mullvad.mullvadvpn.lib.ui.resource.R
@@ -65,16 +66,17 @@ private fun PreviewSelectLocationList(
 ) {
     AppTheme {
         Surface {
-            SelectLocationListContent(
+            SelectLocationList(
                 state = state,
-                lazyListState = rememberLazyListState(),
                 bottomMargin = 0.dp,
-                openDaitaSettings = {},
+                relayListType = RelayListType.Single,
                 onSelectRelayItem = { _, _ -> },
-                onUpdateBottomSheetState = {},
+                openDaitaSettings = {},
                 onAddCustomList = {},
                 onEditCustomLists = {},
+                onUpdateBottomSheetState = {},
                 onToggleExpand = { _, _, _ -> },
+                lazyListStates = SnapshotStateMap(),
             )
         }
     }
@@ -93,8 +95,7 @@ fun SelectLocationList(
     onAddCustomList: () -> Unit,
     onEditCustomLists: (() -> Unit)?,
     onUpdateBottomSheetState: (LocationBottomSheetState) -> Unit,
-    lazyListState: LazyListState,
-    scrollToList: Boolean,
+    lazyListStates: SnapshotStateMap<RelayListType, LazyListState>,
 ) {
     val viewModel =
         koinViewModel<SelectLocationListViewModel>(
@@ -102,18 +103,6 @@ fun SelectLocationList(
             parameters = { parametersOf(relayListType) },
         )
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    // The first time the list is opened and we have content we should scroll to the selected item.
-    // Due to how recomposition works and that the viewmodel is preserved between we need to use
-    // this hack to only scroll the first time.
-    LaunchedEffect(Unit) {
-        val stateActual = viewModel.uiState.first { it is Content }
-        if (scrollToList) {
-            stateActual.indexOfSelectedRelayItem()?.let { index ->
-                lazyListState.scrollToItem(index)
-                lazyListState.animateScrollAndCentralizeItem(index)
-            }
-        }
-    }
 
     CollectSideEffectWithLifecycle(viewModel.uiSideEffect) {
         val stateActual = viewModel.uiState.first { it is Content }
@@ -140,29 +129,77 @@ fun SelectLocationList(
             }
 
         if (index != null && index != -1) {
-            lazyListState.animateScrollCentralizeItem(index)
+            lazyListStates[relayListType]?.animateScrollCentralizeItem(index)
         }
     }
 
-    SelectLocationListContent(
+    SelectLocationList(
         state = state,
-        lazyListState = lazyListState,
         bottomMargin = bottomMargin,
-        openDaitaSettings = openDaitaSettings,
+        relayListType = relayListType,
         onSelectRelayItem = onSelectRelayItem,
-        onUpdateBottomSheetState = onUpdateBottomSheetState,
+        openDaitaSettings = openDaitaSettings,
         onAddCustomList = onAddCustomList,
         onEditCustomLists = onEditCustomLists,
-        onToggleExpand = viewModel::onToggleExpand,
+        onUpdateBottomSheetState = onUpdateBottomSheetState,
+        onToggleExpand = { id, customListId, expand ->
+            viewModel.onToggleExpand(id, customListId, expand)
+        },
+        lazyListStates = lazyListStates,
     )
 }
 
 @Composable
-private fun SelectLocationListContent(
+fun SelectLocationList(
     state: Lce<Unit, SelectLocationListUiState, Unit>,
+    bottomMargin: Dp,
+    relayListType: RelayListType,
+    onSelectRelayItem: (RelayItem, RelayListType) -> Unit,
+    openDaitaSettings: () -> Unit,
+    onAddCustomList: () -> Unit,
+    onEditCustomLists: (() -> Unit)?,
+    onUpdateBottomSheetState: (LocationBottomSheetState) -> Unit,
+    onToggleExpand: (RelayItemId, CustomListId?, Boolean) -> Unit,
+    lazyListStates: SnapshotStateMap<RelayListType, LazyListState>,
+) {
+    when (state) {
+        is Lce.Content -> {
+            val density = LocalDensity.current
+            val lazyListState =
+                lazyListStates.getOrPut(relayListType) {
+                    if (state.value.recentsEnabled) {
+                        // If we have recents we start on the top of the list
+                        rememberLazyListState()
+                    } else {
+                        // If no recents we focus the selected item
+                        val selectedIndex = state.indexOfSelectedRelayItem()
+                        val listItemHeight =
+                            with(density) { ListTokens.listItemMinHeight.toPx().toInt() }
+                        rememberLazyListState(selectedIndex ?: 0, (-2 * listItemHeight))
+                    }
+                }
+
+            SelectLocationListContent(
+                state = state.value,
+                lazyListState = lazyListState,
+                bottomMargin = bottomMargin,
+                onSelectRelayItem = onSelectRelayItem,
+                onUpdateBottomSheetState = onUpdateBottomSheetState,
+                onAddCustomList = onAddCustomList,
+                onEditCustomLists = onEditCustomLists,
+                onToggleExpand = onToggleExpand,
+            )
+        }
+        is Lce.Loading -> Loading()
+        is EntryBlocked -> EntryBlocked(openDaitaSettings = openDaitaSettings)
+    }
+}
+
+@Composable
+private fun SelectLocationListContent(
+    state: SelectLocationListUiState,
     lazyListState: LazyListState,
     bottomMargin: Dp,
-    openDaitaSettings: () -> Unit,
     onSelectRelayItem: (relayItem: RelayItem, relayListType: RelayListType) -> Unit,
     onUpdateBottomSheetState: (LocationBottomSheetState) -> Unit,
     onAddCustomList: () -> Unit,
@@ -183,55 +220,44 @@ private fun SelectLocationListContent(
         contentPadding = PaddingValues(bottom = bottomMargin),
         state = lazyListState,
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement =
-            if (state is EntryBlocked) {
-                Arrangement.Center
-            } else {
-                Arrangement.Top
-            },
     ) {
-        when (state) {
-            is Lce.Loading -> loading()
-            is EntryBlocked -> entryBlocked(openDaitaSettings = openDaitaSettings)
-            is Content -> {
-                // When recents have been disabled and are enabled again and we are at the
-                // top of the list we scroll up so that recents are visible again.
-                val shouldScrollToTop =
-                    state.value.relayListItems.firstOrNull() is RelayListItem.RecentsListHeader &&
-                        prevTopItem !is RelayListItem.RecentsListHeader &&
-                        lazyListState.firstVisibleItemIndex == 0 &&
-                        lazyListState.firstVisibleItemScrollOffset == 0
+        // When recents have been disabled and are enabled again and we are at the
+        // top of the list we scroll up so that recents are visible again.
+        val shouldScrollToTop =
+            state.relayListItems.firstOrNull() is RelayListItem.RecentsListHeader &&
+                prevTopItem !is RelayListItem.RecentsListHeader &&
+                lazyListState.firstVisibleItemIndex == 0 &&
+                lazyListState.firstVisibleItemScrollOffset == 0
 
-                prevTopItem = state.value.relayListItems.firstOrNull()
+        prevTopItem = state.relayListItems.firstOrNull()
 
-                relayListContent(
-                    relayListItems = state.value.relayListItems,
-                    relayListType = state.value.relayListType,
-                    onSelectRelayItem = { onSelectRelayItem(it, state.value.relayListType) },
-                    onToggleExpand = onToggleExpand,
-                    onUpdateBottomSheetState = onUpdateBottomSheetState,
-                    customListHeader = {
-                        CustomListHeader(
-                            onAddCustomList,
-                            if (it.canEdit) onEditCustomLists else null,
-                        )
-                    },
-                )
+        relayListContent(
+            relayListItems = state.relayListItems,
+            relayListType = state.relayListType,
+            onSelectRelayItem = { onSelectRelayItem(it, state.relayListType) },
+            onToggleExpand = onToggleExpand,
+            onUpdateBottomSheetState = onUpdateBottomSheetState,
+            customListHeader = {
+                CustomListHeader(onAddCustomList, if (it.canEdit) onEditCustomLists else null)
+            },
+        )
 
-                if (shouldScrollToTop) {
-                    lazyListState.requestScrollToItem(0)
-                }
-            }
+        if (shouldScrollToTop) {
+            lazyListState.requestScrollToItem(0)
         }
     }
 }
 
-private fun LazyListScope.loading() {
-    item(contentType = ContentType.PROGRESS) { MullvadCircularProgressIndicatorLarge() }
+@Composable
+private fun Loading() {
+    Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        MullvadCircularProgressIndicatorLarge()
+    }
 }
 
-private fun LazyListScope.entryBlocked(openDaitaSettings: () -> Unit) {
-    item(contentType = ContentType.DESCRIPTION) {
+@Composable
+private fun EntryBlocked(openDaitaSettings: () -> Unit) {
+    Column(modifier = Modifier.fillMaxSize()) {
         Text(
             text =
                 stringResource(
@@ -245,11 +271,7 @@ private fun LazyListScope.entryBlocked(openDaitaSettings: () -> Unit) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = Dimens.mediumPadding),
         )
-    }
-    item(contentType = ContentType.SPACER) {
         Spacer(modifier = Modifier.height(Dimens.mediumPadding))
-    }
-    item(contentType = ContentType.BUTTON) {
         PrimaryButton(
             text =
                 stringResource(R.string.open_feature_settings, stringResource(id = R.string.daita)),

--- a/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListUiState.kt
+++ b/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListUiState.kt
@@ -6,4 +6,5 @@ import net.mullvad.mullvadvpn.lib.ui.component.relaylist.RelayListItem
 data class SelectLocationListUiState(
     val relayListType: RelayListType,
     val relayListItems: List<RelayListItem>,
+    val recentsEnabled: Boolean,
 )

--- a/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListViewModel.kt
+++ b/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -25,6 +26,7 @@ import net.mullvad.mullvadvpn.lib.common.util.isEntryAndBlocked
 import net.mullvad.mullvadvpn.lib.model.CustomListId
 import net.mullvad.mullvadvpn.lib.model.GeoLocationId
 import net.mullvad.mullvadvpn.lib.model.MultihopRelayListType
+import net.mullvad.mullvadvpn.lib.model.Recents
 import net.mullvad.mullvadvpn.lib.model.RelayItem
 import net.mullvad.mullvadvpn.lib.model.RelayItemId
 import net.mullvad.mullvadvpn.lib.model.RelayListType
@@ -53,7 +55,9 @@ class SelectLocationListViewModel(
         MutableStateFlow(initialExpand(initialSelection()))
 
     val uiState: StateFlow<Lce<Unit, SelectLocationListUiState, Unit>> =
-        combine(relayListItems(), settingsRepository.settingsUpdates) { relayListItems, settings ->
+        combine(relayListItems(), settingsRepository.settingsUpdates.filterNotNull()) {
+                relayListItems,
+                settings ->
                 if (relayListType.isEntryAndBlocked(settings)) {
                     Lce.Error(Unit)
                 } else {
@@ -61,6 +65,7 @@ class SelectLocationListViewModel(
                         SelectLocationListUiState(
                             relayListType = relayListType,
                             relayListItems = relayListItems,
+                            recentsEnabled = settings.recents is Recents.Enabled,
                         )
                     )
                 }

--- a/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationsListUiStatePreviewParameterProvider.kt
+++ b/android/lib/feature/location/impl/src/main/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationsListUiStatePreviewParameterProvider.kt
@@ -18,6 +18,7 @@ class SelectLocationsListUiStatePreviewParameterProvider :
                             isSearching = false,
                         ),
                     relayListType = RelayListType.Multihop(MultihopRelayListType.EXIT),
+                    recentsEnabled = false,
                 )
             ),
             Lce.Loading(Unit),

--- a/android/lib/feature/location/impl/src/test/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListViewModelTest.kt
+++ b/android/lib/feature/location/impl/src/test/kotlin/net/mullvad/mullvadvpn/feature/location/impl/list/SelectLocationListViewModelTest.kt
@@ -20,6 +20,7 @@ import net.mullvad.mullvadvpn.lib.common.util.entryBlocked
 import net.mullvad.mullvadvpn.lib.model.Constraint
 import net.mullvad.mullvadvpn.lib.model.GeoLocationId
 import net.mullvad.mullvadvpn.lib.model.MultihopRelayListType
+import net.mullvad.mullvadvpn.lib.model.Recents
 import net.mullvad.mullvadvpn.lib.model.RelayItem
 import net.mullvad.mullvadvpn.lib.model.RelayItemSelection
 import net.mullvad.mullvadvpn.lib.model.RelayListType
@@ -206,6 +207,7 @@ class SelectLocationListViewModelTest {
         selectedLocationFlow.value = RelayItemSelection.Multiple(Constraint.Any, Constraint.Any)
         val mockSettings: Settings = mockk()
         every { mockSettings.entryBlocked() } returns true
+        every { mockSettings.recents } returns Recents.Disabled
         settings.value = mockSettings
 
         // Act, Assert
@@ -227,6 +229,7 @@ class SelectLocationListViewModelTest {
         selectedLocationFlow.value = RelayItemSelection.Multiple(Constraint.Any, Constraint.Any)
         val mockSettings: Settings = mockk()
         every { mockSettings.entryBlocked() } returns true
+        every { mockSettings.recents } returns Recents.Disabled
         settings.value = mockSettings
 
         // Act, Assert


### PR DESCRIPTION
After upgrading to compose 1.11.0 we started see flashing of select location list. I narrowed it down to combination of using `Modifier.animateItem()` in combination of animating scroll. To fix this I've removed the usage of `animateScrollAndCentralizeItem` and instead set the correct index when creating the list to begin with.

Relevant issuetracker issue:
https://issuetracker.google.com/issues/352584409


<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10456)
<!-- Reviewable:end -->
