### PR TITLE
Wait for wintun interface to be ready before applying configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Line wrap the file at 100 chars.                                              Th
 ### Fixed
 #### Windows
 - Fix timeout when loading split tunnel driver during boot.
+- Fix race condition in `2026-3.beta1` that could result in inability to create tunnel interface.
 
 
 ## [2026.3-beta1] - 2026-05-19

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6361,8 +6361,7 @@ dependencies = [
 [[package]]
 name = "tun"
 version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebb3e56bb60c1e6650c9317997862ab05864c358add3cfaa34b855ffae583d0"
+source = "git+https://github.com/mullvad/rust-tun?rev=b1b36d383d94148cbb6e33dcc7d37406bc56a3f4#b1b36d383d94148cbb6e33dcc7d37406bc56a3f4"
 dependencies = [
  "bytes",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,13 @@ unused_macro_rules = "warn"
 # usage checkers to see that it's not unused
 ignored = ["prost"]
 
+[patch.crates-io]
+# TODO: Update to latest version on crates.io when this fix has been released:
+# https://github.com/meh/rust-tun/pull/160
+# The current version when writing this (0.8.9) is problematic because it misreports the MTU.
+# Branch: backport-fix-wintun-mtu
+tun = { git = "https://github.com/mullvad/rust-tun", rev = "b1b36d383d94148cbb6e33dcc7d37406bc56a3f4" }
+
 [profile.release]
 opt-level = "s"
 strip = true

--- a/talpid-tunnel/Cargo.toml
+++ b/talpid-tunnel/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 cfg-if = "1.0"
 futures = { workspace = true }
 ipnetwork = { workspace = true }
+log = { workspace = true }
 talpid-routing = { path = "../talpid-routing" }
 talpid-types = { path = "../talpid-types" }
 thiserror = { workspace = true }
@@ -20,7 +21,6 @@ tun = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jnix = { version = "0.5.1", features = ["derive"] }
-log = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 talpid-windows = { path = "../talpid-windows" }

--- a/talpid-tunnel/src/tun_provider/windows.rs
+++ b/talpid-tunnel/src/tun_provider/windows.rs
@@ -1,4 +1,5 @@
 use super::TunConfig;
+use std::time::Duration;
 use std::{io, net::IpAddr, ops::Deref};
 use tun::{self, AbstractDeviceExt};
 use tun::{AbstractDevice, AsyncDevice, Configuration};
@@ -27,6 +28,14 @@ pub enum Error {
     #[error("Failed to get tunnel device name")]
     GetDeviceName(#[source] tun::Error),
 
+    /// Timeout waiting for IP interfaces
+    #[error("Error waiting for IP interfaces")]
+    WaitForInterfaces(#[source] talpid_windows::net::Error),
+
+    /// Failed to configure IP interfaces
+    #[error("Failed to configure MTU and metric")]
+    InitializeInterfaces(#[source] std::io::Error),
+
     /// IO error
     #[error("IO error")]
     Io(#[from] io::Error),
@@ -53,10 +62,13 @@ impl WindowsTunProvider {
         let mut tunnel_device = {
             let mut builder = TunnelDeviceBuilder::default();
 
+            // TODO: see comment on `wait_for_interfaces_sync` for why MTU and metric are not set
+            // here. Revert when fixed.
             // When routing, the metric of a route is equal to the sum of the interface metric and
             // metric value set for the route itself. Setting the interface metric to 1 gives tunnel
             // routes the highest possible priority.
-            builder.config.metric(1);
+            //builder.config.metric(1);
+            //builder.config.mtu(self.config.mtu);
 
             /// Tunnel adapter name
             const ADAPTER_NAME: &str = "Mullvad";
@@ -67,7 +79,6 @@ impl WindowsTunProvider {
             const ADAPTER_GUID: u128 = 0xAFE4_3773_E1F8_4EBB_8536_576A_B86A_FE9A;
 
             builder.config.tun_name(ADAPTER_NAME);
-            builder.config.mtu(self.config.mtu);
             builder
                 .config
                 .platform_config(|cfg: &mut tun::PlatformConfig| {
@@ -79,6 +90,37 @@ impl WindowsTunProvider {
 
             builder.create()?
         };
+
+        let luid = NET_LUID_LH {
+            Value: tunnel_device.dev.tun_luid(),
+        };
+        let has_ipv4 = self.config.addresses.iter().any(|addr| addr.is_ipv4());
+        let has_ipv6 = self.config.addresses.iter().any(|addr| addr.is_ipv6());
+
+        // TODO: `tun` does not wait for IP interfaces to become configurable after creating the tun
+        // interface. This can cause `SetIpInterfaceEntry` to fail when setting metric, MTU, IP
+        // addresses, etc. Upstream a fix.
+        // TODO: This isn't cancellable by the user or TSM, which means tunnel state machine can
+        // become unresponsive if it takes a long time for the interfaces to appear. Seems to happen
+        // for some users.
+        log::debug!("Waiting for IP interfaces");
+        talpid_windows::net::wait_for_interfaces_sync(
+            luid,
+            has_ipv4,
+            has_ipv6,
+            Duration::from_secs(30),
+        )
+        .map_err(Error::WaitForInterfaces)?;
+        log::debug!("Waiting for IP interfaces: done");
+
+        let mtu = self.config.mtu.into();
+        // TODO: see comment on `wait_for_interfaces_sync` for why we don't use tun here.
+        crate::network_interface::initialize_interfaces(
+            luid,
+            has_ipv4.then_some(mtu),
+            has_ipv6.then_some(mtu),
+        )
+        .map_err(Error::InitializeInterfaces)?;
 
         // TODO: `tun` currently cannot handle IPv6 without using netsh,
         // so we add IPs ourselves.

--- a/talpid-windows/src/net.rs
+++ b/talpid-windows/src/net.rs
@@ -70,6 +70,16 @@ pub enum Error {
     #[error("Unexpected DAD state")]
     DadStateError(#[source] DadStateError),
 
+    /// Failed to start interface check.
+    #[cfg(windows)]
+    #[error("Error waiting on IP interfaces")]
+    StartIpInterfaceNotify(#[source] io::Error),
+
+    /// Interface check failed.
+    #[cfg(windows)]
+    #[error("Timed out waiting on IP interfaces")]
+    IpInterfaceTimeout,
+
     /// DAD check failed.
     #[cfg(windows)]
     #[error("Timed out waiting on tunnel device")]
@@ -220,14 +230,49 @@ fn ip_interface_entry_exists(family: AddressFamily, luid: &NET_LUID_LH) -> io::R
 /// Waits until the specified IP interfaces have attached to a given network interface.
 pub async fn wait_for_interfaces(luid: NET_LUID_LH, ipv4: bool, ipv6: bool) -> io::Result<()> {
     let (tx, rx) = futures::channel::oneshot::channel();
+    // Need mutex as `FnMut` is not allowed here
+    let tx = Mutex::new(Some(tx));
 
+    start_wait_for_interfaces(luid, ipv4, ipv6, move || {
+        if let Some(tx) = tx.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
+    })?;
+
+    let _ = rx.await;
+    Ok(())
+}
+
+/// Waits until the specified IP interfaces have appeared for a given network device.
+/// This fails if the interfaces have not appeared after the specified `timeout`.
+pub fn wait_for_interfaces_sync(
+    luid: NET_LUID_LH,
+    ipv4: bool,
+    ipv6: bool,
+    timeout: Duration,
+) -> Result<()> {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+
+    start_wait_for_interfaces(luid, ipv4, ipv6, || {
+        let _ = tx.send(());
+    })
+    .map_err(Error::StartIpInterfaceNotify)?;
+
+    rx.recv_timeout(timeout)
+        .map_err(|_| Error::IpInterfaceTimeout)
+}
+
+fn start_wait_for_interfaces(
+    luid: NET_LUID_LH,
+    ipv4: bool,
+    ipv6: bool,
+    on_interfaces_up: impl Fn() + Sync,
+) -> io::Result<()> {
     let mut found_ipv4 = !ipv4;
     let mut found_ipv6 = !ipv6;
 
-    let mut tx = Some(tx);
-
     let _handle = notify_ip_interface_change(
-        move |row, notification_type| {
+        |row, notification_type| {
             if found_ipv4 && found_ipv6 {
                 return;
             }
@@ -242,24 +287,21 @@ pub async fn wait_for_interfaces(luid: NET_LUID_LH, ipv4: bool, ipv6: bool) -> i
                 AF_INET6 => found_ipv6 = true,
                 _ => (),
             }
-            if found_ipv4
-                && found_ipv6
-                && let Some(tx) = tx.take()
-            {
-                let _ = tx.send(());
+            if found_ipv4 && found_ipv6 {
+                on_interfaces_up();
             }
         },
         None,
     )?;
 
-    // Make sure they don't already exist
+    // Make sure the interfaces were not already up
     if (!ipv4 || ip_interface_entry_exists(AddressFamily::Ipv4, &luid)?)
         && (!ipv6 || ip_interface_entry_exists(AddressFamily::Ipv6, &luid)?)
     {
+        on_interfaces_up();
         return Ok(());
     }
 
-    let _ = rx.await;
     Ok(())
 }
 


### PR DESCRIPTION
This works around an issue in the `tun` crate. Creating a network device does not instantly make it visible everywhere in the network stack, meaning configuration with e.g. `SetIpInterfaceEntry` can fail. Though it is inherently racy and works on most machines. PR fix is just to wait for IP interfaces to appear using `NotifyIpInterfaceChange`.

Fix DES-3036.

# Todo
- [x] Backport fix to `prepare-2026.3`

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10458)
<!-- Reviewable:end -->
