### PR TITLE
Update entry server icon

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/Views/MultihopSelection/Hop.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/Views/MultihopSelection/Hop.swift
@@ -29,10 +29,10 @@ struct Hop {
         } else {
             switch multihopContext {
             case .entry:
-                if selectedLocation is AutomaticLocationNode {
-                    multihopState.icon
+                if multihopState.isWhenNeeded && selectedLocation is AutomaticLocationNode {
+                    .mullvadIconMultihopWhenNeeded
                 } else {
-                    .mullvadServer
+                    .mullvadIconMultihopAlways
                 }
             case .exit:
                 .mullvadLocation


### PR DESCRIPTION
The entry server icon is wrong when multihop is `always` without automatic location.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10466)
<!-- Reviewable:end -->
