### PR TITLE
Fix entry tab when switching multihop mode

### DIFF
--- a/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
+++ b/ios/MullvadVPN/View controllers/SelectLocation/SelectLocationViewModel.swift
@@ -171,14 +171,10 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
                 didUpdateTunnelSettings: { [weak self] _, settings in
                     guard let self else { return }
 
+                    updateMultihopState()
                     reloadAllDataSources()
                     updateSelections()
-                    updateMultihopState()
                     updateConnectedLocations(tunnelManager.tunnelStatus)
-
-                    if !isMultihopActive {
-                        multihopContext = .exit
-                    }
 
                     if !searchText.isEmpty {
                         search(searchText: searchText)
@@ -189,6 +185,10 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
                     )
                     entryContext.filter = activeEntryFilter
                     exitContext.filter = activeExitFilter
+
+                    if !multihopState.isAlways {
+                        multihopContext = .exit
+                    }
                 }
             )
 
@@ -207,9 +207,9 @@ class SelectLocationViewModelImpl: SelectLocationViewModel {
         tunnelManager.addObserver(tunnelObserver)
         self.tunnelObserver = tunnelObserver
 
+        updateMultihopState()
         reloadAllDataSources()
         updateSelections()
-        updateMultihopState()
         updateConnectedLocations(tunnelManager.tunnelStatus)
     }
 


### PR DESCRIPTION
The app acts as if you are still browsing the entry tab, enabling you to select an entry (even though it doesn't change anything when you do so)

Reproduction steps:

- Set multihop to `always`
- In select location view, go to your entry location
- Select the automatic location
- Go back to entry tab
- In the "…" menu, change mode to When needed
- You are still in the entry tab, as evidenced by the filter pill.

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10467)
<!-- Reviewable:end -->
