### PR TITLE
Use safelog for password fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -797,6 +797,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1138,6 +1147,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,7 +1198,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1277,6 +1309,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1356,19 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
+dependencies = [
+ "num-bigint",
+ "num-traits",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -1389,7 +1446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1466,6 +1523,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fluid-let"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
 
 [[package]]
 name = "fnv"
@@ -1718,7 +1781,7 @@ dependencies = [
  "tokio-util 0.7.18",
  "tun 0.8.7",
  "typed-builder 0.21.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "x25519-dalek",
  "zerocopy",
 ]
@@ -3616,7 +3679,17 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3624,6 +3697,15 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -4896,7 +4978,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4966,6 +5048,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
+name = "safelog"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a907e0d82c61b1b06a2030c968eb313dcf432686b77801a26bc4b206f96573"
+dependencies = [
+ "derive_more",
+ "educe",
+ "either",
+ "fluid-let",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4998,7 +5094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5292,7 +5388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5673,6 +5769,7 @@ dependencies = [
  "itertools 0.14.0",
  "jnix",
  "log",
+ "safelog",
  "serde",
  "shadowsocks-crypto",
  "thiserror 2.0.18",
@@ -5744,7 +5841,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6464,7 +6561,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6478,6 +6575,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -6775,7 +6878,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/mullvad-api/src/https_client.rs
+++ b/mullvad-api/src/https_client.rs
@@ -360,7 +360,7 @@ impl From<ApiConnectionMode> for InnerConnectionMode {
                     InnerConnectionMode::Shadowsocks(ShadowsocksConfig {
                         params: ParsedShadowsocksConfig {
                             peer: config.endpoint,
-                            password: config.password,
+                            password: config.password.into_inner(),
                             cipher: config.cipher.kind(),
                         },
                         proxy_context: SsContext::new_shared(ServerType::Local),

--- a/mullvad-daemon/src/migrations/v7.rs
+++ b/mullvad-daemon/src/migrations/v7.rs
@@ -242,7 +242,9 @@ fn migrate_bridge_settings(settings: &mut serde_json::Value) -> Result<()> {
                 endpoint: extract_str(custom_bridge_shadowsocks.get("peer"))?
                     .parse()
                     .map_err(|_| Error::InvalidSettingsContent)?,
-                password: extract_str(custom_bridge_shadowsocks.get("password"))?.to_string(),
+                password: extract_str(custom_bridge_shadowsocks.get("password"))?
+                    .to_string()
+                    .into(),
                 cipher: extract_str(custom_bridge_shadowsocks.get("cipher")).and_then(
                     |cipher| ShadowsocksCipher::new(cipher).or(Err(Error::InvalidSettingsContent)),
                 )?,

--- a/mullvad-ios/src/api_client/helpers.rs
+++ b/mullvad-ios/src/api_client/helpers.rs
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn new_shadowsocks_access_method_setting(
 
     let shadowsocks_configuration = Shadowsocks {
         endpoint,
-        password,
+        password: password.into(),
         cipher,
     };
 

--- a/mullvad-management-interface/src/types/conversions/net.rs
+++ b/mullvad-management-interface/src/types/conversions/net.rs
@@ -384,7 +384,7 @@ mod proxy {
             proto::Shadowsocks {
                 ip: value.endpoint.ip().to_string(),
                 port: value.endpoint.port() as u32,
-                password: value.password,
+                password: value.password.into_inner(),
                 cipher: Some(cipher),
             }
         }

--- a/mullvad-types/src/relay_list.rs
+++ b/mullvad-types/src/relay_list.rs
@@ -516,7 +516,7 @@ impl ShadowsocksEndpointData {
     pub fn to_proxy_settings(&self, addr: IpAddr) -> Shadowsocks {
         Shadowsocks {
             endpoint: SocketAddr::new(addr, self.port),
-            password: self.password.clone(),
+            password: self.password.clone().into(),
             cipher: self.cipher.clone(),
         }
     }

--- a/talpid-types/Cargo.toml
+++ b/talpid-types/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.22.0"
 ipnetwork = { workspace = true, features = ["serde"] }
 itertools.workspace = true
 log = { workspace = true }
+safelog = { version = "0.8.2", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 shadowsocks-crypto.workspace = true
 thiserror = { workspace = true }

--- a/talpid-types/src/net/proxy.rs
+++ b/talpid-types/src/net/proxy.rs
@@ -1,4 +1,5 @@
 use crate::net::Endpoint;
+use safelog::Sensitive;
 use serde::{Deserialize, Serialize};
 use std::{fmt, net::SocketAddr, str::FromStr};
 
@@ -86,7 +87,7 @@ impl From<Shadowsocks> for CustomProxy {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Shadowsocks {
     pub endpoint: SocketAddr,
-    pub password: String,
+    pub password: Sensitive<String>,
     pub cipher: ShadowsocksCipher,
 }
 
@@ -198,7 +199,7 @@ pub struct Socks5Remote {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SocksAuth {
     username: String,
-    password: String,
+    password: Sensitive<String>,
 }
 
 impl SocksAuth {
@@ -258,7 +259,10 @@ impl SocksAuth {
             ));
         }
 
-        Ok(SocksAuth { username, password })
+        Ok(SocksAuth {
+            username,
+            password: password.into(),
+        })
     }
 
     /// Read the username.
@@ -280,7 +284,7 @@ impl Shadowsocks {
     ) -> Self {
         Shadowsocks {
             endpoint: endpoint.into(),
-            password,
+            password: password.into(),
             cipher,
         }
     }


### PR DESCRIPTION
We are currently logging passwords for custom access methods. We should not. At the call site of the log it was not at all obvious that logging a whole access method would disclose this, we will fix the problem at the source - ensure that the password fields do not end up in `Debug` outputs. We should probably use `safelog::Sensitive` in a lot more places than just here. This should fix the logs on iOS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10474)
<!-- Reviewable:end -->
