### PR TITLE
Enable idle connection timeouts in mullvad-api

### DIFF
--- a/mullvad-api/src/rest.rs
+++ b/mullvad-api/src/rest.rs
@@ -35,6 +35,11 @@ const USER_AGENT: &str = "mullvad-app";
 
 pub type Result<T> = std::result::Result<T, Error>;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long an HTTP connection may sit idle in hyper's connection pool before
+/// it is evicted. Closes pooled keepalive sockets (and their upstream proxy
+/// connections, if any) after a quiet period without affecting in-flight
+/// requests.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Describes all the ways a REST request can fail
 #[derive(thiserror::Error, Debug, Clone)]
@@ -176,6 +181,8 @@ impl<T: ConnectionModeProvider + 'static> RequestService<T> {
         );
         let client =
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .pool_idle_timeout(Some(POOL_IDLE_TIMEOUT))
+                .pool_timer(hyper_util::rt::TokioTimer::new())
                 .build(connector.clone());
 
         let (command_tx, command_rx) = mpsc::unbounded();


### PR DESCRIPTION
Forever we have lived without shutting down API connections when not in use. As such, I believe the client has been always rotating to the next access method after the previous one fails to start back up after a long hiatus - I do not believe the API will keep the TCP connection open indefinitely. 

I think we were trusting the default idle connection timeout in the hyper legacy client - but it itself does not actually work unless the client builder also receives a timer. 

I've added somewhat heavy-handed tests to verify the behavior we want - then the changeset is 7 lines and not 150.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mullvadvpn-app/10475)
<!-- Reviewable:end -->
