### PR TITLE
Add support for publishing fdroid repo to dev bucket

### DIFF
--- a/android/docker/Dockerfile
+++ b/android/docker/Dockerfile
@@ -70,7 +70,7 @@ ENV JAVA_HOME=/opt/jdk-21
 
 ARG JDK_SHA256_CHECKSUM=a2def047a73941e01a73739f92755f86b895811afb1f91243db214cff5bdac3f
 
-# Make adb,apk signer, apk analyzer and other tools accessible
+# Make adb, apk signer, apk analyzer and other tools accessible
 ENV PATH="\
 ${JAVA_HOME}/bin\
 :${ANDROID_SDK_ROOT}/platform-tools\
@@ -92,6 +92,7 @@ RUN apt-get update -y && apt-get install -y \
     pcscd \
     python3-pip \
     rclone \
+    python3-qrcode \
     && rm -rf /var/lib/apt/lists/*
 
 # Install fdroid server using pip instead to get a version that is using a later versions of androguard

--- a/android/scripts/containerized-sign.sh
+++ b/android/scripts/containerized-sign.sh
@@ -6,10 +6,12 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONTAINER_RUNNER=${CONTAINER_RUNNER:-"podman"}
 CONTAINER_IMAGE_NAME=$(cat "$SCRIPT_DIR/../../building/android-container-image.txt")
 
-ARTIFACT_DIR=${1:?'Usage: sign.sh <artifact-dir>'}
+WORK_DIR=${1:?'Usage: containerized-sign.sh <work-dir> <bash-command>'}
+# Default to original sign command for backwards compatibility.
+COMMAND=${2:-'shopt -s nullglob; /sign.sh MullvadVPN-*.aab MullvadVPN-*.apk'}
 
-if [[ ! -d "$ARTIFACT_DIR" ]]; then
-    echo "Error: not a directory: $ARTIFACT_DIR"
+if [[ ! -d "$WORK_DIR" ]]; then
+    echo "Error: not a directory: $WORK_DIR"
     exit 1
 fi
 
@@ -36,9 +38,9 @@ trap cleanup EXIT
     --secret YUBIKEY_PIN,type=env \
     -v "$SCRIPT_DIR/wait-for-pcscd.sh:/wait-for-pcscd.sh:Z" \
     -v "$SCRIPT_DIR/sign.sh:/sign.sh:Z" \
-    -v "$ARTIFACT_DIR:/artifact_dir:Z" \
+    -v "$WORK_DIR:/work:Z" \
     "${optional_override_provider_config[@]}" \
-    -w "/artifact_dir" \
+    -w "/work" \
     --entrypoint /wait-for-pcscd.sh \
     "$CONTAINER_IMAGE_NAME" \
-    bash -c 'shopt -s nullglob; /sign.sh MullvadVPN-*.aab MullvadVPN-*.apk'
+    bash -c "$COMMAND"

--- a/android/scripts/containerized-sign.sh
+++ b/android/scripts/containerized-sign.sh
@@ -29,6 +29,10 @@ if [[ -n ${OVERRIDE_PROVIDER_CONFIG-} ]]; then
     optional_override_provider_config=(-v "$OVERRIDE_PROVIDER_CONFIG:/usr/local/etc/pkcs11_java.cfg:Z")
 fi
 
+if [[ -n ${RCLONE_CONFIG_HOST_PATH-} ]]; then
+    optional_rclone_config=(-v "$RCLONE_CONFIG_HOST_PATH:/etc/rclone.conf:ro,Z")
+fi
+
 printf '%s' "$YUBIKEY_PIN" | "$CONTAINER_RUNNER" secret create --replace YUBIKEY_PIN -
 cleanup() { "$CONTAINER_RUNNER" secret rm YUBIKEY_PIN 2>/dev/null || true; }
 trap cleanup EXIT
@@ -40,6 +44,7 @@ trap cleanup EXIT
     -v "$SCRIPT_DIR/sign.sh:/sign.sh:Z" \
     -v "$WORK_DIR:/work:Z" \
     "${optional_override_provider_config[@]}" \
+    "${optional_rclone_config[@]}" \
     -w "/work" \
     --entrypoint /wait-for-pcscd.sh \
     "$CONTAINER_IMAGE_NAME" \

--- a/ci/android/build-server/config.sh
+++ b/ci/android/build-server/config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export FDROID_PUBLISH_ROOT_DIR="$SCRIPT_DIR/publish/fdroid"
+export FDROID_REPOS_DIR="$FDROID_PUBLISH_ROOT_DIR/repos"
+# Must be manually deployed and configured; see fdroid/rclone.conf.template.
+export FDROID_RCLONE_CONFIG_PATH="$SCRIPT_DIR/credentials-android/rclone.conf"

