### PR TITLE
Always allow close on back press on add time bottom sheet

### DIFF
--- a/android/lib/feature/addtime/impl/src/main/java/net/mullvad/mullvadvpn/feature/addtime/impl/AddTimeBottomSheet.kt
+++ b/android/lib/feature/addtime/impl/src/main/java/net/mullvad/mullvadvpn/feature/addtime/impl/AddTimeBottomSheet.kt
@@ -168,8 +168,6 @@ fun AddTimeBottomSheetContent(
         },
         shouldDismissOnClickOutside =
             state is Lc.Content && state.value.purchaseState != PurchaseState.VerificationStarted,
-        shouldDismissOnBackPress =
-            state is Lc.Content && state.value.purchaseState != PurchaseState.VerificationStarted,
     ) {
         when (state) {
             is Lc.Loading ->

--- a/android/lib/ui/component/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/component/MullvadModalBottomSheet.kt
+++ b/android/lib/ui/component/src/main/kotlin/net/mullvad/mullvadvpn/lib/ui/component/MullvadModalBottomSheet.kt
@@ -61,7 +61,6 @@ fun MullvadModalBottomSheet(
     backgroundColor: Color = MaterialTheme.colorScheme.secondaryContainer,
     onBackgroundColor: Color = MaterialTheme.colorScheme.onSurface,
     onDismissRequest: () -> Unit,
-    shouldDismissOnBackPress: Boolean = true,
     shouldDismissOnClickOutside: Boolean = true,
     content: @Composable ColumnScope.(bottomPadding: Dp) -> Unit,
 ) {
@@ -75,10 +74,7 @@ fun MullvadModalBottomSheet(
         contentWindowInsets = { WindowInsets(0, 0, 0, 0) }, // No insets
         dragHandle = { BottomSheetDefaults.DragHandle(color = onBackgroundColor) },
         properties =
-            ModalBottomSheetProperties(
-                shouldDismissOnBackPress = shouldDismissOnBackPress,
-                shouldDismissOnClickOutside = shouldDismissOnClickOutside,
-            ),
+            ModalBottomSheetProperties(shouldDismissOnClickOutside = shouldDismissOnClickOutside),
     ) {
         content(paddingValues.calculateBottomPadding())
         Spacer(


### PR DESCRIPTION
Due to a bug, which has been fixed on the Alpha15 of the material 3 library, but not yet on stable, the `shouldDismissOnBackPress` is not being updated properly.

Issue: https://issuetracker.google.com/issues/330202421

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10468)
<!-- Reviewable:end -->
