### PR TITLE
Tell jemalloc to assume 64KiB page size on ARM Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -244,6 +244,7 @@ function build {
     fi
 
     local cargo_features=()
+    local cargo_env=()
 
     local cargo_crates_to_build=(
         -p mullvad-daemon --bin mullvad-daemon
@@ -264,9 +265,19 @@ function build {
              log_warn "Libraries not found at ${clib_dir}/*"
              log_warn "Check \"dist-assets/binaries\" for build details!"
         fi
+
+        # Tell jemalloc to use 64KiB page size on ARM Linux.
+        #
+        # Jemalloc needs to be compiled with a page size that is >= to the page size of the
+        # system it's running on. Page size is 4KiB, except on ARM where it's configurable.
+        # 64KiB seems like a good upper limit.
+        case $current_target in
+            aarch64-unknown-linux-gnu) cargo_env+=(JEMALLOC_SYS_WITH_LG_PAGE="16");; # 2^16 == 64KiB
+        esac
+
     fi
 
-    cargo build "${cargo_target_arg[@]}" "${cargo_features[@]}" "${CARGO_ARGS[@]}" "${cargo_crates_to_build[@]}"
+    env "${cargo_env[@]}" cargo build "${cargo_target_arg[@]}" "${cargo_features[@]}" "${CARGO_ARGS[@]}" "${cargo_crates_to_build[@]}"
 
     ################################################################################
     # Move binaries to correct locations in dist-assets


### PR DESCRIPTION
Tell jemalloc to use 64KiB page size on ARM Linux.

Jemalloc needs to be compiled with a page size that is >= to the page size of the system it's running on. Page size is 4KiB, except on ARM where it's configurable. 64KiB seems like a good upper limit.

fixes #10461

<!--
PR checklist. Does not need to be included in the submitted PR, but must be honored:

* [ ] The change is added to `CHANGELOG.md` under the `[Unreleased]` header.
* [ ] The change/commits follow the Mullvad coding guidelines: https://github.com/mullvad/coding-guidelines
* [ ] Automatic tests are added for the change, if relevant. All new features must have tests.
* [ ] The PR description should describe:
  * **What** this PR changes
  * **Why** this is wanted
  * If necessary, **how** it's implemented
  * How to **test** the change


👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋
  THIRD PARTY CONTRIBUTOR, PLEASE READ THIS
👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋👋

## Translations and localization

Do you want to contribute translations/localization to this app?
* If you want to correct an existing translation, please fill in this form instead of submitting
  a PR with changes to the PO/xml files: https://docs.google.com/forms/d/e/1FAIpQLSeEFRe0ojdl6QdHPp7Z9qIvdGTc1uSgbswQT6d-VRQ98GBO2w/viewform
* We can't accept translations to new languages from third party contributors.
-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10470)
<!-- Reviewable:end -->