--- a/ci/android/build-server/fdroid.sh
+++ b/ci/android/build-server/fdroid.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -eu
+shopt -s nullglob
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=ci/android/build-server/config.sh
+source "$SCRIPT_DIR/config.sh"
+
+BUILD_DIR="$SCRIPT_DIR/mullvadvpn-app"
+cd "$BUILD_DIR"
+
+function main {
+    case "${1-}" in
+        setup-repo)
+            shift
+            local repo_env=${1:?Usage: setup-repo <repo-env>}
+            setup-repo "$repo_env" || return 1
+            ;;
+        stage)
+            shift
+            if (( $# != 3 )); then
+                echo "Usage: stage <repo-env> <version> <artifact-dir>" >&2
+                return 1
+            fi
+            local repo_env=$1
+            local version=$2
+            local artifact_dir=$3
+            stage "$repo_env" "$version" "$artifact_dir" || return 1
+            ;;
+        publish)
+            shift
+            local repo_env=${1:?Usage: publish <repo-env>}
+            local repo_dir="$FDROID_REPOS_DIR/$repo_env"
+            [[ -d "$repo_dir" ]] || { echo "Unknown repo-env: $repo_env" >&2; return 1; }
+            if [[ -z ${YUBIKEY_PIN-} ]]; then
+                read -rsp "YUBIKEY_PIN = " YUBIKEY_PIN
+                echo ""
+                export YUBIKEY_PIN
+            fi
+            update_and_deploy "$repo_dir" || return 1
+            ;;
+        "")
+            usage >&2
+            return 1
+            ;;
+        *)
+            echo "Unknown subcommand: $1" >&2
+            usage >&2
+            return 1
+            ;;
+    esac
+}
+
+function usage {
+    echo "Usage: $0 <subcommand> [args]"
+    echo
+    echo "Subcommands:"
+    echo "  setup-repo <repo-env>                       bootstrap a single repo dir"
+    echo "  stage <repo-env> <version> <artifact-dir>   stage an APK + changelog into repo-env"
+    echo "  publish <repo-env>                          update+deploy repo-env"
+}
+
+function setup-repo {
+    local repo_env=$1
+    local config_src="$BUILD_DIR/ci/android/build-server/fdroid/config.$repo_env.yml"
+    [[ -f "$config_src" ]] || { echo "Missing config source for: $repo_env" >&2; return 1; }
+    local repo_dir="$FDROID_REPOS_DIR/$repo_env"
+
+    mkdir -p \
+        "$repo_dir/repo/icons" \
+        "$repo_dir/metadata/net.mullvad.mullvadvpn/en-US/images" \
+        "$repo_dir/metadata/net.mullvad.mullvadvpn/en-US/changelogs"
+
+    cp "$config_src" "$repo_dir/config.yml"
+
+    local icon_src="$BUILD_DIR/android/src/main/play/listings/en-US/graphics/icon/icon.png"
+    cp "$icon_src" "$repo_dir/repo/icons/icon.png"
+    cp "$icon_src" "$repo_dir/metadata/net.mullvad.mullvadvpn/en-US/images/icon.png"
+
+    local metadata_dest="$repo_dir/metadata/net.mullvad.mullvadvpn.yml"
+    # Avoid overwriting existing metadata since it contains state (CurrentVersion/CurrentVersionCode).
+    if [[ -e "$metadata_dest" ]]; then
+        echo "Metadata already present at $metadata_dest, leaving it alone."
+    else
+        cp "$BUILD_DIR/ci/android/build-server/fdroid/net.mullvad.mullvadvpn.yml" \
+            "$metadata_dest"
+    fi
+}
+
+function stage {
+    local repo_env=$1
+    local version=$2
+    local artifact_dir=$3
+    local repo_dir="$FDROID_REPOS_DIR/$repo_env"
+    [[ -d "$repo_dir" ]] || { echo "Unknown repo-env: $repo_env" >&2; return 1; }
+
+    # Assume the single .txt in the artifact dir is the F-Droid changelog (named <versionCode>.txt at build time).
+    local changelogs=( "$artifact_dir"/*.txt )
+    (( ${#changelogs[@]} == 1 )) || { echo "Expected exactly one changelog in $artifact_dir" >&2; return 1; }
+
+    cp "$artifact_dir/MullvadVPN-$version.apk" "$repo_dir/repo/"
+    cp "${changelogs[@]}" "$repo_dir/metadata/net.mullvad.mullvadvpn/en-US/changelogs/"
+
+    # Bump current/suggested version only for stable builds.
+    if [[ "$version" != *"-alpha"* && "$version" != *"-beta"* && "$version" != *"-dev-"* ]]; then
+        sed -i -E \
+            -e "s/^CurrentVersion: .*/CurrentVersion: $version/" \
+            -e "s/^CurrentVersionCode: .*/CurrentVersionCode: $(basename "${changelogs[0]}" .txt)/" \
+            "$repo_dir/metadata/net.mullvad.mullvadvpn.yml"
+    fi
+}
+
+function update_and_deploy {
+    local repo_dir=$1
+    local java_opts='--add-opens=jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED'
+
+    RCLONE_CONFIG_HOST_PATH="$FDROID_RCLONE_CONFIG_PATH" \
+    YUBIKEY_PIN=$YUBIKEY_PIN \
+    YUBIKEY_PATH=$(readlink -f /dev/android-jks-signing-key) \
+    "$BUILD_DIR/android/scripts/containerized-sign.sh" "$repo_dir" \
+        "JAVA_TOOL_OPTIONS='$java_opts' fdroid update && fdroid deploy"
+}
+
+main "$@"

--- a/ci/android/build-server/fdroid/config.development.yml
+++ b/ci/android/build-server/fdroid/config.development.yml
@@ -1,0 +1,23 @@
+sdk_path: $ANDROID_HOME
+repo_url: https://fdroid.devmole.eu/fdroid/repo
+repo_name: Mullvad VPN F-Droid repository (development)
+repo_description: >-
+   This is the official Mullvad VPN F-Droid repository. It hosts
+   reproducible binaries with faster updates than the main F-Droid
+   repository. NOTE: The apps in this repository are signed with a
+   different key than the main F-Droid repository (signed by F-Droid
+   rather than us), so switching repositories requires reinstalling
+   apps. We do however use the same signing key across this
+   repository, GitHub Releases and our website.
+archive_older: 0
+# awsbucket is used by rclone
+awsbucket: appteam-android-fdroid-development
+rclone_config: development
+path_to_custom_rclone_config: /etc/rclone.conf
+keystore: NONE
+repo_keyalias: "X.509 Certificate for PIV Authentication"
+smartcardoptions: |
+   -providerClass sun.security.pkcs11.SunPKCS11
+   -providerArg /usr/local/etc/pkcs11_java.cfg
+   -storetype PKCS11
+keystorepass: {env: YUBIKEY_PIN}

--- a/ci/android/build-server/fdroid/net.mullvad.mullvadvpn.yml
+++ b/ci/android/build-server/fdroid/net.mullvad.mullvadvpn.yml
@@ -1,0 +1,27 @@
+AntiFeatures:
+  NonFreeNet:
+    en-US: Depends on the Mullvad VPN service.
+Categories:
+  - Connectivity
+  - Internet
+  - Security
+  - System
+License: GPL-3.0-or-later
+WebSite: https://mullvad.net
+SourceCode: https://github.com/mullvad/mullvadvpn-app
+IssueTracker: https://github.com/mullvad/mullvadvpn-app/issues
+Translation: https://github.com/mullvad/mullvadvpn-app/blob/HEAD/CONTRIBUTING.md#localization--translations
+Changelog: https://github.com/mullvad/mullvadvpn-app/blob/HEAD/android/CHANGELOG.md
+
+AutoName: Mullvad VPN
+
+Summary: >-
+   Protect your online privacy with a fast, trustworthy, and easy-to-use VPN.
+
+Description: >-
+   Free the internet from data collection with Mullvad VPN
+    – a service that helps keep your online activity, identity, and location private.
+   Only €5/month.
+
+CurrentVersion: 0
+CurrentVersionCode: 0

--- a/ci/android/build-server/fdroid/rclone.conf.template
+++ b/ci/android/build-server/fdroid/rclone.conf.template
@@ -1,0 +1,11 @@
+# Template for the rclone config used by fdroid.sh to deploy F-Droid repos.
+# Copy this file, fill in the PLEASE_CONFIGURE_ME placeholders, and deploy it to the
+# path referenced by FDROID_RCLONE_CONFIG_PATH in config.sh.
+
+[development]
+type = s3
+provider = Other
+endpoint = PLEASE_CONFIGURE_ME
+access_key_id = PLEASE_CONFIGURE_ME
+secret_access_key = PLEASE_CONFIGURE_ME
+region = us-east-1

--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -10,6 +10,10 @@ set -eu
 shopt -s nullglob
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# shellcheck source=ci/android/build-server/config.sh
+source "$SCRIPT_DIR/config.sh"
+
 BUILD_DIR="$SCRIPT_DIR/mullvadvpn-app"
 LAST_BUILT_DIR="$SCRIPT_DIR/last-built"
 UPLOAD_DIR="/home/upload/upload"
@@ -47,10 +51,10 @@ fi
 function stage_cdn_upload {
     version=$1
 
-    # Only include files. Skip subdirectories.
+    # Only include files. Skip subdirectories and F-Droid changelogs.
     files=()
     for f in *; do
-        [[ -f "$f" ]] && files+=("$f")
+        [[ -f "$f" && "$f" != *.txt ]] && files+=("$f")
     done
     checksums_path="android+$(hostname)+$version.sha256"
     sha256sum "${files[@]}" > "$checksums_path"
@@ -63,6 +67,17 @@ function stage_for_publishing {
     artifact_dir=$2
 
     (cd "$artifact_dir" && stage_cdn_upload "$version") || return 1
+
+    if [[ $version != *"-dev-"* ]]; then
+        "$SCRIPT_DIR/fdroid.sh" stage development "$version" "$artifact_dir" || return 1
+    fi
+}
+
+function publish_fdroid_repo {
+    local repo_env=$1
+    YUBIKEY_PIN=$YUBIKEY_PIN \
+    "$SCRIPT_DIR/fdroid.sh" publish "$repo_env" \
+        || echo "Failed to publish F-Droid repos for $repo_env"
 }
 
 function run_in_linux_container {
@@ -83,6 +98,9 @@ function build {
     ./building/containerized-build.sh android "$task" || return 1
 
     mv dist/*.{aab,apk} "$artifact_dir" || return 1
+
+    cp android/src/main/play/release-notes/en-US/default.txt \
+        "$artifact_dir/$(cat dist-assets/android-version-code.txt).txt" || return 1
 }
 
 # Checks out the passed git reference passed to the working directory.
@@ -173,6 +191,10 @@ function build_sign_and_publish_ref {
 
     PLAY_CREDENTIALS_PATH="$PLAY_CREDENTIALS_PATH" \
     "$SCRIPT_DIR/upload-play.sh" "$artifact_dir" "$version" || echo "Failed to upload bundle $version"
+
+    if [[ $version != *"-dev-"* ]]; then
+        publish_fdroid_repo development
+    fi
 
     # shellcheck disable=SC2216
     yes | rm -r "$artifact_dir"

--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -151,9 +151,11 @@ function build_sign_and_publish_ref {
 
     # Sign all artifacts
     if [[ "$ENABLE_SIGNING" == "true" ]]; then
+        local sign_command='shopt -s nullglob; /sign.sh MullvadVPN-*.aab MullvadVPN-*.apk'
         YUBIKEY_PIN=$YUBIKEY_PIN \
         YUBIKEY_PATH=$(readlink -f /dev/android-jks-signing-key) \
-        "./android/scripts/containerized-sign.sh" "$BUILD_DIR/$artifact_dir" || return 1
+        "./android/scripts/containerized-sign.sh" "$BUILD_DIR/$artifact_dir" "$sign_command" \
+            || return 1
     else
         echo "WARNING: Signing skipped for $version"
     fi

--- a/ci/android/build-server/run.sh
+++ b/ci/android/build-server/run.sh
@@ -44,7 +44,7 @@ if [[ "$ENABLE_SIGNING" == "true" && -z ${YUBIKEY_PIN-} ]]; then
 fi
 
 # Move files for CDN upload by: buildserver-upload.sh
-function prepare_for_cdn_upload {
+function stage_cdn_upload {
     version=$1
 
     # Only include files. Skip subdirectories.
@@ -56,6 +56,13 @@ function prepare_for_cdn_upload {
     sha256sum "${files[@]}" > "$checksums_path"
 
     cp "${files[@]}" "$checksums_path" "$UPLOAD_DIR/"
+}
+
+function stage_for_publishing {
+    version=$1
+    artifact_dir=$2
+
+    (cd "$artifact_dir" && stage_cdn_upload "$version") || return 1
 }
 
 function run_in_linux_container {
@@ -160,7 +167,7 @@ function build_sign_and_publish_ref {
         echo "WARNING: Signing skipped for $version"
     fi
 
-    (cd "$artifact_dir" && prepare_for_cdn_upload "$version") || return 1
+    stage_for_publishing "$version" "$artifact_dir" || return 1
 
     touch "$LAST_BUILT_DIR/$current_hash"
 


### PR DESCRIPTION
### What
Adds support for publishing our own self-hosted binary F-Droid repository to a development environment. The bucket is only meant for internal evaluation at this point.

### Why
For evaluating adding a public official one. The public one would provide faster updates and improve availability in case the official F-Droid repository is blocked or down.

### How
Generates and deploys the F-Droid repository for stable builds as part of our build server script(s).

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10469)
<!-- Reviewable:end -->
